### PR TITLE
Invalid headers warnings: support for header stacks and unions

### DIFF
--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -1170,6 +1170,16 @@ class FindUninitialized : public Inspector {
             }
         }
 
+        // directionless parameters are set by the control-plane for actions invoked by tables
+        if (auto actionCall = mi->to<ActionCall>()) {
+            for (auto p : actionCall->action->parameters->parameters) {
+                if (p->direction == IR::Direction::None && !mi->substitution.contains(p)) {
+                    headerDefs->setValueToStorage(definitions->storageMap->getStorage(p),
+                                                  TernaryBool::Yes);
+                }
+            }
+        }
+
         // Symbolically call some methods (actions and tables, extern methods)
         std::vector <const IR::IDeclaration *> callee;
         if (auto ac = mi->to<ActionCall>()) {

--- a/testdata/p4_16_samples/invalid-hdr-warnings2.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings2.p4
@@ -25,7 +25,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     H s1;
     H s2;
 
-    action invalid_H(out H s) {
+    action invalid_H(inout H s) {
         s.h1.setInvalid();
         s.h2.setInvalid();
     }
@@ -65,6 +65,9 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         }
 
         invalid_H(hdr);
+
+        hdr.h1.data = 1;            //  hdr.h1 invalid at this point
+        hdr.h2.data = 1;            //  hdr.h2 invalid at this point
     }
 }
 
@@ -89,3 +92,4 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 }
 
 V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples/invalid-hdr-warnings4.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings4.p4
@@ -1,0 +1,137 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header[2] h1;
+    Header[2] h2;
+}
+
+struct M { }
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.h1[0]);
+        hdr.h1[0].data = 1;
+        hdr.h1[1].data = 1;
+        transition init;
+    }
+
+    state init {
+        pkt.extract(hdr.h1[1]);
+        hdr.h1[0].data = 1;
+        hdr.h1[1].data = 1;
+        transition next;
+    }
+
+    state next {
+        hdr.h1[0].setInvalid();
+        pkt.extract(hdr.h1.next);
+        hdr.h1[0].data = 1;
+        hdr.h1[1].data = 1;
+        hdr.h1[0].setInvalid();
+        transition select (hdr.h1[1].data) {
+            0: init;
+            default: accept;
+        }
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    H h;
+    H h_copy;
+    H h_copy2;
+
+    action validateHeader(inout Header hd) {
+        hd.setValid();
+    }
+
+    action invalidateHeader(inout Header hd) {
+        hd.setInvalid();
+    }
+
+    action invalidateStack(inout Header[2] stack) {
+        invalidateHeader(stack[0]);
+        invalidateHeader(stack[1]);
+    } 
+
+    apply {
+        validateHeader(h.h1[0]);
+        h.h1[0].data = 1;
+        h.h1[1] = h.h1[0];
+        h.h1[1].data = 1;
+
+        h.h2 = h.h1;
+        h.h2[0].data = 1;
+        h.h2[1].data = 1;
+
+        h_copy = h;
+        h_copy.h1[0].data = 1;
+        h_copy.h1[1].data = 1;
+        h_copy.h2[0].data = 1;
+        h_copy.h2[1].data = 1;
+
+        invalidateHeader(h.h2[0]);
+        h_copy2 = { h.h1, h.h2 };
+        h_copy2.h1[0].data = 1;
+        h_copy2.h1[1].data = 1;
+        h_copy2.h2[0].data = 1;
+        h_copy2.h2[1].data = 1;
+
+        bit i = 1;
+        h_copy2.h2[i] = h.h2[0];    // no effect in analysis because h.h2[0] is invalid
+
+        h_copy2.h1[0].data = 1;
+        h_copy2.h1[1].data = 1;
+        h_copy2.h2[0].data = 1;
+        h_copy2.h2[1].data = 1;
+
+        validateHeader(h.h2[i]);    // h.h2[0] and h.h2[1] considered valid from this point
+        h_copy2.h2[i] = h.h2[0];
+
+        h_copy2.h1[0].data = 1;
+        h_copy2.h1[1].data = 1;
+        h_copy2.h2[0].data = 1;
+        h_copy2.h2[1].data = 1;
+
+        invalidateStack(h.h1);
+        invalidateStack(h_copy.h1);
+        h_copy.h1[0] = h.h1[i];     // h_copy.h1[0] is invalid from this point because all fields
+                                    // of h.h1 are invalid, so h.h1[i] must be invalid too
+        h_copy.h1[0].data = 1;
+        h_copy.h1[1].data = 1;
+
+        h.h1[1].setValid();
+        h_copy.h1[0] = h.h1[i];     // h.h1[i] could be valid or invalid here depending on i,
+                                    // so h_copy.h1[0] is considered valid from this point in
+                                    // order to avoid false negatives
+        h_copy.h1[0].data = 1;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples/invalid-hdr-warnings4.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings4.p4
@@ -108,7 +108,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         h.h1[1].setValid();
         h_copy.h1[0] = h.h1[i];     // h.h1[i] could be valid or invalid here depending on i,
                                     // so h_copy.h1[0] is considered valid from this point in
-                                    // order to avoid false negatives
+                                    // order to avoid false positives
         h_copy.h1[0].data = 1;
     }
 }

--- a/testdata/p4_16_samples/invalid-hdr-warnings5.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings5.p4
@@ -1,0 +1,109 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header1 {
+    bit<32> data;
+}
+
+header Header2 {
+    bit<16> data;
+}
+
+header_union Union {
+    Header1 h1;
+    Header2 h2;
+    Header1 h3;
+}
+
+struct H {
+    Header1 h1;
+    Union u1;
+    Union u2;
+}
+
+struct M { }
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.u1.h1.setValid();
+        pkt.extract(hdr.u1.h3);
+        hdr.u1.h1.data = 1;
+        hdr.u1.h3.data = 1;
+
+        hdr.u1.h1 = hdr.u1.h3;
+        hdr.u1.h1.data = 1;
+        hdr.u1.h3.data = 1;
+
+        transition select (hdr.u1.h1.data) {
+            0: next;
+            default: last;
+        }
+    }
+
+    state next {
+        pkt.extract(hdr.u1.h2);
+        transition last;
+    }
+
+    state last {
+        hdr.u1.h1.data = 1;
+        hdr.u1.h2.data = 1;
+        hdr.u1.h3.data = 1;
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Union u1;
+    Union u2;
+
+    apply {
+        u1.h1 = { 1 };
+        u2.h1 = u1.h1;
+        u2.h1.data = 1;
+
+        u1.h2.setValid();
+        u2 = u1;
+        u2.h1.data = 1;
+        u2.h2.data = 1;
+
+        if (u2.h2.data == 0) {
+            u1.h1.setValid();
+        } else {
+            u1.h2.setValid();
+        }
+
+        u1.h1.data = 1;
+        u1.h2.data = 1;
+
+        u1.h3.setInvalid();
+
+        u1.h1.data = 1;
+        u1.h2.data = 1;
+        u1.h3.data = 1;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples/invalid-hdr-warnings6.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings6.p4
@@ -1,0 +1,107 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header1 {
+    bit<32> data;
+}
+
+header Header2 {
+    bit<16> data;
+}
+
+header_union Union {
+    Header1 h1;
+    Header2 h2;
+    Header1 h3;
+}
+
+struct H {
+    Header1 h1;
+    Union[2] u;
+}
+
+struct M { }
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.u[0].h1.setValid();
+        pkt.extract(hdr.u[0].h3);
+        hdr.u[0].h1.data = 1;
+        hdr.u[0].h3.data = 1;
+
+        hdr.u[0].h1 = hdr.u[0].h3;
+        hdr.u[0].h1.data = 1;
+        hdr.u[0].h3.data = 1;
+
+        transition select (hdr.u[0].h1.data) {
+            0: next;
+            default: last;
+        }
+    }
+
+    state next {
+        pkt.extract(hdr.u[0].h2);
+        transition last;
+    }
+
+    state last {
+        hdr.u[0].h1.data = 1;
+        hdr.u[0].h2.data = 1;
+        hdr.u[0].h3.data = 1;
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Union[2] u;
+
+    apply {
+        u[0].h1 = { 1 };
+        u[1].h1 = u[0].h1;
+        u[1].h1.data = 1;
+
+        bit i = 0;
+        u[0].h2.setValid();     // u[0].h1 invalid from this point
+        u[1] = u[i];
+        u[1].h1.data = 1;
+        u[1].h2.data = 1;
+
+        if (u[1].h2.data == 0) {
+            u[i].h2.setValid();
+        }
+
+        u[0].h1.data = 1;       // u[0].h1 is invalid either if the then branch is executed (for any i) or not
+        
+        if (u[1].h2.data == 0) {
+            u[i].h1.setValid();
+        } else {
+            u[i].h2.setValid();
+        }
+
+        u[0].h1.data = 1;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples/invalid-hdr-warnings6.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings6.p4
@@ -80,6 +80,15 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         }
 
         u[0].h1.data = 1;
+        u[1].h1.setInvalid();
+
+        u[i].h1.setInvalid();   // no effect
+        u[0].h1.data = 1;
+        u[1].h1.data = 1;
+
+        u[i].h1.setValid();
+        u[0].h1.data = 1;
+        u[1].h1.data = 1;
     }
 }
 

