### PR TITLE
Missed optimization: Struct-assignment in action prevents ConstantFolding (#2249)

### DIFF
--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -66,6 +66,12 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
     struct FuncInfo {
         std::set<cstring>       reads, writes;
         int                     apply_count = 0;
+
+        /// This field is used in assignments. If is_first_write_insert is true, then the
+        /// last inserted expression into the writes set was not in that set before. In
+        /// that case, that expression will be removed from it if, after propagation of the
+        /// values on the left and the right side, the assignment becomes a self-assignment
+        bool                    is_first_write_insert = false;
     };
     std::map<cstring, VarInfo>          available;
     std::map<cstring, TableInfo>        &tables;

--- a/testdata/p4_16_samples/struct_assignment_optimization.p4
+++ b/testdata/p4_16_samples/struct_assignment_optimization.p4
@@ -1,0 +1,67 @@
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct simple_struct {
+    bit<128> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Metadata {}
+
+
+parser p(packet_in pkt,
+               out Headers hdr, inout Metadata meta,
+               inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+
+control ingress(inout Headers hdr, inout Metadata meta,
+                 inout standard_metadata_t stdmeta) {
+    simple_struct test = { 128w0 };
+    action pointless_action() {
+        test = test;
+    }
+
+    apply {
+        pointless_action();
+        if ((test.a != 1) && (test.a <= 1)) {
+            hdr.eth_hdr.eth_type = 16w1;
+        }
+    }
+}
+
+
+control deparser(packet_out packet, in Headers hdr) {
+    apply {
+        packet.emit(hdr);
+    }
+}
+
+control egress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    apply {}
+}
+
+control vrfy(inout Headers hdr, inout Metadata meta) {
+    apply {}
+}
+
+control update(inout Headers hdr, inout Metadata meta) {
+    apply {}
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/issue2147-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2147-1-midend.p4
@@ -5,9 +5,6 @@ control ingress(inout bit<8> h) {
     @hidden action issue21471l5() {
         tmp_0 = h;
     }
-    @hidden action issue21471l7() {
-        h = tmp_0;
-    }
     @hidden table tbl_issue21471l5 {
         actions = {
             issue21471l5();
@@ -20,16 +17,9 @@ control ingress(inout bit<8> h) {
         }
         const default_action = a();
     }
-    @hidden table tbl_issue21471l7 {
-        actions = {
-            issue21471l7();
-        }
-        const default_action = issue21471l7();
-    }
     apply {
         tbl_issue21471l5.apply();
         tbl_a.apply();
-        tbl_issue21471l7.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/struct_assignment_optimization-first.p4
+++ b/testdata/p4_16_samples_outputs/struct_assignment_optimization-first.p4
@@ -1,0 +1,65 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct simple_struct {
+    bit<128> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Metadata {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    simple_struct test = (simple_struct){a = 128w0};
+    action pointless_action() {
+        test = test;
+    }
+    apply {
+        pointless_action();
+        if (test.a != 128w1 && test.a <= 128w1) {
+            hdr.eth_hdr.eth_type = 16w1;
+        }
+    }
+}
+
+control deparser(packet_out packet, in Headers hdr) {
+    apply {
+        packet.emit<Headers>(hdr);
+    }
+}
+
+control egress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vrfy(inout Headers hdr, inout Metadata meta) {
+    apply {
+    }
+}
+
+control update(inout Headers hdr, inout Metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<Headers, Metadata>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/struct_assignment_optimization-frontend.p4
+++ b/testdata/p4_16_samples_outputs/struct_assignment_optimization-frontend.p4
@@ -1,0 +1,65 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct simple_struct {
+    bit<128> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Metadata {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    @name("ingress.test") simple_struct test_0;
+    @name("ingress.pointless_action") action pointless_action() {
+        test_0 = test_0;
+    }
+    apply {
+        test_0 = (simple_struct){a = 128w0};
+        pointless_action();
+        if (test_0.a != 128w1 && test_0.a <= 128w1) {
+            hdr.eth_hdr.eth_type = 16w1;
+        }
+    }
+}
+
+control deparser(packet_out packet, in Headers hdr) {
+    apply {
+        packet.emit<Headers>(hdr);
+    }
+}
+
+control egress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vrfy(inout Headers hdr, inout Metadata meta) {
+    apply {
+    }
+}
+
+control update(inout Headers hdr, inout Metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<Headers, Metadata>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/struct_assignment_optimization-midend.p4
+++ b/testdata/p4_16_samples_outputs/struct_assignment_optimization-midend.p4
@@ -1,0 +1,86 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct simple_struct {
+    bit<128> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Metadata {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    @name("ingress.test") simple_struct test_0;
+    @name("ingress.pointless_action") action pointless_action() {
+    }
+    @hidden action struct_assignment_optimization35() {
+        test_0.a = 128w0;
+    }
+    @hidden action struct_assignment_optimization43() {
+        hdr.eth_hdr.eth_type = 16w1;
+    }
+    @hidden table tbl_struct_assignment_optimization35 {
+        actions = {
+            struct_assignment_optimization35();
+        }
+        const default_action = struct_assignment_optimization35();
+    }
+    @hidden table tbl_pointless_action {
+        actions = {
+            pointless_action();
+        }
+        const default_action = pointless_action();
+    }
+    @hidden table tbl_struct_assignment_optimization43 {
+        actions = {
+            struct_assignment_optimization43();
+        }
+        const default_action = struct_assignment_optimization43();
+    }
+    apply {
+        tbl_struct_assignment_optimization35.apply();
+        tbl_pointless_action.apply();
+        tbl_struct_assignment_optimization43.apply();
+    }
+}
+
+control deparser(packet_out packet, in Headers hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.eth_hdr);
+    }
+}
+
+control egress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vrfy(inout Headers hdr, inout Metadata meta) {
+    apply {
+    }
+}
+
+control update(inout Headers hdr, inout Metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<Headers, Metadata>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/struct_assignment_optimization.p4
+++ b/testdata/p4_16_samples_outputs/struct_assignment_optimization.p4
@@ -1,0 +1,65 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct simple_struct {
+    bit<128> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+struct Metadata {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    simple_struct test = { 128w0 };
+    action pointless_action() {
+        test = test;
+    }
+    apply {
+        pointless_action();
+        if (test.a != 1 && test.a <= 1) {
+            hdr.eth_hdr.eth_type = 16w1;
+        }
+    }
+}
+
+control deparser(packet_out packet, in Headers hdr) {
+    apply {
+        packet.emit(hdr);
+    }
+}
+
+control egress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vrfy(inout Headers hdr, inout Metadata meta) {
+    apply {
+    }
+}
+
+control update(inout Headers hdr, inout Metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+


### PR DESCRIPTION
Fix #2249 
This optimizes _LocalCopyPropagation Pass_ in case there is an assignment in the body of the action, where the left side and the right side of that assignment are equivalent, by not updating the writes set of that action.
As a consequence of this change, the test _issue-2147-1.p4_ failed, so I updated it as well.