### PR TITLE
dbg: replace unordered collections with ordered

### DIFF
--- a/frontends/common/resolveReferences/referenceMap.h
+++ b/frontends/common/resolveReferences/referenceMap.h
@@ -64,7 +64,7 @@ class ReferenceMap final : public ProgramMap, public NameGenerator, public Decla
     bool isv1;
 
     /// Maps paths in the program to declarations.
-    std::map<const IR::Path*, const IR::IDeclaration*> pathToDeclaration;
+    ordered_map<const IR::Path*, const IR::IDeclaration*> pathToDeclaration;
 
     /// Set containing all declarations in the program.
     std::set<const IR::IDeclaration*> used;

--- a/frontends/p4/typeChecking/typeSubstitution.h
+++ b/frontends/p4/typeChecking/typeSubstitution.h
@@ -29,7 +29,7 @@ namespace P4 {
 template <class T>
 class TypeSubstitution : public IHasDbPrint {
  protected:
-    std::map<T, const IR::Type*> binding;
+    ordered_map<T, const IR::Type*> binding;
 
  public:
     TypeSubstitution() = default;

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -46,13 +46,13 @@ class TypeMap final : public ProgramMap {
     std::vector<const IR::Type*> canonicalLists;
 
     // Map each node to its canonical type
-    std::map<const IR::Node*, const IR::Type*> typeMap;
+    ordered_map<const IR::Node*, const IR::Type*> typeMap;
     // All left-values in the program.
-    std::set<const IR::Expression*> leftValues;
+    ordered_set<const IR::Expression*> leftValues;
     // All compile-time constants.  A compile-time constant
     // is not necessarily a constant - it could be a directionless
     // parameter as well.
-    std::set<const IR::Expression*> constants;
+    ordered_set<const IR::Expression*> constants;
     // For each type variable in the program the actual
     // type that is substituted for it.
     TypeVariableSubstitution allTypeVariables;


### PR DESCRIPTION
Replace std::set and std::map with ordered_set and ordered_map to
provide consistent ordering in logs when running with -T typeChecker:3

Addresses issue: #2928 