### PR TITLE
Move cpplint.py to python3

### DIFF
--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
`cpplint.py` is the last tools script that has not been moved to python3 yet.