### PR TITLE
DPDK Backend: Add pipe name prefix to table names in bfRT JSON output

### DIFF
--- a/backends/dpdk/control-plane/bfruntime_arch_handler.h
+++ b/backends/dpdk/control-plane/bfruntime_arch_handler.h
@@ -57,6 +57,10 @@ namespace ControlPlaneAPI {
 /// Declarations specific to standard architectures (v1model & PSA).
 namespace Standard {
 
+cstring prefix(cstring p, cstring str) {
+    return p.isNullOrEmpty() ? str : p + "." + str;
+}
+
 /// Extends P4RuntimeSymbolType for the DPDK extern types.
 class SymbolTypeDPDK final : public SymbolType {
  public:
@@ -85,7 +89,27 @@ struct ActionSelector {
 };
 
 class BFRuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PSA> {
+    std::unordered_map<const IR::Block *, cstring> blockNamePrefixMap;
  public:
+    template <typename Func>
+    void forAllPipeBlocks(const IR::ToplevelBlock* evaluatedProgram, Func function) {
+        auto main = evaluatedProgram->getMain();
+        if (!main)
+            ::error("Program does not contain a `main` module");
+        auto cparams = main->getConstructorParameters();
+        int index = -1;
+        for (auto param : main->constantValue) {
+            index++;
+            if (!param.second) continue;
+            auto pipe = param.second;
+            if (!pipe->is<IR::PackageBlock>())
+                continue;
+            auto idxParam = cparams->getParameter(index);
+            auto pipeName = idxParam->name;
+            function(pipeName, pipe->to<IR::PackageBlock>());
+        }
+    }
+
     using ArchCounterExtern = CounterExtern<Arch::PSA>;
     using CounterTraits = Helpers::CounterlikeTraits<ArchCounterExtern>;
     using ArchMeterExtern = MeterExtern<Arch::PSA>;
@@ -98,7 +122,28 @@ class BFRuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
 
     BFRuntimeArchHandlerPSA(ReferenceMap* refMap, TypeMap* typeMap,
                             const IR::ToplevelBlock* evaluatedProgram)
-        : P4RuntimeArchHandlerCommon<Arch::PSA>(refMap, typeMap, evaluatedProgram) { }
+        : P4RuntimeArchHandlerCommon<Arch::PSA>(refMap, typeMap, evaluatedProgram) {
+        // Create a map of all blocks to their pipe names. This map will
+        // be used during collect and post processing to prefix
+        // table/extern instances wherever applicable with a fully qualified
+        // name. This distinction is necessary when the driver looks up
+        // context.json across multiple pipes for the table name
+        forAllPipeBlocks(evaluatedProgram, [&](cstring pipeName, const IR::PackageBlock* pkg) {
+            Helpers::forAllEvaluatedBlocks(pkg, [&](const IR::Block* block) {
+                auto decl = pkg->node->to<IR::Declaration_Instance>();
+                cstring blockNamePrefix = pipeName;
+                if (decl)
+                    blockNamePrefix = decl->controlPlaneName();
+                blockNamePrefixMap[block] = blockNamePrefix;
+            });
+        });
+    }
+
+    cstring getBlockNamePrefix(const IR::Block* blk) {
+        if (blockNamePrefixMap.count(blk) > 0)
+            return blockNamePrefixMap[blk];
+        return "";
+    }
 
     static p4configv1::Extern* getP4InfoExtern(P4RuntimeSymbolType typeId,
                                                cstring typeName,
@@ -117,12 +162,12 @@ class BFRuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
                                         P4RuntimeSymbolType typeId, cstring typeName,
                                         cstring name, const IR::IAnnotated* annotations,
                                         const ::google::protobuf::Message& message,
-                                        p4configv1::P4Info* p4info) {
+                                        p4configv1::P4Info* p4info, cstring pipeName = "") {
         auto* externType = getP4InfoExtern(typeId, typeName, p4info);
         auto* externInstance = externType->add_instances();
         auto* pre = externInstance->mutable_preamble();
         pre->set_id(symbols.getId(typeId, name));
-        pre->set_name(name);
+        pre->set_name(prefix(pipeName, name));
         pre->set_alias(symbols.getAlias(name));
         Helpers::addAnnotations(pre, annotations);
         Helpers::addDocumentation(pre, annotations);
@@ -144,7 +189,7 @@ class BFRuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
 
     void addActionSelector(const P4RuntimeSymbolTableIface& symbols,
                           p4configv1::P4Info* p4Info,
-                          const ActionSelector& actionSelector) {
+                          const ActionSelector& actionSelector, cstring pipeName = "") {
         ::dpdk::ActionSelector selector;
         selector.set_max_group_size(actionSelector.maxGroupSize);
         selector.set_num_groups(actionSelector.numGroups);
@@ -165,7 +210,7 @@ class BFRuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
         cstring selectorName = profileName + "_sel";
         addP4InfoExternInstance(symbols, SymbolTypeDPDK::ACTION_SELECTOR(),
                 "ActionSelector", selectorName, actionSelector.annotations,
-                selector, p4Info);
+                selector, p4Info, pipeName);
     }
 
     void collectExternInstance(P4RuntimeSymbolTableIface* symbols,
@@ -198,6 +243,12 @@ class BFRuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
         } else {
             table->set_idle_timeout_behavior(p4configv1::Table::NO_TIMEOUT);
         }
+
+        // add pipe name prefix to the table names
+        auto pipeName = getBlockNamePrefix(tableBlock);
+        auto* pre = table->mutable_preamble();
+        if (pre->name() == tableDeclaration->controlPlaneName())
+            pre->set_name(prefix(pipeName, pre->name()));
     }
 
     void addExternInstance(const P4RuntimeSymbolTableIface& symbols,
@@ -208,13 +259,49 @@ class BFRuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
 
         auto decl = externBlock->node->to<IR::Declaration_Instance>();
         if (decl == nullptr) return;
+
+        // DPDK control plane software requires pipe name to be prefixed to the
+        // table and extern names
+        cstring pipeName = getBlockNamePrefix(externBlock);
+
         auto p4RtTypeInfo = p4info->mutable_type_info();
         if (externBlock->type->name == "Digest") {
             auto digest = getDigest(decl, p4RtTypeInfo);
             if (digest) addDigest(symbols, p4info, *digest);
         } else if (externBlock->type->name == "ActionSelector") {
             auto actionSelector = getActionSelector(externBlock);
-            if (actionSelector) addActionSelector(symbols, p4info, *actionSelector);
+            if (actionSelector) addActionSelector(symbols, p4info, *actionSelector, pipeName);
+            for (auto& extType : *p4info->mutable_action_profiles()) {
+                auto* pre = extType.mutable_preamble();
+                if (pre->name() == decl->controlPlaneName()) {
+                    pre->set_name(prefix(pipeName, pre->name()));
+                    break;
+                }
+            }
+        } else if (externBlock->type->name == "ActionProfile") {
+            for (auto& extType : *p4info->mutable_action_profiles()) {
+                auto* pre = extType.mutable_preamble();
+                if (pre->name() == decl->controlPlaneName()) {
+                    pre->set_name(prefix(pipeName, pre->name()));
+                    break;
+                }
+            }
+        } else if (externBlock->type->name == "Meter") {
+            for (auto& extType : *p4info->mutable_meters()) {
+                auto* pre = extType.mutable_preamble();
+                if (pre->name() == decl->controlPlaneName()) {
+                    pre->set_name(prefix(pipeName, pre->name()));
+                    break;
+                }
+            }
+        } else if (externBlock->type->name == "Counter") {
+            for (auto& extType : *p4info->mutable_counters()) {
+                auto* pre = extType.mutable_preamble();
+                if (pre->name() == decl->controlPlaneName()) {
+                    pre->set_name(prefix(pipeName, pre->name()));
+                    break;
+                }
+            }
         }
     }
 

--- a/control-plane/bfruntime.cpp
+++ b/control-plane/bfruntime.cpp
@@ -292,8 +292,7 @@ BFRuntimeGenerator::addKeyField(Util::JsonArray* dataJson, P4Id id, cstring name
 BFRuntimeGenerator::initTableJson(const std::string& name,
         P4Id id, cstring tableType, int64_t size, Util::JsonArray* annotations) {
     auto* tableJson = new Util::JsonObject();
-    const std::string tableName = "pipe." + name;
-    tableJson->emplace("name", tableName);
+    tableJson->emplace("name", name);
     tableJson->emplace("id", id);
     tableJson->emplace("table_type", tableType);
     tableJson->emplace("size", size);

--- a/control-plane/bfruntime.h
+++ b/control-plane/bfruntime.h
@@ -58,7 +58,6 @@ static inline constexpr P4Id getIdPrefix(P4Id id) {
 }
 
 static inline Util::JsonObject* findJsonTable(Util::JsonArray* tablesJson, cstring tblName) {
-    tblName = "pipe." + tblName;
     for (auto *t : *tablesJson) {
         auto *tblObj = t->to<Util::JsonObject>();
         auto tName = tblObj->get("name")->to<Util::JsonValue>()->getString();

--- a/testdata/p4_16_samples_outputs/psa-action-profile1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "size" : 1024,
       "annotations" : [],
@@ -42,7 +42,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.ap",
+      "name" : "ip.MyIC.ap",
       "id" : 298015716,
       "table_type" : "Action",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-action-profile3.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "size" : 1024,
       "annotations" : [],
@@ -42,7 +42,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.tbl2",
+      "name" : "ip.MyIC.tbl2",
       "id" : 47318070,
       "size" : 1024,
       "annotations" : [],
@@ -82,7 +82,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.ap",
+      "name" : "ip.MyIC.ap",
       "id" : 298015716,
       "table_type" : "Action",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-action-profile4.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "size" : 1024,
       "annotations" : [],
@@ -42,7 +42,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.tbl2",
+      "name" : "ip.MyIC.tbl2",
       "id" : 47318070,
       "size" : 1024,
       "annotations" : [],
@@ -82,7 +82,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.ap",
+      "name" : "ip.MyIC.ap",
       "id" : 298015716,
       "table_type" : "Action",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-action-selector1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "size" : 1024,
       "annotations" : [],
@@ -53,7 +53,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.as",
+      "name" : "ip.MyIC.as",
       "id" : 294316857,
       "table_type" : "Action",
       "size" : 1024,
@@ -126,7 +126,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.MyIC.as_sel",
+      "name" : "ip.MyIC.as_sel",
       "id" : 2164374905,
       "table_type" : "Selector",
       "size" : 1024,
@@ -191,7 +191,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.MyIC.as_sel_get_member",
+      "name" : "ip.MyIC.as_sel_get_member",
       "id" : 2181152121,
       "table_type" : "SelectorGetMember",
       "size" : 1,

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "size" : 1024,
       "annotations" : [],
@@ -53,7 +53,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.as",
+      "name" : "ip.MyIC.as",
       "id" : 294316857,
       "table_type" : "Action",
       "size" : 1024,
@@ -126,7 +126,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.MyIC.as_sel",
+      "name" : "ip.MyIC.as_sel",
       "id" : 2164374905,
       "table_type" : "Selector",
       "size" : 1024,
@@ -191,7 +191,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.MyIC.as_sel_get_member",
+      "name" : "ip.MyIC.as_sel_get_member",
       "id" : 2181152121,
       "table_type" : "SelectorGetMember",
       "size" : 1,

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-action-selector4.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-action-selector4.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "size" : 1024,
       "annotations" : [],
@@ -53,7 +53,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.foo",
+      "name" : "ip.MyIC.foo",
       "id" : 49266188,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -75,7 +75,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.as",
+      "name" : "ip.MyIC.as",
       "id" : 294316857,
       "table_type" : "Action",
       "size" : 1024,
@@ -148,7 +148,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.MyIC.as_sel",
+      "name" : "ip.MyIC.as_sel",
       "id" : 2164374905,
       "table_type" : "Selector",
       "size" : 1024,
@@ -213,7 +213,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.MyIC.as_sel_get_member",
+      "name" : "ip.MyIC.as_sel_get_member",
       "id" : 2181152121,
       "table_type" : "SelectorGetMember",
       "size" : 1,

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.cIngress.tbl",
+      "name" : "ip.cIngress.tbl",
       "id" : 34888878,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -24,7 +24,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.cIngress.counter",
+      "name" : "ip.cIngress.counter",
       "id" : 304351549,
       "table_type" : "Counter",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -44,7 +44,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.counter",
+      "name" : "ip.MyIC.counter",
       "id" : 306209163,
       "table_type" : "Counter",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -44,7 +44,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.counter0",
+      "name" : "ip.MyIC.counter0",
       "id" : 303203245,
       "table_type" : "Counter",
       "size" : 1024,
@@ -83,7 +83,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.MyIC.counter1",
+      "name" : "ip.MyIC.counter1",
       "id" : 305966593,
       "table_type" : "Counter",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.counter0",
+      "name" : "ip.MyIC.counter0",
       "id" : 303203245,
       "table_type" : "Counter",
       "size" : 1024,
@@ -41,7 +41,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.MyIC.counter1",
+      "name" : "ip.MyIC.counter1",
       "id" : 305966593,
       "table_type" : "Counter",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -44,7 +44,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.counter",
+      "name" : "ip.MyIC.counter",
       "id" : 306209163,
       "table_type" : "Counter",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -101,7 +101,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.foo",
+      "name" : "ip.MyIC.foo",
       "id" : 49266188,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -200,7 +200,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.bar",
+      "name" : "ip.MyIC.bar",
       "id" : 49390123,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -101,7 +101,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.foo",
+      "name" : "ip.MyIC.foo",
       "id" : 49266188,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -123,7 +123,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.bar",
+      "name" : "ip.MyIC.bar",
       "id" : 49390123,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.egress.tbl",
+      "name" : "ep.egress.tbl",
       "id" : 35478861,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.counter0",
+      "name" : "ip.MyIC.counter0",
       "id" : 303203245,
       "table_type" : "Counter",
       "size" : 1024,
@@ -55,7 +55,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.MyIC.counter1",
+      "name" : "ip.MyIC.counter1",
       "id" : 305966593,
       "table_type" : "Counter",
       "size" : 1024,
@@ -94,7 +94,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.MyIC.counter2",
+      "name" : "ip.MyIC.counter2",
       "id" : 318550906,
       "table_type" : "Counter",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -57,7 +57,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.ingress.counter0",
+      "name" : "ip.ingress.counter0",
       "id" : 314114784,
       "table_type" : "Counter",
       "size" : 1024,
@@ -110,7 +110,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.ingress.counter1",
+      "name" : "ip.ingress.counter1",
       "id" : 318473483,
       "table_type" : "Counter",
       "size" : 1024,
@@ -149,7 +149,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.ingress.counter2",
+      "name" : "ip.ingress.counter2",
       "id" : 313911423,
       "table_type" : "Counter",
       "size" : 1024,
@@ -188,7 +188,7 @@
       "attributes" : []
     },
     {
-      "name" : "pipe.ingress.meter0",
+      "name" : "ip.ingress.meter0",
       "id" : 344514043,
       "table_type" : "Meter",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -57,7 +57,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.ingress.meter0",
+      "name" : "ip.ingress.meter0",
       "id" : 344514043,
       "table_type" : "Meter",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -57,7 +57,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.ingress.meter0",
+      "name" : "ip.ingress.meter0",
       "id" : 344514043,
       "table_type" : "Meter",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "size" : 1024,
       "annotations" : [],
@@ -42,7 +42,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.tbl2",
+      "name" : "ip.MyIC.tbl2",
       "id" : 47318070,
       "size" : 1024,
       "annotations" : [],
@@ -82,7 +82,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.ap",
+      "name" : "ip.MyIC.ap",
       "id" : 298015716,
       "table_type" : "Action",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.route",
+      "name" : "ip.ingress.route",
       "id" : 40550280,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.ingress.tbl",
+      "name" : "ip.ingress.tbl",
       "id" : 44506256,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-header-stack.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-header-stack.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl_idle_timeout",
+      "name" : "ip.MyIC.tbl_idle_timeout",
       "id" : 38763260,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -106,7 +106,7 @@
       "attributes" : ["EntryScope", "IdleTimeout"]
     },
     {
-      "name" : "pipe.MyIC.tbl_no_idle_timeout",
+      "name" : "ip.MyIC.tbl_no_idle_timeout",
       "id" : 46250950,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,
@@ -181,7 +181,7 @@
       "attributes" : ["EntryScope"]
     },
     {
-      "name" : "pipe.MyIC.tbl_no_idle_timeout_prop",
+      "name" : "ip.MyIC.tbl_no_idle_timeout_prop",
       "id" : 43498864,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-isvalid.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-isvalid.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-remove-header.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-remove-header.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.bfrt.json
@@ -2,7 +2,7 @@
   "schema_version" : "1.0.0",
   "tables" : [
     {
-      "name" : "pipe.MyIC.tbl",
+      "name" : "ip.MyIC.tbl",
       "id" : 39967501,
       "table_type" : "MatchAction_Direct",
       "size" : 1024,


### PR DESCRIPTION
This PR fixes https://github.com/p4lang/p4c/issues/2927

The table names in bfRT JSON should use fully qualified names including the pipe name and control block name.
Currently, a fixed pipe name "pipe" is used.

This PR fixes the implementation to output the pipe name as specified in the P4 program.

For example, In the below snippet, the fully qualified name for _tbl_ should be **ip.MyIC.tbl**
```
control MyIC(
   ...
    table tbl {
   ...
    }

    apply {
        tbl.apply();
    }
}
...
IngressPipeline(MyIP(), MyIC(), MyID()) ip;
EgressPipeline(MyEP(), MyEC(), MyED()) ep;

PSA_Switch(
    ip,
    PacketReplicationEngine(),
    ep,
    BufferingQueueingEngine()) main;
```
	