### PR TITLE
For code blocks with '@atomic' use entire block for action synthesis

### DIFF
--- a/midend/actionSynthesis.cpp
+++ b/midend/actionSynthesis.cpp
@@ -125,6 +125,10 @@ const IR::Node* DoSynthesizeActions::postorder(IR::P4Control* control) {
 }
 
 const IR::Node* DoSynthesizeActions::preorder(IR::BlockStatement* statement) {
+    if (statement->annotations->getSingle("atomic")) {
+        return createAction(statement);
+    }
+
     // Find a chain of statements to convert
     auto actbody = new IR::BlockStatement;  // build here new action
     auto left = new IR::BlockStatement(statement->annotations);  // leftover statements


### PR DESCRIPTION
The `SynthesizeActions` pass tries to synthesize actions from code blocks. However, if the code block contains a pragma `@atomic` user intention is to atomically execute the entire block and this pass should honor the pragma. 

This PR adds a check for atomic pragma and uses the entire block for action synthesis.