--- a/testdata/p4_16_samples/invalid-hdr-warnings7.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings7.p4
@@ -1,0 +1,90 @@
+header H1 { bit<32> a; }
+header H2 { bit<32> a; }
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(inout bit<32> param);
+package top(ct _ct);
+
+control c(inout bit<32> x) {
+    U u;
+    H1[2] hs;
+    U[2] us;
+
+    action initialize(out U u1, out H1[2] hs1, out U[2] us1) {
+        // all these should be invalid regardless of the actual arguments
+        u1.h1.a = 1;
+        u1.h2.a = 1;
+        hs1[0].a = 1;
+        hs1[1].a = 1;
+        us1[0].h1.a = 1;
+        us1[0].h2.a = 1;
+
+        u1.h1.setValid();
+        u1.h2.setValid();
+        hs1[0].setValid();
+        hs1[1].setValid();
+        us1[0].h1.setValid();
+        us1[0].h2.setValid();
+    }
+
+    action inout_action1(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        // checking if the valid bits have the same values as before the call
+        u1.h1.a = 1;        // expected invalid
+        u1.h2.a = 1;
+        hs1[0].a = 1;
+        hs1[1].a = 1;
+        us1[0].h1.a = 1;    // expected invalid
+        us1[0].h2.a = 1;
+
+        hs1[0].setInvalid();
+        u1.h1.setValid();
+        us1[0].h1.setValid();
+    }
+
+    action inout_action2(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        bit i = 1;
+        us1[i].h1.setInvalid();  // no effect (we don't know which union needs to be invalidated)
+        us1[i].h2.setValid();    // sets the valid bit of h2 in all unions within the stack
+                                 // without invalidating other valid fields
+    }
+
+    action xor(in U u1, in H1[2] hs1, in U[2] us1, out bit<32> result) {
+        result = u1.h1.a ^ u1.h2.a ^ hs1[0].a ^ hs1[1].a ^ us1[0].h1.a
+                 ^ us1[0].h2.a ^ us1[1].h1.a ^ us1[1].h2.a;
+    }
+
+    apply @noWarn("uninitialized_use") {
+        u.h1.setValid();
+        hs[0].setValid();
+        us[0].h1.setValid();
+
+        initialize(u, hs, us);
+
+        // checking the result of initialize
+        u.h1.a = 1;         // expected invalid
+        u.h2.a = 1;
+        hs[0].a = 1;
+        hs[1].a = 1;
+        us[0].h1.a = 1;     // expected invalid
+        us[0].h2.a = 1;
+
+        inout_action1(u, hs, us);
+
+        // checking the result of inout_action1
+        u.h1.a = 1;
+        u.h2.a = 1;        // expected invalid
+        hs[0].a = 1;       // expected invalid
+        hs[1].a = 1;
+        us[0].h1.a = 1;
+        us[0].h2.a = 1;    // expected invalid
+
+        inout_action2(u, hs, us);
+        xor(u, hs, us, x);
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples/invalid-hdr-warnings8.p4
+++ b/testdata/p4_16_samples/invalid-hdr-warnings8.p4
@@ -1,0 +1,82 @@
+header H1 { bit<32> a; }
+header H2 { bit<32> a; }
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(inout bit<32> param);
+package top(ct _ct);
+
+control c(inout bit<32> x) {
+    U u;
+    H1[2] hs;
+    U[2] us;
+
+    action initialize(out U u1, out H1[2] hs1, out U[2] us1) {
+        // all these should be invalid regardless of the actual arguments
+        u1.h1.a = 1;
+        u1.h2.a = 1;
+        hs1[0].a = 1;
+        hs1[1].a = 1;
+        us1[0].h1.a = 1;
+        us1[0].h2.a = 1;
+
+        u1.h1.setValid();
+        u1.h2.setValid();
+        hs1[0].setValid();
+        hs1[1].setValid();
+        us1[0].h1.setValid();
+        us1[0].h2.setValid();
+    }
+
+    action inout_action1(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        initialize(u1, hs1, us1);
+
+        // checking the result of initialize
+        u1.h1.a = 1;         // expected invalid
+        u1.h2.a = 1;
+        hs1[0].a = 1;
+        hs1[1].a = 1;
+        us1[0].h1.a = 1;     // expected invalid
+        us1[0].h2.a = 1;
+
+        hs1[0].setInvalid();
+        u1.h1.setValid();
+        us1[0].h1.setValid();
+    }
+
+    action inout_action2(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        inout_action1(u1, hs1, us1);
+
+        // checking the result of inout_action1
+        u1.h1.a = 1;
+        u1.h2.a = 1;        // expected invalid
+        hs1[0].a = 1;       // expected invalid
+        hs1[1].a = 1;
+        us1[0].h1.a = 1;
+        us1[0].h2.a = 1;    // expected invalid
+
+        bit i = 1;
+        us1[i].h1.setInvalid();  // no effect (we don't know which union needs to be invalidated)
+        us1[i].h2.setValid();    // sets the valid bit of h2 in all unions within the stack
+                                 // without invalidating other valid fields
+    }
+
+    action xor(in U u1, in H1[2] hs1, in U[2] us1, out bit<32> result) {
+        result = u1.h1.a ^ u1.h2.a ^ hs1[0].a ^ hs1[1].a ^ us1[0].h1.a
+                 ^ us1[0].h2.a ^ us1[1].h1.a ^ us1[1].h2.a;
+    }
+
+    apply @noWarn("uninitialized_use") {
+        u.h1.setValid();
+        hs[0].setValid();
+        us[0].h1.setValid();
+
+        inout_action2(u, hs, us);
+        xor(u, hs, us, x);
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/array_field.p4-stderr
+++ b/testdata/p4_16_samples_outputs/array_field.p4-stderr
@@ -1,0 +1,12 @@
+array_field.p4(27): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s[a]
+        s[a].z = 1;
+        ^^^^
+array_field.p4(28): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s[+]
+        s[a+1].z = 0;
+        ^^^^^^
+array_field.p4(29): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s[tmp]
+        a = f(s[a].z, 0);
+              ^^^^
+array_field.p4(30): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s[tmp_0]
+        a = f(s[a].z, 1);
+              ^^^^

--- a/testdata/p4_16_samples_outputs/array_field1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/array_field1.p4-stderr
@@ -1,0 +1,18 @@
+array_field1.p4(22): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s[tmp_8]
+        s[tmp_8].z = 1w1;
+        ^^^^^^^^
+array_field1.p4(25): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s[tmp_10]
+        s[tmp_10].z = 1w0;
+        ^^^^^^^^^
+array_field1.p4(27): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s[tmp_11]
+        tmp_12 = s[tmp_11].z;
+                 ^^^^^^^^^
+array_field1.p4(29): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s[tmp_11]
+        s[tmp_11].z = tmp_12;
+        ^^^^^^^^^
+array_field1.p4(32): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s[tmp_14]
+        tmp_15 = s[tmp_14].z;
+                 ^^^^^^^^^
+array_field1.p4(34): [--Wwarn=invalid_header] warning: accessing a field of an invalid header s[tmp_14]
+        s[tmp_14].z = tmp_15;
+        ^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/gauntlet_ctrl_plane_hdr.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_ctrl_plane_hdr.p4-stderr
@@ -1,3 +1,0 @@
-gauntlet_ctrl_plane_hdr.p4(25): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header ctrl_hdr
-        h.eth_hdr.dst_addr = ctrl_hdr.dst_addr;
-                             ^^^^^^^^

--- a/testdata/p4_16_samples_outputs/gauntlet_mux_hdr-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_mux_hdr-bmv2.p4-stderr
@@ -1,3 +1,6 @@
+gauntlet_mux_hdr-bmv2.p4(26): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp2[0]
+    if (tmp2[0].a <= 3) {
+        ^^^^^^^
 gauntlet_mux_hdr-bmv2.p4(26): [--Wwarn=uninitialized_use] warning: tmp2[0].a may be uninitialized
     if (tmp2[0].a <= 3) {
         ^^^^^^^^^
@@ -7,6 +10,9 @@ gauntlet_mux_hdr-bmv2.p4(27): [--Wwarn=uninitialized_use] warning: tmp2[1] may n
 gauntlet_mux_hdr-bmv2.p4(28): [--Wwarn=uninitialized_use] warning: tmp1[1] may not be completely initialized
         tmp2[1] = tmp1[1];
                   ^^^^^^^
+gauntlet_mux_hdr-bmv2.p4(30): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp1[0]
+    return tmp1[0].a;
+           ^^^^^^^
 gauntlet_mux_hdr-bmv2.p4(30): [--Wwarn=uninitialized_use] warning: tmp1[0].a may be uninitialized
     return tmp1[0].a;
            ^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-first.p4
@@ -25,7 +25,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     Header h2;
     H s1;
     H s2;
-    action invalid_H(out H s) {
+    action invalid_H(inout H s) {
         s.h1.setInvalid();
         s.h2.setInvalid();
     }
@@ -60,6 +60,8 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
             hdr.h2.data = s1.h1.data;
         }
         invalid_H(hdr);
+        hdr.h1.data = 32w1;
+        hdr.h2.data = 32w1;
     }
 }
 
@@ -84,4 +86,3 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 }
 
 V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
-

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-frontend.p4
@@ -27,6 +27,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name("IngressI.s2") H s2_0;
     @name("IngressI.s") H s_0;
     @name("IngressI.invalid_H") action invalid_H() {
+        s_0 = hdr;
         s_0.h1.setInvalid();
         s_0.h2.setInvalid();
         hdr = s_0;
@@ -46,9 +47,11 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
             h2_0.setValid();
             h2_0.data = 32w0;
         }
+        hdr.h2.data = h2_0.data;
         if (h2_0.data == 32w1) {
             h1_0.setInvalid();
         }
+        hdr.h1.data = h1_0.data;
         h1_0 = h2_0;
         if (h1_0.data == 32w1) {
             s1_0 = (H){h1 = h1_0,h2 = h2_0};
@@ -59,11 +62,15 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
                 } else {
                     s1_0.h1.setInvalid();
                 }
+                hdr.h1.data = s1_0.h1.data;
             } else {
                 s1_0.h1.setValid();
             }
+            hdr.h2.data = s1_0.h1.data;
         }
         invalid_H();
+        hdr.h1.data = 32w1;
+        hdr.h2.data = 32w1;
     }
 }
 
@@ -88,4 +95,3 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 }
 
 V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
-

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2-midend.p4
@@ -30,6 +30,8 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     Header s_0_h1;
     Header s_0_h2;
     @name("IngressI.invalid_H") action invalid_H() {
+        s_0_h1 = hdr.h1;
+        s_0_h2 = hdr.h2;
         s_0_h1.setInvalid();
         s_0_h2.setInvalid();
         hdr.h1 = s_0_h1;
@@ -55,11 +57,17 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @hidden action invalidhdrwarnings2l46() {
         h1_0.setInvalid();
     }
+    @hidden action invalidhdrwarnings2l43() {
+        hdr.h2.data = h2_0.data;
+    }
     @hidden action invalidhdrwarnings2l57() {
         s1_0_h1.setInvalid();
     }
     @hidden action invalidhdrwarnings2l59() {
         s1_0_h1.setInvalid();
+    }
+    @hidden action invalidhdrwarnings2l60() {
+        hdr.h1.data = s1_0_h1.data;
     }
     @hidden action invalidhdrwarnings2l62() {
         s1_0_h1.setValid();
@@ -70,8 +78,16 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         s2_0_h1 = h2_0;
         s2_0_h2 = h2_0;
     }
-    @hidden action invalidhdrwarnings2l50() {
+    @hidden action invalidhdrwarnings2l64() {
+        hdr.h2.data = s1_0_h1.data;
+    }
+    @hidden action invalidhdrwarnings2l49() {
+        hdr.h1.data = h1_0.data;
         h1_0 = h2_0;
+    }
+    @hidden action invalidhdrwarnings2l69() {
+        hdr.h1.data = 32w1;
+        hdr.h2.data = 32w1;
     }
     @hidden table tbl_invalidhdrwarnings2l23 {
         actions = {
@@ -91,17 +107,23 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         }
         const default_action = invalidhdrwarnings2l38();
     }
+    @hidden table tbl_invalidhdrwarnings2l43 {
+        actions = {
+            invalidhdrwarnings2l43();
+        }
+        const default_action = invalidhdrwarnings2l43();
+    }
     @hidden table tbl_invalidhdrwarnings2l46 {
         actions = {
             invalidhdrwarnings2l46();
         }
         const default_action = invalidhdrwarnings2l46();
     }
-    @hidden table tbl_invalidhdrwarnings2l50 {
+    @hidden table tbl_invalidhdrwarnings2l49 {
         actions = {
-            invalidhdrwarnings2l50();
+            invalidhdrwarnings2l49();
         }
-        const default_action = invalidhdrwarnings2l50();
+        const default_action = invalidhdrwarnings2l49();
     }
     @hidden table tbl_invalidhdrwarnings2l53 {
         actions = {
@@ -121,17 +143,35 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         }
         const default_action = invalidhdrwarnings2l59();
     }
+    @hidden table tbl_invalidhdrwarnings2l60 {
+        actions = {
+            invalidhdrwarnings2l60();
+        }
+        const default_action = invalidhdrwarnings2l60();
+    }
     @hidden table tbl_invalidhdrwarnings2l62 {
         actions = {
             invalidhdrwarnings2l62();
         }
         const default_action = invalidhdrwarnings2l62();
     }
+    @hidden table tbl_invalidhdrwarnings2l64 {
+        actions = {
+            invalidhdrwarnings2l64();
+        }
+        const default_action = invalidhdrwarnings2l64();
+    }
     @hidden table tbl_invalid_H {
         actions = {
             invalid_H();
         }
         const default_action = invalid_H();
+    }
+    @hidden table tbl_invalidhdrwarnings2l69 {
+        actions = {
+            invalidhdrwarnings2l69();
+        }
+        const default_action = invalidhdrwarnings2l69();
     }
     apply {
         tbl_invalidhdrwarnings2l23.apply();
@@ -140,10 +180,11 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         } else {
             tbl_invalidhdrwarnings2l38.apply();
         }
+        tbl_invalidhdrwarnings2l43.apply();
         if (h2_0.data == 32w1) {
             tbl_invalidhdrwarnings2l46.apply();
         }
-        tbl_invalidhdrwarnings2l50.apply();
+        tbl_invalidhdrwarnings2l49.apply();
         if (h1_0.data == 32w1) {
             tbl_invalidhdrwarnings2l53.apply();
             if (s2_0_h1.data == 32w0 && s2_0_h2.data == 32w0) {
@@ -152,11 +193,14 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
                 } else {
                     tbl_invalidhdrwarnings2l59.apply();
                 }
+                tbl_invalidhdrwarnings2l60.apply();
             } else {
                 tbl_invalidhdrwarnings2l62.apply();
             }
+            tbl_invalidhdrwarnings2l64.apply();
         }
         tbl_invalid_H.apply();
+        tbl_invalidhdrwarnings2l69.apply();
     }
 }
 
@@ -181,4 +225,3 @@ control ComputeChecksumI(inout H hdr, inout M meta) {
 }
 
 V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
-

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2.p4
@@ -25,7 +25,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     Header h2;
     H s1;
     H s2;
-    action invalid_H(out H s) {
+    action invalid_H(inout H s) {
         s.h1.setInvalid();
         s.h2.setInvalid();
     }
@@ -60,6 +60,8 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
             hdr.h2.data = s1.h1.data;
         }
         invalid_H(hdr);
+        hdr.h1.data = 1;
+        hdr.h2.data = 1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2.p4-stderr
@@ -7,3 +7,9 @@ invalid-hdr-warnings2.p4(60): [--Wwarn=invalid_header] warning: accessing a fiel
 invalid-hdr-warnings2.p4(64): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header s1.h1
             hdr.h2.data = s1.h1.data; // s1.h1 potentially invalid at this point
                           ^^^^^
