### PR TITLE
Solution when p4include may be within the path

### DIFF
--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -172,6 +172,9 @@ bool RemoveUnusedDeclarations::isSystemFile(cstring file) {
     if (file.startsWith(p4includePath)) return true;
     // if the backend is invoked directly with '-I p4include'
     if (file.startsWith("p4include")) return true;
+    // if "-I ./p4include" is specified in the arguments
+    if (file.find("p4include")) return true;
+
     return false;
 }
 

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -169,6 +169,9 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::ParserState* state) {
 
 // Try to guess whether a file is a "system" file
 bool RemoveUnusedDeclarations::isSystemFile(cstring file) {
+    if (file.startsWith(p4includePath)) return true;
+    // If the backend is invoked directly with '-I p4include'
+    // In cases such as  "-I ./p4include", p4include may be within the path
     if (file.find("p4include")) return true;
 
     return false;

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -169,10 +169,6 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::ParserState* state) {
 
 // Try to guess whether a file is a "system" file
 bool RemoveUnusedDeclarations::isSystemFile(cstring file) {
-    if (file.startsWith(p4includePath)) return true;
-    // if the backend is invoked directly with '-I p4include'
-    if (file.startsWith("p4include")) return true;
-    // In cases such as  "-I ./p4include", p4include may be within the path
     if (file.find("p4include")) return true;
 
     return false;

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -172,7 +172,7 @@ bool RemoveUnusedDeclarations::isSystemFile(cstring file) {
     if (file.startsWith(p4includePath)) return true;
     // if the backend is invoked directly with '-I p4include'
     if (file.startsWith("p4include")) return true;
-    // if "-I ./p4include" is specified in the arguments
+    // In cases such as  "-I ./p4include", p4include may be within the path
     if (file.find("p4include")) return true;
 
     return false;


### PR DESCRIPTION
Solves `verify: declaration not found` error when p4include  within the path
This pull request addresses the problem when the path is not at the beginning.
For example launch `parser-unroll-test2.p4` test  with `-I ./p4include` argument