### PR TITLE
Proper constant folding in the abstract interpreter

### DIFF
--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -868,7 +868,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary* expression) {
         clone->expr = li->constant;
         DoConstantFolding cf(refMap, typeMap);
         cf.setCalledBy(this);
-        auto result = expression->apply(cf);
+        auto result = clone->apply(cf);
         BUG_CHECK(result->is<IR::Constant>(), "%1%: expected a constant", result);
         set(expression, new SymbolicInteger(result->to<IR::Constant>()));
         return;
@@ -877,7 +877,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary* expression) {
         clone->expr = new IR::BoolLiteral(li->value);
         DoConstantFolding cf(refMap, typeMap);
         cf.setCalledBy(this);
-        auto result = expression->apply(cf);
+        auto result = clone->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));
         return;
@@ -954,7 +954,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation* expression) {
         clone->right = r->to<SymbolicInteger>()->constant;
         DoConstantFolding cf(refMap, typeMap);
         cf.setCalledBy(this);
-        auto result = expression->apply(cf);
+        auto result = clone->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));
         return;
@@ -964,7 +964,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation* expression) {
         clone->right = new IR::BoolLiteral(r->to<SymbolicBool>()->value);
         DoConstantFolding cf(refMap, typeMap);
         cf.setCalledBy(this);
-        auto result = expression->apply(cf);
+        auto result = clone->apply(cf);
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));
         return;

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -866,6 +866,8 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary* expression) {
     if (l->is<SymbolicInteger>()) {
         auto li = l->to<SymbolicInteger>();
         clone->expr = li->constant;
+        auto type = typeMap->getType(getOriginal(), true);
+        typeMap->setType(clone, type); // needed by the constant folding
         DoConstantFolding cf(refMap, typeMap);
         cf.setCalledBy(this);
         auto result = clone->apply(cf);

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -867,7 +867,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary* expression) {
         auto li = l->to<SymbolicInteger>();
         clone->expr = li->constant;
         auto type = typeMap->getType(getOriginal(), true);
-        typeMap->setType(clone, type); // needed by the constant folding
+        typeMap->setType(clone, type);  // needed by the constant folding
         DoConstantFolding cf(refMap, typeMap);
         cf.setCalledBy(this);
         auto result = clone->apply(cf);


### PR DESCRIPTION
This PR is a much simpler version of https://github.com/p4lang/p4c/pull/2915/files.
@vladyslav-dubina : if there is a test case where the compiler crashes with these changes please post it as a comment.