### PR TITLE
Handle nested headers correctly when flattening

### DIFF
--- a/midend/flattenHeaders.h
+++ b/midend/flattenHeaders.h
@@ -20,29 +20,9 @@ limitations under the License.
 
 #include "ir/ir.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
+#include "flattenInterfaceStructs.h"
 
 namespace P4 {
-
-/**
- * Policy to select which annotations of the nested struct to attach
- * to the struct fields after the nest struct is flattened.
- */
-class AnnotationSelectionPolicy {
- public:
-    virtual ~AnnotationSelectionPolicy() {}
-
-    /**
-     * Call for each nested struct to check if the annotation of the nested
-     * struct should be kept on its fields.
-     *
-     * @return
-     *  true if the annotation should be kept on the field.
-     *  false if the annotation should be discarded.
-     */
-    virtual bool keep(const IR::Annotation*) {
-        return false;
-    }
-};
 
 /**
 Find the types to replace and insert them in the nested struct map.
@@ -50,40 +30,7 @@ Find the types to replace and insert them in the nested struct map.
 class FindHeaderTypesToReplace : public Inspector {
     P4::TypeMap* typeMap;
     AnnotationSelectionPolicy *policy;
-
-    struct HeaderTypeReplacement : public IHasDbPrint {
-        HeaderTypeReplacement(const P4::TypeMap* typeMap, const IR::Type_Header* type,
-                AnnotationSelectionPolicy *policy);
-        const P4::TypeMap *typeMap;
-
-        // Maps nested field names to final field names.
-        // In our example this could be:
-        // .t.s.a -> _t_s_a0;
-        // .t.s.b -> _t_s_b1;
-        // .t.y -> _t_y2;
-        // .x -> _x3;
-        std::map<cstring, cstring> fieldNameRemap;
-        // Holds a new flat type
-        // struct M {
-        //    bit _t_s_a0;
-        //    bool _t_s_b1;
-        //    bit<6> _t_y2;
-        //    bit<3> _x3;
-        // }
-        const IR::Type* replacementType;
-        virtual void dbprint(std::ostream& out) const {
-            out << replacementType;
-        }
-
-        // Helper for constructor
-        void flatten(cstring prefix,
-                     const IR::Type* type,
-                     const IR::Annotations* annos,
-                     IR::IndexedVector<IR::StructField> *fields,
-                     AnnotationSelectionPolicy *policy);
-    };
-
-    ordered_map<cstring, HeaderTypeReplacement*> replacement;
+    ordered_map<cstring, StructTypeReplacement<IR::Type_StructLike>*> replacement;
 
  public:
     explicit FindHeaderTypesToReplace(P4::TypeMap *typeMap,
@@ -94,13 +41,14 @@ class FindHeaderTypesToReplace : public Inspector {
     }
     bool preorder(const IR::Type_Header* type) override;
     void createReplacement(const IR::Type_Header* type, AnnotationSelectionPolicy *policy);
-    HeaderTypeReplacement* getReplacement(const cstring name) const {
+    StructTypeReplacement<IR::Type_StructLike>* getReplacement(const cstring name) const {
         return ::get(replacement, name); }
     bool empty() const { return replacement.empty(); }
 };
 
 /**
- * This pass flattens any nested struct inside a P4 header
+ * This pass flattens any nested struct inside a P4 header.
+   This pass will fail if a header with nested fields is used as a left-value.
 
  * Should be run before the flattenInterfaceStructs pass.
 
@@ -132,7 +80,7 @@ struct local_metadata_t {
   bitvec_hdr bvh1;
 };
 
-The flattened data structures are shown below.  
+The flattened data structures are shown below.
 
 struct alt_t {
     bit<1> valid;
@@ -168,9 +116,9 @@ struct local_metadata_t {
     bitvec_hdr _bvh09;
     bitvec_hdr _bvh110;
 }
-	
+
 */
-class ReplaceHeaders : public Transform {
+class ReplaceHeaders : public Transform, P4WriteContext {
     P4::TypeMap *typeMap;
     FindHeaderTypesToReplace* findHeaderTypesToReplace;
 

--- a/midend/flattenInterfaceStructs.h
+++ b/midend/flattenInterfaceStructs.h
@@ -23,6 +23,27 @@ limitations under the License.
 namespace P4 {
 
 /**
+ * Policy to select which annotations of the nested struct to attach
+ * to the struct fields after the nest struct is flattened.
+ */
+class AnnotationSelectionPolicy {
+ public:
+    virtual ~AnnotationSelectionPolicy() {}
+
+    /**
+     * Call for each nested struct to check if the annotation of the nested
+     * struct should be kept on its fields.
+     *
+     * @return
+     *  true if the annotation should be kept on the field.
+     *  false if the annotation should be discarded.
+     */
+    virtual bool keep(const IR::Annotation*) {
+        return true;
+    }
+};
+
+/**
 Describes how a nested struct type is replaced: the new type to
 replace it and how each field is renamed.  For example, consider
 the following:
@@ -42,8 +63,23 @@ struct M {
    bit<3> x;
 }
 */
+template<typename T>
+// T is the type of objects that will be replaced.  E.g., IR::Type_Struct
 struct StructTypeReplacement : public IHasDbPrint {
-    StructTypeReplacement(const P4::TypeMap* typeMap, const IR::Type_Struct* type);
+    StructTypeReplacement(const P4::TypeMap* typeMap, const IR::Type_StructLike* type,
+                          AnnotationSelectionPolicy *policy) {
+        auto vec = new IR::IndexedVector<IR::StructField>();
+        flatten(typeMap, "", type, type->annotations, vec, policy);
+        if (type->is<IR::Type_Struct>()) {
+            replacementType = new IR::Type_Struct(
+                type->srcInfo, type->name, IR::Annotations::empty, *vec);
+        } else if (type->is<IR::Type_Header>()) {
+            replacementType = new IR::Type_Header(
+                type->srcInfo, type->name, IR::Annotations::empty, *vec);
+        } else {
+            BUG("Unexpected type %1%", type);
+        }
+    }
 
     // Maps nested field names to final field names.
     // In our example this could be:
@@ -55,7 +91,7 @@ struct StructTypeReplacement : public IHasDbPrint {
     // Maps internal fields names to types.
     // .t -> T
     // .t.s -> S
-    std::map<cstring, const IR::Type_Struct*> structFieldMap;
+    std::map<cstring, const IR::Type_StructLike*> structFieldMap;
     // Holds a new flat type
     // struct M {
     //    bit _t_s_a0;
@@ -73,14 +109,62 @@ struct StructTypeReplacement : public IHasDbPrint {
                  cstring prefix,
                  const IR::Type* type,
                  const IR::Annotations* annotations,
-                 IR::IndexedVector<IR::StructField> *fields);
+                 IR::IndexedVector<IR::StructField> *fields,
+                 AnnotationSelectionPolicy* policy) {
+        // Drop name annotations
+        IR::Annotations::Filter f =
+                [](const IR::Annotation* a) { return a->name != IR::Annotation::nameAnnotation; };
+        annotations = annotations->where(f);
+        if (auto st = type->to<T>()) {
+            std::function<bool(const IR::Annotation *)> selector =
+                    [&policy](const IR::Annotation *annot) {
+                        if (!policy)
+                            return false;
+                        return policy->keep(annot);
+                    };
+            auto sannotations = st->annotations->where(selector);
+            structFieldMap.emplace(prefix, st);
+            for (auto f : st->fields) {
+                auto na = new IR::Annotations();
+                na->append(sannotations);
+                na->append(annotations);
+                na->append(f->annotations);
+                auto ft = typeMap->getType(f, true);
+                flatten(typeMap, prefix + "." + f->name, ft, na, fields, policy);
+            }
+            return;
+        }
+        cstring fieldName = prefix.replace(".", "_") +
+                cstring::to_cstring(fieldNameRemap.size());
+        fieldNameRemap.emplace(prefix, fieldName);
+        fields->push_back(new IR::StructField(IR::ID(fieldName), annotations, type->getP4Type()));
+        LOG3("Flatten: " << type << " | " << prefix);
+    }
 
     /// Returns a StructExpression suitable for
     /// initializing a struct for the fields that start with the
     /// given prefix.  For example, for prefix .t and root R this returns
     /// { .s = { .a = R._t_s_a0, .b = R._t_s_b1 }, .y = R._t_y2 }
     const IR::StructExpression* explode(
-        const IR::Expression* root, cstring prefix);
+        const IR::Expression* root, cstring prefix) {
+        auto vec = new IR::IndexedVector<IR::NamedExpression>();
+        auto fieldType = ::get(structFieldMap, prefix);
+        BUG_CHECK(fieldType, "No field for %1%", prefix);
+        for (auto f : fieldType->fields) {
+            cstring fieldName = prefix + "." + f->name.name;
+            auto newFieldname = ::get(fieldNameRemap, fieldName);
+            const IR::Expression* expr;
+            if (!newFieldname.isNullOrEmpty()) {
+                expr = new IR::Member(root, newFieldname);
+            } else {
+                expr = explode(root, fieldName);
+            }
+            vec->push_back(new IR::NamedExpression(f->name, expr));
+        }
+        auto type = fieldType->getP4Type()->to<IR::Type_Name>();
+        return new IR::StructExpression(
+            root->srcInfo, type, type, *vec);
+    }
 };
 
 /**
@@ -91,13 +175,13 @@ struct NestedStructMap {
     P4::ReferenceMap* refMap;
     P4::TypeMap* typeMap;
 
-    ordered_map<const IR::Type*, StructTypeReplacement*> replacement;
+    ordered_map<const IR::Type*, StructTypeReplacement<IR::Type_Struct>*> replacement;
 
     NestedStructMap(P4::ReferenceMap* refMap, P4::TypeMap* typeMap):
             refMap(refMap), typeMap(typeMap)
     { CHECK_NULL(refMap); CHECK_NULL(typeMap); }
     void createReplacement(const IR::Type_Struct* type);
-    StructTypeReplacement* getReplacement(const IR::Type* type) const
+    StructTypeReplacement<IR::Type_Struct>* getReplacement(const IR::Type* type) const
     { return ::get(replacement, type); }
     bool empty() const { return replacement.empty(); }
 };
@@ -160,7 +244,7 @@ top<TFlat>(c()) main;
  */
 class ReplaceStructs : public Transform, P4WriteContext {
     NestedStructMap* replacementMap;
-    std::map<const IR::Parameter*, StructTypeReplacement*> toReplace;
+    std::map<const IR::Parameter*, StructTypeReplacement<IR::Type_Struct>*> toReplace;
 
  public:
     explicit ReplaceStructs(NestedStructMap* sm): replacementMap(sm) {

--- a/midend/flattenInterfaceStructs.h
+++ b/midend/flattenInterfaceStructs.h
@@ -161,7 +161,7 @@ struct StructTypeReplacement : public IHasDbPrint {
             }
             vec->push_back(new IR::NamedExpression(f->name, expr));
         }
-        auto type = fieldType->getP4Type()->to<IR::Type_Name>();
+        auto type = fieldType->getP4Type()->template to<IR::Type_Name>();
         return new IR::StructExpression(
             root->srcInfo, type, type, *vec);
     }

--- a/testdata/p4_16_samples/issue2982.p4
+++ b/testdata/p4_16_samples/issue2982.p4
@@ -1,0 +1,25 @@
+control ComputeChecksum<H>(inout H hdr);
+
+extern void update_checksum_with_payload<T, O>(in T data, out O ck);
+
+struct flags {
+    bit<1>  cwr;
+}
+
+header tcp {
+    flags flags;
+    bit<16> checksum;
+}
+
+struct headers {
+    tcp tcp;
+}
+
+control computeChecksum(inout headers hdr) {
+    apply {
+        update_checksum_with_payload(hdr.tcp.flags, hdr.tcp.checksum);
+    }
+}
+
+package top(ComputeChecksum<headers> _c);
+top(computeChecksum()) main;

--- a/testdata/p4_16_samples_outputs/issue2982-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2982-first.p4
@@ -1,0 +1,24 @@
+control ComputeChecksum<H>(inout H hdr);
+extern void update_checksum_with_payload<T, O>(in T data, out O ck);
+struct flags {
+    bit<1> cwr;
+}
+
+header tcp {
+    flags   flags;
+    bit<16> checksum;
+}
+
+struct headers {
+    tcp tcp;
+}
+
+control computeChecksum(inout headers hdr) {
+    apply {
+        update_checksum_with_payload<flags, bit<16>>(hdr.tcp.flags, hdr.tcp.checksum);
+    }
+}
+
+package top(ComputeChecksum<headers> _c);
+top(computeChecksum()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2982-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2982-frontend.p4
@@ -1,0 +1,24 @@
+control ComputeChecksum<H>(inout H hdr);
+extern void update_checksum_with_payload<T, O>(in T data, out O ck);
+struct flags {
+    bit<1> cwr;
+}
+
+header tcp {
+    flags   flags;
+    bit<16> checksum;
+}
+
+struct headers {
+    tcp tcp;
+}
+
+control computeChecksum(inout headers hdr) {
+    apply {
+        update_checksum_with_payload<flags, bit<16>>(hdr.tcp.flags, hdr.tcp.checksum);
+    }
+}
+
+package top(ComputeChecksum<headers> _c);
+top(computeChecksum()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2982-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2982-midend.p4
@@ -1,0 +1,33 @@
+control ComputeChecksum<H>(inout H hdr);
+extern void update_checksum_with_payload<T, O>(in T data, out O ck);
+struct flags {
+    bit<1> cwr;
+}
+
+header tcp {
+    bit<1>  _flags_cwr0;
+    bit<16> _checksum1;
+}
+
+struct headers {
+    tcp tcp;
+}
+
+control computeChecksum(inout headers hdr) {
+    @hidden action issue2982l20() {
+        update_checksum_with_payload<flags, bit<16>>((flags){cwr = hdr.tcp._flags_cwr0}, hdr.tcp._checksum1);
+    }
+    @hidden table tbl_issue2982l20 {
+        actions = {
+            issue2982l20();
+        }
+        const default_action = issue2982l20();
+    }
+    apply {
+        tbl_issue2982l20.apply();
+    }
+}
+
+package top(ComputeChecksum<headers> _c);
+top(computeChecksum()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2982.p4
+++ b/testdata/p4_16_samples_outputs/issue2982.p4
@@ -1,0 +1,24 @@
+control ComputeChecksum<H>(inout H hdr);
+extern void update_checksum_with_payload<T, O>(in T data, out O ck);
+struct flags {
+    bit<1> cwr;
+}
+
+header tcp {
+    flags   flags;
+    bit<16> checksum;
+}
+
+struct headers {
+    tcp tcp;
+}
+
+control computeChecksum(inout headers hdr) {
+    apply {
+        update_checksum_with_payload(hdr.tcp.flags, hdr.tcp.checksum);
+    }
+}
+
+package top(ComputeChecksum<headers> _c);
+top(computeChecksum()) main;
+

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-first.p4
@@ -21,7 +21,7 @@ struct col_t {
 }
 
 struct local_metadata_t {
-    @field_list(0)
+    @field_list(0) 
     row_t      row0;
     row_t      row1;
     col_t      col;
@@ -107,3 +107,4 @@ control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local
 }
 
 V1Switch<parsed_packet_t, local_metadata_t>(parse(), verifyChecksum(), ingress(), egress(), compute_checksum(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-frontend.p4
@@ -21,7 +21,7 @@ struct col_t {
 }
 
 struct local_metadata_t {
-    @field_list(0)
+    @field_list(0) 
     row_t      row0;
     row_t      row1;
     col_t      col;
@@ -107,3 +107,4 @@ control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local
 }
 
 V1Switch<parsed_packet_t, local_metadata_t>(parse(), verifyChecksum(), ingress(), egress(), compute_checksum(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
@@ -24,17 +24,21 @@ struct col_t {
 }
 
 struct local_metadata_t {
-    @field_list(0)
+    @MNK_annotation("(test flatten)") @field_list(0) 
     bit<1>     _row0_alt0_valid0;
-    @field_list(0)
+    @MNK_annotation("(test flatten)") @field_list(0) 
     bit<7>     _row0_alt0_port1;
-    @field_list(0)
+    @MNK_annotation("(test flatten)") @field_list(0) 
     bit<1>     _row0_alt1_valid2;
-    @field_list(0)
+    @MNK_annotation("(test flatten)") @field_list(0) 
     bit<7>     _row0_alt1_port3;
+    @MNK_annotation("(test flatten)") 
     bit<1>     _row1_alt0_valid4;
+    @MNK_annotation("(test flatten)") 
     bit<7>     _row1_alt0_port5;
+    @MNK_annotation("(test flatten)") 
     bit<1>     _row1_alt1_valid6;
+    @MNK_annotation("(test flatten)") 
     bit<7>     _row1_alt1_port7;
     bitvec_hdr _col_bvh8;
     bitvec_hdr _bvh09;
@@ -140,3 +144,4 @@ control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local
 }
 
 V1Switch<parsed_packet_t, local_metadata_t>(parse(), verifyChecksum(), ingress(), egress(), compute_checksum(), deparser()) main;
+

--- a/testdata/p4_16_samples_outputs/issue383-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2.p4
@@ -21,7 +21,7 @@ struct col_t {
 }
 
 struct local_metadata_t {
-    @field_list(0)
+    @field_list(0) 
     row_t      row0;
     row_t      row1;
     col_t      col;
@@ -105,3 +105,4 @@ control compute_checksum(inout parsed_packet_t hdr, inout local_metadata_t local
 }
 
 V1Switch(parse(), verifyChecksum(), ingress(), egress(), compute_checksum(), deparser()) main;
+


### PR DESCRIPTION
Fixes #2982
There were essentially 2 copies of the class StructTypeReplacement with minor variations, used by two separate passes: flattenInterfaceStructs, and flattenHeaders. These two classes have been unified into a templated class that is reused by both passes. 