### PR TITLE
DPDK Backend: Fixing a regression failure 'not defined on bool and bit<'

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -35,11 +35,6 @@ p4c_add_xfail_reason("dpdk"
 )
 
 p4c_add_xfail_reason("dpdk"
-  "not defined on bool and bit<"
-  testdata/p4_16_samples/psa-register-read-write-2-bmv2.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
   "Error compiling"
   testdata/p4_16_samples/psa-dpdk-lpm-match-err3.p4
   )

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -577,6 +577,7 @@ const IR::Node *IfStatementUnroll::postorder(IR::P4Control *a) {
 // return the expression, else introduce a temporary for the current expression
 // and return the temporary in a pathexpression.
 bool LogicalExpressionUnroll::preorder(const IR::Operation_Unary *u) {
+    visitAgain();
     expressionUnrollSanityCheck(u->expr);
 
     // If the expression is a methodcall expression, do not insert a temporary
@@ -622,6 +623,7 @@ bool LogicalExpressionUnroll::preorder(const IR::Operation_Unary *u) {
 }
 
 bool LogicalExpressionUnroll::preorder(const IR::Operation_Binary *bin) {
+    visitAgain();
     expressionUnrollSanityCheck(bin->left);
     expressionUnrollSanityCheck(bin->right);
     visit(bin->left);
@@ -654,6 +656,7 @@ bool LogicalExpressionUnroll::preorder(const IR::Operation_Binary *bin) {
 }
 
 bool LogicalExpressionUnroll::preorder(const IR::MethodCallExpression *m) {
+    visitAgain();
     auto args = new IR::Vector<IR::Argument>;
     for (auto arg : *m->arguments) {
         expressionUnrollSanityCheck(arg->expression);
@@ -676,20 +679,24 @@ bool LogicalExpressionUnroll::preorder(const IR::MethodCallExpression *m) {
 }
 
 bool LogicalExpressionUnroll::preorder(const IR::Member *) {
+    visitAgain();
     root = nullptr;
     return false;
 }
 
 bool LogicalExpressionUnroll::preorder(const IR::PathExpression *) {
+    visitAgain();
     root = nullptr;
     return false;
 }
 
 bool LogicalExpressionUnroll::preorder(const IR::Constant *) {
+    visitAgain();
     root = nullptr;
     return false;
 }
 bool LogicalExpressionUnroll::preorder(const IR::BoolLiteral *) {
+    visitAgain();
     root = nullptr;
     return false;
 }

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -577,7 +577,6 @@ const IR::Node *IfStatementUnroll::postorder(IR::P4Control *a) {
 // return the expression, else introduce a temporary for the current expression
 // and return the temporary in a pathexpression.
 bool LogicalExpressionUnroll::preorder(const IR::Operation_Unary *u) {
-    visitAgain();
     expressionUnrollSanityCheck(u->expr);
 
     // If the expression is a methodcall expression, do not insert a temporary
@@ -623,7 +622,6 @@ bool LogicalExpressionUnroll::preorder(const IR::Operation_Unary *u) {
 }
 
 bool LogicalExpressionUnroll::preorder(const IR::Operation_Binary *bin) {
-    visitAgain();
     expressionUnrollSanityCheck(bin->left);
     expressionUnrollSanityCheck(bin->right);
     visit(bin->left);
@@ -656,7 +654,6 @@ bool LogicalExpressionUnroll::preorder(const IR::Operation_Binary *bin) {
 }
 
 bool LogicalExpressionUnroll::preorder(const IR::MethodCallExpression *m) {
-    visitAgain();
     auto args = new IR::Vector<IR::Argument>;
     for (auto arg : *m->arguments) {
         expressionUnrollSanityCheck(arg->expression);
@@ -679,24 +676,20 @@ bool LogicalExpressionUnroll::preorder(const IR::MethodCallExpression *m) {
 }
 
 bool LogicalExpressionUnroll::preorder(const IR::Member *) {
-    visitAgain();
     root = nullptr;
     return false;
 }
 
 bool LogicalExpressionUnroll::preorder(const IR::PathExpression *) {
-    visitAgain();
     root = nullptr;
     return false;
 }
 
 bool LogicalExpressionUnroll::preorder(const IR::Constant *) {
-    visitAgain();
     root = nullptr;
     return false;
 }
 bool LogicalExpressionUnroll::preorder(const IR::BoolLiteral *) {
-    visitAgain();
     root = nullptr;
     return false;
 }

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -248,7 +248,7 @@ class LogicalExpressionUnroll : public Inspector {
     }
 
     LogicalExpressionUnroll(P4::ReferenceMap* refMap, DpdkProgramStructure *structure)
-        : refMap(refMap), structure(structure) {}
+        : refMap(refMap), structure(structure) {visitDagOnce = false;}
     bool preorder(const IR::Operation_Unary *a) override;
     bool preorder(const IR::Operation_Binary *a) override;
     bool preorder(const IR::MethodCallExpression *a) override;

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -444,6 +444,8 @@ class BreakLogicalExpressionParenthesis : public Transform {
         } else if (not land->left->is<IR::LOr>() and
                    not land->left->is<IR::Equ>() and
                    not land->left->is<IR::Neq>() and
+                   not land->left->is<IR::Leq>() and
+                   not land->left->is<IR::Geq>() and
                    not land->left->is<IR::Lss>() and
                    not land->left->is<IR::Grt>() and
                    not land->left->is<IR::MethodCallExpression>() and
@@ -478,8 +480,9 @@ class BreakLogicalExpressionParenthesis : public Transform {
 class SwapSimpleExpressionToFrontOfLogicalExpression : public Transform {
     bool is_simple(const IR::Node *n) {
         if (n->is<IR::Equ>() or n->is<IR::Neq>() or n->is<IR::Lss>() or
-            n->is<IR::Grt>() or n->is<IR::MethodCallExpression>() or
-            n->is<IR::PathExpression>() or n->is<IR::Member>()) {
+            n->is<IR::Grt>() or n->is<IR::Geq>() or n->is<IR::Leq>() or
+            n->is<IR::MethodCallExpression>() or n->is<IR::PathExpression>() or
+            n->is<IR::Member>()) {
             return true;
         } else if (not n->is<IR::LAnd>() and not n->is<IR::LOr>()) {
             BUG("Logical Expression Unroll pass failed");

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4-error
@@ -1,0 +1,9 @@
+psa-register-read-write-2-bmv2.p4(85): [--Wwarn=uninitialized_use] warning: orig_data may be uninitialized
+                next_data = orig_data;
+                            ^^^^^^^^^
+psa-register-read-write-2-bmv2.p4(88): [--Wwarn=uninitialized_use] warning: orig_data may be uninitialized
+                next_data = orig_data + 1;
+                            ^^^^^^^^^
+psa-register-read-write-2-bmv2.p4(95): [--Wwarn=uninitialized_use] warning: orig_data may be uninitialized
+            hdr.output_data.word0 = (bit<32>) orig_data;
+                                              ^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4.bfrt.json
@@ -1,0 +1,5 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4.spec
@@ -1,0 +1,136 @@
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct output_data_t {
+	bit<32> word0
+	bit<32> word1
+	bit<32> word2
+	bit<32> word3
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+header ethernet instanceof ethernet_t
+header output_data instanceof output_data_t
+
+struct metadata_t {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<16> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<16> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<48> Ingress_tmp_0
+	bit<8> Ingress_tmp_1
+	bit<48> Ingress_tmp_2
+	bit<8> Ingress_tmp_3
+	bit<48> Ingress_tmp_4
+	bit<8> Ingress_tmp_5
+	bit<48> Ingress_tmp_6
+	bit<8> Ingress_tmp_7
+	bit<48> Ingress_tmp_8
+	bit<8> Ingress_tmp_9
+	bit<48> Ingress_tmp
+	bit<8> Ingress_idx_0
+	bit<16> Ingress_orig_data_0
+	bit<16> Ingress_next_data_0
+}
+metadata instanceof metadata_t
+
+regarray reg_0 size 0x6 initval 0
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	extract h.output_data
+	jmpnv LABEL_END h.ethernet
+	mov m.Ingress_idx_0 h.ethernet.dstAddr
+	mov m.Ingress_tmp_0 h.ethernet.dstAddr
+	shr m.Ingress_tmp_0 0x8
+	mov m.Ingress_tmp_1 m.Ingress_tmp_0
+	mov m.Ingress_tmp_2 h.ethernet.dstAddr
+	shr m.Ingress_tmp_2 0x8
+	mov m.Ingress_tmp_3 m.Ingress_tmp_2
+	jmplt LABEL_END_0 m.Ingress_tmp_1 0x1
+	jmpgt LABEL_END_0 m.Ingress_tmp_3 0x3
+	regrd m.Ingress_orig_data_0 reg_0 m.Ingress_idx_0
+	LABEL_END_0 :	mov m.Ingress_tmp_8 h.ethernet.dstAddr
+	shr m.Ingress_tmp_8 0x8
+	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	jmpneq LABEL_FALSE_1 m.Ingress_tmp_9 0x1
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	shr m.Ingress_tmp 0x20
+	mov m.Ingress_next_data_0 m.Ingress_tmp
+	jmp LABEL_END_1
+	LABEL_FALSE_1 :	mov m.Ingress_tmp_6 h.ethernet.dstAddr
+	shr m.Ingress_tmp_6 0x8
+	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	jmpneq LABEL_FALSE_2 m.Ingress_tmp_7 0x2
+	mov m.Ingress_next_data_0 m.Ingress_orig_data_0
+	jmp LABEL_END_1
+	LABEL_FALSE_2 :	mov m.Ingress_tmp_4 h.ethernet.dstAddr
+	shr m.Ingress_tmp_4 0x8
+	mov m.Ingress_tmp_5 m.Ingress_tmp_4
+	jmpneq LABEL_FALSE_3 m.Ingress_tmp_5 0x3
+	mov m.Ingress_next_data_0 m.Ingress_orig_data_0
+	add m.Ingress_next_data_0 0x1
+	jmp LABEL_END_1
+	LABEL_FALSE_3 :	mov m.Ingress_orig_data_0 0xdead
+	mov m.Ingress_next_data_0 0xbeef
+	LABEL_END_1 :	regwr reg_0 m.Ingress_idx_0 m.Ingress_next_data_0
+	mov h.output_data.word0 m.Ingress_orig_data_0
+	mov h.output_data.word1 m.Ingress_next_data_0
+	LABEL_END :	mov m.psa_ingress_output_metadata_drop 0
+	mov m.psa_ingress_output_metadata_multicast_group 0x0
+	mov m.psa_ingress_output_metadata_egress_port 0x1
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.output_data
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+


### PR DESCRIPTION

When the condition in if statement is a logical operation with complex common subexpression, the expression is evaluated only once and it results in incorrect intermediate program.

For example:
`if (((bit<8>)(hdr.ethernet.dstAddr >> 8) >> 1) && ((bit<8>)(hdr.ethernet.dstAddr >> 8) <= 3))`

In this, the logical expression unroller, generates

 ```
tmp = h.ethernet.dstAddr >> 8;
tmp_0 = (bit<8>)tmp;
if (tmp_0 >= 8w1 && tmp_0 >= 8w1 <= 8w3)
```

This PR attempts to fix this issue by evaluating the complex expression for its every occurrence.