### PR TITLE
dpdk: export egress tables and actions

### DIFF
--- a/backends/dpdk/dpdkProgram.cpp
+++ b/backends/dpdk/dpdkProgram.cpp
@@ -170,9 +170,17 @@ const IR::DpdkAsmProgram *ConvertToDpdkProgram::create(IR::P4Program *prog) {
         dpdkExternDecls.push_back(st);
     }
 
+    auto tables = ingress_converter->getTables();
+    tables.append(egress_converter->getTables());
+
+    auto actions = ingress_converter->getActions();
+    actions.append(egress_converter->getActions());
+
+    auto selectors = ingress_converter->getSelectors();
+    selectors.append(egress_converter->getSelectors());
+
     return new IR::DpdkAsmProgram(
-        headerType, structType, dpdkExternDecls, ingress_converter->getActions(),
-        ingress_converter->getTables(), ingress_converter->getSelectors(),
+        headerType, structType, dpdkExternDecls, actions, tables, selectors,
         statements, structure->get_globals());
 }
 

--- a/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-4.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-4.p4
@@ -1,0 +1,168 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    apply { }
+}
+// END:Parse_Error_Example
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            user_meta.data : exact;
+            8w0x48 : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+// BEGIN:Compute_New_IPv4_Checksum_Example
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+// END:Compute_New_IPv4_Checksum_Example
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.spec
@@ -1,0 +1,148 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<4> dataOffset
+	bit<3> res
+	bit<3> ecn
+	bit<6> ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct metadata {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+	bit<8> Egress_key_0
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.local_metadata_data exact
+		m.Egress_key_0 exact
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq EGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq EGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp EGRESSPARSERIMPL_ACCEPT
+	EGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq EGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp EGRESSPARSERIMPL_ACCEPT
+	EGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	EGRESSPARSERIMPL_ACCEPT :	mov m.Egress_key_0 0x48
+	table tbl
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP : drop
+}
+
+


### PR DESCRIPTION
This commit appends tables and actions from the egress pipeline to be included in the output spec file.

Fixes: #2893