### PR TITLE
Giving warnings on accessing fields of invalid headers

### DIFF
--- a/frontends/p4/removeReturns.h
+++ b/frontends/p4/removeReturns.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define _FRONTENDS_P4_REMOVERETURNS_H_
 
 #include "ir/ir.h"
+#include "frontends/p4/ternaryBool.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
 
@@ -65,17 +66,11 @@ class DoRemoveReturns : public Transform {
     cstring           variableName;
     cstring           retValName;
 
-    enum class Returns {
-        Yes,
-        No,
-        Maybe
-    };
-
-    std::vector<Returns> stack;
-    void push() { stack.push_back(Returns::No); }
+    std::vector<TernaryBool> stack;
+    void push() { stack.push_back(TernaryBool::No); }
     void pop() { stack.pop_back(); }
-    void set(Returns r) { BUG_CHECK(!stack.empty(), "Empty stack"); stack.back() = r; }
-    Returns hasReturned() { BUG_CHECK(!stack.empty(), "Empty stack"); return stack.back(); }
+    void set(TernaryBool r) { BUG_CHECK(!stack.empty(), "Empty stack"); stack.back() = r; }
+    TernaryBool hasReturned() { BUG_CHECK(!stack.empty(), "Empty stack"); return stack.back(); }
 
  public:
     explicit DoRemoveReturns(P4::ReferenceMap* refMap,

--- a/frontends/p4/ternaryBool.h
+++ b/frontends/p4/ternaryBool.h
@@ -1,0 +1,31 @@
+/*
+Copyright 2016 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _FRONTENDS_P4_TERNARYBOOL_H_
+#define _FRONTENDS_P4_TERNARYBOOL_H_
+
+namespace P4 {
+
+    enum class TernaryBool {
+        Yes,
+        No,
+        Maybe
+    };
+
+}  // namespace P4
+
+#endif  /* _FRONTENDS_P4_TERNARYBOOL_H_ */
+

--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -60,6 +60,7 @@ const int ErrorType::WARN_SHADOWING         = 1016;
 const int ErrorType::WARN_IGNORE            = 1017;
 const int ErrorType::WARN_UNINITIALIZED_OUT_PARAM  = 1018;
 const int ErrorType::WARN_UNINITIALIZED_USE = 1019;
+const int ErrorType::WARN_INVALID_HEADER    = 1020;
 const int ErrorType::WARN_MAX_WARNINGS      = 2142;
 
 // map from errorCode to ErrorSig
@@ -102,5 +103,6 @@ std::map<int, cstring> ErrorCatalog::errorCatalog = {
     { ErrorType::WARN_SHADOWING,         "shadow"},
     { ErrorType::WARN_UNINITIALIZED_USE, "uninitialized_use"},
     { ErrorType::WARN_UNINITIALIZED_OUT_PARAM,     "uninitialized_out_param"},
-    { ErrorType::WARN_IGNORE,            "ignore"}
+    { ErrorType::WARN_IGNORE,            "ignore"},
+    { ErrorType::WARN_INVALID_HEADER,    "invalid_header" }
 };

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -72,6 +72,7 @@ class ErrorType {
     static const int WARN_UNREACHABLE;        // parser state unreachable
     static const int WARN_SHADOWING;          // instance shadowing
     static const int WARN_IGNORE;             // simply ignore
+    static const int WARN_INVALID_HEADER;     // access to fields of an invalid header
 
     static const int WARN_MAX_WARNINGS;
 };

--- a/testdata/p4_16_errors_outputs/issue-2123_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue-2123_e.p4-stderr
@@ -4,6 +4,12 @@ issue-2123_e.p4(63): [--Wwarn=uninitialized_use] warning: hdr.ipv4.totalLen may 
 issue-2123_e.p4(64): [--Wwarn=uninitialized_use] warning: hdr.ipv4.totalLen may be uninitialized
             0x0800 .. hdr.ipv4.totalLen : parse_ipv4;
                       ^^^^^^^^^^^^^^^^^
+issue-2123_e.p4(63): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.ipv4
+            hdr.ipv4.totalLen .. 0x0800 : parse_ipv4;
+            ^^^^^^^^
+issue-2123_e.p4(64): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.ipv4
+            0x0800 .. hdr.ipv4.totalLen : parse_ipv4;
+                      ^^^^^^^^
 issue-2123_e.p4(61): [--Werror=invalid] error: 16w0x806-16w0x800: Range end is less than start.
             0x0806 .. 0x0800 : parse_ipv4;
             ^^^^^^

--- a/testdata/p4_16_samples/invalid-hdr-warnings1.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings1.p4
@@ -1,0 +1,80 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M { }
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.h2.data = 1;            // always invalid
+        transition next;
+    }
+
+    state next {
+        if (hdr.h2.data == 1) {     // from start: invalid, from state0: may be invalid  =>  hdr.h2 may be invalid
+            hdr.h1.data = 0;        // from start: invalid, from state0: invalid => hdr.h1 is invalid
+        }
+        pkt.extract(hdr.h1);
+        hdr.h2.setInvalid();
+        transition select (hdr.h1.data) {   // valid
+            0: state0;
+            1: state1;
+            default: accept;
+        }
+    }
+
+    state state0 {
+        hdr.h1.setInvalid();
+        transition select (hdr.h2.data) {  // from next: invalid, from state1: valid => hdr.h2 may be invalid
+            2: state1;
+            default: next;
+        }
+    }
+
+    state state1 {
+        hdr.h2.data = hdr.h2.data + 1;     // from next: invalid, from state0: may be invalid, from state1: valid
+                                           // => hdr.h2 may be invalid
+        hdr.h2.setValid();
+        transition select (hdr.h2.data) {   // valid
+            1: state1;
+            2: state0;
+            default: accept;
+        }
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples/invalid-hdr-warnings2.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings2.p4
@@ -1,0 +1,91 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M { }
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Header h1;
+    Header h2;
+    H s1;
+    H s2;
+
+    action invalid_H(out H s) {
+        s.h1.setInvalid();
+        s.h2.setInvalid();
+    }
+
+    apply {
+        h1 = { 1 };
+        if (hdr.h1.data == 0) {
+            h2 = h1;
+        } else {
+            h2.setValid();
+            h2.data = 0;
+        }
+
+        hdr.h1.data = h1.data;      // h1 valid at this point
+        hdr.h2.data = h2.data;      // h2 valid at this point
+
+        if (h2.data == 1) {
+            h1.setInvalid();
+        }
+
+        hdr.h1.data = h1.data;      // h1 potentially invalid at this point
+        h1 = h2;                    // h1 valid again
+
+        if (h1.data == 1) {
+            s1 = { h1, h2 };
+            s2 = s1;
+            if (s2.h1.data == 0 && s2.h2.data == 0) {
+                if (s1.h1.data > 0)
+                    s1.h1.setInvalid();
+                else
+                    s1.h1.setInvalid();
+                hdr.h1.data = s1.h1.data;   // s1.h1 invalid at this point
+            } else {
+                s1.h1.setValid();
+            }
+            hdr.h2.data = s1.h1.data;       // s1.h1 potentially invalid at this point
+        }
+
+        invalid_H(hdr);
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples/invalid-hdr-warnings3.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings3.p4
@@ -1,0 +1,73 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M { }
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.h1);
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Header h1;
+    Header h2;
+
+    apply {
+        h1.setInvalid();
+        h2.setValid();
+        h1.data = 0;
+        h2.data = 1;
+
+        switch (hdr.h1.data)
+        {
+            0: { h1.setValid(); h2.setInvalid(); }
+            default: { h1.setValid(); h2.setInvalid(); }
+        }
+
+        hdr.h1.data = h1.data;
+        hdr.h1.data = h2.data;
+
+        switch (hdr.h1.data)
+        {
+            0: { h1.setValid(); h2.setValid(); }
+            default: { h1.setInvalid(); h2.setInvalid(); }
+        }
+
+        hdr.h1.data = h1.data;
+        hdr.h1.data = h2.data;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/gauntlet_bounded_loop.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_bounded_loop.p4-stderr
@@ -1,3 +1,6 @@
 gauntlet_bounded_loop.p4(29): [--Wwarn=uninitialized_use] warning: hdr.p.p may be uninitialized
         transition select(hdr.p.p) {
                           ^^^^^^^
+gauntlet_bounded_loop.p4(29): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.p
+        transition select(hdr.p.p) {
+                          ^^^^^

--- a/testdata/p4_16_samples_outputs/gauntlet_ctrl_plane_hdr.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_ctrl_plane_hdr.p4-stderr
@@ -1,0 +1,3 @@
+gauntlet_ctrl_plane_hdr.p4(25): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header ctrl_hdr
+        h.eth_hdr.dst_addr = ctrl_hdr.dst_addr;
+                             ^^^^^^^^

--- a/testdata/p4_16_samples_outputs/gauntlet_hdr_assign_2-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_hdr_assign_2-bmv2.p4-stderr
@@ -1,0 +1,3 @@
+gauntlet_hdr_assign_2-bmv2.p4(39): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h.h
+        h.h.b = 8w3;
+        ^^^

--- a/testdata/p4_16_samples_outputs/gauntlet_infinite_loop.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_infinite_loop.p4-stderr
@@ -19,3 +19,6 @@ gauntlet_infinite_loop.p4(37)
 gauntlet_infinite_loop.p4(23): [--Wwarn=uninitialized_use] warning: padding.p may be uninitialized
         transition select(padding.p) {
                           ^^^^^^^^^
+gauntlet_infinite_loop.p4(23): [--Wwarn=invalid_header] warning: accessing a field of an invalid header padding
+        transition select(padding.p) {
+                          ^^^^^^^

--- a/testdata/p4_16_samples_outputs/gauntlet_set_invalid-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_set_invalid-bmv2.p4-stderr
@@ -1,0 +1,3 @@
+gauntlet_set_invalid-bmv2.p4(37): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h.h
+        h.h.b = 8w1;
+        ^^^

--- a/testdata/p4_16_samples_outputs/header-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/header-bmv2.p4-stderr
@@ -1,0 +1,6 @@
+header-bmv2.p4(27): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp
+        tmp.f = h.f + 1;
+        ^^^
+header-bmv2.p4(28): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp
+        h.f = tmp.f;
+              ^^^

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings1-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings1-first.p4
@@ -1,0 +1,85 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.h2.data = 32w1;
+        transition next;
+    }
+    state next {
+        transition select(hdr.h2.data == 32w1) {
+            true: next_true;
+            false: next_join;
+        }
+    }
+    state next_true {
+        hdr.h1.data = 32w0;
+        transition next_join;
+    }
+    state next_join {
+        pkt.extract<Header>(hdr.h1);
+        hdr.h2.setInvalid();
+        transition select(hdr.h1.data) {
+            32w0: state0;
+            32w1: state1;
+            default: accept;
+        }
+    }
+    state state0 {
+        hdr.h1.setInvalid();
+        transition select(hdr.h2.data) {
+            32w2: state1;
+            default: next;
+        }
+    }
+    state state1 {
+        hdr.h2.data = hdr.h2.data + 32w1;
+        hdr.h2.setValid();
+        transition select(hdr.h2.data) {
+            32w1: state1;
+            32w2: state0;
+            default: accept;
+        }
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings1-frontend.p4
@@ -1,0 +1,84 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.h2.data = 32w1;
+        transition next;
+    }
+    state next {
+        transition select(hdr.h2.data == 32w1) {
+            true: next_true;
+            false: next_join;
+        }
+    }
+    state next_true {
+        transition next_join;
+    }
+    state next_join {
+        pkt.extract<Header>(hdr.h1);
+        hdr.h2.setInvalid();
+        transition select(hdr.h1.data) {
+            32w0: state0;
+            32w1: state1;
+            default: accept;
+        }
+    }
+    state state0 {
+        hdr.h1.setInvalid();
+        transition select(hdr.h2.data) {
+            32w2: state1;
+            default: next;
+        }
+    }
+    state state1 {
+        hdr.h2.data = hdr.h2.data + 32w1;
+        hdr.h2.setValid();
+        transition select(hdr.h2.data) {
+            32w1: state1;
+            32w2: state0;
+            default: accept;
+        }
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings1-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings1-midend.p4
@@ -1,0 +1,89 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.h2.data = 32w1;
+        transition next;
+    }
+    state next {
+        transition select((bit<1>)(hdr.h2.data == 32w1)) {
+            1w1: next_true;
+            1w0: next_join;
+            default: noMatch;
+        }
+    }
+    state next_true {
+        transition next_join;
+    }
+    state next_join {
+        pkt.extract<Header>(hdr.h1);
+        hdr.h2.setInvalid();
+        transition select(hdr.h1.data) {
+            32w0: state0;
+            32w1: state1;
+            default: accept;
+        }
+    }
+    state state0 {
+        hdr.h1.setInvalid();
+        transition select(hdr.h2.data) {
+            32w2: state1;
+            default: next;
+        }
+    }
+    state state1 {
+        hdr.h2.data = hdr.h2.data + 32w1;
+        hdr.h2.setValid();
+        transition select(hdr.h2.data) {
+            32w1: state1;
+            32w2: state0;
+            default: accept;
+        }
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings1.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings1.p4
@@ -1,0 +1,78 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.h2.data = 1;
+        transition next;
+    }
+    state next {
+        if (hdr.h2.data == 1) {
+            hdr.h1.data = 0;
+        }
+        pkt.extract(hdr.h1);
+        hdr.h2.setInvalid();
+        transition select(hdr.h1.data) {
+            0: state0;
+            1: state1;
+            default: accept;
+        }
+    }
+    state state0 {
+        hdr.h1.setInvalid();
+        transition select(hdr.h2.data) {
+            2: state1;
+            default: next;
+        }
+    }
+    state state1 {
+        hdr.h2.data = hdr.h2.data + 1;
+        hdr.h2.setValid();
+        transition select(hdr.h2.data) {
+            1: state1;
+            2: state0;
+            default: accept;
+        }
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings1.p4-stderr
@@ -1,0 +1,18 @@
+invalid-hdr-warnings1.p4(18): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.h2
+        hdr.h2.data = 1; // always invalid
+        ^^^^^^
+invalid-hdr-warnings1.p4(23): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.h2
+        if (hdr.h2.data == 1) { // from start: invalid, from state0: may be invalid  =>  hdr.h2 may be invalid
+            ^^^^^^
+invalid-hdr-warnings1.p4(24): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.h1
+            hdr.h1.data = 0; // from start: invalid, from state0: invalid => hdr.h1 is invalid
+            ^^^^^^
+invalid-hdr-warnings1.p4(37): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.h2
+        transition select (hdr.h2.data) { // from next: invalid, from state1: valid => hdr.h2 may be invalid
+                           ^^^^^^
+invalid-hdr-warnings1.p4(44): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.h2
+        hdr.h2.data = hdr.h2.data + 1; // from next: invalid, from state0: may be invalid, from state1: valid
+        ^^^^^^
+invalid-hdr-warnings1.p4(44): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.h2
+        hdr.h2.data = hdr.h2.data + 1; // from next: invalid, from state0: may be invalid, from state1: valid
+                      ^^^^^^

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-first.p4
@@ -1,0 +1,87 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Header h1;
+    Header h2;
+    H s1;
+    H s2;
+    action invalid_H(out H s) {
+        s.h1.setInvalid();
+        s.h2.setInvalid();
+    }
+    apply {
+        h1 = (Header){data = 32w1};
+        if (hdr.h1.data == 32w0) {
+            h2 = h1;
+        } else {
+            h2.setValid();
+            h2.data = 32w0;
+        }
+        hdr.h1.data = h1.data;
+        hdr.h2.data = h2.data;
+        if (h2.data == 32w1) {
+            h1.setInvalid();
+        }
+        hdr.h1.data = h1.data;
+        h1 = h2;
+        if (h1.data == 32w1) {
+            s1 = (H){h1 = h1,h2 = h2};
+            s2 = s1;
+            if (s2.h1.data == 32w0 && s2.h2.data == 32w0) {
+                if (s1.h1.data > 32w0) {
+                    s1.h1.setInvalid();
+                } else {
+                    s1.h1.setInvalid();
+                }
+                hdr.h1.data = s1.h1.data;
+            } else {
+                s1.h1.setValid();
+            }
+            hdr.h2.data = s1.h1.data;
+        }
+        invalid_H(hdr);
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-frontend.p4
@@ -1,0 +1,91 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("IngressI.h1") Header h1_0;
+    @name("IngressI.h2") Header h2_0;
+    @name("IngressI.s1") H s1_0;
+    @name("IngressI.s2") H s2_0;
+    @name("IngressI.s") H s_0;
+    @name("IngressI.invalid_H") action invalid_H() {
+        s_0.h1.setInvalid();
+        s_0.h2.setInvalid();
+        hdr = s_0;
+    }
+    apply {
+        h1_0.setInvalid();
+        h2_0.setInvalid();
+        s1_0.h1.setInvalid();
+        s1_0.h2.setInvalid();
+        s2_0.h1.setInvalid();
+        s2_0.h2.setInvalid();
+        h1_0.setValid();
+        h1_0 = (Header){data = 32w1};
+        if (hdr.h1.data == 32w0) {
+            h2_0 = h1_0;
+        } else {
+            h2_0.setValid();
+            h2_0.data = 32w0;
+        }
+        if (h2_0.data == 32w1) {
+            h1_0.setInvalid();
+        }
+        h1_0 = h2_0;
+        if (h1_0.data == 32w1) {
+            s1_0 = (H){h1 = h1_0,h2 = h2_0};
+            s2_0 = s1_0;
+            if (s2_0.h1.data == 32w0 && s2_0.h2.data == 32w0) {
+                if (s1_0.h1.data > 32w0) {
+                    s1_0.h1.setInvalid();
+                } else {
+                    s1_0.h1.setInvalid();
+                }
+            } else {
+                s1_0.h1.setValid();
+            }
+        }
+        invalid_H();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-midend.p4
@@ -1,0 +1,184 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("IngressI.h1") Header h1_0;
+    @name("IngressI.h2") Header h2_0;
+    Header s1_0_h1;
+    Header s1_0_h2;
+    Header s2_0_h1;
+    Header s2_0_h2;
+    Header s_0_h1;
+    Header s_0_h2;
+    @name("IngressI.invalid_H") action invalid_H() {
+        s_0_h1.setInvalid();
+        s_0_h2.setInvalid();
+        hdr.h1 = s_0_h1;
+        hdr.h2 = s_0_h2;
+    }
+    @hidden action invalidhdrwarnings2l36() {
+        h2_0 = h1_0;
+    }
+    @hidden action invalidhdrwarnings2l38() {
+        h2_0.setValid();
+        h2_0.data = 32w0;
+    }
+    @hidden action invalidhdrwarnings2l23() {
+        h1_0.setInvalid();
+        h2_0.setInvalid();
+        s1_0_h1.setInvalid();
+        s1_0_h2.setInvalid();
+        s2_0_h1.setInvalid();
+        s2_0_h2.setInvalid();
+        h1_0.setValid();
+        h1_0.data = 32w1;
+    }
+    @hidden action invalidhdrwarnings2l46() {
+        h1_0.setInvalid();
+    }
+    @hidden action invalidhdrwarnings2l57() {
+        s1_0_h1.setInvalid();
+    }
+    @hidden action invalidhdrwarnings2l59() {
+        s1_0_h1.setInvalid();
+    }
+    @hidden action invalidhdrwarnings2l62() {
+        s1_0_h1.setValid();
+    }
+    @hidden action invalidhdrwarnings2l53() {
+        s1_0_h1 = h2_0;
+        s1_0_h2 = h2_0;
+        s2_0_h1 = h2_0;
+        s2_0_h2 = h2_0;
+    }
+    @hidden action invalidhdrwarnings2l50() {
+        h1_0 = h2_0;
+    }
+    @hidden table tbl_invalidhdrwarnings2l23 {
+        actions = {
+            invalidhdrwarnings2l23();
+        }
+        const default_action = invalidhdrwarnings2l23();
+    }
+    @hidden table tbl_invalidhdrwarnings2l36 {
+        actions = {
+            invalidhdrwarnings2l36();
+        }
+        const default_action = invalidhdrwarnings2l36();
+    }
+    @hidden table tbl_invalidhdrwarnings2l38 {
+        actions = {
+            invalidhdrwarnings2l38();
+        }
+        const default_action = invalidhdrwarnings2l38();
+    }
+    @hidden table tbl_invalidhdrwarnings2l46 {
+        actions = {
+            invalidhdrwarnings2l46();
+        }
+        const default_action = invalidhdrwarnings2l46();
+    }
+    @hidden table tbl_invalidhdrwarnings2l50 {
+        actions = {
+            invalidhdrwarnings2l50();
+        }
+        const default_action = invalidhdrwarnings2l50();
+    }
+    @hidden table tbl_invalidhdrwarnings2l53 {
+        actions = {
+            invalidhdrwarnings2l53();
+        }
+        const default_action = invalidhdrwarnings2l53();
+    }
+    @hidden table tbl_invalidhdrwarnings2l57 {
+        actions = {
+            invalidhdrwarnings2l57();
+        }
+        const default_action = invalidhdrwarnings2l57();
+    }
+    @hidden table tbl_invalidhdrwarnings2l59 {
+        actions = {
+            invalidhdrwarnings2l59();
+        }
+        const default_action = invalidhdrwarnings2l59();
+    }
+    @hidden table tbl_invalidhdrwarnings2l62 {
+        actions = {
+            invalidhdrwarnings2l62();
+        }
+        const default_action = invalidhdrwarnings2l62();
+    }
+    @hidden table tbl_invalid_H {
+        actions = {
+            invalid_H();
+        }
+        const default_action = invalid_H();
+    }
+    apply {
+        tbl_invalidhdrwarnings2l23.apply();
+        if (hdr.h1.data == 32w0) {
+            tbl_invalidhdrwarnings2l36.apply();
+        } else {
+            tbl_invalidhdrwarnings2l38.apply();
+        }
+        if (h2_0.data == 32w1) {
+            tbl_invalidhdrwarnings2l46.apply();
+        }
+        tbl_invalidhdrwarnings2l50.apply();
+        if (h1_0.data == 32w1) {
+            tbl_invalidhdrwarnings2l53.apply();
+            if (s2_0_h1.data == 32w0 && s2_0_h2.data == 32w0) {
+                if (s1_0_h1.data > 32w0) {
+                    tbl_invalidhdrwarnings2l57.apply();
+                } else {
+                    tbl_invalidhdrwarnings2l59.apply();
+                }
+            } else {
+                tbl_invalidhdrwarnings2l62.apply();
+            }
+        }
+        tbl_invalid_H.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2.p4
@@ -1,0 +1,87 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Header h1;
+    Header h2;
+    H s1;
+    H s2;
+    action invalid_H(out H s) {
+        s.h1.setInvalid();
+        s.h2.setInvalid();
+    }
+    apply {
+        h1 = { 1 };
+        if (hdr.h1.data == 0) {
+            h2 = h1;
+        } else {
+            h2.setValid();
+            h2.data = 0;
+        }
+        hdr.h1.data = h1.data;
+        hdr.h2.data = h2.data;
+        if (h2.data == 1) {
+            h1.setInvalid();
+        }
+        hdr.h1.data = h1.data;
+        h1 = h2;
+        if (h1.data == 1) {
+            s1 = { h1, h2 };
+            s2 = s1;
+            if (s2.h1.data == 0 && s2.h2.data == 0) {
+                if (s1.h1.data > 0) {
+                    s1.h1.setInvalid();
+                } else {
+                    s1.h1.setInvalid();
+                }
+                hdr.h1.data = s1.h1.data;
+            } else {
+                s1.h1.setValid();
+            }
+            hdr.h2.data = s1.h1.data;
+        }
+        invalid_H(hdr);
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2.p4-stderr
@@ -1,0 +1,9 @@
+invalid-hdr-warnings2.p4(49): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header h1
+        hdr.h1.data = h1.data; // h1 potentially invalid at this point
+                      ^^
+invalid-hdr-warnings2.p4(60): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s1.h1
+                hdr.h1.data = s1.h1.data; // s1.h1 invalid at this point
+                              ^^^^^
+invalid-hdr-warnings2.p4(64): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header s1.h1
+            hdr.h2.data = s1.h1.data; // s1.h1 potentially invalid at this point
+                          ^^^^^

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings3-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings3-first.p4
@@ -1,0 +1,80 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract<Header>(hdr.h1);
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Header h1;
+    Header h2;
+    apply {
+        h1.setInvalid();
+        h2.setValid();
+        h1.data = 32w0;
+        h2.data = 32w1;
+        switch (hdr.h1.data) {
+            32w0: {
+                h1.setValid();
+                h2.setInvalid();
+            }
+            default: {
+                h1.setValid();
+                h2.setInvalid();
+            }
+        }
+        hdr.h1.data = h1.data;
+        hdr.h1.data = h2.data;
+        switch (hdr.h1.data) {
+            32w0: {
+                h1.setValid();
+                h2.setValid();
+            }
+            default: {
+                h1.setInvalid();
+                h2.setInvalid();
+            }
+        }
+        hdr.h1.data = h1.data;
+        hdr.h1.data = h2.data;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings3-frontend.p4
@@ -1,0 +1,79 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract<Header>(hdr.h1);
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("IngressI.h1") Header h1_0;
+    @name("IngressI.h2") Header h2_0;
+    apply {
+        h1_0.setInvalid();
+        h2_0.setInvalid();
+        h1_0.setInvalid();
+        h2_0.setValid();
+        h2_0.data = 32w1;
+        switch (hdr.h1.data) {
+            32w0: {
+                h1_0.setValid();
+                h2_0.setInvalid();
+            }
+            default: {
+                h1_0.setValid();
+                h2_0.setInvalid();
+            }
+        }
+        hdr.h1.data = h2_0.data;
+        switch (hdr.h1.data) {
+            32w0: {
+                h1_0.setValid();
+                h2_0.setValid();
+            }
+            default: {
+                h1_0.setInvalid();
+                h2_0.setInvalid();
+            }
+        }
+        hdr.h1.data = h2_0.data;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings3-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings3-midend.p4
@@ -1,0 +1,202 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract<Header>(hdr.h1);
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("IngressI.h1") Header h1_0;
+    @name("IngressI.h2") Header h2_0;
+    bit<32> switch_0_key;
+    @hidden action switch_0_case() {
+    }
+    @hidden action switch_0_case_0() {
+    }
+    @hidden table switch_0_table {
+        key = {
+            switch_0_key: exact;
+        }
+        actions = {
+            switch_0_case();
+            switch_0_case_0();
+        }
+        const default_action = switch_0_case_0();
+        const entries = {
+                        32w0 : switch_0_case();
+        }
+    }
+    bit<32> switch_1_key;
+    @hidden action switch_1_case() {
+    }
+    @hidden action switch_1_case_0() {
+    }
+    @hidden table switch_1_table {
+        key = {
+            switch_1_key: exact;
+        }
+        actions = {
+            switch_1_case();
+            switch_1_case_0();
+        }
+        const default_action = switch_1_case_0();
+        const entries = {
+                        32w0 : switch_1_case();
+        }
+    }
+    @hidden action invalidhdrwarnings3l35() {
+        h1_0.setValid();
+        h2_0.setInvalid();
+    }
+    @hidden action invalidhdrwarnings3l36() {
+        h1_0.setValid();
+        h2_0.setInvalid();
+    }
+    @hidden action invalidhdrwarnings3l33() {
+        switch_0_key = hdr.h1.data;
+    }
+    @hidden action invalidhdrwarnings3l24() {
+        h1_0.setInvalid();
+        h2_0.setInvalid();
+        h1_0.setInvalid();
+        h2_0.setValid();
+        h2_0.data = 32w1;
+    }
+    @hidden action invalidhdrwarnings3l44() {
+        h1_0.setValid();
+        h2_0.setValid();
+    }
+    @hidden action invalidhdrwarnings3l45() {
+        h1_0.setInvalid();
+        h2_0.setInvalid();
+    }
+    @hidden action invalidhdrwarnings3l42() {
+        switch_1_key = h2_0.data;
+    }
+    @hidden action invalidhdrwarnings3l40() {
+        hdr.h1.data = h2_0.data;
+    }
+    @hidden action invalidhdrwarnings3l49() {
+        hdr.h1.data = h2_0.data;
+    }
+    @hidden table tbl_invalidhdrwarnings3l24 {
+        actions = {
+            invalidhdrwarnings3l24();
+        }
+        const default_action = invalidhdrwarnings3l24();
+    }
+    @hidden table tbl_invalidhdrwarnings3l33 {
+        actions = {
+            invalidhdrwarnings3l33();
+        }
+        const default_action = invalidhdrwarnings3l33();
+    }
+    @hidden table tbl_invalidhdrwarnings3l35 {
+        actions = {
+            invalidhdrwarnings3l35();
+        }
+        const default_action = invalidhdrwarnings3l35();
+    }
+    @hidden table tbl_invalidhdrwarnings3l36 {
+        actions = {
+            invalidhdrwarnings3l36();
+        }
+        const default_action = invalidhdrwarnings3l36();
+    }
+    @hidden table tbl_invalidhdrwarnings3l40 {
+        actions = {
+            invalidhdrwarnings3l40();
+        }
+        const default_action = invalidhdrwarnings3l40();
+    }
+    @hidden table tbl_invalidhdrwarnings3l42 {
+        actions = {
+            invalidhdrwarnings3l42();
+        }
+        const default_action = invalidhdrwarnings3l42();
+    }
+    @hidden table tbl_invalidhdrwarnings3l44 {
+        actions = {
+            invalidhdrwarnings3l44();
+        }
+        const default_action = invalidhdrwarnings3l44();
+    }
+    @hidden table tbl_invalidhdrwarnings3l45 {
+        actions = {
+            invalidhdrwarnings3l45();
+        }
+        const default_action = invalidhdrwarnings3l45();
+    }
+    @hidden table tbl_invalidhdrwarnings3l49 {
+        actions = {
+            invalidhdrwarnings3l49();
+        }
+        const default_action = invalidhdrwarnings3l49();
+    }
+    apply {
+        tbl_invalidhdrwarnings3l24.apply();
+        {
+            tbl_invalidhdrwarnings3l33.apply();
+            switch (switch_0_table.apply().action_run) {
+                switch_0_case: {
+                    tbl_invalidhdrwarnings3l35.apply();
+                }
+                switch_0_case_0: {
+                    tbl_invalidhdrwarnings3l36.apply();
+                }
+            }
+        }
+        tbl_invalidhdrwarnings3l40.apply();
+        {
+            tbl_invalidhdrwarnings3l42.apply();
+            switch (switch_1_table.apply().action_run) {
+                switch_1_case: {
+                    tbl_invalidhdrwarnings3l44.apply();
+                }
+                switch_1_case_0: {
+                    tbl_invalidhdrwarnings3l45.apply();
+                }
+            }
+        }
+        tbl_invalidhdrwarnings3l49.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings3.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings3.p4
@@ -1,0 +1,79 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header h1;
+    Header h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.h1);
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Header h1;
+    Header h2;
+    apply {
+        h1.setInvalid();
+        h2.setValid();
+        h1.data = 0;
+        h2.data = 1;
+        switch (hdr.h1.data) {
+            0: {
+                h1.setValid();
+                h2.setInvalid();
+            }
+            default: {
+                h1.setValid();
+                h2.setInvalid();
+            }
+        }
+        hdr.h1.data = h1.data;
+        hdr.h1.data = h2.data;
+        switch (hdr.h1.data) {
+            0: {
+                h1.setValid();
+                h2.setValid();
+            }
+            default: {
+                h1.setInvalid();
+                h2.setInvalid();
+            }
+        }
+        hdr.h1.data = h1.data;
+        hdr.h1.data = h2.data;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings3.p4-stderr
@@ -1,0 +1,12 @@
+invalid-hdr-warnings3.p4(30): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h1
+        h1.data = 0;
+        ^^
+invalid-hdr-warnings3.p4(40): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h2
+        hdr.h1.data = h2.data;
+                      ^^
+invalid-hdr-warnings3.p4(48): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header h1
+        hdr.h1.data = h1.data;
+                      ^^
+invalid-hdr-warnings3.p4(49): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header h2
+        hdr.h1.data = h2.data;
+                      ^^

--- a/testdata/p4_16_samples_outputs/issue1520-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1520-bmv2.p4-stderr
@@ -1,0 +1,3 @@
+issue1520-bmv2.p4(21): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.h
+ hdr.h.x = 0;
+ ^^^^^

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2.p4-stderr
@@ -1,0 +1,3 @@
+issue1653-bmv2.p4(48): [--Wwarn=invalid_header] warning: accessing a field of an invalid header bh
+        bh.x = h.bvh0.x;
+        ^^

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2.p4-stderr
@@ -1,0 +1,9 @@
+issue1653-complex-bmv2.p4(93): [--Wwarn=invalid_header] warning: accessing a field of an invalid header bh
+        bh.row.alt0.useHash = h.bvh0.row.alt0.useHash;
+        ^^
+issue1653-complex-bmv2.p4(94): [--Wwarn=invalid_header] warning: accessing a field of an invalid header bh
+        bh.row.alt1.type = EthTypes.IPv4;
+        ^^
+issue1653-complex-bmv2.p4(95): [--Wwarn=invalid_header] warning: accessing a field of an invalid header bh
+        h.bvh0.row.alt1.type = bh.row.alt1.type;
+                               ^^

--- a/testdata/p4_16_samples_outputs/issue1937-2-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1937-2-bmv2.p4-stderr
@@ -1,3 +1,12 @@
 issue1937-2-bmv2.p4(33): [--Wwarn=uninitialized_use] warning: hdr.h1.f1 may be uninitialized
         foo.apply(hdr.h1.f1, hdr.h1.f1);
                              ^^^^^^^^^
+issue1937-2-bmv2.p4(33): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.h1
+        foo.apply(hdr.h1.f1, hdr.h1.f1);
+                             ^^^^^^
+issue1937-2-bmv2.p4(33): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.h1
+        foo.apply(hdr.h1.f1, hdr.h1.f1);
+                  ^^^^^^
+issue1937-2-bmv2.p4(34): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.h1
+        foo.apply(hdr.h1.f2);
+                  ^^^^^^

--- a/testdata/p4_16_samples_outputs/issue1937.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1937.p4-stderr
@@ -1,3 +1,12 @@
 issue1937.p4(14): [--Wwarn=uninitialized_use] warning: hdr.f1 may be uninitialized
         foo.apply(hdr.f1, hdr.f1);
                           ^^^^^^
+issue1937.p4(14): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr
+        foo.apply(hdr.f1, hdr.f1);
+                          ^^^
+issue1937.p4(14): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr
+        foo.apply(hdr.f1, hdr.f1);
+                  ^^^
+issue1937.p4(15): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr
+        foo.apply(hdr.f2);
+                  ^^^

--- a/testdata/p4_16_samples_outputs/issue2148.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2148.p4-stderr
@@ -1,3 +1,6 @@
+issue2148.p4(19): [--Wwarn=invalid_header] warning: accessing a field of an invalid header not_initialized
+    if (not_initialized.a < 6) {
+        ^^^^^^^^^^^^^^^
 issue2148.p4(19): [--Wwarn=uninitialized_use] warning: not_initialized.a may be uninitialized
     if (not_initialized.a < 6) {
         ^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue2344.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2344.p4-stderr
@@ -1,9 +1,21 @@
+issue2344.p4(19): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp1
+    if (tmp1.a != 10) {
+        ^^^^
 issue2344.p4(19): [--Wwarn=uninitialized_use] warning: tmp1.a may be uninitialized
     if (tmp1.a != 10) {
         ^^^^^^
+issue2344.p4(20): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp1
+        tmp1.a = tmp1.a + 10;
+        ^^^^
+issue2344.p4(20): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp1
+        tmp1.a = tmp1.a + 10;
+                 ^^^^
 issue2344.p4(20): [--Wwarn=uninitialized_use] warning: tmp1.a may be uninitialized
         tmp1.a = tmp1.a + 10;
                  ^^^^^^
+issue2344.p4(22): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp1
+    return tmp1.a;
+           ^^^^
 issue2344.p4(22): [--Wwarn=uninitialized_use] warning: tmp1.a may be uninitialized
     return tmp1.a;
            ^^^^^^

--- a/testdata/p4_16_samples_outputs/issue2583_simplify_slice.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2583_simplify_slice.p4-stderr
@@ -1,0 +1,21 @@
+issue2583_simplify_slice.p4(26): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        h.data = 0;
+        ^
+issue2583_simplify_slice.p4(27): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        h.data[3:0] = 2; // skipped
+        ^
+issue2583_simplify_slice.p4(29): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        h.data = 7;
+        ^
+issue2583_simplify_slice.p4(30): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        h.data[7:0] = 4; // skipped
+        ^
+issue2583_simplify_slice.p4(31): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        h.data[7:0] = 3; // skipped
+        ^
+issue2583_simplify_slice.p4(32): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        h.data[15:0] = 8; // stays
+        ^
+issue2583_simplify_slice.p4(33): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        h.data[31:16] = 5; // stays
+        ^

--- a/testdata/p4_16_samples_outputs/issue383-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2.p4-stderr
@@ -1,0 +1,6 @@
+issue383-bmv2.p4(97): [--Wwarn=invalid_header] warning: accessing a field of an invalid header bh
+        bh.row.alt0.valid = h.bvh0.row.alt0.valid;
+        ^^
+issue383-bmv2.p4(102): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s.col.bvh
+        s.col.bvh.row.alt0.valid = 0;
+        ^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4-stderr
@@ -1,0 +1,3 @@
+psa-table-hit-miss.p4(62): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.ethernet
+            hdr.ethernet.srcAddr : exact;
+            ^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/uninit.p4-stderr
+++ b/testdata/p4_16_samples_outputs/uninit.p4-stderr
@@ -25,6 +25,24 @@ uninit.p4(42): [--Wwarn=uninitialized_use] warning: stack[1] may not be complete
 uninit.p4(62): [--Wwarn=uninitialized_use] warning: c may be uninitialized
         c = !c; // uninitialized;
              ^
+uninit.p4(34): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        h.data1 = 0;
+        ^
+uninit.p4(36): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        g(h.data2, g(h.data2, h.data2)); // uninitialized
+          ^
+uninit.p4(36): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        g(h.data2, g(h.data2, h.data2)); // uninitialized
+                              ^
+uninit.p4(36): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        g(h.data2, g(h.data2, h.data2)); // uninitialized
+                     ^
+uninit.p4(41): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        h.data2 = h.data3 + 1; // uninitialized
+        ^
+uninit.p4(41): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        h.data2 = h.data3 + 1; // uninitialized
+                  ^
 uninit.p4(82): [--Wwarn=uninitialized_use] warning: b may be uninitialized
         b = b + 1; // uninitialized
             ^


### PR DESCRIPTION
Fix #2784 
This improves the FindUninitialized pass to report warnings on accessing fields of invalid headers. Currently, the warnings are reported only for headers and header fields of structs, but not for header stacks and header unions.

According to the specification, in the following cases headers become valid:

 - calling the setValid method of a header
 - calling the extract extern method of the packet_in type
 - initialization with a list expression
 - initialization with some valid header

In the following cases headers become invalid:

 - calling the setInvalid method of a header
 - initialization with some invalid header

During visiting of the statements in the program, the current values of header valid bits are stored in a map, which is updated each time some of these cases are encountered. When encountering if and switch statements, each branch is entered with the same information that the pass had until that point, and at the end of these statements, the common part of all branches is taken.

Currently, the conditions of if statements are not processed. The pass is visiting each branch with the information that it had until that point. This can lead to giving some false warnings in the situation where there are calls to the isValid method in the condition. For example, the following snippet of code would give warnings for every access to hdr fields in the if block, even though the header hdr is guaranteed to be valid inside the if block.

    hdr.setInvalid();
    if (hdr.isValid()) {   
      // read some hdr fields here   
    }
The expression in the condition can become more complex by adding &&, || and !. So to prevent giving false warnings in this situation, each time isValid call is encountered, that header is temporarily put in a set of 'not-to-report' headers until the end of the block or until that header is again explicitly set to valid or invalid inside that block.
