### PR TITLE
Fix problems with OutOfBound state creation

### DIFF
--- a/midend/parserUnroll.h
+++ b/midend/parserUnroll.h
@@ -197,15 +197,22 @@ class RewriteAllParsers : public Transform {
         if (rewriter->hasOutOfboundState) {
             // generating state with verify(false, error.StackOutOfBounds)
             IR::Vector<IR::Argument>* arguments = new IR::Vector<IR::Argument>();
-            arguments->push_back(new IR::Argument(new IR::BoolLiteral(false)));
+            arguments->push_back(
+                new IR::Argument(new IR::BoolLiteral(IR::Type::Boolean::get(), false)));
             arguments->push_back(new IR::Argument(new IR::Member(
                 new IR::TypeNameExpression(new IR::Type_Name(IR::ID("error"))),
                     IR::ID("StackOutOfBounds"))));
             IR::IndexedVector<IR::StatOrDecl> components;
-            components.push_back(new IR::MethodCallStatement(
-                new IR::MethodCallExpression(new IR::PathExpression(IR::ID("verify")), arguments)));
-            auto* outOfBoundsState = new IR::ParserState(IR::ID(outOfBoundsStateName), components,
-                nullptr);
+            components.push_back(new IR::MethodCallStatement(new IR::MethodCallExpression(
+                IR::Type::Void::get(),
+                new IR::PathExpression(
+                    new IR::Type_Method(IR::Type::Void::get(), new IR::ParameterList(), "*method"),
+                    new IR::Path(IR::ID("verify"))),
+                arguments)));
+            auto* outOfBoundsState = new IR::ParserState(
+                IR::ID(outOfBoundsStateName), components,
+                new IR::PathExpression(new IR::Type_State(),
+                                       new IR::Path(IR::ParserState::reject, false)));
             newParser->states.push_back(outOfBoundsState);
         }
         for (auto& i : rewriter->current.result->states) {

--- a/midend/parserUnroll.h
+++ b/midend/parserUnroll.h
@@ -203,10 +203,16 @@ class RewriteAllParsers : public Transform {
                 new IR::TypeNameExpression(new IR::Type_Name(IR::ID("error"))),
                     IR::ID("StackOutOfBounds"))));
             IR::IndexedVector<IR::StatOrDecl> components;
+            IR::IndexedVector<IR::Parameter> parameters;
+            parameters.push_back(
+                new IR::Parameter(IR::ID("check"), IR::Direction::In, IR::Type::Boolean::get()));
+            parameters.push_back(new IR::Parameter(IR::ID("toSignal"), IR::Direction::In,
+                                                   new IR::Type_Name(IR::ID("error"))));
             components.push_back(new IR::MethodCallStatement(new IR::MethodCallExpression(
                 IR::Type::Void::get(),
                 new IR::PathExpression(
-                    new IR::Type_Method(IR::Type::Void::get(), new IR::ParameterList(), "*method"),
+                    new IR::Type_Method(IR::Type::Void::get(), new IR::ParameterList(parameters),
+                                        "*method"),
                     new IR::Path(IR::ID("verify"))),
                 arguments)));
             auto* outOfBoundsState = new IR::ParserState(

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-midend.p4
@@ -43,6 +43,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
     @name("MyParser.index") int<32> index_0;
     state stateOutOfBound {
         verify(false, error.StackOutOfBounds);
+        transition reject;
     }
     state parse_ipv4 {
         packet.extract<ipv4_t>(hdr.ipv4);

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test2-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test2-midend.p4
@@ -42,6 +42,7 @@ struct headers {
 parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state stateOutOfBound {
         verify(false, error.StackOutOfBounds);
+        transition reject;
     }
     state parse_ipv4 {
         packet.extract<ipv4_t>(hdr.ipv4);

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test3-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test3-midend.p4
@@ -43,6 +43,7 @@ struct headers {
 parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state stateOutOfBound {
         verify(false, error.StackOutOfBounds);
+        transition reject;
     }
     state callMidle {
         hdr.index = hdr.index + 32w1;


### PR DESCRIPTION
Example test: all of parserUnroll tests or issue692-bmv2.p4.
Solves problems related to incorrect generation of verify functions and creation of OutOfBound state