### PR TITLE
Experimental: Allow local typedef declarations

### DIFF
--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -721,7 +721,6 @@ VECTOR_VISIT(IndexedVector, Declaration)
 VECTOR_VISIT(IndexedVector, Declaration_ID)
 VECTOR_VISIT(IndexedVector, Node)
 VECTOR_VISIT(IndexedVector, ParserState)
-VECTOR_VISIT(IndexedVector, StatOrDecl)
 
 #undef VECTOR_VISIT
 

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -203,7 +203,6 @@ class ToP4 : public Inspector {
     bool preorder(const IR::IndexedVector<IR::Declaration>* v) override;
     bool preorder(const IR::IndexedVector<IR::Node>* v) override;
     bool preorder(const IR::IndexedVector<IR::ParserState>* v) override;
-    bool preorder(const IR::IndexedVector<IR::StatOrDecl>* v) override;
 
     // statements
     bool preorder(const IR::AssignmentStatement* s) override;

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -274,7 +274,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %type<IR::Type_Declaration*>  headerTypeDeclaration structTypeDeclaration
                               headerUnionDeclaration derivedTypeDeclaration
                               parserDeclaration controlDeclaration enumDeclaration
-                              typedefDeclaration packageTypeDeclaration typeDeclaration
+                              typedefDeclaration newtypeDeclaration packageTypeDeclaration typeDeclaration
 %type<IR::Type_Error*>      errorDeclaration
 %type<IR::Node*>            fragment
 %type<IR::Node*>            declaration externDeclaration matchKindDeclaration
@@ -1041,6 +1041,7 @@ realTypeArgumentList
 typeDeclaration
     : derivedTypeDeclaration     { $$ = $1; }
     | typedefDeclaration ";"     { $$ = $1; }
+    | newtypeDeclaration ";"     { $$ = $1; }
     | parserTypeDeclaration ";"  { driver.structure->pop(); $$ = $1; }
     | controlTypeDeclaration ";" { driver.structure->pop(); $$ = $1; }
     | packageTypeDeclaration ";" { driver.structure->pop(); $$ = $1; }
@@ -1127,7 +1128,10 @@ typedefDeclaration
           $$ = new IR::Type_Typedef(@4, *$4, new IR::Annotations(*$1), $3); }
     | optAnnotations TYPEDEF derivedTypeDeclaration name   { driver.structure->declareType(*$4);
                         $$ = new IR::Type_Typedef(@4, *$4, new IR::Annotations(*$1), $3); }
