### PR TITLE
Fix install Ubuntu dependencies script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,12 @@ included with `p4c` are documented here:
 Most dependencies can be installed using `apt-get install`:
 
 ```bash
-$ sudo apt-get install cmake g++ git automake libtool libgc-dev bison flex \
+sudo apt-get install cmake g++ git automake libtool libgc-dev bison flex \
 libfl-dev libgmp-dev libboost-dev libboost-iostreams-dev \
 libboost-graph-dev llvm pkg-config python python-scapy python-ipaddr python-ply python3-pip \
 tcpdump
 
-$ pip3 install scapy ply
+pip3 install scapy ply
 ```
 
 For documentation building:


### PR DESCRIPTION
Addition to https://github.com/p4lang/p4c/pull/2853
We should remove `$` symbol because it's not a part of a script, hence we cannot use the copy button.