### PR TITLE
Binary operation with bit and int types

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -622,11 +622,7 @@ const IR::Node* DoConstantFolding::postorder(IR::Slice* e) {
     value = value & mask;
     const IR::Type_Bits *resultType;
     if (auto bitType = e->type->to<IR::Type_Bits>()) {
-      if (bitType->baseName() == "int") {
-        resultType = IR::Type_Bits::get(m - l + 1, true);
-      } else {
-        resultType = IR::Type_Bits::get(m - l + 1);
-      }
+      resultType = IR::Type_Bits::get(m - l + 1, bitType->baseName() == "int");
     }
     return new IR::Constant(e->srcInfo, resultType, value, cbase->base, true);
 }

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -621,8 +621,8 @@ const IR::Node* DoConstantFolding::postorder(IR::Slice* e) {
     mask = (mask << (m - l + 1)) - 1;
     value = value & mask;
     const IR::Type_Bits *resultType;
-    if (auto bitType = e->type->to<IR::Type_Bits>()) {
-      resultType = IR::Type_Bits::get(m - l + 1, bitType->baseName() == "int");
+    if (auto bitType = e->type->checkedTo<IR::Type_Bits>()) {
+      resultType = IR::Type_Bits::get(m - l + 1, bitType->isSigned);
     }
     return new IR::Constant(e->srcInfo, resultType, value, cbase->base, true);
 }

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -494,10 +494,16 @@ DoConstantFolding::binary(const IR::Operation_Binary* e,
     if (!lunk && !runk) {
         // both typed
         if (!ltb->operator==(*rtb)) {
+          if (ltb->baseName() == "bit" && rtb->baseName() == "int") {
+            if (ltb->size == rtb->size) {
+              resultType = ltb;
+            }
+          } else {
             ::error(ErrorType::ERR_INVALID,
-                    "%1%: operands have different types: %2% and %3%",
-                    e, ltb->toString(), rtb->toString());
+                    "%1%: operands have different types: %2% and %3%", e,
+                    ltb->toString(), rtb->toString());
             return e;
+          }
         }
         resultType = rtb;
     } else if (lunk && runk) {

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -318,4 +318,11 @@ TEST_F(P4CParserUnroll, header_union) {
     ASSERT_EQ(parsers.first->states.size(), parsers.second->states.size());
 }
 
+TEST_F(P4CParserUnroll, bitIntTypes) {
+  auto parsers = loadExample("runtime-index-bmv2.p4");
+  ASSERT_TRUE(parsers.first);
+  ASSERT_TRUE(parsers.second);
+  ASSERT_EQ(parsers.first->states.size(), parsers.second->states.size());
+}
+
 }  // namespace Test

--- a/testdata/p4_16_samples/int_type_in_slice.p4
+++ b/testdata/p4_16_samples/int_type_in_slice.p4
@@ -1,0 +1,57 @@
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {}
+
+parser p(packet_in pkt, out Headers h, inout Meta meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(h.eth_hdr);
+        transition parse_h;
+    }
+    state parse_h {
+        pkt.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta meta) {
+  apply { }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply {
+        if (8s1[3:0] == 4s1) {
+            h.h.a = 0;
+        }
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply { }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply { }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;


### PR DESCRIPTION
Helps to solve the error
```
[--Werror=invalid] error: ==: operands have different types: bit<8> and int<8>
        hdr.pool[hdr.ml.idx].val = hdr.vector[0].e;
                 ^^^^^^^^^^
```

`int `and `bit ` are the same and cast to `Type_Bits`. But `Type_Bits-> operator ==` will return `false ` in case of comparing `bit ` with `int`, due to the fact that they have different `baseName`

Example test: runtime-index-bmv2.p4
Add test for ParserUnroll Gtest?