### PR TITLE
Handle bfrt Info for new type

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -1,9 +1,4 @@
 p4c_add_xfail_reason("dpdk"
-  "error: Error when generating BF-RT info for 'Digest' .*: packed type is too complex"
-  testdata/p4_16_samples/psa-example-digest-bmv2.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
   "Expected packet length argument for"
   testdata/p4_16_samples/psa-example-counters-bmv2.p4
   )
@@ -46,6 +41,7 @@ p4c_add_xfail_reason("dpdk"
 
 p4c_add_xfail_reason("dpdk"
   "Unknown extern function"
+  testdata/p4_16_samples/psa-example-digest-bmv2.p4
   testdata/p4_16_samples/psa-example-parser-checksum.p4
   testdata/p4_16_samples/psa-meter6.p4
   )

--- a/control-plane/bfruntime.cpp
+++ b/control-plane/bfruntime.cpp
@@ -55,6 +55,16 @@ TypeSpecParser TypeSpecParser::make(const p4configv1::P4Info& p4info,
                 type = makeTypeBytes(fSpec.bitstring().varbit().max_bitwidth());
         } else if (fSpec.has_bool_()) {
             type = makeTypeBool(1);
+        } else if (fSpec.has_new_type()) {
+            auto newtypes = typeInfo.new_types();
+            auto typeName = fSpec.new_type().name();
+            auto newType = newtypes.find(typeName);
+            if (newType == newtypes.end()) {
+                ::error("New type '%1%' not found in typeInfo for '%2%' '%3%'",
+                        typeName, instanceType, instanceName);
+                return;
+            }
+            type = makeTypeBytes(newType->second.translated_type().sdn_bitwidth());
         }
 
         if (!type) {


### PR DESCRIPTION
Fix regression failure like "Error when generating BF-RT info for 'Digest' .*: packed type is too complex"
for types like 
type PortIdUint_t PortId_t;