### PR TITLE
"Null element" errors which are related with HeaderUnion type

### DIFF
--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -342,16 +342,16 @@ SymbolicValue* SymbolicHeaderUnion::clone() const {
 
 void SymbolicHeaderUnion::assign(const SymbolicValue* other) {
     if (other->is<SymbolicError>()) return;
-    BUG_CHECK(other->is<SymbolicHeaderUnion>(), "%1%: expected a header union", other);
     auto hv = other->to<SymbolicHeaderUnion>();
+    BUG_CHECK(hv, "%1%: expected a header union", other);
     for (auto f : hv->fieldValue)
         fieldValue[f.first]->assign(f.second);
     valid->assign(hv->valid);
 }
 
 bool SymbolicHeaderUnion::merge(const SymbolicValue* other) {
-    BUG_CHECK(other->is<SymbolicHeaderUnion>(), "%1%: expected a header union", other);
     auto hv = other->to<SymbolicHeaderUnion>();
+    BUG_CHECK(hv, "%1%: expected a header union", other);
     bool changes = false;
     for (auto f : hv->fieldValue)
         changes = changes || fieldValue[f.first]->merge(f.second);

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -777,7 +777,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Ternary* expression) {
         clone->e1 = getConstant(e1i);
         clone->e2 = getConstant(e2i);
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = clone->apply(cf);
         checkResult(expression, result);
         return;
@@ -813,7 +813,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Binary* expression) {
         clone->left = getConstant(li);
         clone->right = getConstant(ri);
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = clone->apply(cf);
         checkResult(expression, result);
         return;
@@ -844,7 +844,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary* expression) {
         auto li = l->to<SymbolicInteger>();
         clone->expr = li->constant;
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::Constant>(), "%1%: expected a constant", result);
         set(expression, new SymbolicInteger(result->to<IR::Constant>()));
@@ -853,7 +853,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary* expression) {
         auto li = l->to<SymbolicBool>();
         clone->expr = new IR::BoolLiteral(li->value);
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));
@@ -930,7 +930,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation* expression) {
         clone->left = l->to<SymbolicInteger>()->constant;
         clone->right = r->to<SymbolicInteger>()->constant;
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));
@@ -940,7 +940,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation* expression) {
         clone->left = new IR::BoolLiteral(l->to<SymbolicBool>()->value);
         clone->right = new IR::BoolLiteral(r->to<SymbolicBool>()->value);
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -323,7 +323,7 @@ void SymbolicHeaderUnion::setValid(bool v) {
 
 SymbolicValue* SymbolicHeaderUnion::get(const IR::Node* node, cstring field) const {
     if (valid->isKnown() && !valid->value)
-        return new SymbolicStaticError(node, "Reading field from invalid header");
+        return new SymbolicStaticError(node, "Reading field from invalid header union");
     return SymbolicStruct::get(node, field);
 }
 

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -800,7 +800,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Ternary* expression) {
         clone->e1 = getConstant(e1i);
         clone->e2 = getConstant(e2i);
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = clone->apply(cf);
         checkResult(expression, result);
         return;
@@ -836,7 +836,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Binary* expression) {
         clone->left = getConstant(li);
         clone->right = getConstant(ri);
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = clone->apply(cf);
         checkResult(expression, result);
         return;
@@ -867,7 +867,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary* expression) {
         auto li = l->to<SymbolicInteger>();
         clone->expr = li->constant;
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::Constant>(), "%1%: expected a constant", result);
         set(expression, new SymbolicInteger(result->to<IR::Constant>()));
@@ -876,7 +876,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary* expression) {
         auto li = l->to<SymbolicBool>();
         clone->expr = new IR::BoolLiteral(li->value);
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));
@@ -953,7 +953,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation* expression) {
         clone->left = l->to<SymbolicInteger>()->constant;
         clone->right = r->to<SymbolicInteger>()->constant;
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));
@@ -963,7 +963,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation* expression) {
         clone->left = new IR::BoolLiteral(l->to<SymbolicBool>()->value);
         clone->right = new IR::BoolLiteral(r->to<SymbolicBool>()->value);
         DoConstantFolding cf(refMap, typeMap);
-        //cf.setCalledBy(this);
+        cf.setCalledBy(this);
         auto result = expression->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));

