### PR TITLE
DPDK Backend: Add support for switch statement in p4c-dpdk

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -30,8 +30,6 @@ p4c_add_xfail_reason("dpdk"
 
 p4c_add_xfail_reason("dpdk"
   "Not implemented"
-  testdata/p4_16_samples/psa-action-selector5.p4
-  testdata/p4_16_samples/psa-dpdk-table-key-consolidation-switch.p4
   testdata/p4_16_samples/psa-random.p4
   )
 

--- a/backends/dpdk/dpdk.def
+++ b/backends/dpdk/dpdk.def
@@ -151,6 +151,29 @@ class DpdkJmpMissStatement : DpdkJmpStatement {
         DpdkJmpStatement("jmpnh", label) { }
 }
 
+abstract DpdkJmpActionStatement : DpdkJmpStatement {
+    cstring action;
+    std::ostream& toSpec(std::ostream& out) const override;
+#nodbprint
+#noconstructor
+    DpdkJmpActionStatement(cstring instruction, cstring label, cstring action) :
+        DpdkJmpStatement(instruction, label), action(action) { }
+}
+
+class DpdkJmpOnActionRunStatement : DpdkJmpActionStatement {
+#nodbprint
+#noconstructor
+    DpdkJmpOnActionRunStatement(cstring label, cstring act) :
+        DpdkJmpActionStatement("jmpa", label, act) { }
+}
+
+class DpdkJmpNotOnActionRunStatement : DpdkJmpActionStatement {
+#nodbprint
+#noconstructor
+    DpdkJmpNotOnActionRunStatement(cstring label, cstring act) :
+        DpdkJmpActionStatement("jmpna", label, act) { }
+}
+
 abstract DpdkJmpHeaderStatement : DpdkJmpStatement {
     Expression header;
     std::ostream& toSpec(std::ostream& out) const override;

--- a/backends/dpdk/dpdk.def
+++ b/backends/dpdk/dpdk.def
@@ -160,17 +160,17 @@ abstract DpdkJmpActionStatement : DpdkJmpStatement {
         DpdkJmpStatement(instruction, label), action(action) { }
 }
 
-class DpdkJmpOnActionRunStatement : DpdkJmpActionStatement {
+class DpdkJmpIfActionRunStatement : DpdkJmpActionStatement {
 #nodbprint
 #noconstructor
-    DpdkJmpOnActionRunStatement(cstring label, cstring act) :
+    DpdkJmpIfActionRunStatement(cstring label, cstring act) :
         DpdkJmpActionStatement("jmpa", label, act) { }
 }
 
-class DpdkJmpNotOnActionRunStatement : DpdkJmpActionStatement {
+class DpdkJmpIfActionNotRunStatement : DpdkJmpActionStatement {
 #nodbprint
 #noconstructor
-    DpdkJmpNotOnActionRunStatement(cstring label, cstring act) :
+    DpdkJmpIfActionNotRunStatement(cstring label, cstring act) :
         DpdkJmpActionStatement("jmpna", label, act) { }
 }
 

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -1526,10 +1526,8 @@ const IR::Node* SplitP4TableCommon::postorder(IR::IfStatement* statement) {
 
 const IR::Node* SplitP4TableCommon::postorder(IR::SwitchStatement* statement) {
     auto expr = statement->expression;
-    if (!expr->is<IR::Member>())
-        return statement;
     auto member = expr->to<IR::Member>();
-    if (member->member != "action_run")
+    if (!member || member->member != "action_run")
         return statement;
     if (!member->expr->is<IR::MethodCallExpression>())
         return statement;

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -1526,6 +1526,8 @@ const IR::Node* SplitP4TableCommon::postorder(IR::IfStatement* statement) {
 
 const IR::Node* SplitP4TableCommon::postorder(IR::SwitchStatement* statement) {
     auto expr = statement->expression;
+    if (!expr->is<IR::Member>())
+        return statement;
     auto member = expr->to<IR::Member>();
     if (member->member != "action_run")
         return statement;

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -20,15 +20,13 @@ limitations under the License.
 
 namespace DPDK {
 
-int ConvertStatementToDpdk::next_label_id = 0;
-
 // convert relation comparison statements into the corresponding branching
 // instructions in dpdk.
 void ConvertStatementToDpdk::process_relation_operation(const IR::Expression* dst,
                                                         const IR::Operation_Relation* op) {
-    auto true_label = Util::printf_format("label_%dtrue", next_label_id);
-    auto false_label = Util::printf_format("label_%dfalse", next_label_id);
-    auto end_label = Util::printf_format("label_%dend", next_label_id++);
+    auto true_label = refmap->newName("label_true");
+    auto false_label = refmap->newName("label_false");
+    auto end_label = refmap->newName("label_end");
     if (op->is<IR::Equ>()) {
         add_instr(new IR::DpdkJmpEqualStatement(true_label, op->left, op->right));
     } else if (op->is<IR::Neq>()) {
@@ -75,9 +73,9 @@ void ConvertStatementToDpdk::process_logical_operation(const IR::Expression* dst
                                                         const IR::Operation_Binary* op) {
     if (!op->is<IR::LOr>() && !op->is<IR::LAnd>())
         return;
-    auto true_label = Util::printf_format("label_%dtrue", next_label_id);
-    auto false_label = Util::printf_format("label_%dfalse", next_label_id);
-    auto end_label = Util::printf_format("label_%dend", next_label_id++);
+    auto true_label = refmap->newName("label_true");
+    auto false_label = refmap->newName("label_false");
+    auto end_label = refmap->newName("label_end");
     if (op->is<IR::LOr>()) {
         add_instr(new IR::DpdkJmpEqualStatement(true_label, op->left, new IR::Constant(true)));
         add_instr(new IR::DpdkJmpEqualStatement(true_label, op->right, new IR::Constant(true)));
@@ -194,7 +192,7 @@ bool ConvertStatementToDpdk::preorder(const IR::AssignmentStatement *a) {
                    if (!(hdr.isValid()))
                        var = false;
                 */
-                auto end_label = Util::printf_format("label_%dend", next_label_id++);
+                auto end_label = refmap->newName("label_end");
                 add_instr(new IR::DpdkMovStatement(left, new IR::BoolLiteral(true)));
                 add_instr(new IR::DpdkJmpIfValidStatement(end_label, b->appliedTo));
                 add_instr(new IR::DpdkMovStatement(left, new IR::BoolLiteral(false)));
@@ -220,8 +218,8 @@ bool ConvertStatementToDpdk::preorder(const IR::AssignmentStatement *a) {
                else
                    var = 0;
             */
-            auto true_label = Util::printf_format("label_%dtrue", next_label_id);
-            auto end_label = Util::printf_format("label_%dend", next_label_id++);
+            auto true_label = refmap->newName("label_true");
+            auto end_label = refmap->newName("label_end");
             add_instr(new IR::DpdkJmpEqualStatement(true_label, ln->expr, new IR::Constant(false)));
             add_instr(new IR::DpdkMovStatement(left, new IR::Constant(false)));
             add_instr(new IR::DpdkJmpLabelStatement(end_label));
@@ -433,9 +431,9 @@ bool BranchingInstructionGeneration::generate(const IR::Expression *expr,
 // whether the true or false code block will go first. This is important because
 // following optimization pass might eliminate some redundant jmps and labels.
 bool ConvertStatementToDpdk::preorder(const IR::IfStatement *s) {
-    auto true_label = Util::printf_format("label_%dtrue", next_label_id);
-    auto false_label = Util::printf_format("label_%dfalse", next_label_id);
-    auto end_label = Util::printf_format("label_%dend", next_label_id++);
+    auto true_label = refmap->newName("label_true");
+    auto false_label = refmap->newName("label_false");
+    auto end_label = refmap->newName("label_end");
     auto gen = new BranchingInstructionGeneration(refmap, typemap);
     bool res = gen->generate(s->condition, true_label, false_label, true);
 
@@ -620,7 +618,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
             if (!error->expression->is<IR::Member>())
                 ::error("%1%: must be one of the existing errors", s);
             auto error_id = structure->error_map.at(error->expression->to<IR::Member>()->member);
-            auto end_label = Util::printf_format("label_%dend", next_label_id++);
+            auto end_label = refmap->newName("label_end");
             const IR::BoolLiteral *boolLiteral = condition->expression->to<IR::BoolLiteral>();
             if (!boolLiteral) {
                 add_instr(new IR::DpdkJmpNotEqualStatement(
@@ -691,28 +689,31 @@ bool ConvertStatementToDpdk::preorder(const IR::SwitchStatement *s) {
     auto size = s->cases.size();
     std::vector <cstring> labels;
     cstring label;
-    bool isdefaultPresent = false;
     cstring default_label = "";
-    auto end_label = Util::printf_format("label_endswitch%d", next_label_id++);
+    auto end_label = refmap->newName("label_endswitch");
     // Emit jmp on action run statements and collect labels for each case statement
-    for (unsigned i = 0; i < size; i++) {
+    for (unsigned i = 0; i < size - 1; i++) {
         auto caseLabel = s->cases.at(i);
-        if (caseLabel->label->is<IR::DefaultExpression>()) {
-            label = Util::printf_format("label_default%d", next_label_id++);
-            add_instr(new IR::DpdkJmpLabelStatement(label));
-            default_label = label;
-            isdefaultPresent = true;
-        } else {
-            auto pe = caseLabel->label->to<IR::PathExpression>();
-            CHECK_NULL(pe);
-            label = Util::printf_format("label_action%d", next_label_id++);
-            add_instr(new IR::DpdkJmpOnActionRunStatement(label, pe->path->name.name));
-        }
+        auto pe = caseLabel->label->to<IR::PathExpression>();
+        CHECK_NULL(pe);
+        label = refmap->newName("label_action");
+        add_instr(new IR::DpdkJmpIfActionRunStatement(label, pe->path->name.name));
         labels.push_back(label);
     }
 
-    if (!isdefaultPresent)
+    if (s->cases.at(size-1)->label->is<IR::DefaultExpression>()) {
+        label = refmap->newName("label_default");
+        add_instr(new IR::DpdkJmpLabelStatement(label));
+        default_label = label;
+    } else {
+        auto pe = s->cases.at(size-1)->label->to<IR::PathExpression>();
+        CHECK_NULL(pe);
+        label = refmap->newName("label_action");
+        add_instr(new IR::DpdkJmpIfActionRunStatement(label, pe->path->name.name));
         add_instr(new IR::DpdkJmpLabelStatement(end_label));
+    }
+
+    labels.push_back(label);
 
     // Emit block statements corresponding to each case
     // We emit labels even for the fallthrough case, DpdkAsmOptimization pass will

--- a/backends/dpdk/dpdkHelpers.h
+++ b/backends/dpdk/dpdkHelpers.h
@@ -121,7 +121,6 @@ class BranchingInstructionGeneration {
 };
 
 class ConvertStatementToDpdk : public Inspector {
-    static int next_label_id;
     IR::IndexedVector<IR::DpdkAsmStatement> instructions;
     P4::TypeMap *typemap;
     P4::ReferenceMap *refmap;
@@ -145,7 +144,6 @@ class ConvertStatementToDpdk : public Inspector {
 
     void add_instr(const IR::DpdkAsmStatement *s) { instructions.push_back(s); }
     IR::IndexedVector<IR::DpdkAsmStatement> &get_instr() { return instructions; }
-    int get_label_num() { return next_label_id; }
     void process_logical_operation(const IR::Expression*, const IR::Operation_Binary*);
     void process_relation_operation(const IR::Expression*, const IR::Operation_Relation*);
     cstring append_parser_name(const IR::P4Parser* p, cstring);

--- a/backends/dpdk/midend.cpp
+++ b/backends/dpdk/midend.cpp
@@ -35,6 +35,7 @@ limitations under the License.
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateSerEnums.h"
 #include "midend/eliminateTuples.h"
+#include "midend/eliminateSwitch.h"
 #include "midend/expandEmit.h"
 #include "midend/expandLookahead.h"
 #include "midend/fillEnumMap.h"
@@ -192,6 +193,7 @@ DpdkMidEnd::DpdkMidEnd(CompilerOptions &options,
             new P4::SimplifyControlFlow(&refMap, &typeMap),
             new P4::CompileTimeOperations(),
             new P4::TableHit(&refMap, &typeMap),
+            new P4::EliminateSwitch(&refMap, &typeMap),
             new P4::RemoveLeftSlices(&refMap, &typeMap),
             new P4::TypeChecking(&refMap, &typeMap),
             new P4::MidEndLast(),

--- a/backends/dpdk/spec.cpp
+++ b/backends/dpdk/spec.cpp
@@ -227,6 +227,11 @@ std::ostream& IR::DpdkJmpHeaderStatement::toSpec(std::ostream& out) const {
     return out;
 }
 
+std::ostream& IR::DpdkJmpActionStatement::toSpec(std::ostream& out) const {
+    out << instruction << " " << label << " " << action;
+    return out;
+}
+
 std::ostream& IR::DpdkJmpCondStatement::toSpec(std::ostream& out) const {
     out << instruction << " " << label << " " << DPDK::toStr(src1)
         << " " << DPDK::toStr(src2);

--- a/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
@@ -113,10 +113,10 @@ apply {
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_0END h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
 	table ipv4_da
 	table ipv4_da2
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
 	tx m.pna_main_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/pna-example-template.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-template.p4.spec
@@ -80,9 +80,9 @@ apply {
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_0END h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
 	table ipv4_da_lpm
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
 	tx m.pna_main_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-action-selector4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector4.p4.spec
@@ -142,36 +142,36 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	table tbl
-	jmpnh LABEL_0END
+	jmpnh LABEL_END
 	table as_sel
-	jmpnh LABEL_0END
+	jmpnh LABEL_END
 	table as
-	jmpnh LABEL_0END
+	jmpnh LABEL_END
 	table foo
-	LABEL_0END :	table tbl
-	jmpnh LABEL_3END
+	LABEL_END :	table tbl
+	jmpnh LABEL_END_2
 	table as_sel
-	jmpnh LABEL_3END
+	jmpnh LABEL_END_2
 	table as
-	jmpnh LABEL_3END
+	jmpnh LABEL_END_2
 	table foo
-	LABEL_3END :	table tbl
-	jmpnh LABEL_6END
+	LABEL_END_2 :	table tbl
+	jmpnh LABEL_END_5
 	table as_sel
-	jmpnh LABEL_6END
+	jmpnh LABEL_END_5
 	table as
-	jmpnh LABEL_8FALSE
-	jmp LABEL_6END
-	LABEL_8FALSE :	table foo
-	LABEL_6END :	table tbl
-	jmpnh LABEL_9END
+	jmpnh LABEL_FALSE_7
+	jmp LABEL_END_5
+	LABEL_FALSE_7 :	table foo
+	LABEL_END_5 :	table tbl
+	jmpnh LABEL_END_8
 	table as_sel
-	jmpnh LABEL_9END
+	jmpnh LABEL_END_8
 	table as
-	jmpnh LABEL_11FALSE
-	jmp LABEL_9END
-	LABEL_11FALSE :	table foo
-	LABEL_9END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	jmpnh LABEL_FALSE_10
+	jmp LABEL_END_8
+	LABEL_FALSE_10 :	table foo
+	LABEL_END_8 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop

--- a/testdata/p4_16_samples_outputs/psa-action-selector5.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-action-selector5.p4.bfrt.json
@@ -1,0 +1,288 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.MyIC.tbl",
+      "id" : 39967501,
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [294316857, 2164374905],
+      "table_type" : "MatchAction_Indirect_Selector",
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : true,
+          "read_only" : false,
+          "oneof" : [
+            {
+              "id" : 65539,
+              "name" : "$ACTION_MEMBER_ID",
+              "repeated" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "uint32"
+              }
+            },
+            {
+              "id" : 65540,
+              "name" : "$SELECTOR_GROUP_ID",
+              "repeated" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "uint32"
+              }
+            }
+          ]
+        }
+      ],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.MyIC.foo",
+      "id" : 49266188,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.MyIC.bar",
+      "id" : 49390123,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.MyIC.as",
+      "id" : 294316857,
+      "table_type" : "Action",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65539,
+          "name" : "$ACTION_MEMBER_ID",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 30030382,
+          "name" : "a1",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "param",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 48
+              }
+            }
+          ]
+        },
+        {
+          "id" : 28661769,
+          "name" : "a2",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "param",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 16
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.MyIC.as_sel",
+      "id" : 2164374905,
+      "table_type" : "Selector",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [294316857],
+      "key" : [
+        {
+          "id" : 65560,
+          "name" : "$SELECTOR_GROUP_ID",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65559,
+            "name" : "$ACTION_MEMBER_ID",
+            "repeated" : true,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint32"
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65561,
+            "name" : "$ACTION_MEMBER_STATUS",
+            "repeated" : true,
+            "annotations" : [],
+            "type" : {
+              "type" : "bool"
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65562,
+            "name" : "$MAX_GROUP_SIZE",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint32",
+              "default_value" : 120
+            }
+          }
+        }
+      ],
+      "supported_operations" : [],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.MyIC.as_sel_get_member",
+      "id" : 2181152121,
+      "table_type" : "SelectorGetMember",
+      "size" : 1,
+      "annotations" : [],
+      "depends_on" : [2164374905],
+      "key" : [
+        {
+          "id" : 65560,
+          "name" : "$SELECTOR_GROUP_ID",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint64"
+          }
+        },
+        {
+          "id" : 65563,
+          "name" : "hash_value",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint64"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65559,
+            "name" : "$ACTION_MEMBER_ID",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64"
+            }
+          }
+        }
+      ],
+      "supported_operations" : [],
+      "attributes" : []
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-action-selector5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector5.p4.spec
@@ -152,13 +152,13 @@ apply {
 	extract h.ethernet
 	table tbl
 	table as_sel
-	jmpa LABEL_ACTION1 a1
-	jmpa LABEL_ACTION2 a2
-	jmp LABEL_ENDSWITCH0
-	LABEL_ACTION1 :	table foo
-	jmp LABEL_ENDSWITCH0
-	LABEL_ACTION2 :	table bar
-	LABEL_ENDSWITCH0 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	jmpa LABEL_ACTION a1
+	jmpa LABEL_ACTION_0 a2
+	jmp LABEL_ENDSWITCH
+	LABEL_ACTION :	table foo
+	jmp LABEL_ENDSWITCH
+	LABEL_ACTION_0 :	table bar
+	LABEL_ENDSWITCH :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop

--- a/testdata/p4_16_samples_outputs/psa-action-selector5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector5.p4.spec
@@ -1,0 +1,167 @@
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct a1_arg_t {
+	bit<48> param
+}
+
+struct a2_arg_t {
+	bit<16> param
+}
+
+struct tbl_set_group_id_arg_t {
+	bit<32> group_id
+}
+
+struct user_meta_t {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+	bit<32> Ingress_as_group_id
+	bit<32> Ingress_as_member_id
+}
+metadata instanceof user_meta_t
+
+header ethernet instanceof ethernet_t
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+action NoAction args none {
+	return
+}
+
+action a1 args instanceof a1_arg_t {
+	mov h.ethernet.dstAddr t.param
+	return
+}
+
+action a2 args instanceof a2_arg_t {
+	mov h.ethernet.etherType t.param
+	return
+}
+
+action tbl_set_group_id args instanceof tbl_set_group_id_arg_t {
+	mov m.Ingress_as_group_id t.group_id
+	return
+}
+
+table tbl {
+	key {
+		h.ethernet.srcAddr exact
+	}
+	actions {
+		tbl_set_group_id
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+table as {
+	key {
+		m.Ingress_as_member_id exact
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+table foo {
+	actions {
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+table bar {
+	actions {
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+selector as_sel {
+	group_id m.Ingress_as_group_id
+	selector {
+		m.local_metadata_data
+	}
+	member_id m.Ingress_as_member_id
+	n_groups_max 1024
+	n_members_per_group_max 65536
+}
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	table tbl
+	table as_sel
+	jmpa LABEL_ACTION1 a1
+	jmpa LABEL_ACTION2 a2
+	jmp LABEL_ENDSWITCH0
+	LABEL_ACTION1 :	table foo
+	jmp LABEL_ENDSWITCH0
+	LABEL_ACTION2 :	table bar
+	LABEL_ENDSWITCH0 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.spec
@@ -64,11 +64,11 @@ action NoAction args none {
 }
 
 action execute args none {
-	jmpeq LABEL_1FALSE m.local_metadata_data 0x0
+	jmpeq LABEL_FALSE_0 m.local_metadata_data 0x0
 	mov m.Ingress_tmp_0 0x0
-	jmp LABEL_1END
-	LABEL_1FALSE :	mov m.Ingress_tmp_0 0x1
-	LABEL_1END :	mov m.local_metadata_data m.Ingress_tmp_0
+	jmp LABEL_END_0
+	LABEL_FALSE_0 :	mov m.Ingress_tmp_0 0x1
+	LABEL_END_0 :	mov m.local_metadata_data m.Ingress_tmp_0
 	add m.local_metadata_data 0x1
 	return
 }
@@ -90,11 +90,11 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	jmpeq LABEL_0FALSE m.local_metadata_data 0x0
+	jmpeq LABEL_FALSE m.local_metadata_data 0x0
 	mov m.Ingress_tmp_1 0x2
-	jmp LABEL_0END
-	LABEL_0FALSE :	mov m.Ingress_tmp_1 0x5
-	LABEL_0END :	mov m.local_metadata_data m.Ingress_tmp_1
+	jmp LABEL_END
+	LABEL_FALSE :	mov m.Ingress_tmp_1 0x5
+	LABEL_END :	mov m.local_metadata_data m.Ingress_tmp_1
 	add m.local_metadata_data 0x5
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.spec
@@ -185,21 +185,21 @@ apply {
 	MYIP_PARSE_TCP :	extract h.tcp
 	MYIP_ACCEPT :	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
-	jmpnh LABEL_0END
+	jmpnh LABEL_END
 	mov m.Ingress_foo_ethernet_dstAddr h.ethernet.dstAddr
 	table foo
-	LABEL_0END :	table tbl
-	jmpnh LABEL_1END
+	LABEL_END :	table tbl
+	jmpnh LABEL_END_0
 	table foo
-	LABEL_1END :	table tbl
-	jmpnh LABEL_2FALSE
-	jmp LABEL_2END
-	LABEL_2FALSE :	table bar
-	LABEL_2END :	table tbl
-	jmpnh LABEL_3FALSE
-	jmp LABEL_3END
-	LABEL_3FALSE :	table bar
-	LABEL_3END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END_0 :	table tbl
+	jmpnh LABEL_FALSE_1
+	jmp LABEL_END_1
+	LABEL_FALSE_1 :	table bar
+	LABEL_END_1 :	table tbl
+	jmpnh LABEL_FALSE_2
+	jmp LABEL_END_2
+	LABEL_FALSE_2 :	table bar
+	LABEL_END_2 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.spec
@@ -168,20 +168,20 @@ apply {
 	MYIP_PARSE_TCP :	extract h.tcp
 	MYIP_ACCEPT :	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
-	jmpnh LABEL_0END
+	jmpnh LABEL_END
 	table foo
-	LABEL_0END :	table tbl
-	jmpnh LABEL_1END
+	LABEL_END :	table tbl
+	jmpnh LABEL_END_0
 	table foo
-	LABEL_1END :	table tbl
-	jmpnh LABEL_2FALSE
-	jmp LABEL_2END
-	LABEL_2FALSE :	table bar
-	LABEL_2END :	table tbl
-	jmpnh LABEL_3FALSE
-	jmp LABEL_3END
-	LABEL_3FALSE :	table bar
-	LABEL_3END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END_0 :	table tbl
+	jmpnh LABEL_FALSE_1
+	jmp LABEL_END_1
+	LABEL_FALSE_1 :	table bar
+	LABEL_END_1 :	table tbl
+	jmpnh LABEL_FALSE_2
+	jmp LABEL_END_2
+	LABEL_FALSE_2 :	table bar
+	LABEL_END_2 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.bfrt.json
@@ -1,0 +1,137 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.MyIC.tbl",
+      "id" : 39967501,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "b.data",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "LPM",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 21832421,
+          "name" : "MyIC.a1",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "param",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 48
+              }
+            }
+          ]
+        },
+        {
+          "id" : 23466264,
+          "name" : "MyIC.a2",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "param",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 16
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.MyIC.foo",
+      "id" : 49266188,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.MyIC.bar",
+      "id" : 49390123,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.spec
@@ -1,0 +1,181 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<4> dataOffset
+	bit<3> res
+	bit<3> ecn
+	bit<6> ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct a1_arg_t {
+	bit<48> param
+}
+
+struct a2_arg_t {
+	bit<16> param
+}
+
+struct user_meta_t {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<8> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<8> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+	bit<16> local_metadata_data1
+	bit<48> Ingress_tbl_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof user_meta_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+action NoAction args none {
+	return
+}
+
+action a1 args instanceof a1_arg_t {
+	mov h.ethernet.dstAddr t.param
+	return
+}
+
+action a2 args instanceof a2_arg_t {
+	mov h.ethernet.etherType t.param
+	return
+}
+
+table tbl {
+	key {
+		m.Ingress_tbl_ethernet_srcAddr exact
+		m.local_metadata_data lpm
+	}
+	actions {
+		NoAction
+		a1
+		a2
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+table foo {
+	actions {
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+table bar {
+	actions {
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq MYIP_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq MYIP_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp MYIP_ACCEPT
+	MYIP_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq MYIP_PARSE_TCP m.tmpMask_0 0x4
+	jmp MYIP_ACCEPT
+	MYIP_PARSE_TCP :	extract h.tcp
+	MYIP_ACCEPT :	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	jmpa LABEL_ACTION1 a1
+	jmpa LABEL_ACTION2 a2
+	jmp LABEL_ENDSWITCH0
+	LABEL_ACTION1 :	table foo
+	jmp LABEL_ENDSWITCH0
+	LABEL_ACTION2 :	table bar
+	LABEL_ENDSWITCH0 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.spec
@@ -166,13 +166,13 @@ apply {
 	jmp MYIP_ACCEPT
 	MYIP_PARSE_TCP :	extract h.tcp
 	MYIP_ACCEPT :	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
-	jmpa LABEL_ACTION1 a1
-	jmpa LABEL_ACTION2 a2
-	jmp LABEL_ENDSWITCH0
-	LABEL_ACTION1 :	table foo
-	jmp LABEL_ENDSWITCH0
-	LABEL_ACTION2 :	table bar
-	LABEL_ENDSWITCH0 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	jmpa LABEL_ACTION a1
+	jmpa LABEL_ACTION_0 a2
+	jmp LABEL_ENDSWITCH
+	LABEL_ACTION :	table foo
+	jmp LABEL_ENDSWITCH
+	LABEL_ACTION_0 :	table bar
+	LABEL_ENDSWITCH :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
@@ -136,9 +136,9 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tbl_ethernet_isValid 1
-	jmpv LABEL_0END h.ethernet
+	jmpv LABEL_END h.ethernet
 	mov m.Ingress_tbl_ethernet_isValid 0
-	LABEL_0END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	LABEL_END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
 	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
@@ -138,18 +138,18 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tmp 1
-	jmpv LABEL_0END h.ethernet
+	jmpv LABEL_END h.ethernet
 	mov m.Ingress_tmp 0
-	LABEL_0END :	mov m.Ingress_tmp_0 1
-	jmpv LABEL_1END h.ipv4
+	LABEL_END :	mov m.Ingress_tmp_0 1
+	jmpv LABEL_END_0 h.ipv4
 	mov m.Ingress_tmp_0 0
-	LABEL_1END :	mov m.Ingress_key_0 m.Ingress_tmp
-	jmpeq LABEL_2TRUE m.Ingress_key_0 0x1
-	jmpeq LABEL_2TRUE m.Ingress_tmp_0 0x1
+	LABEL_END_0 :	mov m.Ingress_key_0 m.Ingress_tmp
+	jmpeq LABEL_TRUE m.Ingress_key_0 0x1
+	jmpeq LABEL_TRUE m.Ingress_tmp_0 0x1
 	mov m.Ingress_key_0 0x0
-	jmp LABEL_2END
-	LABEL_2TRUE :	mov m.Ingress_key_0 0x1
-	LABEL_2END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	jmp LABEL_END_1
+	LABEL_TRUE :	mov m.Ingress_key_0 0x1
+	LABEL_END_1 :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
 	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
@@ -140,27 +140,27 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tmp 1
-	jmpv LABEL_0END h.ethernet
+	jmpv LABEL_END h.ethernet
 	mov m.Ingress_tmp 0
-	LABEL_0END :	mov m.Ingress_tmp_0 1
-	jmpv LABEL_1END h.ipv4
+	LABEL_END :	mov m.Ingress_tmp_0 1
+	jmpv LABEL_END_0 h.ipv4
 	mov m.Ingress_tmp_0 0
-	LABEL_1END :	mov m.Ingress_tmp_1 m.Ingress_tmp
-	jmpeq LABEL_2FALSE m.Ingress_tmp_1 0x0
-	jmpeq LABEL_2FALSE m.Ingress_tmp_0 0x0
+	LABEL_END_0 :	mov m.Ingress_tmp_1 m.Ingress_tmp
+	jmpeq LABEL_FALSE m.Ingress_tmp_1 0x0
+	jmpeq LABEL_FALSE m.Ingress_tmp_0 0x0
 	mov m.Ingress_tmp_1 0x1
-	jmp LABEL_2END
-	LABEL_2FALSE :	mov m.Ingress_tmp_1 0x0
-	LABEL_2END :	mov m.Ingress_tmp_2 1
-	jmpv LABEL_3END h.tcp
+	jmp LABEL_END_1
+	LABEL_FALSE :	mov m.Ingress_tmp_1 0x0
+	LABEL_END_1 :	mov m.Ingress_tmp_2 1
+	jmpv LABEL_END_2 h.tcp
 	mov m.Ingress_tmp_2 0
-	LABEL_3END :	mov m.Ingress_key_0 m.Ingress_tmp_1
-	jmpeq LABEL_4TRUE m.Ingress_key_0 0x1
-	jmpeq LABEL_4TRUE m.Ingress_tmp_2 0x1
+	LABEL_END_2 :	mov m.Ingress_key_0 m.Ingress_tmp_1
+	jmpeq LABEL_TRUE_0 m.Ingress_key_0 0x1
+	jmpeq LABEL_TRUE_0 m.Ingress_tmp_2 0x1
 	mov m.Ingress_key_0 0x0
-	jmp LABEL_4END
-	LABEL_4TRUE :	mov m.Ingress_key_0 0x1
-	LABEL_4END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	jmp LABEL_END_3
+	LABEL_TRUE_0 :	mov m.Ingress_key_0 0x1
+	LABEL_END_3 :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
 	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
@@ -140,27 +140,27 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tmp 1
-	jmpv LABEL_0END h.ethernet
+	jmpv LABEL_END h.ethernet
 	mov m.Ingress_tmp 0
-	LABEL_0END :	mov m.Ingress_tmp_0 1
-	jmpv LABEL_1END h.ipv4
+	LABEL_END :	mov m.Ingress_tmp_0 1
+	jmpv LABEL_END_0 h.ipv4
 	mov m.Ingress_tmp_0 0
-	LABEL_1END :	mov m.Ingress_tmp_1 m.Ingress_tmp
-	jmpeq LABEL_2FALSE m.Ingress_tmp_1 0x0
-	jmpeq LABEL_2FALSE m.Ingress_tmp_0 0x0
+	LABEL_END_0 :	mov m.Ingress_tmp_1 m.Ingress_tmp
+	jmpeq LABEL_FALSE m.Ingress_tmp_1 0x0
+	jmpeq LABEL_FALSE m.Ingress_tmp_0 0x0
 	mov m.Ingress_tmp_1 0x1
-	jmp LABEL_2END
-	LABEL_2FALSE :	mov m.Ingress_tmp_1 0x0
-	LABEL_2END :	mov m.Ingress_tmp_2 1
-	jmpv LABEL_3END h.tcp
+	jmp LABEL_END_1
+	LABEL_FALSE :	mov m.Ingress_tmp_1 0x0
+	LABEL_END_1 :	mov m.Ingress_tmp_2 1
+	jmpv LABEL_END_2 h.tcp
 	mov m.Ingress_tmp_2 0
-	LABEL_3END :	mov m.Ingress_key_0 m.Ingress_tmp_1
-	jmpeq LABEL_4TRUE m.Ingress_key_0 0x1
-	jmpeq LABEL_4TRUE m.Ingress_tmp_2 0x1
+	LABEL_END_2 :	mov m.Ingress_key_0 m.Ingress_tmp_1
+	jmpeq LABEL_TRUE_0 m.Ingress_key_0 0x1
+	jmpeq LABEL_TRUE_0 m.Ingress_tmp_2 0x1
 	mov m.Ingress_key_0 0x0
-	jmp LABEL_4END
-	LABEL_4TRUE :	mov m.Ingress_key_0 0x1
-	LABEL_4END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	jmp LABEL_END_3
+	LABEL_TRUE_0 :	mov m.Ingress_key_0 0x1
+	LABEL_END_3 :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
 	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
@@ -137,13 +137,13 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tmp 1
-	jmpv LABEL_0END h.ethernet
+	jmpv LABEL_END h.ethernet
 	mov m.Ingress_tmp 0
-	LABEL_0END :	jmpeq LABEL_1TRUE m.Ingress_tmp 0x0
+	LABEL_END :	jmpeq LABEL_TRUE m.Ingress_tmp 0x0
 	mov m.Ingress_key_0 0x0
-	jmp LABEL_1END
-	LABEL_1TRUE :	mov m.Ingress_key_0 0x1
-	LABEL_1END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	jmp LABEL_END_0
+	LABEL_TRUE :	mov m.Ingress_key_0 0x1
+	LABEL_END_0 :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
 	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
@@ -139,22 +139,22 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_tmp 1
-	jmpv LABEL_0END h.ethernet
+	jmpv LABEL_END h.ethernet
 	mov m.Ingress_tmp 0
-	LABEL_0END :	jmpeq LABEL_1TRUE m.Ingress_tmp 0x0
+	LABEL_END :	jmpeq LABEL_TRUE m.Ingress_tmp 0x0
 	mov m.Ingress_tmp_0 0x0
-	jmp LABEL_1END
-	LABEL_1TRUE :	mov m.Ingress_tmp_0 0x1
-	LABEL_1END :	mov m.Ingress_tmp_1 1
-	jmpv LABEL_2END h.ipv4
+	jmp LABEL_END_0
+	LABEL_TRUE :	mov m.Ingress_tmp_0 0x1
+	LABEL_END_0 :	mov m.Ingress_tmp_1 1
+	jmpv LABEL_END_1 h.ipv4
 	mov m.Ingress_tmp_1 0
-	LABEL_2END :	mov m.Ingress_key_0 m.Ingress_tmp_0
-	jmpeq LABEL_3TRUE m.Ingress_key_0 0x1
-	jmpeq LABEL_3TRUE m.Ingress_tmp_1 0x1
+	LABEL_END_1 :	mov m.Ingress_key_0 m.Ingress_tmp_0
+	jmpeq LABEL_TRUE_0 m.Ingress_key_0 0x1
+	jmpeq LABEL_TRUE_0 m.Ingress_tmp_1 0x1
 	mov m.Ingress_key_0 0x0
-	jmp LABEL_3END
-	LABEL_3TRUE :	mov m.Ingress_key_0 0x1
-	LABEL_3END :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	jmp LABEL_END_2
+	LABEL_TRUE_0 :	mov m.Ingress_key_0 0x1
+	LABEL_END_2 :	mov m.Ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
 	mov m.Ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
@@ -60,34 +60,34 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	jmpneq LABEL_0FALSE h.ethernet.dstAddr 0x8
-	jmpeq LABEL_0FALSE m.psa_ingress_input_metadata_packet_path 0x6
+	jmpneq LABEL_FALSE h.ethernet.dstAddr 0x8
+	jmpeq LABEL_FALSE m.psa_ingress_input_metadata_packet_path 0x6
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
 	mov m.psa_ingress_output_metadata_egress_port 0xfffffffa
-	jmp LABEL_0END
-	LABEL_0FALSE :	mov m.psa_ingress_output_metadata_drop 0
+	jmp LABEL_END
+	LABEL_FALSE :	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
 	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet
-	jmpneq LABEL_1FALSE m.psa_egress_input_metadata_packet_path 0x4
+	jmpneq LABEL_FALSE_0 m.psa_egress_input_metadata_packet_path 0x4
 	mov h.ethernet.etherType 0xface
-	jmp LABEL_1END
-	LABEL_1FALSE :	mov m.psa_egress_output_metadata_clone 1
+	jmp LABEL_END_0
+	LABEL_FALSE_0 :	mov m.psa_egress_output_metadata_clone 1
 	mov m.psa_egress_output_metadata_clone_session_id 0x8
-	jmpneq LABEL_2END h.ethernet.dstAddr 0x9
+	jmpneq LABEL_END_1 h.ethernet.dstAddr 0x9
 	mov m.psa_egress_output_metadata_drop 1
 	mov m.psa_egress_output_metadata_clone_session_id 0x9
-	LABEL_2END :	jmpneq LABEL_3FALSE m.psa_egress_input_metadata_egress_port 0xfffffffa
+	LABEL_END_1 :	jmpneq LABEL_FALSE_2 m.psa_egress_input_metadata_egress_port 0xfffffffa
 	mov h.ethernet.srcAddr 0xbeef
 	mov m.psa_egress_output_metadata_clone_session_id 0xa
-	jmp LABEL_1END
-	LABEL_3FALSE :	jmpneq LABEL_4END h.ethernet.dstAddr 0x8
+	jmp LABEL_END_0
+	LABEL_FALSE_2 :	jmpneq LABEL_END_3 h.ethernet.dstAddr 0x8
 	mov m.psa_egress_output_metadata_clone_session_id 0xb
-	LABEL_4END :	mov h.ethernet.srcAddr 0xcafe
-	LABEL_1END :	emit h.ethernet
+	LABEL_END_3 :	mov h.ethernet.srcAddr 0xcafe
+	LABEL_END_0 :	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
@@ -104,11 +104,11 @@ action NoAction args none {
 
 action execute args instanceof execute_arg_t {
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in_0 m.Ingress_color_out_0
-	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x0
+	jmpneq LABEL_FALSE_0 m.Ingress_color_out_0 0x0
 	mov m.Ingress_tmp 0x1
-	jmp LABEL_1END
-	LABEL_1FALSE :	mov m.Ingress_tmp 0x0
-	LABEL_1END :	mov m.local_metadata_port_out m.Ingress_tmp
+	jmp LABEL_END_0
+	LABEL_FALSE_0 :	mov m.Ingress_tmp 0x0
+	LABEL_END_0 :	mov m.local_metadata_port_out m.Ingress_tmp
 	regwr reg_0 t.index m.local_metadata_port_out
 	return
 }
@@ -134,14 +134,14 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in_0 0x2
-	jmpneq LABEL_0END m.local_metadata_port_out 0x1
+	jmpneq LABEL_END m.local_metadata_port_out 0x1
 	table tbl
 	regadd counter0_0_packets 0x3ff 1
 	regadd counter0_0_bytes 0x3ff 0x14
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3ff 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
@@ -92,11 +92,11 @@ action NoAction args none {
 action execute args instanceof execute_arg_t {
 	mov m.Ingress_tmp_0 h.ipv4.totalLen
 	meter meter0_0 t.index m.Ingress_tmp_0 m.Ingress_color_in_0 m.Ingress_color_out_0
-	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x0
+	jmpneq LABEL_FALSE_0 m.Ingress_color_out_0 0x0
 	mov m.Ingress_tmp 0x1
-	jmp LABEL_1END
-	LABEL_1FALSE :	mov m.Ingress_tmp 0x0
-	LABEL_1END :	mov m.local_metadata_port_out m.Ingress_tmp
+	jmp LABEL_END_0
+	LABEL_FALSE_0 :	mov m.Ingress_tmp 0x0
+	LABEL_END_0 :	mov m.local_metadata_port_out m.Ingress_tmp
 	return
 }
 
@@ -121,9 +121,9 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in_0 0x2
-	jmpneq LABEL_0END m.local_metadata_port_out 0x1
+	jmpneq LABEL_END m.local_metadata_port_out 0x1
 	table tbl
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
@@ -90,11 +90,11 @@ action NoAction args none {
 
 action execute args instanceof execute_arg_t {
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in_0 m.Ingress_color_out_0
-	jmpneq LABEL_1FALSE m.Ingress_color_out_0 0x0
+	jmpneq LABEL_FALSE_0 m.Ingress_color_out_0 0x0
 	mov m.Ingress_tmp 0x1
-	jmp LABEL_1END
-	LABEL_1FALSE :	mov m.Ingress_tmp 0x0
-	LABEL_1END :	mov m.local_metadata_port_out m.Ingress_tmp
+	jmp LABEL_END_0
+	LABEL_FALSE_0 :	mov m.Ingress_tmp 0x0
+	LABEL_END_0 :	mov m.local_metadata_port_out m.Ingress_tmp
 	return
 }
 
@@ -119,9 +119,9 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in_0 0x2
-	jmpneq LABEL_0END m.local_metadata_port_out 0x1
+	jmpneq LABEL_END m.local_metadata_port_out 0x1
 	table tbl
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
@@ -141,9 +141,9 @@ apply {
 	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ipv4.protocol 0x6
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
-	INGRESSPARSERIMPL_ACCEPT :	jmpnv LABEL_0END h.ipv4
+	INGRESSPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
 	table route
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp

--- a/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
@@ -95,10 +95,10 @@ apply {
 	jmpeq MYIP_PARSE_VLAN_TAG2 h.vlan_tag_1.ether_type 0x8100
 	jmp MYIP_ACCEPT
 	MYIP_PARSE_VLAN_TAG2 :	mov m.psa_ingress_input_metadata_parser_error 0x3
-	MYIP_ACCEPT :	jmpnv LABEL_1FALSE h.ethernet
-	jmp LABEL_1END
-	LABEL_1FALSE :	table tbl
-	LABEL_1END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	MYIP_ACCEPT :	jmpnv LABEL_FALSE h.ethernet
+	jmp LABEL_END_0
+	LABEL_FALSE :	table tbl
+	LABEL_END_0 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.vlan_tag_0
 	emit h.vlan_tag_1

--- a/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
@@ -62,19 +62,19 @@ apply {
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_clone 1
 	mov m.psa_ingress_output_metadata_clone_session_id 0x8
-	jmpneq LABEL_0FALSE h.ethernet.dstAddr 0x9
+	jmpneq LABEL_FALSE h.ethernet.dstAddr 0x9
 	mov m.psa_ingress_output_metadata_drop 1
-	jmp LABEL_0END
-	LABEL_0FALSE :	mov h.ethernet.srcAddr 0xcafe
+	jmp LABEL_END
+	LABEL_FALSE :	mov h.ethernet.srcAddr 0xcafe
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
 	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet
-	jmpneq LABEL_1END m.psa_egress_input_metadata_packet_path 0x3
+	jmpneq LABEL_END_0 m.psa_egress_input_metadata_packet_path 0x3
 	mov h.ethernet.etherType 0xface
-	LABEL_1END :	emit h.ethernet
+	LABEL_END_0 :	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-isvalid.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-isvalid.p4.spec
@@ -76,10 +76,10 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	jmpnv LABEL_0FALSE h.ethernet
-	jmp LABEL_0END
-	LABEL_0FALSE :	table tbl
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	jmpnv LABEL_FALSE h.ethernet
+	jmp LABEL_END
+	LABEL_FALSE :	table tbl
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
@@ -85,27 +85,27 @@ apply {
 	mov m.Egress_tmp_0 m.psa_egress_input_metadata_instance
 	mov h.output_data.word1 m.Egress_tmp_0
 	mov h.output_data.word2 0x8
-	jmpneq LABEL_0FALSE m.psa_egress_input_metadata_packet_path 0x0
+	jmpneq LABEL_FALSE m.psa_egress_input_metadata_packet_path 0x0
 	mov h.output_data.word2 0x1
-	jmp LABEL_0END
-	LABEL_0FALSE :	jmpneq LABEL_1FALSE m.psa_egress_input_metadata_packet_path 0x1
+	jmp LABEL_END
+	LABEL_FALSE :	jmpneq LABEL_FALSE_0 m.psa_egress_input_metadata_packet_path 0x1
 	mov h.output_data.word2 0x2
-	jmp LABEL_0END
-	LABEL_1FALSE :	jmpneq LABEL_2FALSE m.psa_egress_input_metadata_packet_path 0x2
+	jmp LABEL_END
+	LABEL_FALSE_0 :	jmpneq LABEL_FALSE_1 m.psa_egress_input_metadata_packet_path 0x2
 	mov h.output_data.word2 0x3
-	jmp LABEL_0END
-	LABEL_2FALSE :	jmpneq LABEL_3FALSE m.psa_egress_input_metadata_packet_path 0x3
+	jmp LABEL_END
+	LABEL_FALSE_1 :	jmpneq LABEL_FALSE_2 m.psa_egress_input_metadata_packet_path 0x3
 	mov h.output_data.word2 0x4
-	jmp LABEL_0END
-	LABEL_3FALSE :	jmpneq LABEL_4FALSE m.psa_egress_input_metadata_packet_path 0x4
+	jmp LABEL_END
+	LABEL_FALSE_2 :	jmpneq LABEL_FALSE_3 m.psa_egress_input_metadata_packet_path 0x4
 	mov h.output_data.word2 0x5
-	jmp LABEL_0END
-	LABEL_4FALSE :	jmpneq LABEL_5FALSE m.psa_egress_input_metadata_packet_path 0x5
+	jmp LABEL_END
+	LABEL_FALSE_3 :	jmpneq LABEL_FALSE_4 m.psa_egress_input_metadata_packet_path 0x5
 	mov h.output_data.word2 0x6
-	jmp LABEL_0END
-	LABEL_5FALSE :	jmpneq LABEL_0END m.psa_egress_input_metadata_packet_path 0x6
+	jmp LABEL_END
+	LABEL_FALSE_4 :	jmpneq LABEL_END m.psa_egress_input_metadata_packet_path 0x6
 	mov h.output_data.word2 0x7
-	LABEL_0END :	mov m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
+	LABEL_END :	mov m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
 	mov h.output_data.word3 m.Egress_tmp_1
 	emit h.ethernet
 	emit h.output_data

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
@@ -82,11 +82,11 @@ apply {
 	add m.Ingress_tmp_3 m.Ingress_tmp_2
 	mov m.Ingress_tmp_4 m.Ingress_tmp_3
 	add m.Ingress_tmp_4 0xfffffffffffb
-	jmpneq LABEL_0END m.Ingress_tmp_4 0x2
+	jmpneq LABEL_END m.Ingress_tmp_4 0x2
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
 	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
@@ -70,9 +70,9 @@ apply {
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
 	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	regrd m.Ingress_tmp regfile_0 0x1
-	jmpneq LABEL_0END m.Ingress_tmp 0x0
+	jmpneq LABEL_END m.Ingress_tmp 0x0
 	mov m.psa_ingress_output_metadata_drop 1
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
@@ -70,36 +70,36 @@ apply {
 	extract h.ethernet
 	extract h.output_data
 	mov m.psa_ingress_output_metadata_drop 0
-	jmpeq LABEL_0FALSE m.psa_ingress_input_metadata_packet_path 0x5
+	jmpeq LABEL_FALSE m.psa_ingress_input_metadata_packet_path 0x5
 	mov h.ethernet.srcAddr 0x100
 	mov m.psa_ingress_output_metadata_resubmit 1
-	jmp LABEL_0END
-	LABEL_0FALSE :	mov h.ethernet.etherType 0xf00d
+	jmp LABEL_END
+	LABEL_FALSE :	mov h.ethernet.etherType 0xf00d
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
 	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	mov h.output_data.word0 0x8
-	jmpneq LABEL_1FALSE m.psa_ingress_input_metadata_packet_path 0x0
+	jmpneq LABEL_FALSE_0 m.psa_ingress_input_metadata_packet_path 0x0
 	mov h.output_data.word0 0x1
-	jmp LABEL_0END
-	LABEL_1FALSE :	jmpneq LABEL_2FALSE m.psa_ingress_input_metadata_packet_path 0x1
+	jmp LABEL_END
+	LABEL_FALSE_0 :	jmpneq LABEL_FALSE_1 m.psa_ingress_input_metadata_packet_path 0x1
 	mov h.output_data.word0 0x2
-	jmp LABEL_0END
-	LABEL_2FALSE :	jmpneq LABEL_3FALSE m.psa_ingress_input_metadata_packet_path 0x2
+	jmp LABEL_END
+	LABEL_FALSE_1 :	jmpneq LABEL_FALSE_2 m.psa_ingress_input_metadata_packet_path 0x2
 	mov h.output_data.word0 0x3
-	jmp LABEL_0END
-	LABEL_3FALSE :	jmpneq LABEL_4FALSE m.psa_ingress_input_metadata_packet_path 0x3
+	jmp LABEL_END
+	LABEL_FALSE_2 :	jmpneq LABEL_FALSE_3 m.psa_ingress_input_metadata_packet_path 0x3
 	mov h.output_data.word0 0x4
-	jmp LABEL_0END
-	LABEL_4FALSE :	jmpneq LABEL_5FALSE m.psa_ingress_input_metadata_packet_path 0x4
+	jmp LABEL_END
+	LABEL_FALSE_3 :	jmpneq LABEL_FALSE_4 m.psa_ingress_input_metadata_packet_path 0x4
 	mov h.output_data.word0 0x5
-	jmp LABEL_0END
-	LABEL_5FALSE :	jmpneq LABEL_6FALSE m.psa_ingress_input_metadata_packet_path 0x5
+	jmp LABEL_END
+	LABEL_FALSE_4 :	jmpneq LABEL_FALSE_5 m.psa_ingress_input_metadata_packet_path 0x5
 	mov h.output_data.word0 0x6
-	jmp LABEL_0END
-	LABEL_6FALSE :	jmpneq LABEL_0END m.psa_ingress_input_metadata_packet_path 0x6
+	jmp LABEL_END
+	LABEL_FALSE_5 :	jmpneq LABEL_END m.psa_ingress_input_metadata_packet_path 0x6
 	mov h.output_data.word0 0x7
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.spec
@@ -83,20 +83,20 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	table tbl
-	jmpnh LABEL_0END
+	jmpnh LABEL_END
 	invalidate h.ethernet
-	LABEL_0END :	table tbl
-	jmpnh LABEL_1FALSE
-	jmp LABEL_1END
-	LABEL_1FALSE :	validate h.ethernet
-	LABEL_1END :	table tbl
-	jmpnh LABEL_2FALSE
-	jmp LABEL_2END
-	LABEL_2FALSE :	validate h.ethernet
-	LABEL_2END :	table tbl
-	jmpnh LABEL_3END
+	LABEL_END :	table tbl
+	jmpnh LABEL_FALSE_0
+	jmp LABEL_END_0
+	LABEL_FALSE_0 :	validate h.ethernet
+	LABEL_END_0 :	table tbl
+	jmpnh LABEL_FALSE_1
+	jmp LABEL_END_1
+	LABEL_FALSE_1 :	validate h.ethernet
+	LABEL_END_1 :	table tbl
+	jmpnh LABEL_END_2
 	invalidate h.ethernet
-	LABEL_3END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END_2 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
@@ -75,9 +75,9 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
 	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
-	jmpneq LABEL_0END h.ethernet.dstAddr 0x0
+	jmpneq LABEL_END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
-	LABEL_0END :	mov m.Ingress_tmp h.ethernet.srcAddr
+	LABEL_END :	mov m.Ingress_tmp h.ethernet.srcAddr
 	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
@@ -88,27 +88,27 @@ apply {
 	mov m.Egress_tmp_0 m.psa_egress_input_metadata_instance
 	mov h.output_data.word1 m.Egress_tmp_0
 	mov h.output_data.word2 0x8
-	jmpneq LABEL_1FALSE m.psa_egress_input_metadata_packet_path 0x0
+	jmpneq LABEL_FALSE_0 m.psa_egress_input_metadata_packet_path 0x0
 	mov h.output_data.word2 0x1
-	jmp LABEL_1END
-	LABEL_1FALSE :	jmpneq LABEL_2FALSE m.psa_egress_input_metadata_packet_path 0x1
+	jmp LABEL_END_0
+	LABEL_FALSE_0 :	jmpneq LABEL_FALSE_1 m.psa_egress_input_metadata_packet_path 0x1
 	mov h.output_data.word2 0x2
-	jmp LABEL_1END
-	LABEL_2FALSE :	jmpneq LABEL_3FALSE m.psa_egress_input_metadata_packet_path 0x2
+	jmp LABEL_END_0
+	LABEL_FALSE_1 :	jmpneq LABEL_FALSE_2 m.psa_egress_input_metadata_packet_path 0x2
 	mov h.output_data.word2 0x3
-	jmp LABEL_1END
-	LABEL_3FALSE :	jmpneq LABEL_4FALSE m.psa_egress_input_metadata_packet_path 0x3
+	jmp LABEL_END_0
+	LABEL_FALSE_2 :	jmpneq LABEL_FALSE_3 m.psa_egress_input_metadata_packet_path 0x3
 	mov h.output_data.word2 0x4
-	jmp LABEL_1END
-	LABEL_4FALSE :	jmpneq LABEL_5FALSE m.psa_egress_input_metadata_packet_path 0x4
+	jmp LABEL_END_0
+	LABEL_FALSE_3 :	jmpneq LABEL_FALSE_4 m.psa_egress_input_metadata_packet_path 0x4
 	mov h.output_data.word2 0x5
-	jmp LABEL_1END
-	LABEL_5FALSE :	jmpneq LABEL_6FALSE m.psa_egress_input_metadata_packet_path 0x5
+	jmp LABEL_END_0
+	LABEL_FALSE_4 :	jmpneq LABEL_FALSE_5 m.psa_egress_input_metadata_packet_path 0x5
 	mov h.output_data.word2 0x6
-	jmp LABEL_1END
-	LABEL_6FALSE :	jmpneq LABEL_1END m.psa_egress_input_metadata_packet_path 0x6
+	jmp LABEL_END_0
+	LABEL_FALSE_5 :	jmpneq LABEL_END_0 m.psa_egress_input_metadata_packet_path 0x6
 	mov h.output_data.word2 0x7
-	LABEL_1END :	mov m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
+	LABEL_END_0 :	mov m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
 	mov h.output_data.word3 m.Egress_tmp_1
 	emit h.ethernet
 	emit h.output_data

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
@@ -63,9 +63,9 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
 	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
-	jmpneq LABEL_0END h.ethernet.dstAddr 0x0
+	jmpneq LABEL_END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
-	LABEL_0END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet
 	emit h.ethernet


### PR DESCRIPTION
This PR adds support for switch statement in p4c-dpdk

- This assumes that the EliminateSwitch pass is run and only expression in switch is of type tbl.apply().action.run
- Couple of tests started passing because of these changes. Adding reference outputs for these tests and updated the XFAIL list.
- Each case within switch is converted to **jmpa** instruction (jump on action run)
