### PR TITLE
dpdk: use header instead of metadata for lookahead in varbit tests

### DIFF
--- a/testdata/p4_16_samples/pna-example-dpdk-varbit.p4
+++ b/testdata/p4_16_samples/pna-example-dpdk-varbit.p4
@@ -26,13 +26,11 @@ header ethernet_t {
 }
 
 header ipv4_base_t {
-    bit<4>  version;
-    bit<4>  ihl;
+    bit<8>  version_ihl;
     bit<8>  diffserv;
     bit<16> totalLen;
     bit<16> identification;
-    bit<3>  flags;
-    bit<13> fragOffset;
+    bit<16> flags_fragOffset;
     bit<8>  ttl;
     bit<8>  protocol;
     bit<16> hdrChecksum;
@@ -49,10 +47,16 @@ header ipv4_option_timestamp_t {
 struct main_metadata_t {
 }
 
+header option_t {
+    bit<8> type;
+    bit<8> len;
+}
+
 struct headers_t {
     ethernet_t ethernet;
     ipv4_base_t             ipv4_base;
     ipv4_option_timestamp_t ipv4_option_timestamp;
+    option_t                option;
 }
 
 parser MainParserImpl(
@@ -70,19 +74,18 @@ parser MainParserImpl(
     }
     state parse_ipv4 {
         pkt.extract(hdr.ipv4_base);
-        transition select(hdr.ipv4_base.ihl) {
-            4w0x5: accept;
+        transition select(hdr.ipv4_base.version_ihl) {
+            8w0x45: accept;
             default: parse_ipv4_options;
         }
     }
     state parse_ipv4_option_timestamp {
-        bit<16> tmp16 = pkt.lookahead<bit<16>>();
-        bit<8> tmp_len = tmp16[7:0];
-        pkt.extract(hdr.ipv4_option_timestamp, (bit<32>)tmp_len * 8 - 16);
+        pkt.extract(hdr.ipv4_option_timestamp, (bit<32>)hdr.option.len * 8 - 16);
         transition accept;
     }
     state parse_ipv4_options {
-        transition select(pkt.lookahead<bit<8>>()) {
+        hdr.option = pkt.lookahead<option_t>();
+        transition select(hdr.option.type) {
             8w0x44 &&& 8w0xff: parse_ipv4_option_timestamp;
             default : accept;
         }

--- a/testdata/p4_16_samples/psa-example-dpdk-varbit-bmv2.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-varbit-bmv2.p4
@@ -10,13 +10,11 @@ header ethernet_t {
 }
 
 header ipv4_base_t {
-    bit<4>  version;
-    bit<4>  ihl;
+    bit<8>  version_ihl;
     bit<8>  diffserv;
     bit<16> totalLen;
     bit<16> identification;
-    bit<3>  flags;
-    bit<13> fragOffset;
+    bit<16> flags_fragOffset;
     bit<8>  ttl;
     bit<8>  protocol;
     bit<16> hdrChecksum;
@@ -30,10 +28,16 @@ header ipv4_option_timestamp_t {
     varbit<304> data;
 }
 
+header option_t {
+    bit<8> type;
+    bit<8> len;
+}
+
 struct headers_t {
     ethernet_t ethernet;
     ipv4_base_t             ipv4_base;
     ipv4_option_timestamp_t ipv4_option_timestamp;
+    option_t                option;
 }
 
 struct EMPTY { };
@@ -55,19 +59,18 @@ parser MyIP(
     }
     state parse_ipv4 {
         packet.extract(hdr.ipv4_base);
-        transition select(hdr.ipv4_base.ihl) {
-            4w0x5: accept;
+        transition select(hdr.ipv4_base.version_ihl) {
+            8w0x45: accept;
             default: parse_ipv4_options;
         }
     }
     state parse_ipv4_option_timestamp {
-        bit<16> tmp16 = packet.lookahead<bit<16>>();
-        bit<8> tmp_len = tmp16[7:0];
-        packet.extract(hdr.ipv4_option_timestamp, (bit<32>)tmp_len * 8 - 16);
+        packet.extract(hdr.ipv4_option_timestamp, (bit<32>)hdr.option.len * 8 - 16);
         transition accept;
     }
     state parse_ipv4_options {
-        transition select(packet.lookahead<bit<8>>()) {
+        hdr.option = packet.lookahead<option_t>();
+        transition select(hdr.option.type) {
             8w0x44 &&& 8w0xff: parse_ipv4_option_timestamp;
             default : accept;
         }

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-first.p4
@@ -9,13 +9,11 @@ header ethernet_t {
 }
 
 header ipv4_base_t {
-    bit<4>  version;
-    bit<4>  ihl;
+    bit<8>  version_ihl;
     bit<8>  diffserv;
     bit<16> totalLen;
     bit<16> identification;
-    bit<3>  flags;
-    bit<13> fragOffset;
+    bit<16> flags_fragOffset;
     bit<8>  ttl;
     bit<8>  protocol;
     bit<16> hdrChecksum;
@@ -32,10 +30,16 @@ header ipv4_option_timestamp_t {
 struct main_metadata_t {
 }
 
+header option_t {
+    bit<8> type;
+    bit<8> len;
+}
+
 struct headers_t {
     ethernet_t              ethernet;
     ipv4_base_t             ipv4_base;
     ipv4_option_timestamp_t ipv4_option_timestamp;
+    option_t                option;
 }
 
 parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
@@ -48,19 +52,18 @@ parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t ma
     }
     state parse_ipv4 {
         pkt.extract<ipv4_base_t>(hdr.ipv4_base);
-        transition select(hdr.ipv4_base.ihl) {
-            4w0x5: accept;
+        transition select(hdr.ipv4_base.version_ihl) {
+            8w0x45: accept;
             default: parse_ipv4_options;
         }
     }
     state parse_ipv4_option_timestamp {
-        bit<16> tmp16 = pkt.lookahead<bit<16>>();
-        bit<8> tmp_len = tmp16[7:0];
-        pkt.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)tmp_len << 3) + 32w4294967280);
+        pkt.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)hdr.option.len << 3) + 32w4294967280);
         transition accept;
     }
     state parse_ipv4_options {
-        transition select(pkt.lookahead<bit<8>>()) {
+        hdr.option = pkt.lookahead<option_t>();
+        transition select(hdr.option.type) {
             8w0x44: parse_ipv4_option_timestamp;
             default: accept;
         }

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-frontend.p4
@@ -9,13 +9,11 @@ header ethernet_t {
 }
 
 header ipv4_base_t {
-    bit<4>  version;
-    bit<4>  ihl;
+    bit<8>  version_ihl;
     bit<8>  diffserv;
     bit<16> totalLen;
     bit<16> identification;
-    bit<3>  flags;
-    bit<13> fragOffset;
+    bit<16> flags_fragOffset;
     bit<8>  ttl;
     bit<8>  protocol;
     bit<16> hdrChecksum;
@@ -32,17 +30,19 @@ header ipv4_option_timestamp_t {
 struct main_metadata_t {
 }
 
+header option_t {
+    bit<8> type;
+    bit<8> len;
+}
+
 struct headers_t {
     ethernet_t              ethernet;
     ipv4_base_t             ipv4_base;
     ipv4_option_timestamp_t ipv4_option_timestamp;
+    option_t                option;
 }
 
 parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
-    @name("MainParserImpl.tmp16") bit<16> tmp16_0;
-    @name("MainParserImpl.tmp_len") bit<8> tmp_len_0;
-    @name("MainParserImpl.tmp") bit<8> tmp;
-    @name("MainParserImpl.tmp_0") bit<8> tmp_0;
     state start {
         pkt.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {
@@ -52,21 +52,18 @@ parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t ma
     }
     state parse_ipv4 {
         pkt.extract<ipv4_base_t>(hdr.ipv4_base);
-        transition select(hdr.ipv4_base.ihl) {
-            4w0x5: accept;
+        transition select(hdr.ipv4_base.version_ihl) {
+            8w0x45: accept;
             default: parse_ipv4_options;
         }
     }
     state parse_ipv4_option_timestamp {
-        tmp16_0 = pkt.lookahead<bit<16>>();
-        tmp_len_0 = tmp16_0[7:0];
-        pkt.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)tmp_len_0 << 3) + 32w4294967280);
+        pkt.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)hdr.option.len << 3) + 32w4294967280);
         transition accept;
     }
     state parse_ipv4_options {
-        tmp_0 = pkt.lookahead<bit<8>>();
-        tmp = tmp_0;
-        transition select(tmp) {
+        hdr.option = pkt.lookahead<option_t>();
+        transition select(hdr.option.type) {
             8w0x44: parse_ipv4_option_timestamp;
             default: accept;
         }

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4
@@ -9,13 +9,11 @@ header ethernet_t {
 }
 
 header ipv4_base_t {
-    bit<4>  version;
-    bit<4>  ihl;
+    bit<8>  version_ihl;
     bit<8>  diffserv;
     bit<16> totalLen;
     bit<16> identification;
-    bit<3>  flags;
-    bit<13> fragOffset;
+    bit<16> flags_fragOffset;
     bit<8>  ttl;
     bit<8>  protocol;
     bit<16> hdrChecksum;
@@ -32,10 +30,16 @@ header ipv4_option_timestamp_t {
 struct main_metadata_t {
 }
 
+header option_t {
+    bit<8> type;
+    bit<8> len;
+}
+
 struct headers_t {
     ethernet_t              ethernet;
     ipv4_base_t             ipv4_base;
     ipv4_option_timestamp_t ipv4_option_timestamp;
+    option_t                option;
 }
 
 parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
@@ -48,19 +52,18 @@ parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t ma
     }
     state parse_ipv4 {
         pkt.extract(hdr.ipv4_base);
-        transition select(hdr.ipv4_base.ihl) {
-            4w0x5: accept;
+        transition select(hdr.ipv4_base.version_ihl) {
+            8w0x45: accept;
             default: parse_ipv4_options;
         }
     }
     state parse_ipv4_option_timestamp {
-        bit<16> tmp16 = pkt.lookahead<bit<16>>();
-        bit<8> tmp_len = tmp16[7:0];
-        pkt.extract(hdr.ipv4_option_timestamp, (bit<32>)tmp_len * 8 - 16);
+        pkt.extract(hdr.ipv4_option_timestamp, (bit<32>)hdr.option.len * 8 - 16);
         transition accept;
     }
     state parse_ipv4_options {
-        transition select(pkt.lookahead<bit<8>>()) {
+        hdr.option = pkt.lookahead<option_t>();
+        transition select(hdr.option.type) {
             8w0x44 &&& 8w0xff: parse_ipv4_option_timestamp;
             default: accept;
         }

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_base_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -24,6 +22,11 @@ struct ipv4_option_timestamp_t {
 	bit<8> value
 	bit<8> len
 	varbit<304> data
+}
+
+struct option_t {
+	bit<8> type
+	bit<8> len
 }
 
 struct a1_arg_t {
@@ -56,12 +59,9 @@ struct main_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
 	bit<8> pna_main_output_metadata_class_of_service
 	bit<32> pna_main_output_metadata_output_port
-	bit<8> MainParserT_parser_tmp_1
-	bit<32> MainParserT_parser_tmp_2
-	bit<32> MainParserT_parser_tmp_3
+	bit<32> MainParserT_parser_tmp_0
+	bit<32> MainParserT_parser_tmp_1
 	bit<32> MainParserT_parser_tmp
-	bit<16> MainParserT_parser_tmp16_0
-	bit<8> MainParserT_parser_tmp_0
 	bit<32> MainParserT_parser_tmp_extract_tmp
 }
 metadata instanceof main_metadata_t
@@ -69,6 +69,7 @@ metadata instanceof main_metadata_t
 header ethernet instanceof ethernet_t
 header ipv4_base instanceof ipv4_base_t
 header ipv4_option_timestamp instanceof ipv4_option_timestamp_t
+header option instanceof option_t
 
 action NoAction args none {
 	return
@@ -116,16 +117,14 @@ apply {
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4_base
-	jmpeq MAINPARSERIMPL_ACCEPT h.ipv4_base.ihl 0x5
-	lookahead m.MainParserT_parser_tmp_0
-	jmpeq MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP m.MainParserT_parser_tmp_0 0x44
+	jmpeq MAINPARSERIMPL_ACCEPT h.ipv4_base.version_ihl 0x45
+	lookahead h.option
+	jmpeq MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP h.option.type 0x44
 	jmp MAINPARSERIMPL_ACCEPT
-	MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP :	lookahead m.MainParserT_parser_tmp16_0
-	mov m.MainParserT_parser_tmp_1 m.MainParserT_parser_tmp16_0
-	mov m.MainParserT_parser_tmp_2 m.MainParserT_parser_tmp_1
-	mov m.MainParserT_parser_tmp_3 m.MainParserT_parser_tmp_2
-	shl m.MainParserT_parser_tmp_3 0x3
-	mov m.MainParserT_parser_tmp m.MainParserT_parser_tmp_3
+	MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP :	mov m.MainParserT_parser_tmp_0 h.option.len
+	mov m.MainParserT_parser_tmp_1 m.MainParserT_parser_tmp_0
+	shl m.MainParserT_parser_tmp_1 0x3
+	mov m.MainParserT_parser_tmp m.MainParserT_parser_tmp_1
 	add m.MainParserT_parser_tmp 0xfffffff0
 	mov m.MainParserT_parser_tmp_extract_tmp m.MainParserT_parser_tmp
 	shr m.MainParserT_parser_tmp_extract_tmp 0x3

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2-first.p4
@@ -9,13 +9,11 @@ header ethernet_t {
 }
 
 header ipv4_base_t {
-    bit<4>  version;
-    bit<4>  ihl;
+    bit<8>  version_ihl;
     bit<8>  diffserv;
     bit<16> totalLen;
     bit<16> identification;
-    bit<3>  flags;
-    bit<13> fragOffset;
+    bit<16> flags_fragOffset;
     bit<8>  ttl;
     bit<8>  protocol;
     bit<16> hdrChecksum;
@@ -29,10 +27,16 @@ header ipv4_option_timestamp_t {
     varbit<304> data;
 }
 
+header option_t {
+    bit<8> type;
+    bit<8> len;
+}
+
 struct headers_t {
     ethernet_t              ethernet;
     ipv4_base_t             ipv4_base;
     ipv4_option_timestamp_t ipv4_option_timestamp;
+    option_t                option;
 }
 
 struct EMPTY {
@@ -48,19 +52,18 @@ parser MyIP(packet_in packet, out headers_t hdr, inout EMPTY b, in psa_ingress_p
     }
     state parse_ipv4 {
         packet.extract<ipv4_base_t>(hdr.ipv4_base);
-        transition select(hdr.ipv4_base.ihl) {
-            4w0x5: accept;
+        transition select(hdr.ipv4_base.version_ihl) {
+            8w0x45: accept;
             default: parse_ipv4_options;
         }
     }
     state parse_ipv4_option_timestamp {
-        bit<16> tmp16 = packet.lookahead<bit<16>>();
-        bit<8> tmp_len = tmp16[7:0];
-        packet.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)tmp_len << 3) + 32w4294967280);
+        packet.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)hdr.option.len << 3) + 32w4294967280);
         transition accept;
     }
     state parse_ipv4_options {
-        transition select(packet.lookahead<bit<8>>()) {
+        hdr.option = packet.lookahead<option_t>();
+        transition select(hdr.option.type) {
             8w0x44: parse_ipv4_option_timestamp;
             default: accept;
         }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2-frontend.p4
@@ -9,13 +9,11 @@ header ethernet_t {
 }
 
 header ipv4_base_t {
-    bit<4>  version;
-    bit<4>  ihl;
+    bit<8>  version_ihl;
     bit<8>  diffserv;
     bit<16> totalLen;
     bit<16> identification;
-    bit<3>  flags;
-    bit<13> fragOffset;
+    bit<16> flags_fragOffset;
     bit<8>  ttl;
     bit<8>  protocol;
     bit<16> hdrChecksum;
@@ -29,20 +27,22 @@ header ipv4_option_timestamp_t {
     varbit<304> data;
 }
 
+header option_t {
+    bit<8> type;
+    bit<8> len;
+}
+
 struct headers_t {
     ethernet_t              ethernet;
     ipv4_base_t             ipv4_base;
     ipv4_option_timestamp_t ipv4_option_timestamp;
+    option_t                option;
 }
 
 struct EMPTY {
 }
 
 parser MyIP(packet_in packet, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
-    @name("MyIP.tmp16") bit<16> tmp16_0;
-    @name("MyIP.tmp_len") bit<8> tmp_len_0;
-    @name("MyIP.tmp") bit<8> tmp;
-    @name("MyIP.tmp_0") bit<8> tmp_0;
     state start {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {
@@ -52,21 +52,18 @@ parser MyIP(packet_in packet, out headers_t hdr, inout EMPTY b, in psa_ingress_p
     }
     state parse_ipv4 {
         packet.extract<ipv4_base_t>(hdr.ipv4_base);
-        transition select(hdr.ipv4_base.ihl) {
-            4w0x5: accept;
+        transition select(hdr.ipv4_base.version_ihl) {
+            8w0x45: accept;
             default: parse_ipv4_options;
         }
     }
     state parse_ipv4_option_timestamp {
-        tmp16_0 = packet.lookahead<bit<16>>();
-        tmp_len_0 = tmp16_0[7:0];
-        packet.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)tmp_len_0 << 3) + 32w4294967280);
+        packet.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)hdr.option.len << 3) + 32w4294967280);
         transition accept;
     }
     state parse_ipv4_options {
-        tmp_0 = packet.lookahead<bit<8>>();
-        tmp = tmp_0;
-        transition select(tmp) {
+        hdr.option = packet.lookahead<option_t>();
+        transition select(hdr.option.type) {
             8w0x44: parse_ipv4_option_timestamp;
             default: accept;
         }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2-midend.p4
@@ -9,13 +9,11 @@ header ethernet_t {
 }
 
 header ipv4_base_t {
-    bit<4>  version;
-    bit<4>  ihl;
+    bit<8>  version_ihl;
     bit<8>  diffserv;
     bit<16> totalLen;
     bit<16> identification;
-    bit<3>  flags;
-    bit<13> fragOffset;
+    bit<16> flags_fragOffset;
     bit<8>  ttl;
     bit<8>  protocol;
     bit<16> hdrChecksum;
@@ -29,18 +27,23 @@ header ipv4_option_timestamp_t {
     varbit<304> data;
 }
 
+header option_t {
+    bit<8> type;
+    bit<8> len;
+}
+
 struct headers_t {
     ethernet_t              ethernet;
     ipv4_base_t             ipv4_base;
     ipv4_option_timestamp_t ipv4_option_timestamp;
+    option_t                option;
 }
 
 struct EMPTY {
 }
 
 parser MyIP(packet_in packet, out headers_t hdr, inout EMPTY b, in psa_ingress_parser_input_metadata_t c, in EMPTY d, in EMPTY e) {
-    @name("MyIP.tmp16") bit<16> tmp16_0;
-    @name("MyIP.tmp_0") bit<8> tmp_0;
+    bit<16> tmp;
     state start {
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {
@@ -50,19 +53,21 @@ parser MyIP(packet_in packet, out headers_t hdr, inout EMPTY b, in psa_ingress_p
     }
     state parse_ipv4 {
         packet.extract<ipv4_base_t>(hdr.ipv4_base);
-        transition select(hdr.ipv4_base.ihl) {
-            4w0x5: accept;
+        transition select(hdr.ipv4_base.version_ihl) {
+            8w0x45: accept;
             default: parse_ipv4_options;
         }
     }
     state parse_ipv4_option_timestamp {
-        tmp16_0 = packet.lookahead<bit<16>>();
-        packet.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)tmp16_0[7:0] << 3) + 32w4294967280);
+        packet.extract<ipv4_option_timestamp_t>(hdr.ipv4_option_timestamp, ((bit<32>)hdr.option.len << 3) + 32w4294967280);
         transition accept;
     }
     state parse_ipv4_options {
-        tmp_0 = packet.lookahead<bit<8>>();
-        transition select(tmp_0) {
+        tmp = packet.lookahead<bit<16>>();
+        hdr.option.setValid();
+        hdr.option.type = tmp[15:8];
+        hdr.option.len = tmp[7:0];
+        transition select(tmp[15:8]) {
             8w0x44: parse_ipv4_option_timestamp;
             default: accept;
         }
@@ -133,18 +138,18 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
 }
 
 control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers_t hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
-    @hidden action psaexampledpdkvarbitbmv2l137() {
+    @hidden action psaexampledpdkvarbitbmv2l140() {
         buffer.emit<ethernet_t>(hdr.ethernet);
         buffer.emit<ipv4_base_t>(hdr.ipv4_base);
     }
-    @hidden table tbl_psaexampledpdkvarbitbmv2l137 {
+    @hidden table tbl_psaexampledpdkvarbitbmv2l140 {
         actions = {
-            psaexampledpdkvarbitbmv2l137();
+            psaexampledpdkvarbitbmv2l140();
         }
-        const default_action = psaexampledpdkvarbitbmv2l137();
+        const default_action = psaexampledpdkvarbitbmv2l140();
     }
     apply {
-        tbl_psaexampledpdkvarbitbmv2l137.apply();
+        tbl_psaexampledpdkvarbitbmv2l140.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2.p4
@@ -9,13 +9,11 @@ header ethernet_t {
 }
 
 header ipv4_base_t {
-    bit<4>  version;
-    bit<4>  ihl;
+    bit<8>  version_ihl;
     bit<8>  diffserv;
     bit<16> totalLen;
     bit<16> identification;
-    bit<3>  flags;
-    bit<13> fragOffset;
+    bit<16> flags_fragOffset;
     bit<8>  ttl;
     bit<8>  protocol;
     bit<16> hdrChecksum;
@@ -29,10 +27,16 @@ header ipv4_option_timestamp_t {
     varbit<304> data;
 }
 
+header option_t {
+    bit<8> type;
+    bit<8> len;
+}
+
 struct headers_t {
     ethernet_t              ethernet;
     ipv4_base_t             ipv4_base;
     ipv4_option_timestamp_t ipv4_option_timestamp;
+    option_t                option;
 }
 
 struct EMPTY {
@@ -48,19 +52,18 @@ parser MyIP(packet_in packet, out headers_t hdr, inout EMPTY b, in psa_ingress_p
     }
     state parse_ipv4 {
         packet.extract(hdr.ipv4_base);
-        transition select(hdr.ipv4_base.ihl) {
-            4w0x5: accept;
+        transition select(hdr.ipv4_base.version_ihl) {
+            8w0x45: accept;
             default: parse_ipv4_options;
         }
     }
     state parse_ipv4_option_timestamp {
-        bit<16> tmp16 = packet.lookahead<bit<16>>();
-        bit<8> tmp_len = tmp16[7:0];
-        packet.extract(hdr.ipv4_option_timestamp, (bit<32>)tmp_len * 8 - 16);
+        packet.extract(hdr.ipv4_option_timestamp, (bit<32>)hdr.option.len * 8 - 16);
         transition accept;
     }
     state parse_ipv4_options {
-        transition select(packet.lookahead<bit<8>>()) {
+        hdr.option = packet.lookahead<option_t>();
+        transition select(hdr.option.type) {
             8w0x44 &&& 8w0xff: parse_ipv4_option_timestamp;
             default: accept;
         }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2.p4.spec
@@ -7,13 +7,11 @@ struct ethernet_t {
 }
 
 struct ipv4_base_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -25,6 +23,11 @@ struct ipv4_option_timestamp_t {
 	bit<8> value
 	bit<8> len
 	varbit<304> data
+}
+
+struct option_t {
+	bit<8> type
+	bit<8> len
 }
 
 struct psa_ingress_output_metadata_t {
@@ -66,6 +69,7 @@ struct tbl_set_member_id_arg_t {
 header ethernet instanceof ethernet_t
 header ipv4_base instanceof ipv4_base_t
 header ipv4_option_timestamp instanceof ipv4_option_timestamp_t
+header option instanceof option_t
 
 struct EMPTY {
 	bit<32> psa_ingress_parser_input_metadata_ingress_port
@@ -94,12 +98,9 @@ struct EMPTY {
 	bit<16> psa_egress_output_metadata_clone_session_id
 	bit<8> psa_egress_output_metadata_drop
 	bit<32> Ingress_ap_member_id
-	bit<8> IngressParser_parser_tmp_1
-	bit<32> IngressParser_parser_tmp_2
-	bit<32> IngressParser_parser_tmp_3
+	bit<32> IngressParser_parser_tmp_0
+	bit<32> IngressParser_parser_tmp_1
 	bit<32> IngressParser_parser_tmp
-	bit<16> IngressParser_parser_tmp16_0
-	bit<8> IngressParser_parser_tmp_0
 	bit<32> IngressParser_parser_tmp_extract_tmp
 }
 metadata instanceof EMPTY
@@ -169,16 +170,14 @@ apply {
 	jmpeq MYIP_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MYIP_ACCEPT
 	MYIP_PARSE_IPV4 :	extract h.ipv4_base
-	jmpeq MYIP_ACCEPT h.ipv4_base.ihl 0x5
-	lookahead m.IngressParser_parser_tmp_0
-	jmpeq MYIP_PARSE_IPV4_OPTION_TIMESTAMP m.IngressParser_parser_tmp_0 0x44
+	jmpeq MYIP_ACCEPT h.ipv4_base.version_ihl 0x45
+	lookahead h.option
+	jmpeq MYIP_PARSE_IPV4_OPTION_TIMESTAMP h.option.type 0x44
 	jmp MYIP_ACCEPT
-	MYIP_PARSE_IPV4_OPTION_TIMESTAMP :	lookahead m.IngressParser_parser_tmp16_0
-	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp16_0
-	mov m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_1
-	mov m.IngressParser_parser_tmp_3 m.IngressParser_parser_tmp_2
-	shl m.IngressParser_parser_tmp_3 0x3
-	mov m.IngressParser_parser_tmp m.IngressParser_parser_tmp_3
+	MYIP_PARSE_IPV4_OPTION_TIMESTAMP :	mov m.IngressParser_parser_tmp_0 h.option.len
+	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
+	shl m.IngressParser_parser_tmp_1 0x3
+	mov m.IngressParser_parser_tmp m.IngressParser_parser_tmp_1
 	add m.IngressParser_parser_tmp 0xfffffff0
 	mov m.IngressParser_parser_tmp_extract_tmp m.IngressParser_parser_tmp
 	shr m.IngressParser_parser_tmp_extract_tmp 0x3


### PR DESCRIPTION
DPDK pipeline library supports lookahead instruction only with header
not with metadata.
Local variable in parser is internally transformed to a main metadata
field which is currently not allowed as an operand for a lookahead
instruction in DPDK pipeline library.
Therefore we currently need to use a header which is part of main
headers structure.

When we use a header with lookahead in source program,
following warning is generated in ParsersUnroll pass in the midend:
```
warning:  packet.extract is ignored. Error: Reading field from invalid header
        packet.extract(hdr.ipv4_option_timestamp, (bit<32>)hdr.option.len * 8 - 16);
```

It is not clear to me whether header returned by lookahead method
should be valid or not and thus whether that warning is false or not.

If lookahead returns valid header then symbolic evaluation used
in ParsersUnroll pass needs to be fixed so that such warning is not
emitted.
If lookahead returns invalid header then I don't see how it could
be used so that we could use the return value.

Also we should handle somehow the case when lookahead is used with
local variable, because that is definitely valid scenario, but
at the moment the generated spec file can not be processed by DPDK
backend.

These tests are intended to test varbit feature, not lookahead, so
this is fixing only the tests so that they can be used to test
varbit with DPDK pipeline library.

Lookahead with local variables and symbolic evaluation of headers
in lookahead can be fixed separately.