### PR TITLE
Fix "dontcare" type method argument

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -735,6 +735,8 @@ TypeInference::assignment(const IR::Node* errorPosition, const IR::Type* destTyp
                           const IR::Expression* sourceExpression) {
     if (destType->is<IR::Type_Unknown>())
         BUG("Unknown destination type");
+    if (destType->is<IR::Type_Dontcare>())
+        return sourceExpression;
     const IR::Type* initType = getType(sourceExpression);
     if (initType == nullptr)
         return sourceExpression;

--- a/testdata/p4_16_samples/methodArgDontcare.p4
+++ b/testdata/p4_16_samples/methodArgDontcare.p4
@@ -1,0 +1,16 @@
+extern E<T> {
+    E();
+    void f(in T arg);
+}
+
+control c() {
+    E<_>() e;
+    apply {
+        e.f(0);
+    }
+}
+
+control proto();
+package top(proto p);
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/methodArgDontcare-first.p4
+++ b/testdata/p4_16_samples_outputs/methodArgDontcare-first.p4
@@ -1,0 +1,16 @@
+extern E<T> {
+    E();
+    void f(in T arg);
+}
+
+control c() {
+    E<_>() e;
+    apply {
+        e.f(0);
+    }
+}
+
+control proto();
+package top(proto p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/methodArgDontcare-frontend.p4
+++ b/testdata/p4_16_samples_outputs/methodArgDontcare-frontend.p4
@@ -1,0 +1,16 @@
+extern E<T> {
+    E();
+    void f(in T arg);
+}
+
+control c() {
+    @name("c.e") E<_>() e_0;
+    apply {
+        e_0.f(0);
+    }
+}
+
+control proto();
+package top(proto p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/methodArgDontcare-midend.p4
+++ b/testdata/p4_16_samples_outputs/methodArgDontcare-midend.p4
@@ -1,0 +1,25 @@
+extern E<T> {
+    E();
+    void f(in T arg);
+}
+
+control c() {
+    @name("c.e") E<_>() e_0;
+    @hidden action methodArgDontcare9() {
+        e_0.f(0);
+    }
+    @hidden table tbl_methodArgDontcare9 {
+        actions = {
+            methodArgDontcare9();
+        }
+        const default_action = methodArgDontcare9();
+    }
+    apply {
+        tbl_methodArgDontcare9.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/methodArgDontcare.p4
+++ b/testdata/p4_16_samples_outputs/methodArgDontcare.p4
@@ -1,0 +1,16 @@
+extern E<T> {
+    E();
+    void f(in T arg);
+}
+
+control c() {
+    E<_>() e;
+    apply {
+        e.f(0);
+    }
+}
+
+control proto();
+package top(proto p);
+
+top(c()) main;


### PR DESCRIPTION
Since ee77e40f0864c1157eb858bb14d6ea94f9837721 frontend (correctly)
inserts type casts of method call arguments if necessary.

However, if a method accepts "dontcare" input parameter and the method
is called with a InfInt value, a cast between these types is also
inserted. But the cast is later rejected during typechecking as
invalid. This commit prevents any cast to Dontcare type to be
inserted.