### PR TITLE
Add C variable initialization

### DIFF
--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -519,7 +519,7 @@ void EBPFControl::emitDeclaration(CodeBuilder* builder, const IR::Declaration* d
         auto vd = decl->to<IR::Declaration_Variable>();
         auto etype = EBPFTypeFactory::instance->create(vd->type);
         builder->emitIndent();
-        etype->declare(builder, vd->name, false);
+        etype->declareInit(builder, vd->name, false);
         builder->endOfStatement(true);
         BUG_CHECK(vd->initializer == nullptr,
                   "%1%: declarations with initializers not supported", decl);

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -32,6 +32,7 @@ class EBPFType : public EBPFObject {
     const IR::Type* type;
     virtual void emit(CodeBuilder* builder) = 0;
     virtual void declare(CodeBuilder* builder, cstring id, bool asPointer) = 0;
+    virtual void declareInit(CodeBuilder* builder, cstring id, bool asPointer) = 0;
     virtual void emitInitializer(CodeBuilder* builder) = 0;
     virtual void declareArray(CodeBuilder* /*builder*/, cstring /*id*/, unsigned /*size*/)
     { BUG("%1%: unsupported array", type); }
@@ -67,6 +68,7 @@ class EBPFBoolType : public EBPFType, public IHasWidth {
     void emit(CodeBuilder* builder) override
     { builder->append("u8"); }
     void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
+    void declareInit(CodeBuilder* builder, cstring id, bool asPointer) override;
     void emitInitializer(CodeBuilder* builder) override
     { builder->append("0"); }
     unsigned widthInBits() override { return 1; }
@@ -84,6 +86,7 @@ class EBPFStackType : public EBPFType, public IHasWidth {
     }
     void emit(CodeBuilder*) override {}
     void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
+    void declareInit(CodeBuilder* builder, cstring id, bool asPointer) override;
     void emitInitializer(CodeBuilder* builder) override;
     unsigned widthInBits() override;
     unsigned implementationWidthInBits() override;
@@ -99,6 +102,7 @@ class EBPFScalarType : public EBPFType, public IHasWidth {
     unsigned alignment() const;
     void emit(CodeBuilder* builder) override;
     void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
+    void declareInit(CodeBuilder* builder, cstring id, bool asPointer) override;
     void emitInitializer(CodeBuilder* builder) override
     { builder->append("0"); }
     unsigned widthInBits() override { return width; }
@@ -117,6 +121,7 @@ class EBPFTypeName : public EBPFType, public IHasWidth {
             EBPFType(type), type(type), canonical(canonical) {}
     void emit(CodeBuilder* builder) override { canonical->emit(builder); }
     void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
+    void declareInit(CodeBuilder* builder, cstring id, bool asPointer) override;
     void emitInitializer(CodeBuilder* builder) override;
     unsigned widthInBits() override;
     unsigned implementationWidthInBits() override;
@@ -144,6 +149,7 @@ class EBPFStructType : public EBPFType, public IHasWidth {
 
     explicit EBPFStructType(const IR::Type_StructLike* strct);
     void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
+    void declareInit(CodeBuilder* builder, cstring id, bool asPointer) override;
     void emitInitializer(CodeBuilder* builder) override;
     unsigned widthInBits() override { return width; }
     unsigned implementationWidthInBits() override { return implWidth; }
@@ -156,6 +162,7 @@ class EBPFEnumType : public EBPFType, public EBPF::IHasWidth {
     explicit EBPFEnumType(const IR::Type_Enum* type) : EBPFType(type) {}
     void emit(CodeBuilder* builder) override;
     void declare(CodeBuilder* builder, cstring id, bool asPointer) override;
+    void declareInit(CodeBuilder* builder, cstring id, bool asPointer) override;
     void emitInitializer(CodeBuilder* builder) override
     { builder->append("0"); }
     unsigned widthInBits() override { return 32; }

--- a/backends/ubpf/ubpfControl.cpp
+++ b/backends/ubpf/ubpfControl.cpp
@@ -623,7 +623,7 @@ namespace UBPF {
             auto vd = decl->to<IR::Declaration_Variable>();
             auto etype = UBPFTypeFactory::instance->create(vd->type);
             builder->emitIndent();
-            etype->declare(builder, vd->name, false);
+            etype->declareInit(builder, vd->name, false);
             builder->endOfStatement(true);
             BUG_CHECK(vd->initializer == nullptr,
                       "%1%: declarations with initializers not supported",

--- a/backends/ubpf/ubpfType.cpp
+++ b/backends/ubpf/ubpfType.cpp
@@ -95,6 +95,22 @@ namespace UBPF {
         }
     }
 
+    void UBPFScalarType::declareInit(EBPF::CodeBuilder *builder, cstring id, bool asPointer) {
+        if (EBPFScalarType::generatesScalar(width)) {
+            emit(builder);
+            if (asPointer)
+                builder->append("*");
+            builder->spc();
+            id = id + cstring(" = 0");
+            builder->append(id);
+        } else {
+            if (asPointer)
+                builder->append("uint8_t*");
+            else
+                builder->appendFormat("uint8_t %s[%d]", id.c_str(), bytesRequired());
+        }
+    }
+
     void UBPFStructType::emit(EBPF::CodeBuilder *builder) {
         builder->emitIndent();
         builder->append(kind);
@@ -140,6 +156,9 @@ namespace UBPF {
         builder->appendFormat("%s", id.c_str());
     }
 
+    void UBPFStructType::declareInit(EBPF::CodeBuilder *builder, cstring id, bool asPointer) {
+        declare(builder, id, asPointer);
+    }
     //////////////////////////////////////////////////////////
 
     void UBPFEnumType::emit(EBPF::CodeBuilder *builder) {
@@ -211,6 +230,10 @@ namespace UBPF {
         builder->append(name);
         builder->spc();
         builder->append(id.c_str());
+    }
+
+    void UBPFListType::declareInit(EBPF::CodeBuilder *builder, cstring id, bool asPointer) {
+        declare(builder, id, asPointer);
     }
 
     void UBPFListType::emitInitializer(EBPF::CodeBuilder* builder) {

--- a/backends/ubpf/ubpfType.h
+++ b/backends/ubpf/ubpfType.h
@@ -53,6 +53,7 @@ namespace UBPF {
         cstring getAsString();
 
         void declare(EBPF::CodeBuilder *builder, cstring id, bool asPointer) override;
+        void declareInit(EBPF::CodeBuilder *builder, cstring id, bool asPointer) override;
     };
 
     class UBPFStructType : public EBPF::EBPFStructType {
@@ -60,6 +61,7 @@ namespace UBPF {
         UBPFStructType(const IR::Type_StructLike* strct) : EBPF::EBPFStructType(strct) {}
         void emit(EBPF::CodeBuilder* builder) override;
         void declare(EBPF::CodeBuilder* builder, cstring id, bool asPointer) override;
+        void declareInit(EBPF::CodeBuilder *builder, cstring id, bool asPointer) override;
     };
 
     class UBPFEnumType : public EBPF::EBPFEnumType {
@@ -100,6 +102,7 @@ namespace UBPF {
         explicit UBPFListType(const IR::Type_List *lst);
         void emitPadding(EBPF::CodeBuilder* builder, Padding* padding);
         void declare(EBPF::CodeBuilder* builder, cstring id, bool asPointer) override;
+        void declareInit(EBPF::CodeBuilder *builder, cstring id, bool asPointer) override;
         void emitInitializer(EBPF::CodeBuilder* builder) override;
         unsigned widthInBits() override { return width; }
         unsigned implementationWidthInBits() override { return implWidth; }


### PR DESCRIPTION
Fixes https://github.com/p4lang/p4c/issues/2822

In current p4c ebpf and ubpf backend code, callers that call declare do not know what type the variable is to declare.  All types implement declare.  So a new declareInit() method is added to code for all types.  The scope of changes is narrow.  Only for the Scalartype, declareInit() is supported - this is my need.  All other declareInit() just default to declare().  In each of ebpfControl.cpp and ubpfControl.cpp, emitDeclaration() is changed to use declareInit().  I have unit tested the changes with my p4tovpp backend.
