### PR TITLE
Check name annotations for duplicates in original program

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -184,6 +184,8 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/issue2664-bmv2.p4
   # This one uses arguments of incorrect types to log_msg
   testdata/p4_16_samples/issue2201-bmv2.p4
+  # Two objects with the same @name annotation
+  testdata/p4_16_samples/issue1949-bmv2.p4
 )
 
 set (BMV2_PARSER_INLINE_TESTS "${P4C_SOURCE_DIR}/testdata/p4_16_samples/parser-inline/*.p4")

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -18,6 +18,7 @@ set (P4_FRONTEND_SRCS
   p4/checkConstants.cpp
   p4/checkCoreMethods.cpp
   p4/checkNamedArgs.cpp
+  p4/checkNameAnnotations.cpp
   p4/createBuiltins.cpp
   p4/def_use.cpp
   p4/defaultArguments.cpp
@@ -85,6 +86,7 @@ set (P4_FRONTEND_HDRS
   p4/checkConstants.h
   p4/checkCoreMethods.h
   p4/checkNamedArgs.h
+  p4/checkNameAnnotations.h
   p4/cloner.h
   p4/commonInlining.h
   p4/coreLibrary.h

--- a/frontends/p4/checkNameAnnotations.cpp
+++ b/frontends/p4/checkNameAnnotations.cpp
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "checkNameAnnotations.h"
+
+namespace P4 {
+
+bool CheckNameAnnotations::preorder(const IR::Annotation* anno) {
+    if (anno->name != IR::Annotation::nameAnnotation)
+        return false;
+    auto parent = findContext<IR::IAnnotated>();
+    auto name = anno->getSingleString();
+    BUG_CHECK(parent != nullptr, "%1% parent of annotation not found", anno);
+    if (name.isNullOrEmpty()) {
+        ::error(ErrorType::ERR_INVALID, "Invalid content for @name annotation %1%", name);
+    }
+    auto it = annotated.find(name);
+    if (it != annotated.end()) {
+        ::warning(ErrorType::WARN_SHADOWING,
+                  "%1% and %2% use the same name in a @name annotation %3%",
+                  parent, it->second, anno);
+    } else {
+        annotated[name] = parent->getNode();
+    }
+    return false;
+}
+
+}  // namespace P4

--- a/frontends/p4/checkNameAnnotations.h
+++ b/frontends/p4/checkNameAnnotations.h
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _FRONTENDS_P4_CHECKNAMEANNOTATIONS_H_
+#define _FRONTENDS_P4_CHECKNAMEANNOTATIONS_H_
+
+#include "ir/ir.h"
+
+namespace P4 {
+
+/// Check if two objects in the initial program have identical name
+/// annotations and report a warning.
+class CheckNameAnnotations : public Inspector {
+    /// List of all annotated objects.
+    std::map<cstring, const IR::Node*> annotated;
+ public:
+    CheckNameAnnotations() {
+        setName("CheckNameAnnotations");
+    }
+
+    bool preorder(const IR::Annotation* anno) override;
+};
+
+}  // namespace P4
+
+#endif /* _FRONTENDS_P4_CHECKNAMEANNOTATIONS_H_ */

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -32,6 +32,7 @@ limitations under the License.
 #include "checkConstants.h"
 #include "checkCoreMethods.h"
 #include "checkNamedArgs.h"
+#include "checkNameAnnotations.h"
 #include "createBuiltins.h"
 #include "defaultArguments.h"
 #include "deprecated.h"
@@ -151,6 +152,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new ResolveReferences(&refMap),  // check shadowing
         new Deprecated(&refMap),
         new CheckNamedArgs(),
+        new CheckNameAnnotations(),
         // Type checking and type inference.  Also inserts
         // explicit casts where implicit casts exist.
         new TypeInference(&refMap, &typeMap, false, false),  // insert casts, dont' check arrays

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -493,17 +493,17 @@ annotation
         { // Initialize with an empty sequence of annotation tokens so that the
           // annotation node is marked as unparsed.
           IR::Vector<IR::AnnotationToken> body;
-          $$ = new IR::Annotation(@1, *$2, body); }
+          $$ = new IR::Annotation(@1+@2, *$2, body); }
     | "@" name "(" annotationBody ")"
-        { $$ = new IR::Annotation(@1, *$2, *$4); }
+        { $$ = new IR::Annotation(@1+@5, *$2, *$4); }
     | "@" name "[" expressionList "]"
-        { $$ = new IR::Annotation(@1, *$2, *$4, true); }
+        { $$ = new IR::Annotation(@1+@5, *$2, *$4, true); }
     | "@" name "[" kvList "]"
-        { $$ = new IR::Annotation(@1, *$2, *$4, true); }
+        { $$ = new IR::Annotation(@1+@5, *$2, *$4, true); }
     // Experimental: backwards compatibility with P4-14 pragmas (which
     // themselves are experimental!)
     | PRAGMA name annotationBody END_PRAGMA
-        { $$ = new IR::Annotation(@1, *$2, *$3, false); }
+        { $$ = new IR::Annotation(@1+@4, *$2, *$3, false); }
     ;
 
 annotationBody

--- a/testdata/p4_16_samples/issue1949-bmv2.p4
+++ b/testdata/p4_16_samples/issue1949-bmv2.p4
@@ -1,0 +1,83 @@
+/*
+Copyright 2019 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+header h1_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+struct headers_t {
+    h1_t h1;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet,
+                  out headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t stdmeta)
+{
+    state start {
+        packet.extract(hdr.h1);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr,
+                    inout metadata_t meta,
+                    inout standard_metadata_t stdmeta)
+{
+    @name(".foo") action act1() {
+        hdr.h1.f1 = hdr.h1.f1 >> 2;
+    }
+    @name(".foo") action act2() {
+        hdr.h1.f1 = hdr.h1.f1 << 3;
+    }
+    table t1 {
+        key = { hdr.h1.f1 : exact; }
+        actions = { act1; act2; NoAction; }
+        const default_action = NoAction;
+    }
+    apply {
+        t1.apply();
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue1949-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1949-bmv2-first.p4
@@ -1,0 +1,68 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header h1_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+struct headers_t {
+    h1_t h1;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract<h1_t>(hdr.h1);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @name(".foo") action act1() {
+        hdr.h1.f1 = hdr.h1.f1 >> 2;
+    }
+    @name(".foo") action act2() {
+        hdr.h1.f1 = hdr.h1.f1 << 3;
+    }
+    table t1 {
+        key = {
+            hdr.h1.f1: exact @name("hdr.h1.f1") ;
+        }
+        actions = {
+            act1();
+            act2();
+            NoAction();
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        t1.apply();
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1949-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1949-bmv2-frontend.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header h1_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+struct headers_t {
+    h1_t h1;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract<h1_t>(hdr.h1);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name(".foo") action act1() {
+        hdr.h1.f1 = hdr.h1.f1 >> 2;
+    }
+    @name(".foo") action act2() {
+        hdr.h1.f1 = hdr.h1.f1 << 3;
+    }
+    @name("ingressImpl.t1") table t1_0 {
+        key = {
+            hdr.h1.f1: exact @name("hdr.h1.f1") ;
+        }
+        actions = {
+            act1();
+            act2();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        t1_0.apply();
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1949-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1949-bmv2-midend.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header h1_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+struct headers_t {
+    h1_t h1;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract<h1_t>(hdr.h1);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name(".foo") action act1() {
+        hdr.h1.f1 = hdr.h1.f1 >> 2;
+    }
+    @name(".foo") action act2() {
+        hdr.h1.f1 = hdr.h1.f1 << 3;
+    }
+    @name("ingressImpl.t1") table t1_0 {
+        key = {
+            hdr.h1.f1: exact @name("hdr.h1.f1") ;
+        }
+        actions = {
+            act1();
+            act2();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        t1_0.apply();
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1949-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1949-bmv2.p4
@@ -1,0 +1,68 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header h1_t {
+    bit<8> f1;
+    bit<8> f2;
+}
+
+struct headers_t {
+    h1_t h1;
+}
+
+struct metadata_t {
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract(hdr.h1);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @name(".foo") action act1() {
+        hdr.h1.f1 = hdr.h1.f1 >> 2;
+    }
+    @name(".foo") action act2() {
+        hdr.h1.f1 = hdr.h1.f1 << 3;
+    }
+    table t1 {
+        key = {
+            hdr.h1.f1: exact;
+        }
+        actions = {
+            act1;
+            act2;
+            NoAction;
+        }
+        const default_action = NoAction;
+    }
+    apply {
+        t1.apply();
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/issue1949-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1949-bmv2.p4-stderr
@@ -1,0 +1,9 @@
+issue1949-bmv2.p4(50): [--Wwarn=shadow] warning: .foo and .foo use the same name in a @name annotation @name
+    @name(".foo") action act2() {
+                         ^^^^
+issue1949-bmv2.p4(47)
+    @name(".foo") action act1() {
+                         ^^^^
+issue1949-bmv2.p4(50)
+    @name(".foo") action act2() {
+    ^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue1949-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue1949-bmv2.p4.p4info.txt
@@ -1,0 +1,44 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 49173205
+    name: "ingressImpl.t1"
+    alias: "t1"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.h1.f1"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 25589981
+  }
+  action_refs {
+    id: 25589981
+  }
+  action_refs {
+    id: 21257015
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 25589981
+    name: "foo"
+    alias: "foo"
+  }
+}
+type_info {
+}


### PR DESCRIPTION
We give a warning if there are two objects in the program that have the same `@name` annotation.
It's not clear that this fix is sufficient - some names are generated internally by the compiler.
Moreover, it is not clear that the control-plane does not tolerate multiple objects with the same name - e.g., if they have different types.
Fixes #1949