### PR TITLE
Forbid egress pipeline in dpdk by default

### DIFF
--- a/backends/dpdk/README.md
+++ b/backends/dpdk/README.md
@@ -45,7 +45,7 @@ To load the 'spec' file in dpdk follow the instructions in the
 - Packet Cloning/Recirculation/Resubmission
 
 ### DPDK target limitations
-- Currently, programs written for DPDK target should limit the functionality in Ingress blocks.  When egress block support gets added to the DPDK target, compiler should generate separate spec file for ingress and egress.
+- Currently, programs written for DPDK target should limit the functionality in Ingress blocks, in case non empty  Egress blocks are present it will be ignored by default unless Hidden temporary option `--enableEgress` used.  When egress block support gets added to the DPDK target, and compiler can generate separate spec file for non empty ingress and egress blocks then option `--enableEgress` will be removed.
 - DPDK architecture assumes the following signatures for programmable block of PSA. P4C-DPDK converts the input program to this form.
 
 ```P4

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -43,7 +43,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
     auto program = tlb->getProgram();
 
     std::set<const IR::P4Table*> invokedInKey;
-    auto convertToDpdk = new ConvertToDpdkProgram(refMap, typeMap, &structure);
+    auto convertToDpdk = new ConvertToDpdkProgram(refMap, typeMap, &structure, options);
     auto genContextJson = new DpdkContextGenerator(refMap, typeMap, &structure, options);
 
     PassManager simplify = {

--- a/backends/dpdk/dpdkProgram.h
+++ b/backends/dpdk/dpdkProgram.h
@@ -31,6 +31,8 @@ limitations under the License.
 #include "ir/ir.h"
 #include "lib/gmputil.h"
 #include "lib/json.h"
+#include "options.h"
+
 namespace DPDK {
 
 /* Maximum size in bits for fields in header and metadata structures */
@@ -40,12 +42,13 @@ class ConvertToDpdkProgram : public Transform {
     P4::TypeMap *typemap;
     P4::ReferenceMap *refmap;
     DpdkProgramStructure *structure;
+    DpdkOptions &options;
     const IR::DpdkAsmProgram *dpdk_program;
 
   public:
     ConvertToDpdkProgram(P4::ReferenceMap *refmap, P4::TypeMap *typemap,
-                         DpdkProgramStructure *structure)
-        : typemap(typemap), refmap(refmap), structure(structure) { }
+                         DpdkProgramStructure *structure, DpdkOptions &options)
+        : typemap(typemap), refmap(refmap), structure(structure), options(options) { }
 
     const IR::DpdkAsmProgram *create(IR::P4Program *prog);
     IR::IndexedVector<IR::DpdkAsmStatement> create_pna_preamble();

--- a/backends/dpdk/options.h
+++ b/backends/dpdk/options.h
@@ -32,6 +32,8 @@ class DpdkOptions : public CompilerOptions {
     bool loadIRFromJson = false;
     // Compilation command line
     static cstring DpdkCompCmd;
+    // Enable/Disable Egress pipeline in psa
+    bool enableEgress = false;
 
     DpdkOptions() {
         registerOption(
@@ -43,6 +45,14 @@ class DpdkOptions : public CompilerOptions {
                 return false;
             },
             "[Dpdk back-end] Lists exact name of all midend passes.\n");
+        registerOption(
+            "--enableEgress", nullptr,
+            [this](const char *) {
+                enableEgress = true;
+                return true;
+            },
+            "[Dpdk back-end] Enable egress pipeline's codegen\n", OptionFlags::Hide);
+
         registerOption("--bf-rt-schema", "file",
                 [this](const char *arg) { bfRtSchema = arg; return true; },
                 "Generate and write BF-RT JSON schema to the specified file");

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
@@ -65,8 +65,6 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	extract h.ethernet
-	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-1.p4.spec
@@ -117,9 +117,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.spec
@@ -125,9 +125,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode.p4.spec
@@ -117,9 +117,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.spec
@@ -116,9 +116,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.spec
@@ -119,9 +119,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.spec
@@ -112,9 +112,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.spec
@@ -120,9 +120,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.spec
@@ -119,9 +119,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
@@ -114,9 +114,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.spec
@@ -120,9 +120,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
@@ -121,9 +121,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
@@ -132,9 +132,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
@@ -143,9 +143,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
@@ -143,9 +143,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
@@ -126,9 +126,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
@@ -137,9 +137,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid7.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid7.p4.spec
@@ -125,9 +125,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4.spec
@@ -60,8 +60,6 @@ apply {
 	INGRESSPARSERIMPL_ACCEPT :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
-	emit h.ethernet
-	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4.spec
@@ -60,10 +60,6 @@ apply {
 	INGRESSPARSERIMPL_ACCEPT :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
-	extract h.ethernet
-	extract h.ipv4
-	emit h.ethernet
-	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-e2e-cloning-basic-bmv2.p4.spec
@@ -31,11 +31,6 @@ struct metadata_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<32> psa_egress_input_metadata_egress_port
-	bit<32> psa_egress_input_metadata_packet_path
-	bit<8> psa_egress_output_metadata_clone
-	bit<16> psa_egress_output_metadata_clone_session_id
-	bit<8> psa_egress_output_metadata_drop
 	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
@@ -59,23 +54,6 @@ apply {
 	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	extract h.ethernet
-	jmpneq LABEL_FALSE_0 m.psa_egress_input_metadata_packet_path 0x4
-	mov h.ethernet.etherType 0xface
-	jmp LABEL_END_0
-	LABEL_FALSE_0 :	mov m.psa_egress_output_metadata_clone 1
-	mov m.psa_egress_output_metadata_clone_session_id 0x8
-	jmpneq LABEL_END_1 h.ethernet.dstAddr 0x9
-	mov m.psa_egress_output_metadata_drop 1
-	mov m.psa_egress_output_metadata_clone_session_id 0x9
-	LABEL_END_1 :	jmpneq LABEL_FALSE_2 m.psa_egress_input_metadata_egress_port 0xfffffffa
-	mov h.ethernet.srcAddr 0xbeef
-	mov m.psa_egress_output_metadata_clone_session_id 0xa
-	jmp LABEL_END_0
-	LABEL_FALSE_2 :	jmpneq LABEL_END_3 h.ethernet.dstAddr 0x8
-	mov m.psa_egress_output_metadata_clone_session_id 0xb
-	LABEL_END_3 :	mov h.ethernet.srcAddr 0xcafe
-	LABEL_END_0 :	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-end-of-ingress-test-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-end-of-ingress-test-bmv2.p4.spec
@@ -1,5 +1,4 @@
 
-
 struct ethernet_t {
 	bit<48> dstAddr
 	bit<48> srcAddr
@@ -40,9 +39,6 @@ struct metadata_t {
 	bit<8> psa_ingress_output_metadata_resubmit
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<32> psa_egress_input_metadata_egress_port
-	bit<32> psa_egress_input_metadata_packet_path
-	bit<16> psa_egress_input_metadata_instance
 	bit<48> Ingress_tmp
 	bit<1> Ingress_tmp_0
 	bit<48> Ingress_tmp_1
@@ -50,14 +46,6 @@ struct metadata_t {
 	bit<48> Ingress_tmp_3
 	bit<16> Ingress_tmp_4
 	bit<16> Ingress_tmp_5
-	bit<16> Egress_tmp
-	bit<8> Egress_tmp_0
-	bit<16> Egress_tmp_1
-	bit<8> Egress_tmp_2
-	bit<16> Egress_tmp_3
-	bit<16> Egress_tmp_4
-	bit<8> Egress_idx
-	bit<16> Egress_write_data
 }
 metadata instanceof metadata_t
 
@@ -116,52 +104,6 @@ apply {
 	mov h.output_data.word0 0x7
 	LABEL_END_2 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	emit h.output_data
-	extract h.ethernet
-	extract h.output_data
-	mov m.Egress_idx h.ethernet.etherType
-	mov m.Egress_tmp_1 h.ethernet.etherType
-	shr m.Egress_tmp_1 0x8
-	mov m.Egress_tmp_2 m.Egress_tmp_1
-	jmpneq LABEL_FALSE_9 m.Egress_tmp_2 0xc0
-	regrd m.Egress_tmp_3 egress_pkt_seen_0 m.Egress_idx
-	mov h.output_data.word0 m.Egress_tmp_3
-	jmp LABEL_END_9
-	LABEL_FALSE_9 :	mov m.Egress_tmp h.ethernet.etherType
-	shr m.Egress_tmp 0x8
-	mov m.Egress_tmp_0 m.Egress_tmp
-	jmpneq LABEL_FALSE_10 m.Egress_tmp_0 0xc1
-	mov m.Egress_write_data h.ethernet.srcAddr
-	regwr egress_pkt_seen_0 m.Egress_idx m.Egress_write_data
-	jmp LABEL_END_9
-	LABEL_FALSE_10 :	jmplt LABEL_TRUE_11 h.ethernet.etherType 0x100
-	jmp LABEL_END_11
-	LABEL_TRUE_11 :	regwr egress_pkt_seen_0 m.Egress_idx 0x1
-	LABEL_END_11 :	mov h.output_data.word1 m.psa_egress_input_metadata_egress_port
-	mov m.Egress_tmp_4 m.psa_egress_input_metadata_instance
-	mov h.output_data.word2 m.Egress_tmp_4
-	mov h.output_data.word3 0x8
-	jmpneq LABEL_FALSE_12 m.psa_egress_input_metadata_packet_path 0x0
-	mov h.output_data.word3 0x1
-	jmp LABEL_END_9
-	LABEL_FALSE_12 :	jmpneq LABEL_FALSE_13 m.psa_egress_input_metadata_packet_path 0x1
-	mov h.output_data.word3 0x2
-	jmp LABEL_END_9
-	LABEL_FALSE_13 :	jmpneq LABEL_FALSE_14 m.psa_egress_input_metadata_packet_path 0x2
-	mov h.output_data.word3 0x3
-	jmp LABEL_END_9
-	LABEL_FALSE_14 :	jmpneq LABEL_FALSE_15 m.psa_egress_input_metadata_packet_path 0x3
-	mov h.output_data.word3 0x4
-	jmp LABEL_END_9
-	LABEL_FALSE_15 :	jmpneq LABEL_FALSE_16 m.psa_egress_input_metadata_packet_path 0x4
-	mov h.output_data.word3 0x5
-	jmp LABEL_END_9
-	LABEL_FALSE_16 :	jmpneq LABEL_FALSE_17 m.psa_egress_input_metadata_packet_path 0x5
-	mov h.output_data.word3 0x6
-	jmp LABEL_END_9
-	LABEL_FALSE_17 :	jmpneq LABEL_END_9 m.psa_egress_input_metadata_packet_path 0x6
-	mov h.output_data.word3 0x7
-	LABEL_END_9 :	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
@@ -1,5 +1,4 @@
 
-
 struct ethernet_t {
 	bit<48> dstAddr
 	bit<48> srcAddr
@@ -123,27 +122,6 @@ apply {
 	INGRESSPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
 	table route
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
-	mov h.cksum_state.state_0 0x0
-	ckadd h.cksum_state.state_0 h.ipv4.version
-	ckadd h.cksum_state.state_0 h.ipv4.ihl
-	ckadd h.cksum_state.state_0 h.ipv4.diffserv
-	ckadd h.cksum_state.state_0 h.ipv4.totalLen
-	ckadd h.cksum_state.state_0 h.ipv4.identification
-	ckadd h.cksum_state.state_0 h.ipv4.flags
-	ckadd h.cksum_state.state_0 h.ipv4.fragOffset
-	ckadd h.cksum_state.state_0 h.ipv4.ttl
-	ckadd h.cksum_state.state_0 h.ipv4.protocol
-	ckadd h.cksum_state.state_0 h.ipv4.srcAddr
-	ckadd h.cksum_state.state_0 h.ipv4.dstAddr
-	mov h.ipv4.hdrChecksum h.cksum_state.state_0
-	mov h.cksum_state.state_0 0x0
-	cksub h.cksum_state.state_0 h.tcp.checksum
-	cksub h.cksum_state.state_0 m.local_metadata__fwd_metadata_old_srcAddr0
-	ckadd h.cksum_state.state_0 h.ipv4.srcAddr
-	mov h.tcp.checksum h.cksum_state.state_0
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.spec
@@ -109,9 +109,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.spec
@@ -1,8 +1,6 @@
 
 
 
-
-
 struct ethernet_t {
 	bit<48> dstAddr
 	bit<48> srcAddr
@@ -111,20 +109,6 @@ apply {
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
-	extract h.ethernet
-	mov m.tmpMask_1 h.ethernet.etherType
-	and m.tmpMask_1 0xc0
-	jmpeq EGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask_1 0x80
-	jmp EGRESSPARSERIMPL_ACCEPT
-	EGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	mov m.tmpMask_2 h.ipv4.protocol
-	and m.tmpMask_2 0xf8
-	jmpeq EGRESSPARSERIMPL_PARSE_TCP m.tmpMask_2 0x10
-	jmp EGRESSPARSERIMPL_ACCEPT
-	EGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
-	EGRESSPARSERIMPL_ACCEPT :	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.spec
@@ -111,8 +111,6 @@ apply {
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
-	emit h.ethernet
-	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.spec
@@ -111,9 +111,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.spec
@@ -113,9 +113,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.spec
@@ -108,9 +108,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.spec
@@ -111,9 +111,6 @@ apply {
 	emit h.ethernet
 	emit h.ipv4
 	emit h.tcp
-	emit h.ethernet
-	emit h.ipv4
-	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-fwd-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-fwd-bmv2.p4.spec
@@ -41,9 +41,6 @@ apply {
 	extract h.ethernet
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	invalidate h.ethernet
-	extract h.ethernet
-	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-i2e-cloning-basic-bmv2.p4.spec
@@ -32,7 +32,6 @@ struct metadata_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<32> psa_egress_input_metadata_packet_path
 	bit<48> Ingress_tmp
 }
 metadata instanceof metadata_t
@@ -56,10 +55,6 @@ apply {
 	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	extract h.ethernet
-	jmpneq LABEL_END_0 m.psa_egress_input_metadata_packet_path 0x3
-	mov h.ethernet.etherType 0xface
-	LABEL_END_0 :	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
@@ -38,14 +38,8 @@ struct metadata_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<8> psa_egress_input_metadata_class_of_service
-	bit<32> psa_egress_input_metadata_egress_port
-	bit<32> psa_egress_input_metadata_packet_path
-	bit<16> psa_egress_input_metadata_instance
 	bit<48> Ingress_tmp
 	bit<1> Ingress_tmp_0
-	bit<16> Egress_tmp
-	bit<8> Egress_tmp_0
 }
 metadata instanceof metadata_t
 
@@ -64,36 +58,6 @@ apply {
 	mov m.Ingress_tmp_0 h.ethernet.srcAddr
 	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp_0
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
-	emit h.ethernet
-	emit h.output_data
-	extract h.ethernet
-	extract h.output_data
-	mov h.output_data.word0 m.psa_egress_input_metadata_egress_port
-	mov m.Egress_tmp m.psa_egress_input_metadata_instance
-	mov h.output_data.word1 m.Egress_tmp
-	mov h.output_data.word2 0x8
-	jmpneq LABEL_FALSE m.psa_egress_input_metadata_packet_path 0x0
-	mov h.output_data.word2 0x1
-	jmp LABEL_END
-	LABEL_FALSE :	jmpneq LABEL_FALSE_0 m.psa_egress_input_metadata_packet_path 0x1
-	mov h.output_data.word2 0x2
-	jmp LABEL_END
-	LABEL_FALSE_0 :	jmpneq LABEL_FALSE_1 m.psa_egress_input_metadata_packet_path 0x2
-	mov h.output_data.word2 0x3
-	jmp LABEL_END
-	LABEL_FALSE_1 :	jmpneq LABEL_FALSE_2 m.psa_egress_input_metadata_packet_path 0x3
-	mov h.output_data.word2 0x4
-	jmp LABEL_END
-	LABEL_FALSE_2 :	jmpneq LABEL_FALSE_3 m.psa_egress_input_metadata_packet_path 0x4
-	mov h.output_data.word2 0x5
-	jmp LABEL_END
-	LABEL_FALSE_3 :	jmpneq LABEL_FALSE_4 m.psa_egress_input_metadata_packet_path 0x5
-	mov h.output_data.word2 0x6
-	jmp LABEL_END
-	LABEL_FALSE_4 :	jmpneq LABEL_END m.psa_egress_input_metadata_packet_path 0x6
-	mov h.output_data.word2 0x7
-	LABEL_END :	mov m.Egress_tmp_0 m.psa_egress_input_metadata_class_of_service
-	mov h.output_data.word3 m.Egress_tmp_0
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-bmv2.p4.spec
@@ -46,7 +46,6 @@ apply {
 	mov m.psa_ingress_output_metadata_multicast_group m.Ingress_tmp
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-corrected-bmv2.p4.spec
@@ -46,8 +46,6 @@ apply {
 	mov m.psa_ingress_output_metadata_multicast_group m.Ingress_tmp
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	extract h.ethernet
-	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.spec
@@ -38,8 +38,6 @@ struct metadata_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<32> psa_egress_input_metadata_egress_port
-	bit<32> psa_egress_input_metadata_packet_path
 	bit<4> Ingress_tmp
 	bit<48> Ingress_tmp_0
 	bit<32> Ingress_int_packet_path
@@ -48,20 +46,6 @@ metadata instanceof metadata_t
 
 header ethernet instanceof ethernet_t
 header output_data instanceof output_data_t
-
-action add args none {
-	add h.ethernet.dstAddr h.ethernet.srcAddr
-	return
-}
-
-table e {
-	actions {
-		add
-	}
-	default_action add args none 
-	size 0x10000
-}
-
 
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
@@ -107,33 +91,6 @@ apply {
 	LABEL_FALSE_7 :	mov h.output_data.word0 m.Ingress_int_packet_path
 	LABEL_END_7 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	emit h.output_data
-	extract h.ethernet
-	extract h.output_data
-	table e
-	jmpneq LABEL_END_8 m.psa_egress_input_metadata_egress_port 0xfffffffa
-	mov h.output_data.word3 0x8
-	jmpneq LABEL_FALSE_9 m.psa_egress_input_metadata_packet_path 0x0
-	mov h.output_data.word3 0x1
-	jmp LABEL_END_8
-	LABEL_FALSE_9 :	jmpneq LABEL_FALSE_10 m.psa_egress_input_metadata_packet_path 0x1
-	mov h.output_data.word3 0x2
-	jmp LABEL_END_8
-	LABEL_FALSE_10 :	jmpneq LABEL_FALSE_11 m.psa_egress_input_metadata_packet_path 0x2
-	mov h.output_data.word3 0x3
-	jmp LABEL_END_8
-	LABEL_FALSE_11 :	jmpneq LABEL_FALSE_12 m.psa_egress_input_metadata_packet_path 0x3
-	mov h.output_data.word3 0x4
-	jmp LABEL_END_8
-	LABEL_FALSE_12 :	jmpneq LABEL_FALSE_13 m.psa_egress_input_metadata_packet_path 0x4
-	mov h.output_data.word3 0x5
-	jmp LABEL_END_8
-	LABEL_FALSE_13 :	jmpneq LABEL_FALSE_14 m.psa_egress_input_metadata_packet_path 0x5
-	mov h.output_data.word3 0x6
-	jmp LABEL_END_8
-	LABEL_FALSE_14 :	jmpneq LABEL_END_8 m.psa_egress_input_metadata_packet_path 0x6
-	mov h.output_data.word3 0x7
-	LABEL_END_8 :	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
@@ -70,8 +70,6 @@ apply {
 	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp_2
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	extract h.ethernet
-	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
@@ -56,8 +56,6 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 1
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	extract h.ethernet
-	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-resubmit-bmv2.p4.spec
@@ -86,9 +86,6 @@ apply {
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data
-	extract h.ethernet
-	emit h.ethernet
-	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-top-level-assignments-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-top-level-assignments-bmv2.p4.spec
@@ -42,7 +42,6 @@ apply {
 	mov m.psa_ingress_output_metadata_egress_port 0x3
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
@@ -38,14 +38,8 @@ struct metadata_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<8> psa_egress_input_metadata_class_of_service
-	bit<32> psa_egress_input_metadata_egress_port
-	bit<32> psa_egress_input_metadata_packet_path
-	bit<16> psa_egress_input_metadata_instance
 	bit<48> Ingress_tmp
 	bit<1> Ingress_tmp_0
-	bit<16> Egress_tmp
-	bit<8> Egress_tmp_0
 }
 metadata instanceof metadata_t
 
@@ -67,36 +61,6 @@ apply {
 	LABEL_END :	mov m.Ingress_tmp_0 h.ethernet.srcAddr
 	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp_0
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
-	emit h.ethernet
-	emit h.output_data
-	extract h.ethernet
-	extract h.output_data
-	mov h.output_data.word0 m.psa_egress_input_metadata_egress_port
-	mov m.Egress_tmp m.psa_egress_input_metadata_instance
-	mov h.output_data.word1 m.Egress_tmp
-	mov h.output_data.word2 0x8
-	jmpneq LABEL_FALSE_0 m.psa_egress_input_metadata_packet_path 0x0
-	mov h.output_data.word2 0x1
-	jmp LABEL_END_0
-	LABEL_FALSE_0 :	jmpneq LABEL_FALSE_1 m.psa_egress_input_metadata_packet_path 0x1
-	mov h.output_data.word2 0x2
-	jmp LABEL_END_0
-	LABEL_FALSE_1 :	jmpneq LABEL_FALSE_2 m.psa_egress_input_metadata_packet_path 0x2
-	mov h.output_data.word2 0x3
-	jmp LABEL_END_0
-	LABEL_FALSE_2 :	jmpneq LABEL_FALSE_3 m.psa_egress_input_metadata_packet_path 0x3
-	mov h.output_data.word2 0x4
-	jmp LABEL_END_0
-	LABEL_FALSE_3 :	jmpneq LABEL_FALSE_4 m.psa_egress_input_metadata_packet_path 0x4
-	mov h.output_data.word2 0x5
-	jmp LABEL_END_0
-	LABEL_FALSE_4 :	jmpneq LABEL_FALSE_5 m.psa_egress_input_metadata_packet_path 0x5
-	mov h.output_data.word2 0x6
-	jmp LABEL_END_0
-	LABEL_FALSE_5 :	jmpneq LABEL_END_0 m.psa_egress_input_metadata_packet_path 0x6
-	mov h.output_data.word2 0x7
-	LABEL_END_0 :	mov m.Egress_tmp_0 m.psa_egress_input_metadata_class_of_service
-	mov h.output_data.word3 m.Egress_tmp_0
 	emit h.ethernet
 	emit h.output_data
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-corrected-bmv2.p4.spec
@@ -49,8 +49,6 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 1
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
-	extract h.ethernet
-	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }


### PR DESCRIPTION
As there are no egress pipeline use case, currently forbid it by default in dpdk.