### PR TITLE
Compiler Bug : overwriting definitions in defuse (#2900)

### DIFF
--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -1038,6 +1038,24 @@ const IR::Node* CopyMatchKeysToSingleStruct::postorder(IR::KeyElement* element) 
     }
     return element;
 }
+const IR::Node* CopyMatchKeysToSingleStruct::doStatement(const IR::Statement* statement,
+                                           const IR::Expression *expression) {
+    LOG3("Visiting " << getOriginal());
+    P4::HasTableApply hta(refMap, typeMap);
+    hta.setCalledBy(this);
+    (void)expression->apply(hta);
+    if (hta.table == nullptr)
+        return statement;
+    auto insertions = get(toInsert, hta.table);
+    if (insertions == nullptr)
+        return statement;
+    auto result = new IR::IndexedVector<IR::StatOrDecl>();
+    for (auto assign : insertions->statements)
+        result->push_back(assign);
+    result->push_back(statement);
+    auto block = new IR::BlockStatement(*result);
+    return block;
+}
 
 namespace Helpers {
 

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -553,11 +553,13 @@ class CopyMatchKeysToSingleStruct : public P4::KeySideEffect {
  public:
     CopyMatchKeysToSingleStruct(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
              std::set<const IR::P4Table*>* invokedInKey)
-             : P4::KeySideEffect (refMap, typeMap, invokedInKey)
-    { setName("CopyMatchKeysToSingleStruct"); }
+             : P4::KeySideEffect(refMap, typeMap, invokedInKey)
+    { setName("CopyMatchKeysToSinSgleStruct"); }
 
     const IR::Node* preorder(IR::Key* key) override;
     const IR::Node* postorder(IR::KeyElement* element) override;
+    const IR::Node* doStatement(const IR::Statement* statement,
+                                const IR::Expression* expression) override;
 };
 
 /**

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -777,8 +777,10 @@ const IR::Node* KeySideEffect::doStatement(const IR::Statement* statement,
         return statement;
 
     auto result = new IR::IndexedVector<IR::StatOrDecl>();
-    for (auto assign : insertions->statements)
-        result->push_back(assign);
+    for (auto assign : insertions->statements){
+        auto cloneAssign = assign->clone();
+        result->push_back(cloneAssign);
+    }
     result->push_back(statement);
     auto block = new IR::BlockStatement(*result);
     return block;

--- a/frontends/p4/sideEffects.h
+++ b/frontends/p4/sideEffects.h
@@ -293,7 +293,8 @@ class KeySideEffect : public Transform {
                   std::set<const IR::P4Table*>* invokedInKey)
             : refMap(refMap), typeMap(typeMap), invokedInKey(invokedInKey)
     { CHECK_NULL(refMap); CHECK_NULL(typeMap); CHECK_NULL(invokedInKey); setName("KeySideEffect"); }
-    const IR::Node* doStatement(const IR::Statement* statement, const IR::Expression* expression);
+    virtual const IR::Node* doStatement(const IR::Statement* statement,
+                                        const IR::Expression* expression);
 
     const IR::Node* preorder(IR::Key* key) override;
 

--- a/testdata/p4_16_samples/issue2900.p4
+++ b/testdata/p4_16_samples/issue2900.p4
@@ -1,0 +1,89 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+    PortId_t dst_port;
+}
+
+bool RxPkt(in pna_main_input_metadata_t istd) {
+    return istd.direction == PNA_Direction_t.NET_TO_HOST;
+}
+bool TxPkt(in pna_main_input_metadata_t istd) {
+    return istd.direction == PNA_Direction_t.HOST_TO_NET;
+}
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    table clb_pinned_flows {
+        key = {
+            SelectByDirection(istd.direction, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr): exact @name("ipv4_addr_0") ;
+            SelectByDirection(istd.direction, hdr.ipv4.dstAddr, hdr.ipv4.srcAddr): exact @name("ipv4_addr_1") ;
+            hdr.ipv4.protocol                                                    : exact;
+        }
+        actions = {
+            NoAction;
+        }
+        const default_action = NoAction;
+    }
+    apply {
+        if (TxPkt(istd)) {
+            clb_pinned_flows.apply();
+        } else {
+            clb_pinned_flows.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2900-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2900-first.p4
@@ -1,0 +1,89 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+    PortId_t dst_port;
+}
+
+bool RxPkt(in pna_main_input_metadata_t istd) {
+    return istd.direction == PNA_Direction_t.NET_TO_HOST;
+}
+bool TxPkt(in pna_main_input_metadata_t istd) {
+    return istd.direction == PNA_Direction_t.HOST_TO_NET;
+}
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    table clb_pinned_flows {
+        key = {
+            SelectByDirection<bit<32>>(istd.direction, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr): exact @name("ipv4_addr_0") ;
+            SelectByDirection<bit<32>>(istd.direction, hdr.ipv4.dstAddr, hdr.ipv4.srcAddr): exact @name("ipv4_addr_1") ;
+            hdr.ipv4.protocol                                                             : exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            NoAction();
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        if (TxPkt(istd)) {
+            clb_pinned_flows.apply();
+        } else {
+            clb_pinned_flows.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2900-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2900-frontend.p4
@@ -1,0 +1,103 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+    PortId_t dst_port;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.key_0") bit<32> key_0;
+    @name("MainControlImpl.key_1") bit<32> key_1;
+    @name("MainControlImpl.key_2") bit<8> key_2;
+    @name("MainControlImpl.tmp") bool tmp;
+    @name("MainControlImpl.istd_0") pna_main_input_metadata_t istd_1;
+    @name("MainControlImpl.hasReturned") bool hasReturned;
+    @name("MainControlImpl.retval") bool retval;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.clb_pinned_flows") table clb_pinned_flows_0 {
+        key = {
+            key_0: exact @name("ipv4_addr_0") ;
+            key_1: exact @name("ipv4_addr_1") ;
+            key_2: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        istd_1 = istd;
+        hasReturned = false;
+        hasReturned = true;
+        retval = istd_1.direction == PNA_Direction_t.HOST_TO_NET;
+        tmp = retval;
+        if (tmp) {
+            key_0 = SelectByDirection<bit<32>>(istd.direction, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr);
+            key_1 = SelectByDirection<bit<32>>(istd.direction, hdr.ipv4.dstAddr, hdr.ipv4.srcAddr);
+            key_2 = hdr.ipv4.protocol;
+            clb_pinned_flows_0.apply();
+        } else {
+            key_0 = SelectByDirection<bit<32>>(istd.direction, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr);
+            key_1 = SelectByDirection<bit<32>>(istd.direction, hdr.ipv4.dstAddr, hdr.ipv4.srcAddr);
+            key_2 = hdr.ipv4.protocol;
+            clb_pinned_flows_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2900-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2900-midend.p4
@@ -1,0 +1,118 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+    PortId_t dst_port;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.key_0") bit<32> key_0;
+    @name("MainControlImpl.key_1") bit<32> key_1;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.clb_pinned_flows") table clb_pinned_flows_0 {
+        key = {
+            key_0            : exact @name("ipv4_addr_0") ;
+            key_1            : exact @name("ipv4_addr_1") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    @hidden action issue2900l63() {
+        key_0 = SelectByDirection<bit<32>>(istd.direction, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr);
+        key_1 = SelectByDirection<bit<32>>(istd.direction, hdr.ipv4.dstAddr, hdr.ipv4.srcAddr);
+    }
+    @hidden action issue2900l63_0() {
+        key_0 = SelectByDirection<bit<32>>(istd.direction, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr);
+        key_1 = SelectByDirection<bit<32>>(istd.direction, hdr.ipv4.dstAddr, hdr.ipv4.srcAddr);
+    }
+    @hidden table tbl_issue2900l63 {
+        actions = {
+            issue2900l63();
+        }
+        const default_action = issue2900l63();
+    }
+    @hidden table tbl_issue2900l63_0 {
+        actions = {
+            issue2900l63_0();
+        }
+        const default_action = issue2900l63_0();
+    }
+    apply {
+        if (istd.direction == PNA_Direction_t.HOST_TO_NET) {
+            tbl_issue2900l63.apply();
+            clb_pinned_flows_0.apply();
+        } else {
+            tbl_issue2900l63_0.apply();
+            clb_pinned_flows_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action issue2900l83() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_issue2900l83 {
+        actions = {
+            issue2900l83();
+        }
+        const default_action = issue2900l83();
+    }
+    apply {
+        tbl_issue2900l83.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2900.p4
+++ b/testdata/p4_16_samples_outputs/issue2900.p4
@@ -1,0 +1,89 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+    PortId_t dst_port;
+}
+
+bool RxPkt(in pna_main_input_metadata_t istd) {
+    return istd.direction == PNA_Direction_t.NET_TO_HOST;
+}
+bool TxPkt(in pna_main_input_metadata_t istd) {
+    return istd.direction == PNA_Direction_t.HOST_TO_NET;
+}
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    table clb_pinned_flows {
+        key = {
+            SelectByDirection(istd.direction, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr): exact @name("ipv4_addr_0") ;
+            SelectByDirection(istd.direction, hdr.ipv4.dstAddr, hdr.ipv4.srcAddr): exact @name("ipv4_addr_1") ;
+            hdr.ipv4.protocol                                                    : exact;
+        }
+        actions = {
+            NoAction;
+        }
+        const default_action = NoAction;
+    }
+    apply {
+        if (TxPkt(istd)) {
+            clb_pinned_flows.apply();
+        } else {
+            clb_pinned_flows.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+


### PR DESCRIPTION
Fixes #2900 

Bug in file def_use in method setDefinitionsAt class AllDefinitions
 In that method definition in map atPoint is overridden

This happens beacuse there is more than one AsssignStatement with the same id
Pass KeySideEffect is creating those AssignStatements (in method KeySideEffect::doStatement)
This method creates a BlockStatement and inserts AssignStatements from TableInsertions variable and then inserts that block before tbl.apply()

Bug is removed by cloning an AssignStatement before inserting it in a BlockStatement

Backend pass CopyMatchKeysToSingleStruct inherits KeySideEffect
Backend uses this pass to transform tables such that all the Match keys are part of the same header/metadata struct
With cloning two test fail (psa-dpdk-table-key-consolidation-if*) in spec file
This happens because for every assignment DpdkMovStatement is created and inserted in instractions (pass ConvertStatementToDpdk)
There is no need for this new DpdkMovStatements because src is already in dest (it is done the first time we call tbl.apply)

This is fixed by setting SideEffect::doStatement to be virtual and  overriding it in class CopyMatchKeysToSingleStruct
In this override there is no cloning
