### PR TITLE
Add debug messages for generated eBPF programs

### DIFF
--- a/backends/ebpf/ebpfBackend.cpp
+++ b/backends/ebpf/ebpfBackend.cpp
@@ -40,7 +40,7 @@ void run_ebpf_backend(const EbpfOptions& options, const IR::ToplevelBlock* tople
 
     Target* target;
     if (options.target.isNullOrEmpty() || options.target == "kernel") {
-        target = new KernelSamplesTarget();
+        target = new KernelSamplesTarget(options.emitTraceMessages);
     } else if (options.target == "bcc") {
         target = new BccTarget();
     } else if (options.target == "test") {

--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -137,6 +137,9 @@ bool ControlBodyTranslator::preorder(const IR::MethodCallExpression* expression)
         // Action arguments have been eliminated by the mid-end.
         BUG_CHECK(expression->arguments->size() == 0,
                   "%1%: unexpected arguments for action call", expression);
+        cstring msg = Util::printf_format("Control: explicit calling action %s()",
+                                          ac->action->name.name);
+        builder->target->emitTraceMessage(builder, msg.c_str());
         visit(ac->action->body);
         return false;
     }
@@ -289,12 +292,16 @@ void ControlBodyTranslator::processMethod(const P4::ExternMethod* method) {
 }
 
 void ControlBodyTranslator::processApply(const P4::ApplyMethod* method) {
-    builder->emitIndent();
+    P4::ParameterSubstitution binding;
+    cstring actionVariableName, msgStr;
     auto table = control->getTable(method->object->getName().name);
     BUG_CHECK(table != nullptr, "No table for %1%", method->expr);
 
-    P4::ParameterSubstitution binding;
-    cstring actionVariableName;
+    msgStr = Util::printf_format("Control: applying %s", method->object->getName().name);
+    builder->target->emitTraceMessage(builder, msgStr.c_str());
+
+    builder->emitIndent();
+
     if (!saveAction.empty()) {
         actionVariableName = saveAction.at(saveAction.size() - 1);
         if (!actionVariableName.isNullOrEmpty()) {
@@ -325,6 +332,7 @@ void ControlBodyTranslator::processApply(const P4::ApplyMethod* method) {
     if (table->keyGenerator != nullptr) {
         builder->emitIndent();
         builder->appendLine("/* perform lookup */");
+        builder->target->emitTraceMessage(builder, "Control: performing table lookup");
         builder->emitIndent();
         builder->target->emitTableLookup(builder, table->dataMapName, keyname, valueName);
         builder->endOfStatement(true);
@@ -336,6 +344,7 @@ void ControlBodyTranslator::processApply(const P4::ApplyMethod* method) {
 
     builder->emitIndent();
     builder->appendLine("/* miss; find default action */");
+    builder->target->emitTraceMessage(builder, "Control: Entry not found, going to default action");
     builder->emitIndent();
     builder->appendFormat("%s = 0", control->hitVariable.c_str());
     builder->endOfStatement(true);
@@ -366,12 +375,19 @@ void ControlBodyTranslator::processApply(const P4::ApplyMethod* method) {
     }
     toDereference.clear();
 
-    builder->blockEnd(true);
+    builder->blockEnd(false);
+    builder->appendFormat(" else ");
+    builder->blockStart();
+    builder->target->emitTraceMessage(builder, "Control: Entry not found, aborting");
     builder->emitIndent();
-    builder->appendFormat("else return %s", builder->target->abortReturnCode().c_str());
+    builder->appendFormat("return %s", builder->target->abortReturnCode().c_str());
     builder->endOfStatement(true);
+    builder->blockEnd(true);
 
     builder->blockEnd(true);
+
+    msgStr = Util::printf_format("Control: %s applied", method->object->getName().name);
+    builder->target->emitTraceMessage(builder, msgStr.c_str());
 }
 
 bool ControlBodyTranslator::preorder(const IR::ExitStatement*) {

--- a/backends/ebpf/ebpfOptions.cpp
+++ b/backends/ebpf/ebpfOptions.cpp
@@ -23,4 +23,7 @@ EbpfOptions::EbpfOptions() {
         registerOption("--emit-externs", nullptr,
                 [this](const char*) { emitExterns = true; return true; },
                 "[ebpf back-end] Allow for user-provided implementation of extern functions.");
+        registerOption("--trace", nullptr,
+                [this](const char*) { emitTraceMessages = true; return true; },
+                "Generate tracing messages of packet processing");
 }

--- a/backends/ebpf/ebpfOptions.h
+++ b/backends/ebpf/ebpfOptions.h
@@ -29,6 +29,8 @@ class EbpfOptions : public CompilerOptions {
     bool loadIRFromJson = false;
     // Externs generation
     bool emitExterns = false;
+    // tracing eBPF code execution
+    bool emitTraceMessages = false;
     EbpfOptions();
 };
 

--- a/backends/ebpf/ebpfProgram.cpp
+++ b/backends/ebpf/ebpfProgram.cpp
@@ -204,6 +204,8 @@ void EBPFProgram::emitPreamble(CodeBuilder* builder) {
     builder->newline();
     builder->appendLine("void* memcpy(void* dest, const void* src, size_t num);");
     builder->newline();
+
+    builder->target->emitPreamble(builder);
 }
 
 void EBPFProgram::emitLocalVariables(CodeBuilder* builder) {
@@ -253,8 +255,11 @@ void EBPFProgram::emitPipeline(CodeBuilder* builder) {
     builder->newline();
     builder->emitIndent();
     builder->blockStart();
+    builder->target->emitTraceMessage(builder, "Control: packet processing started");
     control->emit(builder);
     builder->blockEnd(true);
+    builder->target->emitTraceMessage(builder, "Control: packet processing finished, pass=%d",
+                                      1, control->accept->name.name.c_str());
 }
 
 }  // namespace EBPF

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -65,6 +65,17 @@ class Target {
     virtual cstring sysMapPath() const = 0;
 
     virtual void emitPreamble(Util::SourceCodeBuilder* builder) const;
+    /// Emit trace message which will be printed during packet processing (if enabled).
+    /// @param builder Actual source code builder.
+    /// @param format Format string, interpreted by `printk`-like function. For more
+    ///        information see documentation for `bpf_trace_printk`.
+    /// @param argc Number of variadic arguments. Up to 3 arguments can be passed
+    ///        due to limitation of eBPF.
+    /// @param ... Arguments to the format string, they must be C string and valid code in C.
+    ///
+    /// To print variable value: `emitTraceMessage(builder, "var=%u", 1, "var_name")`
+    /// To print expression value: `emitTraceMessage(builder, "diff=%d", 1, "var1 - var2")`
+    /// To print just message: `emitTraceMessage(builder, "Here")`
     virtual void emitTraceMessage(Util::SourceCodeBuilder* builder,
                                   const char* format, int argc, ...) const;
     virtual void emitTraceMessage(Util::SourceCodeBuilder* builder, const char* format) const;


### PR DESCRIPTION
This PR adds `--trace` flag to the p4c-ebpf compiler. With the option enabled, p4c-ebpf compiler will generate additional debug logs that will be printed by eBPF program during packet processing. These logs might be helpful when debugging compiler, P4 programs or some tools. This option should only be used for troubleshooting as it decreases performance.

With this option disabled (which is by default) performance should not be affected because debug messages are not emitted into C code.

To see debug messages from program read from /sys/kernel/debug/tracing/trace_pipe file or use `bpftool prog tracelog`.