### PR TITLE
ParserState skipping

### DIFF
--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -262,6 +262,9 @@ class ParserSymbolicInterpreter {
             result->set(p, value);
         }
         for (auto d : parser->parserLocals) {
+            if (d->to<IR::ParserState>()) {
+                continue;
+            }
             auto type = typeMap->getType(d);
             SymbolicValue* value = nullptr;
             if (d->is<IR::Declaration_Constant>()) {


### PR DESCRIPTION
Skips ParserState in parserUnroll pass.
This is necessary due to the fact that the appearance of 
```
state start @name(".$start") {
    select{(bit<32>)standard_metadata.instance_type} {
      0: start_0
      1: start_e2e_mirrored
      2: start_i2e_mirrored
      default: noMatch } }
state start_0 @name(".start") {
    accept; }
```
is similar to the bug of the translator from p4_14 to p4_16 standard.
With these changes, parser_pragma2.p4 should pass without errors.