### PR TITLE
FlattenInterfaceStruct: add type to a new member

### DIFF
--- a/midend/flattenInterfaceStructs.cpp
+++ b/midend/flattenInterfaceStructs.cpp
@@ -116,7 +116,7 @@ const IR::Node* ReplaceStructs::postorder(IR::Member* expression) {
         // replaced by the NestedStructs pass.)
         result = repl->explode(pe, prefix);
     } else {
-        result = new IR::Member(pe, newFieldName);
+        result = new IR::Member(expression->type, pe, newFieldName);
     }
     LOG3("Replacing " << expression << " with " << result);
     return result;

--- a/test/gtest/transforms.cpp
+++ b/test/gtest/transforms.cpp
@@ -63,7 +63,7 @@ class MidEndForFlatten : public PassManager {
             evaluator,
             new P4::MidEndLast()
         });
- 
+
         toplevel = evaluator->getToplevelBlock();
     }
     IR::ToplevelBlock* process(const IR::P4Program *&program) {
@@ -77,7 +77,8 @@ const IR::Expression* getKeyExpression(const IR::P4Program* program, const char*
     CHECK_NULL(controlName);
     CHECK_NULL(tableName);
     CHECK_NULL(fieldName);
-    const auto* control = program->getDeclsByName(controlName)->toVector()->at(0)->to<IR::P4Control>();
+    const auto* control =
+        program->getDeclsByName(controlName)->toVector()->at(0)->to<IR::P4Control>();
     const auto* table = control->getDeclByName(tableName)->to<IR::P4Table>();
     for (auto key : table->getKey()->keyElements) {
         std::ostringstream output;

--- a/test/gtest/transforms.cpp
+++ b/test/gtest/transforms.cpp
@@ -20,6 +20,9 @@ limitations under the License.
 #include "ir/visitor.h"
 #include "lib/source_file.h"
 
+#include "frontends/common/options.h"
+#include "frontends/p4/createBuiltins.h"
+
 namespace Test {
 
 class P4C_IR : public P4CTest { };
@@ -41,6 +44,73 @@ TEST_F(P4C_IR, Transform) {
     IR::Expression* e = new IR::Add(Util::SourceInfo(), c, c);
     auto* n = e->apply(TestTrans(c));
     EXPECT_EQ(e, n);
+}
+
+class MidEndForFlatten : public PassManager {
+ public:
+    P4::ReferenceMap    refMap;
+    P4::TypeMap         typeMap;
+    IR::ToplevelBlock   *toplevel = nullptr;
+
+    explicit MidEndForFlatten(CompilerOptions options) {
+        bool isv1 = options.langVersion == CompilerOptions::FrontendVersion::P4_14;
+        refMap.setIsV1(isv1);
+        auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
+        setName("MidEndForFlatten");
+
+        addPasses({
+            new P4::FlattenInterfaceStructs(&refMap, &typeMap),
+            evaluator,
+            new P4::MidEndLast()
+        });
+ 
+        toplevel = evaluator->getToplevelBlock();
+    }
+    IR::ToplevelBlock* process(const IR::P4Program *&program) {
+        program = program->apply(*this);
+        return toplevel; }
+};
+
+const IR::Expression* getKeyExpression(const IR::P4Program* program, const char* controlName,
+                                       const char* tableName, const char* fieldName) {
+    CHECK_NULL(program);
+    CHECK_NULL(controlName);
+    CHECK_NULL(tableName);
+    CHECK_NULL(fieldName);
+    const auto* control = program->getDeclsByName(controlName)->toVector()->at(0)->to<IR::P4Control>();
+    const auto* table = control->getDeclByName(tableName)->to<IR::P4Table>();
+    for (auto key : table->getKey()->keyElements) {
+        std::ostringstream output;
+        key->expression->dbprint(output);
+        if (output.str().find(fieldName) != std::string::npos) {
+            return key->expression;
+        }
+    }
+    return nullptr;
+}
+
+TEST_F(P4C_IR, FlattenInterface) {
+    AutoCompileContext autoP4TestContext(new P4CContextWithOptions<P4TestOptions>);
+    auto& options = P4TestContext::get().options();
+    const char* argv = "./gtestp4c";
+    options.process(1, (char* const*)&argv);
+    options.langVersion = CompilerOptions::FrontendVersion::P4_16;
+    const IR::P4Program* load_model(const char* curFile, CompilerOptions& options);
+    const IR::P4Program* program = load_model("issue983-bmv2.p4", options);
+    P4::FrontEnd frontend;
+    program = frontend.run(options, program);
+    CHECK_NULL(program);
+    MidEndForFlatten flattenMidend(options);
+    const auto* newProgram = program->apply(flattenMidend);
+    const auto* oldKeyExpression =
+        getKeyExpression(program, "ingress", "debug_table_cksum1_0", "exp_etherType");
+    const auto* newKeyExpression =
+        getKeyExpression(newProgram, "ingress", "debug_table_cksum1_0", "exp_etherType");
+    CHECK_NULL(oldKeyExpression);
+    CHECK_NULL(newKeyExpression);
+    CHECK_NULL(oldKeyExpression->type);
+    CHECK_NULL(newKeyExpression->type);
+    ASSERT_TRUE(oldKeyExpression->type->equiv(*newKeyExpression->type));
 }
 
 }  // namespace Test


### PR DESCRIPTION
This small change sets corresponded type for a new member. Otherwise, [this](https://github.com/p4lang/p4c/blob/17edf85a8421df2d151c79440c94a354d17ae195/testdata/p4_16_samples/issue983-bmv2.p4#L70) key will have metadata type, but not bit<16>.