### PR TITLE
loop_revisit method for dealing with recursive loops in the IR

### DIFF
--- a/ir/ir-inline.h
+++ b/ir/ir-inline.h
@@ -24,18 +24,24 @@ limitations under the License.
     { Node::traceVisit("Mod post"); v.postorder(this); }                                        \
     TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Modifier &v, const Node *n) const  \
     { Node::traceVisit("Mod revisit"); v.revisit(this, n); }                                    \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(Modifier &v) const            \
+    { Node::traceVisit("Mod loop_revisit"); v.loop_revisit(this); }                             \
     TEMPLATE INLINE bool IR::CLASS TT::apply_visitor_preorder(Inspector &v) const               \
     { Node::traceVisit("Insp pre"); return v.preorder(this); }                                  \
     TEMPLATE INLINE void IR::CLASS TT::apply_visitor_postorder(Inspector &v) const              \
     { Node::traceVisit("Insp post"); v.postorder(this); }                                       \
     TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Inspector &v) const                \
     { Node::traceVisit("Insp revisit"); v.revisit(this); }                                      \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(Inspector &v) const           \
+    { Node::traceVisit("Insp loop_revisit"); v.loop_revisit(this); }                            \
     TEMPLATE INLINE const IR::Node *IR::CLASS TT::apply_visitor_preorder(Transform &v)          \
     { Node::traceVisit("Trans pre"); return v.preorder(this); }                                 \
     TEMPLATE INLINE const IR::Node *IR::CLASS TT::apply_visitor_postorder(Transform &v)         \
     { Node::traceVisit("Trans post"); return v.postorder(this); }                               \
     TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Transform &v, const Node *n) const \
-    { Node::traceVisit("Trans revisit"); v.revisit(this, n); }
+    { Node::traceVisit("Trans revisit"); v.revisit(this, n); }                                  \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(Transform &v) const           \
+    { Node::traceVisit("Trans loop_revisit"); v.loop_revisit(this); }
 
 IRNODE_ALL_TEMPLATES(DEFINE_APPLY_FUNCTIONS, inline)
 

