### PR TITLE
Fix: Issue #2279 - Implementing the GlobalCopyPropagation pass

### DIFF
--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -39,6 +39,7 @@ limitations under the License.
 #include "midend/replaceSelectRange.h"
 #include "midend/expandEmit.h"
 #include "midend/expandLookahead.h"
+#include "midend/global_copyprop.h"
 #include "midend/local_copyprop.h"
 #include "midend/midEndLast.h"
 #include "midend/nestedStructs.h"
@@ -105,8 +106,11 @@ MidEnd::MidEnd(CompilerOptions& options, std::ostream* outStream) {
         new P4::Predication(&refMap),
         new P4::MoveDeclarations(),  // more may have been introduced
         new P4::ConstantFolding(&refMap, &typeMap),
-        new P4::LocalCopyPropagation(&refMap, &typeMap),
-        new P4::ConstantFolding(&refMap, &typeMap),
+        new P4::GlobalCopyPropagation(&refMap, &typeMap),
+        new PassRepeated({
+            new P4::LocalCopyPropagation(&refMap, &typeMap),
+            new P4::ConstantFolding(&refMap, &typeMap),
+        }),
         new P4::StrengthReduction(&refMap, &typeMap),
         new P4::MoveDeclarations(),  // more may have been introduced
         new P4::SimplifyControlFlow(&refMap, &typeMap),

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -28,6 +28,7 @@ set (MIDEND_SRCS
   flattenHeaders.cpp
   flattenInterfaceStructs.cpp
   interpreter.cpp
+  global_copyprop.cpp
   local_copyprop.cpp
   nestedStructs.cpp
   noMatch.cpp
@@ -71,6 +72,7 @@ set (MIDEND_HDRS
   flattenInterfaceStructs.h
   has_side_effects.h
   interpreter.h
+  global_copyprop.h
   local_copyprop.h
   midEndLast.h
   nestedStructs.h

--- a/midend/global_copyprop.cpp
+++ b/midend/global_copyprop.cpp
@@ -1,0 +1,313 @@
+#include "global_copyprop.h"
+
+namespace P4 {
+
+/// Convert an expression into a string that uniqely identifies the lvalue referenced.
+/// Return null cstring if not a reference to a lvalue.
+static cstring lvalue_name(const IR::Expression *exp) {
+    if (auto p = exp->to<IR::PathExpression>())
+        return p->path->name;
+    if (auto m = exp->to<IR::Member>()) {
+        if (auto base = lvalue_name(m->expr))
+            return base + "." + m->member;
+    } else if (auto a = exp->to<IR::ArrayIndex>()) {
+        if (auto k = a->right->to<IR::Constant>()) {
+            if (auto base = lvalue_name(a->left))
+                return base + "[" + std::to_string(k->asInt()) + "]";
+        }
+    } else if (auto sl = exp->to<IR::Slice>()) {
+        if (auto e0 = lvalue_name(sl->e0))
+            return e0;
+    }
+    return cstring();
+}
+
+/// Test to see if names denote overlapping locations.
+bool names_overlap(cstring name1, cstring name2) {
+    if (name1 == name2) return true;
+    if (name1.startsWith(name2) && strchr(".[", name1.get(name2.size())))
+        return true;
+    if (name2.startsWith(name1) && strchr(".[", name2.get(name1.size())))
+        return true;
+    return false;
+}
+
+// Removes outdated values for variables.
+void removeVarsContaining(std::map<cstring, const IR::Expression*> *vars, cstring name) {
+    LOG6("removeVarsContaining(" << name << ")");
+    for (auto &var : *vars) {
+        LOG7("  checking entry: " << var.first << " = " << var.second);
+        if (names_overlap(var.first, name)) {
+            LOG4("  dropping the value for '" << var.first << "' as '"
+                     << name << "' is being assigned to");
+            var.second = nullptr;
+        }
+    }
+}
+
+// Removes values if they have changed
+void compareValuesInMaps(std::map<cstring, const IR::Expression*> *oldValues,
+                            std::map<cstring, const IR::Expression*> *newValues) {
+    for (auto it : *newValues) {
+        auto oldValue = (*oldValues)[it.first];
+        if (((it.second == nullptr) ^ (oldValue == nullptr)) ||
+                it.second && oldValue && !(it.second->equiv(*oldValue)))
+            removeVarsContaining(oldValues, it.first);
+    }
+}
+
+// Removes values if they are used as Out/InOut parameter
+void checkParametersForMap(const IR::ParameterList *params,
+                            std::map<cstring, const IR::Expression*> *vars) {
+    for (auto param : params->parameters)
+        if (param->hasOut())
+            removeVarsContaining(vars, param->name.name);
+}
+
+bool FindVariableValues::preorder(const IR::P4Control *ctrl) {
+    LOG2("FindVariableValues working on control: " << ctrl->name);
+    working = true;
+
+    return true;
+}
+
+void FindVariableValues::postorder(const IR::P4Control *ctrl) {
+    LOG2("FindVariableValues finished working on control: " << ctrl->name);
+    // Clear map as the pass works on every control block separately
+    vars.clear();
+    working = false;
+}
+
+bool FindVariableValues::preorder(const IR::P4Action *act) {
+    return false;
+}
+
+bool FindVariableValues::preorder(const IR::P4Table *tab) {
+    return false;
+}
+
+// When visiting IfStatement nodes the literal values assigned to variables in those
+// 'ifTrue' and 'ifFalse' blocks can't be retained in the 'vars' container since the
+// path taken can't be determined in compile time. Therefore a copy is made to preserve
+// the state of the map before those blocks, and all variables that are possibly changed
+// in these blocks are removed from the original map.
+bool FindVariableValues::preorder(const IR::IfStatement *stat) {
+    std::map<cstring, const IR::Expression*> copyOfVars(vars);
+    LOG3("Working on 'IfStatement->ifTrue' block: " << stat->ifTrue);
+    visit(stat->ifTrue);
+    // Check if some variables had their values changed when visiting 'ifTrue' block.
+    compareValuesInMaps(&copyOfVars, &vars);
+    // Restore old state of map
+    vars = copyOfVars;
+    LOG3("Finished 'IfStatement->ifTrue' block: " << stat->ifTrue);
+    LOG3("Working on 'IfStatement->ifFalse' block: " << stat->ifFalse);
+    visit(stat->ifFalse);
+    // Check if some variables had their values changed when visiting 'ifFalse' block.
+    compareValuesInMaps(&copyOfVars, &vars);
+    // Restore old state of map
+    vars = copyOfVars;
+    LOG3("Finished 'IfStatement->ifFalse' block: " << stat->ifFalse);
+
+    return false;
+}
+
+// Update the value for the 'stat->left' variable.
+bool FindVariableValues::preorder(const IR::AssignmentStatement *stat) {
+    if (!working || lvalue_name(stat->left).isNullOrEmpty())
+        return false;
+
+    LOG5("Working on statement: " << stat);
+    // Remove old values
+    if (vars[lvalue_name(stat->left)] == nullptr ||
+            !(stat->right->equiv(*(vars[lvalue_name(stat->left)]))))
+        removeVarsContaining(&vars, lvalue_name(stat->left));
+    // Set value
+    if (auto lit = stat->right->to<IR::Literal>()) {
+        if (stat->left->is<IR::Slice>())
+            return false;
+        vars[lvalue_name(stat->left)] = lit;
+        LOG5("  Setting value: " << lit << ", for: " << stat->left);
+    } else if (auto lit = vars[lvalue_name(stat->right)]->to<IR::Literal>()) {
+        if (stat->left->is<IR::Slice>() || stat->right->is<IR::Slice>())
+            return false;
+        vars[lvalue_name(stat->left)] = lit;
+        LOG5("  Setting value: " << lit << ", for: " << stat->left);
+    }
+
+    return false;
+}
+
+// The core idea of this pass is represented here, it works on 'ActionCall' nodes by accessing
+// the body of the action using the pointer acquired by resolving the 'MethodCallExpression'.
+// An entry in the 'actions' map is set for the action node that was acquired by resolving
+// the 'ActionCall'.
+void FindVariableValues::postorder(const IR::MethodCallExpression *mc) {
+    if (!working || mc->method->is<IR::Member>())
+        return;
+
+    LOG5("Working on 'MethodCallexpression': " << mc);
+    auto *mi = MethodInstance::resolve(mc, refMap, typeMap, true);
+    // Remove entries in the 'vars' map for variables that are used as 'Out' or 'InOut' parameters.
+    if (auto aCall = mi->to<ActionCall>()) {
+        // Check to see if an entry already exists for this action, this should not happen
+        // if the preconditions of this pass have been met.
+        if (actions->find(aCall->action) == actions->end()) {
+            // Add an entry in the 'actions' map for the action being called.
+            LOG6("  Is 'ActionCall'. Adding entry for action: " << aCall->action);
+            (*actions)[aCall->action] = new std::map<cstring, const IR::Expression*>(vars);
+            visit(aCall->action->body);
+        } else {
+            LOG6("  Is 'ActionCall'. Entry already exists for this action: " << aCall->action);
+        }
+    } else if (auto eFun = mi->to<ExternFunction>()) {
+        LOG6("  Is 'ExternFunction'. Checking params for: " << eFun->method);
+        checkParametersForMap(eFun->method->getParameters(), &vars);
+    } else if (auto fCall = mi->to<FunctionCall>()) {
+        LOG6("  Is 'FunctionCall'. Checking params for: " << fCall->function);
+        checkParametersForMap(fCall->function->getParameters(), &vars);
+    }
+    LOG5("Finished 'MethodCallExpression': " << mc);
+}
+
+// Returns value stored for variable denoted with 'name'.
+// Returns nullptr if nothing is stored.
+const IR::Expression *DoGlobalCopyPropagation::copyprop_name(cstring name) {
+    if (name.isNullOrEmpty() || !performRewrite) return nullptr;
+    LOG6("Propagating value: " << (*vars)[name] << " for variable: " << name);
+    return (*vars)[name];
+}
+
+const IR::Expression *DoGlobalCopyPropagation::postorder(IR::PathExpression *path) {
+    if (!performRewrite)
+        return path;
+
+    auto ret = copyprop_name(path->path->name);
+    return ret ? ret : path;
+}
+
+const IR::Expression *DoGlobalCopyPropagation::preorder(IR::Member *member) {
+    if (!performRewrite)
+        return member;
+
+    if (auto name = lvalue_name(member)) {
+        prune();
+        if (auto rv = copyprop_name(name))
+            return rv;
+    }
+    return member;
+}
+
+const IR::Expression *DoGlobalCopyPropagation::preorder(IR::ArrayIndex *arr) {
+    if (!performRewrite)
+        return arr;
+
+    if (auto name = lvalue_name(arr)) {
+        prune();
+        if (auto rv = copyprop_name(name)) {
+            return rv;
+        }
+    }
+    return arr;
+}
+
+// If information for this action is available work on action body and propagate values.
+const IR::P4Action *DoGlobalCopyPropagation::preorder(IR::P4Action *act) {
+    if (actions->find(getOriginal()) != actions->end()) {
+        performRewrite = true;
+        vars = actions->find(getOriginal())->second;
+        LOG2("DoGlobalCopyPropagation working on action: " << act->name);
+    } else {
+        performRewrite = false;
+    }
+
+    return act;
+}
+
+const IR::P4Action *DoGlobalCopyPropagation::postorder(IR::P4Action *act) {
+    performRewrite = false;
+    LOG2("DoGlobalCopyPropagation finished action: " << act->name);
+    return act;
+}
+
+IR::MethodCallExpression *DoGlobalCopyPropagation::postorder(IR::MethodCallExpression *mc) {
+    if (!performRewrite || mc->method->is<IR::Member>())
+        return mc;
+
+    auto *mi = MethodInstance::resolve(mc, refMap, typeMap, true);
+    LOG5("Working on 'MethodCallExpression' : " << mc);
+    // Remove entries in the 'vars' map for variables that are used as 'Out' or 'InOut' parameters.
+    if (auto eFun = mi->to<ExternFunction>()) {
+        LOG6("  Is 'ExternFunction'. Checking params for: " << eFun->method);
+        checkParametersForMap(eFun->method->getParameters(), vars);
+    } else if (auto fCall = mi->to<P4::FunctionCall>()) {
+        LOG6("  Is 'FunctionCall'. Checking params for: " << fCall->function);
+        checkParametersForMap(fCall->function->getParameters(), vars);
+    }
+    LOG5("Finished 'MethodCallExpression' : " << mc);
+
+    return mc;
+}
+
+
+// When visiting IfStatement nodes the literal values assigned to variables in those
+// 'ifTrue' and 'ifFalse' blocks can't be retained in the 'vars' container since the
+// path taken can't be determined in compile time. Therefore a copy is made to preserve
+// the state of the map before those blocks, and all variables that are possibly changed
+// in these blocks are removed from the original map.
+IR::IfStatement *DoGlobalCopyPropagation::preorder(IR::IfStatement *stat) {
+    if (!performRewrite)
+        return stat;
+
+    std::map<cstring, const IR::Expression*> copyOfVars(*vars);
+    LOG3("Working on 'IfStatement->ifTrue' block: " << stat->ifTrue);
+    visit(stat->ifTrue);
+    // Check if some variables had their values changed when visiting 'ifTrue' block.
+    compareValuesInMaps(&copyOfVars, vars);
+    // Restore old state of map
+    *vars = copyOfVars;
+    LOG3("Finished 'IfStatement->ifTrue' block: " << stat->ifTrue);
+    LOG3("Working on 'IfStatement->ifFalse' block: " << stat->ifFalse);
+    visit(stat->ifFalse);
+    // Check if some variables had their values changed when visiting 'ifFalse' block.
+    compareValuesInMaps(&copyOfVars, vars);
+    // Restore old state of map
+    *vars = copyOfVars;
+    LOG3("Finished 'IfStatement->ifFalse' block: " << stat->ifFalse);
+    prune();
+
+    return stat;
+}
+
+// Propagate values for variables on the right side of the statement
+// and update value for 'stat->left' variable if needed.
+const IR::Node *DoGlobalCopyPropagation::preorder(IR::AssignmentStatement *stat) {
+    if (!performRewrite)
+        return stat;
+
+    LOG5("Working on statement: " << stat);
+    LOG6("  Visiting right side of statement");
+    visit(stat->right);
+    // Remove old values
+    if ((*vars)[lvalue_name(stat->left)] == nullptr ||
+            !(stat->right->equiv(*((*vars)[lvalue_name(stat->left)]))))
+        removeVarsContaining(vars, lvalue_name(stat->left));
+    performRewrite = false;
+    LOG6("  Visiting left side of statement");
+    visit(stat->left);
+    performRewrite = true;
+    prune();
+    // Store the value for 'stat->left' if it is now a constant. If it is an assignment to an
+    // identical literal as already stored in the 'vars' container the statement is removed.
+    if (auto lit = stat->right->to<IR::Literal>()) {
+        if (stat->left->is<IR::Slice>())
+            return stat;
+        if ((*vars)[lvalue_name(stat->left)] && lit->equiv(*((*vars)[lvalue_name(stat->left)])))
+            return new IR::EmptyStatement();
+        (*vars)[lvalue_name(stat->left)] = lit;
+        LOG5("  Setting value: " << lit << ", for: " << stat->left);
+    }
+
+    return stat;
+}
+
+}  // namespace P4

--- a/midend/global_copyprop.h
+++ b/midend/global_copyprop.h
@@ -1,0 +1,147 @@
+#ifndef MIDEND_GLOBAL_COPYPROP_H_
+#define MIDEND_GLOBAL_COPYPROP_H_
+
+#include "ir/ir.h"
+#include "frontends/p4/typeChecking/typeChecker.h"
+#include "frontends/common/resolveReferences/referenceMap.h"
+
+namespace P4 {
+/**
+Global copy propagation, currently only operationg on control blocks where it optimizes the bodies
+of actions by propagating literal values for variables used in those actions. Pass is limited
+to only optimizing actions called in the 'apply' body of the control block and has no effect
+on actions found in tables.
+This pass is designed as an extension of the LocalCopyPropagation pass, but the logic has been
+separated into a standalone pass to avoid additionally complicating the LocalCopyProp pass.
+GlobalCopyPropagation pass was made with the intent of being used together with the existing
+LocalCopyPropagation pass, and therefore doesn't introduce some of the features of that pass.
+
+The logic of this pass is divided into 2 passes, an Inspector pass that collects information
+on the variables used in the program and their values at the time of the action call and a
+Transformer pass that uses this information to edit the action bodies.
+The nature of the below mentionied optimization is such that it requires retroactive
+transformations to the action bodies, and this was the reason for having 2 separate passes.
+
+The main situation that this pass optimizes is given below:
+  ...
+  control ing(out bit<16> y, ...) {
+    bit<16> x;
+    action do_action() {
+      y = x;
+    }
+
+    apply {
+      x = 16w5;
+      do_action();
+    }
+  }
+  ...
+
+, and after optimization:
+  ...
+  control ing(out bit<16> y, ...) {
+    action do_action() {
+      y = 16w5;
+    }
+
+    apply {
+      do_action();
+    }
+  }
+  ...
+
+  @pre  This pass should be run after the LocalizeAllActions frontend pass, which ensures that each
+        action is invoked only once.
+*/
+
+/**
+ * This pass operates on control blocks and collects information about the state of the
+ * variables in that block and later distributes this information to the Transformer pass.
+ * Information is represented as a map that contains literal values for variables that need to
+ * be propagated, each action node has it's own map of information.
+ */
+class FindVariableValues final : public Inspector {
+  ReferenceMap                                                          *refMap;
+  TypeMap                                                               *typeMap;
+  // Container for storing constant values for variables, is used as a representation of
+  // the current state of the variables in the program. Keys are variable names and values
+  // are pointers to 'Expression' nodes that represent a literal value for that variable.
+  std::map<cstring, const IR::Expression*>                              &vars;
+  // Container used to store information needed for later propagating by the Transformer pass.
+  // Keys for outer map are pointers to action nodes whose bodies need to be rewritten by the
+  // Transformer pass and values are maps that store literal values for variables.
+  // This inner map uses the name of the variable as a key and the pointer to the 'Expression'
+  // node, that represents a literal, as a value.
+  std::map<const IR::Node*, std::map<cstring, const IR::Expression*>*>  *actions;
+  // Flag for controlling which IR nodes this pass operates on
+  bool                                                                  working = false;
+
+  bool preorder(const IR::IfStatement *) override;
+  void postorder(const IR::P4Control *) override;
+  bool preorder(const IR::P4Control *) override;
+  bool preorder(const IR::P4Table *) override;
+  bool preorder(const IR::P4Action *) override;
+  bool preorder(const IR::AssignmentStatement *) override;
+  void postorder(const IR::MethodCallExpression *) override;
+
+ public:
+  FindVariableValues(ReferenceMap* refMap, TypeMap* typeMap,
+      std::map<const IR::Node*, std::map<cstring, const IR::Expression*>*> *acts) :
+          refMap(refMap), typeMap(typeMap), vars(*new std::map<cstring, const IR::Expression*>),
+          actions(acts) {}
+};
+
+/**
+ * This pass operates on action bodies and is ran right after the Inspector pass.
+ * It propagates the values for variables that got their values assigned to them
+ * before the action call.
+ */
+class DoGlobalCopyPropagation final : public Transform {
+  ReferenceMap                                                          *refMap;
+  TypeMap                                                               *typeMap;
+  // Container for storing constant values for variables, used as a representation of
+  // the current state of the variables in the program. Keys are variable names and values
+  // are pointers to 'Expression' nodes that represent a literal value for that variable.
+  std::map<cstring, const IR::Expression*>                              *vars = nullptr;
+  // Container used to store information needed for propagating.
+  // Keys for outer map are pointers to action nodes whose bodies need to be rewritten by this pass
+  // and values represent maps that store literal values for variables.
+  // This inner map uses the name of the variable as a key and the pointer to the 'Expression'
+  // node, that represents a literal, as a value.
+  std::map<const IR::Node*, std::map<cstring, const IR::Expression*>*>  *actions;
+  // Flag for controlling which IR nodes this pass operates on
+  bool                                                                  performRewrite = false;
+
+ public:
+  explicit DoGlobalCopyPropagation(ReferenceMap* rM, TypeMap* tM,
+      std::map<const IR::Node*, std::map<cstring, const IR::Expression*>*> *acts) :
+          refMap(rM), typeMap(tM), actions(acts) {}
+
+  // Returns the stored value for the used variable
+  const IR::Expression *copyprop_name(cstring name);
+
+  IR::IfStatement *preorder(IR::IfStatement *) override;
+  const IR::Expression *postorder(IR::PathExpression *) override;
+  const IR::Expression *preorder(IR::ArrayIndex *) override;
+  const IR::Expression *preorder(IR::Member *) override;
+  const IR::Node *preorder(IR::AssignmentStatement *) override;
+  const IR::P4Action *preorder(IR::P4Action *) override;
+  const IR::P4Action *postorder(IR::P4Action *) override;
+  IR::MethodCallExpression *postorder(IR::MethodCallExpression *) override;
+};
+
+class GlobalCopyPropagation : public PassManager {
+ public:
+  GlobalCopyPropagation(ReferenceMap* rM, TypeMap* tM) {
+    passes.push_back(new TypeChecking(rM, tM, true));
+    auto acts =
+          new std::map<const IR::Node*, std::map<cstring, const IR::Expression*>*>;
+    passes.push_back(new FindVariableValues(rM, tM, acts));
+    passes.push_back(new DoGlobalCopyPropagation(rM, tM, acts));
+    setName("GlobalCopyPropagation");
+  }
+};
+
+}  // namespace P4
+
+#endif /* MIDEND_GLOBAL_COPYPROP_H_ */

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -661,4 +661,24 @@ IR::ParserState *DoLocalCopyPropagation::postorder(IR::ParserState *state) {
     return state;
 }
 
+// Reset the state of internal data structures after traversing IR,
+// needed for this pass to function correctly when used in a PassRepeated
+Visitor::profile_t DoLocalCopyPropagation::init_apply(const IR::Node* node) {
+    // clear maps
+    available.clear();
+    tables.clear();
+    actions.clear();
+    methods.clear();
+    states.clear();
+    // reset pointers
+    inferForFunc = nullptr;
+    inferForTable = nullptr;
+    // reset flags
+    need_key_rewrite = false;
+    elimUnusedTables = false;
+    working = false;
+
+    return Transform::init_apply(node);
+}
+
 }  // namespace P4

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -116,6 +116,7 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
     const IR::P4Parser *postorder(IR::P4Parser *) override;
     IR::ParserState *preorder(IR::ParserState *) override;
     IR::ParserState *postorder(IR::ParserState *) override;
+    Visitor::profile_t init_apply(const IR::Node* node) override;
     class ElimDead;
     class RewriteTableKeys;
 

--- a/testdata/p4_14_samples_outputs/parser_pragma2-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2-midend.p4
@@ -9,7 +9,6 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name("ParserImpl.tmp_0") bit<32> tmp_0;
     @name(".$start") state start {
         transition select((bit<32>)standard_metadata.instance_type) {
             32w0: start_0;
@@ -22,7 +21,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition accept;
     }
     @packet_entry @name(".start_e2e_mirrored") state start_e2e_mirrored {
-        tmp_0 = packet.lookahead<bit<32>>();
+        packet.lookahead<bit<32>>();
         transition accept;
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {

--- a/testdata/p4_16_samples/issue2279.p4
+++ b/testdata/p4_16_samples/issue2279.p4
@@ -1,0 +1,24 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 2 ? 16w3 : 16w1);
+    }
+    apply {
+        do_action();
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;

--- a/testdata/p4_16_samples/issue2279_1.p4
+++ b/testdata/p4_16_samples/issue2279_1.p4
@@ -1,0 +1,26 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 2 ? 16w3 : 16w1);
+        tmp_val[7:0] = 8w4;
+    }
+    apply {
+        do_action();
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples/issue2279_2.p4
+++ b/testdata/p4_16_samples/issue2279_2.p4
@@ -1,0 +1,26 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 2 ? 16w3 : 16w1);
+        tmp_val = 16w4;
+    }
+    apply {
+        do_action();
+        tmp_val = 16w1;
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;

--- a/testdata/p4_16_samples/issue2279_3.p4
+++ b/testdata/p4_16_samples/issue2279_3.p4
@@ -1,0 +1,25 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bool tmp_val = false;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val ? 16w3 : 16w1);
+        tmp_val = true;
+    }
+    apply {
+        do_action();
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;

--- a/testdata/p4_16_samples/issue2279_4.p4
+++ b/testdata/p4_16_samples/issue2279_4.p4
@@ -1,0 +1,27 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 2 ? 16w3 : 16w1);
+    }
+    apply {
+        do_action();
+        if (tmp_val > 2) {
+            tmp_val = hdr.eth_hdr.eth_type / 2 - tmp_val;
+        }
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/action_call_ebpf-midend.p4
+++ b/testdata/p4_16_samples_outputs/action_call_ebpf-midend.p4
@@ -11,18 +11,8 @@ parser prs(packet_in p, out Headers_t headers) {
 }
 
 control pipe(inout Headers_t headers, out bool pass) {
-    @name("pipe.x") bool x_0;
     @name("pipe.Reject") action Reject() {
-        pass = x_0;
-    }
-    @hidden action action_call_ebpf34() {
-        x_0 = true;
-    }
-    @hidden table tbl_action_call_ebpf34 {
-        actions = {
-            action_call_ebpf34();
-        }
-        const default_action = action_call_ebpf34();
+        pass = true;
     }
     @hidden table tbl_Reject {
         actions = {
@@ -31,7 +21,6 @@ control pipe(inout Headers_t headers, out bool pass) {
         const default_action = Reject();
     }
     apply {
-        tbl_action_call_ebpf34.apply();
         tbl_Reject.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/array_field1-midend.p4
+++ b/testdata/p4_16_samples_outputs/array_field1-midend.p4
@@ -12,7 +12,7 @@ control my(out H[2] s) {
     @name("my.act") action act() {
         s[32w0].z = 1w1;
         s[32w1].z = 1w0;
-        tmp_3 = s[32w0].z;
+        tmp_3 = 1w1;
         tmp_4 = f(tmp_3, 1w0);
         s[32w0].z = tmp_3;
         tmp_6 = s[(bit<32>)tmp_4].z;

--- a/testdata/p4_16_samples_outputs/decl2-midend.p4
+++ b/testdata/p4_16_samples_outputs/decl2-midend.p4
@@ -1,15 +1,5 @@
 control p() {
-    @name("p.x_1") bit<1> x_3;
     @name("p.b") action b() {
-    }
-    @hidden action decl2l32() {
-        x_3 = 1w0;
-    }
-    @hidden table tbl_decl2l32 {
-        actions = {
-            decl2l32();
-        }
-        const default_action = decl2l32();
     }
     @hidden table tbl_b {
         actions = {
@@ -18,7 +8,6 @@ control p() {
         const default_action = b();
     }
     apply {
-        tbl_decl2l32.apply();
         tbl_b.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/direct-action-midend.p4
+++ b/testdata/p4_16_samples_outputs/direct-action-midend.p4
@@ -1,16 +1,6 @@
 control c(inout bit<16> y) {
-    @name("c.x") bit<32> x_0;
     @name("c.a") action a() {
-        y = (bit<16>)x_0;
-    }
-    @hidden action directaction18() {
-        x_0 = 32w2;
-    }
-    @hidden table tbl_directaction18 {
-        actions = {
-            directaction18();
-        }
-        const default_action = directaction18();
+        y = 16w2;
     }
     @hidden table tbl_a {
         actions = {
@@ -19,7 +9,6 @@ control c(inout bit<16> y) {
         const default_action = a();
     }
     apply {
-        tbl_directaction18.apply();
         tbl_a.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/direct-action1-midend.p4
+++ b/testdata/p4_16_samples_outputs/direct-action1-midend.p4
@@ -1,16 +1,6 @@
 control c(inout bit<16> y) {
-    @name("c.x") bit<32> x_0;
     @name("c.a") action a() {
-        y = (bit<16>)x_0;
-    }
-    @hidden action directaction1l18() {
-        x_0 = 32w10;
-    }
-    @hidden table tbl_directaction1l18 {
-        actions = {
-            directaction1l18();
-        }
-        const default_action = directaction1l18();
+        y = 16w10;
     }
     @hidden table tbl_a {
         actions = {
@@ -19,7 +9,6 @@ control c(inout bit<16> y) {
         const default_action = a();
     }
     apply {
-        tbl_directaction1l18.apply();
         tbl_a.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/function-midend.p4
+++ b/testdata/p4_16_samples_outputs/function-midend.p4
@@ -1,27 +1,6 @@
 control c(out bit<16> b) {
-    @name("c.hasReturned") bool hasReturned;
-    @name("c.retval") bit<16> retval;
-    @hidden action function4() {
-        hasReturned = true;
-        retval = 16w12;
-    }
-    @hidden action act() {
-        hasReturned = false;
-    }
     @hidden action function9() {
-        b = retval;
-    }
-    @hidden table tbl_act {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
-    @hidden table tbl_function4 {
-        actions = {
-            function4();
-        }
-        const default_action = function4();
+        b = 16w12;
     }
     @hidden table tbl_function9 {
         actions = {
@@ -30,12 +9,6 @@ control c(out bit<16> b) {
         const default_action = function9();
     }
     apply {
-        tbl_act.apply();
-        if (hasReturned) {
-            ;
-        } else {
-            tbl_function4.apply();
-        }
         tbl_function9.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/gauntlet_copy_out-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_copy_out-bmv2-midend.p4
@@ -22,21 +22,10 @@ struct Meta {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.c") bit<8> c_0;
     @name("ingress.do_thing") action do_thing() {
-        h.h.a = c_0;
+        h.h.a = 8w12;
     }
     @name("ingress.do_thing") action do_thing_1() {
-        h.h.a = c_0;
-    }
-    @hidden action gauntlet_copy_outbmv2l23() {
-        c_0 = 8w12;
-    }
-    @hidden table tbl_gauntlet_copy_outbmv2l23 {
-        actions = {
-            gauntlet_copy_outbmv2l23();
-        }
-        const default_action = gauntlet_copy_outbmv2l23();
     }
     @hidden table tbl_do_thing {
         actions = {
@@ -51,7 +40,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         const default_action = do_thing_1();
     }
     apply {
-        tbl_gauntlet_copy_outbmv2l23.apply();
         tbl_do_thing.apply();
         tbl_do_thing_0.apply();
     }

--- a/testdata/p4_16_samples_outputs/gauntlet_enum_assign-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_enum_assign-bmv2-midend.p4
@@ -14,7 +14,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.do_thing") action do_thing() {
         cond = sm.enq_timestamp != 32w6;
         tmp.ingress_port = (sm.enq_timestamp != 32w6 ? sm.ingress_port : tmp.ingress_port);
-        tmp.egress_spec = (sm.enq_timestamp != 32w6 ? sm.egress_spec : tmp.egress_spec);
+        tmp.egress_spec = (sm.enq_timestamp != 32w6 ? 9w2 : tmp.egress_spec);
         tmp.egress_port = (sm.enq_timestamp != 32w6 ? sm.egress_port : tmp.egress_port);
         tmp.instance_type = (sm.enq_timestamp != 32w6 ? sm.instance_type : tmp.instance_type);
         tmp.packet_length = (sm.enq_timestamp != 32w6 ? sm.packet_length : tmp.packet_length);
@@ -30,7 +30,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         tmp.parser_error = (sm.enq_timestamp != 32w6 ? sm.parser_error : tmp.parser_error);
         tmp.priority = (sm.enq_timestamp != 32w6 ? sm.priority : tmp.priority);
         sm.ingress_port = (sm.enq_timestamp != 32w6 ? tmp.ingress_port : sm.ingress_port);
-        sm.egress_spec = (sm.enq_timestamp != 32w6 ? tmp.egress_spec : sm.egress_spec);
+        sm.egress_spec = (sm.enq_timestamp != 32w6 ? tmp.egress_spec : 9w2);
         sm.egress_port = (sm.enq_timestamp != 32w6 ? tmp.egress_port : sm.egress_port);
         sm.instance_type = (sm.enq_timestamp != 32w6 ? tmp.instance_type : sm.instance_type);
         sm.packet_length = (sm.enq_timestamp != 32w6 ? tmp.packet_length : sm.packet_length);

--- a/testdata/p4_16_samples_outputs/gauntlet_function_return-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_function_return-bmv2-midend.p4
@@ -14,7 +14,6 @@ struct Meta {
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.d_0") bit<32> d;
     @name("ingress.action_thing") action action_thing() {
         sm.enq_timestamp = 32w1;
     }

--- a/testdata/p4_16_samples_outputs/gauntlet_index_5-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_index_5-bmv2-midend.p4
@@ -30,17 +30,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.tmp") bit<48> tmp;
     @name("ingress.simple_action") action simple_action() {
-    }
-    @hidden action gauntlet_index_5bmv2l35() {
-        tmp = h.eth_hdr.dst_addr;
-    }
-    @hidden table tbl_gauntlet_index_5bmv2l35 {
-        actions = {
-            gauntlet_index_5bmv2l35();
-        }
-        const default_action = gauntlet_index_5bmv2l35();
     }
     @hidden table tbl_simple_action {
         actions = {
@@ -49,7 +39,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         const default_action = simple_action();
     }
     apply {
-        tbl_gauntlet_index_5bmv2l35.apply();
         tbl_simple_action.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/gauntlet_inout_slice_table_key-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_inout_slice_table_key-bmv2-midend.p4
@@ -24,7 +24,6 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.tmp_val") bit<8> tmp_val_0;
-    @name("ingress.tmp") bit<4> tmp;
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
     @name("ingress.simple_action") action simple_action() {
@@ -40,7 +39,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     }
     @hidden action gauntlet_inout_slice_table_keybmv2l27() {
         tmp_val_0 = 8w1;
-        tmp = 4w0;
     }
     @hidden action gauntlet_inout_slice_table_keybmv2l41() {
         h.eth_hdr.eth_type = 16w1;

--- a/testdata/p4_16_samples_outputs/gauntlet_mux_validity-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_mux_validity-bmv2-midend.p4
@@ -29,30 +29,8 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.b") bool b_0;
-    @name("ingress.tmp") bit<16> tmp;
-    @name("ingress.tmp_0") bit<16> tmp_0;
-    @name("ingress.dummy_1") H dummy;
-    @name("ingress.hasReturned") bool hasReturned;
-    @name("ingress.retval") bit<16> retval;
     @name("ingress.dummy") action dummy_2() {
-        dummy = (b_0 ? h.h : dummy);
-        hasReturned = (b_0 ? true : hasReturned);
-        retval = (b_0 ? 16w1 : retval);
-        h.h = (b_0 ? dummy : h.h);
-        tmp_0 = (b_0 ? retval : tmp_0);
-        tmp = (b_0 ? tmp_0 : tmp);
-        tmp = (b_0 ? tmp_0 : 16w1);
-        h.eth_hdr.eth_type = (b_0 ? tmp_0 : 16w1);
-    }
-    @hidden action gauntlet_mux_validitybmv2l37() {
-        b_0 = false;
-    }
-    @hidden table tbl_gauntlet_mux_validitybmv2l37 {
-        actions = {
-            gauntlet_mux_validitybmv2l37();
-        }
-        const default_action = gauntlet_mux_validitybmv2l37();
+        h.eth_hdr.eth_type = 16w1;
     }
     @hidden table tbl_dummy {
         actions = {
@@ -61,7 +39,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         const default_action = dummy_2();
     }
     apply {
-        tbl_gauntlet_mux_validitybmv2l37.apply();
         tbl_dummy.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/gauntlet_nested_switch-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_nested_switch-bmv2-midend.p4
@@ -23,7 +23,6 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.hasReturned") bool hasReturned;
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
     @name("ingress.call_action") action call_action() {
@@ -36,48 +35,14 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         }
         default_action = NoAction_1();
     }
-    @hidden action act() {
-        hasReturned = false;
-    }
-    @hidden action gauntlet_nested_switchbmv2l47() {
-        h.eth_hdr.eth_type = 16w1;
-    }
-    @hidden action gauntlet_nested_switchbmv2l38() {
-        hasReturned = true;
-    }
-    @hidden table tbl_act {
-        actions = {
-            act();
-        }
-        const default_action = act();
-    }
     @hidden table tbl_call_action {
         actions = {
             call_action();
         }
         const default_action = call_action();
     }
-    @hidden table tbl_gauntlet_nested_switchbmv2l38 {
-        actions = {
-            gauntlet_nested_switchbmv2l38();
-        }
-        const default_action = gauntlet_nested_switchbmv2l38();
-    }
-    @hidden table tbl_gauntlet_nested_switchbmv2l47 {
-        actions = {
-            gauntlet_nested_switchbmv2l47();
-        }
-        const default_action = gauntlet_nested_switchbmv2l47();
-    }
     apply {
-        tbl_act.apply();
         tbl_call_action.apply();
-        tbl_gauntlet_nested_switchbmv2l38.apply();
-        if (hasReturned) {
-            ;
-        } else {
-            tbl_gauntlet_nested_switchbmv2l47.apply();
-        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_2-bmv2-midend.p4
@@ -29,19 +29,8 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.tmp_1") bit<8> tmp_2;
-    @name("ingress.tmp") bit<8> tmp_4;
     @name("ingress.do_thing") action do_thing() {
-        h.h.a = tmp_2;
-    }
-    @hidden action act() {
-        tmp_2 = 8w3;
-    }
-    @hidden table tbl_act {
-        actions = {
-            act();
-        }
-        const default_action = act();
+        h.h.a = 8w3;
     }
     @hidden table tbl_do_thing {
         actions = {
@@ -50,7 +39,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         const default_action = do_thing();
     }
     apply {
-        tbl_act.apply();
         tbl_do_thing.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_3-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_3-bmv2-midend.p4
@@ -32,7 +32,6 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.val_0") bit<8> val;
     @name("ingress.val_1") bit<8> val_2;
     @hidden action gauntlet_side_effect_order_3bmv2l46() {
         m.tmp = val_2;

--- a/testdata/p4_16_samples_outputs/inline-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-midend.p4
@@ -1,16 +1,6 @@
 control p(out bit<1> y) {
-    @name("p.x") bit<1> x_2;
     @name("p.b") action b() {
-        y = x_2;
-    }
-    @hidden action inline33() {
-        x_2 = 1w1;
-    }
-    @hidden table tbl_inline33 {
-        actions = {
-            inline33();
-        }
-        const default_action = inline33();
+        y = 1w1;
     }
     @hidden table tbl_b {
         actions = {
@@ -19,7 +9,6 @@ control p(out bit<1> y) {
         const default_action = b();
     }
     apply {
-        tbl_inline33.apply();
         tbl_b.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-midend.p4
@@ -53,7 +53,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         h_0_h1[0] = hd_10;
     }
     @name("IngressI.validateHeader") action validateHeader_1() {
-        hd_11 = h_0_h2[tmp];
+        hd_11 = h_0_h2[1w1];
         hd_11.setValid();
         h_0_h2[tmp] = hd_11;
     }

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6-midend.p4
@@ -47,12 +47,6 @@ parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t
 
 control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
     @name("IngressI.u") Union[2] u_0;
-    @hidden action invalidhdrwarnings6l77() {
-        u_0[1w0].h1.setValid();
-    }
-    @hidden action invalidhdrwarnings6l79() {
-        u_0[1w0].h2.setValid();
-    }
     @hidden action invalidhdrwarnings6l57() {
         u_0[0].h1.setInvalid();
         u_0[0].h2.setInvalid();
@@ -69,8 +63,7 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         u_0[1].h2 = u_0[1w0].h2;
         u_0[1].h3 = u_0[1w0].h3;
         u_0[1].h2.data = 16w1;
-    }
-    @hidden action invalidhdrwarnings6l83() {
+        u_0[1w0].h2.setValid();
         u_0[1].h1.setInvalid();
         u_0[1w0].h1.setInvalid();
         u_0[1w0].h1.setValid();
@@ -81,32 +74,8 @@ control IngressI(inout H hdr, inout M meta, inout standard_metadata_t smeta) {
         }
         const default_action = invalidhdrwarnings6l57();
     }
-    @hidden table tbl_invalidhdrwarnings6l77 {
-        actions = {
-            invalidhdrwarnings6l77();
-        }
-        const default_action = invalidhdrwarnings6l77();
-    }
-    @hidden table tbl_invalidhdrwarnings6l79 {
-        actions = {
-            invalidhdrwarnings6l79();
-        }
-        const default_action = invalidhdrwarnings6l79();
-    }
-    @hidden table tbl_invalidhdrwarnings6l83 {
-        actions = {
-            invalidhdrwarnings6l83();
-        }
-        const default_action = invalidhdrwarnings6l83();
-    }
     apply {
         tbl_invalidhdrwarnings6l57.apply();
-        if (u_0[1].h2.data == 16w0) {
-            tbl_invalidhdrwarnings6l77.apply();
-        } else {
-            tbl_invalidhdrwarnings6l79.apply();
-        }
-        tbl_invalidhdrwarnings6l83.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings7-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings7-midend.p4
@@ -23,7 +23,6 @@ control c(inout bit<32> x) {
     @name("c.u1") U u1_1;
     @name("c.hs1") H1[2] hs1_1;
     @name("c.us1") U[2] us1_1;
-    @name("c.u1") U u1_2;
     @name("c.us1") U[2] us1_2;
     @name("c.u1") U u1_3;
     @name("c.hs1") H1[2] hs1_3;
@@ -66,12 +65,9 @@ control c(inout bit<32> x) {
         us_0 = us1_1;
     }
     @name("c.inout_action2") action inout_action2() {
-        u1_2.h1 = u_0.h1;
-        u1_2.h2 = u_0.h2;
         us1_2 = us_0;
         us1_2[1w1].h1.setInvalid();
         us1_2[1w1].h2.setValid();
-        u_0.h2 = u1_2.h2;
         us_0 = us1_2;
     }
     @name("c.xor") action xor() {

--- a/testdata/p4_16_samples_outputs/issue1452-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1452-midend.p4
@@ -1,7 +1,5 @@
 control c() {
-    @name("c.x") bit<32> x_0;
     @name("c.a") action a() {
-        x_0 = 32w1;
     }
     @hidden table tbl_a {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2-midend.p4
@@ -70,7 +70,6 @@ struct headers {
 
 parser PROTParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("PROTParser.inf_0") prot_i_t inf_0;
-    bit<8> meta_0_currPos;
     currenti_t meta_0_currenti;
     state start {
         packet.extract<preamble_t>(hdr.preamble);
@@ -91,15 +90,13 @@ parser PROTParser(packet_in packet, out headers hdr, inout metadata meta, inout 
         meta._addrLen2 = meta._addrLen2 + (9w64 - (meta._addrLen2 & 9w63) & 9w63);
         meta._currPos3 = (bit<8>)(9w3 + (meta._addrLen2 >> 6));
         inf_0.setInvalid();
-        meta_0_currPos = (bit<8>)(9w3 + (meta._addrLen2 >> 6));
         meta_0_currenti.upDirection = meta._currenti_upDirection4;
         packet.extract<prot_i_t>(inf_0);
         meta_0_currenti.upDirection = meta._currenti_upDirection4 + (bit<1>)(hdr.prot_common.curri == (bit<8>)(9w3 + (meta._addrLen2 >> 6))) * inf_0.upDirection;
-        meta_0_currPos = (bit<8>)(9w3 + (meta._addrLen2 >> 6)) + 8w1;
         hdr.prot_inf_0 = inf_0;
         meta._hLeft1 = inf_0.segLen;
-        meta._currPos3 = meta_0_currPos;
-        meta._currenti_upDirection4 = meta_0_currenti.upDirection;
+        meta._currPos3 = (bit<8>)(9w3 + (meta._addrLen2 >> 6)) + 8w1;
+        meta._currenti_upDirection4 = meta._currenti_upDirection4 + (bit<1>)(hdr.prot_common.curri == (bit<8>)(9w3 + (meta._addrLen2 >> 6))) * inf_0.upDirection;
         transition parse_prot_h_0_pre;
     }
     state parse_prot_h_0_pre {
@@ -122,11 +119,9 @@ parser PROTParser(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     state parse_prot_inf_1 {
         inf_0.setInvalid();
-        meta_0_currPos = meta._currPos3;
         meta_0_currenti.upDirection = meta._currenti_upDirection4;
         packet.extract<prot_i_t>(inf_0);
         meta_0_currenti.upDirection = meta._currenti_upDirection4 + (bit<1>)(hdr.prot_common.curri == meta._currPos3) * inf_0.upDirection;
-        meta_0_currPos = meta._currPos3 + 8w1;
         hdr.prot_inf_1 = inf_0;
         meta._hLeft1 = inf_0.segLen;
         meta._currPos3 = meta._currPos3 + 8w1;

--- a/testdata/p4_16_samples_outputs/issue210-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue210-midend.p4
@@ -1,18 +1,8 @@
 #include <core.p4>
 
 control Ing(out bit<32> a) {
-    @name("Ing.b") bool b_0;
     @name("Ing.cond") action cond() {
-        a = (b_0 ? 32w5 : 32w10);
-    }
-    @hidden action issue210l30() {
-        b_0 = true;
-    }
-    @hidden table tbl_issue210l30 {
-        actions = {
-            issue210l30();
-        }
-        const default_action = issue210l30();
+        a = 32w5;
     }
     @hidden table tbl_cond {
         actions = {
@@ -21,7 +11,6 @@ control Ing(out bit<32> a) {
         const default_action = cond();
     }
     apply {
-        tbl_issue210l30.apply();
         tbl_cond.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue2147-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2147-1-midend.p4
@@ -1,15 +1,5 @@
 control ingress(inout bit<8> h) {
-    @name("ingress.tmp") bit<8> tmp_0;
     @name("ingress.a") action a() {
-    }
-    @hidden action issue21471l5() {
-        tmp_0 = h;
-    }
-    @hidden table tbl_issue21471l5 {
-        actions = {
-            issue21471l5();
-        }
-        const default_action = issue21471l5();
     }
     @hidden table tbl_a {
         actions = {
@@ -18,7 +8,6 @@ control ingress(inout bit<8> h) {
         const default_action = a();
     }
     apply {
-        tbl_issue21471l5.apply();
         tbl_a.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue2176-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2176-bmv2-midend.p4
@@ -37,16 +37,11 @@ parser p(packet_in pkt, out Parsed_packet hdr, inout Metadata meta, inout standa
 }
 
 control ingress(inout Parsed_packet h, inout Metadata m, inout standard_metadata_t sm) {
-    @name("ingress.tmp") bit<8> tmp;
-    @name("ingress.tmp_0") bit<8> tmp_0;
     @name("ingress.tmp_1") bit<8> tmp_1;
     @name("ingress.do_action_2") action do_action_0() {
-        tmp_0 = 8w2;
         tmp_1 = 8w0;
     }
     @hidden action act() {
-        tmp = h.h.b;
-        tmp_0 = h.h.b;
         tmp_1 = h.h.b;
     }
     @hidden action issue2176bmv2l45() {

--- a/testdata/p4_16_samples_outputs/issue2279-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2279-first.p4
@@ -1,0 +1,25 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 16w2 ? 16w3 : 16w1);
+    }
+    apply {
+        do_action();
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279-frontend.p4
@@ -1,0 +1,29 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    @name("c.tmp_val") bit<16> tmp_val_0;
+    @name("c.do_action") action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+    }
+    @name("c.do_action") action do_action_1() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+    }
+    apply {
+        tmp_val_0 = 16w3;
+        do_action();
+        do_action_1();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279-midend.p4
@@ -1,0 +1,39 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    @name("c.do_action") action do_action() {
+        hdr.eth_hdr.eth_type = 16w6;
+    }
+    @name("c.do_action") action do_action_1() {
+        hdr.eth_hdr.eth_type = 16w6;
+    }
+    @hidden table tbl_do_action {
+        actions = {
+            do_action();
+        }
+        const default_action = do_action();
+    }
+    @hidden table tbl_do_action_0 {
+        actions = {
+            do_action_1();
+        }
+        const default_action = do_action_1();
+    }
+    apply {
+        tbl_do_action.apply();
+        tbl_do_action_0.apply();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279.p4
+++ b/testdata/p4_16_samples_outputs/issue2279.p4
@@ -1,0 +1,25 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 2 ? 16w3 : 16w1);
+    }
+    apply {
+        do_action();
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_1-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_1-first.p4
@@ -1,0 +1,26 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 16w2 ? 16w3 : 16w1);
+        tmp_val[7:0] = 8w4;
+    }
+    apply {
+        do_action();
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_1-frontend.p4
@@ -1,0 +1,31 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    @name("c.tmp_val") bit<16> tmp_val_0;
+    @name("c.do_action") action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+        tmp_val_0[7:0] = 8w4;
+    }
+    @name("c.do_action") action do_action_1() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+        tmp_val_0[7:0] = 8w4;
+    }
+    apply {
+        tmp_val_0 = 16w3;
+        do_action();
+        do_action_1();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_1-midend.p4
@@ -1,0 +1,52 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    @name("c.tmp_val") bit<16> tmp_val_0;
+    @name("c.do_action") action do_action() {
+        hdr.eth_hdr.eth_type = 16w6;
+        tmp_val_0[7:0] = 8w4;
+    }
+    @name("c.do_action") action do_action_1() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+        tmp_val_0[7:0] = 8w4;
+    }
+    @hidden action issue2279_1l12() {
+        tmp_val_0 = 16w3;
+    }
+    @hidden table tbl_issue2279_1l12 {
+        actions = {
+            issue2279_1l12();
+        }
+        const default_action = issue2279_1l12();
+    }
+    @hidden table tbl_do_action {
+        actions = {
+            do_action();
+        }
+        const default_action = do_action();
+    }
+    @hidden table tbl_do_action_0 {
+        actions = {
+            do_action_1();
+        }
+        const default_action = do_action_1();
+    }
+    apply {
+        tbl_issue2279_1l12.apply();
+        tbl_do_action.apply();
+        tbl_do_action_0.apply();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_1.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_1.p4
@@ -1,0 +1,26 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 2 ? 16w3 : 16w1);
+        tmp_val[7:0] = 8w4;
+    }
+    apply {
+        do_action();
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_2-first.p4
@@ -1,0 +1,27 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 16w2 ? 16w3 : 16w1);
+        tmp_val = 16w4;
+    }
+    apply {
+        do_action();
+        tmp_val = 16w1;
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_2-frontend.p4
@@ -1,0 +1,30 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    @name("c.tmp_val") bit<16> tmp_val_0;
+    @name("c.do_action") action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+    }
+    @name("c.do_action") action do_action_1() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+    }
+    apply {
+        tmp_val_0 = 16w3;
+        do_action();
+        tmp_val_0 = 16w1;
+        do_action_1();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_2-midend.p4
@@ -1,0 +1,39 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    @name("c.do_action") action do_action() {
+        hdr.eth_hdr.eth_type = 16w6;
+    }
+    @name("c.do_action") action do_action_1() {
+        hdr.eth_hdr.eth_type = 16w4;
+    }
+    @hidden table tbl_do_action {
+        actions = {
+            do_action();
+        }
+        const default_action = do_action();
+    }
+    @hidden table tbl_do_action_0 {
+        actions = {
+            do_action_1();
+        }
+        const default_action = do_action_1();
+    }
+    apply {
+        tbl_do_action.apply();
+        tbl_do_action_0.apply();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_2.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_2.p4
@@ -1,0 +1,27 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 2 ? 16w3 : 16w1);
+        tmp_val = 16w4;
+    }
+    apply {
+        do_action();
+        tmp_val = 16w1;
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_3-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_3-first.p4
@@ -1,0 +1,26 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bool tmp_val = false;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val ? 16w3 : 16w1);
+        tmp_val = true;
+    }
+    apply {
+        do_action();
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_3-frontend.p4
@@ -1,0 +1,31 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    @name("c.tmp_val") bool tmp_val_0;
+    @name("c.do_action") action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 ? 16w3 : 16w1);
+        tmp_val_0 = true;
+    }
+    @name("c.do_action") action do_action_1() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 ? 16w3 : 16w1);
+        tmp_val_0 = true;
+    }
+    apply {
+        tmp_val_0 = false;
+        do_action();
+        do_action_1();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_3-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_3-midend.p4
@@ -1,0 +1,39 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    @name("c.do_action") action do_action() {
+        hdr.eth_hdr.eth_type = 16w4;
+    }
+    @name("c.do_action") action do_action_1() {
+        hdr.eth_hdr.eth_type = 16w6;
+    }
+    @hidden table tbl_do_action {
+        actions = {
+            do_action();
+        }
+        const default_action = do_action();
+    }
+    @hidden table tbl_do_action_0 {
+        actions = {
+            do_action_1();
+        }
+        const default_action = do_action_1();
+    }
+    apply {
+        tbl_do_action.apply();
+        tbl_do_action_0.apply();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_3.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_3.p4
@@ -1,0 +1,26 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bool tmp_val = false;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val ? 16w3 : 16w1);
+        tmp_val = true;
+    }
+    apply {
+        do_action();
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_4-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_4-first.p4
@@ -1,0 +1,28 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 16w2 ? 16w3 : 16w1);
+    }
+    apply {
+        do_action();
+        if (tmp_val > 16w2) {
+            tmp_val = (hdr.eth_hdr.eth_type >> 1) - tmp_val;
+        }
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_4-frontend.p4
@@ -1,0 +1,32 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    @name("c.tmp_val") bit<16> tmp_val_0;
+    @name("c.do_action") action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+    }
+    @name("c.do_action") action do_action_1() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+    }
+    apply {
+        tmp_val_0 = 16w3;
+        do_action();
+        if (tmp_val_0 > 16w2) {
+            tmp_val_0 = (hdr.eth_hdr.eth_type >> 1) - tmp_val_0;
+        }
+        do_action_1();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_4-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_4-midend.p4
@@ -1,0 +1,60 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    @name("c.tmp_val") bit<16> tmp_val_0;
+    @name("c.do_action") action do_action() {
+        hdr.eth_hdr.eth_type = 16w6;
+    }
+    @name("c.do_action") action do_action_1() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+    }
+    @hidden action issue2279_4l12() {
+        tmp_val_0 = 16w3;
+    }
+    @hidden action issue2279_4l19() {
+        tmp_val_0 = (hdr.eth_hdr.eth_type >> 1) + 16w65533;
+    }
+    @hidden table tbl_issue2279_4l12 {
+        actions = {
+            issue2279_4l12();
+        }
+        const default_action = issue2279_4l12();
+    }
+    @hidden table tbl_do_action {
+        actions = {
+            do_action();
+        }
+        const default_action = do_action();
+    }
+    @hidden table tbl_issue2279_4l19 {
+        actions = {
+            issue2279_4l19();
+        }
+        const default_action = issue2279_4l19();
+    }
+    @hidden table tbl_do_action_0 {
+        actions = {
+            do_action_1();
+        }
+        const default_action = do_action_1();
+    }
+    apply {
+        tbl_issue2279_4l12.apply();
+        tbl_do_action.apply();
+        tbl_issue2279_4l19.apply();
+        tbl_do_action_0.apply();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2279_4.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_4.p4
@@ -1,0 +1,28 @@
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control c(inout Headers hdr) {
+    bit<16> tmp_val = 16w3;
+    action do_action() {
+        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 2 ? 16w3 : 16w1);
+    }
+    apply {
+        do_action();
+        if (tmp_val > 2) {
+            tmp_val = hdr.eth_hdr.eth_type / 2 - tmp_val;
+        }
+        do_action();
+    }
+}
+
+control proto(inout Headers hdr);
+package top(proto _p);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2288-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2288-midend.p4
@@ -6,8 +6,6 @@ struct Headers {
 }
 
 control ingress(inout Headers h) {
-    @name("ingress.tmp_0") bool tmp_0;
-    @name("ingress.tmp_1") bit<8> tmp_1;
     @name("ingress.tmp_3") bit<8> tmp_3;
     @name("ingress.a") action a_1() {
         h.b = 8w0;
@@ -22,18 +20,6 @@ control ingress(inout Headers h) {
         default_action = a_1();
     }
     @hidden action act() {
-        tmp_0 = true;
-    }
-    @hidden action act_0() {
-        tmp_0 = false;
-    }
-    @hidden action issue2288l25() {
-        tmp_1 = h.a;
-    }
-    @hidden action issue2288l25_0() {
-        tmp_1 = h.b;
-    }
-    @hidden action act_1() {
         tmp_3 = h.a;
         h.a = 8w3;
         h.a = tmp_3;
@@ -44,42 +30,9 @@ control ingress(inout Headers h) {
         }
         const default_action = act();
     }
-    @hidden table tbl_act_0 {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
-    }
-    @hidden table tbl_issue2288l25 {
-        actions = {
-            issue2288l25();
-        }
-        const default_action = issue2288l25();
-    }
-    @hidden table tbl_issue2288l25_0 {
-        actions = {
-            issue2288l25_0();
-        }
-        const default_action = issue2288l25_0();
-    }
-    @hidden table tbl_act_1 {
-        actions = {
-            act_1();
-        }
-        const default_action = act_1();
-    }
     apply {
-        if (t_0.apply().hit) {
-            tbl_act.apply();
-        } else {
-            tbl_act_0.apply();
-        }
-        if (tmp_0) {
-            tbl_issue2288l25.apply();
-        } else {
-            tbl_issue2288l25_0.apply();
-        }
-        tbl_act_1.apply();
+        t_0.apply();
+        tbl_act.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue232-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue232-bmv2-midend.p4
@@ -28,9 +28,7 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 }
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    @name("Eg.val") Value val_0;
     @name("Eg.test") action test() {
-        val_0.field1 = val_0.field1;
     }
     @hidden table tbl_test {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue2345-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-1-midend.p4
@@ -26,14 +26,14 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     ethernet_t val1_eth_hdr;
     ethernet_t val_eth_hdr;
     @name("ingress.simple_action") action simple_action() {
-        h.eth_hdr.src_addr = (h.eth_hdr.eth_type == 16w1 ? h.eth_hdr.src_addr : 48w1);
-        val1_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr : h.eth_hdr);
-        val_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr : val1_eth_hdr);
-        val_eth_hdr.dst_addr = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr.dst_addr : 48w2);
-        val_eth_hdr.eth_type = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr.eth_type : 16w4);
-        val1_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr : val_eth_hdr);
-        val1_eth_hdr.dst_addr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr.dst_addr : 48w3);
-        h.eth_hdr = (h.eth_hdr.eth_type == 16w1 ? h.eth_hdr : val1_eth_hdr);
+        h.eth_hdr.src_addr = 48w1;
+        val1_eth_hdr = h.eth_hdr;
+        val_eth_hdr = h.eth_hdr;
+        val_eth_hdr.dst_addr = 48w2;
+        val_eth_hdr.eth_type = 16w4;
+        val1_eth_hdr = val_eth_hdr;
+        val1_eth_hdr.dst_addr = 48w3;
+        h.eth_hdr = val1_eth_hdr;
     }
     @hidden action issue23451l47() {
         h.eth_hdr.src_addr = 48w2;

--- a/testdata/p4_16_samples_outputs/issue2345-2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-2-midend.p4
@@ -23,24 +23,21 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.hasReturned") bool hasReturned;
     ethernet_t val_eth_hdr;
     ethernet_t val1_eth_hdr;
     ethernet_t val1_2_eth_hdr;
     @name("ingress.simple_action") action simple_action() {
-        hasReturned = false;
-        hasReturned = h.eth_hdr.eth_type == 16w1;
-        h.eth_hdr.src_addr = (h.eth_hdr.eth_type == 16w1 ? h.eth_hdr.src_addr : 48w1);
-        val_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr : h.eth_hdr);
-        val1_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr : val_eth_hdr);
-        val1_eth_hdr.dst_addr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr.dst_addr : val1_eth_hdr.dst_addr + 48w3);
-        val_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr : val1_eth_hdr);
-        val_eth_hdr.eth_type = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr.eth_type : 16w2);
-        val1_2_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val1_2_eth_hdr : val_eth_hdr);
-        val1_2_eth_hdr.dst_addr = (h.eth_hdr.eth_type == 16w1 ? val1_2_eth_hdr.dst_addr : val1_2_eth_hdr.dst_addr + 48w3);
-        val_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr : val1_2_eth_hdr);
-        h.eth_hdr = (h.eth_hdr.eth_type == 16w1 ? h.eth_hdr : val_eth_hdr);
-        h.eth_hdr.dst_addr = (hasReturned ? h.eth_hdr.dst_addr : h.eth_hdr.dst_addr + 48w4);
+        h.eth_hdr.src_addr = 48w1;
+        val_eth_hdr = h.eth_hdr;
+        val1_eth_hdr = h.eth_hdr;
+        val1_eth_hdr.dst_addr = val1_eth_hdr.dst_addr + 48w3;
+        val_eth_hdr = val1_eth_hdr;
+        val_eth_hdr.eth_type = 16w2;
+        val1_2_eth_hdr = val_eth_hdr;
+        val1_2_eth_hdr.dst_addr = val1_2_eth_hdr.dst_addr + 48w3;
+        val_eth_hdr = val1_2_eth_hdr;
+        h.eth_hdr = val1_2_eth_hdr;
+        h.eth_hdr.dst_addr = h.eth_hdr.dst_addr + 48w4;
     }
     @hidden action issue23452l49() {
         h.eth_hdr.src_addr = 48w2;

--- a/testdata/p4_16_samples_outputs/issue2345-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-midend.p4
@@ -23,11 +23,8 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    ethernet_t val_eth_hdr;
     @name("ingress.simple_action") action simple_action() {
-        h.eth_hdr.src_addr = (h.eth_hdr.eth_type == 16w1 ? h.eth_hdr.src_addr : 48w1);
-        val_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr : h.eth_hdr);
-        h.eth_hdr = (h.eth_hdr.eth_type == 16w1 ? h.eth_hdr : val_eth_hdr);
+        h.eth_hdr.src_addr = 48w1;
     }
     @hidden action issue2345l40() {
         h.eth_hdr.src_addr = 48w2;

--- a/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-multiple_dependencies-midend.p4
@@ -24,25 +24,12 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     ethernet_t val1_eth_hdr;
-    @name("ingress.dst") bit<48> dst;
-    @name("ingress.type") bit<16> type_1;
-    @name("ingress.c") bool c_0;
-    @name("ingress.c1") bool c1_0;
     @name("ingress.simple_action") action simple_action() {
-        h.eth_hdr.src_addr = (h.eth_hdr.eth_type == 16w1 ? h.eth_hdr.src_addr : 48w1);
-        val1_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr : h.eth_hdr);
-        dst = (h.eth_hdr.eth_type == 16w1 ? dst : val1_eth_hdr.dst_addr);
-        type_1 = (h.eth_hdr.eth_type == 16w1 ? type_1 : val1_eth_hdr.eth_type);
-        c_0 = (h.eth_hdr.eth_type == 16w1 ? c_0 : true);
-        c1_0 = (h.eth_hdr.eth_type == 16w1 ? c1_0 : false);
-        type_1 = type_1;
-        dst = (h.eth_hdr.eth_type == 16w1 ? 48w1 : (c_0 ? (c1_0 ? 48w1 : dst) : dst));
-        dst = (h.eth_hdr.eth_type == 16w1 ? 48w2 : (c_0 ? (c1_0 ? dst : 48w2) : dst));
-        type_1 = (h.eth_hdr.eth_type == 16w1 ? type_1 : (c_0 ? type_1 : 16w3));
-        val1_eth_hdr.dst_addr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr.dst_addr : dst);
-        val1_eth_hdr.eth_type = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr.eth_type : type_1);
-        val1_eth_hdr.dst_addr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr.dst_addr : val1_eth_hdr.dst_addr + 48w3);
-        h.eth_hdr = (h.eth_hdr.eth_type == 16w1 ? h.eth_hdr : val1_eth_hdr);
+        h.eth_hdr.src_addr = 48w1;
+        val1_eth_hdr = h.eth_hdr;
+        val1_eth_hdr.dst_addr = 48w2;
+        val1_eth_hdr.dst_addr = 48w5;
+        h.eth_hdr = val1_eth_hdr;
     }
     @hidden action issue2345multiple_dependencies60() {
         h.eth_hdr.src_addr = 48w2;

--- a/testdata/p4_16_samples_outputs/issue2345-with_nested_if-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-with_nested_if-midend.p4
@@ -25,25 +25,19 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     ethernet_t val1_eth_hdr;
     ethernet_t val_eth_hdr;
-    @name("ingress.c") bool c_0;
-    @name("ingress.c1") bool c1_0;
-    @name("ingress.c2") bool c2_0;
     @name("ingress.simple_action") action simple_action() {
-        h.eth_hdr.src_addr = (h.eth_hdr.eth_type == 16w1 ? h.eth_hdr.src_addr : 48w1);
-        val1_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr : h.eth_hdr);
-        val_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr : val1_eth_hdr);
-        c_0 = (h.eth_hdr.eth_type == 16w1 ? c_0 : true);
-        c1_0 = (h.eth_hdr.eth_type == 16w1 ? c1_0 : false);
-        c2_0 = (h.eth_hdr.eth_type == 16w1 ? c2_0 : true);
-        val_eth_hdr.eth_type = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr.eth_type : (c_0 ? 16w0 : val_eth_hdr.eth_type));
-        val_eth_hdr.eth_type = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr.eth_type : (c_0 ? (c1_0 ? val_eth_hdr.eth_type + 16w1 : val_eth_hdr.eth_type) : val_eth_hdr.eth_type));
-        val_eth_hdr.eth_type = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr.eth_type : (c_0 ? (c1_0 ? val_eth_hdr.eth_type : val_eth_hdr.eth_type + 16w2) : val_eth_hdr.eth_type));
-        val_eth_hdr.eth_type = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr.eth_type : (c_0 ? val_eth_hdr.eth_type + 16w3 : val_eth_hdr.eth_type));
-        val_eth_hdr.eth_type = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr.eth_type : (c_0 ? val_eth_hdr.eth_type : (c2_0 ? val_eth_hdr.eth_type + 16w4 : val_eth_hdr.eth_type)));
-        val_eth_hdr.eth_type = (h.eth_hdr.eth_type == 16w1 ? val_eth_hdr.eth_type : (c_0 ? val_eth_hdr.eth_type : (c2_0 ? val_eth_hdr.eth_type : val_eth_hdr.eth_type + 16w5)));
-        val1_eth_hdr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr : val_eth_hdr);
-        val1_eth_hdr.dst_addr = (h.eth_hdr.eth_type == 16w1 ? val1_eth_hdr.dst_addr : 48w3);
-        h.eth_hdr = (h.eth_hdr.eth_type == 16w1 ? h.eth_hdr : val1_eth_hdr);
+        h.eth_hdr.src_addr = 48w1;
+        val1_eth_hdr = h.eth_hdr;
+        val_eth_hdr = h.eth_hdr;
+        val_eth_hdr.eth_type = 16w0;
+        val_eth_hdr.eth_type = 16w0;
+        val_eth_hdr.eth_type = 16w2;
+        val_eth_hdr.eth_type = 16w5;
+        val_eth_hdr.eth_type = 16w5;
+        val_eth_hdr.eth_type = 16w5;
+        val1_eth_hdr = val_eth_hdr;
+        val1_eth_hdr.dst_addr = 48w3;
+        h.eth_hdr = val1_eth_hdr;
     }
     @hidden action issue2345with_nested_if65() {
         h.eth_hdr.src_addr = 48w2;

--- a/testdata/p4_16_samples_outputs/issue2359-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2359-midend.p4
@@ -28,8 +28,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.do_action") action do_action() {
         val_0 = h.eth_hdr.src_addr;
         h.eth_hdr.src_addr = h.eth_hdr.src_addr;
-        hasExited = (h.eth_hdr.eth_type == 16w1 ? hasExited : true);
-        h.eth_hdr.src_addr = (hasExited ? h.eth_hdr.src_addr : val_0);
+        hasExited = !(h.eth_hdr.eth_type == 16w1);
+        h.eth_hdr.src_addr = (h.eth_hdr.eth_type == 16w1 ? val_0 : h.eth_hdr.src_addr);
     }
     @hidden action act() {
         hasExited = false;

--- a/testdata/p4_16_samples_outputs/issue2375-1-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2375-1-bmv2-midend.p4
@@ -23,20 +23,7 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.tmp") bool tmp_0;
-    @name("ingress.val") bool val;
     @name("ingress.do_action") action do_action() {
-        val = tmp_0;
-        tmp_0 = val;
-    }
-    @hidden action issue23751bmv2l33() {
-        tmp_0 = false;
-    }
-    @hidden table tbl_issue23751bmv2l33 {
-        actions = {
-            issue23751bmv2l33();
-        }
-        const default_action = issue23751bmv2l33();
     }
     @hidden table tbl_do_action {
         actions = {
@@ -45,7 +32,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         const default_action = do_action();
     }
     apply {
-        tbl_issue23751bmv2l33.apply();
         tbl_do_action.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue2375-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2375-bmv2-midend.p4
@@ -23,13 +23,9 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.tmp") bool tmp_0;
-    @name("ingress.val2") bool val2_0;
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
     @name("ingress.do_action") action do_action() {
-        val2_0 = tmp_0;
-        tmp_0 = val2_0;
     }
     @name("ingress.simple_table") table simple_table_0 {
         key = {
@@ -40,17 +36,7 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         }
         default_action = NoAction_1();
     }
-    @hidden action issue2375bmv2l30() {
-        tmp_0 = false;
-    }
-    @hidden table tbl_issue2375bmv2l30 {
-        actions = {
-            issue2375bmv2l30();
-        }
-        const default_action = issue2375bmv2l30();
-    }
     apply {
-        tbl_issue2375bmv2l30.apply();
         simple_table_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/issue2393-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2393-midend.p4
@@ -13,7 +13,6 @@ control ingress(inout Headers h) {
     @name("ingress.tmp_bool") bool tmp_bool_0;
     @name("ingress.val_undefined") bool val_undefined_0;
     @name("ingress.tmp") bit<16> tmp_4;
-    @name("ingress.val_undefined") bool val_undefined_2;
     @name(".do_global_action") action do_global_action_0() {
         tmp = 16w0;
     }

--- a/testdata/p4_16_samples_outputs/mux-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/mux-bmv2-midend.p4
@@ -20,21 +20,7 @@ control Ing(inout Headers headers, inout Metadata meta, inout standard_metadata_
 }
 
 control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t standard_meta) {
-    @name("Eg.res") bit<64> res_0;
-    @name("Eg.val") bit<64> val_0;
     @name("Eg.update") action update() {
-        val_0 = res_0;
-        val_0[31:0] = res_0[31:0];
-        res_0 = val_0;
-    }
-    @hidden action muxbmv2l58() {
-        res_0 = 64w0;
-    }
-    @hidden table tbl_muxbmv2l58 {
-        actions = {
-            muxbmv2l58();
-        }
-        const default_action = muxbmv2l58();
     }
     @hidden table tbl_update {
         actions = {
@@ -43,7 +29,6 @@ control Eg(inout Headers hdrs, inout Metadata meta, inout standard_metadata_t st
         const default_action = update();
     }
     apply {
-        tbl_muxbmv2l58.apply();
         tbl_update.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/named-arg1-midend.p4
+++ b/testdata/p4_16_samples_outputs/named-arg1-midend.p4
@@ -9,21 +9,18 @@ parser par(out bool b) {
 
 control c(out bool b) {
     @name("c.xv") bit<16> xv_0;
-    @name("c.b_1") bool b_1;
     @name("c.a") action a() {
         xv_0 = 16w65533;
     }
     @name("c.a") action a_1() {
         xv_0 = 16w0;
     }
-    @hidden action namedarg1l22() {
+    @hidden action namedarg1l40() {
         b = xv_0 == 16w0;
-        b_1 = xv_0 == 16w1;
-        b = b_1;
+        b = xv_0 == 16w1;
         xv_0 = 16w1;
         xv_0 = 16w1;
         b = false;
-        b_1 = true;
         b = true;
         xv_0 = 16w1;
     }
@@ -39,16 +36,16 @@ control c(out bool b) {
         }
         const default_action = a_1();
     }
-    @hidden table tbl_namedarg1l22 {
+    @hidden table tbl_namedarg1l40 {
         actions = {
-            namedarg1l22();
+            namedarg1l40();
         }
-        const default_action = namedarg1l22();
+        const default_action = namedarg1l40();
     }
     apply {
         tbl_a.apply();
         tbl_a_0.apply();
-        tbl_namedarg1l22.apply();
+        tbl_namedarg1l40.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/predication_issue_1-midend.p4
+++ b/testdata/p4_16_samples_outputs/predication_issue_1-midend.p4
@@ -23,16 +23,8 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.tmp") bool tmp;
-    @name("ingress.tmp_0") bool tmp_0;
-    @name("ingress.hasReturned") bool hasReturned;
-    @name("ingress.retval") bool retval;
     @name(".assign") action assign_0() {
-        hasReturned = true;
-        retval = true;
-        tmp = retval;
-        tmp_0 = (tmp ? 16w0xdead != h.eth_hdr.eth_type : false);
-        h.eth_hdr.dst_addr = (tmp_0 ? 48w1 : h.eth_hdr.dst_addr);
+        h.eth_hdr.dst_addr = (16w0xdead != h.eth_hdr.eth_type ? 48w1 : h.eth_hdr.dst_addr);
     }
     @hidden table tbl_assign {
         actions = {

--- a/testdata/p4_16_samples_outputs/predication_issue_2-midend.p4
+++ b/testdata/p4_16_samples_outputs/predication_issue_2-midend.p4
@@ -36,22 +36,11 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.val") bit<8> val;
-    @name("ingress.val_0") bit<8> val_2;
-    @name("ingress.bound_0") bit<8> bound;
-    @name("ingress.hasReturned") bool hasReturned;
-    @name("ingress.retval") bit<8> retval;
     @name("ingress.tmp") bit<8> tmp;
     @name("ingress.simple_action") action simple_action() {
-        val_2 = h.idx.idx;
-        bound = 8w1;
-        hasReturned = false;
-        tmp = (val_2 < bound ? val_2 : tmp);
-        tmp = (val_2 < bound ? val_2 : bound);
-        hasReturned = true;
-        retval = tmp;
-        val = retval;
-        h.h[val].a = 8w1;
+        tmp = (h.idx.idx < 8w1 ? h.idx.idx : tmp);
+        tmp = (h.idx.idx < 8w1 ? h.idx.idx : 8w1);
+        h.h[(h.idx.idx < 8w1 ? h.idx.idx : 8w1)].a = 8w1;
     }
     @hidden table tbl_simple_action {
         actions = {

--- a/testdata/p4_16_samples_outputs/predication_issue_3-midend.p4
+++ b/testdata/p4_16_samples_outputs/predication_issue_3-midend.p4
@@ -30,34 +30,8 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
-    @name("ingress.bool_val") bool bool_val_0;
-    @name("ingress.tmp_0") bit<3> tmp;
-    @name("ingress.tmp_1") bit<3> tmp_0;
-    @name("ingress.val_0") bit<3> val;
-    @name("ingress.bound_0") bit<3> bound;
-    @name("ingress.hasReturned") bool hasReturned;
-    @name("ingress.retval") bit<3> retval;
-    @name("ingress.tmp") bit<3> tmp_1;
     @name("ingress.perform_action") action perform_action() {
-        val = (bool_val_0 ? 3w0 : val);
-        bound = (bool_val_0 ? 3w1 : bound);
-        hasReturned = (bool_val_0 ? false : hasReturned);
-        tmp_1 = (bool_val_0 ? (val < bound ? val : tmp_1) : tmp_1);
-        tmp_1 = (bool_val_0 ? (val < bound ? val : bound) : tmp_1);
-        hasReturned = (bool_val_0 ? true : hasReturned);
-        retval = (bool_val_0 ? tmp_1 : retval);
-        tmp = (bool_val_0 ? retval : tmp);
-        tmp_0 = (bool_val_0 ? tmp : tmp_0);
-        h.h[(bool_val_0 ? tmp_0 : 3w0)].a = (bool_val_0 ? 8w1 : h.h[(bool_val_0 ? tmp_0 : 3w0)].a);
-    }
-    @hidden action predication_issue_3l38() {
-        bool_val_0 = true;
-    }
-    @hidden table tbl_predication_issue_3l38 {
-        actions = {
-            predication_issue_3l38();
-        }
-        const default_action = predication_issue_3l38();
+        h.h[3w0].a = 8w1;
     }
     @hidden table tbl_perform_action {
         actions = {
@@ -66,7 +40,6 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         const default_action = perform_action();
     }
     apply {
-        tbl_predication_issue_3l38.apply();
         tbl_perform_action.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2-midend.p4
@@ -58,7 +58,7 @@ control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_inpu
     @name(".update_pkt_ip_byte_count") action update_pkt_ip_byte_count_0() {
         s_0 = tmp_0;
         s_0[79:48] = tmp_0[79:48] + 32w1;
-        s_0[47:0] = s_0[47:0] + (bit<48>)hdr.ipv4.totalLen;
+        s_0[47:0] = s_0[47:0] + 48w14;
         tmp_0 = s_0;
     }
     @name("ingress.port_pkt_ip_bytes_in") Register<PacketByteCountState_t, PortId_t>(32w512) port_pkt_ip_bytes_in_0;

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2-midend.p4
@@ -37,7 +37,7 @@ control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress
         regfile_0.write(32w1, 48w3);
         regfile_0.write(32w2, 48w4);
         tmp = regfile_0.read(32w1);
-        hdr.ethernet.dstAddr = tmp + regfile_0.read(32w2) + 48w281474976710651;
+        hdr.ethernet.dstAddr = regfile_0.read(32w1) + regfile_0.read(32w2) + 48w281474976710651;
     }
     @hidden table tbl_psaregistercomplexbmv2l60 {
         actions = {

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2-midend.p4
@@ -36,7 +36,6 @@ parser IngressParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t user
 
 control cIngress(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
     @noWarnUnused @name(".send_to_port") action send_to_port_0() {
-        ostd.drop = false;
         ostd.multicast_group = 32w0;
         ostd.egress_port = (PortIdUint_t)hdr.ethernet.dstAddr;
     }

--- a/testdata/p4_16_samples_outputs/struct_assignment_optimization-midend.p4
+++ b/testdata/p4_16_samples_outputs/struct_assignment_optimization-midend.p4
@@ -27,20 +27,10 @@ parser p(packet_in pkt, out Headers hdr, inout Metadata meta, inout standard_met
 }
 
 control ingress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t stdmeta) {
-    @name("ingress.test") simple_struct test_0;
     @name("ingress.pointless_action") action pointless_action() {
-    }
-    @hidden action struct_assignment_optimization35() {
-        test_0.a = 128w0;
     }
     @hidden action struct_assignment_optimization43() {
         hdr.eth_hdr.eth_type = 16w1;
-    }
-    @hidden table tbl_struct_assignment_optimization35 {
-        actions = {
-            struct_assignment_optimization35();
-        }
-        const default_action = struct_assignment_optimization35();
     }
     @hidden table tbl_pointless_action {
         actions = {
@@ -55,7 +45,6 @@ control ingress(inout Headers hdr, inout Metadata meta, inout standard_metadata_
         const default_action = struct_assignment_optimization43();
     }
     apply {
-        tbl_struct_assignment_optimization35.apply();
         tbl_pointless_action.apply();
         tbl_struct_assignment_optimization43.apply();
     }

--- a/testdata/p4_16_samples_outputs/xor_test-midend.p4
+++ b/testdata/p4_16_samples_outputs/xor_test-midend.p4
@@ -77,7 +77,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
         hdr.ipv4.srcAddr = (hdr.ipv4.isValid() ? hdr.ipv4.srcAddr ^ 32w0x12345678 : hdr.ipv4.srcAddr);
         meta.after1 = (hdr.ipv4.isValid() ? hdr.ipv4.srcAddr : meta.after1);
         cond_0 = hdr.ethernet.isValid();
-        hdr.ipv4.protocol = (cond_0 ? (hdr.ethernet.isValid() ? hdr.ipv4.protocol ^ 8w1 : hdr.ipv4.protocol) : hdr.ipv4.protocol);
+        hdr.ipv4.protocol = (hdr.ethernet.isValid() ? (hdr.ethernet.isValid() ? hdr.ipv4.protocol ^ 8w1 : hdr.ipv4.protocol) : hdr.ipv4.protocol);
         meta.before2 = (cond_0 ? hdr.ipv4.dstAddr : meta.before2);
         hdr.ipv4.dstAddr = (cond_0 ? hdr.ipv4.dstAddr ^ 32w0x12345678 : hdr.ipv4.dstAddr);
         meta.after2 = (cond_0 ? hdr.ipv4.dstAddr : meta.after2);


### PR DESCRIPTION
This PR introduces a new pass with the idea of implementing copy propagation logic, but on a 'global' level (regarding control blocks), with the goal of optimizing situations similar to the one described in the #2279 issue. The optimization described isn't a responsibility of the StrengthReduction pass' logic (as mentioned in the issue), it seems like it should be covered in the copy propagation logic of this compiler.

The logic was implemented as a standalone pass rather than expanding upon the existing LocalCopyPropagation pass, this was done to avoid needlessly complicating the already complex logic of the LocalCopyPropagation pass. Having said that, the new pass was designed with the idea of being run in tandem with the LocalCopyPropagation pass and doesn't introduce some of the optimizations that are already included in the existing pass. (This may warrant putting these 2 passes in a new pass manager and running them as such, for now I have just placed them as one after another in the 'p4test/midend.cpp', where the GlobalCopyPropagation is run first because I believe this order is more logical when you look at the optimizations it introduces)

The optimization mentioned in the issue #2279 is accomplished by visiting the body of the action after the 'ActionCall' node, that corresponds to the action mentioned, is visited. This way we retroactively edit the body of the action and propagate any values that are known at that time.

The only thing that seems problematic to me, and was during the process of developing this pass, is that doesn't seem to be a way of retroactively editing the body of the action without using the 'const_cast'  feature. This is needed because after resolving the 'ActionCall' in the preorder function of IR node 'MethodCallExpression' the action pointer that is available to use is a 'const IR::P4Action*' and doing any editing to the body of the action pointed to by this pointer is impossible, therefore the solution I found is forcefully getting rid of the problematic 'const' part. 
Any suggestions regarding this problem are welcome.