### PR TITLE
DPDK backend: Fixing couple of issues in counter implementation and extend jump and label optimizations in action body

### DIFF
--- a/backends/dpdk/dpdkAsmOpt.cpp
+++ b/backends/dpdk/dpdkAsmOpt.cpp
@@ -85,8 +85,8 @@ const IR::IndexedVector<IR::DpdkAsmStatement> *RemoveConsecutiveJmpAndLabel::rem
             new_l->push_back(stmt);
         }
     }
-    // Do not remove jump to LABEL_DROP as LABEL_DROP is not part of statement list
-    // and should not be optimized here.
+    // Do not remove jump to LABEL_DROP as LABEL_DROP is not part of statement list and
+    // should not be optimized here.
     if (cache && cache->label == "LABEL_DROP")
         new_l->push_back(cache);
     return  new_l;

--- a/backends/dpdk/dpdkAsmOpt.h
+++ b/backends/dpdk/dpdkAsmOpt.h
@@ -43,7 +43,22 @@ namespace DPDK {
 // This pass removes label that no jmps jump to
 class RemoveRedundantLabel : public Transform {
   public:
-    const IR::Node *postorder(IR::DpdkListStatement *l) override;
+    const IR::IndexedVector<IR::DpdkAsmStatement> *removeRedundantLabel(
+                      const IR::IndexedVector<IR::DpdkAsmStatement> &s);
+
+    const IR::Node *postorder(IR::DpdkListStatement *l) override {
+        const IR::IndexedVector<IR::DpdkAsmStatement> *newStmts;
+        newStmts = removeRedundantLabel(l->statements);
+        l->statements = *newStmts;
+        return l;
+    }
+
+    const IR::Node *postorder(IR::DpdkAction *l) override {
+        const IR::IndexedVector<IR::DpdkAsmStatement> *newStmts;
+        newStmts = removeRedundantLabel(l->statements);
+        l->statements = *newStmts;
+        return l;
+    }
 };
 
 // This pass removes jmps that jump to a label that is immediately after it.
@@ -55,7 +70,21 @@ class RemoveRedundantLabel : public Transform {
 
 class RemoveConsecutiveJmpAndLabel : public Transform {
   public:
-    const IR::Node *postorder(IR::DpdkListStatement *l) override;
+    const IR::IndexedVector<IR::DpdkAsmStatement> *removeJmpAndLabel(
+                   const IR::IndexedVector<IR::DpdkAsmStatement> &s);
+    const IR::Node *postorder(IR::DpdkListStatement *l) override {
+        const IR::IndexedVector<IR::DpdkAsmStatement> *newStmts;
+        newStmts = removeJmpAndLabel(l->statements);
+        l->statements = *newStmts;
+        return l;
+    }
+
+    const IR::Node *postorder(IR::DpdkAction *l) override {
+        const IR::IndexedVector<IR::DpdkAsmStatement> *newStmts;
+        newStmts = removeJmpAndLabel(l->statements);
+        l->statements = *newStmts;
+        return l;
+    }
 };
 
 // This pass removes labels whose next instruction is a jmp statement. This pass
@@ -75,7 +104,22 @@ class RemoveConsecutiveJmpAndLabel : public Transform {
 
 class ThreadJumps : public Transform {
   public:
-    const IR::Node *postorder(IR::DpdkListStatement *l) override;
+    const IR::IndexedVector<IR::DpdkAsmStatement> *threadJumps(
+             const IR::IndexedVector<IR::DpdkAsmStatement> &s);
+
+    const IR::Node *postorder(IR::DpdkListStatement *l) override {
+        const IR::IndexedVector<IR::DpdkAsmStatement> *newStmts;
+        newStmts = threadJumps(l->statements);
+        l->statements = *newStmts;
+        return l;
+    }
+
+    const IR::Node *postorder(IR::DpdkAction *l) override {
+        const IR::IndexedVector<IR::DpdkAsmStatement> *newStmts;
+        newStmts = threadJumps(l->statements);
+        l->statements = *newStmts;
+        return l;
+    }
 };
 
 // This pass removes labels whose next instruction is a label. In addition, it
@@ -83,9 +127,26 @@ class ThreadJumps : public Transform {
 
 class RemoveLabelAfterLabel : public Transform {
   public:
-    const IR::Node *postorder(IR::DpdkListStatement *l) override;
+    const IR::IndexedVector<IR::DpdkAsmStatement> *removeLabelAfterLabel(
+                  const IR::IndexedVector<IR::DpdkAsmStatement> &s);
+
+    const IR::Node *postorder(IR::DpdkListStatement *l) override {
+        const IR::IndexedVector<IR::DpdkAsmStatement> *newStmts;
+        newStmts = removeLabelAfterLabel(l->statements);
+        l->statements = *newStmts;
+        return l;
+    }
+
+    const IR::Node *postorder(IR::DpdkAction *l) override {
+        const IR::IndexedVector<IR::DpdkAsmStatement> *newStmts;
+        newStmts = removeLabelAfterLabel(l->statements);
+        l->statements = *newStmts;
+        return l;
+    }
 };
 
+// Instructions can only appear in actions and apply block of .spec file.
+// All these individual passes work on the actions and apply block of .spec file.
 class DpdkAsmOptimization : public PassRepeated {
   private:
   public:

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -497,18 +497,21 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                     auto counter = a->object->getName();
                     if (args->size() == 2)
                         incr = args->at(1)->expression;
+                    if (!incr && value > 0) {
+                        ::error(ErrorType::ERR_UNEXPECTED,
+                                "Expected packet length argument for %1%", a->object->getName());
+                        return false;
+                    }
                     if (value == 2) {
-                        if (incr) {
-                            add_instr(new IR::DpdkCounterCountStatement(counter+"_packets",
-                                                                        index, incr));
-                            add_instr(new IR::DpdkCounterCountStatement(counter+"_bytes",
+                        add_instr(new IR::DpdkCounterCountStatement(counter+"_packets",
                                                                         index));
-                        } else {
-                           ::error(ErrorType::ERR_UNEXPECTED,
-                                   "Expected packet length argument for %1%", a->object->getName());
-                        }
-                     } else {
-                         add_instr(new IR::DpdkCounterCountStatement(counter, index, incr));
+                        add_instr(new IR::DpdkCounterCountStatement(counter+"_bytes",
+                                                                        index, incr));
+                    } else {
+                         if (value == 1)
+                             add_instr(new IR::DpdkCounterCountStatement(counter, index, incr));
+                         else
+                             add_instr(new IR::DpdkCounterCountStatement(counter, index));
                      }
                 }
             } else {

--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -105,6 +105,9 @@ set (P4_XFAIL_TESTS
   # This program uses a list of expressions on the 'psa_implementation' property
   # which is currently unsupported
   testdata/p4_16_samples/psa-action-profile2.p4
+  # This program uses conditional execution inside action body which is currently
+  # unsupported
+  testdata/p4_16_samples/psa-dpdk-action-jumpOpt.p4
   )
 # we invoke p4c with --p4runtime-files even for programs in p4_16_errors. This
 # enables us to use p4_16_errors even for programs which pass compilation but

--- a/testdata/p4_16_samples/psa-example-dpdk-counter.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-counter.p4
@@ -33,9 +33,9 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
     apply {
-        counter0.count(1024, 20);
-        counter1.count(512, 64);
-        counter2.count(1024);
+        counter0.count(1023, 20);
+        counter1.count(512);
+        counter2.count(1023, 64);
     }
 }
 

--- a/testdata/p4_16_samples/psa-example-dpdk-externs.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-externs.p4
@@ -75,9 +75,9 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     apply {
         if (user_meta.port_out == 1) {
             tbl.apply();
-            counter0.count(1024, 20);
-            counter1.count(512, 64);
-            counter2.count(1024);
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
         } else {
             return;

--- a/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.spec
@@ -65,7 +65,7 @@ action NoAction args none {
 
 action execute args none {
 	jmpeq LABEL_1FALSE m.local_metadata_data 0x0
-	LABEL_1TRUE :	mov m.Ingress_tmp_0 0x0
+	mov m.Ingress_tmp_0 0x0
 	jmp LABEL_1END
 	LABEL_1FALSE :	mov m.Ingress_tmp_0 0x1
 	LABEL_1END :	mov m.local_metadata_data m.Ingress_tmp_0

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-first.p4
@@ -33,9 +33,9 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
     Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2;
     apply {
-        counter0.count(12w1024, 32w20);
-        counter1.count(12w512, 32w64);
-        counter2.count(12w1024);
+        counter0.count(12w1023, 32w20);
+        counter1.count(12w512);
+        counter2.count(12w1023, 32w64);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-frontend.p4
@@ -33,9 +33,9 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     @name("MyIC.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
     @name("MyIC.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
     apply {
-        counter0_0.count(12w1024, 32w20);
-        counter1_0.count(12w512, 32w64);
-        counter2_0.count(12w1024);
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512);
+        counter2_0.count(12w1023, 32w64);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-midend.p4
@@ -33,9 +33,9 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     @name("MyIC.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
     @name("MyIC.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
     @hidden action psaexampledpdkcounter36() {
-        counter0_0.count(12w1024, 32w20);
-        counter1_0.count(12w512, 32w64);
-        counter2_0.count(12w1024);
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512);
+        counter2_0.count(12w1023, 32w64);
     }
     @hidden table tbl_psaexampledpdkcounter36 {
         actions = {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4
@@ -33,9 +33,9 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
     apply {
-        counter0.count(1024, 20);
-        counter1.count(512, 64);
-        counter2.count(1024);
+        counter0.count(1023, 20);
+        counter1.count(512);
+        counter2.count(1023, 64);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4.spec
@@ -71,10 +71,10 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	regadd counter0_0_packets 0x400 0x14
-	regadd counter0_0_bytes 0x400 1
-	regadd counter1_0 0x200 0x40
-	regadd counter2_0 0x400 1
+	regadd counter0_0_packets 0x3ff 1
+	regadd counter0_0_bytes 0x3ff 0x14
+	regadd counter1_0 0x200 1
+	regadd counter2_0 0x3ff 0x40
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP : drop

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-first.p4
@@ -76,9 +76,9 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     apply {
         if (user_meta.port_out == 32w1) {
             tbl.apply();
-            counter0.count(12w1024, 32w20);
-            counter1.count(12w512, 32w64);
-            counter2.count(12w1024);
+            counter0.count(12w1023, 32w20);
+            counter1.count(12w512);
+            counter2.count(12w1023, 32w64);
             user_meta.port_out = reg.read(12w1);
         } else {
             return;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-frontend.p4
@@ -87,9 +87,9 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         color_in_0 = PSA_MeterColor_t.RED;
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
-            counter0_0.count(12w1024, 32w20);
-            counter1_0.count(12w512, 32w64);
-            counter2_0.count(12w1024);
+            counter0_0.count(12w1023, 32w20);
+            counter1_0.count(12w512);
+            counter2_0.count(12w1023, 32w64);
             user_meta.port_out = reg_0.read(12w1);
         } else {
             hasReturned = true;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-midend.p4
@@ -76,9 +76,9 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         default_action = NoAction_1();
     }
     @hidden action psaexampledpdkexterns78() {
-        counter0_0.count(12w1024, 32w20);
-        counter1_0.count(12w512, 32w64);
-        counter2_0.count(12w1024);
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512);
+        counter2_0.count(12w1023, 32w64);
         user_meta.port_out = reg_0.read(12w1);
     }
     @hidden action psaexampledpdkexterns60() {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4
@@ -75,9 +75,9 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     apply {
         if (user_meta.port_out == 1) {
             tbl.apply();
-            counter0.count(1024, 20);
-            counter1.count(512, 64);
-            counter2.count(1024);
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
         } else {
             return;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
@@ -105,7 +105,7 @@ action NoAction args none {
 action execute args instanceof execute_arg_t {
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in_0 m.Ingress_color_out_0
 	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x1
-	LABEL_1TRUE :	mov m.Ingress_tmp 0x1
+	mov m.Ingress_tmp 0x1
 	jmp LABEL_1END
 	LABEL_1FALSE :	mov m.Ingress_tmp 0x0
 	LABEL_1END :	mov m.local_metadata_port_out m.Ingress_tmp
@@ -136,10 +136,10 @@ apply {
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in_0 0x0
 	jmpneq LABEL_0END m.local_metadata_port_out 0x1
 	table tbl
-	regadd counter0_0_packets 0x400 0x14
-	regadd counter0_0_bytes 0x400 1
-	regadd counter1_0 0x200 0x40
-	regadd counter2_0 0x400 1
+	regadd counter0_0_packets 0x3ff 1
+	regadd counter0_0_bytes 0x3ff 0x14
+	regadd counter1_0 0x200 1
+	regadd counter2_0 0x3ff 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
@@ -91,7 +91,7 @@ action NoAction args none {
 action execute args instanceof execute_arg_t {
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in_0 m.Ingress_color_out_0
 	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x1
-	LABEL_1TRUE :	mov m.Ingress_tmp 0x1
+	mov m.Ingress_tmp 0x1
 	jmp LABEL_1END
 	LABEL_1FALSE :	mov m.Ingress_tmp 0x0
 	LABEL_1END :	mov m.local_metadata_port_out m.Ingress_tmp

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
@@ -91,7 +91,7 @@ action NoAction args none {
 action execute args instanceof execute_arg_t {
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in_0 m.Ingress_color_out_0
 	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x1
-	LABEL_1TRUE :	mov m.Ingress_tmp 0x1
+	mov m.Ingress_tmp 0x1
 	jmp LABEL_1END
 	LABEL_1FALSE :	mov m.Ingress_tmp 0x0
 	LABEL_1END :	mov m.local_metadata_port_out m.Ingress_tmp

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.spec
@@ -96,7 +96,8 @@ apply {
 	LABEL_2END :	table tbl
 	jmpnh LABEL_3END
 	invalidate h.ethernet
-	LABEL_3END :	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_3END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP : drop
 }
 


### PR DESCRIPTION
This PR includes the following changes
1) Fixing the increment value for packet and byte counters. The count method should increment the counter by packet length for byte counter and by 1 for packet counter.
2) Added parameter checks for the counters.
3) Modified tests related to counters as per the above change
4) In some cases, two labels are generated back to back. Extended the Asm optimization passes for removing redundant labels and jumps in action body also.
5) Added a test for label optimization in action body.
6) Updated p4test XFAIL list as p4test does not support conditional execution in action body
7) Updated reference outputs