### PR TITLE
DPDK backend: Add support for using isValid as table key

### DIFF
--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -55,12 +55,12 @@ void ConvertStatementToDpdk::process_relation_operation(const IR::Expression* ds
    Hence we convert the expression var = a LOP b into if-else statements.
    var = a || b            ||     var = a && b
 => if (a){                 ||=>   if (!a)
-       var = 1;            ||         var = 0;
+       var = true;         ||         var = false;
    } else {                ||     } else {
        if (b)              ||         if (!b)
-           var = 1;        ||             var = 0;
+           var = true;     ||             var = false;
        else                ||         else
-           var = 0;        ||             var = 1;
+           var = false;    ||             var = true;
    }                       ||     }
 
    This function assumes complex logical operations are converted to simple expressions by

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -51,9 +51,53 @@ void ConvertStatementToDpdk::process_relation_operation(const IR::Expression* ds
     add_instr(new IR::DpdkLabelStatement(end_label));
 }
 
+/* DPDK target does not support storing result of logical operations such as || and &&.
+   Hence we convert the expression var = a LOP b into if-else statements.
+   var = a || b            ||     var = a && b
+=> if (a){                 ||=>   if (!a)
+       var = 1;            ||         var = 0;
+   } else {                ||     } else {
+       if (b)              ||         if (!b)
+           var = 1;        ||             var = 0;
+       else                ||         else
+           var = 0;        ||             var = 1;
+   }                       ||     }
+
+   This function assumes complex logical operations are converted to simple expressions by
+   ConvertLogicalExpression pass.
+*/
+void ConvertStatementToDpdk::process_logical_operation(const IR::Expression* dst,
+                                                        const IR::Operation_Binary* op) {
+    if (!op->is<IR::LOr>() && !op->is<IR::LAnd>())
+        return;
+    auto true_label = Util::printf_format("label_%dtrue", next_label_id);
+    auto false_label = Util::printf_format("label_%dfalse", next_label_id);
+    auto end_label = Util::printf_format("label_%dend", next_label_id++);
+    if (op->is<IR::LOr>()) {
+        add_instr(new IR::DpdkJmpEqualStatement(true_label, op->left, new IR::Constant(true)));
+        add_instr(new IR::DpdkJmpEqualStatement(true_label, op->right, new IR::Constant(true)));
+        add_instr(new IR::DpdkMovStatement(dst, new IR::Constant(false)));
+        add_instr(new IR::DpdkJmpLabelStatement(end_label));
+        add_instr(new IR::DpdkLabelStatement(true_label));
+        add_instr(new IR::DpdkMovStatement(dst, new IR::Constant(true)));
+        add_instr(new IR::DpdkLabelStatement(end_label));
+    } else if (op->is<IR::LAnd>()) {
+        add_instr(new IR::DpdkJmpEqualStatement(false_label, op->left, new IR::Constant(false)));
+        add_instr(new IR::DpdkJmpEqualStatement(false_label, op->right, new IR::Constant(false)));
+        add_instr(new IR::DpdkMovStatement(dst, new IR::Constant(true)));
+        add_instr(new IR::DpdkJmpLabelStatement(end_label));
+        add_instr(new IR::DpdkLabelStatement(false_label));
+        add_instr(new IR::DpdkMovStatement(dst, new IR::Constant(false)));
+        add_instr(new IR::DpdkLabelStatement(end_label));
+    } else {
+        BUG("%1% not implemented.", op);
+    }
+}
+
 bool ConvertStatementToDpdk::preorder(const IR::AssignmentStatement *a) {
     auto left = a->left;
     auto right = a->right;
+
     IR::DpdkAsmStatement *i = nullptr;
 
     if (auto r = right->to<IR::Operation_Relation>()) {
@@ -69,10 +113,8 @@ bool ConvertStatementToDpdk::preorder(const IR::AssignmentStatement *a) {
             i = new IR::DpdkShrStatement(left, r->left, r->right);
         } else if (right->is<IR::Equ>()) {
             i = new IR::DpdkEquStatement(left, r->left, r->right);
-        } else if (right->is<IR::LAnd>()) {
-            i = new IR::DpdkLAndStatement(left, r->left, r->right);
-        } else if (right->is<IR::LOr>()) {
-            i = new IR::DpdkLOrStatement(left, r->left, r->right);
+        } else if (right->is<IR::LOr>() || right->is<IR::LAnd>()) {
+            process_logical_operation(left, r);
         } else if (right->is<IR::Leq>()) {
             i = new IR::DpdkLeqStatement(left, r->left, r->right);
         } else if (right->is<IR::BOr>()) {
@@ -138,7 +180,21 @@ bool ConvertStatementToDpdk::preorder(const IR::AssignmentStatement *a) {
                 BUG("%1% Not implemented", e->originalExternType->name);
             }
         } else if (auto b = mi->to<P4::BuiltInMethod>()) {
-            BUG("%1% Not Implemented", b->name);
+            if (b->name == "isValid") {
+                /* DPDK target does not support isvalid() method call as RHS of assignment
+                   Hence, var = hdr.isValid() is translated as
+                   var = true;
+                   if (!(hdr.isValid()))
+                       var = false;
+                */
+                auto end_label = Util::printf_format("label_%dend", next_label_id++);
+                add_instr(new IR::DpdkMovStatement(left, new IR::BoolLiteral(true)));
+                add_instr(new IR::DpdkJmpIfValidStatement(end_label, b->appliedTo));
+                add_instr(new IR::DpdkMovStatement(left, new IR::BoolLiteral(false)));
+                i = new IR::DpdkLabelStatement(end_label);
+            } else {
+                BUG("%1% Not Implemented", b->name);
+            }
         } else {
             BUG("%1% Not implemented", m);
         }
@@ -150,7 +206,21 @@ bool ConvertStatementToDpdk::preorder(const IR::AssignmentStatement *a) {
         } else if (auto c = right->to<IR::Cmpl>()) {
             i = new IR::DpdkCmplStatement(left, c->expr);
         } else if (auto ln = right->to<IR::LNot>()) {
-            i = new IR::DpdkLNotStatement(left, ln->expr);
+            /* DPDK target does not support storing result of logical NOT operation.
+               Hence we convert the expression var = !a into if-else statement.
+               if (a == 0)
+                   var = 1;
+               else
+                   var = 0;
+            */
+            auto true_label = Util::printf_format("label_%dtrue", next_label_id);
+            auto end_label = Util::printf_format("label_%dend", next_label_id++);
+            add_instr(new IR::DpdkJmpEqualStatement(true_label, ln->expr, new IR::Constant(false)));
+            add_instr(new IR::DpdkMovStatement(left, new IR::Constant(false)));
+            add_instr(new IR::DpdkJmpLabelStatement(end_label));
+            add_instr(new IR::DpdkLabelStatement(true_label));
+            add_instr(new IR::DpdkMovStatement(left, new IR::Constant(true)));
+            i = new IR::DpdkLabelStatement(end_label);
         } else {
             std::cerr << right->node_type_name() << std::endl;
             BUG("Not implemented.");

--- a/backends/dpdk/dpdkHelpers.h
+++ b/backends/dpdk/dpdkHelpers.h
@@ -161,6 +161,7 @@ class ConvertStatementToDpdk : public Inspector {
     void add_instr(const IR::DpdkAsmStatement *s) { instructions.push_back(s); }
     IR::IndexedVector<IR::DpdkAsmStatement> &get_instr() { return instructions; }
     int get_label_num() { return next_label_id; }
+    void process_logical_operation(const IR::Expression*, const IR::Operation_Binary*);
     void process_relation_operation(const IR::Expression*, const IR::Operation_Relation*);
     cstring append_parser_name(const IR::P4Parser* p, cstring);
     void set_parser(const IR::P4Parser* p) { parser = p; }

--- a/testdata/p4_16_samples/psa-dpdk-table-key-isValid1.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-isValid1.p4
@@ -1,0 +1,166 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.isValid(): exact;
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+            tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-isValid2.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-isValid2.p4
@@ -1,0 +1,166 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.isValid() || hdr.ipv4.isValid(): exact @name ("hdrValid") ;
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+            tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-isValid3.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-isValid3.p4
@@ -1,0 +1,166 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.isValid() && hdr.ipv4.isValid() || hdr.tcp.isValid(): exact @name ("hdrValid") ;
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+            tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-isValid4.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-isValid4.p4
@@ -1,0 +1,166 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.isValid() && hdr.ipv4.isValid() || hdr.tcp.isValid(): optional @name ("hdrValid") ;
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+            tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-isValid5.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-isValid5.p4
@@ -1,0 +1,166 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            !(hdr.ethernet.isValid()): exact @name ("hdrValid") ;
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+            tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-isValid6.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-isValid6.p4
@@ -1,0 +1,166 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            !(hdr.ethernet.isValid()) || hdr.ipv4.isValid(): exact @name ("hdrValid") ;
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+            tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
@@ -1,0 +1,155 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<4> dataOffset
+	bit<3> res
+	bit<3> ecn
+	bit<6> ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct metadata {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+	bit<8> Ingress_tbl_ethernet_isValid
+	bit<48> Ingress_tbl_ethernet_dstAddr
+	bit<48> Ingress_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.Ingress_tbl_ethernet_isValid exact
+		m.Ingress_tbl_ethernet_dstAddr exact
+		m.Ingress_tbl_ethernet_srcAddr exact
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tbl_ethernet_isValid 1
+	jmpv LABEL_0END h.ethernet
+	mov m.Ingress_tbl_ethernet_isValid 0
+	LABEL_0END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
@@ -1,0 +1,166 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<4> dataOffset
+	bit<3> res
+	bit<3> ecn
+	bit<6> ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct metadata {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+	bit<8> Ingress_tmp
+	bit<8> Ingress_tmp_0
+	bit<8> Ingress_key_0
+	bit<48> Ingress_tbl_ethernet_dstAddr
+	bit<48> Ingress_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.Ingress_key_0 exact
+		m.Ingress_tbl_ethernet_dstAddr exact
+		m.Ingress_tbl_ethernet_srcAddr exact
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tmp 1
+	jmpv LABEL_0END h.ethernet
+	mov m.Ingress_tmp 0
+	LABEL_0END :	mov m.Ingress_tmp_0 1
+	jmpv LABEL_1END h.ipv4
+	mov m.Ingress_tmp_0 0
+	LABEL_1END :	mov m.Ingress_key_0 m.Ingress_tmp
+	jmpeq LABEL_2TRUE m.Ingress_key_0 0x1
+	jmpeq LABEL_2TRUE m.Ingress_tmp_0 0x1
+	mov m.Ingress_key_0 0x0
+	jmp LABEL_2END
+	LABEL_2TRUE :	mov m.Ingress_key_0 0x1
+	LABEL_2END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
@@ -1,0 +1,177 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<4> dataOffset
+	bit<3> res
+	bit<3> ecn
+	bit<6> ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct metadata {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+	bit<8> Ingress_tmp
+	bit<8> Ingress_tmp_0
+	bit<8> Ingress_tmp_1
+	bit<8> Ingress_tmp_2
+	bit<8> Ingress_key_0
+	bit<48> Ingress_tbl_ethernet_dstAddr
+	bit<48> Ingress_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.Ingress_key_0 exact
+		m.Ingress_tbl_ethernet_dstAddr exact
+		m.Ingress_tbl_ethernet_srcAddr exact
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tmp 1
+	jmpv LABEL_0END h.ethernet
+	mov m.Ingress_tmp 0
+	LABEL_0END :	mov m.Ingress_tmp_0 1
+	jmpv LABEL_1END h.ipv4
+	mov m.Ingress_tmp_0 0
+	LABEL_1END :	mov m.Ingress_tmp_1 m.Ingress_tmp
+	jmpeq LABEL_2FALSE m.Ingress_tmp_1 0x0
+	jmpeq LABEL_2FALSE m.Ingress_tmp_0 0x0
+	mov m.Ingress_tmp_1 0x1
+	jmp LABEL_2END
+	LABEL_2FALSE :	mov m.Ingress_tmp_1 0x0
+	LABEL_2END :	mov m.Ingress_tmp_2 1
+	jmpv LABEL_3END h.tcp
+	mov m.Ingress_tmp_2 0
+	LABEL_3END :	mov m.Ingress_key_0 m.Ingress_tmp_1
+	jmpeq LABEL_4TRUE m.Ingress_key_0 0x1
+	jmpeq LABEL_4TRUE m.Ingress_tmp_2 0x1
+	mov m.Ingress_key_0 0x0
+	jmp LABEL_4END
+	LABEL_4TRUE :	mov m.Ingress_key_0 0x1
+	LABEL_4END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
@@ -1,0 +1,177 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<4> dataOffset
+	bit<3> res
+	bit<3> ecn
+	bit<6> ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct metadata {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+	bit<8> Ingress_tmp
+	bit<8> Ingress_tmp_0
+	bit<8> Ingress_tmp_1
+	bit<8> Ingress_tmp_2
+	bit<8> Ingress_key_0
+	bit<48> Ingress_tbl_ethernet_dstAddr
+	bit<48> Ingress_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.Ingress_key_0 optional
+		m.Ingress_tbl_ethernet_dstAddr exact
+		m.Ingress_tbl_ethernet_srcAddr exact
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tmp 1
+	jmpv LABEL_0END h.ethernet
+	mov m.Ingress_tmp 0
+	LABEL_0END :	mov m.Ingress_tmp_0 1
+	jmpv LABEL_1END h.ipv4
+	mov m.Ingress_tmp_0 0
+	LABEL_1END :	mov m.Ingress_tmp_1 m.Ingress_tmp
+	jmpeq LABEL_2FALSE m.Ingress_tmp_1 0x0
+	jmpeq LABEL_2FALSE m.Ingress_tmp_0 0x0
+	mov m.Ingress_tmp_1 0x1
+	jmp LABEL_2END
+	LABEL_2FALSE :	mov m.Ingress_tmp_1 0x0
+	LABEL_2END :	mov m.Ingress_tmp_2 1
+	jmpv LABEL_3END h.tcp
+	mov m.Ingress_tmp_2 0
+	LABEL_3END :	mov m.Ingress_key_0 m.Ingress_tmp_1
+	jmpeq LABEL_4TRUE m.Ingress_key_0 0x1
+	jmpeq LABEL_4TRUE m.Ingress_tmp_2 0x1
+	mov m.Ingress_key_0 0x0
+	jmp LABEL_4END
+	LABEL_4TRUE :	mov m.Ingress_key_0 0x1
+	LABEL_4END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
@@ -1,0 +1,160 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<4> dataOffset
+	bit<3> res
+	bit<3> ecn
+	bit<6> ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct metadata {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+	bit<8> Ingress_tmp
+	bit<8> Ingress_key_0
+	bit<48> Ingress_tbl_ethernet_dstAddr
+	bit<48> Ingress_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.Ingress_key_0 exact
+		m.Ingress_tbl_ethernet_dstAddr exact
+		m.Ingress_tbl_ethernet_srcAddr exact
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tmp 1
+	jmpv LABEL_0END h.ethernet
+	mov m.Ingress_tmp 0
+	LABEL_0END :	jmpeq LABEL_1TRUE m.Ingress_tmp 0x0
+	mov m.Ingress_key_0 0x0
+	jmp LABEL_1END
+	LABEL_1TRUE :	mov m.Ingress_key_0 0x1
+	LABEL_1END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
@@ -1,0 +1,171 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<4> dataOffset
+	bit<3> res
+	bit<3> ecn
+	bit<6> ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct metadata {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+	bit<8> Ingress_tmp
+	bit<8> Ingress_tmp_0
+	bit<8> Ingress_tmp_1
+	bit<8> Ingress_key_0
+	bit<48> Ingress_tbl_ethernet_dstAddr
+	bit<48> Ingress_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.Ingress_key_0 exact
+		m.Ingress_tbl_ethernet_dstAddr exact
+		m.Ingress_tbl_ethernet_srcAddr exact
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tmp 1
+	jmpv LABEL_0END h.ethernet
+	mov m.Ingress_tmp 0
+	LABEL_0END :	jmpeq LABEL_1TRUE m.Ingress_tmp 0x0
+	mov m.Ingress_tmp_0 0x0
+	jmp LABEL_1END
+	LABEL_1TRUE :	mov m.Ingress_tmp_0 0x1
+	LABEL_1END :	mov m.Ingress_tmp_1 1
+	jmpv LABEL_2END h.ipv4
+	mov m.Ingress_tmp_1 0
+	LABEL_2END :	mov m.Ingress_key_0 m.Ingress_tmp_0
+	jmpeq LABEL_3TRUE m.Ingress_key_0 0x1
+	jmpeq LABEL_3TRUE m.Ingress_tmp_1 0x1
+	mov m.Ingress_key_0 0x0
+	jmp LABEL_3END
+	LABEL_3TRUE :	mov m.Ingress_key_0 0x1
+	LABEL_3END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+


### PR DESCRIPTION
This PR includes changes for
- Adding support for using isValid as table key. 
- Handling logical operations as RHS of assignment

The table key having _isValid_ method call is first assigned to a temporary and then the temporary variable is used a table key.
This temporary variable is moved to metadata as DPDK requires all temporary variables to be moved to metadata.

```
table tbl {
    key = {
         hdr.ethernet.isValid() : exact @name ("hdrValid");
         hdr.ethernet.srcAddr : exact ;
      }
}

```
gets translated to 

```
struct metadata {
    ....
      bit<8> key;
}
..
table tbl {
    key = {
          key : exact @name ("hdrValid");
          hdr.ethernet.srcAddr : exact ;
      }
}

apply {
       key = hdr.ethernet.isValid();
       tbl.apply();
}

```