+invalid-hdr-warnings2.p4(69): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.h1
+        hdr.h1.data = 1; //  hdr.h1 invalid at this point
+        ^^^^^^
+invalid-hdr-warnings2.p4(70): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.h2
+        hdr.h2.data = 1; //  hdr.h2 invalid at this point
+        ^^^^^^

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-first.p4
@@ -1,0 +1,120 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header[2] h1;
+    Header[2] h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract<Header>(hdr.h1[0]);
+        hdr.h1[0].data = 32w1;
+        hdr.h1[1].data = 32w1;
+        transition init;
+    }
+    state init {
+        pkt.extract<Header>(hdr.h1[1]);
+        hdr.h1[0].data = 32w1;
+        hdr.h1[1].data = 32w1;
+        transition next;
+    }
+    state next {
+        hdr.h1[0].setInvalid();
+        pkt.extract<Header>(hdr.h1.next);
+        hdr.h1[0].data = 32w1;
+        hdr.h1[1].data = 32w1;
+        hdr.h1[0].setInvalid();
+        transition select(hdr.h1[1].data) {
+            32w0: init;
+            default: accept;
+        }
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    H h;
+    H h_copy;
+    H h_copy2;
+    action validateHeader(inout Header hd) {
+        hd.setValid();
+    }
+    action invalidateHeader(inout Header hd) {
+        hd.setInvalid();
+    }
+    action invalidateStack(inout Header[2] stack) {
+        invalidateHeader(stack[0]);
+        invalidateHeader(stack[1]);
+    }
+    apply {
+        validateHeader(h.h1[0]);
+        h.h1[0].data = 32w1;
+        h.h1[1] = h.h1[0];
+        h.h1[1].data = 32w1;
+        h.h2 = h.h1;
+        h.h2[0].data = 32w1;
+        h.h2[1].data = 32w1;
+        h_copy = h;
+        h_copy.h1[0].data = 32w1;
+        h_copy.h1[1].data = 32w1;
+        h_copy.h2[0].data = 32w1;
+        h_copy.h2[1].data = 32w1;
+        invalidateHeader(h.h2[0]);
+        h_copy2 = (H){h1 = h.h1,h2 = h.h2};
+        h_copy2.h1[0].data = 32w1;
+        h_copy2.h1[1].data = 32w1;
+        h_copy2.h2[0].data = 32w1;
+        h_copy2.h2[1].data = 32w1;
+        bit<1> i = 1w1;
+        h_copy2.h2[i] = h.h2[0];
+        h_copy2.h1[0].data = 32w1;
+        h_copy2.h1[1].data = 32w1;
+        h_copy2.h2[0].data = 32w1;
+        h_copy2.h2[1].data = 32w1;
+        validateHeader(h.h2[i]);
+        h_copy2.h2[i] = h.h2[0];
+        h_copy2.h1[0].data = 32w1;
+        h_copy2.h1[1].data = 32w1;
+        h_copy2.h2[0].data = 32w1;
+        h_copy2.h2[1].data = 32w1;
+        invalidateStack(h.h1);
+        invalidateStack(h_copy.h1);
+        h_copy.h1[0] = h.h1[i];
+        h_copy.h1[0].data = 32w1;
+        h_copy.h1[1].data = 32w1;
+        h.h1[1].setValid();
+        h_copy.h1[0] = h.h1[i];
+        h_copy.h1[0].data = 32w1;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-frontend.p4
@@ -1,0 +1,140 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header[2] h1;
+    Header[2] h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract<Header>(hdr.h1[0]);
+        transition init;
+    }
+    state init {
+        pkt.extract<Header>(hdr.h1[1]);
+        hdr.h1[0].setInvalid();
+        pkt.extract<Header>(hdr.h1.next);
+        hdr.h1[0].data = 32w1;
+        hdr.h1[1].data = 32w1;
+        hdr.h1[0].setInvalid();
+        transition select(hdr.h1[1].data) {
+            32w0: init;
+            default: accept;
+        }
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("IngressI.h") H h_0;
+    @name("IngressI.h_copy") H h_copy_0;
+    @name("IngressI.h_copy2") H h_copy2_0;
+    @name("IngressI.i") bit<1> i_0;
+    @name("IngressI.tmp") bit<1> tmp;
+    @name("IngressI.hd") Header hd_0;
+    @name("IngressI.hd") Header hd_1;
+    @name("IngressI.hd") Header hd_8;
+    @name("IngressI.hd") Header hd_9;
+    @name("IngressI.hd") Header hd_10;
+    @name("IngressI.hd") Header hd_11;
+    @name("IngressI.hd") Header hd_12;
+    @name("IngressI.stack") Header[2] stack_0;
+    @name("IngressI.stack") Header[2] stack_2;
+    @name("IngressI.validateHeader") action validateHeader() {
+        hd_10 = h_0.h1[0];
+        hd_10.setValid();
+        h_0.h1[0] = hd_10;
+    }
+    @name("IngressI.validateHeader") action validateHeader_1() {
+        hd_11 = h_0.h2[tmp];
+        hd_11.setValid();
+        h_0.h2[tmp] = hd_11;
+    }
+    @name("IngressI.invalidateHeader") action invalidateHeader() {
+        hd_12 = h_0.h2[0];
+        hd_12.setInvalid();
+        h_0.h2[0] = hd_12;
+    }
+    @name("IngressI.invalidateStack") action invalidateStack() {
+        stack_0 = h_0.h1;
+        hd_0 = stack_0[0];
+        hd_0.setInvalid();
+        stack_0[0] = hd_0;
+        hd_1 = stack_0[1];
+        hd_1.setInvalid();
+        stack_0[1] = hd_1;
+        h_0.h1 = stack_0;
+    }
+    @name("IngressI.invalidateStack") action invalidateStack_1() {
+        stack_2 = h_copy_0.h1;
+        hd_8 = stack_2[0];
+        hd_8.setInvalid();
+        stack_2[0] = hd_8;
+        hd_9 = stack_2[1];
+        hd_9.setInvalid();
+        stack_2[1] = hd_9;
+        h_copy_0.h1 = stack_2;
+    }
+    apply {
+        h_0.h1[0].setInvalid();
+        h_0.h1[1].setInvalid();
+        h_0.h2[0].setInvalid();
+        h_0.h2[1].setInvalid();
+        h_copy_0.h1[0].setInvalid();
+        h_copy_0.h1[1].setInvalid();
+        h_copy_0.h2[0].setInvalid();
+        h_copy_0.h2[1].setInvalid();
+        h_copy2_0.h1[0].setInvalid();
+        h_copy2_0.h1[1].setInvalid();
+        h_copy2_0.h2[0].setInvalid();
+        h_copy2_0.h2[1].setInvalid();
+        validateHeader();
+        h_0.h1[0].data = 32w1;
+        h_0.h1[1] = h_0.h1[0];
+        h_0.h1[1].data = 32w1;
+        h_0.h2 = h_0.h1;
+        h_0.h2[0].data = 32w1;
+        h_0.h2[1].data = 32w1;
+        h_copy_0 = h_0;
+        h_copy_0.h1[0].data = 32w1;
+        h_copy_0.h1[1].data = 32w1;
+        invalidateHeader();
+        i_0 = 1w1;
+        tmp = i_0;
+        validateHeader_1();
+        invalidateStack();
+        invalidateStack_1();
+        h_0.h1[1].setValid();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-midend.p4
@@ -1,0 +1,205 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header[2] h1;
+    Header[2] h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract<Header>(hdr.h1[0]);
+        transition init;
+    }
+    state init {
+        pkt.extract<Header>(hdr.h1[1]);
+        hdr.h1[0].setInvalid();
+        pkt.extract<Header>(hdr.h1.next);
+        hdr.h1[0].data = 32w1;
+        hdr.h1[1].data = 32w1;
+        hdr.h1[0].setInvalid();
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Header[2] h_0_h1;
+    Header[2] h_0_h2;
+    Header[2] h_copy_0_h1;
+    Header[2] h_copy_0_h2;
+    Header[2] h_copy2_0_h1;
+    Header[2] h_copy2_0_h2;
+    @name("IngressI.tmp") bit<1> tmp;
+    @name("IngressI.hd") Header hd_0;
+    @name("IngressI.hd") Header hd_1;
+    @name("IngressI.hd") Header hd_8;
+    @name("IngressI.hd") Header hd_9;
+    @name("IngressI.hd") Header hd_10;
+    @name("IngressI.hd") Header hd_11;
+    @name("IngressI.hd") Header hd_12;
+    @name("IngressI.stack") Header[2] stack_0;
+    @name("IngressI.stack") Header[2] stack_2;
+    @name("IngressI.validateHeader") action validateHeader() {
+        hd_10 = h_0_h1[0];
+        hd_10.setValid();
+        h_0_h1[0] = hd_10;
+    }
+    @name("IngressI.validateHeader") action validateHeader_1() {
+        hd_11 = h_0_h2[tmp];
+        hd_11.setValid();
+        h_0_h2[tmp] = hd_11;
+    }
+    @name("IngressI.invalidateHeader") action invalidateHeader() {
+        hd_12 = h_0_h2[0];
+        hd_12.setInvalid();
+        h_0_h2[0] = hd_12;
+    }
+    @name("IngressI.invalidateStack") action invalidateStack() {
+        stack_0 = h_0_h1;
+        hd_0 = stack_0[0];
+        hd_0.setInvalid();
+        stack_0[0] = hd_0;
+        hd_1 = stack_0[1];
+        hd_1.setInvalid();
+        stack_0[1] = hd_1;
+        h_0_h1 = stack_0;
+    }
+    @name("IngressI.invalidateStack") action invalidateStack_1() {
+        stack_2 = h_copy_0_h1;
+        hd_8 = stack_2[0];
+        hd_8.setInvalid();
+        stack_2[0] = hd_8;
+        hd_9 = stack_2[1];
+        hd_9.setInvalid();
+        stack_2[1] = hd_9;
+        h_copy_0_h1 = stack_2;
+    }
+    @hidden action invalidhdrwarnings4l45() {
+        h_0_h1[0].setInvalid();
+        h_0_h1[1].setInvalid();
+        h_0_h2[0].setInvalid();
+        h_0_h2[1].setInvalid();
+        h_copy_0_h1[0].setInvalid();
+        h_copy_0_h1[1].setInvalid();
+        h_copy_0_h2[0].setInvalid();
+        h_copy_0_h2[1].setInvalid();
+        h_copy2_0_h1[0].setInvalid();
+        h_copy2_0_h1[1].setInvalid();
+        h_copy2_0_h2[0].setInvalid();
+        h_copy2_0_h2[1].setInvalid();
+    }
+    @hidden action invalidhdrwarnings4l64() {
+        h_0_h1[0].data = 32w1;
+        h_0_h1[1] = h_0_h1[0];
+        h_0_h1[1].data = 32w1;
+        h_0_h2 = h_0_h1;
+        h_0_h2[0].data = 32w1;
+        h_0_h2[1].data = 32w1;
+        h_copy_0_h1 = h_0_h1;
+        h_copy_0_h2 = h_0_h2;
+        h_copy_0_h1[0].data = 32w1;
+        h_copy_0_h1[1].data = 32w1;
+    }
+    @hidden action invalidhdrwarnings4l93() {
+        tmp = 1w1;
+    }
+    @hidden action invalidhdrwarnings4l108() {
+        h_0_h1[1].setValid();
+    }
+    @hidden table tbl_invalidhdrwarnings4l45 {
+        actions = {
+            invalidhdrwarnings4l45();
+        }
+        const default_action = invalidhdrwarnings4l45();
+    }
+    @hidden table tbl_validateHeader {
+        actions = {
+            validateHeader();
+        }
+        const default_action = validateHeader();
+    }
+    @hidden table tbl_invalidhdrwarnings4l64 {
+        actions = {
+            invalidhdrwarnings4l64();
+        }
+        const default_action = invalidhdrwarnings4l64();
+    }
+    @hidden table tbl_invalidateHeader {
+        actions = {
+            invalidateHeader();
+        }
+        const default_action = invalidateHeader();
+    }
+    @hidden table tbl_invalidhdrwarnings4l93 {
+        actions = {
+            invalidhdrwarnings4l93();
+        }
+        const default_action = invalidhdrwarnings4l93();
+    }
+    @hidden table tbl_validateHeader_0 {
+        actions = {
+            validateHeader_1();
+        }
+        const default_action = validateHeader_1();
+    }
+    @hidden table tbl_invalidateStack {
+        actions = {
+            invalidateStack();
+        }
+        const default_action = invalidateStack();
+    }
+    @hidden table tbl_invalidateStack_0 {
+        actions = {
+            invalidateStack_1();
+        }
+        const default_action = invalidateStack_1();
+    }
+    @hidden table tbl_invalidhdrwarnings4l108 {
+        actions = {
+            invalidhdrwarnings4l108();
+        }
+        const default_action = invalidhdrwarnings4l108();
+    }
+    apply {
+        tbl_invalidhdrwarnings4l45.apply();
+        tbl_validateHeader.apply();
+        tbl_invalidhdrwarnings4l64.apply();
+        tbl_invalidateHeader.apply();
+        tbl_invalidhdrwarnings4l93.apply();
+        tbl_validateHeader_0.apply();
+        tbl_invalidateStack.apply();
+        tbl_invalidateStack_0.apply();
+        tbl_invalidhdrwarnings4l108.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4.p4
@@ -1,0 +1,120 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header {
+    bit<32> data;
+}
+
+struct H {
+    Header[2] h1;
+    Header[2] h2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        pkt.extract(hdr.h1[0]);
+        hdr.h1[0].data = 1;
+        hdr.h1[1].data = 1;
+        transition init;
+    }
+    state init {
+        pkt.extract(hdr.h1[1]);
+        hdr.h1[0].data = 1;
+        hdr.h1[1].data = 1;
+        transition next;
+    }
+    state next {
+        hdr.h1[0].setInvalid();
+        pkt.extract(hdr.h1.next);
+        hdr.h1[0].data = 1;
+        hdr.h1[1].data = 1;
+        hdr.h1[0].setInvalid();
+        transition select(hdr.h1[1].data) {
+            0: init;
+            default: accept;
+        }
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    H h;
+    H h_copy;
+    H h_copy2;
+    action validateHeader(inout Header hd) {
+        hd.setValid();
+    }
+    action invalidateHeader(inout Header hd) {
+        hd.setInvalid();
+    }
+    action invalidateStack(inout Header[2] stack) {
+        invalidateHeader(stack[0]);
+        invalidateHeader(stack[1]);
+    }
+    apply {
+        validateHeader(h.h1[0]);
+        h.h1[0].data = 1;
+        h.h1[1] = h.h1[0];
+        h.h1[1].data = 1;
+        h.h2 = h.h1;
+        h.h2[0].data = 1;
+        h.h2[1].data = 1;
+        h_copy = h;
+        h_copy.h1[0].data = 1;
+        h_copy.h1[1].data = 1;
+        h_copy.h2[0].data = 1;
+        h_copy.h2[1].data = 1;
+        invalidateHeader(h.h2[0]);
+        h_copy2 = { h.h1, h.h2 };
+        h_copy2.h1[0].data = 1;
+        h_copy2.h1[1].data = 1;
+        h_copy2.h2[0].data = 1;
+        h_copy2.h2[1].data = 1;
+        bit<1> i = 1;
+        h_copy2.h2[i] = h.h2[0];
+        h_copy2.h1[0].data = 1;
+        h_copy2.h1[1].data = 1;
+        h_copy2.h2[0].data = 1;
+        h_copy2.h2[1].data = 1;
+        validateHeader(h.h2[i]);
+        h_copy2.h2[i] = h.h2[0];
+        h_copy2.h1[0].data = 1;
+        h_copy2.h1[1].data = 1;
+        h_copy2.h2[0].data = 1;
+        h_copy2.h2[1].data = 1;
+        invalidateStack(h.h1);
+        invalidateStack(h_copy.h1);
+        h_copy.h1[0] = h.h1[i];
+        h_copy.h1[0].data = 1;
+        h_copy.h1[1].data = 1;
+        h.h1[1].setValid();
+        h_copy.h1[0] = h.h1[i];
+        h_copy.h1[0].data = 1;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4.p4-stderr
@@ -1,0 +1,22 @@
+invalid-hdr-warnings4.p4(20): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.h1[1]
+        hdr.h1[1].data = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings4.p4(26): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.h1[0]
+        hdr.h1[0].data = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings4.p4(63): [--Wwarn=uninitialized_use] warning: h.h1[0] may not be completely initialized
+        validateHeader(h.h1[0]);
+                       ^^^^^^^
+invalid-hdr-warnings4.p4(82): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h_copy2.h2[0]
+        h_copy2.h2[0].data = 1;
+        ^^^^^^^^^^^^^
+invalid-hdr-warnings4.p4(90): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h_copy2.h2[0]
+        h_copy2.h2[0].data = 1;
+        ^^^^^^^^^^^^^
+invalid-hdr-warnings4.p4(105): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h_copy.h1[0]
+        h_copy.h1[0].data = 1;
+        ^^^^^^^^^^^^
+invalid-hdr-warnings4.p4(106): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h_copy.h1[1]
+        h_copy.h1[1].data = 1;
+        ^^^^^^^^^^^^
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4.p4.p4info.txt
@@ -1,0 +1,24 @@
+pkg_info {
+  arch: "v1model"
+}
+actions {
+  preamble {
+    id: 22733763
+    name: "IngressI.validateHeader"
+    alias: "validateHeader"
+  }
+}
+actions {
+  preamble {
+    id: 19774285
+    name: "IngressI.invalidateHeader"
+    alias: "invalidateHeader"
+  }
+}
+actions {
+  preamble {
+    id: 26792443
+    name: "IngressI.invalidateStack"
+    alias: "invalidateStack"
+  }
+}

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings5-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings5-first.p4
@@ -1,0 +1,100 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header1 {
+    bit<32> data;
+}
+
+header Header2 {
+    bit<16> data;
+}
+
+header_union Union {
+    Header1 h1;
+    Header2 h2;
+    Header1 h3;
+}
+
+struct H {
+    Header1 h1;
+    Union   u1;
+    Union   u2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.u1.h1.setValid();
+        pkt.extract<Header1>(hdr.u1.h3);
+        hdr.u1.h1.data = 32w1;
+        hdr.u1.h3.data = 32w1;
+        hdr.u1.h1 = hdr.u1.h3;
+        hdr.u1.h1.data = 32w1;
+        hdr.u1.h3.data = 32w1;
+        transition select(hdr.u1.h1.data) {
+            32w0: next;
+            default: last;
+        }
+    }
+    state next {
+        pkt.extract<Header2>(hdr.u1.h2);
+        transition last;
+    }
+    state last {
+        hdr.u1.h1.data = 32w1;
+        hdr.u1.h2.data = 16w1;
+        hdr.u1.h3.data = 32w1;
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Union u1;
+    Union u2;
+    apply {
+        u1.h1 = (Header1){data = 32w1};
+        u2.h1 = u1.h1;
+        u2.h1.data = 32w1;
+        u1.h2.setValid();
+        u2 = u1;
+        u2.h1.data = 32w1;
+        u2.h2.data = 16w1;
+        if (u2.h2.data == 16w0) {
+            u1.h1.setValid();
+        } else {
+            u1.h2.setValid();
+        }
+        u1.h1.data = 32w1;
+        u1.h2.data = 16w1;
+        u1.h3.setInvalid();
+        u1.h1.data = 32w1;
+        u1.h2.data = 16w1;
+        u1.h3.data = 32w1;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings5-frontend.p4
@@ -1,0 +1,97 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header1 {
+    bit<32> data;
+}
+
+header Header2 {
+    bit<16> data;
+}
+
+header_union Union {
+    Header1 h1;
+    Header2 h2;
+    Header1 h3;
+}
+
+struct H {
+    Header1 h1;
+    Union   u1;
+    Union   u2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.u1.h1.setValid();
+        pkt.extract<Header1>(hdr.u1.h3);
+        hdr.u1.h3.data = 32w1;
+        hdr.u1.h1 = hdr.u1.h3;
+        hdr.u1.h1.data = 32w1;
+        transition select(hdr.u1.h1.data) {
+            32w0: next;
+            default: last;
+        }
+    }
+    state next {
+        pkt.extract<Header2>(hdr.u1.h2);
+        transition last;
+    }
+    state last {
+        hdr.u1.h1.data = 32w1;
+        hdr.u1.h2.data = 16w1;
+        hdr.u1.h3.data = 32w1;
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("IngressI.u1") Union u1_0;
+    @name("IngressI.u2") Union u2_0;
+    apply {
+        u1_0.h1.setInvalid();
+        u1_0.h2.setInvalid();
+        u1_0.h3.setInvalid();
+        u2_0.h1.setInvalid();
+        u2_0.h2.setInvalid();
+        u2_0.h3.setInvalid();
+        u1_0.h1.setValid();
+        u1_0.h1 = (Header1){data = 32w1};
+        u1_0.h2.setValid();
+        u2_0 = u1_0;
+        u2_0.h2.data = 16w1;
+        if (u2_0.h2.data == 16w0) {
+            u1_0.h1.setValid();
+        } else {
+            u1_0.h2.setValid();
+        }
+        u1_0.h3.setInvalid();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings5-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings5-midend.p4
@@ -1,0 +1,101 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header1 {
+    bit<32> data;
+}
+
+header Header2 {
+    bit<16> data;
+}
+
+header_union Union {
+    Header1 h1;
+    Header2 h2;
+    Header1 h3;
+}
+
+struct H {
+    Header1 h1;
+    Union   u1;
+    Union   u2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.u1.h1.setValid();
+        pkt.extract<Header1>(hdr.u1.h3);
+        hdr.u1.h3.data = 32w1;
+        hdr.u1.h1 = hdr.u1.h3;
+        hdr.u1.h1.data = 32w1;
+        transition last;
+    }
+    state next {
+        pkt.extract<Header2>(hdr.u1.h2);
+        transition last;
+    }
+    state last {
+        hdr.u1.h1.data = 32w1;
+        hdr.u1.h2.data = 16w1;
+        hdr.u1.h3.data = 32w1;
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("IngressI.u1") Union u1_0;
+    @name("IngressI.u2") Union u2_0;
+    @hidden action invalidhdrwarnings5l58() {
+        u1_0.h1.setInvalid();
+        u1_0.h2.setInvalid();
+        u1_0.h3.setInvalid();
+        u2_0.h1.setInvalid();
+        u2_0.h2.setInvalid();
+        u2_0.h3.setInvalid();
+        u1_0.h1.setValid();
+        u1_0.h1.data = 32w1;
+        u1_0.h2.setValid();
+        u2_0.h1 = u1_0.h1;
+        u2_0.h2 = u1_0.h2;
+        u2_0.h3 = u1_0.h3;
+        u2_0.h2.data = 16w1;
+        u1_0.h2.setValid();
+        u1_0.h3.setInvalid();
+    }
+    @hidden table tbl_invalidhdrwarnings5l58 {
+        actions = {
+            invalidhdrwarnings5l58();
+        }
+        const default_action = invalidhdrwarnings5l58();
+    }
+    apply {
+        tbl_invalidhdrwarnings5l58.apply();
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings5.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings5.p4
@@ -1,0 +1,100 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header1 {
+    bit<32> data;
+}
+
+header Header2 {
+    bit<16> data;
+}
+
+header_union Union {
+    Header1 h1;
+    Header2 h2;
+    Header1 h3;
+}
+
+struct H {
+    Header1 h1;
+    Union   u1;
+    Union   u2;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.u1.h1.setValid();
+        pkt.extract(hdr.u1.h3);
+        hdr.u1.h1.data = 1;
+        hdr.u1.h3.data = 1;
+        hdr.u1.h1 = hdr.u1.h3;
+        hdr.u1.h1.data = 1;
+        hdr.u1.h3.data = 1;
+        transition select(hdr.u1.h1.data) {
+            0: next;
+            default: last;
+        }
+    }
+    state next {
+        pkt.extract(hdr.u1.h2);
+        transition last;
+    }
+    state last {
+        hdr.u1.h1.data = 1;
+        hdr.u1.h2.data = 1;
+        hdr.u1.h3.data = 1;
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Union u1;
+    Union u2;
+    apply {
+        u1.h1 = { 1 };
+        u2.h1 = u1.h1;
+        u2.h1.data = 1;
+        u1.h2.setValid();
+        u2 = u1;
+        u2.h1.data = 1;
+        u2.h2.data = 1;
+        if (u2.h2.data == 0) {
+            u1.h1.setValid();
+        } else {
+            u1.h2.setValid();
+        }
+        u1.h1.data = 1;
+        u1.h2.data = 1;
+        u1.h3.setInvalid();
+        u1.h1.data = 1;
+        u1.h2.data = 1;
+        u1.h3.data = 1;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings5.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings5.p4-stderr
@@ -1,0 +1,37 @@
+invalid-hdr-warnings5.p4(31): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.u1.h1
+        hdr.u1.h1.data = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings5.p4(36): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.u1.h3
+        hdr.u1.h3.data = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings5.p4(50): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u1.h1
+        hdr.u1.h1.data = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings5.p4(51): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u1.h2
+        hdr.u1.h2.data = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings5.p4(52): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.u1.h3
+        hdr.u1.h3.data = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings5.p4(67): [--Wwarn=uninitialized_use] warning: u1 may not be completely initialized
+        u2 = u1;
+             ^^
+invalid-hdr-warnings5.p4(68): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u2.h1
+        u2.h1.data = 1;
+        ^^^^^
+invalid-hdr-warnings5.p4(77): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header u1.h1
+        u1.h1.data = 1;
+        ^^^^^
+invalid-hdr-warnings5.p4(78): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header u1.h2
+        u1.h2.data = 1;
+        ^^^^^
+invalid-hdr-warnings5.p4(82): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h1
+        u1.h1.data = 1;
+        ^^^^^
+invalid-hdr-warnings5.p4(83): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h2
+        u1.h2.data = 1;
+        ^^^^^
+invalid-hdr-warnings5.p4(84): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h3
+        u1.h3.data = 1;
+        ^^^^^
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings5.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings5.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "v1model"
+}

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-first.p4
@@ -1,0 +1,98 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header1 {
+    bit<32> data;
+}
+
+header Header2 {
+    bit<16> data;
+}
+
+header_union Union {
+    Header1 h1;
+    Header2 h2;
+    Header1 h3;
+}
+
+struct H {
+    Header1  h1;
+    Union[2] u;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.u[0].h1.setValid();
+        pkt.extract<Header1>(hdr.u[0].h3);
+        hdr.u[0].h1.data = 32w1;
+        hdr.u[0].h3.data = 32w1;
+        hdr.u[0].h1 = hdr.u[0].h3;
+        hdr.u[0].h1.data = 32w1;
+        hdr.u[0].h3.data = 32w1;
+        transition select(hdr.u[0].h1.data) {
+            32w0: next;
+            default: last;
+        }
+    }
+    state next {
+        pkt.extract<Header2>(hdr.u[0].h2);
+        transition last;
+    }
+    state last {
+        hdr.u[0].h1.data = 32w1;
+        hdr.u[0].h2.data = 16w1;
+        hdr.u[0].h3.data = 32w1;
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Union[2] u;
+    apply {
+        u[0].h1 = (Header1){data = 32w1};
+        u[1].h1 = u[0].h1;
+        u[1].h1.data = 32w1;
+        bit<1> i = 1w0;
+        u[0].h2.setValid();
+        u[1] = u[i];
+        u[1].h1.data = 32w1;
+        u[1].h2.data = 16w1;
+        if (u[1].h2.data == 16w0) {
+            u[i].h2.setValid();
+        }
+        u[0].h1.data = 32w1;
+        if (u[1].h2.data == 16w0) {
+            u[i].h1.setValid();
+        } else {
+            u[i].h2.setValid();
+        }
+        u[0].h1.data = 32w1;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-first.p4
@@ -71,6 +71,13 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
             u[i].h2.setValid();
         }
         u[0].h1.data = 32w1;
+        u[1].h1.setInvalid();
+        u[i].h1.setInvalid();
+        u[0].h1.data = 32w1;
+        u[1].h1.data = 32w1;
+        u[i].h1.setValid();
+        u[0].h1.data = 32w1;
+        u[1].h1.data = 32w1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-frontend.p4
@@ -1,0 +1,101 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header1 {
+    bit<32> data;
+}
+
+header Header2 {
+    bit<16> data;
+}
+
+header_union Union {
+    Header1 h1;
+    Header2 h2;
+    Header1 h3;
+}
+
+struct H {
+    Header1  h1;
+    Union[2] u;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.u[0].h1.setValid();
+        pkt.extract<Header1>(hdr.u[0].h3);
+        hdr.u[0].h3.data = 32w1;
+        hdr.u[0].h1 = hdr.u[0].h3;
+        hdr.u[0].h1.data = 32w1;
+        transition select(hdr.u[0].h1.data) {
+            32w0: next;
+            default: last;
+        }
+    }
+    state next {
+        pkt.extract<Header2>(hdr.u[0].h2);
+        transition last;
+    }
+    state last {
+        hdr.u[0].h1.data = 32w1;
+        hdr.u[0].h2.data = 16w1;
+        hdr.u[0].h3.data = 32w1;
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("IngressI.u") Union[2] u_0;
+    @name("IngressI.i") bit<1> i_0;
+    apply {
+        u_0[0].h1.setInvalid();
+        u_0[0].h2.setInvalid();
+        u_0[0].h3.setInvalid();
+        u_0[1].h1.setInvalid();
+        u_0[1].h2.setInvalid();
+        u_0[1].h3.setInvalid();
+        u_0[0].h1.setValid();
+        u_0[0].h1 = (Header1){data = 32w1};
+        u_0[1].h1 = u_0[0].h1;
+        u_0[1].h1.data = 32w1;
+        i_0 = 1w0;
+        u_0[0].h2.setValid();
+        u_0[1] = u_0[i_0];
+        u_0[1].h2.data = 16w1;
+        if (u_0[1].h2.data == 16w0) {
+            u_0[i_0].h2.setValid();
+        }
+        if (u_0[1].h2.data == 16w0) {
+            u_0[i_0].h1.setValid();
+        } else {
+            u_0[i_0].h2.setValid();
+        }
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-frontend.p4
@@ -74,6 +74,9 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         } else {
             u_0[i_0].h2.setValid();
         }
+        u_0[1].h1.setInvalid();
+        u_0[i_0].h1.setInvalid();
+        u_0[i_0].h1.setValid();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-midend.p4
@@ -70,6 +70,11 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         u_0[1].h3 = u_0[1w0].h3;
         u_0[1].h2.data = 16w1;
     }
+    @hidden action invalidhdrwarnings6l83() {
+        u_0[1].h1.setInvalid();
+        u_0[1w0].h1.setInvalid();
+        u_0[1w0].h1.setValid();
+    }
     @hidden table tbl_invalidhdrwarnings6l57 {
         actions = {
             invalidhdrwarnings6l57();
@@ -88,6 +93,12 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         }
         const default_action = invalidhdrwarnings6l79();
     }
+    @hidden table tbl_invalidhdrwarnings6l83 {
+        actions = {
+            invalidhdrwarnings6l83();
+        }
+        const default_action = invalidhdrwarnings6l83();
+    }
     apply {
         tbl_invalidhdrwarnings6l57.apply();
         if (u_0[1].h2.data == 16w0) {
@@ -95,6 +106,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         } else {
             tbl_invalidhdrwarnings6l79.apply();
         }
+        tbl_invalidhdrwarnings6l83.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-midend.p4
@@ -1,0 +1,122 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header1 {
+    bit<32> data;
+}
+
+header Header2 {
+    bit<16> data;
+}
+
+header_union Union {
+    Header1 h1;
+    Header2 h2;
+    Header1 h3;
+}
+
+struct H {
+    Header1  h1;
+    Union[2] u;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.u[0].h1.setValid();
+        pkt.extract<Header1>(hdr.u[0].h3);
+        hdr.u[0].h3.data = 32w1;
+        hdr.u[0].h1 = hdr.u[0].h3;
+        hdr.u[0].h1.data = 32w1;
+        transition last;
+    }
+    state next {
+        pkt.extract<Header2>(hdr.u[0].h2);
+        transition last;
+    }
+    state last {
+        hdr.u[0].h1.data = 32w1;
+        hdr.u[0].h2.data = 16w1;
+        hdr.u[0].h3.data = 32w1;
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    @name("IngressI.u") Union[2] u_0;
+    @hidden action invalidhdrwarnings6l77() {
+        u_0[1w0].h1.setValid();
+    }
+    @hidden action invalidhdrwarnings6l79() {
+        u_0[1w0].h2.setValid();
+    }
+    @hidden action invalidhdrwarnings6l57() {
+        u_0[0].h1.setInvalid();
+        u_0[0].h2.setInvalid();
+        u_0[0].h3.setInvalid();
+        u_0[1].h1.setInvalid();
+        u_0[1].h2.setInvalid();
+        u_0[1].h3.setInvalid();
+        u_0[0].h1.setValid();
+        u_0[0].h1.data = 32w1;
+        u_0[1].h1 = u_0[0].h1;
+        u_0[1].h1.data = 32w1;
+        u_0[0].h2.setValid();
+        u_0[1].h1 = u_0[1w0].h1;
+        u_0[1].h2 = u_0[1w0].h2;
+        u_0[1].h3 = u_0[1w0].h3;
+        u_0[1].h2.data = 16w1;
+    }
+    @hidden table tbl_invalidhdrwarnings6l57 {
+        actions = {
+            invalidhdrwarnings6l57();
+        }
+        const default_action = invalidhdrwarnings6l57();
+    }
+    @hidden table tbl_invalidhdrwarnings6l77 {
+        actions = {
+            invalidhdrwarnings6l77();
+        }
+        const default_action = invalidhdrwarnings6l77();
+    }
+    @hidden table tbl_invalidhdrwarnings6l79 {
+        actions = {
+            invalidhdrwarnings6l79();
+        }
+        const default_action = invalidhdrwarnings6l79();
+    }
+    apply {
+        tbl_invalidhdrwarnings6l57.apply();
+        if (u_0[1].h2.data == 16w0) {
+            tbl_invalidhdrwarnings6l77.apply();
+        } else {
+            tbl_invalidhdrwarnings6l79.apply();
+        }
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch<H, M>(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4
@@ -1,0 +1,98 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header Header1 {
+    bit<32> data;
+}
+
+header Header2 {
+    bit<16> data;
+}
+
+header_union Union {
+    Header1 h1;
+    Header2 h2;
+    Header1 h3;
+}
+
+struct H {
+    Header1  h1;
+    Union[2] u;
+}
+
+struct M {
+}
+
+parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t smeta) {
+    state start {
+        hdr.u[0].h1.setValid();
+        pkt.extract(hdr.u[0].h3);
+        hdr.u[0].h1.data = 1;
+        hdr.u[0].h3.data = 1;
+        hdr.u[0].h1 = hdr.u[0].h3;
+        hdr.u[0].h1.data = 1;
+        hdr.u[0].h3.data = 1;
+        transition select(hdr.u[0].h1.data) {
+            0: next;
+            default: last;
+        }
+    }
+    state next {
+        pkt.extract(hdr.u[0].h2);
+        transition last;
+    }
+    state last {
+        hdr.u[0].h1.data = 1;
+        hdr.u[0].h2.data = 1;
+        hdr.u[0].h3.data = 1;
+        transition accept;
+    }
+}
+
+control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    Union[2] u;
+    apply {
+        u[0].h1 = { 1 };
+        u[1].h1 = u[0].h1;
+        u[1].h1.data = 1;
+        bit<1> i = 0;
+        u[0].h2.setValid();
+        u[1] = u[i];
+        u[1].h1.data = 1;
+        u[1].h2.data = 1;
+        if (u[1].h2.data == 0) {
+            u[i].h2.setValid();
+        }
+        u[0].h1.data = 1;
+        if (u[1].h2.data == 0) {
+            u[i].h1.setValid();
+        } else {
+            u[i].h2.setValid();
+        }
+        u[0].h1.data = 1;
+    }
+}
+
+control EgressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
+    apply {
+    }
+}
+
+control DeparserI(packet_out pk, in H hdr) {
+    apply {
+    }
+}
+
+control VerifyChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+control ComputeChecksumI(inout H hdr, inout M meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserI(), VerifyChecksumI(), IngressI(), EgressI(), ComputeChecksumI(), DeparserI()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4
@@ -71,6 +71,13 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
             u[i].h2.setValid();
         }
         u[0].h1.data = 1;
+        u[1].h1.setInvalid();
+        u[i].h1.setInvalid();
+        u[0].h1.data = 1;
+        u[1].h1.data = 1;
+        u[i].h1.setValid();
+        u[0].h1.data = 1;
+        u[1].h1.data = 1;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4-stderr
@@ -1,0 +1,25 @@
+invalid-hdr-warnings6.p4(30): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.u[0].h1
+        hdr.u[0].h1.data = 1;
+        ^^^^^^^^^^^
+invalid-hdr-warnings6.p4(35): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.u[0].h3
+        hdr.u[0].h3.data = 1;
+        ^^^^^^^^^^^
+invalid-hdr-warnings6.p4(49): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u[0].h1
+        hdr.u[0].h1.data = 1;
+        ^^^^^^^^^^^
+invalid-hdr-warnings6.p4(50): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u[0].h2
+        hdr.u[0].h2.data = 1;
+        ^^^^^^^^^^^
+invalid-hdr-warnings6.p4(51): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.u[0].h3
+        hdr.u[0].h3.data = 1;
+        ^^^^^^^^^^^
+invalid-hdr-warnings6.p4(66): [--Wwarn=uninitialized_use] warning: u[i] may not be completely initialized
+        u[1] = u[i];
+               ^^^^
+invalid-hdr-warnings6.p4(74): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u[0].h1
+        u[0].h1.data = 1; // u[0].h1 is invalid either if the then branch is executed (for any i) or not
+        ^^^^^^^
+invalid-hdr-warnings6.p4(82): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header u[0].h1
+        u[0].h1.data = 1;
+        ^^^^^^^
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4-stderr
@@ -22,4 +22,9 @@ invalid-hdr-warnings6.p4(74): [--Wwarn=invalid_header] warning: accessing a fiel
 invalid-hdr-warnings6.p4(82): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header u[0].h1
         u[0].h1.data = 1;
         ^^^^^^^
-
+invalid-hdr-warnings6.p4(86): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header u[0].h1
+        u[0].h1.data = 1;
+        ^^^^^^^
+invalid-hdr-warnings6.p4(87): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u[1].h1
+        u[1].h1.data = 1;
+        ^^^^^^^

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "v1model"
+}

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings7-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings7-first.p4
@@ -1,0 +1,77 @@
+header H1 {
+    bit<32> a;
+}
+
+header H2 {
+    bit<32> a;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(inout bit<32> param);
+package top(ct _ct);
+control c(inout bit<32> x) {
+    U u;
+    H1[2] hs;
+    U[2] us;
+    action initialize(out U u1, out H1[2] hs1, out U[2] us1) {
+        u1.h1.a = 32w1;
+        u1.h2.a = 32w1;
+        hs1[0].a = 32w1;
+        hs1[1].a = 32w1;
+        us1[0].h1.a = 32w1;
+        us1[0].h2.a = 32w1;
+        u1.h1.setValid();
+        u1.h2.setValid();
+        hs1[0].setValid();
+        hs1[1].setValid();
+        us1[0].h1.setValid();
+        us1[0].h2.setValid();
+    }
+    action inout_action1(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        u1.h1.a = 32w1;
+        u1.h2.a = 32w1;
+        hs1[0].a = 32w1;
+        hs1[1].a = 32w1;
+        us1[0].h1.a = 32w1;
+        us1[0].h2.a = 32w1;
+        hs1[0].setInvalid();
+        u1.h1.setValid();
+        us1[0].h1.setValid();
+    }
+    action inout_action2(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        bit<1> i = 1w1;
+        us1[i].h1.setInvalid();
+        us1[i].h2.setValid();
+    }
+    action xor(in U u1, in H1[2] hs1, in U[2] us1, out bit<32> result) {
+        result = u1.h1.a ^ u1.h2.a ^ hs1[0].a ^ hs1[1].a ^ us1[0].h1.a ^ us1[0].h2.a ^ us1[1].h1.a ^ us1[1].h2.a;
+    }
+    apply @noWarn("uninitialized_use") {
+        u.h1.setValid();
+        hs[0].setValid();
+        us[0].h1.setValid();
+        initialize(u, hs, us);
+        u.h1.a = 32w1;
+        u.h2.a = 32w1;
+        hs[0].a = 32w1;
+        hs[1].a = 32w1;
+        us[0].h1.a = 32w1;
+        us[0].h2.a = 32w1;
+        inout_action1(u, hs, us);
+        u.h1.a = 32w1;
+        u.h2.a = 32w1;
+        hs[0].a = 32w1;
+        hs[1].a = 32w1;
+        us[0].h1.a = 32w1;
+        us[0].h2.a = 32w1;
+        inout_action2(u, hs, us);
+        xor(u, hs, us, x);
+    }
+}
+
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings7-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings7-frontend.p4
@@ -1,0 +1,118 @@
+header H1 {
+    bit<32> a;
+}
+
+header H2 {
+    bit<32> a;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(inout bit<32> param);
+package top(ct _ct);
+control c(inout bit<32> x) {
+    @name("c.u") U u_0;
+    @name("c.hs") H1[2] hs_0;
+    @name("c.us") U[2] us_0;
+    @name("c.i") bit<1> i_0;
+    @name("c.u1") U u1_0;
+    @name("c.hs1") H1[2] hs1_0;
+    @name("c.us1") U[2] us1_0;
+    @name("c.u1") U u1_1;
+    @name("c.hs1") H1[2] hs1_1;
+    @name("c.us1") U[2] us1_1;
+    @name("c.u1") U u1_2;
+    @name("c.hs1") H1[2] hs1_2;
+    @name("c.us1") U[2] us1_2;
+    @name("c.u1") U u1_3;
+    @name("c.hs1") H1[2] hs1_3;
+    @name("c.us1") U[2] us1_3;
+    @name("c.result") bit<32> result_0;
+    @name("c.initialize") action initialize() {
+        u1_0.h1.a = 32w1;
+        u1_0.h2.a = 32w1;
+        hs1_0[0].a = 32w1;
+        hs1_0[1].a = 32w1;
+        us1_0[0].h1.a = 32w1;
+        us1_0[0].h2.a = 32w1;
+        u1_0.h1.setValid();
+        u1_0.h2.setValid();
+        hs1_0[0].setValid();
+        hs1_0[1].setValid();
+        us1_0[0].h1.setValid();
+        us1_0[0].h2.setValid();
+        u_0 = u1_0;
+        hs_0 = hs1_0;
+        us_0 = us1_0;
+    }
+    @name("c.inout_action1") action inout_action1() {
+        u1_1 = u_0;
+        hs1_1 = hs_0;
+        us1_1 = us_0;
+        u1_1.h1.a = 32w1;
+        u1_1.h2.a = 32w1;
+        hs1_1[0].a = 32w1;
+        hs1_1[1].a = 32w1;
+        us1_1[0].h1.a = 32w1;
+        us1_1[0].h2.a = 32w1;
+        hs1_1[0].setInvalid();
+        u1_1.h1.setValid();
+        us1_1[0].h1.setValid();
+        u_0 = u1_1;
+        hs_0 = hs1_1;
+        us_0 = us1_1;
+    }
+    @name("c.inout_action2") action inout_action2() {
+        u1_2 = u_0;
+        hs1_2 = hs_0;
+        us1_2 = us_0;
+        i_0 = 1w1;
+        us1_2[i_0].h1.setInvalid();
+        us1_2[i_0].h2.setValid();
+        u_0 = u1_2;
+        hs_0 = hs1_2;
+        us_0 = us1_2;
+    }
+    @name("c.xor") action xor() {
+        u1_3 = u_0;
+        hs1_3 = hs_0;
+        us1_3 = us_0;
+        result_0 = u1_3.h1.a ^ u1_3.h2.a ^ hs1_3[0].a ^ hs1_3[1].a ^ us1_3[0].h1.a ^ us1_3[0].h2.a ^ us1_3[1].h1.a ^ us1_3[1].h2.a;
+        x = result_0;
+    }
+    apply @noWarn("uninitialized_use") {
+        u_0.h1.setInvalid();
+        u_0.h2.setInvalid();
+        hs_0[0].setInvalid();
+        hs_0[1].setInvalid();
+        us_0[0].h1.setInvalid();
+        us_0[0].h2.setInvalid();
+        us_0[1].h1.setInvalid();
+        us_0[1].h2.setInvalid();
+        u_0.h1.setValid();
+        hs_0[0].setValid();
+        us_0[0].h1.setValid();
+        initialize();
+        u_0.h1.a = 32w1;
+        u_0.h2.a = 32w1;
+        hs_0[0].a = 32w1;
+        hs_0[1].a = 32w1;
+        us_0[0].h1.a = 32w1;
+        us_0[0].h2.a = 32w1;
+        inout_action1();
+        u_0.h1.a = 32w1;
+        u_0.h2.a = 32w1;
+        hs_0[0].a = 32w1;
+        hs_0[1].a = 32w1;
+        us_0[0].h1.a = 32w1;
+        us_0[0].h2.a = 32w1;
+        inout_action2();
+        xor();
+    }
+}
+
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings7-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings7-midend.p4
@@ -1,0 +1,167 @@
+header H1 {
+    bit<32> a;
+}
+
+header H2 {
+    bit<32> a;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(inout bit<32> param);
+package top(ct _ct);
+control c(inout bit<32> x) {
+    @name("c.u") U u_0;
+    @name("c.hs") H1[2] hs_0;
+    @name("c.us") U[2] us_0;
+    @name("c.u1") U u1_0;
+    @name("c.hs1") H1[2] hs1_0;
+    @name("c.us1") U[2] us1_0;
+    @name("c.u1") U u1_1;
+    @name("c.hs1") H1[2] hs1_1;
+    @name("c.us1") U[2] us1_1;
+    @name("c.u1") U u1_2;
+    @name("c.us1") U[2] us1_2;
+    @name("c.u1") U u1_3;
+    @name("c.hs1") H1[2] hs1_3;
+    @name("c.us1") U[2] us1_3;
+    @name("c.initialize") action initialize() {
+        u1_0.h1.a = 32w1;
+        u1_0.h2.a = 32w1;
+        hs1_0[0].a = 32w1;
+        hs1_0[1].a = 32w1;
+        us1_0[0].h1.a = 32w1;
+        us1_0[0].h2.a = 32w1;
+        u1_0.h1.setValid();
+        u1_0.h2.setValid();
+        hs1_0[0].setValid();
+        hs1_0[1].setValid();
+        us1_0[0].h1.setValid();
+        us1_0[0].h2.setValid();
+        u_0.h1 = u1_0.h1;
+        u_0.h2 = u1_0.h2;
+        hs_0 = hs1_0;
+        us_0 = us1_0;
+    }
+    @name("c.inout_action1") action inout_action1() {
+        u1_1.h1 = u_0.h1;
+        u1_1.h2 = u_0.h2;
+        hs1_1 = hs_0;
+        us1_1 = us_0;
+        u1_1.h1.a = 32w1;
+        u1_1.h2.a = 32w1;
+        hs1_1[0].a = 32w1;
+        hs1_1[1].a = 32w1;
+        us1_1[0].h1.a = 32w1;
+        us1_1[0].h2.a = 32w1;
+        hs1_1[0].setInvalid();
+        u1_1.h1.setValid();
+        us1_1[0].h1.setValid();
+        u_0.h1 = u1_1.h1;
+        u_0.h2 = u1_1.h2;
+        hs_0 = hs1_1;
+        us_0 = us1_1;
+    }
+    @name("c.inout_action2") action inout_action2() {
+        u1_2.h1 = u_0.h1;
+        u1_2.h2 = u_0.h2;
+        us1_2 = us_0;
+        us1_2[1w1].h1.setInvalid();
+        us1_2[1w1].h2.setValid();
+        u_0.h2 = u1_2.h2;
+        us_0 = us1_2;
+    }
+    @name("c.xor") action xor() {
+        u1_3.h1 = u_0.h1;
+        u1_3.h2 = u_0.h2;
+        hs1_3 = hs_0;
+        us1_3 = us_0;
+        x = u1_3.h1.a ^ u1_3.h2.a ^ hs1_3[0].a ^ hs1_3[1].a ^ us1_3[0].h1.a ^ us1_3[0].h2.a ^ us1_3[1].h1.a ^ us1_3[1].h2.a;
+    }
+    @hidden action invalidhdrwarnings7l13() {
+        u_0.h1.setInvalid();
+        u_0.h2.setInvalid();
+        hs_0[0].setInvalid();
+        hs_0[1].setInvalid();
+        us_0[0].h1.setInvalid();
+        us_0[0].h2.setInvalid();
+        us_0[1].h1.setInvalid();
+        us_0[1].h2.setInvalid();
+        u_0.h1.setValid();
+        hs_0[0].setValid();
+        us_0[0].h1.setValid();
+    }
+    @hidden action invalidhdrwarnings7l68() {
+        u_0.h1.a = 32w1;
+        u_0.h2.a = 32w1;
+        hs_0[0].a = 32w1;
+        hs_0[1].a = 32w1;
+        us_0[0].h1.a = 32w1;
+        us_0[0].h2.a = 32w1;
+    }
+    @hidden action invalidhdrwarnings7l78() {
+        u_0.h1.a = 32w1;
+        u_0.h2.a = 32w1;
+        hs_0[0].a = 32w1;
+        hs_0[1].a = 32w1;
+        us_0[0].h1.a = 32w1;
+        us_0[0].h2.a = 32w1;
+    }
+    @hidden table tbl_invalidhdrwarnings7l13 {
+        actions = {
+            invalidhdrwarnings7l13();
+        }
+        const default_action = invalidhdrwarnings7l13();
+    }
+    @hidden table tbl_initialize {
+        actions = {
+            initialize();
+        }
+        const default_action = initialize();
+    }
+    @hidden table tbl_invalidhdrwarnings7l68 {
+        actions = {
+            invalidhdrwarnings7l68();
+        }
+        const default_action = invalidhdrwarnings7l68();
+    }
+    @hidden table tbl_inout_action1 {
+        actions = {
+            inout_action1();
+        }
+        const default_action = inout_action1();
+    }
+    @hidden table tbl_invalidhdrwarnings7l78 {
+        actions = {
+            invalidhdrwarnings7l78();
+        }
+        const default_action = invalidhdrwarnings7l78();
+    }
+    @hidden table tbl_inout_action2 {
+        actions = {
+            inout_action2();
+        }
+        const default_action = inout_action2();
+    }
+    @hidden table tbl_xor {
+        actions = {
+            xor();
+        }
+        const default_action = xor();
+    }
+    apply @noWarn("uninitialized_use") {
+        tbl_invalidhdrwarnings7l13.apply();
+        tbl_initialize.apply();
+        tbl_invalidhdrwarnings7l68.apply();
+        tbl_inout_action1.apply();
+        tbl_invalidhdrwarnings7l78.apply();
+        tbl_inout_action2.apply();
+        tbl_xor.apply();
+    }
+}
+
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings7.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings7.p4
@@ -1,0 +1,77 @@
+header H1 {
+    bit<32> a;
+}
+
+header H2 {
+    bit<32> a;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(inout bit<32> param);
+package top(ct _ct);
+control c(inout bit<32> x) {
+    U u;
+    H1[2] hs;
+    U[2] us;
+    action initialize(out U u1, out H1[2] hs1, out U[2] us1) {
+        u1.h1.a = 1;
+        u1.h2.a = 1;
+        hs1[0].a = 1;
+        hs1[1].a = 1;
+        us1[0].h1.a = 1;
+        us1[0].h2.a = 1;
+        u1.h1.setValid();
+        u1.h2.setValid();
+        hs1[0].setValid();
+        hs1[1].setValid();
+        us1[0].h1.setValid();
+        us1[0].h2.setValid();
+    }
+    action inout_action1(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        u1.h1.a = 1;
+        u1.h2.a = 1;
+        hs1[0].a = 1;
+        hs1[1].a = 1;
+        us1[0].h1.a = 1;
+        us1[0].h2.a = 1;
+        hs1[0].setInvalid();
+        u1.h1.setValid();
+        us1[0].h1.setValid();
+    }
+    action inout_action2(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        bit<1> i = 1;
+        us1[i].h1.setInvalid();
+        us1[i].h2.setValid();
+    }
+    action xor(in U u1, in H1[2] hs1, in U[2] us1, out bit<32> result) {
+        result = u1.h1.a ^ u1.h2.a ^ hs1[0].a ^ hs1[1].a ^ us1[0].h1.a ^ us1[0].h2.a ^ us1[1].h1.a ^ us1[1].h2.a;
+    }
+    apply @noWarn("uninitialized_use") {
+        u.h1.setValid();
+        hs[0].setValid();
+        us[0].h1.setValid();
+        initialize(u, hs, us);
+        u.h1.a = 1;
+        u.h2.a = 1;
+        hs[0].a = 1;
+        hs[1].a = 1;
+        us[0].h1.a = 1;
+        us[0].h2.a = 1;
+        inout_action1(u, hs, us);
+        u.h1.a = 1;
+        u.h2.a = 1;
+        hs[0].a = 1;
+        hs[1].a = 1;
+        us[0].h1.a = 1;
+        us[0].h2.a = 1;
+        inout_action2(u, hs, us);
+        xor(u, hs, us, x);
+    }
+}
+
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings7.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings7.p4-stderr
@@ -1,0 +1,49 @@
+invalid-hdr-warnings7.p4(19): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h1
+        u1.h1.a = 1;
+        ^^^^^
+invalid-hdr-warnings7.p4(20): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h2
+        u1.h2.a = 1;
+        ^^^^^
+invalid-hdr-warnings7.p4(21): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hs1[0]
+        hs1[0].a = 1;
+        ^^^^^^
+invalid-hdr-warnings7.p4(22): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hs1[1]
+        hs1[1].a = 1;
+        ^^^^^^
+invalid-hdr-warnings7.p4(23): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us1[0].h1
+        us1[0].h1.a = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings7.p4(24): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us1[0].h2
+        us1[0].h2.a = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings7.p4(68): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u.h1
+        u.h1.a = 1; // expected invalid
+        ^^^^
+invalid-hdr-warnings7.p4(72): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us[0].h1
+        us[0].h1.a = 1; // expected invalid
+        ^^^^^^^^
+invalid-hdr-warnings7.p4(36): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h1
+        u1.h1.a = 1; // expected invalid
+        ^^^^^
+invalid-hdr-warnings7.p4(40): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us1[0].h1
+        us1[0].h1.a = 1; // expected invalid
+        ^^^^^^^^^
+invalid-hdr-warnings7.p4(79): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u.h2
+        u.h2.a = 1; // expected invalid
+        ^^^^
+invalid-hdr-warnings7.p4(80): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hs[0]
+        hs[0].a = 1; // expected invalid
+        ^^^^^
+invalid-hdr-warnings7.p4(83): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us[0].h2
+        us[0].h2.a = 1; // expected invalid
+        ^^^^^^^^
+invalid-hdr-warnings7.p4(56): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h2
+        result = u1.h1.a ^ u1.h2.a ^ hs1[0].a ^ hs1[1].a ^ us1[0].h1.a
+                           ^^^^^
+invalid-hdr-warnings7.p4(56): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hs1[0]
+        result = u1.h1.a ^ u1.h2.a ^ hs1[0].a ^ hs1[1].a ^ us1[0].h1.a
+                                     ^^^^^^
+invalid-hdr-warnings7.p4(57): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us1[1].h1
+                 ^ us1[0].h2.a ^ us1[1].h1.a ^ us1[1].h2.a;
+                                 ^^^^^^^^^
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings8-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings8-first.p4
@@ -1,0 +1,71 @@
+header H1 {
+    bit<32> a;
+}
+
+header H2 {
+    bit<32> a;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(inout bit<32> param);
+package top(ct _ct);
+control c(inout bit<32> x) {
+    U u;
+    H1[2] hs;
+    U[2] us;
+    action initialize(out U u1, out H1[2] hs1, out U[2] us1) {
+        u1.h1.a = 32w1;
+        u1.h2.a = 32w1;
+        hs1[0].a = 32w1;
+        hs1[1].a = 32w1;
+        us1[0].h1.a = 32w1;
+        us1[0].h2.a = 32w1;
+        u1.h1.setValid();
+        u1.h2.setValid();
+        hs1[0].setValid();
+        hs1[1].setValid();
+        us1[0].h1.setValid();
+        us1[0].h2.setValid();
+    }
+    action inout_action1(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        initialize(u1, hs1, us1);
+        u1.h1.a = 32w1;
+        u1.h2.a = 32w1;
+        hs1[0].a = 32w1;
+        hs1[1].a = 32w1;
+        us1[0].h1.a = 32w1;
+        us1[0].h2.a = 32w1;
+        hs1[0].setInvalid();
+        u1.h1.setValid();
+        us1[0].h1.setValid();
+    }
+    action inout_action2(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        inout_action1(u1, hs1, us1);
+        u1.h1.a = 32w1;
+        u1.h2.a = 32w1;
+        hs1[0].a = 32w1;
+        hs1[1].a = 32w1;
+        us1[0].h1.a = 32w1;
+        us1[0].h2.a = 32w1;
+        bit<1> i = 1w1;
+        us1[i].h1.setInvalid();
+        us1[i].h2.setValid();
+    }
+    action xor(in U u1, in H1[2] hs1, in U[2] us1, out bit<32> result) {
+        result = u1.h1.a ^ u1.h2.a ^ hs1[0].a ^ hs1[1].a ^ us1[0].h1.a ^ us1[0].h2.a ^ us1[1].h1.a ^ us1[1].h2.a;
+    }
+    apply @noWarn("uninitialized_use") {
+        u.h1.setValid();
+        hs[0].setValid();
+        us[0].h1.setValid();
+        inout_action2(u, hs, us);
+        xor(u, hs, us, x);
+    }
+}
+
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings8-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings8-frontend.p4
@@ -1,0 +1,106 @@
+header H1 {
+    bit<32> a;
+}
+
+header H2 {
+    bit<32> a;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(inout bit<32> param);
+package top(ct _ct);
+control c(inout bit<32> x) {
+    @name("c.u") U u_0;
+    @name("c.hs") H1[2] hs_0;
+    @name("c.us") U[2] us_0;
+    @name("c.i") bit<1> i_0;
+    @name("c.u1") U u1_2;
+    @name("c.hs1") H1[2] hs1_2;
+    @name("c.us1") U[2] us1_2;
+    @name("c.u1") U u1_3;
+    @name("c.hs1") H1[2] hs1_3;
+    @name("c.us1") U[2] us1_3;
+    @name("c.u1") U u1_5;
+    @name("c.hs1") H1[2] hs1_5;
+    @name("c.us1") U[2] us1_5;
+    @name("c.u1") U u1_6;
+    @name("c.hs1") H1[2] hs1_6;
+    @name("c.us1") U[2] us1_6;
+    @name("c.result") bit<32> result_0;
+    @name("c.inout_action2") action inout_action2() {
+        u1_5 = u_0;
+        hs1_5 = hs_0;
+        us1_5 = us_0;
+        u1_2 = u1_5;
+        hs1_2 = hs1_5;
+        us1_2 = us1_5;
+        u1_3.h1.a = 32w1;
+        u1_3.h2.a = 32w1;
+        hs1_3[0].a = 32w1;
+        hs1_3[1].a = 32w1;
+        us1_3[0].h1.a = 32w1;
+        us1_3[0].h2.a = 32w1;
+        u1_3.h1.setValid();
+        u1_3.h2.setValid();
+        hs1_3[0].setValid();
+        hs1_3[1].setValid();
+        us1_3[0].h1.setValid();
+        us1_3[0].h2.setValid();
+        u1_2 = u1_3;
+        hs1_2 = hs1_3;
+        us1_2 = us1_3;
+        u1_2.h1.a = 32w1;
+        u1_2.h2.a = 32w1;
+        hs1_2[0].a = 32w1;
+        hs1_2[1].a = 32w1;
+        us1_2[0].h1.a = 32w1;
+        us1_2[0].h2.a = 32w1;
+        hs1_2[0].setInvalid();
+        u1_2.h1.setValid();
+        us1_2[0].h1.setValid();
+        u1_5 = u1_2;
+        hs1_5 = hs1_2;
+        us1_5 = us1_2;
+        u1_5.h1.a = 32w1;
+        u1_5.h2.a = 32w1;
+        hs1_5[0].a = 32w1;
+        hs1_5[1].a = 32w1;
+        us1_5[0].h1.a = 32w1;
+        us1_5[0].h2.a = 32w1;
+        i_0 = 1w1;
+        us1_5[i_0].h1.setInvalid();
+        us1_5[i_0].h2.setValid();
+        u_0 = u1_5;
+        hs_0 = hs1_5;
+        us_0 = us1_5;
+    }
+    @name("c.xor") action xor() {
+        u1_6 = u_0;
+        hs1_6 = hs_0;
+        us1_6 = us_0;
+        result_0 = u1_6.h1.a ^ u1_6.h2.a ^ hs1_6[0].a ^ hs1_6[1].a ^ us1_6[0].h1.a ^ us1_6[0].h2.a ^ us1_6[1].h1.a ^ us1_6[1].h2.a;
+        x = result_0;
+    }
+    apply @noWarn("uninitialized_use") {
+        u_0.h1.setInvalid();
+        u_0.h2.setInvalid();
+        hs_0[0].setInvalid();
+        hs_0[1].setInvalid();
+        us_0[0].h1.setInvalid();
+        us_0[0].h2.setInvalid();
+        us_0[1].h1.setInvalid();
+        us_0[1].h2.setInvalid();
+        u_0.h1.setValid();
+        hs_0[0].setValid();
+        us_0[0].h1.setValid();
+        inout_action2();
+        xor();
+    }
+}
+
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings8-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings8-midend.p4
@@ -1,0 +1,129 @@
+header H1 {
+    bit<32> a;
+}
+
+header H2 {
+    bit<32> a;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(inout bit<32> param);
+package top(ct _ct);
+control c(inout bit<32> x) {
+    @name("c.u") U u_0;
+    @name("c.hs") H1[2] hs_0;
+    @name("c.us") U[2] us_0;
+    @name("c.u1") U u1_2;
+    @name("c.hs1") H1[2] hs1_2;
+    @name("c.us1") U[2] us1_2;
+    @name("c.u1") U u1_3;
+    @name("c.hs1") H1[2] hs1_3;
+    @name("c.us1") U[2] us1_3;
+    @name("c.u1") U u1_5;
+    @name("c.hs1") H1[2] hs1_5;
+    @name("c.us1") U[2] us1_5;
+    @name("c.u1") U u1_6;
+    @name("c.hs1") H1[2] hs1_6;
+    @name("c.us1") U[2] us1_6;
+    @name("c.inout_action2") action inout_action2() {
+        u1_5.h1 = u_0.h1;
+        u1_5.h2 = u_0.h2;
+        hs1_5 = hs_0;
+        us1_5 = us_0;
+        u1_2.h1 = u_0.h1;
+        u1_2.h2 = u_0.h2;
+        hs1_2 = hs_0;
+        us1_2 = us_0;
+        u1_3.h1.a = 32w1;
+        u1_3.h2.a = 32w1;
+        hs1_3[0].a = 32w1;
+        hs1_3[1].a = 32w1;
+        us1_3[0].h1.a = 32w1;
+        us1_3[0].h2.a = 32w1;
+        u1_3.h1.setValid();
+        u1_3.h2.setValid();
+        hs1_3[0].setValid();
+        hs1_3[1].setValid();
+        us1_3[0].h1.setValid();
+        us1_3[0].h2.setValid();
+        u1_2.h1 = u1_3.h1;
+        u1_2.h2 = u1_3.h2;
+        hs1_2 = hs1_3;
+        us1_2 = us1_3;
+        u1_2.h1.a = 32w1;
+        u1_2.h2.a = 32w1;
+        hs1_2[0].a = 32w1;
+        hs1_2[1].a = 32w1;
+        us1_2[0].h1.a = 32w1;
+        us1_2[0].h2.a = 32w1;
+        hs1_2[0].setInvalid();
+        u1_2.h1.setValid();
+        us1_2[0].h1.setValid();
+        u1_5.h1 = u1_2.h1;
+        u1_5.h2 = u1_2.h2;
+        hs1_5 = hs1_2;
+        us1_5 = us1_2;
+        u1_5.h1.a = 32w1;
+        u1_5.h2.a = 32w1;
+        hs1_5[0].a = 32w1;
+        hs1_5[1].a = 32w1;
+        us1_5[0].h1.a = 32w1;
+        us1_5[0].h2.a = 32w1;
+        us1_5[1w1].h1.setInvalid();
+        us1_5[1w1].h2.setValid();
+        u_0.h1 = u1_5.h1;
+        u_0.h2 = u1_5.h2;
+        hs_0 = hs1_5;
+        us_0 = us1_5;
+    }
+    @name("c.xor") action xor() {
+        u1_6.h1 = u_0.h1;
+        u1_6.h2 = u_0.h2;
+        hs1_6 = hs_0;
+        us1_6 = us_0;
+        x = u1_6.h1.a ^ u1_6.h2.a ^ hs1_6[0].a ^ hs1_6[1].a ^ us1_6[0].h1.a ^ us1_6[0].h2.a ^ us1_6[1].h1.a ^ us1_6[1].h2.a;
+    }
+    @hidden action invalidhdrwarnings8l13() {
+        u_0.h1.setInvalid();
+        u_0.h2.setInvalid();
+        hs_0[0].setInvalid();
+        hs_0[1].setInvalid();
+        us_0[0].h1.setInvalid();
+        us_0[0].h2.setInvalid();
+        us_0[1].h1.setInvalid();
+        us_0[1].h2.setInvalid();
+        u_0.h1.setValid();
+        hs_0[0].setValid();
+        us_0[0].h1.setValid();
+    }
+    @hidden table tbl_invalidhdrwarnings8l13 {
+        actions = {
+            invalidhdrwarnings8l13();
+        }
+        const default_action = invalidhdrwarnings8l13();
+    }
+    @hidden table tbl_inout_action2 {
+        actions = {
+            inout_action2();
+        }
+        const default_action = inout_action2();
+    }
+    @hidden table tbl_xor {
+        actions = {
+            xor();
+        }
+        const default_action = xor();
+    }
+    apply @noWarn("uninitialized_use") {
+        tbl_invalidhdrwarnings8l13.apply();
+        tbl_inout_action2.apply();
+        tbl_xor.apply();
+    }
+}
+
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings8.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings8.p4
@@ -1,0 +1,71 @@
+header H1 {
+    bit<32> a;
+}
+
+header H2 {
+    bit<32> a;
+}
+
+header_union U {
+    H1 h1;
+    H2 h2;
+}
+
+control ct(inout bit<32> param);
+package top(ct _ct);
+control c(inout bit<32> x) {
+    U u;
+    H1[2] hs;
+    U[2] us;
+    action initialize(out U u1, out H1[2] hs1, out U[2] us1) {
+        u1.h1.a = 1;
+        u1.h2.a = 1;
+        hs1[0].a = 1;
+        hs1[1].a = 1;
+        us1[0].h1.a = 1;
+        us1[0].h2.a = 1;
+        u1.h1.setValid();
+        u1.h2.setValid();
+        hs1[0].setValid();
+        hs1[1].setValid();
+        us1[0].h1.setValid();
+        us1[0].h2.setValid();
+    }
+    action inout_action1(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        initialize(u1, hs1, us1);
+        u1.h1.a = 1;
+        u1.h2.a = 1;
+        hs1[0].a = 1;
+        hs1[1].a = 1;
+        us1[0].h1.a = 1;
+        us1[0].h2.a = 1;
+        hs1[0].setInvalid();
+        u1.h1.setValid();
+        us1[0].h1.setValid();
+    }
+    action inout_action2(inout U u1, inout H1[2] hs1, inout U[2] us1) {
+        inout_action1(u1, hs1, us1);
+        u1.h1.a = 1;
+        u1.h2.a = 1;
+        hs1[0].a = 1;
+        hs1[1].a = 1;
+        us1[0].h1.a = 1;
+        us1[0].h2.a = 1;
+        bit<1> i = 1;
+        us1[i].h1.setInvalid();
+        us1[i].h2.setValid();
+    }
+    action xor(in U u1, in H1[2] hs1, in U[2] us1, out bit<32> result) {
+        result = u1.h1.a ^ u1.h2.a ^ hs1[0].a ^ hs1[1].a ^ us1[0].h1.a ^ us1[0].h2.a ^ us1[1].h1.a ^ us1[1].h2.a;
+    }
+    apply @noWarn("uninitialized_use") {
+        u.h1.setValid();
+        hs[0].setValid();
+        us[0].h1.setValid();
+        inout_action2(u, hs, us);
+        xor(u, hs, us, x);
+    }
+}
+
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings8.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings8.p4-stderr
@@ -1,0 +1,43 @@
+invalid-hdr-warnings8.p4(19): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h1
+        u1.h1.a = 1;
+        ^^^^^
+invalid-hdr-warnings8.p4(20): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h2
+        u1.h2.a = 1;
+        ^^^^^
+invalid-hdr-warnings8.p4(21): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hs1[0]
+        hs1[0].a = 1;
+        ^^^^^^
+invalid-hdr-warnings8.p4(22): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hs1[1]
+        hs1[1].a = 1;
+        ^^^^^^
+invalid-hdr-warnings8.p4(23): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us1[0].h1
+        us1[0].h1.a = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings8.p4(24): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us1[0].h2
+        us1[0].h2.a = 1;
+        ^^^^^^^^^
+invalid-hdr-warnings8.p4(38): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h1
+        u1.h1.a = 1; // expected invalid
+        ^^^^^
+invalid-hdr-warnings8.p4(42): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us1[0].h1
+        us1[0].h1.a = 1; // expected invalid
+        ^^^^^^^^^
+invalid-hdr-warnings8.p4(55): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h2
+        u1.h2.a = 1; // expected invalid
+        ^^^^^
+invalid-hdr-warnings8.p4(56): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hs1[0]
+        hs1[0].a = 1; // expected invalid
+        ^^^^^^
+invalid-hdr-warnings8.p4(59): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us1[0].h2
+        us1[0].h2.a = 1; // expected invalid
+        ^^^^^^^^^
+invalid-hdr-warnings8.p4(68): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u1.h2
+        result = u1.h1.a ^ u1.h2.a ^ hs1[0].a ^ hs1[1].a ^ us1[0].h1.a
+                           ^^^^^
+invalid-hdr-warnings8.p4(68): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hs1[0]
+        result = u1.h1.a ^ u1.h2.a ^ hs1[0].a ^ hs1[1].a ^ us1[0].h1.a
+                                     ^^^^^^
+invalid-hdr-warnings8.p4(69): [--Wwarn=invalid_header] warning: accessing a field of an invalid header us1[1].h1
+                 ^ us1[0].h2.a ^ us1[1].h1.a ^ us1[1].h2.a;
+                                 ^^^^^^^^^
+

--- a/testdata/p4_16_samples_outputs/issue561.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue561.p4-stderr
@@ -4,6 +4,21 @@ issue561.p4(35): [--Wwarn=uninitialized_use] warning: u.h1.f may be uninitialize
 issue561.p4(35): [--Wwarn=uninitialized_use] warning: u.h2.g may be uninitialized
         x = u.h1.f + u.h2.g;
                      ^^^^^^
+issue561.p4(40): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u.h2
+        u.h2.g = 0;
+        ^^^^
+issue561.p4(41): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u.h2
+        x = x + u.h2.g;
+                ^^^^
+issue561.p4(45): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u2[1].h2
+        x = x + u2[1].h2.g + u2[0].h1.f;
+                ^^^^^^^^
 issue561.p4(45): [--Wwarn=uninitialized_use] warning: u2[1].h2.g may be uninitialized
         x = x + u2[1].h2.g + u2[0].h1.f;
                 ^^^^^^^^^^
+issue561.p4(35): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u.h1
+        x = u.h1.f + u.h2.g;
+            ^^^^
+issue561.p4(35): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u.h2
+        x = u.h1.f + u.h2.g;
+                     ^^^^

--- a/testdata/p4_16_samples_outputs/stack-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/stack-bmv2.p4-stderr
@@ -1,0 +1,6 @@
+stack-bmv2.p4(27): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp[0]
+        tmp[0].f = h.f + 1;
+        ^^^^^^
+stack-bmv2.p4(28): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp[0]
+        h.f = tmp[0].f;
+              ^^^^^^

--- a/testdata/p4_16_samples_outputs/stack-bvec-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/stack-bvec-bmv2.p4-stderr
@@ -1,0 +1,15 @@
+stack-bvec-bmv2.p4(38): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp[0]
+ tmp[0].row.alt1.valid = 1;
+ ^^^^^^
+stack-bvec-bmv2.p4(39): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp[0]
+ tmp[0].f = h.f + 1;
+ ^^^^^^
+stack-bvec-bmv2.p4(40): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp[0]
+ h.f = tmp[0].f;
+       ^^^^^^
+stack-bvec-bmv2.p4(41): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp[0]
+ tmp[0].row.alt0.port = h.row.alt0.port + 1;
+ ^^^^^^
+stack-bvec-bmv2.p4(42): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp[0]
+ h.row.alt1.valid = tmp[0].row.alt1.valid;
+                    ^^^^^^

--- a/testdata/p4_16_samples_outputs/union4-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/union4-bmv2.p4-stderr
@@ -1,0 +1,3 @@
+union4-bmv2.p4(80): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h.u.h2
+            h.u.h1.a = h.u.h2.b[7:0];
+                       ^^^^^^


### PR DESCRIPTION
This is the second part of #2881. The methods of the HeaderDefinitions class are updated to support the operations on unions and stacks.

Header unions are modeled as structs of headers. Writing to the valid bit of a union field implicitly invalidates the valid bits of all other fields.

For header stacks, the valid bit of each element is stored separately. In the case of reading a header stack with an index that is not constant, the valid bit is the result of an OR operation applied to the valid bits of all elements within the stack. In the case of writing to a header stack with a non-constant index, if such writing makes an element valid, the value is propagated to all elements of the stack. If such writing makes an element invalid, that operation is ignored to avoid spurious warnings.

For stacks of header unions, similarly to header stacks, each union is stored separately. In the case of reading a field of a union within the stack with a non-constant index, the valid bit is the result of an OR operation applied to the corresponding field of all unions within the stack. In the case of writing, if such writing makes a field valid, the value is propagated to the corresponding field in all unions of the stack **without** invalidating other valid fields (in order to avoid spurious warnings).