### PR TITLE
GlobalCopyPropagation is too agressive in switch statements (#2956)

### DIFF
--- a/midend/global_copyprop.cpp
+++ b/midend/global_copyprop.cpp
@@ -111,6 +111,23 @@ bool FindVariableValues::preorder(const IR::IfStatement *stat) {
     return false;
 }
 
+// Switch statement is equivalent to a series of If stataments
+// That's why implementation for visiting SwitchStatement is the same as for visiting IfStatement
+bool FindVariableValues::preorder(const IR::SwitchStatement *stat) {
+    std::map<cstring, const IR::Expression*> copyOfVars(vars);
+    for (auto caseStatement : stat->cases) {
+        LOG3("Working on case: " << caseStatement->label->toString()
+            << " block: " << caseStatement->statement);
+        visit(caseStatement->statement);
+        compareValuesInMaps(&copyOfVars, &vars);
+        vars = copyOfVars;
+        LOG3("Finished case: " << caseStatement->label->toString()
+            << " block: " << caseStatement->statement);
+    }
+
+    return false;
+}
+
 // Update the value for the 'stat->left' variable.
 bool FindVariableValues::preorder(const IR::AssignmentStatement *stat) {
     if (!working || lvalue_name(stat->left).isNullOrEmpty())

--- a/midend/global_copyprop.h
+++ b/midend/global_copyprop.h
@@ -77,6 +77,7 @@ class FindVariableValues final : public Inspector {
   bool                                                                  working = false;
 
   bool preorder(const IR::IfStatement *) override;
+  bool preorder(const IR::SwitchStatement *) override;
   void postorder(const IR::P4Control *) override;
   bool preorder(const IR::P4Control *) override;
   bool preorder(const IR::P4Table *) override;

--- a/testdata/p4_16_samples/issue2956.p4
+++ b/testdata/p4_16_samples/issue2956.p4
@@ -1,0 +1,52 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    action simple_assign() {
+        h.eth_hdr.eth_type = 1;
+    }
+    table dummy_table {
+        key = {
+            h.eth_hdr.src_addr: exact @name("key") ;
+        }
+        actions = {
+            NoAction();
+            simple_assign();
+        }
+    }
+    apply {
+        switch (dummy_table.apply().action_run) {
+            simple_assign: {
+                simple_assign();
+            }
+            NoAction: {
+            }
+        }
+        simple_assign();
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2956-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2956-first.p4
@@ -1,0 +1,53 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    action simple_assign() {
+        h.eth_hdr.eth_type = 16w1;
+    }
+    table dummy_table {
+        key = {
+            h.eth_hdr.src_addr: exact @name("key") ;
+        }
+        actions = {
+            NoAction();
+            simple_assign();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        switch (dummy_table.apply().action_run) {
+            simple_assign: {
+                simple_assign();
+            }
+            NoAction: {
+            }
+        }
+        simple_assign();
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2956-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2956-frontend.p4
@@ -1,0 +1,58 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.simple_assign") action simple_assign() {
+        h.eth_hdr.eth_type = 16w1;
+    }
+    @name("ingress.simple_assign") action simple_assign_1() {
+        h.eth_hdr.eth_type = 16w1;
+    }
+    @name("ingress.simple_assign") action simple_assign_2() {
+        h.eth_hdr.eth_type = 16w1;
+    }
+    @name("ingress.dummy_table") table dummy_table_0 {
+        key = {
+            h.eth_hdr.src_addr: exact @name("key") ;
+        }
+        actions = {
+            NoAction_1();
+            simple_assign();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        switch (dummy_table_0.apply().action_run) {
+            simple_assign: {
+                simple_assign_1();
+            }
+            NoAction_1: {
+            }
+        }
+        simple_assign_2();
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2956-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2956-midend.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.simple_assign") action simple_assign() {
+        h.eth_hdr.eth_type = 16w1;
+    }
+    @name("ingress.simple_assign") action simple_assign_1() {
+        h.eth_hdr.eth_type = 16w1;
+    }
+    @name("ingress.simple_assign") action simple_assign_2() {
+        h.eth_hdr.eth_type = 16w1;
+    }
+    @name("ingress.dummy_table") table dummy_table_0 {
+        key = {
+            h.eth_hdr.src_addr: exact @name("key") ;
+        }
+        actions = {
+            NoAction_1();
+            simple_assign();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden table tbl_simple_assign {
+        actions = {
+            simple_assign_1();
+        }
+        const default_action = simple_assign_1();
+    }
+    @hidden table tbl_simple_assign_0 {
+        actions = {
+            simple_assign_2();
+        }
+        const default_action = simple_assign_2();
+    }
+    apply {
+        switch (dummy_table_0.apply().action_run) {
+            simple_assign: {
+                tbl_simple_assign.apply();
+            }
+            NoAction_1: {
+            }
+        }
+        tbl_simple_assign_0.apply();
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2956.p4
+++ b/testdata/p4_16_samples_outputs/issue2956.p4
@@ -1,0 +1,52 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+parser p(packet_in pkt, out Headers hdr) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    action simple_assign() {
+        h.eth_hdr.eth_type = 1;
+    }
+    table dummy_table {
+        key = {
+            h.eth_hdr.src_addr: exact @name("key") ;
+        }
+        actions = {
+            NoAction();
+            simple_assign();
+        }
+    }
+    apply {
+        switch (dummy_table.apply().action_run) {
+            simple_assign: {
+                simple_assign();
+            }
+            NoAction: {
+            }
+        }
+        simple_assign();
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+


### PR DESCRIPTION
Fixes issue #2956 
* Added preorder of switch statement for FindVariableValue pass
* There is no need for these in DoGlobalCopyPropagation because this pass operates on action bodies only and  switch statements aren't allowed within an action 