### PR TITLE
DPDK Backend: Add initial support for generating runtime files for PNA architecture

### DIFF
--- a/backends/dpdk/control-plane/bfruntime_arch_handler.h
+++ b/backends/dpdk/control-plane/bfruntime_arch_handler.h
@@ -142,7 +142,7 @@ class BFRuntimeArchHandlerPSA final : public P4RuntimeArchHandlerCommon<Arch::PS
     cstring getBlockNamePrefix(const IR::Block* blk) {
         if (blockNamePrefixMap.count(blk) > 0)
             return blockNamePrefixMap[blk];
-        return "";
+        return "pipe";
     }
 
     static p4configv1::Extern* getP4InfoExtern(P4RuntimeSymbolType typeId,

--- a/backends/dpdk/dpdkContext.h
+++ b/backends/dpdk/dpdkContext.h
@@ -78,7 +78,11 @@ struct TopLevelCtxt{
         compileCommand = compileCommand.replace("(from pragmas)", "");
         compileCommand = compileCommand.trim();
         progName =  options.file;
-        progName = progName.findlast('/');
+        auto fileName = progName.findlast('/');
+        // Handle the case when input file is in the current working directory.
+        // fileName would be null in that case, hence progName should remain unchanged.
+        if (fileName)
+            progName = fileName;
         auto fileext = progName.find(".");
         progName = progName.replace(fileext, "");
         progName = progName.trim("/\t\n\r");

--- a/backends/dpdk/main.cpp
+++ b/backends/dpdk/main.cpp
@@ -98,9 +98,12 @@ int main(int argc, char *const argv[]) {
 
     if (!options.bfRtSchema.isNullOrEmpty()) {
         auto p4RuntimeSerializer = P4::P4RuntimeSerializer::get();
-        p4RuntimeSerializer->registerArch("psa",
+        if (options.arch == "psa")
+            p4RuntimeSerializer->registerArch("psa",
                 new P4::ControlPlaneAPI::Standard::PSAArchHandlerBuilderForDPDK());
-
+        if (options.arch == "pna")
+            p4RuntimeSerializer->registerArch("pna",
+                new P4::ControlPlaneAPI::Standard::PSAArchHandlerBuilderForDPDK());
         auto p4Runtime = P4::generateP4Runtime(program, options.arch);
         auto p4rt = new P4::BFRT::BFRuntimeSchemaGenerator(*p4Runtime.p4Info);
         std::ostream* out = openFile(options.bfRtSchema, false);

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -267,6 +267,22 @@ PSAArchHandlerBuilder::operator()(
     return new P4RuntimeArchHandlerPSA(refMap, typeMap, evaluatedProgram);
 }
 
+/// Implements @ref P4RuntimeArchHandlerIface for the PNA architecture.
+/// We re-use PSA to handle externs as most of the PSA externs are available for PNA as well.
+class P4RuntimeArchHandlerPNA final : public P4RuntimeArchHandlerCommon<Arch::PSA> {
+ public:
+    P4RuntimeArchHandlerPNA(ReferenceMap* refMap,
+                             TypeMap* typeMap,
+                             const IR::ToplevelBlock* evaluatedProgram)
+            : P4RuntimeArchHandlerCommon<Arch::PSA>(refMap, typeMap, evaluatedProgram) { }
+};
+
+P4RuntimeArchHandlerIface*
+PNAArchHandlerBuilder::operator()(
+        ReferenceMap* refMap, TypeMap* typeMap, const IR::ToplevelBlock* evaluatedProgram) const {
+    return new P4RuntimeArchHandlerPNA(refMap, typeMap, evaluatedProgram);
+}
+
 /// Implements @ref P4RuntimeArchHandlerIface for the UBPF architecture.
 /// We re-use PSA to handle externs.
 /// Rationale: The only configurable extern object in ubpf_model.p4 is Register.

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -2069,6 +2069,7 @@ P4RuntimeSerializer::serializeP4RuntimeIfRequired(const P4RuntimeAPI& p4Runtime,
 P4RuntimeSerializer::P4RuntimeSerializer() {
     registerArch("v1model", new ControlPlaneAPI::Standard::V1ModelArchHandlerBuilder());
     registerArch("psa", new ControlPlaneAPI::Standard::PSAArchHandlerBuilder());
+    registerArch("pna", new ControlPlaneAPI::Standard::PNAArchHandlerBuilder());
     registerArch("ubpf", new ControlPlaneAPI::Standard::UBPFArchHandlerBuilder());
 }
 


### PR DESCRIPTION
This PR adds support for generating runtime files (P4info, bfRT json and context json ) for PNA architecture.
Since PNA derives from most of the externs from PSA, currently the PSA arch handler is used for PNA as well. 
