### PR TITLE
DPDK backend: Handle custom values for PSA_Meter_t enum

### DIFF
--- a/backends/dpdk/midend.cpp
+++ b/backends/dpdk/midend.cpp
@@ -71,6 +71,18 @@ class EnumOn32Bits : public P4::ChooseEnumRepresentation {
     bool convert(const IR::Type_Enum *) const override {
         return true;
     }
+
+    /* This function assigns DPDK target compatible values to the enums */
+    unsigned encoding(const IR::Type_Enum *type, unsigned n) const override {
+        if (type->name == "PSA_MeterColor_t") {
+           /* DPDK target assumes the following values for Meter colors
+              (Green: 0, Yellow: 1, Red: 2)
+              For PSA, the default values are  RED: 0, Green: 1, Yellow: 2 */
+            return (n + 2) % 3;
+        }
+        return n;
+    }
+
     unsigned enumSize(unsigned) const override { return 32; }
  public:
     EnumOn32Bits() {}

--- a/midend/convertEnums.cpp
+++ b/midend/convertEnums.cpp
@@ -42,11 +42,13 @@ const IR::Node* DoConvertEnums::postorder(IR::Member* expression) {
     if (!ei)
         return expression;
     if (ei->is<SimpleEnumInstance>()) {
-        auto r = ::get(repr, ei->type->to<IR::Type_Enum>());
+        auto type = ei->type->to<IR::Type_Enum>();
+        auto r = ::get(repr, type);
         if (r == nullptr)
             return expression;
         unsigned value = r->get(ei->name.name);
-        auto cst = new IR::Constant(expression->srcInfo, r->type, value);
+        unsigned encoded_value = policy->encoding(type, value);
+        auto cst = new IR::Constant(expression->srcInfo, r->type, encoded_value);
         return cst;
     }
     return expression;

--- a/midend/convertEnums.h
+++ b/midend/convertEnums.h
@@ -31,6 +31,9 @@ class ChooseEnumRepresentation {
     virtual ~ChooseEnumRepresentation() {}
     // If true this type has to be converted.
     virtual bool convert(const IR::Type_Enum* type) const = 0;
+    // Returns the value to be assigned to the enum Constant.
+    // Maps to the index of member in the enum by default.
+    virtual unsigned encoding(const IR::Type_Enum *, unsigned n) const { return n; }
     // enumCount is the number of different enum values.
     // The returned value is the width of Type_Bits used
     // to represent the enum.  Obviously, we must have

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
@@ -104,7 +104,7 @@ action NoAction args none {
 
 action execute args instanceof execute_arg_t {
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in_0 m.Ingress_color_out_0
-	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x1
+	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x0
 	mov m.Ingress_tmp 0x1
 	jmp LABEL_1END
 	LABEL_1FALSE :	mov m.Ingress_tmp 0x0
@@ -133,7 +133,7 @@ apply {
 	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in_0 0x0
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in_0 0x2
 	jmpneq LABEL_0END m.local_metadata_port_out 0x1
 	table tbl
 	regadd counter0_0_packets 0x3ff 1

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
@@ -90,7 +90,7 @@ action NoAction args none {
 
 action execute args instanceof execute_arg_t {
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in_0 m.Ingress_color_out_0
-	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x1
+	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x0
 	mov m.Ingress_tmp 0x1
 	jmp LABEL_1END
 	LABEL_1FALSE :	mov m.Ingress_tmp 0x0
@@ -118,7 +118,7 @@ apply {
 	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in_0 0x0
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in_0 0x2
 	jmpneq LABEL_0END m.local_metadata_port_out 0x1
 	table tbl
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
@@ -90,7 +90,7 @@ action NoAction args none {
 
 action execute args instanceof execute_arg_t {
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in_0 m.Ingress_color_out_0
-	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x1
+	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x0
 	mov m.Ingress_tmp 0x1
 	jmp LABEL_1END
 	LABEL_1FALSE :	mov m.Ingress_tmp 0x0
@@ -118,7 +118,7 @@ apply {
 	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in_0 0x0
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in_0 0x2
 	jmpneq LABEL_0END m.local_metadata_port_out 0x1
 	table tbl
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0


### PR DESCRIPTION
This PR is to fix the issue mentioned in https://github.com/p4lang/p4c/issues/2874

The changes include
1) Improving the convertEnums midend pass to allow custom encoding of the enum constants by the backends. 
2) Customizing the enum values in the DPDK backend to emit DPDK compatible meter color values
PSA Meter color values are `RED = 0, GREEN = 1, YELLOW = 2 `and DPDK target implementation has the 
following meter color enum values `GREEN = 0, YELLOW = 1,  RED = 2`
3) Reference outputs updated