### PR TITLE
Allow masks in select expressions

### DIFF
--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -48,10 +48,28 @@ bool CodeGenInspector::preorder(const IR::Declaration_Variable* decl) {
     return false;
 }
 
+static cstring getMask(P4::TypeMap* typeMap, const IR::Node* node) {
+    auto type = typeMap->getType(node, true);
+    cstring mask = "";
+    if (auto tb = type->to<IR::Type_Bits>()) {
+        if (tb->size != 8 && tb->size != 16 && tb->size != 32 && tb->size != 64)
+            mask = " & ((1 << " + Util::toString(tb->size) + ") - 1)";
+    }
+    return mask;
+}
+
 bool CodeGenInspector::preorder(const IR::Operation_Binary* b) {
-    widthCheck(b);
+    if (!b->is<IR::BOr>() &&
+        !b->is<IR::BAnd>() &&
+        !b->is<IR::BXor>() &&
+        !b->is<IR::Equ>() &&
+        !b->is<IR::Neq>())
+        widthCheck(b);
+    cstring mask = getMask(typeMap, b);
     int prec = expressionPrecedence;
-    bool useParens = getParent<IR::IfStatement>() == nullptr;
+    bool useParens = getParent<IR::IfStatement>() == nullptr || mask != "";
+    if (mask != "")
+        builder->append("(");
     if (useParens)
         builder->append("(");
     visit(b->left);
@@ -62,7 +80,10 @@ bool CodeGenInspector::preorder(const IR::Operation_Binary* b) {
     visit(b->right);
     if (useParens)
         builder->append(")");
+    builder->append(mask);
     expressionPrecedence = prec;
+    if (mask != "")
+        builder->append(")");
     return false;
 }
 
@@ -99,7 +120,6 @@ bool CodeGenInspector::comparison(const IR::Operation_Relation* b) {
 }
 
 bool CodeGenInspector::preorder(const IR::Mux* b) {
-    widthCheck(b);
     int prec = expressionPrecedence;
     bool useParens = prec >= b->getPrecedence();
     if (useParens)
@@ -121,7 +141,10 @@ bool CodeGenInspector::preorder(const IR::Mux* b) {
 bool CodeGenInspector::preorder(const IR::Operation_Unary* u) {
     widthCheck(u);
     int prec = expressionPrecedence;
-    bool useParens = prec > u->getPrecedence();
+    cstring mask = getMask(typeMap, u);
+    bool useParens = prec > u->getPrecedence() || mask != "";
+    if (mask != "")
+        builder->append("(");
     if (useParens)
         builder->append("(");
     builder->append(u->getStringOp());
@@ -129,6 +152,9 @@ bool CodeGenInspector::preorder(const IR::Operation_Unary* u) {
     visit(u->expr);
     expressionPrecedence = prec;
     if (useParens)
+        builder->append(")");
+    builder->append(mask);
+    if (mask != "")
         builder->append(")");
     return false;
 }
@@ -388,11 +414,13 @@ void CodeGenInspector::widthCheck(const IR::Node* node) const {
     if (tb->size % 8 == 0 && EBPFScalarType::generatesScalar(tb->size))
         return;
 
-    if (tb->size <= 64)
-        // This is a bug which we can probably fix
-        BUG("%1%: Computations on %2% bits not yet supported", node, tb->size);
-    // We could argue that this may not be supported ever
-    ::error(ErrorType::ERR_OVERLIMIT,
+    if (tb->size <= 64) {
+        if (!tb->isSigned)
+            return;
+        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
+               "%1%: Computations on signed %2% bits not yet supported", node, tb->size);
+    }
+    ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
             "%1%: Computations on %2% bits not supported", node, tb->size);
 }
 

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -151,19 +151,21 @@ bool StateTranslationVisitor::preorder(const IR::SelectExpression* expression) {
 
 bool StateTranslationVisitor::preorder(const IR::SelectCase* selectCase) {
     builder->emitIndent();
-    builder->appendFormat("if ((%s", selectValue);
     if (auto mask = selectCase->keyset->to<IR::Mask>()) {
+        builder->appendFormat("if ((%s", selectValue);
         builder->append(" & ");
         visit(mask->right);
         builder->append(") == (");
         visit(mask->left);
         builder->append(" & ");
         visit(mask->right);
+        builder->append("))");
     } else {
+        builder->appendFormat("if (%s", selectValue);
         builder->append(" == ");
         visit(selectCase->keyset);
+        builder->append(")");
     }
-    builder->append("))");
     builder->append("goto ");
     visit(selectCase->state);
     builder->endOfStatement(true);

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -64,7 +64,7 @@ EBPFBoolType::declare(CodeBuilder* builder, cstring id, bool asPointer) {
 
 void
 EBPFBoolType::declareInit(CodeBuilder* builder, cstring id, bool asPointer) {
-  declare(builder, id, asPointer);
+    declare(builder, id, asPointer);
 }
 
 /////////////////////////////////////////////////////////////

--- a/backends/ebpf/midend.cpp
+++ b/backends/ebpf/midend.cpp
@@ -98,7 +98,7 @@ const IR::ToplevelBlock* MidEnd::run(EbpfOptions& options,
             new P4::SimplifySelectList(&refMap, &typeMap),
             new P4::MoveDeclarations(),  // more may have been introduced
             new P4::RemoveSelectBooleans(&refMap, &typeMap),
-            new P4::SingleArgumentSelect(),
+            new P4::SingleArgumentSelect(&refMap, &typeMap),
             new P4::ConstantFolding(&refMap, &typeMap),
             new P4::SimplifyControlFlow(&refMap, &typeMap),
             new P4::TableHit(&refMap, &typeMap),

--- a/backends/ubpf/midend.cpp
+++ b/backends/ubpf/midend.cpp
@@ -96,7 +96,7 @@ MidEnd::run(EbpfOptions& options, const IR::P4Program* program, std::ostream* ou
                 new P4::SimplifySelectList(&refMap, &typeMap),
                 new P4::MoveDeclarations(),  // more may have been introduced
                 new P4::RemoveSelectBooleans(&refMap, &typeMap),
-                new P4::SingleArgumentSelect(),
+                new P4::SingleArgumentSelect(&refMap, &typeMap),
                 new P4::ConstantFolding(&refMap, &typeMap),
                 new P4::SimplifyControlFlow(&refMap, &typeMap),
                 new P4::TableHit(&refMap, &typeMap),

--- a/backends/ubpf/ubpfParser.cpp
+++ b/backends/ubpf/ubpfParser.cpp
@@ -26,7 +26,9 @@ namespace UBPF {
 
 namespace {
 class UBPFStateTranslationVisitor : public EBPF::CodeGenInspector {
-    bool hasDefault;
+    // stores the result of evaluating the select argument
+    cstring selectValue;
+
     P4::P4CoreLibrary& p4lib;
     const UBPFParserState* state;
 
@@ -49,7 +51,7 @@ class UBPFStateTranslationVisitor : public EBPF::CodeGenInspector {
  public:
     explicit UBPFStateTranslationVisitor(const UBPFParserState* state) :
             CodeGenInspector(state->parser->program->refMap, state->parser->program->typeMap),
-            hasDefault(false), p4lib(P4::P4CoreLibrary::instance), state(state) {}
+            p4lib(P4::P4CoreLibrary::instance), state(state) {}
     bool preorder(const IR::ParserState* state) override;
     bool preorder(const IR::SelectCase* selectCase) override;
     bool preorder(const IR::SelectExpression* expression) override;
@@ -105,7 +107,7 @@ bool UBPFStateTranslationVisitor::preorder(const IR::ParserState* parserState) {
     visit(parserState->components, "components");
     if (parserState->selectExpression == nullptr) {
         builder->emitIndent();
-        builder->append("goto ");
+        builder->append(" goto ");
         builder->append(IR::ParserState::reject);
         builder->endOfStatement(true);
     } else if (parserState->selectExpression->is<IR::SelectExpression>()) {
@@ -126,14 +128,19 @@ bool UBPFStateTranslationVisitor::preorder(const IR::ParserState* parserState) {
 
 bool UBPFStateTranslationVisitor::preorder(const IR::SelectCase* selectCase) {
     builder->emitIndent();
-    if (selectCase->keyset->is<IR::DefaultExpression>()) {
-        hasDefault = true;
-        builder->append("default: ");
+    builder->appendFormat("if ((%s", selectValue);
+    if (auto mask = selectCase->keyset->to<IR::Mask>()) {
+        builder->append(" & ");
+        visit(mask->right);
+        builder->append(") == (");
+        visit(mask->left);
+        builder->append(" & ");
+        visit(mask->right);
     } else {
-        builder->append("case ");
+        builder->append(" == ");
         visit(selectCase->keyset);
-        builder->append(": ");
     }
+    builder->append("))");
     builder->append("goto ");
     visit(selectCase->state);
     builder->endOfStatement(true);
@@ -141,29 +148,29 @@ bool UBPFStateTranslationVisitor::preorder(const IR::SelectCase* selectCase) {
 }
 
 bool UBPFStateTranslationVisitor::preorder(const IR::SelectExpression* expression) {
-    hasDefault = false;
-    if (expression->select->components.size() != 1) {
-        // TODO: this does not handle correctly tuples
-        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
-                "%1%: only supporting a single argument for select", expression->select);
-        return false;
+    BUG_CHECK(expression->select->components.size() == 1,
+              "%1%: tuple not eliminated in select",
+              expression->select);
+    selectValue = state->parser->program->refMap->newName("select");
+    auto type = state->parser->program->typeMap->getType(expression->select, true);
+    if (auto list = type->to<IR::Type_List>()) {
+        BUG_CHECK(list->components.size() == 1, "%1% list type with more than 1 element", list);
+        type = list->components.at(0);
     }
+    auto etype = UBPFTypeFactory::instance->create(type);
     builder->emitIndent();
-    builder->append("switch (");
+    etype->declare(builder, selectValue, false);
+    builder->endOfStatement(true);
+    builder->emitIndent();
+    builder->appendFormat("%s = ", selectValue);
     visit(expression->select);
-    builder->append(") ");
-    builder->blockStart();
-
+    builder->endOfStatement(true);
     for (auto e : expression->selectCases)
         visit(e);
 
-    if (!hasDefault) {
-        builder->emitIndent();
-        builder->appendFormat("default: goto %s;", IR::ParserState::reject.c_str());
-        builder->newline();
-    }
-
-    builder->blockEnd(true);
+    builder->emitIndent();
+    builder->appendFormat("else goto %s;", IR::ParserState::reject.c_str());
+    builder->newline();
     return false;
 }
 

--- a/backends/ubpf/ubpfParser.cpp
+++ b/backends/ubpf/ubpfParser.cpp
@@ -128,19 +128,21 @@ bool UBPFStateTranslationVisitor::preorder(const IR::ParserState* parserState) {
 
 bool UBPFStateTranslationVisitor::preorder(const IR::SelectCase* selectCase) {
     builder->emitIndent();
-    builder->appendFormat("if ((%s", selectValue);
     if (auto mask = selectCase->keyset->to<IR::Mask>()) {
+        builder->appendFormat("if ((%s", selectValue);
         builder->append(" & ");
         visit(mask->right);
         builder->append(") == (");
         visit(mask->left);
         builder->append(" & ");
         visit(mask->right);
+        builder->append("))");
     } else {
+        builder->appendFormat("if (%s", selectValue);
         builder->append(" == ");
         visit(selectCase->keyset);
+        builder->append(")");
     }
-    builder->append("))");
     builder->append("goto ");
     visit(selectCase->state);
     builder->endOfStatement(true);

--- a/frontends/p4/commonInlining.h
+++ b/frontends/p4/commonInlining.h
@@ -17,6 +17,11 @@ limitations under the License.
 #ifndef _FRONTENDS_P4_COMMONINLINING_H_
 #define _FRONTENDS_P4_COMMONINLINING_H_
 
+#define DEBUG_INLINER 0
+
+#if DEBUG_INLINER
+#include "frontends/p4/toP4/toP4.h"
+#endif
 #include "frontends/p4/callGraph.h"
 #include "ir/ir.h"
 
@@ -177,7 +182,7 @@ class InlineDriver : public Visitor {
             if (::errorCount() > 0)
                 break;
 
-#if 0
+#if DEBUG_INLINER
             // debugging code; we don't have an easy way to dump the program here,
             // since we are not between passes
             ToP4 top4(&std::cout, false, nullptr);

--- a/frontends/p4/inlining.h
+++ b/frontends/p4/inlining.h
@@ -250,7 +250,7 @@ class InlinePass : public PassManager {
         new TypeChecking(refMap, typeMap),
         new DiscoverInlining(&toInline, refMap, typeMap, evaluator),
         new InlineDriver<InlineList, InlineSummary>(&toInline, new GeneralInliner(refMap->isV1())),
-        new RemoveAllUnusedDeclarations(refMap) }) { }
+        new RemoveAllUnusedDeclarations(refMap) }) { setName("InlinePass"); }
 };
 
 /**
@@ -267,7 +267,7 @@ class Inline : public PassRepeated {
         new InlinePass(refMap, typeMap, evaluator),
         // After inlining the output of the evaluator changes, so
         // we have to run it again
-        evaluator }) {}
+        evaluator }) { setName("Inline"); }
 
     /// Do not propagate annotation \p name during inlining
     static void setAnnotationNoPropagate(cstring name) {

--- a/midend/singleArgumentSelect.cpp
+++ b/midend/singleArgumentSelect.cpp
@@ -2,29 +2,69 @@
 
 namespace P4 {
 
-static const IR::Expression* convertList(const IR::Expression* expression) {
+DoSingleArgumentSelect::Pair::Pair(const IR::Expression* e, const IR::Type* type) {
+    auto srcInfo = e->srcInfo;
+    if (auto m = e->to<IR::Mask>()) {
+        expr = m->left;
+        mask = m->right;
+        hasMask = true;
+    } else if (e->is<IR::DefaultExpression>()) {
+        expr = new IR::Constant(srcInfo, type, 0, 16);
+        mask = new IR::Constant(srcInfo, type, 0, 16);
+        hasMask = true;
+    } else {
+        expr = e;
+        mask = new IR::Constant(srcInfo, type, Util::maskFromSlice(type->width_bits()-1, 0), 16);
+        hasMask = false;
+    }
+}
+
+static const IR::Expression* convertList(
+    const IR::Expression* expression, const IR::Type* selectListType) {
+    if (expression->is<IR::DefaultExpression>()) {
+        int width = selectListType->width_bits();
+        auto type = new IR::Type_Bits(width, false);
+        return new IR::Mask(expression->srcInfo,
+                            new IR::Constant(type, 0, 16),
+                            new IR::Constant(type, 0, 16));
+    }
     auto list = expression->to<IR::ListExpression>();
     if (list == nullptr)
         return expression;
     BUG_CHECK(list->components.size() > 0, "%1%: No components", list);
-    auto expr = list->components.at(0);
-    for (size_t i = 1; i < list->components.size(); i++)
-        expr = new IR::Concat(expr, list->components.at(i));
-    return expr;
+    auto tt = selectListType->checkedTo<IR::Type_List>();
+    BUG_CHECK(list->size() == tt->components.size(),
+              "%1% and %2% do not have the same size",
+              list, tt);
+    auto p = new DoSingleArgumentSelect::Pair(list->components.at(0), tt->components.at(0));
+    auto hasMask = p->hasMask;
+    auto expr = p->expr;
+    auto mask = p->mask;
+    for (size_t i = 1; i < list->components.size(); i++) {
+        p = new DoSingleArgumentSelect::Pair(list->components.at(i), tt->components.at(i));
+        expr = new IR::Concat(expr, p->expr);
+        mask = new IR::Concat(mask, p->mask);
+        hasMask = hasMask || p->hasMask;
+    }
+    if (!hasMask)
+        return expr;
+    else
+        return new IR::Mask(expression->srcInfo, expr, mask);
 }
 
-bool SingleArgumentSelect::preorder(IR::SelectExpression* expression) {
+bool DoSingleArgumentSelect::preorder(IR::SelectExpression* expression) {
     if (expression->select->size() <= 1)
         return false;
-    auto conv = convertList(expression->select);
+    selectListType = typeMap->getType(expression->select, true);
+    auto conv = convertList(expression->select, selectListType);
     auto list = new IR::ListExpression(IR::Vector<IR::Expression>());
     list->push_back(conv);
     expression->select = list;
     return true;
 }
 
-bool SingleArgumentSelect::preorder(IR::SelectCase* selCase) {
-    selCase->keyset = convertList(selCase->keyset);
+bool DoSingleArgumentSelect::preorder(IR::SelectCase* selCase) {
+    selCase->keyset = convertList(selCase->keyset, selectListType);
     return false;
 }
 

--- a/midend/singleArgumentSelect.cpp
+++ b/midend/singleArgumentSelect.cpp
@@ -53,8 +53,6 @@ static const IR::Expression* convertList(
 }
 
 bool DoSingleArgumentSelect::preorder(IR::SelectExpression* expression) {
-    if (expression->select->size() <= 1)
-        return false;
     selectListType = typeMap->getType(expression->select, true);
     auto conv = convertList(expression->select, selectListType);
     auto list = new IR::ListExpression(IR::Vector<IR::Expression>());

--- a/midend/singleArgumentSelect.cpp
+++ b/midend/singleArgumentSelect.cpp
@@ -62,7 +62,7 @@ void DoSingleArgumentSelect::checkExpressionType(const IR::Expression* expressio
     if (type->is<IR::Type_Bits>()) {
         return;
     } else if (auto le = expression->to<IR::ListExpression>()) {
-        for (auto c: le->components) {
+        for (auto c : le->components) {
             checkExpressionType(c);
         }
     } else {

--- a/midend/singleArgumentSelect.h
+++ b/midend/singleArgumentSelect.h
@@ -18,24 +18,49 @@ limitations under the License.
 #define _MIDEND_SINGLEARGUMENTSELECT_H_
 
 #include "ir/ir.h"
+#include "frontends/p4/typeChecking/typeChecker.h"
 
 namespace P4 {
 
 /**
-   Converts select(a, b, c) into select(a ++ b ++ c).
+   Converts select(a, b, c) into select(a ++ b ++ c) &&& (maska ++ maskb ++ maskc).
    A similar transformation is done for the labels.
    @pre
    This should be run after SimplifySelectList and RemoveSelectBooleans.
    It assumes that all select arguments are scalar values.
 */
-class SingleArgumentSelect : public Modifier {
+class DoSingleArgumentSelect : public Modifier {
+    TypeMap* typeMap;
+    const IR::Type* selectListType;
  public:
-    SingleArgumentSelect() {
-        setName("SingleArgumentSelect");
+    explicit DoSingleArgumentSelect(TypeMap* typeMap):
+            typeMap(typeMap), selectListType(nullptr) {
+        setName("DoSingleArgumentSelect");
     }
+
+    /// A pair of expression representing an expression and a mask
+    struct Pair {
+        const IR::Expression* expr;
+        const IR::Expression* mask;
+        bool hasMask;
+
+        Pair(const IR::Expression* source, const IR::Type* type);
+    };
 
     bool preorder(IR::SelectCase* selCase) override;
     bool preorder(IR::SelectExpression* expression) override;
+};
+
+class SingleArgumentSelect : public PassManager {
+ public:
+    SingleArgumentSelect(ReferenceMap* refMap, TypeMap* typeMap,
+                         TypeChecking* typeChecking = nullptr) {
+        if (!typeChecking)
+            typeChecking = new TypeChecking(refMap, typeMap);
+        passes.push_back(typeChecking);
+        passes.push_back(new DoSingleArgumentSelect(typeMap));
+        setName("SingleArgumentSelect");
+    }
 };
 
 }  // namespace P4

--- a/midend/singleArgumentSelect.h
+++ b/midend/singleArgumentSelect.h
@@ -27,7 +27,7 @@ namespace P4 {
    A similar transformation is done for the labels.
    @pre
    This should be run after SimplifySelectList and RemoveSelectBooleans.
-   It assumes that all select arguments are scalar values.
+   It assumes that all select arguments are scalar values of type Type_Bits.
 */
 class DoSingleArgumentSelect : public Modifier {
     TypeMap* typeMap;
@@ -46,6 +46,10 @@ class DoSingleArgumentSelect : public Modifier {
 
         Pair(const IR::Expression* source, const IR::Type* type);
     };
+
+    // Validate that the expression contains only subexpressions
+    // of supported types.
+    void checkExpressionType(const IR::Expression* expression);
 
     bool preorder(IR::SelectCase* selCase) override;
     bool preorder(IR::SelectExpression* expression) override;

--- a/testdata/p4_16_samples/issue2816-1_ebpf.p4
+++ b/testdata/p4_16_samples/issue2816-1_ebpf.p4
@@ -1,0 +1,88 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <ebpf_model.p4>
+#include <core.p4>
+
+#include "ebpf_headers.p4"
+
+struct Headers_t
+{
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers)
+{
+    state start
+    {
+        p.extract(headers.ethernet);
+        transition select(headers.ethernet.etherType)
+        {
+            16w0x800 : ip;
+            default : reject;
+        }
+    }
+
+    state ip
+    {
+        p.extract(headers.ipv4);
+	transition select(headers.ipv4.ihl, headers.ipv4.protocol,  headers.ipv4.diffserv) {
+	     (_,_,_): parse_l4;
+	     (_,17,_): parse_l4;
+	     (_,_,1): parse_l4;
+	     default: reject;
+	}
+    }
+
+    state parse_l4 {
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass)
+{
+    action Reject(IPv4Address add)
+    {
+        pass = false;
+        headers.ipv4.srcAddr = add;
+    }
+
+    table Check_src_ip {
+        key = { headers.ipv4.srcAddr : exact; }
+        actions =
+        {
+            Reject;
+            NoAction;
+        }
+
+        implementation = hash_table(1024);
+        const default_action = NoAction;
+    }
+
+    apply {
+        pass = true;
+
+        switch (Check_src_ip.apply().action_run) {
+        Reject: {
+            pass = false;
+        }
+        NoAction: {}
+        }
+    }
+}
+
+ebpfFilter(prs(), pipe()) main;

--- a/testdata/p4_16_samples/issue2816_ebpf.p4
+++ b/testdata/p4_16_samples/issue2816_ebpf.p4
@@ -1,0 +1,54 @@
+#include <ebpf_model.p4>
+#include <core.p4>
+
+#include "ebpf_headers.p4"
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract(headers.ethernet);
+        transition select(headers.ethernet.etherType, 16w1) {
+            (default, 16w1) : ip;
+            default : reject;
+        }
+    }
+
+    state ip {
+        p.extract(headers.ipv4);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    action invalidate() {
+        headers.ipv4.setInvalid();
+        headers.ethernet.setInvalid();
+        pass = true;
+    }
+    action drop() {
+        pass = false;
+    }
+    table t {
+        key = {
+            headers.ipv4.srcAddr : exact;
+            headers.ipv4.dstAddr : exact;
+            headers.ethernet.dstAddr : exact;
+            headers.ethernet.srcAddr: exact;
+        }
+        actions = {
+            invalidate; drop;
+        }
+        implementation = hash_table(10);
+        default_action = drop;
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+ebpfFilter(prs(), pipe()) main;

--- a/testdata/p4_16_samples_outputs/issue2816-1_ebpf-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2816-1_ebpf-first.p4
@@ -1,0 +1,83 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition select(headers.ipv4.ihl, headers.ipv4.protocol, headers.ipv4.diffserv) {
+            (default, default, default): parse_l4;
+            (default, 8w17, default): parse_l4;
+            (default, default, 8w1): parse_l4;
+            default: reject;
+        }
+    }
+    state parse_l4 {
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    action Reject(IPv4Address add) {
+        pass = false;
+        headers.ipv4.srcAddr = add;
+    }
+    table Check_src_ip {
+        key = {
+            headers.ipv4.srcAddr: exact @name("headers.ipv4.srcAddr") ;
+        }
+        actions = {
+            Reject();
+            NoAction();
+        }
+        implementation = hash_table(32w1024);
+        const default_action = NoAction();
+    }
+    apply {
+        pass = true;
+        switch (Check_src_ip.apply().action_run) {
+            Reject: {
+                pass = false;
+            }
+            NoAction: {
+            }
+        }
+    }
+}
+
+ebpfFilter<Headers_t>(prs(), pipe()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2816-1_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2816-1_ebpf-frontend.p4
@@ -1,0 +1,85 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition select(headers.ipv4.ihl, headers.ipv4.protocol, headers.ipv4.diffserv) {
+            (default, default, default): parse_l4;
+            (default, 8w17, default): parse_l4;
+            (default, default, 8w1): parse_l4;
+            default: reject;
+        }
+    }
+    state parse_l4 {
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
+        pass = false;
+        headers.ipv4.srcAddr = add_1;
+    }
+    @name("pipe.Check_src_ip") table Check_src_ip_0 {
+        key = {
+            headers.ipv4.srcAddr: exact @name("headers.ipv4.srcAddr") ;
+        }
+        actions = {
+            Reject();
+            NoAction_1();
+        }
+        implementation = hash_table(32w1024);
+        const default_action = NoAction_1();
+    }
+    apply {
+        pass = true;
+        switch (Check_src_ip_0.apply().action_run) {
+            Reject: {
+                pass = false;
+            }
+            NoAction_1: {
+            }
+        }
+    }
+}
+
+ebpfFilter<Headers_t>(prs(), pipe()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2816-1_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2816-1_ebpf-midend.p4
@@ -1,0 +1,103 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition select(headers.ipv4.ihl, headers.ipv4.protocol, headers.ipv4.diffserv) {
+            (default, default, default): parse_l4;
+            (default, 8w17, default): parse_l4;
+            (default, default, 8w1): parse_l4;
+            default: reject;
+        }
+    }
+    state parse_l4 {
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("pipe.Reject") action Reject(@name("add") IPv4Address add_1) {
+        pass = false;
+        headers.ipv4.srcAddr = add_1;
+    }
+    @name("pipe.Check_src_ip") table Check_src_ip_0 {
+        key = {
+            headers.ipv4.srcAddr: exact @name("headers.ipv4.srcAddr") ;
+        }
+        actions = {
+            Reject();
+            NoAction_1();
+        }
+        implementation = hash_table(32w1024);
+        const default_action = NoAction_1();
+    }
+    @hidden action issue28161_ebpf81() {
+        pass = false;
+    }
+    @hidden action issue28161_ebpf77() {
+        pass = true;
+    }
+    @hidden table tbl_issue28161_ebpf77 {
+        actions = {
+            issue28161_ebpf77();
+        }
+        const default_action = issue28161_ebpf77();
+    }
+    @hidden table tbl_issue28161_ebpf81 {
+        actions = {
+            issue28161_ebpf81();
+        }
+        const default_action = issue28161_ebpf81();
+    }
+    apply {
+        tbl_issue28161_ebpf77.apply();
+        switch (Check_src_ip_0.apply().action_run) {
+            Reject: {
+                tbl_issue28161_ebpf81.apply();
+            }
+            NoAction_1: {
+            }
+        }
+    }
+}
+
+ebpfFilter<Headers_t>(prs(), pipe()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2816-1_ebpf.p4
+++ b/testdata/p4_16_samples_outputs/issue2816-1_ebpf.p4
@@ -1,0 +1,83 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract(headers.ipv4);
+        transition select(headers.ipv4.ihl, headers.ipv4.protocol, headers.ipv4.diffserv) {
+            (default, default, default): parse_l4;
+            (default, 17, default): parse_l4;
+            (default, default, 1): parse_l4;
+            default: reject;
+        }
+    }
+    state parse_l4 {
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    action Reject(IPv4Address add) {
+        pass = false;
+        headers.ipv4.srcAddr = add;
+    }
+    table Check_src_ip {
+        key = {
+            headers.ipv4.srcAddr: exact;
+        }
+        actions = {
+            Reject;
+            NoAction;
+        }
+        implementation = hash_table(1024);
+        const default_action = NoAction;
+    }
+    apply {
+        pass = true;
+        switch (Check_src_ip.apply().action_run) {
+            Reject: {
+                pass = false;
+            }
+            NoAction: {
+            }
+        }
+    }
+}
+
+ebpfFilter(prs(), pipe()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2816_ebpf-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2816_ebpf-first.p4
@@ -1,0 +1,75 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType, 16w1) {
+            (default, 16w1): ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    action invalidate() {
+        headers.ipv4.setInvalid();
+        headers.ethernet.setInvalid();
+        pass = true;
+    }
+    action drop() {
+        pass = false;
+    }
+    table t {
+        key = {
+            headers.ipv4.srcAddr    : exact @name("headers.ipv4.srcAddr") ;
+            headers.ipv4.dstAddr    : exact @name("headers.ipv4.dstAddr") ;
+            headers.ethernet.dstAddr: exact @name("headers.ethernet.dstAddr") ;
+            headers.ethernet.srcAddr: exact @name("headers.ethernet.srcAddr") ;
+        }
+        actions = {
+            invalidate();
+            drop();
+        }
+        implementation = hash_table(32w10);
+        default_action = drop();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+ebpfFilter<Headers_t>(prs(), pipe()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2816_ebpf-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2816_ebpf-frontend.p4
@@ -1,0 +1,75 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType, 16w1) {
+            (default, 16w1): ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    @name("pipe.invalidate") action invalidate() {
+        headers.ipv4.setInvalid();
+        headers.ethernet.setInvalid();
+        pass = true;
+    }
+    @name("pipe.drop") action drop() {
+        pass = false;
+    }
+    @name("pipe.t") table t_0 {
+        key = {
+            headers.ipv4.srcAddr    : exact @name("headers.ipv4.srcAddr") ;
+            headers.ipv4.dstAddr    : exact @name("headers.ipv4.dstAddr") ;
+            headers.ethernet.dstAddr: exact @name("headers.ethernet.dstAddr") ;
+            headers.ethernet.srcAddr: exact @name("headers.ethernet.srcAddr") ;
+        }
+        actions = {
+            invalidate();
+            drop();
+        }
+        implementation = hash_table(32w10);
+        default_action = drop();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+ebpfFilter<Headers_t>(prs(), pipe()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2816_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2816_ebpf-midend.p4
@@ -1,0 +1,75 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType, 16w1) {
+            (default, 16w1): ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    @name("pipe.invalidate") action invalidate() {
+        headers.ipv4.setInvalid();
+        headers.ethernet.setInvalid();
+        pass = true;
+    }
+    @name("pipe.drop") action drop() {
+        pass = false;
+    }
+    @name("pipe.t") table t_0 {
+        key = {
+            headers.ipv4.srcAddr    : exact @name("headers.ipv4.srcAddr") ;
+            headers.ipv4.dstAddr    : exact @name("headers.ipv4.dstAddr") ;
+            headers.ethernet.dstAddr: exact @name("headers.ethernet.dstAddr") ;
+            headers.ethernet.srcAddr: exact @name("headers.ethernet.srcAddr") ;
+        }
+        actions = {
+            invalidate();
+            drop();
+        }
+        implementation = hash_table(32w10);
+        default_action = drop();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+ebpfFilter<Headers_t>(prs(), pipe()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2816_ebpf.p4
+++ b/testdata/p4_16_samples_outputs/issue2816_ebpf.p4
@@ -1,0 +1,75 @@
+#include <core.p4>
+#include <ebpf_model.p4>
+
+@ethernetaddress typedef bit<48> EthernetAddress;
+@ipv4address typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+struct Headers_t {
+    Ethernet_h ethernet;
+    IPv4_h     ipv4;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract(headers.ethernet);
+        transition select(headers.ethernet.etherType, 16w1) {
+            (default, 16w1): ip;
+            default: reject;
+        }
+    }
+    state ip {
+        p.extract(headers.ipv4);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+    action invalidate() {
+        headers.ipv4.setInvalid();
+        headers.ethernet.setInvalid();
+        pass = true;
+    }
+    action drop() {
+        pass = false;
+    }
+    table t {
+        key = {
+            headers.ipv4.srcAddr    : exact;
+            headers.ipv4.dstAddr    : exact;
+            headers.ethernet.dstAddr: exact;
+            headers.ethernet.srcAddr: exact;
+        }
+        actions = {
+            invalidate;
+            drop;
+        }
+        implementation = hash_table(10);
+        default_action = drop;
+    }
+    apply {
+        t.apply();
+    }
+}
+
+ebpfFilter(prs(), pipe()) main;
+


### PR DESCRIPTION
Fixes #2816 
@osinstom : you may want to consider applying similar fixes to the ubpf back-end.
In fact, this scheme is better than it used to be, but it is still not general enough: it won't handle select expressions where the expression has more than 64 bits combined.