### PR TITLE
Silence warnings automatically if @nowarn appears in the context

### DIFF
--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -198,7 +198,7 @@ ActionConverter::convertActionParams(const IR::ParameterList *parameters,
                                      Util::JsonArray* params) {
     for (auto p : *parameters->getEnumerator()) {
         if (!ctxt->refMap->isUsed(p))
-            ::warning(ErrorType::WARN_UNUSED, "Unused action parameter %1%", p);
+            warn(ErrorType::WARN_UNUSED, "Unused action parameter %1%", p);
 
         auto param = new Util::JsonObject();
         param->emplace("name", p->externalName());

--- a/backends/common/removeComplexExpressions.cpp
+++ b/backends/common/removeComplexExpressions.cpp
@@ -90,6 +90,7 @@ RemoveComplexExpressions::simplifyExpression(const IR::Expression* expression, b
         return expression;
     } else {
         ComplexExpression ce;
+        cd.setCalledBy(this);
         (void)expression->apply(ce);
         if (force || ce.isComplex) {
             LOG3("Moved into temporary " << dbp(expression));

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -355,7 +355,9 @@ const IR::Node *StatementUnroll::preorder(IR::AssignmentStatement *a) {
         expressionUnrollSanityCheck(bin->right);
         expressionUnrollSanityCheck(bin->left);
         auto left_unroller = new ExpressionUnroll(refMap, structure);
+        left_unroller->setCalledBy(this);
         auto right_unroller = new ExpressionUnroll(refMap, structure);
+        right_unroller->setCalledBy(this);
         bin->left->apply(*left_unroller);
         const IR::Expression *left_tmp = left_unroller->root;
         bin->right->apply(*right_unroller);
@@ -386,6 +388,7 @@ const IR::Node *StatementUnroll::preorder(IR::AssignmentStatement *a) {
         auto code_block = new IR::IndexedVector<IR::StatOrDecl>;
         expressionUnrollSanityCheck(un->expr);
         auto unroller = new ExpressionUnroll(refMap, structure);
+        unroller->setCalledBy(this);
         un->expr->apply(*unroller);
         prune();
         const IR::Expression *un_tmp = unroller->root;
@@ -522,6 +525,7 @@ const IR::Node *IfStatementUnroll::postorder(IR::IfStatement *i) {
     auto code_block = new IR::IndexedVector<IR::StatOrDecl>;
     expressionUnrollSanityCheck(i->condition);
     auto unroller = new LogicalExpressionUnroll(refMap, structure);
+    unroller->setCalledBy(this);
     i->condition->apply(*unroller);
     for (auto i : unroller->stmt)
         code_block->push_back(i);
@@ -959,7 +963,7 @@ const IR::Node* CopyMatchKeysToSingleStruct::preorder(IR::Key* keys) {
     } else {
         ::warning(ErrorType::WARN_MISMATCH, "Mismatched header/metadata struct for key "
                   "elements in table %1%. Copying all match fields to metadata",
-                   findOrigCtxt<IR::P4Table>()->name.toString());
+                  findOrigCtxt<IR::P4Table>()->name.toString());
         LOG3("Will pull out " << keys);
     }
     return keys;
@@ -1551,4 +1555,3 @@ void CollectAddOnMissTable::postorder(const IR::MethodCallStatement *mcs) {
 }
 
 }  // namespace DPDK
-

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -397,9 +397,9 @@ class CollectExternDeclaration : public Inspector {
                 } else {
                     /* Check if the meter is of PACKETS (0) type */
                     if (d->arguments->at(1)->expression->to<IR::Constant>()->asUnsigned() == 0)
-                        ::warning(ErrorType::WARN_UNSUPPORTED,
-                                  "%1%: Packet metering is not supported." \
-                                  " Falling back to byte metering.", d);
+                        warn(ErrorType::WARN_UNSUPPORTED,
+                             "%1%: Packet metering is not supported."
+                             " Falling back to byte metering.", d);
                 }
             } else if (externTypeName == "Counter") {
                 if (d->arguments->size() != 2 ) {

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -670,6 +670,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
         }
     } else if (auto a = mi->to<P4::ActionCall>()) {
         auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure);
+        helper->setCalledBy(this);
         a->action->body->apply(*helper);
         for (auto i : helper->get_instr()) {
             add_instr(i);

--- a/backends/dpdk/dpdkProgram.cpp
+++ b/backends/dpdk/dpdkProgram.cpp
@@ -477,6 +477,7 @@ bool ConvertToDpdkParser::preorder(const IR::ParserState *) { return false; }
 // =====================Control=============================
 bool ConvertToDpdkControl::preorder(const IR::P4Action *a) {
     auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure);
+    helper->setCalledBy(this);
     a->body->apply(*helper);
     auto stmt_list = new IR::IndexedVector<IR::DpdkAsmStatement>();
     for (auto i : helper->get_instr())
@@ -612,6 +613,7 @@ bool ConvertToDpdkControl::preorder(const IR::P4Control *c) {
         }
     }
     auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure);
+    helper->setCalledBy(this);
     c->body->apply(*helper);
     if (deparser) {
         add_inst(new IR::DpdkJmpNotEqualStatement("LABEL_DROP",

--- a/frontends/p4/actionsInlining.cpp
+++ b/frontends/p4/actionsInlining.cpp
@@ -116,6 +116,7 @@ const IR::Node* ActionsInliner::preorder(IR::MethodCallStatement* statement) {
     }
 
     SubstituteParameters sp(refMap, &subst, &tvs);
+    sp.setCalledBy(this);
     auto clone = callee->apply(sp);
     if (::errorCount() > 0)
         return statement;

--- a/frontends/p4/actionsInlining.h
+++ b/frontends/p4/actionsInlining.h
@@ -95,8 +95,11 @@ class InlineActions : public Transform {
     };
     const IR::V1Program *preorder(IR::V1Program *gl) override { return global = gl; }
     const IR::Node *preorder(IR::Primitive *p) override {
-        if (auto af = global->get<IR::ActionFunction>(p->name))
-            return af->action.clone()->apply(SubstActionArgs(af, p));
+        if (auto af = global->get<IR::ActionFunction>(p->name)) {
+            SubstActionArgs saa(af, p);
+            saa.setCalledBy(this);
+            return af->action.clone()->apply(saa);
+        }
         return p; }
 };
 

--- a/frontends/p4/checkConstants.cpp
+++ b/frontends/p4/checkConstants.cpp
@@ -35,7 +35,7 @@ void DoCheckConstants::postorder(const IR::MethodCallExpression* expression) {
 
 void DoCheckConstants::postorder(const IR::KeyElement* key) {
     if (key->expression->is<IR::Literal>())
-        ::warning(ErrorType::WARN_MISMATCH, "%1%: Constant key field", key->expression);
+        warn(ErrorType::WARN_MISMATCH, "%1%: Constant key field", key->expression);
 }
 
 void DoCheckConstants::postorder(const IR::P4Table* table) {

--- a/frontends/p4/createBuiltins.cpp
+++ b/frontends/p4/createBuiltins.cpp
@@ -57,7 +57,7 @@ void CreateBuiltins::postorder(IR::Entry* entry) {
 
 void CreateBuiltins::postorder(IR::ParserState* state) {
     if (state->selectExpression == nullptr) {
-        warning(ErrorType::WARN_PARSER_TRANSITION, "%1%: implicit transition to `reject'", state);
+        warn(ErrorType::WARN_PARSER_TRANSITION, "%1%: implicit transition to `reject'", state);
         state->selectExpression = new IR::PathExpression(IR::ParserState::reject);
     }
 }

--- a/frontends/p4/fromv1.0/converters.cpp
+++ b/frontends/p4/fromv1.0/converters.cpp
@@ -45,7 +45,7 @@ const IR::Node* ExpressionConverter::postorder(IR::Mask* expression) {
     auto cst = expression->right->to<IR::Constant>();
     big_int value = cst->value;
     if (value == 0) {
-        ::warning(ErrorType::WARN_INVALID, "%1%: zero mask", expression->right);
+        warn(ErrorType::WARN_INVALID, "%1%: zero mask", expression->right);
         return cst;
     }
     auto range = Util::findOnes(value);
@@ -462,6 +462,7 @@ const IR::StructField *TypeConverter::postorder(IR::StructField *field) {
             if (len->expr.size() == 1) {
                 auto lenexpr = len->expr[0];
                 ValidateLenExpr vle(type, field);
+                vle.setCalledBy(this);
                 lenexpr->apply(vle);
                 auto scale = new IR::Mul(lenexpr->srcInfo, lenexpr, new IR::Constant(8));
                 auto fieldlen = new IR::Sub(

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -187,8 +187,8 @@ class DiscoverStructure : public Inspector {
     { CHECK_NULL(structure); setName("DiscoverStructure"); }
 
     void postorder(const IR::ParserException* ex) override {
-        ::warning(ErrorType::WARN_UNSUPPORTED, "%1%: parser exception is not translated to P4-16",
-                  ex); }
+        warn(ErrorType::WARN_UNSUPPORTED, "%1%: parser exception is not translated to P4-16",
+             ex); }
     void postorder(const IR::Metadata* md) override
     { structure->metadata.emplace(md); checkReserved(md, md->name, "metadata"); }
     void postorder(const IR::Header* hd) override
@@ -596,6 +596,7 @@ class FixExtracts final : public Transform {
 
         // Create actual extract
         RewriteLength rewrite(fixed->fixedHeaderType, var);
+        rewrite.setCalledBy(this);
         auto length = fixed->headerLength->apply(rewrite);
         auto args = new IR::Vector<IR::Argument>();
         args->push_back(arg->clone());

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -833,7 +833,8 @@ ProgramStructure::convertActionProfile(const IR::ActionProfile* action_profile, 
         auto size = new IR::Constant(
             action_profile->srcInfo, v1model.action_profile.sizeType, action_profile->size);
         args->push_back(new IR::Argument(size)); }
-    auto decl = new IR::Declaration_Instance(newName, annos, type, args, nullptr);
+    auto decl = new IR::Declaration_Instance(
+        action_profile->srcInfo, newName, annos, type, args, nullptr);
     return decl;
 }
 

--- a/frontends/p4/inlining.cpp
+++ b/frontends/p4/inlining.cpp
@@ -855,8 +855,10 @@ const IR::Node* GeneralInliner::preorder(IR::ParserState* state) {
         cstring nextState = refMap->newName(state->name);
         std::map<cstring, cstring> renameMap;
         ComputeNewStateNames cnn(refMap, callee->name.name, nextState, &renameMap);
+        cnn.setCalledBy(this);
         (void)callee->apply(cnn);
         RenameStates rs(&renameMap);
+        rs.setCalledBy(this);
         auto renamed = callee->apply(rs);
         IR::ID newStartName(::get(renameMap, IR::ParserState::start), IR::ParserState::start);
         auto newState = new IR::ParserState(srcInfo, name, annotations, current,

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -144,7 +144,7 @@ void ParseAnnotations::postorder(IR::Annotation* annotation) {
         // Unknown annotation. Leave as is, but warn if desired.
         if (warnUnknown && warned.count(name) == 0) {
             warned.insert(name);
-            ::warning(ErrorType::WARN_UNKNOWN, "Unknown annotation: %1%", annotation->name);
+            warn(ErrorType::WARN_UNKNOWN, "Unknown annotation: %1%", annotation->name);
         }
         return;
     }

--- a/frontends/p4/removeParameters.cpp
+++ b/frontends/p4/removeParameters.cpp
@@ -150,6 +150,7 @@ const IR::Node* DoRemoveActionParameters::postorder(IR::P4Action* action) {
         return action;
 
     InsertBeforeExits ibf(postamble);
+    ibf.setCalledBy(this);
     auto actionBody = action->body->apply(ibf)->to<IR::BlockStatement>();
     body->append(actionBody->components);
     body->append(*postamble);
@@ -163,6 +164,7 @@ const IR::Node* DoRemoveActionParameters::postorder(IR::P4Action* action) {
 
 const IR::Node* DoRemoveActionParameters::postorder(IR::ActionListElement* element) {
     RemoveMethodCallArguments rmca;
+    rmca.setCalledBy(this);
     element->expression = element->expression->apply(rmca)->to<IR::Expression>();
     return element;
 }
@@ -171,9 +173,11 @@ const IR::Node* DoRemoveActionParameters::postorder(IR::MethodCallExpression* ex
     auto orig = getOriginal<IR::MethodCallExpression>();
     if (invocations->isCall(orig)) {
         RemoveMethodCallArguments rmca;
+        rmca.setCalledBy(this);
         return expression->apply(rmca);
     } else if (unsigned toRemove = invocations->argsToRemove(orig)) {
         RemoveMethodCallArguments rmca(toRemove);
+        rmca.setCalledBy(this);
         return expression->apply(rmca);
     }
     return expression;

--- a/frontends/p4/removeReturns.cpp
+++ b/frontends/p4/removeReturns.cpp
@@ -21,6 +21,7 @@ namespace P4 {
 
 const IR::Node* DoRemoveReturns::preorder(IR::P4Action* action) {
     HasExits he;
+    he.setCalledBy(this);
     (void)action->apply(he);
     if (!he.hasReturns) {
         // don't pollute the code unnecessarily
@@ -54,6 +55,7 @@ const IR::Node* DoRemoveReturns::preorder(IR::Function* function) {
     }
 
     HasExits he;
+    he.setCalledBy(this);
     (void)function->apply(he);
     if (!he.hasReturns) {
         // don't pollute the code unnecessarily
@@ -95,6 +97,7 @@ const IR::Node* DoRemoveReturns::preorder(IR::P4Control* control) {
     visit(control->controlLocals, "controlLocals");
 
     HasExits he;
+    he.setCalledBy(this);
     (void)control->body->apply(he);
     if (!he.hasReturns) {
         // don't pollute the code unnecessarily

--- a/frontends/p4/sideEffects.h
+++ b/frontends/p4/sideEffects.h
@@ -100,10 +100,10 @@ class SideEffects : public Inspector {
             refMap(refMap), typeMap(typeMap) { setName("SideEffects"); }
 
     /// @return true if the expression may have side-effects.
-    static bool check(const IR::Expression* expression,
-                      ReferenceMap* refMap,
-                      TypeMap* typeMap) {
+    static bool check(const IR::Expression* expression, const Visitor* calledBy,
+                      ReferenceMap* refMap, TypeMap* typeMap) {
         SideEffects se(refMap, typeMap);
+        se.setCalledBy(calledBy);
         expression->apply(se);
         return se.nodeWithSideEffect != nullptr;
     }
@@ -334,6 +334,7 @@ class TablesInKeys : public Inspector {
         if (!findContext<IR::Key>())
             return;
         HasTableApply hta(refMap, typeMap);
+        hta.setCalledBy(this);
         (void)mce->apply(hta);
         if (hta.table != nullptr) {
             LOG2("Table " << hta.table << " invoked in key of another table");

--- a/frontends/p4/simplify.cpp
+++ b/frontends/p4/simplify.cpp
@@ -71,7 +71,7 @@ const IR::Node* DoSimplifyControlFlow::postorder(IR::IfStatement* statement)  {
         statement->ifTrue = e;
     }
 
-    if (SideEffects::check(statement->condition, refMap, typeMap))
+    if (SideEffects::check(statement->condition, this, refMap, typeMap))
         return statement;
     if (statement->ifTrue->is<IR::EmptyStatement>() &&
         (statement->ifFalse == nullptr || statement->ifFalse->is<IR::EmptyStatement>()))
@@ -110,7 +110,7 @@ const IR::Node* DoSimplifyControlFlow::postorder(IR::SwitchStatement* statement)
             if ((*it)->statement != nullptr)
                 break;
             else
-                ::warning(ErrorType::WARN_MISSING, "%1%: fallthrough with no statement", last); }
+                warn(ErrorType::WARN_MISSING, "%1%: fallthrough with no statement", last); }
         statement->cases.erase(it.base(), statement->cases.end()); }
     return statement;
 }

--- a/frontends/p4/simplifyParsers.cpp
+++ b/frontends/p4/simplifyParsers.cpp
@@ -73,8 +73,8 @@ class RemoveUnreachableStates : public Transform {
         auto orig = getOriginal<IR::ParserState>();
         if (reachable.find(orig) == reachable.end()) {
             if (state->name == IR::ParserState::accept) {
-                ::warning(ErrorType::WARN_UNREACHABLE,
-                          "%1% state in %2% is unreachable", state, findContext<IR::P4Parser>());
+                warn(ErrorType::WARN_UNREACHABLE,
+                     "%1% state in %2% is unreachable", state, findContext<IR::P4Parser>());
                 return state;
             } else  {
                 LOG1("Removing unreachable state " << dbp(state));
@@ -200,6 +200,7 @@ class SimplifyParser : public PassManager {
 
 const IR::Node* DoSimplifyParsers::preorder(IR::P4Parser* parser) {
     SimplifyParser simpl(refMap);
+    simpl.setCalledBy(this);
     return parser->apply(simpl);
 }
 

--- a/frontends/p4/specializeGenericFunctions.cpp
+++ b/frontends/p4/specializeGenericFunctions.cpp
@@ -37,6 +37,7 @@ const IR::Node* SpecializeFunctions::postorder(IR::Function* function) {
             TypeVariableSubstitution ts;
             ts.setBindings(function, function->type->typeParameters, methodCall->typeArguments);
             TypeSubstitutionVisitor tsv(specMap->typeMap, &ts);
+            tsv.setCalledBy(this);
             LOG3("Substitution " << ts);
             auto specialized = function->apply(tsv)->to<IR::Function>();
             auto renamed = new IR::Function(

--- a/frontends/p4/specializeGenericTypes.cpp
+++ b/frontends/p4/specializeGenericTypes.cpp
@@ -128,6 +128,7 @@ const IR::Node* CreateSpecializedTypes::postorder(IR::Type_Declaration* type) {
             TypeVariableSubstitution ts;
             ts.setBindings(type, genDecl->getTypeParameters(), specialized->arguments);
             TypeSubstitutionVisitor tsv(specMap->typeMap, &ts);
+            tsv.setCalledBy(this);
             auto renamed = type->apply(tsv)->to<IR::Type_StructLike>()->clone();
             cstring name = it.second->name;
             auto empty = new IR::TypeParameters();

--- a/frontends/p4/strengthReduction.h
+++ b/frontends/p4/strengthReduction.h
@@ -61,7 +61,7 @@ class DoStrengthReduction final : public Transform {
     /// has side-effects.  If we had a refMap or a typeMap
     /// we could use them here.
     bool hasSideEffects(const IR::Expression* expr) const {
-        return SideEffects::check(expr, nullptr, nullptr);
+        return SideEffects::check(expr, this, nullptr, nullptr);
     }
 
  public:

--- a/frontends/p4/tableKeyNames.cpp
+++ b/frontends/p4/tableKeyNames.cpp
@@ -130,6 +130,7 @@ const IR::Node* DoTableKeyNames::postorder(IR::KeyElement* keyElement) {
         // already present: no changes
         return keyElement;
     KeyNameGenerator kng(typeMap);;
+    kng.setCalledBy(this);
     (void)keyElement->expression->apply(kng);
     cstring name = kng.getName(keyElement->expression);
 

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -447,9 +447,9 @@ bool ToP4::preorder(const IR::Type_Extern* t) {
     builder.blockStart();
 
     if (t->attributes.size() != 0)
-        ::warning(ErrorType::WARN_UNSUPPORTED,
-                  "%1%: extern has attributes, which are not supported "
-                  "in P4-16, and thus are not emitted as P4-16", t);
+        warn(ErrorType::WARN_UNSUPPORTED,
+             "%1%: extern has attributes, which are not supported "
+             "in P4-16, and thus are not emitted as P4-16", t);
 
     setVecSep(";\n", ";\n");
     bool decl = isDeclaration;

--- a/frontends/p4/typeChecking/typeConstraints.h
+++ b/frontends/p4/typeChecking/typeConstraints.h
@@ -51,6 +51,7 @@ class Explain : public Inspector {
             return;
         explanation += "Where '" + tv->toString() + "' is bound to '" + val->toString() + "'\n";
         Explain erec(subst);  // recursive explain variables in this substitution
+        erec.setCalledBy(this);
         val->apply(erec);
         explanation += erec.explanation;
     }

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -84,7 +84,7 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Parser* cont) {
 const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Table* table) {
     if (!refMap->isUsed(getOriginal<IR::IDeclaration>())) {
         if (giveWarning(getOriginal()))
-            ::warning(ErrorType::WARN_UNUSED, "Table %1% is not used; removing", table);
+            warn(ErrorType::WARN_UNUSED, "Table %1% is not used; removing", table);
         LOG3("Removing " << table);
         table = nullptr;
     }
@@ -96,7 +96,7 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::Declaration_Variable* dec
     prune();
     if (decl->initializer == nullptr)
         return process(decl);
-    if (!SideEffects::check(decl->initializer, nullptr, nullptr))
+    if (!SideEffects::check(decl->initializer, this, nullptr, nullptr))
         return process(decl);
     return decl;
 }
@@ -121,7 +121,7 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::Declaration_Instance* dec
         return decl;
     if (!refMap->isUsed(getOriginal<IR::Declaration_Instance>())) {
         if (giveWarning(getOriginal()))
-            ::warning(ErrorType::WARN_UNUSED, "%1%: unused instance", decl);
+            warn(ErrorType::WARN_UNUSED, "%1%: unused instance", decl);
         // We won't delete extern instances; these may be useful even if not references.
         auto type = decl->type;
         if (type->is<IR::Type_Specialized>())

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -28,10 +28,6 @@ Visitor::profile_t RemoveUnusedDeclarations::init_apply(const IR::Node* node) {
 bool RemoveUnusedDeclarations::giveWarning(const IR::Node* node) {
     if (warned == nullptr)
         return false;
-    if (auto anno = node->to<IR::IAnnotated>())
-        if (auto warn = anno->getAnnotation(IR::Annotation::noWarnAnnotation))
-            if (warn->getSingleString() == "unused")
-                return false;
     auto p = warned->emplace(node);
     LOG3("Warn about " << dbp(node) << " " << p.second);
     return p.second;

--- a/frontends/p4/validateParsedProgram.cpp
+++ b/frontends/p4/validateParsedProgram.cpp
@@ -211,9 +211,9 @@ void ValidateParsedProgram::postorder(const IR::SwitchStatement* statement) {
                         "%1% has multiple 'default' labels: %2% and %3%.",
                         statement, defaultFound->label, c->label);
             else
-                ::warning(ErrorType::WARN_ORDERING,
-                          "%1%: label following 'default' %2% label.",
-                          c->label, defaultFound->label);
+                warn(ErrorType::WARN_ORDERING,
+                     "%1%: label following 'default' %2% label.",
+                     c->label, defaultFound->label);
             break;
         }
         if (c->label->is<IR::DefaultExpression>())

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -81,12 +81,13 @@ class ParserState : ISimpleNamespace, Declaration, IAnnotated {
 }
 
 // A parser that contains all states (unlike the P4 v1.0 parser, which is really just a state)
-class P4Parser : Type_Declaration, INestedNamespace, ISimpleNamespace, IApply, IContainer {
+class P4Parser : Type_Declaration, INestedNamespace, ISimpleNamespace, IApply, IContainer, IAnnotated {
     Type_Parser                                 type;
     optional ParameterList                      constructorParams = new ParameterList;
     optional inline IndexedVector<Declaration>  parserLocals;
     optional inline IndexedVector<ParserState>  states;
 
+    Annotations getAnnotations() const { return type->getAnnotations(); }
     TypeParameters getTypeParameters() const override { return type->getTypeParameters(); }
     std::vector<INamespace> getNestedNamespaces() const override {
         return { type->typeParameters, type->applyParams, constructorParams }; }
@@ -112,12 +113,13 @@ class P4Parser : Type_Declaration, INestedNamespace, ISimpleNamespace, IApply, I
     toString { return cstring("parser ") + externalName(); }
 }
 
-class P4Control : Type_Declaration, INestedNamespace, ISimpleNamespace, IApply, IContainer {
+class P4Control : Type_Declaration, INestedNamespace, ISimpleNamespace, IApply, IContainer, IAnnotated {
     Type_Control                                type;
     optional ParameterList                      constructorParams = new ParameterList;
     optional inline IndexedVector<Declaration>  controlLocals;
     BlockStatement                              body;
 
+    Annotations getAnnotations() const { return type->getAnnotations(); }
     TypeParameters getTypeParameters() const override { return type->getTypeParameters(); }
     std::vector<INamespace> getNestedNamespaces() const override {
         return { type->typeParameters, type->applyParams, constructorParams }; }

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -57,6 +57,8 @@ class ErrorReporter {
     /// If the error has been reported, return true. Otherwise, insert add the error to the
     /// list of seen errors, and return false.
     bool error_reported(int err, const Util::SourceInfo source) {
+        if (!source.isValid())
+            return false;
         auto p = errorTracker.emplace(err, source);
         return !p.second;  // if insertion took place, then we have not seen the error.
     }

--- a/midend/checkSize.h
+++ b/midend/checkSize.h
@@ -34,15 +34,15 @@ class CheckTableSize : public Modifier {
         auto key = table->getKey();
         if (key == nullptr) {
             if (size->value != 1) {
-                ::warning(ErrorType::WARN_MISMATCH,
-                          "%1%: size %2% specified for table without keys", table, size);
+                warn(ErrorType::WARN_MISMATCH,
+                     "%1%: size %2% specified for table without keys", table, size);
                 deleteSize = true;
             }
         }
         auto entries = table->properties->getProperty(IR::TableProperties::entriesPropertyName);
         if (entries != nullptr && entries->isConstant) {
-            ::warning(ErrorType::WARN_MISMATCH,
-                      "%1%: size %2% specified for table with constant entries", table, size);
+            warn(ErrorType::WARN_MISMATCH,
+                 "%1%: size %2% specified for table with constant entries", table, size);
             deleteSize = true;
         }
         if (deleteSize) {

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -662,6 +662,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Ternary* expression) {
         clone->e1 = getConstant(e1i);
         clone->e2 = getConstant(e2i);
         DoConstantFolding cf(refMap, typeMap);
+        cf.setCalledBy(this);
         auto result = clone->apply(cf);
         checkResult(expression, result);
         return;
@@ -697,6 +698,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Binary* expression) {
         clone->left = getConstant(li);
         clone->right = getConstant(ri);
         DoConstantFolding cf(refMap, typeMap);
+        cf.setCalledBy(this);
         auto result = clone->apply(cf);
         checkResult(expression, result);
         return;
@@ -727,6 +729,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary* expression) {
         auto li = l->to<SymbolicInteger>();
         clone->expr = li->constant;
         DoConstantFolding cf(refMap, typeMap);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::Constant>(), "%1%: expected a constant", result);
         set(expression, new SymbolicInteger(result->to<IR::Constant>()));
@@ -735,6 +738,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary* expression) {
         auto li = l->to<SymbolicBool>();
         clone->expr = new IR::BoolLiteral(li->value);
         DoConstantFolding cf(refMap, typeMap);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));
@@ -811,6 +815,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation* expression) {
         clone->left = l->to<SymbolicInteger>()->constant;
         clone->right = r->to<SymbolicInteger>()->constant;
         DoConstantFolding cf(refMap, typeMap);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));
@@ -820,6 +825,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation* expression) {
         clone->left = new IR::BoolLiteral(l->to<SymbolicBool>()->value);
         clone->right = new IR::BoolLiteral(r->to<SymbolicBool>()->value);
         DoConstantFolding cf(refMap, typeMap);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -121,7 +121,7 @@ class DoLocalCopyPropagation::ElimDead : public Transform {
         return act; }
 
  public:
-    explicit ElimDead(DoLocalCopyPropagation &self) : self(self) {}
+    explicit ElimDead(DoLocalCopyPropagation &self) : self(self) { setCalledBy(&self); }
 };
 
 class DoLocalCopyPropagation::RewriteTableKeys : public Transform {
@@ -154,7 +154,7 @@ class DoLocalCopyPropagation::RewriteTableKeys : public Transform {
         return exp; }
 
  public:
-    explicit RewriteTableKeys(DoLocalCopyPropagation &self) : self(self) {}
+    explicit RewriteTableKeys(DoLocalCopyPropagation &self) : self(self) { setCalledBy(&self); }
 };
 
 void DoLocalCopyPropagation::flow_merge(Visitor &a_) {

--- a/midend/parserUnroll.h
+++ b/midend/parserUnroll.h
@@ -186,6 +186,7 @@ class RewriteAllParsers : public Transform {
     const IR::Node* postorder(IR::P4Parser* parser) override {
         // making rewriting
         auto rewriter = new ParserRewriter(refMap, typeMap, unroll);
+        rewriter->setCalledBy(this);
         parser->apply(*rewriter);
         /// make a new parser
         BUG_CHECK(rewriter->current.result,

--- a/midend/predication.cpp
+++ b/midend/predication.cpp
@@ -141,6 +141,7 @@ const IR::Expression* Predication::clone(const IR::Expression* expression) {
     // an expression. This is most obvious if one clone is on the LHS and one
     // on the RHS of an assigment.
     ClonePathExpressions cloner;
+    cloner.setCalledBy(this);
     return expression->apply(cloner);
 }
 
@@ -149,6 +150,7 @@ const IR::Node* Predication::clone(const IR::AssignmentStatement* statement) {
     // in the end different code will be generated for the different clones of
     // an expression.
     ClonePathExpressions cloner;
+    cloner.setCalledBy(this);
     return statement->apply(cloner);
 }
 
@@ -172,6 +174,7 @@ const IR::Node* Predication::preorder(IR::AssignmentStatement* statement) {
     // The expressionReplacer responsible for transforming this statement
     ExpressionReplacer replacer(clone(statement)->to<IR::AssignmentStatement>(),
             traversalPath, conditions);
+    replacer.setCalledBy(this);
     dependencies.clear();
     visit(statement->right);
     LOG2("Finished visiting right side of statement");
@@ -331,6 +334,7 @@ const IR::Node* Predication::preorder(IR::IfStatement* statement) {
     --ifNestingLevel;
     prune();
     // Remove all empty statements which are inside this 'rv' block
+    remover.setCalledBy(this);
     return rv->apply(remover);
 }
 

--- a/midend/removeExits.cpp
+++ b/midend/removeExits.cpp
@@ -92,6 +92,7 @@ const IR::Node* DoRemoveExits::preorder(IR::P4Action* action) {
 
 const IR::Node* DoRemoveExits::preorder(IR::P4Control* control) {
     HasExits he;
+    he.setCalledBy(this);
     (void)control->apply(he);
     if (!he.hasExits) {
         // don't pollute the code unnecessarily
@@ -162,6 +163,7 @@ const IR::Node* DoRemoveExits::preorder(IR::IfStatement* statement) {
     push();
 
     CallsExit ce(refMap, typeMap, &callsExit);
+    ce.setCalledBy(this);
     (void)statement->condition->apply(ce);
     auto rcond = ce.callsExit ? TernaryBool::Maybe : TernaryBool::No;
 
@@ -202,6 +204,7 @@ const IR::Node* DoRemoveExits::preorder(IR::IfStatement* statement) {
 const IR::Node* DoRemoveExits::preorder(IR::SwitchStatement* statement) {
     auto r = TernaryBool::No;
     CallsExit ce(refMap, typeMap, &callsExit);
+    ce.setCalledBy(this);
     (void)statement->expression->apply(ce);
 
     /* FIXME -- alter cases in place rather than allocating a new Vector */
@@ -238,6 +241,7 @@ const IR::Node* DoRemoveExits::preorder(IR::SwitchStatement* statement) {
 
 const IR::Node* DoRemoveExits::preorder(IR::AssignmentStatement* statement) {
     CallsExit ce(refMap, typeMap, &callsExit);
+    ce.setCalledBy(this);
     (void)statement->apply(ce);
     if (ce.callsExit)
         set(TernaryBool::Maybe);
@@ -246,6 +250,7 @@ const IR::Node* DoRemoveExits::preorder(IR::AssignmentStatement* statement) {
 
 const IR::Node* DoRemoveExits::preorder(IR::MethodCallStatement* statement) {
     CallsExit ce(refMap, typeMap, &callsExit);
+    ce.setCalledBy(this);
     (void)statement->apply(ce);
     if (ce.callsExit)
         set(TernaryBool::Maybe);

--- a/midend/replaceSelectRange.cpp
+++ b/midend/replaceSelectRange.cpp
@@ -143,11 +143,11 @@ const IR::Node* DoReplaceSelectRange::postorder(IR::SelectCase* sc) {
             newCases->push_back(new IR::SelectCase(sc->srcInfo, le, sc->state));
         }
         if (newCases->size() > MAX_CASES) {
-            ::warning(ErrorType::ERR_OVERLIMIT,
-                      "select key set expression with a range expands into %2% "
-                      "ternary key set expressions, which may lead to run-time "
-                      "performance or parser configuration space issues in some"
-                      " targets.", sc, newCases->size());
+            warn(ErrorType::ERR_OVERLIMIT,
+                 "select key set expression with a range expands into %2% "
+                 "ternary key set expressions, which may lead to run-time "
+                 "performance or parser configuration space issues in some"
+                 " targets.", sc, newCases->size());
         }
 
         return newCases;

--- a/midend/simplifyKey.cpp
+++ b/midend/simplifyKey.cpp
@@ -86,6 +86,7 @@ const IR::Node* DoSimplifyKey::doStatement(const IR::Statement* statement,
                                            const IR::Expression *expression) {
     LOG3("Visiting " << getOriginal());
     HasTableApply hta(refMap, typeMap);
+    hta.setCalledBy(this);
     (void)expression->apply(hta);
     if (hta.table == nullptr)
         return statement;

--- a/midend/simplifySelectCases.cpp
+++ b/midend/simplifySelectCases.cpp
@@ -60,7 +60,7 @@ const IR::Node* DoSimplifySelectCases::preorder(IR::SelectExpression* expression
     bool changes = false;
     for (auto c : expression->selectCases) {
         if (seenDefault) {
-            ::warning(ErrorType::WARN_PARSER_TRANSITION, "%1%: unreachable", c);
+            warn(ErrorType::WARN_PARSER_TRANSITION, "%1%: unreachable", c);
             changes = true;
             continue;
         }
@@ -73,8 +73,8 @@ const IR::Node* DoSimplifySelectCases::preorder(IR::SelectExpression* expression
     if (changes) {
         if (cases.size() == 1) {
             // just one default label
-            ::warning(ErrorType::WARN_PARSER_TRANSITION,
-                      "%1%: transition does not depend on select argument", expression->select);
+            warn(ErrorType::WARN_PARSER_TRANSITION,
+                 "%1%: transition does not depend on select argument", expression->select);
             return cases.at(0)->state;
         }
         expression->selectCases = std::move(cases);

--- a/midend/validateProperties.cpp
+++ b/midend/validateProperties.cpp
@@ -5,7 +5,7 @@ namespace P4 {
 void ValidateTableProperties::postorder(const IR::Property* property) {
     if (legalProperties.find(property->name.name) != legalProperties.end())
         return;
-    ::warning(ErrorType::WARN_IGNORE_PROPERTY, "Unknown table property: %1%", property);
+    warn(ErrorType::WARN_IGNORE_PROPERTY, "Unknown table property: %1%", property);
 }
 
 }  // namespace P4

--- a/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
+++ b/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
@@ -82,5 +82,9 @@ action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, d
 sai_p4.p4(303)
 table port {
 ^
-[--Wwarn=unused] warning: .next_hop_group: unused instance
-[--Wwarn=unused] warning: .vlan: unused instance
+sai_p4.p4(469): [--Wwarn=unused] warning: .next_hop_group: unused instance
+action_profile next_hop_group {
+^
+sai_p4.p4(332): [--Wwarn=unused] warning: .vlan: unused instance
+action_profile vlan {
+^

--- a/testdata/p4_16_samples/uninit-nowarnings.p4
+++ b/testdata/p4_16_samples/uninit-nowarnings.p4
@@ -1,0 +1,116 @@
+/*
+Copyright 2016 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+
+header Header {
+    bit<32> data1;
+    bit<32> data2;
+    bit<32> data3;
+}
+
+extern void func(in Header h);
+extern bit<32> g(inout bit<32> v, in bit<32> w);
+
+@noWarn("uninitialized_use")
+parser p1(packet_in p, out Header h) {
+    Header[2] stack;
+    bool b;
+    bool c;
+    bool d;
+
+    @noWarn("invalid_header")
+    @noWarn("ordering")
+    state start {
+        h.data1 = 0;
+        func(h);  // uninitialized
+        g(h.data2, g(h.data2, h.data2));  // uninitialized
+        transition next;
+    }
+
+    @noWarn("invalid_header")
+    state next {
+        h.data2 = h.data3 + 1;  // uninitialized
+        stack[0] = stack[1];  // uninitialized
+        b = stack[1].isValid();
+        transition select (h.isValid()) {
+            true: next1;
+            false: next2;
+        }
+    }
+
+    state next1 {
+        d = false;
+        transition next3;
+    }
+
+    state next2 {
+        c = true;
+        d = c;
+        transition next3;
+    }
+
+    state next3 {
+        c = !c;  // uninitialized;
+        d = !d;
+        transition accept;
+    }
+}
+
+control c(out bit<32> v) {  // uninitialized
+    bit<32> b;
+    bit<32> d = 1;
+    bit<32> setByAction;
+
+    action a1() { setByAction = 1; }
+    action a2() { setByAction = 1; }
+
+    table t {
+        actions = { a1; a2; }
+        default_action = a1();
+    }
+
+    apply @noWarn("uninitialized_use")
+    {
+        b = b + 1;  // uninitialized
+        d = d + 1;
+        bit<32> e;
+        bit<32> f;
+        if (e > 0) {  // uninitialized
+            e = 1;
+            f = 2;
+        } else {
+            f = 3;
+        }
+        e = e + 1;  // uninitialized
+        bool touched;
+        switch (t.apply().action_run) {
+            a1: { touched = true; }
+        }
+        touched = !touched;  // uninitialized
+        if (e > 0)
+            t.apply();
+        else
+            a1();
+        setByAction = setByAction + 1;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+control cproto(out bit<32> v);
+package top(proto _p, cproto _c);
+
+top(p1(), c()) main;

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings1.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "v1model"
+}

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings2.p4.p4info.txt
@@ -1,0 +1,10 @@
+pkg_info {
+  arch: "v1model"
+}
+actions {
+  preamble {
+    id: 32920635
+    name: "IngressI.invalid_H"
+    alias: "invalid_H"
+  }
+}

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings3.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "v1model"
+}

--- a/testdata/p4_16_samples_outputs/issue2409.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2409.p4-stderr
@@ -5,3 +5,4 @@ issue2409.p4(3)
 parser p(out bit<32> z) {
        ^
 [--Wwarn=parser-transition] warning: SelectCase: unreachable case
+[--Wwarn=parser-transition] warning: SelectCase: unreachable case

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4-first.p4
@@ -1,0 +1,128 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 16w1;
+    }
+    table tbl {
+        key = {
+            user_meta.data: exact @name("user_meta.data") ;
+            8w0x48        : exact @name("0x48") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4-frontend.p4
@@ -1,0 +1,130 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("egress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("egress.tbl") table tbl_0 {
+        key = {
+            user_meta.data: exact @name("user_meta.data") ;
+            8w0x48        : exact @name("0x48") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4-midend.p4
@@ -1,0 +1,159 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 &&& 8w252: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    bit<8> key_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("egress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("egress.tbl") table tbl_0 {
+        key = {
+            user_meta.data: exact @name("user_meta.data") ;
+            key_0         : exact @name("0x48") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psadpdktablekeyconsolidationmixedkeys4l119() {
+        key_0 = 8w0x48;
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys4l119 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys4l119();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys4l119();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys4l119.apply();
+        tbl_0.apply();
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys4l137() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys4l137 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys4l137();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys4l137();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys4l137.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys4l153() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys4l153 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys4l153();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys4l153();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys4l153.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4
@@ -1,0 +1,127 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800 &&& 0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            user_meta.data: exact;
+            8w0x48        : exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4-stderr
@@ -1,0 +1,6 @@
+psa-dpdk-table-key-consolidation-mixed-keys-4.p4(119): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            8w0x48 : exact;
+            ^^^^^^
+psa-dpdk-table-key-consolidation-mixed-keys-4.p4(119): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
+            8w0x48 : exact;
+            ^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.p4info.txt
@@ -1,0 +1,46 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 35478861
+    name: "egress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "user_meta.data"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "0x48"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 17082815
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 17082815
+    name: "egress.execute"
+    alias: "execute"
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
@@ -90,7 +90,7 @@ action NoAction args none {
 }
 
 action execute args instanceof execute_arg_t {
-	cast  h.ipv4.totalLen bit_32 m.Ingress_tmp_0
+	mov m.Ingress_tmp_0 h.ipv4.totalLen
 	meter meter0_0 t.index m.Ingress_tmp_0 m.Ingress_color_in_0 m.Ingress_color_out_0
 	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x0
 	mov m.Ingress_tmp 0x1

--- a/testdata/p4_16_samples_outputs/uninit-nowarnings-first.p4
+++ b/testdata/p4_16_samples_outputs/uninit-nowarnings-first.p4
@@ -1,0 +1,98 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data1;
+    bit<32> data2;
+    bit<32> data3;
+}
+
+extern void func(in Header h);
+extern bit<32> g(inout bit<32> v, in bit<32> w);
+@noWarn("uninitialized_use") parser p1(packet_in p, out Header h) {
+    Header[2] stack;
+    bool b;
+    bool c;
+    bool d;
+    @noWarn("invalid_header") @noWarn("ordering") state start {
+        h.data1 = 32w0;
+        func(h);
+        g(h.data2, g(h.data2, h.data2));
+        transition next;
+    }
+    @noWarn("invalid_header") state next {
+        h.data2 = h.data3 + 32w1;
+        stack[0] = stack[1];
+        b = stack[1].isValid();
+        transition select(h.isValid()) {
+            true: next1;
+            false: next2;
+        }
+    }
+    state next1 {
+        d = false;
+        transition next3;
+    }
+    state next2 {
+        c = true;
+        d = c;
+        transition next3;
+    }
+    state next3 {
+        c = !c;
+        d = !d;
+        transition accept;
+    }
+}
+
+control c(out bit<32> v) {
+    bit<32> b;
+    bit<32> d = 32w1;
+    bit<32> setByAction;
+    action a1() {
+        setByAction = 32w1;
+    }
+    action a2() {
+        setByAction = 32w1;
+    }
+    table t {
+        actions = {
+            a1();
+            a2();
+        }
+        default_action = a1();
+    }
+    apply @noWarn("uninitialized_use") {
+        b = b + 32w1;
+        d = d + 32w1;
+        bit<32> e;
+        bit<32> f;
+        if (e > 32w0) {
+            e = 32w1;
+            f = 32w2;
+        } else {
+            f = 32w3;
+        }
+        e = e + 32w1;
+        bool touched;
+        switch (t.apply().action_run) {
+            a1: {
+                touched = true;
+            }
+            default: {
+            }
+        }
+        touched = !touched;
+        if (e > 32w0) {
+            t.apply();
+        } else {
+            a1();
+        }
+        setByAction = setByAction + 32w1;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+control cproto(out bit<32> v);
+package top(proto _p, cproto _c);
+top(p1(), c()) main;
+

--- a/testdata/p4_16_samples_outputs/uninit-nowarnings-frontend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-nowarnings-frontend.p4
@@ -1,0 +1,85 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data1;
+    bit<32> data2;
+    bit<32> data3;
+}
+
+extern void func(in Header h);
+extern bit<32> g(inout bit<32> v, in bit<32> w);
+@noWarn("uninitialized_use") parser p1(packet_in p, out Header h) {
+    @name("p1.stack") Header[2] stack_0;
+    @name("p1.tmp") bit<32> tmp;
+    @name("p1.tmp_0") bit<32> tmp_0;
+    @name("p1.tmp_1") bit<32> tmp_1;
+    @noWarn("invalid_header") @noWarn("ordering") state start {
+        stack_0[0].setInvalid();
+        stack_0[1].setInvalid();
+        h.data1 = 32w0;
+        func(h);
+        tmp = h.data2;
+        tmp_0 = h.data2;
+        tmp_1 = g(h.data2, tmp_0);
+        g(tmp, tmp_1);
+        transition next;
+    }
+    @noWarn("invalid_header") state next {
+        h.data2 = h.data3 + 32w1;
+        transition select(h.isValid()) {
+            true: next1;
+            false: next2;
+        }
+    }
+    state next1 {
+        transition next3;
+    }
+    state next2 {
+        transition next3;
+    }
+    state next3 {
+        transition accept;
+    }
+}
+
+control c(out bit<32> v) {
+    @name("c.e") bit<32> e_0;
+    @name("c.a1") action a1() {
+    }
+    @name("c.a1") action a1_1() {
+    }
+    @name("c.a2") action a2() {
+    }
+    @name("c.t") table t_0 {
+        actions = {
+            a1();
+            a2();
+        }
+        default_action = a1();
+    }
+    apply @noWarn("uninitialized_use") {
+        if (e_0 > 32w0) {
+            e_0 = 32w1;
+        } else {
+            ;
+        }
+        e_0 = e_0 + 32w1;
+        switch (t_0.apply().action_run) {
+            a1: {
+            }
+            default: {
+            }
+        }
+        if (e_0 > 32w0) {
+            t_0.apply();
+        } else {
+            a1_1();
+        }
+    }
+}
+
+parser proto(packet_in p, out Header h);
+control cproto(out bit<32> v);
+package top(proto _p, cproto _c);
+top(p1(), c()) main;
+

--- a/testdata/p4_16_samples_outputs/uninit-nowarnings-midend.p4
+++ b/testdata/p4_16_samples_outputs/uninit-nowarnings-midend.p4
@@ -1,0 +1,114 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data1;
+    bit<32> data2;
+    bit<32> data3;
+}
+
+extern void func(in Header h);
+extern bit<32> g(inout bit<32> v, in bit<32> w);
+@noWarn("uninitialized_use") parser p1(packet_in p, out Header h) {
+    @name("p1.stack") Header[2] stack_0;
+    @name("p1.tmp") bit<32> tmp;
+    @name("p1.tmp_0") bit<32> tmp_0;
+    @name("p1.tmp_1") bit<32> tmp_1;
+    @noWarn("invalid_header") @noWarn("ordering") state start {
+        stack_0[0].setInvalid();
+        stack_0[1].setInvalid();
+        h.data1 = 32w0;
+        func(h);
+        tmp = h.data2;
+        tmp_0 = h.data2;
+        tmp_1 = g(h.data2, tmp_0);
+        g(tmp, tmp_1);
+        transition next;
+    }
+    @noWarn("invalid_header") state next {
+        h.data2 = h.data3 + 32w1;
+        transition select((bit<1>)h.isValid()) {
+            1w1: next1;
+            1w0: next2;
+            default: noMatch;
+        }
+    }
+    state next1 {
+        transition next3;
+    }
+    state next2 {
+        transition next3;
+    }
+    state next3 {
+        transition accept;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
+    }
+}
+
+control c(out bit<32> v) {
+    @name("c.e") bit<32> e_0;
+    @name("c.a1") action a1() {
+    }
+    @name("c.a1") action a1_1() {
+    }
+    @name("c.a2") action a2() {
+    }
+    @name("c.t") table t_0 {
+        actions = {
+            a1();
+            a2();
+        }
+        default_action = a1();
+    }
+    @hidden action uninitnowarnings93() {
+        e_0 = 32w1;
+    }
+    @hidden action uninitnowarnings98() {
+        e_0 = e_0 + 32w1;
+    }
+    @hidden table tbl_uninitnowarnings93 {
+        actions = {
+            uninitnowarnings93();
+        }
+        const default_action = uninitnowarnings93();
+    }
+    @hidden table tbl_uninitnowarnings98 {
+        actions = {
+            uninitnowarnings98();
+        }
+        const default_action = uninitnowarnings98();
+    }
+    @hidden table tbl_a1 {
+        actions = {
+            a1_1();
+        }
+        const default_action = a1_1();
+    }
+    apply @noWarn("uninitialized_use") {
+        if (e_0 > 32w0) {
+            tbl_uninitnowarnings93.apply();
+        } else {
+            ;
+        }
+        tbl_uninitnowarnings98.apply();
+        switch (t_0.apply().action_run) {
+            a1: {
+            }
+            default: {
+            }
+        }
+        if (e_0 > 32w0) {
+            t_0.apply();
+        } else {
+            tbl_a1.apply();
+        }
+    }
+}
+
+parser proto(packet_in p, out Header h);
+control cproto(out bit<32> v);
+package top(proto _p, cproto _c);
+top(p1(), c()) main;
+

--- a/testdata/p4_16_samples_outputs/uninit-nowarnings.p4
+++ b/testdata/p4_16_samples_outputs/uninit-nowarnings.p4
@@ -1,0 +1,96 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data1;
+    bit<32> data2;
+    bit<32> data3;
+}
+
+extern void func(in Header h);
+extern bit<32> g(inout bit<32> v, in bit<32> w);
+@noWarn("uninitialized_use") parser p1(packet_in p, out Header h) {
+    Header[2] stack;
+    bool b;
+    bool c;
+    bool d;
+    @noWarn("invalid_header") @noWarn("ordering") state start {
+        h.data1 = 0;
+        func(h);
+        g(h.data2, g(h.data2, h.data2));
+        transition next;
+    }
+    @noWarn("invalid_header") state next {
+        h.data2 = h.data3 + 1;
+        stack[0] = stack[1];
+        b = stack[1].isValid();
+        transition select(h.isValid()) {
+            true: next1;
+            false: next2;
+        }
+    }
+    state next1 {
+        d = false;
+        transition next3;
+    }
+    state next2 {
+        c = true;
+        d = c;
+        transition next3;
+    }
+    state next3 {
+        c = !c;
+        d = !d;
+        transition accept;
+    }
+}
+
+control c(out bit<32> v) {
+    bit<32> b;
+    bit<32> d = 1;
+    bit<32> setByAction;
+    action a1() {
+        setByAction = 1;
+    }
+    action a2() {
+        setByAction = 1;
+    }
+    table t {
+        actions = {
+            a1;
+            a2;
+        }
+        default_action = a1();
+    }
+    apply @noWarn("uninitialized_use") {
+        b = b + 1;
+        d = d + 1;
+        bit<32> e;
+        bit<32> f;
+        if (e > 0) {
+            e = 1;
+            f = 2;
+        } else {
+            f = 3;
+        }
+        e = e + 1;
+        bool touched;
+        switch (t.apply().action_run) {
+            a1: {
+                touched = true;
+            }
+        }
+        touched = !touched;
+        if (e > 0) {
+            t.apply();
+        } else {
+            a1();
+        }
+        setByAction = setByAction + 1;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+control cproto(out bit<32> v);
+package top(proto _p, cproto _c);
+top(p1(), c()) main;
+

--- a/testdata/p4_16_samples_outputs/uninit-nowarnings.p4-stderr
+++ b/testdata/p4_16_samples_outputs/uninit-nowarnings.p4-stderr
@@ -1,0 +1,6 @@
+uninit-nowarnings.p4(73): [--Wwarn=uninitialized_out_param] warning: out parameter 'v' may be uninitialized when 'c' terminates
+control c(out bit<32> v) { // uninitialized
+                      ^
+uninit-nowarnings.p4(73)
+control c(out bit<32> v) { // uninitialized
+        ^


### PR DESCRIPTION
The base change is relatively easy: a warn function has been added to the visitor, and it checks the context of a node to see if it has a noWarn suitable annotation. 
The more complicated changes come because some visitors create other visitors and invoke them; for this purpose a new field called_by has been added to visitors. The check for warnings thus can span multiple visitors, but the called_by field must be maintained manually.
There may be still cases where this does not work, which will need to be handled manually probably.
Fixes #2895