### PR TITLE
dpdk: fix unsupported parser loop bug

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -4,7 +4,7 @@ p4c_add_xfail_reason("dpdk"
   )
 
 p4c_add_xfail_reason("dpdk"
-  "Unsupported parser loop"
+  "Expected packet length argument for"
   testdata/p4_16_samples/psa-example-counters-bmv2.p4
   )
 

--- a/backends/dpdk/dpdkProgram.cpp
+++ b/backends/dpdk/dpdkProgram.cpp
@@ -356,22 +356,19 @@ bool ConvertToDpdkParser::preorder(const IR::P4Parser *p) {
     for (auto state : p->states) {
         if (state->name == "start")
             stack.push_back(state);
-        degree_map.insert({state->name.toString(), 0});
-        state_map.insert({state->name.toString(), state});
+        degree_map.insert({state->name, 0});
+        state_map.insert({state->name, state});
     }
     for (auto state : p->states) {
         if (state->selectExpression) {
-            if (state->selectExpression->is<IR::SelectExpression>()) {
-                auto select =
-                    state->selectExpression->to<IR::SelectExpression>();
+            if (auto select = state->selectExpression->to<IR::SelectExpression>()) {
                 for (auto pair : select->selectCases) {
                     auto got = degree_map.find(pair->state->path->name);
                     if (got != degree_map.end()) {
                         got->second++;
                     }
                 }
-            } else if (auto path =
-                           state->selectExpression->to<IR::PathExpression>()) {
+            } else if (auto path = state->selectExpression->to<IR::PathExpression>()) {
                 auto got = degree_map.find(path->path->name);
                 if (got != degree_map.end()) {
                     got->second++;
@@ -453,8 +450,7 @@ bool ConvertToDpdkParser::preorder(const IR::P4Parser *p) {
                         }
                     }
                 }
-            } else if (auto path =
-                           state->selectExpression->to<IR::PathExpression>()) {
+            } else if (auto path = state->selectExpression->to<IR::PathExpression>()) {
                 auto i = new IR::DpdkJmpLabelStatement(
                         append_parser_name(p, path->path->name));
                 add_instr(i);
@@ -464,17 +460,15 @@ bool ConvertToDpdkParser::preorder(const IR::P4Parser *p) {
         }
         // ===========
         if (state->selectExpression) {
-            if (state->selectExpression->is<IR::SelectExpression>()) {
-                auto select =
-                    state->selectExpression->to<IR::SelectExpression>();
+            if (auto select = state->selectExpression->to<IR::SelectExpression>()) {
                 for (auto pair : select->selectCases) {
-                    auto result = degree_map.find(pair->state->toString());
+                    auto result = degree_map.find(pair->state->path->name);
                     if (result != degree_map.end()) {
                         result->second--;
                     }
                 }
-            } else if (state->selectExpression->is<IR::PathExpression>()) {
-                auto got = degree_map.find(state->selectExpression->toString());
+            } else if (auto path = state->selectExpression->to<IR::PathExpression>()) {
+                auto got = degree_map.find(path->path->name);
                 if (got != degree_map.end()) {
                     got->second--;
                 }


### PR DESCRIPTION
IR::ID has 2 names, current name (class member 'name') and original
name which should refer to the name originally used in the P4 source
code (class member 'originalName').

Different ways of getting textual representation of the name as
cstring leads to different results.
Some ways return the current name while other ways return the original
name.
Mixing these can lead to problems as it happened also in this case.

This commit makes the use of the names consistent in the method
where the bug occurred.