### PR TITLE
dpdk: use varbit field size for extract in bytes instead of bits

### DIFF
--- a/backends/dpdk/README.md
+++ b/backends/dpdk/README.md
@@ -64,6 +64,12 @@ control EgressDeparser (packet_out buffer, inout H hdr, in M meta);
 
 - Size of all structure fields to be multiple of 8 bits and should not be greater than 64-bit. (This limitation is planned to be removed by grouping fields into fields which are multiple of 8-bits)
 - Combination of header and metadata as table key is not allowed. (This limitation is removed by P4C by copying the differing match key fields to metadata)
+- Extract instruction in DPDK target with 2 arguments expects the second argument to be the number
+of bytes to be extracted into the varbit field of the header.
+In P4 the second argument of the extract method is the number of bits.
+Compiler generates instructions which compute the size in bytes from the value in bits.
+If the value in bits is not aligned to 8 bits, the value is rounded down to the lower
+mutiple of 8 bits.
 
 ## Contacts
 

--- a/backends/dpdk/README.md
+++ b/backends/dpdk/README.md
@@ -68,8 +68,8 @@ control EgressDeparser (packet_out buffer, inout H hdr, in M meta);
 of bytes to be extracted into the varbit field of the header.
 In P4 the second argument of the extract method is the number of bits.
 Compiler generates instructions which compute the size in bytes from the value in bits.
-If the value in bits is not aligned to 8 bits, the value is rounded down to the lower
-mutiple of 8 bits.
+If the value in bits is not a multiple of 8, the value is rounded down to the lower
+multiple of 8 bits.
 
 ## Contacts
 

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -88,6 +88,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new CollectProgramStructure(refMap, typeMap, &structure),
         new InspectDpdkProgram(refMap, typeMap, &structure),
         new CheckExternInvocation(refMap, typeMap, &structure),
+        new TypeWidthValidator(),
         new DpdkArchLast(),
         new VisitFunctor([this, genContextJson] {
             // Serialize context json object into user specified file

--- a/backends/dpdk/dpdkHelpers.h
+++ b/backends/dpdk/dpdkHelpers.h
@@ -138,7 +138,7 @@ class TypeWidthValidator : public Inspector {
         LOG3("Validating Type_Varbits: " << type);
         if (type->size % 8 != 0) {
             ::error(ErrorType::ERR_UNSUPPORTED,
-                    "%1% Maximum varbit width (%2%) not aligned to 8 bits",
+                    "%1% varbit width (%2%) not aligned to 8 bits",
                     type->srcInfo, type->size);
         }
     }

--- a/backends/dpdk/dpdkHelpers.h
+++ b/backends/dpdk/dpdkHelpers.h
@@ -133,18 +133,34 @@ class BranchingInstructionGeneration {
     bool generate(const IR::Expression *, cstring, cstring, bool);
 };
 
+class TypeWidthValidator : public Inspector {
+    void postorder(const IR::Type_Varbits *type) override {
+        LOG3("Validating Type_Varbits: " << type);
+        if (type->size % 8 != 0) {
+            ::error(ErrorType::ERR_UNSUPPORTED,
+                    "%1% Maximum varbit width (%2%) not aligned to 8 bits",
+                    type->srcInfo, type->size);
+        }
+    }
+};
+
 class ConvertStatementToDpdk : public Inspector {
     IR::IndexedVector<IR::DpdkAsmStatement> instructions;
     P4::TypeMap *typemap;
     P4::ReferenceMap *refmap;
     DpdkProgramStructure *structure;
     const IR::P4Parser *parser = nullptr;
+    IR::Type_Struct *metadataStruct = nullptr;
 
   public:
     ConvertStatementToDpdk(
         P4::ReferenceMap *refmap, P4::TypeMap *typemap,
         DpdkProgramStructure *structure)
         : typemap(typemap), refmap(refmap), structure(structure) {}
+    ConvertStatementToDpdk(
+        P4::ReferenceMap *refmap, P4::TypeMap *typemap,
+        DpdkProgramStructure *structure, IR::Type_Struct *metadataStruct)
+        : typemap(typemap), refmap(refmap), structure(structure), metadataStruct(metadataStruct) {}
     IR::IndexedVector<IR::DpdkAsmStatement> getInstructions() {
         return instructions;
     }

--- a/backends/dpdk/dpdkProgram.cpp
+++ b/backends/dpdk/dpdkProgram.cpp
@@ -393,7 +393,7 @@ bool ConvertToDpdkParser::preorder(const IR::P4Parser *p) {
             add_instr(i);
         auto c = state->components;
         for (auto stat : c) {
-            DPDK::ConvertStatementToDpdk h(refmap, typemap, structure);
+            DPDK::ConvertStatementToDpdk h(refmap, typemap, structure, metadataStruct);
             h.set_parser(p);
             stat->apply(h);
             for (auto i : h.get_instr())

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4.spec
@@ -62,6 +62,7 @@ struct main_metadata_t {
 	bit<32> MainParserT_parser_tmp
 	bit<16> MainParserT_parser_tmp16_0
 	bit<8> MainParserT_parser_tmp_0
+	bit<32> MainParserT_parser_tmp_extract_tmp
 }
 metadata instanceof main_metadata_t
 
@@ -126,7 +127,9 @@ apply {
 	shl m.MainParserT_parser_tmp_3 0x3
 	mov m.MainParserT_parser_tmp m.MainParserT_parser_tmp_3
 	add m.MainParserT_parser_tmp 0xfffffff0
-	extract h.ipv4_option_timestamp m.MainParserT_parser_tmp
+	mov m.MainParserT_parser_tmp_extract_tmp m.MainParserT_parser_tmp
+	shr m.MainParserT_parser_tmp_extract_tmp 0x3
+	extract h.ipv4_option_timestamp m.MainParserT_parser_tmp_extract_tmp
 	MAINPARSERIMPL_ACCEPT :	mov m.pna_main_output_metadata_output_port 0x0
 	table tbl
 	table tbl2

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2.p4.spec
@@ -100,6 +100,7 @@ struct EMPTY {
 	bit<32> IngressParser_parser_tmp
 	bit<16> IngressParser_parser_tmp16_0
 	bit<8> IngressParser_parser_tmp_0
+	bit<32> IngressParser_parser_tmp_extract_tmp
 }
 metadata instanceof EMPTY
 
@@ -179,7 +180,9 @@ apply {
 	shl m.IngressParser_parser_tmp_3 0x3
 	mov m.IngressParser_parser_tmp m.IngressParser_parser_tmp_3
 	add m.IngressParser_parser_tmp 0xfffffff0
-	extract h.ipv4_option_timestamp m.IngressParser_parser_tmp
+	mov m.IngressParser_parser_tmp_extract_tmp m.IngressParser_parser_tmp
+	shr m.IngressParser_parser_tmp_extract_tmp 0x3
+	extract h.ipv4_option_timestamp m.IngressParser_parser_tmp_extract_tmp
 	MYIP_ACCEPT :	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0
 	mov m.psa_ingress_output_metadata_egress_port 0x0


### PR DESCRIPTION
DPDK target expects the size of varbit field for extract instruction
in bytes, but compiler was using the same value as in the P4 source
code which is a size in bits.
This commit adds the instructions to make a computation of the size
in bytes instead of bits.