### PR TITLE
Allow nullptr refmap and typemap in StrenghtReduction.

### DIFF
--- a/frontends/p4/strengthReduction.h
+++ b/frontends/p4/strengthReduction.h
@@ -105,7 +105,6 @@ class StrengthReduction : public PassManager {
             if (!typeChecking)
                 typeChecking = new TypeChecking(refMap, typeMap, true);
             passes.push_back(typeChecking); }
-        passes.push_back(typeChecking);
         passes.push_back(new DoStrengthReduction());
     }
 };

--- a/frontends/p4/strengthReduction.h
+++ b/frontends/p4/strengthReduction.h
@@ -101,8 +101,10 @@ class StrengthReduction : public PassManager {
  public:
     StrengthReduction(ReferenceMap* refMap, TypeMap* typeMap,
             TypeChecking* typeChecking = nullptr) {
-        if (!typeChecking)
-            typeChecking = new TypeChecking(refMap, typeMap, true);
+        if (typeMap != nullptr) {
+            if (!typeChecking)
+                typeChecking = new TypeChecking(refMap, typeMap, true);
+            passes.push_back(typeChecking); }
         passes.push_back(typeChecking);
         passes.push_back(new DoStrengthReduction());
     }


### PR DESCRIPTION
For StrengthReduction, do not type check if no type map is provided. This is similar to how [constantFolding](https://github.com/p4lang/p4c/blob/main/frontends/common/constantFolding.h#L161) works. This allows the use of StrenghtReduction on fully-typed IR expressions without needing to initialize a dummy type and ref map beforehand. This can be useful when one wants to optimize automatically generated IR expressions. 