### PR TITLE
Improve portability of backtrace.cpp

### DIFF
--- a/lib/backtrace.cpp
+++ b/lib/backtrace.cpp
@@ -43,12 +43,12 @@ void backtrace_fill_stacktrace(std::string &msg, void *const*backtrace, int size
 #endif
 }
 
-namespace std {
-
 #ifdef __GLIBC__
 /* DANGER -- overrides for glibc++ exception throwers to include a stack trace.
  * correct functions depends on library internals, so may not work on some versions
  * and will fail with non-GNU libc++. These function are declared in bits/functexcept.h. */
+
+namespace std {
 
 void __throw_bad_alloc() {
     throw backtrace_exception<bad_alloc>();


### PR DESCRIPTION
* Only use backtrace_symbols in execinfo.h if present: we correctly
  guard the call to backtrace, but not the one to backtrace_symbols.
* Do not prefix the function definition with the std namespace for the
  __throw* functions to avoid compilation errors if there is no
  corresponding function declaration in libstd.

Fixes #2698
See #2922