### PR TITLE
improve include path to bpf_endian.h

### DIFF
--- a/backends/ebpf/runtime/ebpf_kernel.h
+++ b/backends/ebpf/runtime/ebpf_kernel.h
@@ -25,7 +25,7 @@ limitations under the License.
 
 #include "ebpf_common.h"
 
-#include "bpf_endian.h" // definitions for bpf_ntohs etc...
+#include <bpf/bpf_endian.h> // definitions for bpf_ntohs etc...
 
 #undef htonl
 #undef htons
@@ -47,7 +47,7 @@ limitations under the License.
  */
 #ifdef CONTROL_PLANE // BEGIN EBPF USER SPACE DEFINITIONS
 
-#include "bpf.h" // bpf_obj_get/pin, bpf_map_update_elem
+#include <bpf/bpf.h> // bpf_obj_get/pin, bpf_map_update_elem
 
 #define BPF_USER_MAP_UPDATE_ELEM(index, key, value, flags)\
     bpf_map_update_elem(index, key, value, flags)
@@ -59,7 +59,7 @@ limitations under the License.
 #include <linux/pkt_cls.h>  // TC_ACT_OK, TC_ACT_SHOT
 #include "linux/bpf.h"  // types, and general bpf definitions
 // This file contains the definitions of all the kernel bpf essentials
-#include "bpf_helpers.h"
+#include <bpf/bpf_helpers.h>
 
 
 /* a helper structure used by an eBPF C program

--- a/backends/ebpf/runtime/kernel.mk
+++ b/backends/ebpf/runtime/kernel.mk
@@ -3,7 +3,7 @@ ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # Argument for the CLANG compiler
 LLC ?= llc
 CLANG ?= clang
-override INCLUDES+= -I$(ROOT_DIR) -I$(ROOT_DIR)usr/include/bpf/ -I$(ROOT_DIR)contrib/libbpf/include/uapi/
+override INCLUDES+= -I$(ROOT_DIR) -I$(ROOT_DIR)usr/include/ -I$(ROOT_DIR)contrib/libbpf/include/uapi/
 override LIBS+=
 # Optimization flags to save space
 override CFLAGS+= -O2 -g -D__KERNEL__ -D__ASM_SYSREG_H \

--- a/backends/ebpf/targets/kernel_target.py
+++ b/backends/ebpf/targets/kernel_target.py
@@ -62,7 +62,7 @@ class Target(EBPFTarget):
         # add the folder local to the P4 file to the list of includes
         args += "INCLUDES+=-I%s " % os.path.dirname(self.options.p4filename)
         # some kernel specific includes for libbpf
-        args += "INCLUDES+=-I%s/usr/include/bpf " % self.runtimedir
+        args += "INCLUDES+=-I%s/usr/include " % self.runtimedir
         args += "INCLUDES+=-I%s/contrib/libbpf/include/uapi " % self.runtimedir
         args += "LIBS+=%s/usr/lib64/libbpf.a " % self.runtimedir
         args += "LIBS+=-lz "


### PR DESCRIPTION
On fedora rawhide with clang 13, there are multiple false positve
test failures similar to

p4c/backends/ebpf/runtime/ebpf_kernel.h:28:10: fatal error:
  'bpf_endian.h' file not found

The libbfp-devel package installs bpf_endian.h to /usr/include/bpf/
The ./build_libbpf script installs it to
${CMAKE_CURRENT_SOURCE_DIR}/runtime/usr/include/bpf/

So the include should have a bpf/ prefix.
And since it is a system header the ""'s changed to <>'s