### PR TITLE
Experimental support for typeof keyword

### DIFF
--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -285,6 +285,14 @@ bool ToP4::preorder(const IR::Type_Typedef* t) {
     return false;
 }
 
+bool ToP4::preorder(const IR::Typeof* t) {
+    dump(2);
+    builder.append("typeof(");
+    visit(t->expression);
+    builder.append(")");
+    return false;
+}
+
 bool ToP4::preorder(const IR::Type_Newtype* t) {
     dump(2);
     visit(t->annotations);

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -158,6 +158,7 @@ class ToP4 : public Inspector {
     bool preorder(const IR::Type_Extern* t) override;
     bool preorder(const IR::Type_Unknown* t) override;
     bool preorder(const IR::Type_BaseList* t) override;
+    bool preorder(const IR::Typeof* t) override;
 
     // declarations
     bool preorder(const IR::Declaration_Constant* cst) override;

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1475,6 +1475,17 @@ const IR::Node* TypeInference::postorder(IR::Type_Typedef* tdecl) {
     return tdecl;
 }
 
+const IR::Node* TypeInference::postorder(IR::Typeof* tof) {
+    if (done()) return tof;
+    auto type = getType(tof->expression);
+    if (type == nullptr)
+        return tof;
+    auto tt = new IR::Type_Type(type);
+    setType(getOriginal(), tt);
+    setType(tof, tt);
+    return tof;
+}
+
 const IR::Node* TypeInference::postorder(IR::Type_Stack* type) {
     auto canon = setTypeType(type);
     if (canon == nullptr)

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -216,6 +216,7 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::P4Parser* cont) override;
     const IR::Node* postorder(IR::Method* method) override;
 
+    const IR::Node* postorder(IR::Typeof* type) override;
     const IR::Node* postorder(IR::Type_Type* type) override;
     const IR::Node* postorder(IR::Type_Error* decl) override;
     const IR::Node* postorder(IR::Type_InfInt* type) override;

--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -181,6 +181,8 @@ using Parser = P4::P4Parser;
                   return makeToken(TUPLE); }
 "typedef"       { BEGIN(driver.saveState); driver.template_args = false;
                   return makeToken(TYPEDEF); }
+"typeof"        { BEGIN(driver.saveState); driver.template_args = false;
+                  return makeToken(TYPEOF); }
 "varbit"        { BEGIN(driver.saveState); driver.template_args = true;
                   return makeToken(VARBIT); }
 "value_set"     { BEGIN(driver.saveState); driver.template_args = true;

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -216,7 +216,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %token<Token>      ABSTRACT ACTION ACTIONS APPLY BOOL BIT CONST CONTROL DEFAULT
                    ELSE ENTRIES ENUM ERROR EXIT EXTERN HEADER HEADER_UNION IF IN INOUT
                    INT KEY SELECT MATCH_KIND TYPE OUT PACKAGE PARSER PRAGMA RETURN STATE
-                   STRING STRUCT SWITCH TABLE TRANSITION TUPLE TYPEDEF VARBIT VALUESET VOID
+                   STRING STRUCT SWITCH TABLE TRANSITION TUPLE TYPEDEF TYPEOF VARBIT VALUESET VOID
 
 %token<cstring> IDENTIFIER TYPE_IDENTIFIER STRING_LITERAL
 %token<UnparsedConstant>  INTEGER
@@ -236,6 +236,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
                             nonBraceExpression
 %type<ConstType*>           baseType typeOrVoid specializedType headerStackType
                             typeRef tupleType typeArg realTypeArg namedType
+                            typeofDeclaration
 %type<IR::Type_Name*>       typeName
 %type<IR::Argument*>        argument
 %type<IR::Vector<IR::Argument>*>  argumentList nonEmptyArgList
@@ -452,6 +453,7 @@ nonTypeName
     | STATE       { $$ = new IR::ID(@1, "state"); }
     | ENTRIES     { $$ = new IR::ID(@1, "entries"); }
     | TYPE        { $$ = new IR::ID(@1, "type"); }
+    | TYPEOF      { $$ = new IR::ID(@1, "typeof"); }
     ;
 
 name
@@ -465,6 +467,7 @@ nonTableKwName
     | APPLY            { $$ = new IR::ID(@1, "apply"); }
     | STATE            { $$ = new IR::ID(@1, "state"); }
     | TYPE             { $$ = new IR::ID(@1, "type"); }
+    | TYPEOF           { $$ = new IR::ID(@1, "typeof"); }
     ;
 
 optCONST
@@ -561,6 +564,7 @@ annotationToken
     | TRUE             { $$ = $1; }
     | TUPLE            { $$ = $1; }
     | TYPEDEF          { $$ = $1; }
+    | TYPEOF           { $$ = $1; }
     | VARBIT           { $$ = $1; }
     | VALUESET         { $$ = $1; }
     | VOID             { $$ = $1; }
@@ -1053,6 +1057,10 @@ derivedTypeDeclaration
     | enumDeclaration                  { $$ = $1; }
     ;
 
+typeofDeclaration
+    : TYPEOF "(" expression ")"        { $$ = new IR::Typeof(@3, $3); }
+    ;
+
 headerTypeDeclaration
     : optAnnotations HEADER name { driver.structure->pushContainerType(*$3, true); } optTypeParameters {
         driver.structure->markAsTemplate(*$3);
@@ -1126,6 +1134,8 @@ typedefDeclaration
     : optAnnotations TYPEDEF typeRef name   { driver.structure->declareType(*$4);
           $$ = new IR::Type_Typedef(@4, *$4, new IR::Annotations(*$1), $3); }
     | optAnnotations TYPEDEF derivedTypeDeclaration name   { driver.structure->declareType(*$4);
+                        $$ = new IR::Type_Typedef(@4, *$4, new IR::Annotations(*$1), $3); }
+    | optAnnotations TYPEDEF typeofDeclaration name { driver.structure->declareType(*$4);
                         $$ = new IR::Type_Typedef(@4, *$4, new IR::Annotations(*$1), $3); }
     | optAnnotations TYPE typeRef name   { driver.structure->declareType(*$4);
           $$ = new IR::Type_Newtype(@4, *$4, new IR::Annotations(*$1), $3); }

--- a/ir/type.def
+++ b/ir/type.def
@@ -675,4 +675,11 @@ class Type_Extern : Type_Declaration, INestedNamespace, IGeneralNamespace,
     { return lookupMethod(name, arguments); }
 }
 
+/// Represents the type of the expression, typeof(expression) in P4.
+class Typeof : Type {
+    Expression expression;
+    Type getP4Type() const override { return this; }
+#nodbprint
+}
+
 /** @} *//* end group irdefs */

--- a/testdata/p4_16_samples/typeof.p4
+++ b/testdata/p4_16_samples/typeof.p4
@@ -1,0 +1,14 @@
+const bit<32> b = 0;
+typedef typeof(b) T;
+const T c = 1;
+
+control C(out bit<32> x);
+package top(C _c);
+
+control impl(out bit<32> x) {
+    apply {
+        x = c;
+    }
+}
+
+top(impl()) main;

--- a/testdata/p4_16_samples_outputs/typeof-first.p4
+++ b/testdata/p4_16_samples_outputs/typeof-first.p4
@@ -1,0 +1,13 @@
+const bit<32> b = 32w0;
+typedef typeof(32w0) T;
+const T c = 32w1;
+control C(out bit<32> x);
+package top(C _c);
+control impl(out bit<32> x) {
+    apply {
+        x = 32w1;
+    }
+}
+
+top(impl()) main;
+

--- a/testdata/p4_16_samples_outputs/typeof-frontend.p4
+++ b/testdata/p4_16_samples_outputs/typeof-frontend.p4
@@ -1,0 +1,10 @@
+control C(out bit<32> x);
+package top(C _c);
+control impl(out bit<32> x) {
+    apply {
+        x = 32w1;
+    }
+}
+
+top(impl()) main;
+

--- a/testdata/p4_16_samples_outputs/typeof-midend.p4
+++ b/testdata/p4_16_samples_outputs/typeof-midend.p4
@@ -1,0 +1,19 @@
+control C(out bit<32> x);
+package top(C _c);
+control impl(out bit<32> x) {
+    @hidden action typeof10() {
+        x = 32w1;
+    }
+    @hidden table tbl_typeof10 {
+        actions = {
+            typeof10();
+        }
+        const default_action = typeof10();
+    }
+    apply {
+        tbl_typeof10.apply();
+    }
+}
+
+top(impl()) main;
+

--- a/testdata/p4_16_samples_outputs/typeof.p4
+++ b/testdata/p4_16_samples_outputs/typeof.p4
@@ -1,0 +1,13 @@
+const bit<32> b = 0;
+typedef typeof(b) T;
+const T c = 1;
+control C(out bit<32> x);
+package top(C _c);
+control impl(out bit<32> x) {
+    apply {
+        x = c;
+    }
+}
+
+top(impl()) main;
+


### PR DESCRIPTION
Here is a simple example:
```
const bit<32> b = 0;
typedef typeof(b) T;
const T c = 1;
```

Here `b` can be replaced by an arbitrary expression. The expression is never evaluated, so it only needs to typecheck.
`typeof` is an "expression" that returns a type. In this implementation it can only be used within a `typedef`.