### PR TITLE
Fix undefined behavior in GlobalCopyPropagation pass

### DIFF
--- a/midend/global_copyprop.cpp
+++ b/midend/global_copyprop.cpp
@@ -127,7 +127,10 @@ bool FindVariableValues::preorder(const IR::AssignmentStatement *stat) {
             return false;
         vars[lvalue_name(stat->left)] = lit;
         LOG5("  Setting value: " << lit << ", for: " << stat->left);
-    } else if (auto lit = vars[lvalue_name(stat->right)]->to<IR::Literal>()) {
+    } else if (auto v = vars[lvalue_name(stat->right)]) {
+        auto lit = v->to<IR::Literal>();
+        if (lit == nullptr)
+            return false;
         if (stat->left->is<IR::Slice>() || stat->right->is<IR::Slice>())
             return false;
         vars[lvalue_name(stat->left)] = lit;


### PR DESCRIPTION
The code was calling a method on a NULL pointer.
While this will work most of the time with most compilers, this is still
undefined behavior. As a result, when compiling with O3 the compiler may
assume that the method is never called with a NULL pointer to optimize
code.
In our case the compiler can assume that to<T> is not called on a NULL
pointer and therefore that dynamic_cast is not called with a NULL
pointer. This can lead to the NULL pointer check in dynamic_cast
([example](https://github.com/gcc-mirror/gcc/blob/29a1af24eface3620e348be9429e7c2e872accbc/libstdc%2B%2B-v3/libsupc%2B%2B/dyncast.cc#L50-L51))
being eliminated and we end up with a runtime crash.

Fixes #2944