### PR TITLE
 SimplifyDefUse does not respect method calls in stack indices in parsers #2957 

### DIFF
--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -1335,6 +1335,7 @@ class FindUninitialized : public Inspector {
         if (basetype->is<IR::Type_Stack>()) {
             if (expression->member.name == IR::Type_Stack::next ||
                 expression->member.name == IR::Type_Stack::last) {
+                // Accessing these fields implies reading the whole stack
                 auto save  = lhs;
                 lhs = false;
                 visit(expression->expr);

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -1335,6 +1335,11 @@ class FindUninitialized : public Inspector {
         if (basetype->is<IR::Type_Stack>()) {
             if (expression->member.name == IR::Type_Stack::next ||
                 expression->member.name == IR::Type_Stack::last) {
+                auto save  = lhs;
+                lhs = false;
+                visit(expression->expr);
+                storage = getReads(expression->expr, true);
+                lhs = save;
                 reads(expression, storage);
                 registerUses(expression, false);
                 if (!lhs && expression->member.name == IR::Type_Stack::next)

--- a/testdata/p4_16_samples/issue2957.p4
+++ b/testdata/p4_16_samples/issue2957.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    return (val < bound ? val : bound);
+}
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+extern bit<8> extern_call(inout H val);
+parser p(packet_in pkt, out Headers hdr) {
+    H tmp = { extern_call(hdr.h[max(3w1, 3w2)]) };
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h.next);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    apply {
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-frontend.p4
@@ -21,6 +21,8 @@ parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t
     }
     state init {
         pkt.extract<Header>(hdr.h1[1]);
+        hdr.h1[0].data = 32w1;
+        hdr.h1[1].data = 32w1;
         hdr.h1[0].setInvalid();
         pkt.extract<Header>(hdr.h1.next);
         hdr.h1[0].data = 32w1;

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4-midend.p4
@@ -21,6 +21,8 @@ parser ParserI(packet_in pkt, out H hdr, inout M meta, inout standard_metadata_t
     }
     state init {
         pkt.extract<Header>(hdr.h1[1]);
+        hdr.h1[0].data = 32w1;
+        hdr.h1[1].data = 32w1;
         hdr.h1[0].setInvalid();
         pkt.extract<Header>(hdr.h1.next);
         hdr.h1[0].data = 32w1;

--- a/testdata/p4_16_samples_outputs/issue2957-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2957-first.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    return (val < bound ? val : bound);
+}
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+extern bit<8> extern_call(inout H val);
+parser p(packet_in pkt, out Headers hdr) {
+    H tmp = (H){a = extern_call(hdr.h[max(3w1, 3w2)])};
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h.next);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    apply {
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2957-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2957-frontend.p4
@@ -1,0 +1,63 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+extern bit<8> extern_call(inout H val);
+parser p(packet_in pkt, out Headers hdr) {
+    @name("p.tmp_2") bit<3> tmp;
+    @name("p.tmp_3") bit<3> tmp_2;
+    @name("p.tmp_4") H tmp_3;
+    @name("p.tmp_5") bit<8> tmp_4;
+    @name("p.val_0") bit<3> val_1;
+    @name("p.bound_0") bit<3> bound;
+    @name("p.hasReturned") bool hasReturned;
+    @name("p.retval") bit<3> retval;
+    @name("p.tmp") bit<3> tmp_5;
+    state start {
+        val_1 = 3w1;
+        bound = 3w2;
+        hasReturned = false;
+        if (val_1 < bound) {
+            tmp_5 = val_1;
+        } else {
+            tmp_5 = bound;
+        }
+        hasReturned = true;
+        retval = tmp_5;
+        tmp = retval;
+        tmp_2 = tmp;
+        tmp_3 = hdr.h[tmp_2];
+        tmp_4 = extern_call(tmp_3);
+        hdr.h[tmp_2] = tmp_3;
+        transition start_0;
+    }
+    state start_0 {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h.next);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    apply {
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2957-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2957-midend.p4
@@ -1,0 +1,40 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+extern bit<8> extern_call(inout H val);
+parser p(packet_in pkt, out Headers hdr) {
+    @name("p.tmp_4") H tmp_3;
+    state start {
+        tmp_3 = hdr.h[3w1];
+        extern_call(tmp_3);
+        hdr.h[3w1] = tmp_3;
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h.next);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    apply {
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2957.p4
+++ b/testdata/p4_16_samples_outputs/issue2957.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    return (val < bound ? val : bound);
+}
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H[2]       h;
+}
+
+extern bit<8> extern_call(inout H val);
+parser p(packet_in pkt, out Headers hdr) {
+    H tmp = { extern_call(hdr.h[max(3w1, 3w2)]) };
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h.next);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h) {
+    apply {
+    }
+}
+
+parser Parser(packet_in b, out Headers hdr);
+control Ingress(inout Headers hdr);
+package top(Parser p, Ingress ig);
+top(p(), ingress()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2957.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2957.p4-stderr
@@ -1,0 +1,3 @@
+issue2957.p4(23): [--Wwarn=uninitialized_use] warning: hdr.h[tmp_3] may not be completely initialized
+    H tmp = {extern_call(hdr.h[max(3w1, 3w2)])};
+                         ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Bug #2957  
Discussion in PR #3004 

- For member expression added write for next/last as a read/write to the whole stack

- Added test for example issue2957.p4

- Changed test output for invalid-hdr-warnings4.p4
Besides writing pkt.extract(hdr.k1.next) is also reading a whole stack, so assignments hdr.h1[0].data = 32w1; hdr.h1[1].data = 32w1; (preceding) are saved.
They won't be deleted because they are preserved by pkt.extract(hdr.k1.next) and this ProgramPoint is always saved in hasUses, because it has a side effect. 