### PR TITLE
Run CI tests with Fedora

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - name: Build (Linux)
+    - name: Build (Ubuntu Linux)
       run: |
         tools/start_ccache
         # To flush out issues with unified vs. non-unified builds,
@@ -40,9 +40,47 @@ jobs:
 
       # run with sudo (...) --privileged
       # this is needed to create network namespaces for the ebpf tests
-    - name: Run tests (Linux)
+    - name: Run tests (Ubuntu Linux)
       run: |
         sudo docker run --privileged -w /p4c/build -e $CTEST_PARALLEL_LEVEL p4c ctest --output-on-failure --schedule-random
+      if: matrix.unified == 'ON'
+
+  # Build and test p4c on Fedora
+  build-fedora-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        unified: [ON, OFF]
+        enable_gmp: [ON, OFF]
+        exclude:
+          - unified: OFF
+            enable_gmp: OFF
+    # This job runs in Fedora container that runs in Ubuntu VM
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
+    env:
+      CTEST_PARALLEL_LEVEL: 4
+    steps:
+    # We need to install git here because it is not provided out of the box in Fedora container
+    - name: Install git
+      run: dnf install -y -q git
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Install dependencies (Fedora Linux)
+      run: tools/install_fedora_deps.sh
+
+    - name: Build p4c (Fedora Linux)
+      run: |
+        ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_UNIFIED_COMPILATION=${{matrix.unified}} -DENABLE_GMP=${{ matrix.enable_gmp }}
+        make -j2 -C build
+
+    - name: Run p4c tests (Fedora Linux)
+      run: ctest --output-on-failure --schedule-random
+      working-directory: ./build
       if: matrix.unified == 'ON'
 
   # Build and test p4c on MacOS 10.15

--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ For documentation building:
 sudo dnf install -y doxygen graphviz texlive-scheme-full
 ```
 
+You can also look at the [dependencies installation script](tools/install_fedora_deps.sh)
+for a fresh Fedora instance.
+
 ## macOS dependencies
 
 Installing on macOS:

--- a/tools/install_fedora_deps.sh
+++ b/tools/install_fedora_deps.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -e
+
+sudo dnf install -y -q \
+    automake \
+    bison \
+    boost-devel \
+    boost-filesystem \
+    boost-graph \
+    boost-iostreams \
+    boost-program-options \
+    boost-system \
+    boost-test \
+    boost-thread \
+    clang \
+    cmake \
+    cpp \
+    elfutils-libelf-devel \
+    flex \
+    g++ \
+    gc-devel \
+    git \
+    gmp-devel \
+    grpc-devel \
+    grpc-plugins \
+    iproute \
+    iptables-legacy \
+    libevent-devel \
+    libfl-devel \
+    libpcap-devel \
+    libtool \
+    llvm \
+    make \
+    nanomsg-devel \
+    net-tools \
+    openssl-devel \
+    pkg-config \
+    protobuf-devel \
+    protobuf-static \
+    python3 \
+    python3-pip \
+    python3-thrift \
+    readline-devel \
+    tcpdump \
+    thrift-devel \
+    valgrind \
+    zlib-devel
+
+sudo pip3 install ipaddr ply ptf scapy==2.4.5 wheel
+
+MAKEFLAGS="-j$(nproc)"
+export MAKEFLAGS
+
+# Install PI from source
+tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
+
+pushd "${tmp_dir}"
+git clone --recurse-submodules --depth=1 https://github.com/p4lang/PI
+cd PI
+./autogen.sh
+./configure --with-proto
+make
+make install
+popd
+
+# Install BMv2 from source
+pushd "${tmp_dir}"
+git clone --depth=1 https://github.com/p4lang/behavioral-model
+cd behavioral-model
+./autogen.sh
+./configure --with-pdfixed --with-thrift --with-pi --with-stress-tests --enable-debugger
+make
+make install-strip
+
+cd targets/simple_switch_grpc/
+./autogen.sh
+./configure --with-thrift
+make
+make install-strip
+popd
+
+rm -rf "${tmp_dir}"


### PR DESCRIPTION
As a follow up on the discussion in https://github.com/p4lang/p4c/pull/3076, this pull request extends the CI to run P4C tests with Fedora in addition to Ubuntu.