### PR TITLE
Remove colors from error messages when redirected to a file

### DIFF
--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -39,7 +39,7 @@ inline bool is_cerr_redirected() {
 
 /// Function used to delete color in case of cerr output being redirected
 inline const char *cerr_colorize(const char *color) {
-    if(is_cerr_redirected()){
+    if (is_cerr_redirected()) {
         return "";
     }
     return color;
@@ -47,7 +47,7 @@ inline const char *cerr_colorize(const char *color) {
 
 /// Used to clear colors on terminal
 inline const char *cerr_clear_colors() {
-    if(is_cerr_redirected()){
+    if (is_cerr_redirected()) {
         return "";
     }
     return ANSI_CLR;

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -20,6 +20,7 @@ limitations under the License.
 #define _LIB_EXCEPTIONS_H_
 
 #include <exception>
+#include <unistd.h>
 #include "lib/error_helper.h"
 
 namespace Util {
@@ -28,6 +29,7 @@ namespace Util {
 constexpr char ANSI_RED[]  = "\e[31m";
 constexpr char ANSI_BLUE[] = "\e[34m";
 constexpr char ANSI_CLR[]  = "\e[0m";
+
 
 /// Base class for all exceptions.
 /// The constructor uses boost::format for the format string, i.e.,
@@ -54,13 +56,24 @@ class CompilerBug final : public P4CExceptionBase {
  public:
     template <typename... T>
     CompilerBug(const char* format, T... args)
-            : P4CExceptionBase(format, args...)
-    { message = cstring(ANSI_RED) + "Compiler Bug" + ANSI_CLR + ":\n" + message; }
+            : P4CExceptionBase(format, args...) { 
+        // Check if output is redirected and if so, then don't color text so that
+        // escape characters are not present
+        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr; 
+        message = (isCerrRedirected ? "" : cstring(ANSI_RED)) + "Compiler Bug" 
+                + (isCerrRedirected ? "" : ANSI_CLR) + ":\n" + message; 
+    }
+
     template <typename... T>
     CompilerBug(int line, const char* file, const char* format, T... args)
-            : P4CExceptionBase(format, args...)
-    { message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
-                + ANSI_RED + "Compiler Bug" + ANSI_CLR + ": " + message; }
+            : P4CExceptionBase(format, args...) {
+        // Check if output is redirected and if so, then don't color text so that
+        // escape characters are not present
+        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr; 
+        message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
+                + (isCerrRedirected ? "" : ANSI_RED) + "Compiler Bug" 
+                + (isCerrRedirected ? "" : ANSI_CLR) + ": " + message; 
+    }
 };
 
 /// This class indicates an unimplemented feature in the compiler
@@ -68,13 +81,22 @@ class CompilerUnimplemented final : public P4CExceptionBase {
  public:
     template <typename... T>
     CompilerUnimplemented(const char* format, T... args)
-            : P4CExceptionBase(format, args...)
-    { message = cstring(ANSI_BLUE) +"Not yet implemented"+ ANSI_CLR + ":\n" + message; }
+            : P4CExceptionBase(format, args...) { 
+        // Do not add colors when redirecting to stderr
+        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;
+        message = (isCerrRedirected ? "" : cstring(ANSI_BLUE)) + "Not yet implemented"
+                + (isCerrRedirected ? "" : ANSI_CLR) + ":\n" + message; 
+    }
+    
     template <typename... T>
     CompilerUnimplemented(int line, const char* file, const char* format, T... args)
-            : P4CExceptionBase(format, args...)
-    { message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
-                ANSI_BLUE + "Unimplemented compiler support" + ANSI_CLR + ": " + message; }
+            : P4CExceptionBase(format, args...) {
+        // Do not add colors when redirecting to stderr
+        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;
+        message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" 
+                + (isCerrRedirected ? "" : ANSI_BLUE) + "Unimplemented compiler support" 
+                + (isCerrRedirected ? "" : ANSI_CLR) + ": " + message; 
+    }
 };
 
 

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -30,6 +30,10 @@ constexpr char ANSI_RED[]  = "\e[31m";
 constexpr char ANSI_BLUE[] = "\e[34m";
 constexpr char ANSI_CLR[]  = "\e[0m";
 
+/// Checks if stderr is redirected to a file
+bool is_cerr_redirected() {
+    return ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
+}
 
 /// Base class for all exceptions.
 /// The constructor uses boost::format for the format string, i.e.,
@@ -59,20 +63,16 @@ class CompilerBug final : public P4CExceptionBase {
             : P4CExceptionBase(format, args...) {
         // Check if output is redirected and if so, then don't color text so that
         // escape characters are not present
-        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
-        message = (isCerrRedirected ? "" : cstring(ANSI_RED)) + "Compiler Bug"
-                + (isCerrRedirected ? "" : ANSI_CLR) + ":\n" + message;
+        message = (is_cerr_redirected() ? "" : cstring(ANSI_RED)) + "Compiler Bug"
+                + (is_cerr_redirected() ? "" : ANSI_CLR) + ":\n" + message;
     }
 
     template <typename... T>
     CompilerBug(int line, const char* file, const char* format, T... args)
             : P4CExceptionBase(format, args...) {
-        // Check if output is redirected and if so, then don't color text so that
-        // escape characters are not present
-        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
         message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
-                + (isCerrRedirected ? "" : ANSI_RED) + "Compiler Bug"
-                + (isCerrRedirected ? "" : ANSI_CLR) + ": " + message;
+                + (is_cerr_redirected() ? "" : ANSI_RED) + "Compiler Bug"
+                + (is_cerr_redirected() ? "" : ANSI_CLR) + ": " + message;
     }
 };
 
@@ -83,19 +83,16 @@ class CompilerUnimplemented final : public P4CExceptionBase {
     CompilerUnimplemented(const char* format, T... args)
             : P4CExceptionBase(format, args...) {
         // Do not add colors when redirecting to stderr
-        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
-        message = (isCerrRedirected ? "" : cstring(ANSI_BLUE)) + "Not yet implemented"
-                + (isCerrRedirected ? "" : ANSI_CLR) + ":\n" + message;
+        message = (is_cerr_redirected() ? "" : cstring(ANSI_BLUE)) + "Not yet implemented"
+                + (is_cerr_redirected() ? "" : ANSI_CLR) + ":\n" + message;
     }
 
     template <typename... T>
     CompilerUnimplemented(int line, const char* file, const char* format, T... args)
             : P4CExceptionBase(format, args...) {
-        // Do not add colors when redirecting to stderr
-        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
         message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n"
-                + (isCerrRedirected ? "" : ANSI_BLUE) + "Unimplemented compiler support"
-                + (isCerrRedirected ? "" : ANSI_CLR) + ": " + message;
+                + (is_cerr_redirected() ? "" : ANSI_BLUE) + "Unimplemented compiler support"
+                + (is_cerr_redirected() ? "" : ANSI_CLR) + ": " + message;
     }
 };
 

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -19,8 +19,8 @@ limitations under the License.
 #ifndef _LIB_EXCEPTIONS_H_
 #define _LIB_EXCEPTIONS_H_
 
-#include <exception>
 #include <unistd.h>
+#include <exception>
 #include "lib/error_helper.h"
 
 namespace Util {
@@ -56,12 +56,12 @@ class CompilerBug final : public P4CExceptionBase {
  public:
     template <typename... T>
     CompilerBug(const char* format, T... args)
-            : P4CExceptionBase(format, args...) { 
+            : P4CExceptionBase(format, args...) {
         // Check if output is redirected and if so, then don't color text so that
         // escape characters are not present
-        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr; 
-        message = (isCerrRedirected ? "" : cstring(ANSI_RED)) + "Compiler Bug" 
-                + (isCerrRedirected ? "" : ANSI_CLR) + ":\n" + message; 
+        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
+        message = (isCerrRedirected ? "" : cstring(ANSI_RED)) + "Compiler Bug"
+                + (isCerrRedirected ? "" : ANSI_CLR) + ":\n" + message;
     }
 
     template <typename... T>
@@ -69,10 +69,10 @@ class CompilerBug final : public P4CExceptionBase {
             : P4CExceptionBase(format, args...) {
         // Check if output is redirected and if so, then don't color text so that
         // escape characters are not present
-        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr; 
+        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
         message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
-                + (isCerrRedirected ? "" : ANSI_RED) + "Compiler Bug" 
-                + (isCerrRedirected ? "" : ANSI_CLR) + ": " + message; 
+                + (isCerrRedirected ? "" : ANSI_RED) + "Compiler Bug"
+                + (isCerrRedirected ? "" : ANSI_CLR) + ": " + message;
     }
 };
 
@@ -81,21 +81,21 @@ class CompilerUnimplemented final : public P4CExceptionBase {
  public:
     template <typename... T>
     CompilerUnimplemented(const char* format, T... args)
-            : P4CExceptionBase(format, args...) { 
+            : P4CExceptionBase(format, args...) {
         // Do not add colors when redirecting to stderr
-        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;
+        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
         message = (isCerrRedirected ? "" : cstring(ANSI_BLUE)) + "Not yet implemented"
-                + (isCerrRedirected ? "" : ANSI_CLR) + ":\n" + message; 
+                + (isCerrRedirected ? "" : ANSI_CLR) + ":\n" + message;
     }
-    
+
     template <typename... T>
     CompilerUnimplemented(int line, const char* file, const char* format, T... args)
             : P4CExceptionBase(format, args...) {
         // Do not add colors when redirecting to stderr
-        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;
-        message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" 
-                + (isCerrRedirected ? "" : ANSI_BLUE) + "Unimplemented compiler support" 
-                + (isCerrRedirected ? "" : ANSI_CLR) + ": " + message; 
+        const bool isCerrRedirected = ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
+        message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n"
+                + (isCerrRedirected ? "" : ANSI_BLUE) + "Unimplemented compiler support"
+                + (isCerrRedirected ? "" : ANSI_CLR) + ": " + message;
     }
 };
 

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -31,7 +31,7 @@ constexpr char ANSI_BLUE[] = "\e[34m";
 constexpr char ANSI_CLR[]  = "\e[0m";
 
 /// Checks if stderr is redirected to a file
-bool is_cerr_redirected() {
+inline bool is_cerr_redirected() {
     return ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
 }
 

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -33,7 +33,12 @@ constexpr char ANSI_CLR[]  = "\e[0m";
 /// Checks if stderr is redirected to a file
 /// Check is done only once and then saved to a static variable
 inline bool is_cerr_redirected() {
-    static bool is_redir = ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
+    static bool initialized(false);
+    static bool is_redir;
+    if (!initialized) {
+        initialized = true;
+        is_redir = ttyname(fileno(stderr)) == nullptr;  // NOLINT(runtime/threadsafe_fn)
+    }
     return is_redir;
 }
 

--- a/test/gtest/exception_test.cpp
+++ b/test/gtest/exception_test.cpp
@@ -30,7 +30,7 @@ TEST(UtilException, Messages) {
         cstring err(ex.what());
         cstring redir_msg("Compiler Bug:\ntest\n");
         cstring no_redir_msg = cstring(ANSI_RED) + "Compiler Bug" + ANSI_CLR +":\ntest\n";
-        // The error message might or might not be colorized based on if the test are redirected 
+        // The error message might or might not be colorized based on if the test are redirected
         // or not, to make sure both options are valid an array is used.
         bool is_content_correct = (err == redir_msg) || (err == no_redir_msg);
         EXPECT_EQ(is_content_correct, true);

--- a/test/gtest/exception_test.cpp
+++ b/test/gtest/exception_test.cpp
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <unistd.h>
 #include <exception>
 
 #include "gtest/gtest.h"

--- a/test/gtest/exception_test.cpp
+++ b/test/gtest/exception_test.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 #include <unistd.h>
 #include <exception>
 
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
@@ -32,10 +31,10 @@ TEST(UtilException, Messages) {
         cstring err(ex.what());
         cstring redir_msg("Compiler Bug:\ntest\n");
         cstring no_redir_msg = cstring(ANSI_RED) + "Compiler Bug" + ANSI_CLR +":\ntest\n";
-        cstring opts[] = {redir_msg, no_redir_msg};
         // The error message might or might not be colorized based on if the test are redirected 
         // or not, to make sure both options are valid an array is used.
-        EXPECT_THAT(opts, ::testing::Contains(err));
+        bool is_content_correct = (err == redir_msg) || (err == no_redir_msg);
+        EXPECT_EQ(is_content_correct, true);
     }
 
     try {

--- a/test/gtest/exception_test.cpp
+++ b/test/gtest/exception_test.cpp
@@ -14,8 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <unistd.h>
 #include <exception>
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
@@ -28,8 +30,12 @@ TEST(UtilException, Messages) {
         throw CompilerBug("test");
     } catch (std::exception &ex) {
         cstring err(ex.what());
-        cstring expected = cstring(ANSI_RED) + "Compiler Bug" + ANSI_CLR +":\ntest\n";
-        EXPECT_EQ(expected, err);
+        cstring redir_msg("Compiler Bug:\ntest\n");
+        cstring no_redir_msg = cstring(ANSI_RED) + "Compiler Bug" + ANSI_CLR +":\ntest\n";
+        cstring opts[] = {redir_msg, no_redir_msg};
+        // The error message might or might not be colorized based on if the test are redirected 
+        // or not, to make sure both options are valid an array is used.
+        EXPECT_THAT(opts, ::testing::Contains(err));
     }
 
     try {


### PR DESCRIPTION
This change makes sure that no escape characters for terminal colorizations are present in error logs when standard error output is redirected to a file.