### PR TITLE
Fixed wrong warning for header union and header union stack

### DIFF
--- a/testdata/p4_16_samples/wrong-warning.p4
+++ b/testdata/p4_16_samples/wrong-warning.p4
@@ -1,0 +1,132 @@
+/*
+Copyright 2020 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct headers_t {
+    ethernet_t    ethernet;
+}
+
+header h1_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+header h2_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+header_union hu1_t {
+    h1_t h1;
+    h2_t h2;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet,
+                  out headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t stdmeta)
+{
+    state start {
+        packet.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control ingressImpl(inout headers_t hdr,
+                    inout metadata_t meta,
+                    inout standard_metadata_t stdmeta)
+{
+    h1_t h1;
+    h1_t h1b;
+    h2_t h2;
+    hu1_t hu1;
+    hu1_t hu1b;
+
+    h1_t[2] a1;
+    h1_t[2] a1b;
+    h2_t[2] a2;
+    hu1_t[2] au1;
+    hu1_t[2] au1b;
+
+    apply {
+        hu1b.h1 = {hdr.ethernet.dstAddr[45:38], hdr.ethernet.dstAddr[44:37]};
+        // hu1b is now completely initialized, but at least some
+        // versions of p4c give a warning below when hu1b is used on
+        // the right-hand side of an assignment.
+
+        // Including the following commented-out line eliminates the
+        // warning, so it appears that p4c is incorrectly issuing this
+        // warning because the warning-generation code has been
+        // written assuming that all members of the header union must
+        // be initialized, in order for the header union to be
+        // considered initialized.
+        //hu1b.h2 = {hdr.ethernet.dstAddr[45:38], hdr.ethernet.dstAddr[44:37]};
+
+        hu1 = hu1b;
+
+        // Same test case as above, but for stack with header_union
+        // elements.
+        au1b[0].h1 = {hdr.ethernet.dstAddr[37:30], hdr.ethernet.dstAddr[36:29]};
+        au1b[1].h2 = {hdr.ethernet.dstAddr[35:28], hdr.ethernet.dstAddr[34:27]};
+        
+        au1 = au1b;
+        
+        a1 = a1b;
+    }
+}
+
+control egressImpl(inout headers_t hdr,
+                   inout metadata_t meta,
+                   inout standard_metadata_t stdmeta)
+{
+    apply { }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control deparserImpl(packet_out packet,
+                     in headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+V1Switch(parserImpl(),
+         verifyChecksum(),
+         ingressImpl(),
+         egressImpl(),
+         updateChecksum(),
+         deparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings5.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings5.p4-stderr
@@ -13,9 +13,6 @@ invalid-hdr-warnings5.p4(51): [--Wwarn=invalid_header] warning: accessing a fiel
 invalid-hdr-warnings5.p4(52): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.u1.h3
         hdr.u1.h3.data = 1;
         ^^^^^^^^^
-invalid-hdr-warnings5.p4(67): [--Wwarn=uninitialized_use] warning: u1 may not be completely initialized
-        u2 = u1;
-             ^^
 invalid-hdr-warnings5.p4(68): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u2.h1
         u2.h1.data = 1;
         ^^^^^

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4-stderr
@@ -13,9 +13,6 @@ invalid-hdr-warnings6.p4(50): [--Wwarn=invalid_header] warning: accessing a fiel
 invalid-hdr-warnings6.p4(51): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.u[0].h3
         hdr.u[0].h3.data = 1;
         ^^^^^^^^^^^
-invalid-hdr-warnings6.p4(66): [--Wwarn=uninitialized_use] warning: u[i] may not be completely initialized
-        u[1] = u[i];
-               ^^^^
 invalid-hdr-warnings6.p4(74): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u[0].h1
         u[0].h1.data = 1; // u[0].h1 is invalid either if the then branch is executed (for any i) or not
         ^^^^^^^

--- a/testdata/p4_16_samples_outputs/wrong-warning-first.p4
+++ b/testdata/p4_16_samples_outputs/wrong-warning-first.p4
@@ -1,0 +1,84 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+header h1_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+header h2_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+header_union hu1_t {
+    h1_t h1;
+    h2_t h2;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    h1_t h1;
+    h1_t h1b;
+    h2_t h2;
+    hu1_t hu1;
+    hu1_t hu1b;
+    h1_t[2] a1;
+    h1_t[2] a1b;
+    h2_t[2] a2;
+    hu1_t[2] au1;
+    hu1_t[2] au1b;
+    apply {
+        hu1b.h1 = (h1_t){f1 = hdr.ethernet.dstAddr[45:38],f2 = hdr.ethernet.dstAddr[44:37]};
+        hu1 = hu1b;
+        au1b[0].h1 = (h1_t){f1 = hdr.ethernet.dstAddr[37:30],f2 = hdr.ethernet.dstAddr[36:29]};
+        au1b[1].h2 = (h2_t){f1 = hdr.ethernet.dstAddr[35:28],f2 = hdr.ethernet.dstAddr[34:27]};
+        au1 = au1b;
+        a1 = a1b;
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/wrong-warning-frontend.p4
+++ b/testdata/p4_16_samples_outputs/wrong-warning-frontend.p4
@@ -1,0 +1,90 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+header h1_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+header h2_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+header_union hu1_t {
+    h1_t h1;
+    h2_t h2;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @name("ingressImpl.hu1") hu1_t hu1_0;
+    @name("ingressImpl.hu1b") hu1_t hu1b_0;
+    @name("ingressImpl.a1") h1_t[2] a1_0;
+    @name("ingressImpl.a1b") h1_t[2] a1b_0;
+    @name("ingressImpl.au1") hu1_t[2] au1_0;
+    @name("ingressImpl.au1b") hu1_t[2] au1b_0;
+    apply {
+        hu1_0.h1.setInvalid();
+        hu1_0.h2.setInvalid();
+        hu1b_0.h1.setInvalid();
+        hu1b_0.h2.setInvalid();
+        a1_0[0].setInvalid();
+        a1_0[1].setInvalid();
+        a1b_0[0].setInvalid();
+        a1b_0[1].setInvalid();
+        au1_0[0].h1.setInvalid();
+        au1_0[0].h2.setInvalid();
+        au1_0[1].h1.setInvalid();
+        au1_0[1].h2.setInvalid();
+        au1b_0[0].h1.setInvalid();
+        au1b_0[0].h2.setInvalid();
+        au1b_0[1].h1.setInvalid();
+        au1b_0[1].h2.setInvalid();
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/wrong-warning-midend.p4
+++ b/testdata/p4_16_samples_outputs/wrong-warning-midend.p4
@@ -1,0 +1,99 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+header h1_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+header h2_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+header_union hu1_t {
+    h1_t h1;
+    h2_t h2;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @name("ingressImpl.hu1") hu1_t hu1_0;
+    @name("ingressImpl.hu1b") hu1_t hu1b_0;
+    @name("ingressImpl.a1") h1_t[2] a1_0;
+    @name("ingressImpl.a1b") h1_t[2] a1b_0;
+    @name("ingressImpl.au1") hu1_t[2] au1_0;
+    @name("ingressImpl.au1b") hu1_t[2] au1b_0;
+    @hidden action wrongwarning72() {
+        hu1_0.h1.setInvalid();
+        hu1_0.h2.setInvalid();
+        hu1b_0.h1.setInvalid();
+        hu1b_0.h2.setInvalid();
+        a1_0[0].setInvalid();
+        a1_0[1].setInvalid();
+        a1b_0[0].setInvalid();
+        a1b_0[1].setInvalid();
+        au1_0[0].h1.setInvalid();
+        au1_0[0].h2.setInvalid();
+        au1_0[1].h1.setInvalid();
+        au1_0[1].h2.setInvalid();
+        au1b_0[0].h1.setInvalid();
+        au1b_0[0].h2.setInvalid();
+        au1b_0[1].h1.setInvalid();
+        au1b_0[1].h2.setInvalid();
+    }
+    @hidden table tbl_wrongwarning72 {
+        actions = {
+            wrongwarning72();
+        }
+        const default_action = wrongwarning72();
+    }
+    apply {
+        tbl_wrongwarning72.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/wrong-warning.p4
+++ b/testdata/p4_16_samples_outputs/wrong-warning.p4
@@ -1,0 +1,84 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+header h1_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+header h2_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+header_union hu1_t {
+    h1_t h1;
+    h2_t h2;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    h1_t h1;
+    h1_t h1b;
+    h2_t h2;
+    hu1_t hu1;
+    hu1_t hu1b;
+    h1_t[2] a1;
+    h1_t[2] a1b;
+    h2_t[2] a2;
+    hu1_t[2] au1;
+    hu1_t[2] au1b;
+    apply {
+        hu1b.h1 = { hdr.ethernet.dstAddr[45:38], hdr.ethernet.dstAddr[44:37] };
+        hu1 = hu1b;
+        au1b[0].h1 = { hdr.ethernet.dstAddr[37:30], hdr.ethernet.dstAddr[36:29] };
+        au1b[1].h2 = { hdr.ethernet.dstAddr[35:28], hdr.ethernet.dstAddr[34:27] };
+        au1 = au1b;
+        a1 = a1b;
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+V1Switch(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/wrong-warning.p4-stderr
+++ b/testdata/p4_16_samples_outputs/wrong-warning.p4-stderr
@@ -1,0 +1,3 @@
+wrong-warning.p4(104): [--Wwarn=uninitialized_use] warning: a1b may not be completely initialized
+        a1 = a1b;
+             ^^^

--- a/testdata/p4_16_samples_outputs/wrong-warning.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/wrong-warning.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "v1model"
+}


### PR DESCRIPTION
Fixed wrong warning for header unions and header union stacks. (#2229)
There was a warning that a header union is not initialized if only one member of the union is initialized.
Unlike other StructLike types header unions are initialized when only one member of the union is initialized, so the warning was not correct.

Initialization checking in method FindUninitialized::registerUses() was looking at all members at the same time, and if one of them was uninitialized, it returned the warning. This is now modified so that if a header union is detected, it checks all members separately, and if at least one of them is initialized it doesn't return the warning. If it is a header union stack it does the same as above, but for each element of the stack.