### PR TITLE
Cleanup override warnings

### DIFF
--- a/backends/dpdk/control-plane/bfruntime_arch_handler.h
+++ b/backends/dpdk/control-plane/bfruntime_arch_handler.h
@@ -169,7 +169,7 @@ class BFRuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
     }
 
     void collectExternInstance(P4RuntimeSymbolTableIface* symbols,
-                               const IR::ExternBlock* externBlock) {
+                               const IR::ExternBlock* externBlock) override {
         P4RuntimeArchHandlerCommon<Arch::PSA>::collectExternInstance(symbols, externBlock);
 
         auto decl = externBlock->node->to<IR::IDeclaration>();
@@ -187,7 +187,7 @@ class BFRuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
     void addTableProperties(const P4RuntimeSymbolTableIface& symbols,
                             p4configv1::P4Info* p4info,
                             p4configv1::Table* table,
-                            const IR::TableBlock* tableBlock) {
+                            const IR::TableBlock* tableBlock) override {
         P4RuntimeArchHandlerCommon<Arch::PSA>::addTableProperties(
             symbols, p4info, table, tableBlock);
 

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -87,7 +87,7 @@ class P4Parser : Type_Declaration, INestedNamespace, ISimpleNamespace, IApply, I
     optional inline IndexedVector<Declaration>  parserLocals;
     optional inline IndexedVector<ParserState>  states;
 
-    Annotations getAnnotations() const { return type->getAnnotations(); }
+    Annotations getAnnotations() const override { return type->getAnnotations(); }
     TypeParameters getTypeParameters() const override { return type->getTypeParameters(); }
     std::vector<INamespace> getNestedNamespaces() const override {
         return { type->typeParameters, type->applyParams, constructorParams }; }
@@ -119,7 +119,7 @@ class P4Control : Type_Declaration, INestedNamespace, ISimpleNamespace, IApply, 
     optional inline IndexedVector<Declaration>  controlLocals;
     BlockStatement                              body;
 
-    Annotations getAnnotations() const { return type->getAnnotations(); }
+    Annotations getAnnotations() const override { return type->getAnnotations(); }
     TypeParameters getTypeParameters() const override { return type->getTypeParameters(); }
     std::vector<INamespace> getNestedNamespaces() const override {
         return { type->typeParameters, type->applyParams, constructorParams }; }


### PR DESCRIPTION
With clang 13, there is this representative warning
ir/ir.def:90:28: warning: 'getAnnotations' overrides a member function
  but is not marked 'override' [-Winconsistent-missing-override]

So add some override's.