### PR TITLE
SimplifyDefUse does not respect method calls in stack indices in parsers. Bug fixed (#2957)

### DIFF
--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -1286,6 +1286,16 @@ class FindUninitialized : public Inspector {
                 if (isControlOrParserApply || mi->is<ExternMethod>() || mi->is<ExternFunction>()) {
                     if (typeMap->getType(expr->expression, true)->is<IR::Type_Header>()) {
                         headerDefs->update(expr->expression, TernaryBool::Yes);
+                        if (expr->expression->is<IR::Member>()) {
+                            auto member = expr->expression->to<IR::Member>();
+                            if (member->member == IR::Type_Stack::next ||
+                                member->member == IR::Type_Stack::last){
+                                auto loc = headerDefs->getStorageLocation(member->expr);
+                                auto def = getCurrentDefinitions();
+                                auto points = def->getPoints(loc);
+                                hasUses->add(points);
+                            }
+                        }
                     } else {
                         auto locations = headerDefs->getStorageLocation(expr->expression);
                         for (auto storage : *locations) {

--- a/testdata/p4_16_samples/issue2957.p4
+++ b/testdata/p4_16_samples/issue2957.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    return (val < bound ? val : bound);
+}
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+extern bit<8> extern_call(inout H val);
+parser p(packet_in pkt, out Headers hdr) {
+    H tmp = { extern_call(hdr.h[max(3w1, 3w2)]) };
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h.next);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    apply {
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-frontend.p4
@@ -21,6 +21,8 @@ parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t
     }
     state init {
         pkt.extract<Header>(hdr.h1[1]);
+        hdr.h1[0].data = 32w1;
+        hdr.h1[1].data = 32w1;
         hdr.h1[0].setInvalid();
         pkt.extract<Header>(hdr.h1.next);
         hdr.h1[0].data = 32w1;

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-midend.p4
@@ -21,6 +21,8 @@ parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t
     }
     state init {
         pkt.extract<Header>(hdr.h1[1]);
+        hdr.h1[0].data = 32w1;
+        hdr.h1[1].data = 32w1;
         hdr.h1[0].setInvalid();
         pkt.extract<Header>(hdr.h1.next);
         hdr.h1[0].data = 32w1;

--- a/testdata/p4_16_samples_outputs/issue2957-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2957-first.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    return (val < bound ? val : bound);
+}
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+extern bit<8> extern_call(inout H val);
+parser p(packet_in pkt, out Headers hdr) {
+    H tmp = (H){a = extern_call(hdr.h[max(3w1, 3w2)])};
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h.next);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    apply {
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2957-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2957-frontend.p4
@@ -1,0 +1,63 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+extern bit<8> extern_call(inout H val);
+parser p(packet_in pkt, out Headers hdr) {
+    @name("p.tmp_2") bit<3> tmp;
+    @name("p.tmp_3") bit<3> tmp_2;
+    @name("p.tmp_4") H tmp_3;
+    @name("p.tmp_5") bit<8> tmp_4;
+    @name("p.val_0") bit<3> val_1;
+    @name("p.bound_0") bit<3> bound;
+    @name("p.hasReturned") bool hasReturned;
+    @name("p.retval") bit<3> retval;
+    @name("p.tmp") bit<3> tmp_5;
+    state start {
+        val_1 = 3w1;
+        bound = 3w2;
+        hasReturned = false;
+        if (val_1 < bound) {
+            tmp_5 = val_1;
+        } else {
+            tmp_5 = bound;
+        }
+        hasReturned = true;
+        retval = tmp_5;
+        tmp = retval;
+        tmp_2 = tmp;
+        tmp_3 = hdr.h[tmp_2];
+        tmp_4 = extern_call(tmp_3);
+        hdr.h[tmp_2] = tmp_3;
+        transition start_0;
+    }
+    state start_0 {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h.next);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    apply {
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2957-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2957-midend.p4
@@ -1,0 +1,40 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+extern bit<8> extern_call(inout H val);
+parser p(packet_in pkt, out Headers hdr) {
+    @name("p.tmp_4") H tmp_3;
+    state start {
+        tmp_3 = hdr.h[3w1];
+        extern_call(tmp_3);
+        hdr.h[3w1] = tmp_3;
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h.next);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    apply {
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2957.p4
+++ b/testdata/p4_16_samples_outputs/issue2957.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    return (val < bound ? val : bound);
+}
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+extern bit<8> extern_call(inout H val);
+parser p(packet_in pkt, out Headers hdr) {
+    H tmp = { extern_call(hdr.h[max(3w1, 3w2)]) };
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h.next);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    apply {
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2957.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2957.p4-stderr
@@ -1,0 +1,3 @@
+issue2957.p4(23): [--Wwarn=uninitialized_use] warning: hdr.h[tmp_3] may not be completely initialized
+    H tmp = {extern_call(hdr.h[max(3w1, 3w2)])};
+                         ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Bug fixed (#2957)

Bug occurs because  ComputeWriteSet pass, when visiting packet.extract(hdr.h.next), sets definition to whole stack that the packet.extract is the last to wrote there.

FindUninitialized pass after a BlockStatements saves ProgramPoints that last wrote to InOut/Out parameters in that block. (in issue2957.p4 after parser block, pass sees that the packet last wrote to stack and saves just that point, there is no information that it was partially written)

- Added fix when visiting MethodCallExpression. 
 Whenever parameter is a member with member name next, save ProgramPoints that wrote last to that location to hasUses  (because if it is a member with next there is now information which element of stack was written, so points that wrote before need to be saved)


- Added test for issue2957

- Changed output for invalid-hdr-warnings4 because there can be a case where assignments shouldn't be removed (like in issue2957) 
In invalid-hdr-warning4-frontend because of pkt.extract(hdr.h1.next) points that last changed hdr.h1 are saved. In this case lines 24 and 25 (hdr.h1[0].data = 32w1; hdr.h1[1].data = 32w1;)
This makes sense because with packet.extract we don't know which element was written, so we need to save both of these assignments.
And if we are keeping a point packet.extract(hdr.h1.next) there is a justification for keeping assignment statements  in line 24 and 25.