### PR TITLE
When doing copyprop use original source position

### DIFF
--- a/frontends/common/copySrcInfo.h
+++ b/frontends/common/copySrcInfo.h
@@ -1,0 +1,41 @@
+/*
+Copyright 2022-present VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+namespace P4 {
+
+#ifndef FRONTENDS_COMMON_COPYSRCINFO_H_
+#define FRONTENDS_COMMON_COPYSRCINFO_H_
+
+#include "ir/ir.h"
+
+/// This simple visitor copies the specified source information
+/// to the root node of the IR tree that it is invoked on.
+class CopySrcInfo : public Transform {
+    const Util::SourceInfo &srcInfo;
+ public:
+    explicit CopySrcInfo(const Util::SourceInfo& srcInfo): srcInfo(srcInfo) {}
+    /// Only visit first node.
+    const IR::Node* preorder(IR::Node* node) {
+        auto result = node->clone();
+        result->srcInfo = srcInfo;
+        prune();
+        return result;
+    }
+};
+
+}  // namespace P4
+
+#endif // FRONTENDS_COMMON_COPYSRCINFO_H_

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -95,7 +95,7 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
     void visit_local_decl(const IR::Declaration_Variable *);
     const IR::Node *postorder(IR::Declaration_Variable *) override;
     IR::Expression *preorder(IR::Expression *m) override;
-    const IR::Expression *copyprop_name(cstring name);
+    const IR::Expression *copyprop_name(cstring name, const Util::SourceInfo& srcInfo);
     const IR::Expression *postorder(IR::PathExpression *) override;
     const IR::Expression *preorder(IR::Member *) override;
     const IR::Expression *preorder(IR::ArrayIndex *) override;

--- a/testdata/p4_16_samples_outputs/gauntlet_side_effects_in_mux-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_side_effects_in_mux-bmv2-midend.p4
@@ -30,28 +30,19 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 }
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @name("ingress.tmp") bit<16> tmp;
     @name("ingress.hPSe_0") bit<8> hPSe;
     @name("ingress.hPSe_1") bit<8> hPSe_2;
-    @hidden action act() {
-        h.h.a = hPSe;
-    }
-    @hidden action act_0() {
-        h.h.b = hPSe_2;
-    }
     @hidden action gauntlet_side_effects_in_muxbmv2l36() {
-        h.eth_hdr.eth_type = 16w2;
+        h.h.a = hPSe;
+        tmp = 16w2;
     }
-    @hidden table tbl_act {
-        actions = {
-            act();
-        }
-        const default_action = act();
+    @hidden action gauntlet_side_effects_in_muxbmv2l36_0() {
+        h.h.b = hPSe_2;
+        tmp = 16w2;
     }
-    @hidden table tbl_act_0 {
-        actions = {
-            act_0();
-        }
-        const default_action = act_0();
+    @hidden action gauntlet_side_effects_in_muxbmv2l36_1() {
+        h.eth_hdr.eth_type = tmp;
     }
     @hidden table tbl_gauntlet_side_effects_in_muxbmv2l36 {
         actions = {
@@ -59,13 +50,25 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         }
         const default_action = gauntlet_side_effects_in_muxbmv2l36();
     }
+    @hidden table tbl_gauntlet_side_effects_in_muxbmv2l36_0 {
+        actions = {
+            gauntlet_side_effects_in_muxbmv2l36_0();
+        }
+        const default_action = gauntlet_side_effects_in_muxbmv2l36_0();
+    }
+    @hidden table tbl_gauntlet_side_effects_in_muxbmv2l36_1 {
+        actions = {
+            gauntlet_side_effects_in_muxbmv2l36_1();
+        }
+        const default_action = gauntlet_side_effects_in_muxbmv2l36_1();
+    }
     apply {
         if (h.eth_hdr.src_addr == 48w5) {
-            tbl_act.apply();
+            tbl_gauntlet_side_effects_in_muxbmv2l36.apply();
         } else {
-            tbl_act_0.apply();
+            tbl_gauntlet_side_effects_in_muxbmv2l36_0.apply();
         }
-        tbl_gauntlet_side_effects_in_muxbmv2l36.apply();
+        tbl_gauntlet_side_effects_in_muxbmv2l36_1.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4-error
@@ -1,7 +1,7 @@
 psa-switch-expression-without-default.p4(126): [--Wwarn=missing] warning: SwitchCase: fallthrough with no statement
             92:
             ^^
-psa-switch-expression-without-default.p4(102): [--Wwarn=mismatch] warning: 16w16: constant expression in switch
-    bit<16> tmp = 16;
-                  ^^
+psa-switch-expression-without-default.p4(122): [--Wwarn=mismatch] warning: 16w16: constant expression in switch
+        switch (tmp) {
+                ^^^
 [--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4-stderr
@@ -1,6 +1,6 @@
 psa-switch-expression-without-default.p4(126): [--Wwarn=missing] warning: SwitchCase: fallthrough with no statement
             92:
             ^^
-psa-switch-expression-without-default.p4(102): [--Wwarn=mismatch] warning: 16w16: constant expression in switch
-    bit<16> tmp = 16;
-                  ^^
+psa-switch-expression-without-default.p4(122): [--Wwarn=mismatch] warning: 16w16: constant expression in switch
+        switch (tmp) {
+                ^^^


### PR DESCRIPTION
Fixes #2678 
This has been cherry-picked from https://github.com/mbudiu-vmw/p4c-clone/commit/d22c2a2
This should only influence error messages give to users.