### PR TITLE
Modernize run-bmv2-test a little

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -149,7 +149,7 @@ set (BMV2_PSA_TEST_SUITES
 
 # -p to use psa switch model
 # -a to pass flags to compiler
-set (testExtraFlags "${testExtraFlags} -p -a '--target bmv2 --arch psa'")
+set (testExtraFlags "${testExtraFlags} -p -a='--target bmv2 --arch psa'")
 
 set (XFAIL_TESTS
   # This test defines two lpm keys for a table.
@@ -202,7 +202,7 @@ set (XFAIL_TESTS
 if (HAVE_SIMPLE_SWITCH)
   p4c_add_tests("bmv2" ${BMV2_DRIVER} "${BMV2_V1MODEL_TEST_SUITES}" "${XFAIL_TESTS}")
   add_library(extern_func_module MODULE EXCLUDE_FROM_ALL "${P4C_SOURCE_DIR}/testdata/extern_modules/extern-funcs-bmv2.cpp" )
-  p4c_add_test_with_args("bmv2" ${BMV2_DRIVER} FALSE "bmv2_emit_externs" "testdata/p4_16_samples/extern-funcs-bmv2.p4" "-a --emit-externs --target-specific-switch-arg \"--load-modules ${CMAKE_CURRENT_BINARY_DIR}/libextern_func_module.so\" --init \"make extern_func_module\"" "")
+  p4c_add_test_with_args("bmv2" ${BMV2_DRIVER} FALSE "bmv2_emit_externs" "testdata/p4_16_samples/extern-funcs-bmv2.p4" "-a=--emit-externs --target-specific-switch-arg=\"--load-modules ${CMAKE_CURRENT_BINARY_DIR}/libextern_func_module.so\" --init=\"make extern_func_module\"" "")
 else()
   MESSAGE(WARNING "BMv2 simple switch is not available, not adding v1model BMv2 tests")
 endif()

--- a/backends/ebpf/run-ebpf-test.py
+++ b/backends/ebpf/run-ebpf-test.py
@@ -91,16 +91,6 @@ class Options(object):
         self.extern = ""                # Path to C file with extern definition
 
 
-def check_path(path):
-    """Checks if a path is an actual directory and converts the input
-        to an absolute path"""
-    if not os.path.exists(path):
-        msg = "{0} does not exist".format(path)
-        raise argparse.ArgumentTypeError(msg)
-    else:
-        return os.path.abspath(os.path.expanduser(path))
-
-
 def run_model(ebpf, stffile):
     result = ebpf.generate_model_inputs(stffile)
     if result != SUCCESS:
@@ -183,8 +173,8 @@ if __name__ == '__main__':
     # Parse options and process argv
     args, argv = PARSER.parse_known_args()
     options = Options()
-    options.compiler = check_path(args.compiler)
-    options.p4filename = check_path(args.p4filename)
+    options.compiler = check_if_file(args.compiler)
+    options.p4filename = check_if_file(args.p4filename)
     options.verbose = args.verbose
     options.replace = args.replace
     options.cleanupTmp = args.nocleanup

--- a/backends/ubpf/run-ubpf-test.py
+++ b/backends/ubpf/run-ubpf-test.py
@@ -28,8 +28,8 @@ if __name__ == "__main__":
     # Parse options and process argv
     args, argv = arg_parser.parse_known_args()
     options = run_ebpf_test.Options()
-    options.compiler = run_ebpf_test.check_path(args.compiler)
-    options.p4filename = run_ebpf_test.check_path(args.p4filename)
+    options.compiler = run_ebpf_test.check_if_file(args.compiler)
+    options.p4filename = run_ebpf_test.check_if_file(args.p4filename)
     options.verbose = args.verbose
     options.replace = args.replace
     options.cleanupTmp = args.nocleanup

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -20,6 +20,7 @@
 import subprocess
 from subprocess import Popen
 from threading import Timer
+from pathlib import Path
 import sys
 import os
 from scapy.packet import Raw
@@ -141,3 +142,35 @@ def check_root():
     """ This function returns False if the user does not have root privileges.
         Caution: Only works on Unix systems """
     return (os.getuid() == 0)
+
+
+class PathError(RuntimeError):
+    pass
+
+def check_if_file(input_path):
+    """Checks if a path is a file and converts the input
+        to an absolute path"""
+    input_path = Path(input_path)
+    if not input_path.exists():
+        msg = "{0} does not exist".format(input_path)
+        report_err(sys.stderr, msg)
+        sys.exit(1)
+    if not input_path.is_file():
+        msg = "{0} is not a file".format(input_path)
+        report_err(sys.stderr, msg)
+        sys.exit(1)
+    return str(input_path.absolute())
+
+def check_if_dir(input_path):
+    """Checks if a path is an actual directory and converts the input
+        to an absolute path"""
+    input_path = Path(input_path)
+    if not input_path.exists():
+        msg = "{0} does not exist".format(input_path)
+        report_err(sys.stderr, msg)
+        sys.exit(1)
+    if not input_path.is_dir():
+        msg = "{0} is not a directory".format(input_path)
+        report_err(sys.stderr, msg)
+        sys.exit(1)
+    return str(input_path.absolute())


### PR DESCRIPTION
Update the file to use proper arguments etc instead of custom parsing. Makes extending the script much easier.
Also add a new option `--testfile`, which allows for specifying your own path for test files. 