--- a/ir/node.h
+++ b/ir/node.h
@@ -73,12 +73,15 @@ class Node : public virtual INode {
     virtual bool apply_visitor_preorder(Modifier &v);
     virtual void apply_visitor_postorder(Modifier &v);
     virtual void apply_visitor_revisit(Modifier &v, const Node *n) const;
+    virtual void apply_visitor_loop_revisit(Modifier &v) const;
     virtual bool apply_visitor_preorder(Inspector &v) const;
     virtual void apply_visitor_postorder(Inspector &v) const;
     virtual void apply_visitor_revisit(Inspector &v) const;
+    virtual void apply_visitor_loop_revisit(Inspector &v) const;
     virtual const Node *apply_visitor_preorder(Transform &v);
     virtual const Node *apply_visitor_postorder(Transform &v);
     virtual void apply_visitor_revisit(Transform &v, const Node *n) const;
+    virtual void apply_visitor_loop_revisit(Transform &v) const;
     Node &operator=(const Node &) = default;
     Node &operator=(Node &&) = default;
 
@@ -168,12 +171,15 @@ inline bool equiv(const INode *a, const INode *b) {
     bool apply_visitor_preorder(Modifier &v) override;                      \
     void apply_visitor_postorder(Modifier &v) override;                     \
     void apply_visitor_revisit(Modifier &v, const Node *n) const override;  \
+    void apply_visitor_loop_revisit(Modifier &v) const override;            \
     bool apply_visitor_preorder(Inspector &v) const override;               \
     void apply_visitor_postorder(Inspector &v) const override;              \
     void apply_visitor_revisit(Inspector &v) const override;                \
+    void apply_visitor_loop_revisit(Inspector &v) const override;           \
     const Node *apply_visitor_preorder(Transform &v) override;              \
     const Node *apply_visitor_postorder(Transform &v) override;             \
     void apply_visitor_revisit(Transform &v, const Node *n) const override; \
+    void apply_visitor_loop_revisit(Transform &v) const override;           \
 
 /* only define 'apply' for a limited number of classes (those we want to call
  * visitors directly on), as defining it and making it virtual would mean that

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -299,13 +299,16 @@ class Modifier : public virtual Visitor {
     virtual bool preorder(IR::Node *) { return true; }
     virtual void postorder(IR::Node *) {}
     virtual void revisit(const IR::Node *, const IR::Node *) {}
+    virtual void loop_revisit(const IR::Node *) { BUG("IR loop detected"); }
 #define DECLARE_VISIT_FUNCTIONS(CLASS, BASE)                            \
     virtual bool preorder(IR::CLASS *);                                 \
     virtual void postorder(IR::CLASS *);                                \
-    virtual void revisit(const IR::CLASS *, const IR::CLASS *);
+    virtual void revisit(const IR::CLASS *, const IR::CLASS *);         \
+    virtual void loop_revisit(const IR::CLASS *);
     IRNODE_ALL_SUBCLASSES(DECLARE_VISIT_FUNCTIONS)
 #undef DECLARE_VISIT_FUNCTIONS
     void revisit_visited();
+    bool visit_in_progress(const IR::Node *) const;
 };
 
 class Inspector : public virtual Visitor {
@@ -319,13 +322,18 @@ class Inspector : public virtual Visitor {
     virtual bool preorder(const IR::Node *) { return true; }  // return 'false' to prune
     virtual void postorder(const IR::Node *) {}
     virtual void revisit(const IR::Node *) {}
+    virtual void loop_revisit(const IR::Node *) { BUG("IR loop detected"); }
 #define DECLARE_VISIT_FUNCTIONS(CLASS, BASE)                            \
     virtual bool preorder(const IR::CLASS *);                           \
     virtual void postorder(const IR::CLASS *);                          \
-    virtual void revisit(const IR::CLASS *);
+    virtual void revisit(const IR::CLASS *);                            \
+    virtual void loop_revisit(const IR::CLASS *);
     IRNODE_ALL_SUBCLASSES(DECLARE_VISIT_FUNCTIONS)
 #undef DECLARE_VISIT_FUNCTIONS
     void revisit_visited();
+    bool visit_in_progress(const IR::Node *n) const {
+        if (visited->count(n)) return visited->at(n).done;
+        return false; }
 };
 
 class Transform : public virtual Visitor {
@@ -340,13 +348,16 @@ class Transform : public virtual Visitor {
     virtual const IR::Node *preorder(IR::Node *n) {return n;}
     virtual const IR::Node *postorder(IR::Node *n) {return n;}
     virtual void revisit(const IR::Node *, const IR::Node *) {}
+    virtual void loop_revisit(const IR::Node *) { BUG("IR loop detected"); }
 #define DECLARE_VISIT_FUNCTIONS(CLASS, BASE)                            \
     virtual const IR::Node *preorder(IR::CLASS *);                      \
     virtual const IR::Node *postorder(IR::CLASS *);                     \
-    virtual void revisit(const IR::CLASS *, const IR::Node *);
+    virtual void revisit(const IR::CLASS *, const IR::Node *);          \
+    virtual void loop_revisit(const IR::CLASS *);
     IRNODE_ALL_SUBCLASSES(DECLARE_VISIT_FUNCTIONS)
 #undef DECLARE_VISIT_FUNCTIONS
     void revisit_visited();
+    bool visit_in_progress(const IR::Node *) const;
     // can only be called usefully from a 'preorder' function (directly or indirectly)
     void prune() { prune_flag = true; }
 


### PR DESCRIPTION
- by default will BUG("IR loop detected") (the old behavior), but allows
  writing visitor passes that can override and deal with it.

This is an experimental infrastructure extension that is most useful with the ResolutionContext/apply with context param stuff added awhile back -- using that code, a visitor can look up symbols and recursively visit the definition of the symbol, but doing so may lead to loops in the traversal.  This change allows dealing with those resulting loops rather than just exiting with a BUG (though that is still the default behavior) by overriding the loop_revisit method in the Visitor subclass.