### PR TITLE
dpdk: support of PNA extern send_to_port

### DIFF
--- a/backends/dpdk/CMakeLists.txt
+++ b/backends/dpdk/CMakeLists.txt
@@ -63,6 +63,7 @@ set(P4C_DPDK_HEADERS
     ../bmv2/common/lower.h
     backend.h
     midend.h
+    dpdkCheckExternInvocation.h
     dpdkHelpers.h
     dpdkProgram.h
     dpdkArch.h

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -65,6 +65,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new CollectMetadataHeaderInfo(&structure),
         new ConvertToDpdkArch(refMap, &structure),
         new InjectJumboStruct(&structure),
+        new InjectOutputPortMetadataField(&structure),
         new P4::ClearTypeMap(typeMap),
         new P4::TypeChecking(refMap, typeMap, true),
         new CopyMatchKeysToSingleStruct(refMap, typeMap, &invokedInKey),

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "backend.h"
 #include "dpdkArch.h"
 #include "dpdkAsmOpt.h"
+#include "dpdkCheckExternInvocation.h"
 #include "dpdkHelpers.h"
 #include "dpdkProgram.h"
 #include "dpdkContext.h"
@@ -86,6 +87,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new P4::TypeChecking(refMap, typeMap, true),
         new CollectProgramStructure(refMap, typeMap, &structure),
         new InspectDpdkProgram(refMap, typeMap, &structure),
+        new CheckExternInvocation(refMap, typeMap, &structure),
         new DpdkArchLast(),
         new VisitFunctor([this, genContextJson] {
             // Serialize context json object into user specified file

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -24,6 +24,7 @@ limitations under the License.
  */
 
 #include "dpdkArch.h"
+#include "dpdkHelpers.h"
 #include "frontends/p4/coreLibrary.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/externInstance.h"
@@ -362,6 +363,15 @@ const IR::Node *InjectJumboStruct::preorder(IR::Type_Struct *s) {
         auto *annotations = new IR::Annotations(
             {new IR::Annotation(IR::ID("__packet_data__"), {})});
         return new IR::Type_Struct(s->name, annotations, s->fields);
+    }
+    return s;
+}
+
+const IR::Node *InjectOutputPortMetadataField::preorder(IR::Type_Struct *s) {
+    if (structure->p4arch == "pna" && s->name.name == structure->local_metadata_type) {
+        s->fields.push_back(new IR::StructField(
+            IR::ID(PnaMainOutputMetadataOutputPortName), IR::Type_Bits::get(32)));
+        LOG3("Metadata structure after injecting output port:" << std::endl << s);
     }
     return s;
 }

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -95,6 +95,19 @@ class InjectJumboStruct : public Transform {
     const IR::Node *preorder(IR::Type_Struct *s) override;
 };
 
+// This pass injects metadata field which is used as port for 'tx' instruction
+// into the single metadata struct.
+// This pass has to be applied after CollectMetadataHeaderInfo fills
+// local_metadata_type field and ConvertToDpdkArch fills p4arch field of
+// DpdkProgramStructure which is passed to the constructor.
+class InjectOutputPortMetadataField : public Transform {
+    DpdkProgramStructure *structure;
+
+  public:
+    InjectOutputPortMetadataField(DpdkProgramStructure *structure) : structure(structure) {}
+    const IR::Node *preorder(IR::Type_Struct *s) override;
+};
+
 // This class is helpful for StatementUnroll and IfStatementUnroll. Since dpdk
 // asm is not able to process complex expression, e.g., a = b + c * d. We need
 // break it down. Therefore, we need some temporary variables to hold the

--- a/backends/dpdk/dpdkCheckExternInvocation.h
+++ b/backends/dpdk/dpdkCheckExternInvocation.h
@@ -1,0 +1,171 @@
+/*
+Copyright 2021 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef BACKENDS_DPDK_DPDKCHECKEXTERNINVOCATION_H_
+#define BACKENDS_DPDK_DPDKCHECKEXTERNINVOCATION_H_
+
+#include "ir/ir.h"
+#include "ir/visitor.h"
+#include "frontends/p4/methodInstance.h"
+#include "midend/checkExternInvocationCommon.h"
+
+namespace P4 {
+class ReferenceMap;
+class TypeMap;
+}
+
+namespace DPDK {
+
+/**
+ * @brief Class for checking constraints for invocations of PNA architecture extern
+ *        methods and functions.
+ */
+class CheckPNAExternInvocation : public P4::CheckExternInvocationCommon {
+    DpdkProgramStructure *structure;
+
+    enum block_t {
+        MAIN_PARSER = 0,
+        PRE_CONTROL,
+        MAIN_CONTROL,
+        MAIN_DEPARSER,
+        BLOCK_COUNT,
+    };
+
+    virtual void initPipeConstraints() override {
+        bitvec validInMainControl;
+        validInMainControl.setbit(MAIN_CONTROL);
+        setPipeConstraints("send_to_port", validInMainControl);
+        // Add new constraints here
+    }
+
+    virtual cstring getBlockName(int bit) override {
+        static const char* lookup[] = {"main parser", "pre control", "main control", "main deparser"};
+        BUG_CHECK(sizeof(lookup)/sizeof(lookup[0]) == BLOCK_COUNT, "Bad lookup table");
+        return lookup[bit % BLOCK_COUNT];
+    }
+
+    const IR::P4Parser *getParser(const cstring parserName) {
+        if (auto p = findContext<IR::P4Parser>()) {
+            if (structure->parsers.count(parserName) != 0 &&
+                    structure->parsers.at(parserName)->name == p->name) {
+                return p;
+            }
+        }
+        return nullptr;
+    }
+
+    const IR::P4Control *getControl(const cstring controlName) {
+        if (auto c = findContext<IR::P4Control>()) {
+            if (structure->pipelines.count(controlName) != 0 &&
+                    structure->pipelines.at(controlName)->name == c->name) {
+                return c;
+            }
+        }
+        return nullptr;
+    }
+
+    const IR::P4Control *getDeparser(const cstring deparserName) {
+        if (auto d = findContext<IR::P4Control>()) {
+            if (structure->deparsers.count(deparserName) != 0 &&
+                    structure->deparsers.at(deparserName)->name == d->name) {
+                return d;
+            }
+        }
+        return nullptr;
+    }
+
+    void checkBlock(const IR::MethodCallExpression *expr,
+            const cstring externType, const cstring externName) {
+        bitvec pos;
+
+        LOG4("externType: " << externType << ", externName: " << externName);
+
+        if (pipeConstraints.count(externType)) {
+            if (auto block = getParser("MainParserT")) {
+                LOG4("MainParser: " << (void*)block << " " << dbp(block));
+                pos.setbit(MAIN_PARSER);
+                checkPipeConstraints(externType, pos, expr, externName, block->name);
+            } else if (auto block = getControl("PreControlT")) {
+                LOG4("PreControl: " << (void*)block << " " << dbp(block));
+                pos.setbit(PRE_CONTROL);
+                checkPipeConstraints(externType, pos, expr, externName, block->name);
+            } else if (auto block = getControl("MainControlT")) {
+                LOG4("MainControl: " << (void*)block << " " << dbp(block));
+                pos.setbit(MAIN_CONTROL);
+                checkPipeConstraints(externType, pos, expr, externName, block->name);
+            } else if (auto block = getDeparser("MainDeparserT")) {
+                LOG4("MainDeparser: " << (void*)block << " " << dbp(block));
+                pos.setbit(MAIN_DEPARSER);
+                checkPipeConstraints(externType, pos, expr, externName, block->name);
+            } else {
+                LOG4("Other");
+            }
+        } else {
+            LOG1("Pipe constraints not defined for: " << externType);
+        }
+    }
+
+    virtual void checkExtern(const P4::ExternMethod *extMethod,
+            const IR::MethodCallExpression *expr) override {
+        LOG3("ExternMethod: " << extMethod << ", MethodCallExpression: " << expr);
+        checkBlock(expr, extMethod->originalExternType->name, extMethod->object->getName().name);
+    }
+
+    virtual void checkExtern(const P4::ExternFunction *extFunction,
+            const IR::MethodCallExpression *expr) override {
+        LOG3("ExternFunction: " << extFunction << ", MethodCallExpression: " << expr);
+        checkBlock(expr, expr->method->toString(), "");
+    }
+
+ public:
+    CheckPNAExternInvocation(P4::ReferenceMap *refMap, P4::TypeMap *typeMap,
+            DpdkProgramStructure *structure) :
+            P4::CheckExternInvocationCommon(refMap, typeMap), structure(structure) {
+        initPipeConstraints();
+    }
+};
+
+/**
+ * @brief Class which chooses the correct class for checking the constraints for invocations
+ *        of extern methods and functions depending on the architecture.
+ */
+class CheckExternInvocation : public Inspector {
+    P4::ReferenceMap     *refMap;
+    P4::TypeMap          *typeMap;
+    DpdkProgramStructure *structure;
+  public:
+    CheckExternInvocation(P4::ReferenceMap *refMap, P4::TypeMap *typeMap,
+            DpdkProgramStructure *structure) :
+            refMap(refMap), typeMap(typeMap), structure(structure) {}
+
+    bool preorder(const IR::P4Program *program) {
+        if (structure->p4arch == "pna") {
+            LOG1("Checking extern invocations for PNA architecture.");
+            auto checker = new CheckPNAExternInvocation(refMap, typeMap, structure);
+            program->apply(*checker);
+        } else if (structure->p4arch == "psa") {
+            LOG1("Checking extern invocations for PSA architecture.");
+            // Add class checking PSA constraints here.
+        } else {
+            LOG1("Unknown architecture: " << structure->p4arch << ", not checking constraints.");
+        }
+        return false;
+    }
+};
+
+} // namespace DPDK
+
+#endif /* BACKENDS_DPDK_DPDKCHECKEXTERNINVOCATION_H_ */

--- a/backends/dpdk/dpdkHelpers.h
+++ b/backends/dpdk/dpdkHelpers.h
@@ -35,6 +35,19 @@ limitations under the License.
 #define TOSTR_DECLA(NAME) std::ostream &toStr(std::ostream &, IR::NAME *)
 
 namespace DPDK {
+
+/**
+ * @brief Name of the metadata used as output port.
+ *
+ * PNA specification does not contain standard metadata for specifying output port.
+ * rte_swx_pipeline in DPDK uses instruction 'tx' to specify the output port for a packet.
+ * To send a packet to a specific port, we need to do the following:
+ * - add definition of new metadata field to main metadata structure for rte_swx_pipeline
+ * - use the same name of this newly defined metadata field when assigning value of output port
+ * - use this metadata field with 'tx' instruction
+ */
+const char PnaMainOutputMetadataOutputPortName[] = "pna_main_output_metadata_output_port";
+
 /* This class will generate a optimized jmp and label control flow.
  * Couple of examples here
  *

--- a/backends/dpdk/dpdkProgram.cpp
+++ b/backends/dpdk/dpdkProgram.cpp
@@ -87,7 +87,7 @@ IR::IndexedVector<IR::DpdkAsmStatement> ConvertToDpdkProgram::create_psa_preambl
 IR::IndexedVector<IR::DpdkAsmStatement> ConvertToDpdkProgram::create_pna_postamble() {
     IR::IndexedVector<IR::DpdkAsmStatement> instr;
     instr.push_back(new IR::DpdkTxStatement(
-        new IR::Member(new IR::PathExpression("m"), "pna_main_output_metadata_egress_port")));
+        new IR::Member(new IR::PathExpression("m"), PnaMainOutputMetadataOutputPortName)));
     return instr;
 }
 
@@ -607,6 +607,7 @@ bool ConvertToDpdkControl::preorder(const IR::P4Table *t) {
 }
 
 bool ConvertToDpdkControl::preorder(const IR::P4Control *c) {
+    LOG3("P4Control: " << dbp(c) << std::endl << c);
     for (auto l : c->controlLocals) {
         if (!l->is<IR::P4Action>() && !l->is<IR::P4Table>()) {
             structure->push_variable(new IR::DpdkDeclaration(l));
@@ -622,6 +623,7 @@ bool ConvertToDpdkControl::preorder(const IR::P4Control *c) {
 
     for (auto i : helper->get_instr()) {
         add_inst(i);
+        LOG3("Adding instruction: " << i);
     }
 
     return true;

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -55,6 +55,7 @@ set (MIDEND_SRCS
 set (MIDEND_HDRS
   actionSynthesis.h
   checkSize.h
+  checkExternInvocationCommon.h
   compileTimeOps.h
   complexComparison.h
   convertEnums.h

--- a/midend/checkExternInvocationCommon.h
+++ b/midend/checkExternInvocationCommon.h
@@ -1,0 +1,165 @@
+/*
+Copyright 2021 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MIDEND_CHECKEXTERNINVOCATIONCOMMON_H_
+#define MIDEND_CHECKEXTERNINVOCATIONCOMMON_H_
+
+#include "ir/ir.h"
+#include "ir/visitor.h"
+#include "lib/bitvec.h"
+#include "frontends/p4/methodInstance.h"
+
+namespace P4 {
+
+class ReferenceMap;
+class TypeMap;
+
+/**
+ * @brief Base class which can be used to prepare classes for checking constraints
+ *        for invocations of externs (both methods and pure functions) in parsers and
+ *        control blocks.
+ *
+ * This class contains basic operations which should be common for checkers used for
+ * various targets and architectures.
+ *
+ * Example class which inherits from this base class can be seen
+ * in backends/dpdk/dpdkCheckExternInvocation.h.
+ */
+class CheckExternInvocationCommon : public Inspector {
+ protected:
+    ReferenceMap *refMap;
+    TypeMap *typeMap;
+    std::map<cstring /* extType */, bitvec> pipeConstraints;
+
+    /**
+     * @brief Method used to initialize the constraints.
+     *
+     * Method setPipeConstraints() can be used in implementation of initPipeConstraints()
+     * method to initialize the constraints.
+     *
+     * Method initPipeConstraints() should be called in the constructor of inheriting class.
+     */
+    virtual void initPipeConstraints() = 0;
+
+    /**
+     * @brief Get the name of the block which is represented in bit vector (bitvec)
+     *        by bit with index given by 'bit' parameter.
+     *
+     * @param bit Index of bit which represents the block in bit vector.
+     * @return cstring Name of the block represented by index with 'bit' parameter value.
+     */
+    virtual cstring getBlockName(int bit) = 0;
+
+    /**
+     * @brief Method for checking constraints of extern method given by parameters.
+     *
+     * If there are no constraints for extern methods, inheriting class does not need
+     * to implement this method.
+     *
+     * @param extMethod Pointer to object representing extern method.
+     * @param expr Pointer to method call expression.
+     */
+    virtual void checkExtern(const ExternMethod *extMethod,
+            const IR::MethodCallExpression *expr) { (void)extMethod; (void)expr; }
+
+    /**
+     * @brief Method for checking constraints of extern functions given by parameters.
+     *
+     * If there are no constraints for extern functions, inheriting class does not need
+     * to implement this method.
+     *
+     * @param extMethod Pointer to object representing extern function.
+     * @param expr Pointer to function call expression.
+     */
+    virtual void checkExtern(const ExternFunction *extFunction,
+            const IR::MethodCallExpression *expr) { (void)extFunction; (void)expr; }
+
+    /**
+     * @brief Get the name of the block which is represented by bit set in the bitvec.
+     *
+     * @param vec Bit vector.
+     * @return cstring Name of the block represented by index of set bit in the bitvec.
+     */
+    cstring extractBlock(bitvec vec) {
+        int bit = vec.ffs(0);
+        BUG_CHECK(vec.ffs(bit), "Trying to extract multiple block encodings");
+        return getBlockName(bit);
+    }
+
+    /**
+     * @brief Set the pipe (parser/control block) constraints.
+     *
+     * Should be used in the initPipeConstraints() method.
+     *
+     * @param extType Name of the extern object or function for which we set constraints.
+     * @param vec Bit vector representing the blocks (parser/control) in which the use
+     *            of extern object method or function is valid.
+     */
+    void setPipeConstraints(cstring extType, bitvec vec) {
+        if (!pipeConstraints.count(extType)) {
+            pipeConstraints.emplace(extType, vec);
+        } else {
+            auto &cons = pipeConstraints.at(extType);
+            cons |= vec;
+        }
+    }
+
+    /**
+     * @brief Check if the invocation of extern object method or extern function is valid
+     *        in the block where it is invoked.
+     *
+     * @param extType Name of the extern object or extern function.
+     * @param bv Bit vector which has set the bit representing the block in which the extern
+     *           object method or extern function is invoked.
+     * @param expr Method or function call expression.
+     * @param extName Name of extern object in case of extern object method invocation.
+     *                Empty string ("") in case of extern function invocation.
+     * @param pipe Name of the parser or control block in which the method or the function
+     *             is invoked.
+     */
+    void checkPipeConstraints(cstring extType, bitvec bv,
+            const IR::MethodCallExpression *expr, cstring extName, cstring pipe) {
+        BUG_CHECK(pipeConstraints.count(extType), "pipe constraints not defined for %1%",
+            extType);
+        auto constraint = pipeConstraints.at(extType) & bv;
+        if (!bv.empty() && constraint.empty()) {
+            if (extName != "")
+                ::error("%s %s %s cannot be used in the %s %s", expr->srcInfo,
+                        extType, extName, pipe, extractBlock(bv));
+            else
+                ::error("%s %s cannot be used in the %s %s", expr->srcInfo,
+                        extType, pipe, extractBlock(bv));
+        }
+    }
+
+    CheckExternInvocationCommon(ReferenceMap *refMap, TypeMap *typeMap) :
+        refMap(refMap), typeMap(typeMap) {}
+
+ public:
+    bool preorder(const IR::MethodCallExpression *expr) override {
+        auto mi = MethodInstance::resolve(expr, refMap, typeMap);
+        if (auto extMethod = mi->to<ExternMethod>()) {
+            checkExtern(extMethod, expr);
+        } else if (auto extFunction = mi->to<ExternFunction>()) {
+            checkExtern(extFunction, expr);
+        }
+        return false;
+    }
+};
+
+}  // namespace P4
+
+#endif /* MIDEND_CHECKEXTERNINVOCATIONCOMMON_H_ */

--- a/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
@@ -50,6 +50,7 @@ struct main_metadata_t {
 	bit<8> pna_main_input_metadata_class_of_service
 	bit<32> pna_main_input_metadata_input_port
 	bit<8> pna_main_output_metadata_class_of_service
+	bit<32> pna_main_output_metadata_output_port
 	bit<32> MainControlT_tmp
 	bit<32> MainControlT_tmp_0
 }
@@ -119,7 +120,7 @@ apply {
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
-	tx m.pna_main_output_metadata_egress_port
+	tx m.pna_main_output_metadata_output_port
 }
 
 

--- a/testdata/p4_16_samples_outputs/pna-example-template.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-template.p4.spec
@@ -45,6 +45,7 @@ struct main_metadata_t {
 	bit<8> pna_main_input_metadata_class_of_service
 	bit<32> pna_main_input_metadata_input_port
 	bit<8> pna_main_output_metadata_class_of_service
+	bit<32> pna_main_output_metadata_output_port
 }
 metadata instanceof main_metadata_t
 
@@ -85,7 +86,7 @@ apply {
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
-	tx m.pna_main_output_metadata_egress_port
+	tx m.pna_main_output_metadata_output_port
 }
 
 


### PR DESCRIPTION
send_to_port() extern for PNA architecture has been added recently, but instructions were not generated properly.
This commit fixes the generated instructions.
Metadata field used as operand for 'tx' instruction is added to the main metadata structure.
The name of the field set when send_to_port extern is used is unified with the name of the field used as operand for 'tx' instruction.