### PR TITLE
DPDK Backend: Fix a bug in handling GEQ and LEQ operations

### DIFF
--- a/testdata/p4_16_samples/psa-dpdk-errorcode-2.p4
+++ b/testdata/p4_16_samples/psa-dpdk-errorcode-2.p4
@@ -1,0 +1,173 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+error {
+    InvalidEthernetType
+}
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        verify(hdr.ethernet.etherType >= 0x800, error.InvalidEthernetType);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    bool err;
+    action execute() {
+        if (!err) {
+            user_meta.data = 1;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr : ternary;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+        err = istd.parser_error != error.NoError;
+        tbl.apply();
+    }
+}
+// END:Parse_Error_Example
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+// BEGIN:Compute_New_IPv4_Checksum_Example
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+// END:Compute_New_IPv4_Checksum_Example
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2-first.p4
@@ -1,0 +1,135 @@
+error {
+    InvalidEthernetType
+}
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        verify(hdr.ethernet.etherType >= 16w0x800, error.InvalidEthernetType);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    bool err;
+    action execute() {
+        if (err) {
+            ;
+        } else {
+            user_meta.data = 16w1;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: ternary @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        err = istd.parser_error != error.NoError;
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2-frontend.p4
@@ -1,0 +1,137 @@
+error {
+    InvalidEthernetType
+}
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        verify(hdr.ethernet.etherType >= 16w0x800, error.InvalidEthernetType);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.err") bool err_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        if (err_0) {
+            ;
+        } else {
+            user_meta.data = 16w1;
+        }
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: ternary @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        err_0 = istd.parser_error != error.NoError;
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2-midend.p4
@@ -1,0 +1,160 @@
+error {
+    InvalidEthernetType
+}
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        verify(hdr.ethernet.etherType >= 16w0x800, error.InvalidEthernetType);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 &&& 8w252: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.err") bool err_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = (err_0 ? user_meta.data : 16w1);
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: ternary @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psadpdkerrorcode2l106() {
+        err_0 = istd.parser_error != error.NoError;
+    }
+    @hidden table tbl_psadpdkerrorcode2l106 {
+        actions = {
+            psadpdkerrorcode2l106();
+        }
+        const default_action = psadpdkerrorcode2l106();
+    }
+    apply {
+        tbl_psadpdkerrorcode2l106.apply();
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psadpdkerrorcode2l142() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdkerrorcode2l142 {
+        actions = {
+            psadpdkerrorcode2l142();
+        }
+        const default_action = psadpdkerrorcode2l142();
+    }
+    apply {
+        tbl_psadpdkerrorcode2l142.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action psadpdkerrorcode2l158() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdkerrorcode2l158 {
+        actions = {
+            psadpdkerrorcode2l158();
+        }
+        const default_action = psadpdkerrorcode2l158();
+    }
+    apply {
+        tbl_psadpdkerrorcode2l158.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4
@@ -1,0 +1,132 @@
+error {
+    InvalidEthernetType
+}
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        verify(hdr.ethernet.etherType >= 0x800, error.InvalidEthernetType);
+        transition select(hdr.ethernet.etherType) {
+            0x800 &&& 0xf00: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    bool err;
+    action execute() {
+        if (!err) {
+            user_meta.data = 1;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: ternary;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        err = istd.parser_error != error.NoError;
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4-error
@@ -1,0 +1,6 @@
+psa.p4(546): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(575): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4-stderr
@@ -1,0 +1,6 @@
+psa.p4(546): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(575): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.bfrt.json
@@ -1,0 +1,59 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Ternary",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 65537,
+          "name" : "$MATCH_PRIORITY",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.p4info.txt
@@ -1,0 +1,40 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.spec
@@ -1,0 +1,158 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<4> dataOffset
+	bit<3> res
+	bit<3> ecn
+	bit<6> ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct metadata {
+	bit<32> psa_ingress_parser_input_metadata_ingress_port
+	bit<32> psa_ingress_parser_input_metadata_packet_path
+	bit<32> psa_egress_parser_input_metadata_egress_port
+	bit<32> psa_egress_parser_input_metadata_packet_path
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<32> psa_ingress_input_metadata_packet_path
+	bit<64> psa_ingress_input_metadata_ingress_timestamp
+	bit<16> psa_ingress_input_metadata_parser_error
+	bit<8> psa_ingress_output_metadata_class_of_service
+	bit<8> psa_ingress_output_metadata_clone
+	bit<16> psa_ingress_output_metadata_clone_session_id
+	bit<8> psa_ingress_output_metadata_drop
+	bit<8> psa_ingress_output_metadata_resubmit
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<8> psa_egress_input_metadata_class_of_service
+	bit<32> psa_egress_input_metadata_egress_port
+	bit<32> psa_egress_input_metadata_packet_path
+	bit<16> psa_egress_input_metadata_instance
+	bit<64> psa_egress_input_metadata_egress_timestamp
+	bit<16> psa_egress_input_metadata_parser_error
+	bit<32> psa_egress_deparser_input_metadata_egress_port
+	bit<8> psa_egress_output_metadata_clone
+	bit<16> psa_egress_output_metadata_clone_session_id
+	bit<8> psa_egress_output_metadata_drop
+	bit<16> local_metadata_data
+	bit<8> Ingress_err_0
+	bit<8> IngressParser_parser_tmp
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+action NoAction args none {
+	return
+}
+
+action execute args none {
+	jmpneq LABEL_FALSE_1 m.Ingress_err_0 0x1
+	jmp LABEL_END_2
+	LABEL_FALSE_1 :	mov m.local_metadata_data 0x1
+	LABEL_END_2 :	return
+}
+
+table tbl {
+	key {
+		h.ethernet.srcAddr wildcard
+	}
+	actions {
+		NoAction
+		execute
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	jmplt LABEL_FALSE h.ethernet.etherType 0x800
+	mov m.IngressParser_parser_tmp 0x1
+	jmp LABEL_END
+	LABEL_FALSE :	mov m.IngressParser_parser_tmp 0x0
+	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp 0
+	mov m.psa_ingress_input_metadata_parser_error 0x7
+	jmp INGRESSPARSERIMPL_ACCEPT
+	LABEL_END_0 :	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	jmpneq LABEL_TRUE_0 m.psa_ingress_input_metadata_parser_error 0x0
+	mov m.Ingress_err_0 0x0
+	jmp LABEL_END_1
+	LABEL_TRUE_0 :	mov m.Ingress_err_0 0x1
+	LABEL_END_1 :	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+


### PR DESCRIPTION
This PR fixes an issue with the order in which the labels and jumps were generated for GEQ and LEQ operations. 

Since dpdk does have a conditional jump for GEQ and LEQ, we negate the condition. However, the true and false blocks were not swapped which was leading to unreachable code.