### PR TITLE
ir: fix deprecated directive warnings

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -31,7 +31,7 @@ limitations under the License.
 %define parse.assert true
 
 // Enable verbose error reporting.
-%error-verbose
+%define parse.error verbose
 
 // Declare dependencies.
 %code requires {

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -31,7 +31,7 @@ limitations under the License.
 %define parse.assert true
 
 // Enable verbose error reporting.
-%error-verbose
+%define parse.error verbose
 
 // Declare dependencies.
 %code requires {

--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -92,7 +92,7 @@ static IrNamespace *current_namespace = LookupScope().resolve(0);
 %type<str>                      name expression optInitializer fieldName methodName body
 %type<lookup>                   lookup_scope
 
-%error-verbose
+%define parse.error verbose
 %locations
 
 %nonassoc COMMENTBLOCK


### PR DESCRIPTION
This pull request fixes the following warnings:

```
ir-generator.ypp:95.1-14: warning: deprecated directive: ‘%error-verbose’, use ‘%define parse.error verbose’ [-Wdeprecated]
   95 | %error-verbose
      | ^~~~~~~~~~~~~~
      | %define parse.error verbose
```
```
parsers/p4/p4parser.ypp:24.1-36: warning: deprecated directive: ‘%define parser_class_name {P4Parser}’, use ‘%define api.parser.class {P4Parser}’ [-Wdeprecated]
   24 | %define parser_class_name {P4Parser}
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | %define api.parser.class {P4Parser}
```
```
parsers/v1/v1parser.ypp:24.1-36: warning: deprecated directive: ‘%define parser_class_name {V1Parser}’, use ‘%define api.parser.class {V1Parser}’ [-Wdeprecated]
   24 | %define parser_class_name {V1Parser}
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | %define api.parser.class {V1Parser}
parsers/v1/v1parser.ypp:34.1-14: warning: deprecated directive: ‘%error-verbose’, use ‘%define parse.error verbose’ [-Wdeprecated]
   34 | %error-verbose
      | ^~~~~~~~~~~~~~
      | %define parse.error verbose
```

The changes in this pull request are auto-generated using the following commands:
```bash
bison -u ./frontends/parsers/p4/p4parser.ypp
bison -u ./frontends/parsers/v1/v1parser.ypp
bison -u ./tools/ir-generator/ir-generator.ypp
```