### PR TITLE
Update the p4c Docker image periodically

### DIFF
--- a/.github/workflows/ci-container-image.yml
+++ b/.github/workflows/ci-container-image.yml
@@ -1,14 +1,17 @@
 name: Build and push latest image to container registry
 
-# This job should ideally also execute when the base image (p4lang/pi) is updated
 on:
   push:
     branches:
       - main
+  schedule:
+    # Ideally, we would update the image every time the base image (p4lang/behavioral-model)
+    # is updated, this is good enough.
+    - cron: '15 0-23/4 * * *' # "At minute 15 past every 4th hour from midnight through 23."
 
 jobs:
   build:
-    if: ${{ github.repository == 'p4lang/p4c' && github.event_name == 'push' }}
+    if: ${{ github.repository == 'p4lang/p4c' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -27,11 +30,18 @@ jobs:
         fi
         echo "Tag is $TAG"
         echo "::set-output name=tag::$TAG"
-    - name: Build and push container image to registry
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      run: |
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        docker build -t p4lang/p4c:${{ steps.get-tag.outputs.tag }} .
-        docker push p4lang/p4c:${{ steps.get-tag.outputs.tag }}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Build and push Docker image to registry
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: p4lang/p4c:${{ steps.get-tag.outputs.tag }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
Other p4lang Docker images are now updated periodically. We do the same
thing for p4c to pick up updates to the base images even when the p4c
repo itself is not updated.
We update the image every 4 hours. To avoid using using too much compute
in Github actions, we update the workflow definition to 1) use native
Docker actions and 2) leverage the Github actions cache. When the base
image (p4lang/behavioral-model) has not been updated and there are no
changes to the p4c code, the workflow will complete in less than a
minute.