### PR TITLE
DPDK Backend: Fix conditional jumps when condition is LEQ or GEQ

### DIFF
--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -229,11 +229,9 @@ class LogicalExpressionUnroll : public Inspector {
     static bool is_logical(const IR::Operation_Binary *bin) {
         if (bin->is<IR::LAnd>() || bin->is<IR::LOr>() || bin->is<IR::Leq>() ||
             bin->is<IR::Equ>() || bin->is<IR::Neq>() || bin->is<IR::Grt>() ||
-            bin->is<IR::Lss>())
+            bin->is<IR::Lss>() || bin->is<IR::Geq>() || bin->is<IR::Leq>())
             return true;
-        else if (bin->is<IR::Geq>() or bin->is<IR::Leq>()) {
-            BUG("%1%: not implemented", bin);
-        } else
+          else
             return false;
     }
 

--- a/testdata/p4_16_samples/psa-example-dpdk-meter.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-meter.p4
@@ -12,7 +12,7 @@ header ipv4_t {
     bit<4>  version;
     bit<4>  ihl;
     bit<8>  diffserv;
-    bit<32> totalLen;
+    bit<16> totalLen;
     bit<16> identification;
     bit<3>  flags;
     bit<13> fragOffset;
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-first.p4
@@ -12,7 +12,7 @@ header ipv4_t {
     bit<4>  version;
     bit<4>  ihl;
     bit<8>  diffserv;
-    bit<32> totalLen;
+    bit<16> totalLen;
     bit<16> identification;
     bit<3>  flags;
     bit<13> fragOffset;
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-frontend.p4
@@ -12,7 +12,7 @@ header ipv4_t {
     bit<4>  version;
     bit<4>  ihl;
     bit<8>  diffserv;
-    bit<32> totalLen;
+    bit<16> totalLen;
     bit<16> identification;
     bit<3>  flags;
     bit<13> fragOffset;
@@ -59,7 +59,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
-        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-midend.p4
@@ -12,7 +12,7 @@ header ipv4_t {
     bit<4>  version;
     bit<4>  ihl;
     bit<8>  diffserv;
-    bit<32> totalLen;
+    bit<16> totalLen;
     bit<16> identification;
     bit<3>  flags;
     bit<13> fragOffset;
@@ -57,7 +57,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
-        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     @name("ingress.tbl") table tbl_0 {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4
@@ -12,7 +12,7 @@ header ipv4_t {
     bit<4>  version;
     bit<4>  ihl;
     bit<8>  diffserv;
-    bit<32> totalLen;
+    bit<16> totalLen;
     bit<16> identification;
     bit<3>  flags;
     bit<13> fragOffset;
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
@@ -10,7 +10,7 @@ struct ipv4_t {
 	bit<4> version
 	bit<4> ihl
 	bit<8> diffserv
-	bit<32> totalLen
+	bit<16> totalLen
 	bit<16> identification
 	bit<3> flags
 	bit<13> fragOffset
@@ -53,6 +53,7 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_drop
 	bit<32> local_metadata_port_in
 	bit<32> local_metadata_port_out
+	bit<32> Ingress_tmp_0
 	bit<32> Ingress_color_out_0
 	bit<32> Ingress_color_in_0
 	bit<32> Ingress_tmp
@@ -89,7 +90,8 @@ action NoAction args none {
 }
 
 action execute args instanceof execute_arg_t {
-	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in_0 m.Ingress_color_out_0
+	cast  h.ipv4.totalLen bit_32 m.Ingress_tmp_0
+	meter meter0_0 t.index m.Ingress_tmp_0 m.Ingress_color_in_0 m.Ingress_color_out_0
 	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x0
 	mov m.Ingress_tmp 0x1
 	jmp LABEL_1END


### PR DESCRIPTION
DPDK backend does not have instructions corresponding to conditional jump on GEQ(>=) and LEQ(<=) comparisons.
Hence, for these cases we negate the condition and jump on false block label.

```
if (a <= b)                                                     if (a > b)
    <true block>                       =>                          <false block>
else                                                            else
    <false block>                                                  <true block>

```


This PR fixes the existing support for these conditional jump instructions.

Also, corrected one of the example testcase for dpdk meter.