### PR TITLE
Allow backend to skip input file check

### DIFF
--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -58,8 +58,8 @@ const int ErrorType::WARN_PARSER_TRANSITION = 1014;
 const int ErrorType::WARN_UNREACHABLE       = 1015;
 const int ErrorType::WARN_SHADOWING         = 1016;
 const int ErrorType::WARN_IGNORE            = 1017;
-const int ErrorType::WARN_UNINITIALIZED_OUT_PARAM  = 1017;
-const int ErrorType::WARN_UNINITIALIZED_USE = 1018;
+const int ErrorType::WARN_UNINITIALIZED_OUT_PARAM  = 1018;
+const int ErrorType::WARN_UNINITIALIZED_USE = 1019;
 const int ErrorType::WARN_MAX_WARNINGS      = 2142;
 
 // map from errorCode to ErrorSig

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4-stderr
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4-stderr
@@ -1,3 +1,3 @@
-action_profile_max_group_size_annotation.p4(39): [--Wwarn=uninitialized_out_param] warning: Ignoring annotation @max_group_size on action profile 'ap', which does not have a selector
+action_profile_max_group_size_annotation.p4(39): [--Wwarn=ignore] warning: Ignoring annotation @max_group_size on action profile 'ap', which does not have a selector
         @name("ap") @max_group_size(200) implementation = action_profile(32w128);
                                          ^^^^^^^^^^^^^^

--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -197,6 +197,17 @@ class BackendDriver:
             # its commands and the order in which they execute
             pass
 
+    def should_not_check_input(self, opts):
+        """
+        Custom backends can use this function to implement their own --help* options
+        which don't require input file to be specified. In such cases, this function
+        should be overloaded and return true whenever such option has been specified by
+        the user.
+        As a result, dummy.p4 will be used as a source file to prevent sanity checking
+        from failing.
+        """
+        return False
+
     def enable_commands(self, cmdsEnabled):
         """
         Defines the order in which the steps are executed and which commands


### PR DESCRIPTION
Backends might want to implement custom --help-* options and in that
case they need a way to signal the driver that this option does not
require input source file to be set.

Since some sanity checks rely on the fact input has been provided,
we set the input to dummy.p4 so those checks still work.