--- a/midend/interpreter.h
+++ b/midend/interpreter.h
@@ -410,8 +410,24 @@ class SymbolicHeader : public SymbolicStruct {
     bool equals(const SymbolicValue* other) const override;
 };
 
+class SymbolicHeaderUnion : public SymbolicStruct {
+ public:
+    explicit SymbolicHeaderUnion(const IR::Type_HeaderUnion* type) : SymbolicStruct(type) {}
+    SymbolicBool* valid = nullptr;
+    SymbolicHeaderUnion(const IR::Type_HeaderUnion* type, bool uninitialized,
+                   const SymbolicValueFactory* factory);
+    virtual void setValid(bool v);
+    SymbolicValue* clone() const override;
+    SymbolicValue* get(const IR::Node* node, cstring field) const override;
+    void setAllUnknown() override;
+    void assign(const SymbolicValue* other) override;
+    void dbprint(std::ostream& out) const override;
+    bool merge(const SymbolicValue* other) override;
+    bool equals(const SymbolicValue* other) const override;
+};
+
 class SymbolicArray final : public SymbolicValue {
-    std::vector<SymbolicHeader*> values;
+    std::vector<SymbolicStruct*> values;
     friend class AnyElement;
     explicit SymbolicArray(const IR::Type_Stack* type) :
             SymbolicValue(type), size(type->getSize()),
@@ -436,7 +452,6 @@ class SymbolicArray final : public SymbolicValue {
     SymbolicValue* clone() const override;
     SymbolicValue* next(const IR::Node* node);
     SymbolicValue* last(const IR::Node* node);
-    SymbolicValue* lastIndex(const IR::Node* node);
     bool isScalar() const override { return false; }
     void setAllUnknown() override;
     void assign(const SymbolicValue* other) override;

--- a/midend/interpreter.h
+++ b/midend/interpreter.h
@@ -452,6 +452,7 @@ class SymbolicArray final : public SymbolicValue {
     SymbolicValue* clone() const override;
     SymbolicValue* next(const IR::Node* node);
     SymbolicValue* last(const IR::Node* node);
+    SymbolicValue* lastIndex(const IR::Node* node);
     bool isScalar() const override { return false; }
     void setAllUnknown() override;
     void assign(const SymbolicValue* other) override;

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -315,7 +315,9 @@ TEST_F(P4CParserUnroll, header_union) {
     auto parsers =  loadExample("issue561-7-bmv2.p4");
     ASSERT_TRUE(parsers.first);
     ASSERT_TRUE(parsers.second);
-    // adding outOfBound state
+    // The extra state in parsers.second is the outOfBound state that's correct.
+    // But due to the fact that parsers.first does not have such an outOfBound state,
+    // we have to subtract it from parsers.second.
     ASSERT_EQ(parsers.first->states.size(), parsers.second->states.size() - 1);
 }
 

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -310,5 +310,13 @@ TEST_F(P4CParserUnroll, t1_Cond) {
     ASSERT_TRUE(parsers.second);
     ASSERT_EQ(parsers.first->states.size(), parsers.second->states.size());
 }
+ 
+TEST_F(P4CParserUnroll, header_union) {
+    auto parsers =  loadExample("issue561-7-bmv2.p4");
+    ASSERT_TRUE(parsers.first);
+    ASSERT_TRUE(parsers.second);
+    // adding outOfBound state
+    ASSERT_EQ(parsers.first->states.size(), parsers.second->states.size() - 1);
+}
 
 }  // namespace Test

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -310,7 +310,7 @@ TEST_F(P4CParserUnroll, t1_Cond) {
     ASSERT_TRUE(parsers.second);
     ASSERT_EQ(parsers.first->states.size(), parsers.second->states.size());
 }
- 
+
 TEST_F(P4CParserUnroll, header_union) {
     auto parsers =  loadExample("issue561-7-bmv2.p4");
     ASSERT_TRUE(parsers.first);


### PR DESCRIPTION
Solving "Null element" errors  which are related with HeaderUnion type.
Tests for example : issue561-7-bmv2.p4 , issue561-4-bmv2.p4,  issue561-5-bmv2.p4,  issue561-6-bmv2.p4.
Use `--loopsUnroll` argument for programs starting
