### PR TITLE
Use Status::ok() accessor

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -148,7 +148,7 @@ static bool writeJsonTo(const Message& message, std::ostream* destination) {
     options.add_whitespace = true;
 
     std::string output;
-    if (MessageToJsonString(message, &output, options) != Status::OK) {
+    if (!MessageToJsonString(message, &output, options).ok()) {
         ::error(ErrorType::ERR_IO,
                 "Failed to serialize protobuf message to JSON");
         return false;


### PR DESCRIPTION
Status::OK is dropped in later protobuf versions