-    | optAnnotations TYPE typeRef name   { driver.structure->declareType(*$4);
+    ;
+
+newtypeDeclaration
+    : optAnnotations TYPE typeRef name   { driver.structure->declareType(*$4);
           $$ = new IR::Type_Newtype(@4, *$4, new IR::Annotations(*$1), $3); }
     | optAnnotations TYPE derivedTypeDeclaration name   { driver.structure->declareType(*$4);
                         $$ = new IR::Type_Newtype(@4, *$4, new IR::Annotations(*$1), $3); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -259,8 +259,8 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
                             directApplication
 %type<IR::BlockStatement*>  blockStatement parserBlockStatement controlBody
                             objInitializer
-%type<IR::StatOrDecl*>      statementOrDeclaration parserStatement
-%type<IR::IndexedVector<IR::StatOrDecl>*>  objDeclarations statOrDeclList
+%type<IR::Node*>            statementOrDeclaration parserStatement
+%type<IR::IndexedVector<IR::Node>*>  objDeclarations statOrDeclList
                                            parserStatements
 %type<IR::SwitchCase*>      switchCase
 %type<IR::Vector<IR::SwitchCase>*>  switchCases

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1229,6 +1229,7 @@ switchLabel
 
 statementOrDeclaration
     : variableDeclaration      { $$ = $1; }
+    | typedefDeclaration       { $$ = $1; }
     | constantDeclaration      { $$ = $1; }
     | statement                { $$ = $1; }
     | instantiation            { $$ = $1; }

--- a/ir/base.def
+++ b/ir/base.def
@@ -124,12 +124,15 @@ class Type_Unknown : Type_Base {
     toString{ return "Unknown type"; }
 }
 
-/// A statement or a declaration
-abstract StatOrDecl {}
+#emit
+// This used to be an abstract class used for a statement or a declaration.
+// We keep this for backward compatibility.
+#define StatOrDecl Node
+#end
 
 /// Two declarations with the same name are not necessarily the same declaration.
 /// That's why declid is used to distinguish them.
-abstract Declaration : StatOrDecl, IDeclaration {
+abstract Declaration : IDeclaration {
     ID          name;
     int declid = nextId++;
     ID getName() const override { return name; }

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -57,7 +57,7 @@
 
 class ParserState : ISimpleNamespace, Declaration, IAnnotated {
     optional Annotations                        annotations = Annotations::empty;
-    optional inline IndexedVector<StatOrDecl>   components;
+    optional inline IndexedVector<Node>         components;
     // selectExpression can be a SelectExpression, or a PathExpression representing a state
     NullOK Expression                   selectExpression;
 
@@ -415,7 +415,7 @@ class P4Program : IGeneralNamespace {
 
 ///////////////////////////// Statements //////////////////////////
 
-abstract Statement : StatOrDecl {}
+abstract Statement {}
 
 class ExitStatement : Statement {
     toString{ return "exit"; }
@@ -452,12 +452,12 @@ class IfStatement : Statement {
 
 class BlockStatement : Statement, ISimpleNamespace, IAnnotated {
     optional Annotations                        annotations = Annotations::empty;
-    optional inline IndexedVector<StatOrDecl>   components;
+    optional inline IndexedVector<Node>         components;
     IDeclaration getDeclByName(cstring name) const override {
         return components.getDeclaration(name); }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {
         return components.getDeclarations(); }
-    void push_back(StatOrDecl st) { components.push_back(st); }
+    void push_back(Node st) { components.push_back(st); }
     Annotations getAnnotations() const override { return annotations; }
 }
 

--- a/ir/write_context.cpp
+++ b/ir/write_context.cpp
@@ -95,8 +95,10 @@ bool P4WriteContext::isRead(bool root_value) {
                 return true; }
             auto param = type->parameters->getParameter(ctxt->parent->child_index);
             return param->direction != IR::Direction::Out; } }
+    /* We have changed StatOrDecl to be the same as Node
     if (ctxt->node->is<IR::IndexedVector<IR::StatOrDecl>>())
         return false;
+    */
     if (ctxt->node->is<IR::IfStatement>())
         return ctxt->child_index == 0;
     return true;

--- a/testdata/p4_16_samples/localTypedef.p4
+++ b/testdata/p4_16_samples/localTypedef.p4
@@ -1,0 +1,16 @@
+control C(out bit<16> result) {
+    apply {
+        typedef bit<32> T;
+        T x = 5;
+        {
+            typedef bit<16> T;
+            T y = 6;
+            result = (bit<16>)x + y;
+        }
+    }
+}
+
+control CT(out bit<16> r);
+package top(CT _c);
+
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/localTypedef-first.p4
+++ b/testdata/p4_16_samples_outputs/localTypedef-first.p4
@@ -1,0 +1,16 @@
+control C(out bit<16> result) {
+    apply {
+        typedef bit<32> T;
+        bit<32> x = 32w5;
+        {
+            typedef bit<16> T;
+            bit<16> y = 16w6;
+            result = (bit<16>)x + y;
+        }
+    }
+}
+
+control CT(out bit<16> r);
+package top(CT _c);
+top(C()) main;
+

--- a/testdata/p4_16_samples_outputs/localTypedef-frontend.p4
+++ b/testdata/p4_16_samples_outputs/localTypedef-frontend.p4
@@ -1,0 +1,14 @@
+control C(out bit<16> result) {
+    @name("C.x") bit<32> x_0;
+    @name("C.y") bit<16> y_0;
+    apply {
+        x_0 = 32w5;
+        y_0 = 16w6;
+        result = (bit<16>)x_0 + y_0;
+    }
+}
+
+control CT(out bit<16> r);
+package top(CT _c);
+top(C()) main;
+

--- a/testdata/p4_16_samples_outputs/localTypedef-midend.p4
+++ b/testdata/p4_16_samples_outputs/localTypedef-midend.p4
@@ -1,0 +1,19 @@
+control C(out bit<16> result) {
+    @hidden action localTypedef8() {
+        result = 16w11;
+    }
+    @hidden table tbl_localTypedef8 {
+        actions = {
+            localTypedef8();
+        }
+        const default_action = localTypedef8();
+    }
+    apply {
+        tbl_localTypedef8.apply();
+    }
+}
+
+control CT(out bit<16> r);
+package top(CT _c);
+top(C()) main;
+

--- a/testdata/p4_16_samples_outputs/localTypedef.p4
+++ b/testdata/p4_16_samples_outputs/localTypedef.p4
@@ -1,0 +1,18 @@
+control C(out bit<16> result) {
+    apply {
+        typedef bit<32> T;
+        ;
+        T x = 5;
+        {
+            typedef bit<16> T;
+            ;
+            T y = 6;
+            result = (bit<16>)x + y;
+        }
+    }
+}
+
+control CT(out bit<16> r);
+package top(CT _c);
+top(C()) main;
+

--- a/testdata/p4_16_samples_outputs/localTypedef.p4-stderr
+++ b/testdata/p4_16_samples_outputs/localTypedef.p4-stderr
@@ -1,0 +1,6 @@
+localTypedef.p4(6): [--Wwarn=shadow] warning: 'T' shadows 'T'
+            typedef bit<16> T;
+                            ^
+localTypedef.p4(3)
+        typedef bit<32> T;
+                        ^


### PR DESCRIPTION
This should be discussed by the language design working group.
This feature would be useful to make the `typeof` operator from #3017 much more useful.
With this change one can write:
```
control C(out bit<16> result) {
    apply {
        typedef bit<32> T;
        T x = 5;
        result = x; }}
```
All standard scoping rules apply to the `typedef`. No other types can be declared locally, only `typedef`. This means that there are no issues with types that may not be visible globally - only names that may not be visible globally.

Unfortunately this required a relatively important change in the IR representation, which only supports single inheritance: the replacement of the StatOrDecl abstract class with its base class Node. So now block statements contain a `Vector<Node>` instead of a `Vector<StatOrDecl>`.  This may require some changes in third-party backends.
