### PR TITLE
Bazel rules for the graphs backend.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -315,3 +315,57 @@ cc_library(
         ":lib",
     ],
 )
+
+# These rules build the graphs backend
+cc_binary(
+    name = "p4c_graphs",
+    srcs = [
+        "backends/graphs/p4c-graphs.cpp",
+    ],
+    data = [":p4include"],
+    linkopts = [
+        "-lgmp",
+        "-lgmpxx",
+    ],
+    deps = [
+        ":config_h",
+        ":ir_frontend_midend_control_plane",
+        ":lib",
+        ":p4c_backend_graphs_lib",
+    ],
+)
+
+genrule(
+    name = "p4c_graphs_version",
+    srcs = ["backends/graphs/version.h.cmake"],
+    outs = ["backends/graphs/version.h"],
+    cmd = "sed 's|@P4C_VERSION@|0.0.0.0|g' $(SRCS) > $(OUTS)",
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "p4c_backend_graphs_lib",
+    srcs = [
+        "backends/graphs/controls.cpp",
+        "backends/graphs/graphs.cpp",
+        "backends/graphs/p4c-graphs.cpp",
+        "backends/graphs/parsers.cpp",
+    ],
+    hdrs = [
+        "backends/graphs/controls.h",
+        "backends/graphs/graphs.h",
+        "backends/graphs/parsers.h",
+        "backends/graphs/version.h",
+    ],
+    defines = [
+        # Disable ADL for boost, otherwise the method resolution for
+        # `ordered_map` and `graph` clash on method `boost::get`
+        "BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP",
+    ],
+    deps = [
+        ":config_h",
+        ":ir_frontend_midend_control_plane",
+        ":lib",
+        "@boost//:graph",
+    ],
+)

--- a/bazel/example/p4/BUILD.bazel
+++ b/bazel/example/p4/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library")
+load("@com_github_p4lang_p4c//:bazel/p4_library.bzl", "p4_library", "p4_graphs")
 
 p4_library(
   name = "program",
@@ -17,4 +17,11 @@ p4_library(
   target_out = "program.bmv2.json",     # Optional.
   arch = "v1model",                     # Optional (default: "v1model").
   visibility = ["//:__subpackages__"],  # Optional.
+)
+
+p4_graphs(
+  name = "program_graphs",
+  src = "program.p4",
+  deps = ["empty.p4"],
+  out = "program_graphs.dot",
 )

--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -168,7 +168,7 @@ def _p4_graphs_impl(ctx):
             mkdir "{graph_dir}"
             # Run the compiler
             "{p4c}" {p4c_args}
-            # Merge all output graphs
+            # Merge all output graphs, the * needs to be outside the quotes for globbing
             cat "{graph_dir}"/* > {output_file}
         """.format(
             p4c = p4c.path,

--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -207,7 +207,7 @@ p4_graphs = rule(
             default = "",
         ),
         "_p4c": attr.label(
-            default = Label("@com_github_p4lang_p4c//:p4c_bmv2"),
+            default = Label("@com_github_p4lang_p4c//:p4c_graphs"),
             executable = True,
             cfg = "target",
         ),

--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -27,12 +27,12 @@ def _extract_p4c_inputs(ctx):
     return p4deps + [p4file]
 
 def _run_shell_cmd_with_p4c(ctx, command, **run_shell_kwargs):
-    """Run given sequence of shell commands using `run_shell` action after
-setting up the C compiler toolchain.
+    """Run given shell command using `run_shell` action after setting up
+       the C compiler toolchain.
 
-This function also sets up the `tools` parameter for `run_shell` to
-set up p4c and the cpp toolchain, and `kwargs` is passed to
-`run_shell`.
+       This function also sets up the `tools` parameter for `run_shell` to
+       set up p4c and the cpp toolchain, and `kwargs` is passed to
+       `run_shell`.
     """
 
     if not hasattr(ctx.executable, "_p4c"):

--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -142,6 +142,8 @@ def _p4_graphs_impl(ctx):
     include_dirs = {d.dirname: 0 for d in p4deps}  # Use dict to express set.
     include_dirs["."] = 0  # Enable include paths relative to workspace root.
     args += [("-I" + dir) for dir in include_dirs.keys()]
+    if not output_file.path.lower().endswith(".dot"):
+        fail("The output graph file must have extension .dot")
 
     cpp_toolchain = find_cpp_toolchain(ctx)
     ctx.actions.run_shell(

--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -22,9 +22,7 @@ def _extract_common_p4c_args(ctx):
 
 def _extract_p4c_inputs(ctx):
     """Extract input p4 files to give to p4c from the build rule context."""
-    p4file = ctx.file.src
-    p4deps = ctx.files._p4include + ctx.files.deps
-    return p4deps + [p4file]
+    return ctx.files._p4include + ctx.files.deps + [ctx.file.src]
 
 def _run_shell_cmd_with_p4c(ctx, command, **run_shell_kwargs):
     """Run given shell command using `run_shell` action after setting up


### PR DESCRIPTION
This PR adds
- a target (`:p4c_graphs`) to build the compiler binary with the graphs
  backend, and
- a build rule `p4_graphs` to invoke this backend and merge the graph
  files

so that the graphs backend can be used in other projects using Bazel.

We need a new build rule (rather than specifying a different binary for
`_p4c` in the `p4_library` rule) because the graphs backend does
not use the normal output file arguments and uses a separate argument to
specify the output *directory* to write the graphs in. The names of the
output files depend on the content of the input p4 file, and blaze
outputs cannot be directories (they can be file groups but we do not
know the exact file names without effectively running the p4 compiler).
So, we cannot directly use the output files in a blaze target. Instead,
this build rule concatenates the output graphs into a single GraphViz
file. The output file can later be processed by `gvpack` and `dot` to
produce a single large graph (the original graphs are embedded as
subgraphs). It can also be parsed by other tools to extract specific
graphs.