### PR TITLE
DPDK Backend: Fix verify statement support and few other minor issues

### DIFF
--- a/backends/dpdk/dpdk.def
+++ b/backends/dpdk/dpdk.def
@@ -460,8 +460,8 @@ class DpdkGetChecksumStatement: DpdkAsmStatement, IDPDKNode {
 }
 
 class DpdkCastStatement: DpdkAsmStatement, IDPDKNode {
-    Expression src;
     Expression dst;
+    Expression src;
     Type type;
     std::ostream& toSpec(std::ostream& out) const override;
 #nodbprint

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -435,8 +435,8 @@ bool ExpressionUnroll::preorder(const IR::Operation_Unary *u) {
             un_expr = new IR::Cmpl(root);
         } else if (u->to<IR::LNot>()) {
             un_expr = new IR::LNot(root);
-        } else if (u->to<IR::Cast>()) {
-            un_expr = new IR::Cast(u->type, root);
+        } else if (auto c = u->to<IR::Cast>()) {
+            un_expr = new IR::Cast(c->destType, root);
         } else {
             std::cout << u->node_type_name() << std::endl;
             BUG("Not Implemented");
@@ -957,7 +957,7 @@ const IR::Node* CopyMatchKeysToSingleStruct::preorder(IR::Key* keys) {
         // This prune will prevent the postorder(IR::KeyElement*) below from executing
         prune();
     } else {
-        ::warning(ErrorType::WARN_UNSUPPORTED, "Mismatched header/metadata struct for key "
+        ::warning(ErrorType::WARN_MISMATCH, "Mismatched header/metadata struct for key "
                   "elements in table %1%. Copying all match fields to metadata",
                    findOrigCtxt<IR::P4Table>()->name.toString());
         LOG3("Will pull out " << keys);

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -21,15 +21,6 @@ namespace DPDK {
 
 int ConvertStatementToDpdk::next_label_id = 0;
 
-IR::Declaration_Variable *ConvertStatementToDpdk::addNewTmpVarToMetadata(cstring name,
-                                                                         const IR::Type* type) {
-    auto newTmpVar =  new IR::Declaration_Variable(IR::ID(
-                                                   refmap->newName(name)), type);
-    metadataStruct->fields.push_back(new IR::StructField(IR::ID
-                                     (newTmpVar->name.name), newTmpVar->type));
-    return newTmpVar;
-}
-
 // convert relation comparison statements into the corresponding branching
 // instructions in dpdk.
 void ConvertStatementToDpdk::process_relation_operation(const IR::Expression* dst,
@@ -628,16 +619,13 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                 ::error("%1%: must be one of the existing errors", s);
             auto error_id = structure->error_map.at(error->expression->to<IR::Member>()->member);
             auto end_label = Util::printf_format("label_%dend", next_label_id++);
-            if (condition->expression->is<IR::BoolLiteral>()) {
-                auto tmpDecl = addNewTmpVarToMetadata("tmpVerify", condition->expression->type);
-                auto tmpVerify = new IR::PathExpression(IR::ID("m." + tmpDecl->name.name));
-                add_instr(new IR::DpdkMovStatement(tmpVerify, condition->expression));
-                add_instr(new IR::DpdkJmpNotEqualStatement(end_label, tmpVerify,
-                                                           new IR::BoolLiteral(false)));
-            } else {
+            const IR::BoolLiteral *boolLiteral = condition->expression->to<IR::BoolLiteral>();
+            if (!boolLiteral) {
                 add_instr(new IR::DpdkJmpNotEqualStatement(
                             end_label,
                             condition->expression, new IR::BoolLiteral(false)));
+            } else if (boolLiteral->value == true) {
+                return false;
             }
             auto tmp = new IR::PathExpression(
                                    IR::ID("m.psa_ingress_input_metadata_parser_error"));
@@ -680,7 +668,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
             BUG("%1% function not implemented.", s);
         }
     } else if (auto a = mi->to<P4::ActionCall>()) {
-        auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure, nullptr);
+        auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure);
         a->action->body->apply(*helper);
         for (auto i : helper->get_instr()) {
             add_instr(i);

--- a/backends/dpdk/dpdkHelpers.h
+++ b/backends/dpdk/dpdkHelpers.h
@@ -127,12 +127,13 @@ class ConvertStatementToDpdk : public Inspector {
     P4::ReferenceMap *refmap;
     DpdkProgramStructure *structure;
     const IR::P4Parser *parser = nullptr;
+    IR::Type_Struct *metadataStruct;
 
   public:
     ConvertStatementToDpdk(
         P4::ReferenceMap *refmap, P4::TypeMap *typemap,
-        DpdkProgramStructure *structure)
-        : typemap(typemap), refmap(refmap), structure(structure) {}
+        DpdkProgramStructure *structure, IR::Type_Struct *metadataStruct)
+        : typemap(typemap), refmap(refmap), structure(structure), metadataStruct(metadataStruct) {}
     IR::IndexedVector<IR::DpdkAsmStatement> getInstructions() {
         return instructions;
     }
@@ -142,6 +143,7 @@ class ConvertStatementToDpdk : public Inspector {
     bool preorder(const IR::IfStatement *a) override;
     bool preorder(const IR::MethodCallStatement *a) override;
     bool preorder(const IR::SwitchStatement* a) override;
+    IR::Declaration_Variable *addNewTmpVarToMetadata (cstring name, const IR::Type* type);
 
     void add_instr(const IR::DpdkAsmStatement *s) { instructions.push_back(s); }
     IR::IndexedVector<IR::DpdkAsmStatement> &get_instr() { return instructions; }

--- a/backends/dpdk/dpdkHelpers.h
+++ b/backends/dpdk/dpdkHelpers.h
@@ -127,13 +127,12 @@ class ConvertStatementToDpdk : public Inspector {
     P4::ReferenceMap *refmap;
     DpdkProgramStructure *structure;
     const IR::P4Parser *parser = nullptr;
-    IR::Type_Struct *metadataStruct;
 
   public:
     ConvertStatementToDpdk(
         P4::ReferenceMap *refmap, P4::TypeMap *typemap,
-        DpdkProgramStructure *structure, IR::Type_Struct *metadataStruct)
-        : typemap(typemap), refmap(refmap), structure(structure), metadataStruct(metadataStruct) {}
+        DpdkProgramStructure *structure)
+        : typemap(typemap), refmap(refmap), structure(structure) {}
     IR::IndexedVector<IR::DpdkAsmStatement> getInstructions() {
         return instructions;
     }
@@ -143,7 +142,6 @@ class ConvertStatementToDpdk : public Inspector {
     bool preorder(const IR::IfStatement *a) override;
     bool preorder(const IR::MethodCallStatement *a) override;
     bool preorder(const IR::SwitchStatement* a) override;
-    IR::Declaration_Variable *addNewTmpVarToMetadata (cstring name, const IR::Type* type);
 
     void add_instr(const IR::DpdkAsmStatement *s) { instructions.push_back(s); }
     IR::IndexedVector<IR::DpdkAsmStatement> &get_instr() { return instructions; }

--- a/backends/dpdk/dpdkProgram.cpp
+++ b/backends/dpdk/dpdkProgram.cpp
@@ -357,7 +357,7 @@ bool ConvertToDpdkParser::preorder(const IR::P4Parser *p) {
             add_instr(i);
         auto c = state->components;
         for (auto stat : c) {
-            DPDK::ConvertStatementToDpdk h(refmap, typemap, structure, metadataStruct);
+            DPDK::ConvertStatementToDpdk h(refmap, typemap, structure);
             h.set_parser(p);
             stat->apply(h);
             for (auto i : h.get_instr())
@@ -476,7 +476,7 @@ bool ConvertToDpdkParser::preorder(const IR::ParserState *) { return false; }
 
 // =====================Control=============================
 bool ConvertToDpdkControl::preorder(const IR::P4Action *a) {
-    auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure, nullptr);
+    auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure);
     a->body->apply(*helper);
     auto stmt_list = new IR::IndexedVector<IR::DpdkAsmStatement>();
     for (auto i : helper->get_instr())
@@ -611,7 +611,7 @@ bool ConvertToDpdkControl::preorder(const IR::P4Control *c) {
             structure->push_variable(new IR::DpdkDeclaration(l));
         }
     }
-    auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure, nullptr);
+    auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure);
     c->body->apply(*helper);
     if (deparser) {
         add_inst(new IR::DpdkJmpNotEqualStatement("LABEL_DROP",

--- a/backends/dpdk/spec.cpp
+++ b/backends/dpdk/spec.cpp
@@ -545,9 +545,7 @@ std::ostream &IR::DpdkGetChecksumStatement::toSpec(std::ostream &out) const {
 }
 
 std::ostream &IR::DpdkCastStatement::toSpec(std::ostream &out) const {
-    out << "cast "
-        << " " << DPDK::toStr(dst) << " " << DPDK::toStr(type) << " "
-        << DPDK::toStr(src);
+    out << "mov " << " " << DPDK::toStr(dst) << " " << DPDK::toStr(src);
     return out;
 }
 

--- a/backends/dpdk/spec.cpp
+++ b/backends/dpdk/spec.cpp
@@ -545,7 +545,7 @@ std::ostream &IR::DpdkGetChecksumStatement::toSpec(std::ostream &out) const {
 }
 
 std::ostream &IR::DpdkCastStatement::toSpec(std::ostream &out) const {
-    out << "mov " << " " << DPDK::toStr(dst) << " " << DPDK::toStr(src);
+    out << "mov " << DPDK::toStr(dst) << " " << DPDK::toStr(src);
     return out;
 }
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1.p4.spec
@@ -126,7 +126,7 @@ apply {
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3.p4.spec
@@ -166,7 +166,7 @@ apply {
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-action-profile4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4.p4.spec
@@ -164,7 +164,7 @@ apply {
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1.p4.spec
@@ -140,7 +140,7 @@ apply {
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4.spec
@@ -142,7 +142,7 @@ apply {
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4-error
@@ -1,1 +1,1 @@
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4.spec
@@ -106,7 +106,7 @@ apply {
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-action-selector4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector4.p4.spec
@@ -174,7 +174,7 @@ apply {
 	LABEL_9END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
@@ -79,7 +79,7 @@ apply {
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
@@ -79,14 +79,14 @@ apply {
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_egress_port
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
@@ -79,7 +79,7 @@ apply {
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
+	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.spec
@@ -99,7 +99,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4.spec
@@ -88,7 +88,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4.spec
@@ -92,7 +92,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4.spec
@@ -69,7 +69,7 @@ apply {
 	regadd counter0_0 0x400 1
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4.spec
@@ -80,7 +80,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.spec
@@ -88,7 +88,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4-error
@@ -1,1 +1,1 @@
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.spec
@@ -144,7 +144,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4-error
@@ -7,4 +7,4 @@ psa-dpdk-lpm-match-err5.p4(99): [--Wwarn=ignore-prop] warning: KeyElement: const
 psa-dpdk-lpm-match-err5.p4(99): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
             8w0x3648 : exact;
             ^^^^^^^^
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.spec
@@ -147,7 +147,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.spec
@@ -140,7 +140,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4-error
@@ -1,2 +1,2 @@
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table foo. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table foo. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.spec
@@ -202,7 +202,7 @@ apply {
 	LABEL_3END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4-error
@@ -1,1 +1,1 @@
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.spec
@@ -184,7 +184,7 @@ apply {
 	LABEL_3END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4-error
@@ -4,4 +4,4 @@ psa-dpdk-table-key-consolidation-mixed-keys-1.p4(96): [--Wwarn=ignore-prop] warn
 psa-dpdk-table-key-consolidation-mixed-keys-1.p4(96): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
             8w0x48 : exact;
             ^^^^^^
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.spec
@@ -148,7 +148,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4-error
@@ -4,4 +4,4 @@ psa-dpdk-table-key-consolidation-mixed-keys-2.p4(98): [--Wwarn=ignore-prop] warn
 psa-dpdk-table-key-consolidation-mixed-keys-2.p4(98): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
             8w0x48 : exact;
             ^^^^^^
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.spec
@@ -147,7 +147,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
@@ -142,7 +142,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.spec
@@ -142,7 +142,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4-error
@@ -4,4 +4,4 @@ psa-dpdk-table-key-consolidation-mixed-keys.p4(99): [--Wwarn=ignore-prop] warnin
 psa-dpdk-table-key-consolidation-mixed-keys.p4(99): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
             8w0x48 : exact;
             ^^^^^^
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.spec
@@ -148,7 +148,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4-error
@@ -1,1 +1,1 @@
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
@@ -149,7 +149,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4-error
@@ -1,1 +1,1 @@
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
@@ -160,7 +160,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4-error
@@ -1,1 +1,1 @@
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
@@ -171,7 +171,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4-error
@@ -1,1 +1,1 @@
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
@@ -171,7 +171,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4-error
@@ -1,1 +1,1 @@
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
@@ -154,7 +154,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4-error
@@ -1,1 +1,1 @@
-[--Wwarn=unsupported] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
@@ -165,7 +165,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4.spec
@@ -85,7 +85,7 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4.spec
@@ -87,7 +87,7 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
@@ -68,7 +68,7 @@ apply {
 	jmp LABEL_0END
 	LABEL_0FALSE :	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
@@ -68,7 +68,7 @@ apply {
 	jmp LABEL_0END
 	LABEL_0FALSE :	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
+	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
@@ -68,7 +68,7 @@ apply {
 	jmp LABEL_0END
 	LABEL_0FALSE :	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_egress_port
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet
@@ -89,7 +89,7 @@ apply {
 	LABEL_4END :	mov h.ethernet.srcAddr 0xcafe
 	LABEL_1END :	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4.spec
@@ -77,7 +77,7 @@ apply {
 	regadd counter2_0 0x3ff 0x40
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
@@ -145,7 +145,7 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-local-variable.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-local-variable.p4.spec
@@ -63,7 +63,7 @@ apply {
 	mov h.ethernet.etherType 0xff
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
@@ -125,7 +125,7 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
@@ -125,7 +125,7 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit.p4.spec
@@ -201,9 +201,9 @@ apply {
 	validate m.IngressParser_parser_tmp_hdr_0
 	mov m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_1
 	shr m.IngressParser_parser_tmp_2 0x8
-	mov  m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_hdr_0.value
-	mov  m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_hdr_0.len
-	mov  m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_3
+	mov  m.IngressParser_parser_tmp_hdr_0.value m.IngressParser_parser_tmp_2
+	mov  m.IngressParser_parser_tmp_hdr_0.len m.IngressParser_parser_tmp_1
+	mov  m.IngressParser_parser_tmp_3 m.IngressParser_parser_tmp_1
 	mov m.IngressParser_parser_tmp_4 m.IngressParser_parser_tmp_3
 	shl m.IngressParser_parser_tmp_4 0x3
 	mov m.IngressParser_parser_tmp m.IngressParser_parser_tmp_4

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit.p4.spec
@@ -201,9 +201,9 @@ apply {
 	validate m.IngressParser_parser_tmp_hdr_0
 	mov m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_1
 	shr m.IngressParser_parser_tmp_2 0x8
-	mov  m.IngressParser_parser_tmp_hdr_0.value m.IngressParser_parser_tmp_2
-	mov  m.IngressParser_parser_tmp_hdr_0.len m.IngressParser_parser_tmp_1
-	mov  m.IngressParser_parser_tmp_3 m.IngressParser_parser_tmp_1
+	mov m.IngressParser_parser_tmp_hdr_0.value m.IngressParser_parser_tmp_2
+	mov m.IngressParser_parser_tmp_hdr_0.len m.IngressParser_parser_tmp_1
+	mov m.IngressParser_parser_tmp_3 m.IngressParser_parser_tmp_1
 	mov m.IngressParser_parser_tmp_4 m.IngressParser_parser_tmp_3
 	shl m.IngressParser_parser_tmp_4 0x3
 	mov m.IngressParser_parser_tmp m.IngressParser_parser_tmp_4

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit.p4.spec
@@ -87,7 +87,6 @@ struct EMPTY {
 	ipv4_options_t IngressParser_parser_tmp_hdr_0
 	bit<8> IngressParser_parser_tmp_0
 	bit<16> IngressParser_parser_tmp_1
-	bit<8> tmpVerify
 }
 metadata instanceof EMPTY
 
@@ -213,9 +212,7 @@ apply {
 	lookahead m.IngressParser_parser_tmp_0
 	jmpeq MYIP_PARSE_IPV4_OPTION_TIMESTAMP1 m.IngressParser_parser_tmp_0 0x44
 	jmp MYIP_ACCEPT
-	MYIP_PARSE_IPV4_OPTION_TIMESTAMP1 :	mov m.tmpVerify 0
-	jmpneq MYIP_ACCEPT m.tmpVerify 0
-	mov m.psa_ingress_input_metadata_parser_error 0x3
+	MYIP_PARSE_IPV4_OPTION_TIMESTAMP1 :	mov m.psa_ingress_input_metadata_parser_error 0x3
 	MYIP_ACCEPT :	mov m.Ingress_tbl_0_member_id 0x0
 	table tbl
 	table tbl_0_member_table

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit.p4.spec
@@ -87,6 +87,7 @@ struct EMPTY {
 	ipv4_options_t IngressParser_parser_tmp_hdr_0
 	bit<8> IngressParser_parser_tmp_0
 	bit<16> IngressParser_parser_tmp_1
+	bit<8> tmpVerify
 }
 metadata instanceof EMPTY
 
@@ -201,9 +202,9 @@ apply {
 	validate m.IngressParser_parser_tmp_hdr_0
 	mov m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_1
 	shr m.IngressParser_parser_tmp_2 0x8
-	cast  m.IngressParser_parser_tmp_2 bit_8 m.IngressParser_parser_tmp_hdr_0.value
-	cast  m.IngressParser_parser_tmp_1 bit_8 m.IngressParser_parser_tmp_hdr_0.len
-	cast  m.IngressParser_parser_tmp_1 bit_32 m.IngressParser_parser_tmp_3
+	mov  m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_hdr_0.value
+	mov  m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_hdr_0.len
+	mov  m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_3
 	mov m.IngressParser_parser_tmp_4 m.IngressParser_parser_tmp_3
 	shl m.IngressParser_parser_tmp_4 0x3
 	mov m.IngressParser_parser_tmp m.IngressParser_parser_tmp_4
@@ -212,8 +213,9 @@ apply {
 	lookahead m.IngressParser_parser_tmp_0
 	jmpeq MYIP_PARSE_IPV4_OPTION_TIMESTAMP1 m.IngressParser_parser_tmp_0 0x44
 	jmp MYIP_ACCEPT
-	MYIP_PARSE_IPV4_OPTION_TIMESTAMP1 :	jmpeq MYIP_ACCEPT 0 0
-	mov metadata 0x3
+	MYIP_PARSE_IPV4_OPTION_TIMESTAMP1 :	mov m.tmpVerify 0
+	jmpneq MYIP_ACCEPT m.tmpVerify 0
+	mov m.psa_ingress_input_metadata_parser_error 0x3
 	MYIP_ACCEPT :	mov m.Ingress_tbl_0_member_id 0x0
 	table tbl
 	table tbl_0_member_table
@@ -223,7 +225,7 @@ apply {
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
@@ -169,7 +169,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.spec
@@ -85,7 +85,7 @@ apply {
 	table tbl
 	mov h.dstAddr m.local_metadata_meta
 	mov h.srcAddr m.local_metadata_meta2
-	mov  h.etherType m.local_metadata_meta3
+	mov h.etherType m.local_metadata_meta3
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.spec
@@ -85,7 +85,7 @@ apply {
 	table tbl
 	mov h.dstAddr m.local_metadata_meta
 	mov h.srcAddr m.local_metadata_meta2
-	mov  m.local_metadata_meta3 h.etherType
+	mov  h.etherType m.local_metadata_meta3
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.spec
@@ -85,10 +85,10 @@ apply {
 	table tbl
 	mov h.dstAddr m.local_metadata_meta
 	mov h.srcAddr m.local_metadata_meta2
-	cast  m.local_metadata_meta3 bit_16 h.etherType
+	mov  m.local_metadata_meta3 h.etherType
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.spec
@@ -137,7 +137,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.spec
@@ -155,7 +155,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.spec
@@ -138,7 +138,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.spec
@@ -141,7 +141,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.spec
@@ -135,7 +135,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.spec
@@ -138,7 +138,7 @@ apply {
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-fwd-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-fwd-bmv2.p4.spec
@@ -67,7 +67,7 @@ apply {
 	extract h.ethernet
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
@@ -94,8 +94,7 @@ apply {
 	MYIP_PARSE_VLAN_TAG1 :	extract h.vlan_tag_1
 	jmpeq MYIP_PARSE_VLAN_TAG2 h.vlan_tag_1.ether_type 0x8100
 	jmp MYIP_ACCEPT
-	MYIP_PARSE_VLAN_TAG2 :	jmpeq MYIP_ACCEPT 0 0
-	mov metadata 0x3
+	MYIP_PARSE_VLAN_TAG2 :	mov m.psa_ingress_input_metadata_parser_error 0x3
 	MYIP_ACCEPT :	jmpnv LABEL_1FALSE h.ethernet
 	jmp LABEL_1END
 	LABEL_1FALSE :	table tbl
@@ -104,7 +103,7 @@ apply {
 	emit h.vlan_tag_0
 	emit h.vlan_tag_1
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
@@ -68,7 +68,7 @@ apply {
 	LABEL_0FALSE :	mov h.ethernet.srcAddr 0xcafe
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_egress_port
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet
@@ -76,7 +76,7 @@ apply {
 	mov h.ethernet.etherType 0xface
 	LABEL_1END :	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
@@ -68,7 +68,7 @@ apply {
 	LABEL_0FALSE :	mov h.ethernet.srcAddr 0xcafe
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
@@ -68,7 +68,7 @@ apply {
 	LABEL_0FALSE :	mov h.ethernet.srcAddr 0xcafe
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
+	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.spec
@@ -132,7 +132,7 @@ apply {
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-isvalid.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-isvalid.p4.spec
@@ -81,7 +81,7 @@ apply {
 	LABEL_0FALSE :	table tbl
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4.spec
@@ -80,7 +80,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4.spec
@@ -80,7 +80,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
@@ -73,17 +73,17 @@ apply {
 	extract h.ethernet
 	extract h.output_data
 	mov m.psa_ingress_output_metadata_drop 0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_multicast_group
-	cast  h.ethernet.srcAddr bit_1 m.Ingress_tmp
-	cast  m.Ingress_tmp bit_8 m.psa_ingress_output_metadata_class_of_service
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_multicast_group
+	mov  h.ethernet.srcAddr m.Ingress_tmp
+	mov  m.Ingress_tmp m.psa_ingress_output_metadata_class_of_service
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data
 	extract h.ethernet
 	extract h.output_data
-	cast  m.psa_egress_input_metadata_egress_port bit_32 h.output_data.word0
-	cast  m.psa_egress_input_metadata_instance bit_16 m.Egress_tmp_0
-	cast  m.Egress_tmp_0 bit_32 h.output_data.word1
+	mov  m.psa_egress_input_metadata_egress_port h.output_data.word0
+	mov  m.psa_egress_input_metadata_instance m.Egress_tmp_0
+	mov  m.Egress_tmp_0 h.output_data.word1
 	mov h.output_data.word2 0x8
 	jmpneq LABEL_0FALSE m.psa_egress_input_metadata_packet_path 0x0
 	mov h.output_data.word2 0x1
@@ -105,12 +105,12 @@ apply {
 	jmp LABEL_0END
 	LABEL_5FALSE :	jmpneq LABEL_0END m.psa_egress_input_metadata_packet_path 0x6
 	mov h.output_data.word2 0x7
-	LABEL_0END :	cast  m.psa_egress_input_metadata_class_of_service bit_8 m.Egress_tmp_1
-	cast  m.Egress_tmp_1 bit_32 h.output_data.word3
+	LABEL_0END :	mov  m.psa_egress_input_metadata_class_of_service m.Egress_tmp_1
+	mov  m.Egress_tmp_1 h.output_data.word3
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
@@ -73,17 +73,17 @@ apply {
 	extract h.ethernet
 	extract h.output_data
 	mov m.psa_ingress_output_metadata_drop 0
-	mov  m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
-	mov  m.Ingress_tmp h.ethernet.srcAddr
-	mov  m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp
+	mov m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
+	mov m.Ingress_tmp h.ethernet.srcAddr
+	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data
 	extract h.ethernet
 	extract h.output_data
-	mov  h.output_data.word0 m.psa_egress_input_metadata_egress_port
-	mov  m.Egress_tmp_0 m.psa_egress_input_metadata_instance
-	mov  h.output_data.word1 m.Egress_tmp_0
+	mov h.output_data.word0 m.psa_egress_input_metadata_egress_port
+	mov m.Egress_tmp_0 m.psa_egress_input_metadata_instance
+	mov h.output_data.word1 m.Egress_tmp_0
 	mov h.output_data.word2 0x8
 	jmpneq LABEL_0FALSE m.psa_egress_input_metadata_packet_path 0x0
 	mov h.output_data.word2 0x1
@@ -105,8 +105,8 @@ apply {
 	jmp LABEL_0END
 	LABEL_5FALSE :	jmpneq LABEL_0END m.psa_egress_input_metadata_packet_path 0x6
 	mov h.output_data.word2 0x7
-	LABEL_0END :	mov  m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
-	mov  h.output_data.word3 m.Egress_tmp_1
+	LABEL_0END :	mov m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
+	mov h.output_data.word3 m.Egress_tmp_1
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
@@ -73,17 +73,17 @@ apply {
 	extract h.ethernet
 	extract h.output_data
 	mov m.psa_ingress_output_metadata_drop 0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_multicast_group
-	mov  h.ethernet.srcAddr m.Ingress_tmp
-	mov  m.Ingress_tmp m.psa_ingress_output_metadata_class_of_service
+	mov  m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
+	mov  m.Ingress_tmp h.ethernet.srcAddr
+	mov  m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data
 	extract h.ethernet
 	extract h.output_data
-	mov  m.psa_egress_input_metadata_egress_port h.output_data.word0
-	mov  m.psa_egress_input_metadata_instance m.Egress_tmp_0
-	mov  m.Egress_tmp_0 h.output_data.word1
+	mov  h.output_data.word0 m.psa_egress_input_metadata_egress_port
+	mov  m.Egress_tmp_0 m.psa_egress_input_metadata_instance
+	mov  h.output_data.word1 m.Egress_tmp_0
 	mov h.output_data.word2 0x8
 	jmpneq LABEL_0FALSE m.psa_egress_input_metadata_packet_path 0x0
 	mov h.output_data.word2 0x1
@@ -105,8 +105,8 @@ apply {
 	jmp LABEL_0END
 	LABEL_5FALSE :	jmpneq LABEL_0END m.psa_egress_input_metadata_packet_path 0x6
 	mov h.output_data.word2 0x7
-	LABEL_0END :	mov  m.psa_egress_input_metadata_class_of_service m.Egress_tmp_1
-	mov  m.Egress_tmp_1 h.output_data.word3
+	LABEL_0END :	mov  m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
+	mov  h.output_data.word3 m.Egress_tmp_1
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
@@ -61,7 +61,7 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_multicast_group
+	mov  m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
@@ -61,12 +61,12 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_multicast_group
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_multicast_group
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
@@ -61,7 +61,7 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
-	mov  m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
+	mov m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
@@ -61,13 +61,13 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_multicast_group
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_multicast_group
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
@@ -61,7 +61,7 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_multicast_group
+	mov  m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
@@ -61,7 +61,7 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
-	mov  m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
+	mov m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
@@ -85,13 +85,13 @@ apply {
 	jmpneq LABEL_0END m.Ingress_tmp_4 0x2
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_egress_port
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
@@ -85,7 +85,7 @@ apply {
 	jmpneq LABEL_0END m.Ingress_tmp_4 0x2
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
+	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
@@ -85,7 +85,7 @@ apply {
 	jmpneq LABEL_0END m.Ingress_tmp_4 0x2
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
@@ -68,7 +68,7 @@ apply {
 	regrd h.ethernet.dstAddr regfile_0 0x1
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
+	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	regrd m.Ingress_tmp regfile_0 0x1
 	jmpneq LABEL_0END m.Ingress_tmp 0x0
 	mov m.psa_ingress_output_metadata_drop 1

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
@@ -68,7 +68,7 @@ apply {
 	regrd h.ethernet.dstAddr regfile_0 0x1
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_egress_port
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
 	regrd m.Ingress_tmp regfile_0 0x1
 	jmpneq LABEL_0END m.Ingress_tmp 0x0
 	mov m.psa_ingress_output_metadata_drop 1
@@ -77,7 +77,7 @@ apply {
 	extract h.ethernet
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
@@ -68,7 +68,7 @@ apply {
 	regrd h.ethernet.dstAddr regfile_0 0x1
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	regrd m.Ingress_tmp regfile_0 0x1
 	jmpneq LABEL_0END m.Ingress_tmp 0x0
 	mov m.psa_ingress_output_metadata_drop 1

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.spec
@@ -91,7 +91,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.spec
@@ -93,7 +93,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.spec
@@ -93,7 +93,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-remove-header.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-remove-header.p4.spec
@@ -85,7 +85,7 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
@@ -77,7 +77,7 @@ apply {
 	LABEL_0FALSE :	mov h.ethernet.etherType 0xf00d
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
+	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	mov h.output_data.word0 0x8
 	jmpneq LABEL_1FALSE m.psa_ingress_input_metadata_packet_path 0x0
 	mov h.output_data.word0 0x1

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
@@ -77,7 +77,7 @@ apply {
 	LABEL_0FALSE :	mov h.ethernet.etherType 0xf00d
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	mov h.output_data.word0 0x8
 	jmpneq LABEL_1FALSE m.psa_ingress_input_metadata_packet_path 0x0
 	mov h.output_data.word0 0x1

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
@@ -77,7 +77,7 @@ apply {
 	LABEL_0FALSE :	mov h.ethernet.etherType 0xf00d
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_egress_port
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
 	mov h.output_data.word0 0x8
 	jmpneq LABEL_1FALSE m.psa_ingress_input_metadata_packet_path 0x0
 	mov h.output_data.word0 0x1
@@ -106,7 +106,7 @@ apply {
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.spec
@@ -98,7 +98,7 @@ apply {
 	invalidate h.ethernet
 	LABEL_3END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-top-level-assignments-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-top-level-assignments-bmv2.p4.spec
@@ -66,7 +66,7 @@ apply {
 	emit h.ethernet
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
@@ -74,19 +74,19 @@ apply {
 	extract h.output_data
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_egress_port
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
 	jmpneq LABEL_0END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
-	LABEL_0END :	cast  h.ethernet.srcAddr bit_1 m.Ingress_tmp
-	cast  m.Ingress_tmp bit_8 m.psa_ingress_output_metadata_class_of_service
+	LABEL_0END :	mov  h.ethernet.srcAddr m.Ingress_tmp
+	mov  m.Ingress_tmp m.psa_ingress_output_metadata_class_of_service
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data
 	extract h.ethernet
 	extract h.output_data
-	cast  m.psa_egress_input_metadata_egress_port bit_32 h.output_data.word0
-	cast  m.psa_egress_input_metadata_instance bit_16 m.Egress_tmp_0
-	cast  m.Egress_tmp_0 bit_32 h.output_data.word1
+	mov  m.psa_egress_input_metadata_egress_port h.output_data.word0
+	mov  m.psa_egress_input_metadata_instance m.Egress_tmp_0
+	mov  m.Egress_tmp_0 h.output_data.word1
 	mov h.output_data.word2 0x8
 	jmpneq LABEL_1FALSE m.psa_egress_input_metadata_packet_path 0x0
 	mov h.output_data.word2 0x1
@@ -108,12 +108,12 @@ apply {
 	jmp LABEL_1END
 	LABEL_6FALSE :	jmpneq LABEL_1END m.psa_egress_input_metadata_packet_path 0x6
 	mov h.output_data.word2 0x7
-	LABEL_1END :	cast  m.psa_egress_input_metadata_class_of_service bit_8 m.Egress_tmp_1
-	cast  m.Egress_tmp_1 bit_32 h.output_data.word3
+	LABEL_1END :	mov  m.psa_egress_input_metadata_class_of_service m.Egress_tmp_1
+	mov  m.Egress_tmp_1 h.output_data.word3
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
@@ -74,19 +74,19 @@ apply {
 	extract h.output_data
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
+	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	jmpneq LABEL_0END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
-	LABEL_0END :	mov  h.ethernet.srcAddr m.Ingress_tmp
-	mov  m.Ingress_tmp m.psa_ingress_output_metadata_class_of_service
+	LABEL_0END :	mov  m.Ingress_tmp h.ethernet.srcAddr
+	mov  m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data
 	extract h.ethernet
 	extract h.output_data
-	mov  m.psa_egress_input_metadata_egress_port h.output_data.word0
-	mov  m.psa_egress_input_metadata_instance m.Egress_tmp_0
-	mov  m.Egress_tmp_0 h.output_data.word1
+	mov  h.output_data.word0 m.psa_egress_input_metadata_egress_port
+	mov  m.Egress_tmp_0 m.psa_egress_input_metadata_instance
+	mov  h.output_data.word1 m.Egress_tmp_0
 	mov h.output_data.word2 0x8
 	jmpneq LABEL_1FALSE m.psa_egress_input_metadata_packet_path 0x0
 	mov h.output_data.word2 0x1
@@ -108,8 +108,8 @@ apply {
 	jmp LABEL_1END
 	LABEL_6FALSE :	jmpneq LABEL_1END m.psa_egress_input_metadata_packet_path 0x6
 	mov h.output_data.word2 0x7
-	LABEL_1END :	mov  m.psa_egress_input_metadata_class_of_service m.Egress_tmp_1
-	mov  m.Egress_tmp_1 h.output_data.word3
+	LABEL_1END :	mov  m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
+	mov  h.output_data.word3 m.Egress_tmp_1
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
@@ -74,19 +74,19 @@ apply {
 	extract h.output_data
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	jmpneq LABEL_0END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
-	LABEL_0END :	mov  m.Ingress_tmp h.ethernet.srcAddr
-	mov  m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp
+	LABEL_0END :	mov m.Ingress_tmp h.ethernet.srcAddr
+	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data
 	extract h.ethernet
 	extract h.output_data
-	mov  h.output_data.word0 m.psa_egress_input_metadata_egress_port
-	mov  m.Egress_tmp_0 m.psa_egress_input_metadata_instance
-	mov  h.output_data.word1 m.Egress_tmp_0
+	mov h.output_data.word0 m.psa_egress_input_metadata_egress_port
+	mov m.Egress_tmp_0 m.psa_egress_input_metadata_instance
+	mov h.output_data.word1 m.Egress_tmp_0
 	mov h.output_data.word2 0x8
 	jmpneq LABEL_1FALSE m.psa_egress_input_metadata_packet_path 0x0
 	mov h.output_data.word2 0x1
@@ -108,8 +108,8 @@ apply {
 	jmp LABEL_1END
 	LABEL_6FALSE :	jmpneq LABEL_1END m.psa_egress_input_metadata_packet_path 0x6
 	mov h.output_data.word2 0x7
-	LABEL_1END :	mov  m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
-	mov  h.output_data.word3 m.Egress_tmp_1
+	LABEL_1END :	mov m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
+	mov h.output_data.word3 m.Egress_tmp_1
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
@@ -62,7 +62,7 @@ apply {
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	cast  h.ethernet.dstAddr bit_32 m.psa_ingress_output_metadata_egress_port
+	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
 	jmpneq LABEL_0END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
@@ -70,7 +70,7 @@ apply {
 	extract h.ethernet
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
-	drop
+	LABEL_DROP :	drop
 }
 
 

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
@@ -62,7 +62,7 @@ apply {
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	jmpneq LABEL_0END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
@@ -62,7 +62,7 @@ apply {
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov  h.ethernet.dstAddr m.psa_ingress_output_metadata_egress_port
+	mov  m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	jmpneq LABEL_0END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
 	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0


### PR DESCRIPTION
This PR fixes the following issues:

1) Handled boolean literals in verify statement
2) Moving error id from verify method to standard metadata for parser error
3) Emitting missing Label before drop instruction at the end.
4) Change warning type for mismatched header fields
5) Change cast to mov instruction as it is not a valid instruction.