### PR TITLE
Pragma fix

### DIFF
--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -729,7 +729,7 @@ class CheckIfMultiEntryPoint: public Inspector {
 class InsertCompilerGeneratedStartState: public Transform {
     ProgramStructure* structure;
     IR::Vector<IR::Node>               allTypeDecls;
-    IR::IndexedVector<IR::Declaration> varDecls;
+    IR::IndexedVector<IR::ParserState> parserStates;
     IR::Vector<IR::SelectCase>         selCases;
     cstring newStartState;
     cstring newInstanceType;
@@ -793,11 +793,11 @@ class InsertCompilerGeneratedStartState: public Transform {
         auto annos = new IR::Annotations();
         annos->add(new IR::Annotation(IR::Annotation::nameAnnotation, ".$start"));
         auto startState = new IR::ParserState(IR::ParserState::start, annos, selects);
-        varDecls.push_back(startState);
+        parserStates.push_back(startState);
 
-        if (!varDecls.empty()) {
-            parser->parserLocals.append(varDecls);
-            varDecls.clear();
+        if (!parserStates.empty()) {
+            parser->states.append(parserStates);
+            parserStates.clear();
         }
         return parser;
     }

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -109,6 +109,8 @@ class P4Parser : Type_Declaration, INestedNamespace, ISimpleNamespace, IApply, I
         parserLocals.check_null();
         states.check_null();
         checkDuplicates();
+        for (auto d : parserLocals)
+            BUG_CHECK(!d->is<ParserState>(), "%1%: state in locals", d);
     }
     toString { return cstring("parser ") + externalName(); }
 }

--- a/midend/global_copyprop.cpp
+++ b/midend/global_copyprop.cpp
@@ -51,7 +51,7 @@ void compareValuesInMaps(std::map<cstring, const IR::Expression*> *oldValues,
     for (auto it : *newValues) {
         auto oldValue = (*oldValues)[it.first];
         if (((it.second == nullptr) ^ (oldValue == nullptr)) ||
-                it.second && oldValue && !(it.second->equiv(*oldValue)))
+            (it.second && oldValue && !(it.second->equiv(*oldValue))))
             removeVarsContaining(oldValues, it.first);
     }
 }
@@ -78,11 +78,11 @@ void FindVariableValues::postorder(const IR::P4Control *ctrl) {
     working = false;
 }
 
-bool FindVariableValues::preorder(const IR::P4Action *act) {
+bool FindVariableValues::preorder(const IR::P4Action*) {
     return false;
 }
 
-bool FindVariableValues::preorder(const IR::P4Table *tab) {
+bool FindVariableValues::preorder(const IR::P4Table*) {
     return false;
 }
 

--- a/testdata/p4_14_samples_outputs/parser_pragma-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-first.p4
@@ -15,13 +15,6 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".$start") state start {
-        transition select((InstanceType_0)standard_metadata.instance_type) {
-            InstanceType_0.START: start_0;
-            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
-            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
-        }
-    }
     @name(".start") state start_0 {
         transition accept;
     }
@@ -30,6 +23,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
         transition accept;
+    }
+    @name(".$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_pragma-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-frontend.p4
@@ -15,13 +15,6 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".$start") state start {
-        transition select((InstanceType_0)standard_metadata.instance_type) {
-            InstanceType_0.START: start_0;
-            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
-            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
-        }
-    }
     @name(".start") state start_0 {
         transition accept;
     }
@@ -30,6 +23,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
         transition accept;
+    }
+    @name(".$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_pragma-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma-midend.p4
@@ -9,14 +9,6 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".$start") state start {
-        transition select((bit<32>)standard_metadata.instance_type) {
-            32w0: start_0;
-            32w1: start_e2e_mirrored;
-            32w2: start_i2e_mirrored;
-            default: noMatch;
-        }
-    }
     @name(".start") state start_0 {
         transition accept;
     }
@@ -25,6 +17,14 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
         transition accept;
+    }
+    @name(".$start") state start {
+        transition select((bit<32>)standard_metadata.instance_type) {
+            32w0: start_0;
+            32w1: start_e2e_mirrored;
+            32w2: start_i2e_mirrored;
+            default: noMatch;
+        }
     }
     state noMatch {
         verify(false, error.NoMatch);

--- a/testdata/p4_14_samples_outputs/parser_pragma.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma.p4
@@ -15,13 +15,6 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".$start") state start {
-        transition select((InstanceType_0)standard_metadata.instance_type) {
-            InstanceType_0.START: start_0;
-            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
-            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
-        }
-    }
     @name(".start") state start_0 {
         transition accept;
     }
@@ -30,6 +23,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
         transition accept;
+    }
+    @name(".$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_pragma2-first.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2-first.p4
@@ -15,13 +15,6 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".$start") state start {
-        transition select((InstanceType_0)standard_metadata.instance_type) {
-            InstanceType_0.START: start_0;
-            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
-            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
-        }
-    }
     @name(".Cowles") state Cowles {
         transition accept;
     }
@@ -36,6 +29,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
         transition accept;
+    }
+    @name(".$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_pragma2-frontend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2-frontend.p4
@@ -17,13 +17,6 @@ struct headers {
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("ParserImpl.tmp") bit<32> tmp;
     @name("ParserImpl.tmp_0") bit<32> tmp_0;
-    @name(".$start") state start {
-        transition select((InstanceType_0)standard_metadata.instance_type) {
-            InstanceType_0.START: start_0;
-            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
-            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
-        }
-    }
     @name(".Cowles") state Cowles {
         transition accept;
     }
@@ -40,6 +33,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
         transition accept;
+    }
+    @name(".$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
+        }
     }
 }
 

--- a/testdata/p4_14_samples_outputs/parser_pragma2-midend.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2-midend.p4
@@ -9,14 +9,6 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".$start") state start {
-        transition select((bit<32>)standard_metadata.instance_type) {
-            32w0: start_0;
-            32w1: start_e2e_mirrored;
-            32w2: start_i2e_mirrored;
-            default: noMatch;
-        }
-    }
     @name(".start") state start_0 {
         transition accept;
     }
@@ -26,6 +18,14 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
         transition accept;
+    }
+    @name(".$start") state start {
+        transition select((bit<32>)standard_metadata.instance_type) {
+            32w0: start_0;
+            32w1: start_e2e_mirrored;
+            32w2: start_i2e_mirrored;
+            default: noMatch;
+        }
     }
     state noMatch {
         verify(false, error.NoMatch);

--- a/testdata/p4_14_samples_outputs/parser_pragma2.p4
+++ b/testdata/p4_14_samples_outputs/parser_pragma2.p4
@@ -15,13 +15,6 @@ struct headers {
 }
 
 parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
-    @name(".$start") state start {
-        transition select((InstanceType_0)standard_metadata.instance_type) {
-            InstanceType_0.START: start_0;
-            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
-            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
-        }
-    }
     @name(".Cowles") state Cowles {
         transition accept;
     }
@@ -36,6 +29,13 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
         transition accept;
+    }
+    @name(".$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_e2e_mirrored: start_e2e_mirrored;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
+        }
     }
 }
 


### PR DESCRIPTION
A rarely used code path inside the p4-14 to p4-16 conversion was inserting parser states in the local variables instead of the states array. This is the real fix to the problem reported in #2942.
