### PR TITLE
Support errors for parserUnroll

### DIFF
--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -836,7 +836,11 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation* expression) {
 
 void ExpressionEvaluator::postorder(const IR::Member* expression) {
     auto type = typeMap->getType(expression, true);
-    if (type->is<IR::Type_MethodBase>() || type->is<IR::Type_Error>()) {
+    if (type->is<IR::Type_Error>()) {
+        set(expression, new SymbolicEnum(expression->type, expression->member));
+        return;
+    }
+    if (type->is<IR::Type_MethodBase>()) {
         // not really void, but we can't do anything with this anyway
         set(expression, SymbolicVoid::get());
         return;


### PR DESCRIPTION
These small changes allow to pass assignments of error type through parserUnroll. These changes allow to pass issue510-bmv2 example through parserUnroll without error : "Assign to void". 