### PR TITLE
psa: Add missing new line in error message

### DIFF
--- a/backends/bmv2/psa_switch/psaSwitch.h
+++ b/backends/bmv2/psa_switch/psaSwitch.h
@@ -191,7 +191,7 @@ class ParsePsaArchitecture : public Inspector {
 
     void modelError(const char* format, const IR::INode* node) {
         ::error(ErrorType::ERR_MODEL,
-                (cstring(format) + "Are you using an up-to-date 'psa.p4'?").c_str(),
+                (cstring(format) + "\nAre you using an up-to-date 'psa.p4'?").c_str(),
                 node->getNode());
     }
 


### PR DESCRIPTION
This patch adds a missing new line between two error messages.

Before:
```
error: Package package PSA_Switch has no parameter named 'ingress'Are you using an up-to-date 'psa.p4'?
```

After:
```
error: Package package PSA_Switch has no parameter named 'ingress'
Are you using an up-to-date 'psa.p4'?
```