### PR TITLE
Fix install dependencies `bash` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ included with `p4c` are documented here:
 Most dependencies can be installed using `apt-get install`:
 
 ```bash
-$ sudo apt-get install cmake g++ git automake libtool libgc-dev bison flex
-libfl-dev libgmp-dev libboost-dev libboost-iostreams-dev
-libboost-graph-dev llvm pkg-config python python-scapy python-ipaddr python-ply python3-pip
+$ sudo apt-get install cmake g++ git automake libtool libgc-dev bison flex \
+libfl-dev libgmp-dev libboost-dev libboost-iostreams-dev \
+libboost-graph-dev llvm pkg-config python python-scapy python-ipaddr python-ply python3-pip \
 tcpdump
 
 $ pip3 install scapy ply


### PR DESCRIPTION
Fix Ubuntu dependencies installation script.
Without these `\` we can't just copy a script