### PR TITLE
dpdk: explictly discard upper bits when downcasting

### DIFF
--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
@@ -52,6 +52,7 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
+	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
 
@@ -79,7 +80,9 @@ apply {
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
@@ -51,6 +51,7 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
+	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
 
@@ -68,7 +69,9 @@ apply {
 	jmp LABEL_END
 	LABEL_FALSE :	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
@@ -51,6 +51,7 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
+	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
 
@@ -68,7 +69,9 @@ apply {
 	LABEL_FALSE :	mov h.ethernet.srcAddr 0xcafe
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
@@ -58,9 +58,10 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
-	bit<16> Egress_tmp_0
-	bit<8> Egress_tmp_1
-	bit<1> Ingress_tmp
+	bit<16> Egress_tmp_1
+	bit<8> Egress_tmp_2
+	bit<48> Ingress_tmp
+	bit<1> Ingress_tmp_0
 }
 metadata instanceof metadata_t
 
@@ -73,17 +74,19 @@ apply {
 	extract h.ethernet
 	extract h.output_data
 	mov m.psa_ingress_output_metadata_drop 0
-	mov m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
-	mov m.Ingress_tmp h.ethernet.srcAddr
-	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_multicast_group m.Ingress_tmp
+	mov m.Ingress_tmp_0 h.ethernet.srcAddr
+	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp_0
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data
 	extract h.ethernet
 	extract h.output_data
 	mov h.output_data.word0 m.psa_egress_input_metadata_egress_port
-	mov m.Egress_tmp_0 m.psa_egress_input_metadata_instance
-	mov h.output_data.word1 m.Egress_tmp_0
+	mov m.Egress_tmp_1 m.psa_egress_input_metadata_instance
+	mov h.output_data.word1 m.Egress_tmp_1
 	mov h.output_data.word2 0x8
 	jmpneq LABEL_FALSE m.psa_egress_input_metadata_packet_path 0x0
 	mov h.output_data.word2 0x1
@@ -105,8 +108,8 @@ apply {
 	jmp LABEL_END
 	LABEL_FALSE_4 :	jmpneq LABEL_END m.psa_egress_input_metadata_packet_path 0x6
 	mov h.output_data.word2 0x7
-	LABEL_END :	mov m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
-	mov h.output_data.word3 m.Egress_tmp_1
+	LABEL_END :	mov m.Egress_tmp_2 m.psa_egress_input_metadata_class_of_service
+	mov h.output_data.word3 m.Egress_tmp_2
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
@@ -51,6 +51,7 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
+	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
 
@@ -61,7 +62,9 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
-	mov m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_multicast_group m.Ingress_tmp
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
@@ -51,6 +51,7 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
+	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
 
@@ -61,7 +62,9 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
-	mov m.psa_ingress_output_metadata_multicast_group h.ethernet.dstAddr
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_multicast_group m.Ingress_tmp
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.spec
@@ -58,7 +58,8 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
-	bit<4> Ingress_tmp
+	bit<4> Ingress_tmp_0
+	bit<48> Ingress_tmp
 	bit<32> Ingress_int_packet_path_0
 }
 metadata instanceof metadata_t
@@ -85,12 +86,14 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	extract h.output_data
-	mov m.Ingress_tmp h.ethernet.dstAddr
-	jmplt LABEL_FALSE m.Ingress_tmp 0x4
+	mov m.Ingress_tmp_0 h.ethernet.dstAddr
+	jmplt LABEL_FALSE m.Ingress_tmp_0 0x4
 	mov h.output_data.word1 m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
 	jmp LABEL_END
 	LABEL_FALSE :	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
@@ -52,11 +52,12 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
-	bit<48> Ingress_tmp_2
 	bit<48> Ingress_tmp_3
 	bit<48> Ingress_tmp_4
+	bit<48> Ingress_tmp_5
 	bit<48> Ingress_tmp_0
 	bit<48> Ingress_tmp_1
+	bit<48> Ingress_tmp_2
 	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
@@ -72,20 +73,22 @@ apply {
 	regwr regfile_0 0x1 0x3
 	regwr regfile_0 0x2 0x4
 	regrd m.Ingress_tmp regfile_0 0x1
-	regrd m.Ingress_tmp_0 regfile_0 0x2
-	mov m.Ingress_tmp_1 m.Ingress_tmp
-	add m.Ingress_tmp_1 m.Ingress_tmp_0
-	mov h.ethernet.dstAddr m.Ingress_tmp_1
+	regrd m.Ingress_tmp_1 regfile_0 0x2
+	mov m.Ingress_tmp_2 m.Ingress_tmp
+	add m.Ingress_tmp_2 m.Ingress_tmp_1
+	mov h.ethernet.dstAddr m.Ingress_tmp_2
 	add h.ethernet.dstAddr 0xfffffffffffb
-	regrd m.Ingress_tmp_2 regfile_0 0x2
-	mov m.Ingress_tmp_3 m.Ingress_tmp
-	add m.Ingress_tmp_3 m.Ingress_tmp_2
-	mov m.Ingress_tmp_4 m.Ingress_tmp_3
-	add m.Ingress_tmp_4 0xfffffffffffb
-	jmpneq LABEL_END m.Ingress_tmp_4 0x2
+	regrd m.Ingress_tmp_3 regfile_0 0x2
+	mov m.Ingress_tmp_4 m.Ingress_tmp
+	add m.Ingress_tmp_4 m.Ingress_tmp_3
+	mov m.Ingress_tmp_5 m.Ingress_tmp_4
+	add m.Ingress_tmp_5 0xfffffffffffb
+	jmpneq LABEL_END m.Ingress_tmp_5 0x2
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.Ingress_tmp_0 h.ethernet.dstAddr
+	and m.Ingress_tmp_0 0xffffffff
+	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp_0
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
@@ -52,6 +52,7 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
+	bit<48> Ingress_tmp_0
 	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
@@ -68,9 +69,11 @@ apply {
 	regrd h.ethernet.dstAddr regfile_0 0x1
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
-	regrd m.Ingress_tmp regfile_0 0x1
-	jmpneq LABEL_END m.Ingress_tmp 0x0
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
+	regrd m.Ingress_tmp_0 regfile_0 0x1
+	jmpneq LABEL_END m.Ingress_tmp_0 0x0
 	mov m.psa_ingress_output_metadata_drop 1
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
@@ -58,6 +58,7 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
+	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
 
@@ -77,7 +78,9 @@ apply {
 	LABEL_FALSE :	mov h.ethernet.etherType 0xf00d
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
 	mov h.output_data.word0 0x8
 	jmpneq LABEL_FALSE_0 m.psa_ingress_input_metadata_packet_path 0x0
 	mov h.output_data.word0 0x1

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
@@ -58,9 +58,10 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
-	bit<16> Egress_tmp_0
-	bit<8> Egress_tmp_1
-	bit<1> Ingress_tmp
+	bit<16> Egress_tmp_1
+	bit<8> Egress_tmp_2
+	bit<48> Ingress_tmp
+	bit<1> Ingress_tmp_0
 }
 metadata instanceof metadata_t
 
@@ -74,19 +75,21 @@ apply {
 	extract h.output_data
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
 	jmpneq LABEL_END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
-	LABEL_END :	mov m.Ingress_tmp h.ethernet.srcAddr
-	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp
+	LABEL_END :	mov m.Ingress_tmp_0 h.ethernet.srcAddr
+	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp_0
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data
 	extract h.ethernet
 	extract h.output_data
 	mov h.output_data.word0 m.psa_egress_input_metadata_egress_port
-	mov m.Egress_tmp_0 m.psa_egress_input_metadata_instance
-	mov h.output_data.word1 m.Egress_tmp_0
+	mov m.Egress_tmp_1 m.psa_egress_input_metadata_instance
+	mov h.output_data.word1 m.Egress_tmp_1
 	mov h.output_data.word2 0x8
 	jmpneq LABEL_FALSE_0 m.psa_egress_input_metadata_packet_path 0x0
 	mov h.output_data.word2 0x1
@@ -108,8 +111,8 @@ apply {
 	jmp LABEL_END_0
 	LABEL_FALSE_5 :	jmpneq LABEL_END_0 m.psa_egress_input_metadata_packet_path 0x6
 	mov h.output_data.word2 0x7
-	LABEL_END_0 :	mov m.Egress_tmp_1 m.psa_egress_input_metadata_class_of_service
-	mov h.output_data.word3 m.Egress_tmp_1
+	LABEL_END_0 :	mov m.Egress_tmp_2 m.psa_egress_input_metadata_class_of_service
+	mov h.output_data.word3 m.Egress_tmp_2
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
@@ -51,6 +51,7 @@ struct metadata_t {
 	bit<8> psa_egress_output_metadata_clone
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
+	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
 
@@ -62,7 +63,9 @@ apply {
 	extract h.ethernet
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
-	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	and m.Ingress_tmp 0xffffffff
+	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
 	jmpneq LABEL_END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0


### PR DESCRIPTION
* dpdk: explictly discard upper bits when downcasting
Explicitly discard extra bits by creating a temporary
and masking with correct bit width