### PR TITLE
annotation to disable strength reduction in a block

### DIFF
--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -145,6 +145,10 @@ class DoConstantFolding : public Transform {
     const IR::Node* postorder(IR::IfStatement* statement) override;
     const IR::Node* preorder(IR::AssignmentStatement* statement) override;
     const IR::Node* preorder(IR::ArrayIndex* e) override;
+    const IR::BlockStatement *preorder(IR::BlockStatement *bs) override {
+        if (bs->annotations->getSingle("disable_optimization"))
+            prune();
+        return bs; }
 };
 
 /** Optionally runs @ref TypeChecking if @p typeMap is not

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -28,6 +28,7 @@ ParseAnnotations::HandlerMap ParseAnnotations::standardHandlers() {
             PARSE_EMPTY(IR::Annotation::optionalAnnotation),
             PARSE_EMPTY(IR::Annotation::pureAnnotation),
             PARSE_EMPTY(IR::Annotation::noSideEffectsAnnotation),
+            PARSE_EMPTY("disable_optimization"),
 
             // string literal argument.
             PARSE(IR::Annotation::nameAnnotation, StringLiteral),

--- a/frontends/p4/reassociation.h
+++ b/frontends/p4/reassociation.h
@@ -41,6 +41,10 @@ class Reassociation final : public Transform {
     { return reassociate(expr); }
     const IR::Node* postorder(IR::BXor* expr) override
     { return reassociate(expr); }
+    const IR::BlockStatement *preorder(IR::BlockStatement *bs) override {
+        if (bs->annotations->getSingle("disable_optimization"))
+            prune();
+        return bs; }
 };
 
 }  // namespace P4

--- a/frontends/p4/strengthReduction.h
+++ b/frontends/p4/strengthReduction.h
@@ -91,6 +91,11 @@ class DoStrengthReduction final : public Transform {
     const IR::Node* postorder(IR::Slice* expr) override;
     const IR::Node* postorder(IR::Mask* expr) override;
     const IR::Node* postorder(IR::Range* expr) override;
+
+    const IR::BlockStatement *preorder(IR::BlockStatement *bs) override {
+        if (bs->annotations->getSingle("disable_optimization"))
+            prune();
+        return bs; }
 };
 
 class StrengthReduction : public PassManager {


### PR DESCRIPTION
This is a very trivial addition to allow disabling strength reduction in pieces of the code that is not really relevant to to language at all (its an annotation that does not affect program semantics at all), but I'm of mixed mind because it is probably not useful for programmers in any meaningful way.

The impetus for this actually comes from some hardware people who are trying to test corner cases in our hardware and are having difficulties because the compiler keeps modifying/eliminating their code, so the program ends up bypassing what they are trying to test.  This particular case happpens very early on in the frontend where we can't really avoid it in our custom midend/backend code.  I'm open to discussions of better ways similar things might be done -- perhaps some kind of target-specific policies that could be applied to frontend passes (as is used in the midend code in a number of places?)