### PR TITLE
Remove uses of `incompatible_use_toolchain_transition` now that it is…

### DIFF
--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -151,7 +151,6 @@ p4_library = rule(
         ),
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )
 
@@ -232,6 +231,5 @@ p4_graphs = rule(
         ),
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )


### PR DESCRIPTION
… enabled by

default in Bazel 5.0.

This is a step towards removing it entirely.

Part of https://github.com/bazelbuild/bazel/issues/14127.