### PR TITLE
DPDK: Implementation for non byte aligned metadata and header fields

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -19,6 +19,17 @@ p4c_add_xfail_reason("dpdk"
   )
 
 p4c_add_xfail_reason("dpdk"
+  "not implemented"
+  testdata/p4_16_samples/psa-example-dpdk-byte-alignment_3.p4
+  testdata/p4_16_samples/psa-example-dpdk-byte-alignment_4.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  "cannot be the target of an assignment"
+  testdata/p4_16_samples/psa-example-dpdk-byte-alignment_2.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
   "Not implemented"
   testdata/p4_16_samples/psa-random.p4
   )

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -52,6 +52,8 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new P4::ClearTypeMap(typeMap),
         new P4::TypeChecking(refMap, typeMap),
         // TBD: implement dpdk lowering passes instead of reusing bmv2's lowering pass.
+
+        new ByteAlignment(typeMap, refMap, &structure),
         new BMV2::LowerExpressions(typeMap),
         new DismantleMuxExpressions(typeMap, refMap),
         new P4::RemoveComplexExpressions(refMap, typeMap,
@@ -103,6 +105,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
                 out->flush();
             }
         }),
+        new ReplaceHdrMetaField(typeMap, refMap, &structure),
         // convert to assembly program
         convertToDpdk,
     };

--- a/backends/dpdk/dpdkProgramStructure.h
+++ b/backends/dpdk/dpdkProgramStructure.h
@@ -51,6 +51,7 @@ struct DpdkProgramStructure {
     cstring header_type;
     IR::IndexedVector<IR::StructField> compiler_added_fields;
     IR::Vector<IR::Type> used_metadata;
+    ordered_map<cstring, std::vector<struct hdrFieldInfo>> hdrFieldInfoList;
 
     void push_variable(const IR::DpdkDeclaration * d) {
         variables.push_back(d); }
@@ -89,6 +90,25 @@ struct DpdkProgramStructure {
      */
     bool isPNA(void) {
         return (p4arch == "pna") ? true : false;
+    }
+};
+
+struct hdrFieldInfo {
+    cstring modifiedName;
+    cstring headerStr;
+    unsigned modifiedWidth;
+    unsigned offset;
+    unsigned lsb;
+    unsigned msb;
+    unsigned fieldWidth;
+    hdrFieldInfo() {
+        modifiedName = "";
+        headerStr = "";
+        modifiedWidth = 0;
+        offset = 0;
+        lsb = 0;
+        msb = 0;
+        fieldWidth = 0;
     }
 };
 

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_1.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_1.p4
@@ -1,0 +1,139 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+		verify(hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6)
+           hdr.ipv4.ihl = 5;
+        if (hdr.ipv4.version == 6)
+           hdr.ipv4.ihl = 6;
+    }
+    
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;                                           // Works fine
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_2.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_2.p4
@@ -1,0 +1,139 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6)
+           hdr.ipv4.ihl = 5;
+        if (hdr.ipv4.version == 6)
+           hdr.ipv4.ihl = 6;
+    }
+    
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum[3:0] = 4;
+        hdr.ipv4.version = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_3.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_3.p4
@@ -1,0 +1,140 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6)
+           hdr.ipv4.ihl = 5;
+        if (hdr.ipv4.version == 6)
+           hdr.ipv4.ihl = 6;
+    }
+    
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+            hdr.ipv4.hdrChecksum[4:0]: exact;
+            hdr.ipv4.version: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_4.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_4.p4
@@ -1,0 +1,229 @@
+/*
+Copyright 2017 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "bmv2/psa.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+    bit<32> old_srcAddr;
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        //verify(parsed_hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(parsed_hdr.ipv4.protocol) {
+            6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+// BEGIN:Incremental_Checksum_Table
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd) {
+    action drop() {
+      ingress_drop(ostd);
+    }
+    action forward(PortId_t port, bit<32> srcAddr) {
+      user_meta.fwd_metadata.old_srcAddr = hdr.ipv4.srcAddr;
+      hdr.ipv4.srcAddr = srcAddr;
+      send_to_port(ostd, port);
+    }
+    table route {
+        key = { hdr.ipv4.dstAddr : lpm; }
+        actions = {
+          forward;
+          drop;
+        }
+    }
+    apply {
+        if(hdr.ipv4.isValid()) {
+          route.apply();
+        }
+    }
+}
+// END:Incremental_Checksum_Table
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata user_meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+	InternetChecksum() ck;
+    apply {
+	 ck.clear();
+        ck.add({
+            /* 16-bit word  0   */ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv,
+            /* 16-bit word  1   */ hdr.ipv4.totalLen,
+            /* 16-bit word  2   */ hdr.ipv4.identification,
+            /* 16-bit word  3   */ hdr.ipv4.flags, hdr.ipv4.fragOffset,
+            /* 16-bit word  4   */ hdr.ipv4.ttl, hdr.ipv4.protocol,
+            /* 16-bit word  5 skip hdr.ipv4.hdrChecksum, */
+            /* 16-bit words 6-7 */ hdr.ipv4.srcAddr,
+            /* 16-bit words 8-9 */ hdr.ipv4.dstAddr
+            });
+        hdr.ipv4.hdrChecksum = ck.get();
+        // Update TCP checksum
+        // This clear() call is necessary for correct behavior, since
+        // the same instance 'ck' is reused from above for the same
+        // packet.  If a second InternetChecksum instance other than
+        // 'ck' were used below instead, this clear() call would be
+        // unnecessary.
+        ck.clear();
+        // Subtract the original TCP checksum
+        ck.subtract({hdr.tcp.checksum});
+        // Subtract the effect of the original IPv4 source address,
+        // which is part of the TCP 'pseudo-header' for the purposes
+        // of TCP checksum calculation (see RFC 793), then add the
+        // effect of the new IPv4 source address.
+        ck.subtract({user_meta.fwd_metadata.old_srcAddr});
+        ck.add({hdr.ipv4.srcAddr});
+        hdr.tcp.checksum = ck.get();
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+// BEGIN:Incremental_Checksum_Example
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata user_meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_5.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_5.p4
@@ -1,0 +1,139 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+	bit<17> val;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6)
+           hdr.ipv4.ihl = 5;
+        if (hdr.ipv4.version == 6)
+           hdr.ipv4.ihl = 6;
+    }
+    
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;                                           // Works fine
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_6.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_6.p4
@@ -1,0 +1,149 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<4> f1;
+    bit<4> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+	s1_t s1;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.version == 6)
+           hdr.ipv4.ihl = 6;
+		if (user_meta.temp == 6) {
+            hdr.ipv4.s1 = {7,8};
+        } else {
+            hdr.ipv4.s1 = {7,9};
+        }
+    }
+    
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_7.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_7.p4
@@ -1,0 +1,157 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<3> f1;
+    bit<5> f2;
+}
+
+struct s2_t {
+    bit<5> f1;
+    bit<3> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+	s1_t s1;
+	s2_t s2;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.version == 6)
+           hdr.ipv4.ihl = 6;
+		if (user_meta.temp == 6) {
+            hdr.ipv4.s1 = {2,3};
+            hdr.ipv4.s2 = {2,3};
+        } else {
+            hdr.ipv4.s1 = {3,2};
+            hdr.ipv4.s2 = {3,2};
+        }
+    }
+    
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_8.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_8.p4
@@ -1,0 +1,157 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<8> f1;
+    bit<3> f2;
+}
+
+struct s2_t {
+    bit<5> f1;
+    bit<8> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+	s1_t s1;
+	s2_t s2;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.version == 6)
+           hdr.ipv4.ihl = 6;
+		if (user_meta.temp == 6) {
+            hdr.ipv4.s1 = {2,3};
+            hdr.ipv4.s2 = {2,3};
+        } else {
+            hdr.ipv4.s1 = {3,2};
+            hdr.ipv4.s2 = {3,2};
+        }
+    }
+    
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-action-selector.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-action-selector.p4.spec
@@ -7,13 +7,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum

--- a/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum

--- a/testdata/p4_16_samples_outputs/pna-example-SelectByDirection.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-SelectByDirection.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum

--- a/testdata/p4_16_samples_outputs/pna-example-SelectByDirection1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-SelectByDirection1.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum

--- a/testdata/p4_16_samples_outputs/pna-example-SelectByDirection2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-SelectByDirection2.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum

--- a/testdata/p4_16_samples_outputs/pna-example-template.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-template.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum

--- a/testdata/p4_16_samples_outputs/pna-example-tunnel.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-tunnel.p4.spec
@@ -6,16 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
-	bit<6> dscp
-	bit<2> ecn
+	bit<8> version_ihl
+	bit<8> dscp_ecn
 	bit<16> total_len
 	bit<16> identification
-	bit<1> reserved
-	bit<1> do_not_fragment
-	bit<1> more_fragments
-	bit<13> frag_offset
+	bit<16> reserved_do_not_fragment_more_fragments_frag_offset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> header_checksum
@@ -41,7 +36,7 @@ struct local_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> local_metadata__outer_ipv4_dst0
 	bit<24> local_metadata__tunnel_id1
-	bit<4> local_metadata__tunnel_tun_type3
+	bit<32> local_metadata__tunnel_tun_type3
 	bit<32> pna_main_output_metadata_output_port
 	bit<32> MainControlT_tunnel_decap_ipv4_tunnel_term_table_outer_ipv4_src_addr
 	bit<32> MainControlT_tunnel_decap_ipv4_tunnel_term_table_outer_ipv4_dst_addr

--- a/testdata/p4_16_samples_outputs/pna-issue3041.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-issue3041.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_base_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -42,10 +40,12 @@ struct a2_arg_t {
 struct main_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> pna_main_output_metadata_output_port
-	bit<32> MainParserT_parser_tmp
+	bit<8> MainParserT_parser_tmp
 	bit<32> MainParserT_parser_tmp_0
 	bit<32> MainParserT_parser_tmp_1
-	bit<32> MainParserT_parser_tmp_1_extract_tmp
+	bit<32> MainParserT_parser_tmp_2
+	bit<32> MainParserT_parser_tmp_3
+	bit<32> MainParserT_parser_tmp_3_extract_tmp
 }
 metadata instanceof main_metadata_t
 
@@ -100,18 +100,21 @@ apply {
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4_base
-	jmpeq MAINPARSERIMPL_ACCEPT h.ipv4_base.ihl 0x5
+	mov m.MainParserT_parser_tmp h.ipv4_base.version_ihl
+	shr m.MainParserT_parser_tmp 0x4
+	mov m.MainParserT_parser_tmp_2 m.MainParserT_parser_tmp
+	jmpeq MAINPARSERIMPL_ACCEPT m.MainParserT_parser_tmp_2 0x5
 	lookahead h.option
 	jmpeq MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP h.option.type 0x44
 	jmp MAINPARSERIMPL_ACCEPT
-	MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP :	mov m.MainParserT_parser_tmp h.option.len
-	mov m.MainParserT_parser_tmp_0 m.MainParserT_parser_tmp
-	shl m.MainParserT_parser_tmp_0 0x3
+	MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP :	mov m.MainParserT_parser_tmp_0 h.option.len
 	mov m.MainParserT_parser_tmp_1 m.MainParserT_parser_tmp_0
-	add m.MainParserT_parser_tmp_1 0xfffffff0
-	mov m.MainParserT_parser_tmp_1_extract_tmp m.MainParserT_parser_tmp_1
-	shr m.MainParserT_parser_tmp_1_extract_tmp 0x3
-	extract h.ipv4_option_timestamp m.MainParserT_parser_tmp_1_extract_tmp
+	shl m.MainParserT_parser_tmp_1 0x3
+	mov m.MainParserT_parser_tmp_3 m.MainParserT_parser_tmp_1
+	add m.MainParserT_parser_tmp_3 0xfffffff0
+	mov m.MainParserT_parser_tmp_3_extract_tmp m.MainParserT_parser_tmp_3
+	shr m.MainParserT_parser_tmp_3_extract_tmp 0x3
+	extract h.ipv4_option_timestamp m.MainParserT_parser_tmp_3_extract_tmp
 	MAINPARSERIMPL_ACCEPT :	mov m.pna_main_output_metadata_output_port 0x0
 	table tbl
 	table tbl2

--- a/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -25,10 +23,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> flags
+	bit<16> dataOffset_res_ecn_flags
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr
@@ -55,16 +50,16 @@ struct next_hop_arg_t {
 
 struct main_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
-	bit<1> local_metadata_rng_result1
-	bit<1> local_metadata_val1
-	bit<1> local_metadata_val2
+	bit<32> local_metadata_rng_result1
+	bit<32> local_metadata_val1
+	bit<32> local_metadata_val2
 	bit<32> pna_main_output_metadata_output_port
 	bit<32> MainControlT_tmp
 	bit<32> MainControlT_tmp_0
-	bit<1> MainControlT_tmp_1
-	bit<1> MainControlT_tmp_2
-	bit<1> MainControlT_tmp_3
-	bit<1> MainControlT_tmp_4
+	bit<32> MainControlT_tmp_1
+	bit<32> MainControlT_tmp_2
+	bit<32> MainControlT_tmp_3
+	bit<32> MainControlT_tmp_4
 }
 metadata instanceof main_metadata_t
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-1.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -27,10 +25,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -27,10 +25,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -27,10 +25,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -26,10 +24,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid7.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid7.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-bmv2.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum

--- a/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-drop-all-corrected-bmv2.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum

--- a/testdata/p4_16_samples_outputs/psa-end-of-ingress-test-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-end-of-ingress-test-bmv2.p4.spec
@@ -40,9 +40,9 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> Ingress_tmp
-	bit<1> Ingress_tmp_0
+	bit<32> Ingress_tmp_0
 	bit<48> Ingress_tmp_1
-	bit<1> Ingress_tmp_2
+	bit<32> Ingress_tmp_2
 	bit<48> Ingress_tmp_3
 	bit<16> Ingress_tmp_4
 	bit<16> Ingress_tmp_5

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-first.p4
@@ -1,0 +1,138 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(32w1024) reg;
+    Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 4w5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {
+            hdr.ipv4.ihl = 4w5;
+        }
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (user_meta.port_out == 32w1) {
+            tbl.apply();
+            counter0.count(12w1023, 32w20);
+            counter1.count(12w512);
+            counter2.count(12w1023, 32w64);
+            user_meta.port_out = reg.read(12w1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-frontend.p4
@@ -1,0 +1,151 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @name("ingress.tmp") bit<32> tmp;
+    @name("ingress.hasReturned") bool hasReturned;
+    @name("ingress.version") bit<4> version_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        if (color_out_0 == PSA_MeterColor_t.GREEN) {
+            tmp = 32w1;
+        } else {
+            tmp = 32w0;
+        }
+        user_meta.port_out = tmp;
+        reg_0.write(index_1, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {
+            hdr.ipv4.ihl = 4w5;
+        }
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+    }
+    @name("ingress.test") action test() {
+        version_0 = hdr.ipv4.version;
+        if (version_0 == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        hasReturned = false;
+        color_in_0 = PSA_MeterColor_t.RED;
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            counter0_0.count(12w1023, 32w20);
+            counter1_0.count(12w512);
+            counter2_0.count(12w1023, 32w64);
+            user_meta.port_out = reg_0.read(12w1);
+            test();
+        } else {
+            hasReturned = true;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-midend.p4
@@ -1,0 +1,166 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
+        hdr.ipv4.ihl = 4w5;
+        hdr.ipv4.ihl = (hdr.ipv4.version == 4w6 ? 4w6 : 4w5);
+    }
+    @name("ingress.test") action test() {
+        hdr.ipv4.hdrChecksum[3:0] = (hdr.ipv4.version == 4w4 ? hdr.ipv4.version + 4w5 : hdr.ipv4.hdrChecksum[3:0]);
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psaexampledpdkbytealignment_1l99() {
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512);
+        counter2_0.count(12w1023, 32w64);
+        user_meta.port_out = reg_0.read(12w1);
+    }
+    @hidden action psaexampledpdkbytealignment_1l70() {
+        color_in_0 = PSA_MeterColor_t.RED;
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_1l70 {
+        actions = {
+            psaexampledpdkbytealignment_1l70();
+        }
+        const default_action = psaexampledpdkbytealignment_1l70();
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_1l99 {
+        actions = {
+            psaexampledpdkbytealignment_1l99();
+        }
+        const default_action = psaexampledpdkbytealignment_1l99();
+    }
+    @hidden table tbl_test {
+        actions = {
+            test();
+        }
+        const default_action = test();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_1l70.apply();
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            tbl_psaexampledpdkbytealignment_1l99.apply();
+            tbl_test.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psaexampledpdkbytealignment_1l123() {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_1l123 {
+        actions = {
+            psaexampledpdkbytealignment_1l123();
+        }
+        const default_action = psaexampledpdkbytealignment_1l123();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_1l123.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4
@@ -1,0 +1,137 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6) {
+            hdr.ipv4.ihl = 5;
+        }
+        if (hdr.ipv4.version == 6) {
+            hdr.ipv4.ihl = 6;
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4-error
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4-stderr
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.bfrt.json
@@ -1,0 +1,272 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "index",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 12
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.ingress.counter0",
+      "id" : 314114784,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65553,
+            "name" : "$COUNTER_SPEC_BYTES",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65554,
+            "name" : "$COUNTER_SPEC_PKTS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.counter1",
+      "id" : 318473483,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65554,
+            "name" : "$COUNTER_SPEC_PKTS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.counter2",
+      "id" : 313911423,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65553,
+            "name" : "$COUNTER_SPEC_BYTES",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.meter0",
+      "id" : 344514043,
+      "table_type" : "Meter",
+      "size" : 1024,
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65555,
+          "name" : "$METER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65545,
+            "name" : "$METER_SPEC_CIR_KBPS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65546,
+            "name" : "$METER_SPEC_PIR_KBPS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65547,
+            "name" : "$METER_SPEC_CBS_KBITS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65548,
+            "name" : "$METER_SPEC_PBS_KBITS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        }
+      ],
+      "supported_operations" : [],
+      "attributes" : ["MeterByteCountAdjust"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.p4info.txt
@@ -1,0 +1,111 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+  params {
+    id: 1
+    name: "index"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 30967736
+    name: "ingress.test"
+    alias: "test"
+  }
+}
+counters {
+  preamble {
+    id: 314114784
+    name: "ingress.counter0"
+    alias: "counter0"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 318473483
+    name: "ingress.counter1"
+    alias: "counter1"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 313911423
+    name: "ingress.counter2"
+    alias: "counter2"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+meters {
+  preamble {
+    id: 344514043
+    name: "ingress.meter0"
+    alias: "meter0"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+registers {
+  preamble {
+    id: 382856063
+    name: "ingress.reg"
+    alias: "reg"
+  }
+  type_spec {
+    bitstring {
+      bit {
+        bitwidth: 32
+      }
+    }
+  }
+  size: 1024
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.spec
@@ -1,0 +1,181 @@
+
+
+
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<32> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct execute_1_arg_t {
+	bit<32> index
+}
+
+struct metadata_t {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<32> local_metadata_port_out
+	bit<8> IngressParser_parser_tmp
+	bit<32> IngressParser_parser_tmp_0
+	bit<8> IngressParser_parser_tmp_1
+	bit<32> IngressParser_parser_tmp_2
+	bit<32> Ingress_tmp
+	bit<32> Ingress_tmp_0
+	bit<32> Ingress_tmp_1
+	bit<8> Ingress_tmp_2
+	bit<8> Ingress_tmp_3
+	bit<8> Ingress_tmp_4
+	bit<16> Ingress_tmp_5
+	bit<32> Ingress_tmp_6
+	bit<32> Ingress_tmp_7
+	bit<16> Ingress_tmp_8
+	bit<16> Ingress_tmp_9
+	bit<32> Ingress_color_out
+	bit<32> Ingress_color_in
+	bit<32> Ingress_tmp_10
+}
+metadata instanceof metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray counter0_0_packets size 0x400 initval 0x0
+
+regarray counter0_0_bytes size 0x400 initval 0x0
+
+regarray counter1_0 size 0x400 initval 0x0
+
+regarray counter2_0 size 0x400 initval 0x0
+
+regarray reg_0 size 0x400 initval 0
+
+metarray meter0_0 size 0x400
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args instanceof execute_1_arg_t {
+	mov m.Ingress_tmp_2 h.ipv4.version_ihl
+	and m.Ingress_tmp_2 0xf
+	mov h.ipv4.version_ihl m.Ingress_tmp_2
+	or h.ipv4.version_ihl 0x50
+	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in m.Ingress_color_out
+	jmpneq LABEL_FALSE_2 m.Ingress_color_out 0x0
+	mov m.Ingress_tmp_10 0x1
+	jmp LABEL_END_3
+	LABEL_FALSE_2 :	mov m.Ingress_tmp_10 0x0
+	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_10
+	regwr reg_0 t.index m.local_metadata_port_out
+	mov m.Ingress_tmp h.ipv4.hdrChecksum
+	jmpneq LABEL_END_4 m.Ingress_tmp 0x6
+	mov m.Ingress_tmp_3 h.ipv4.version_ihl
+	and m.Ingress_tmp_3 0xf
+	mov h.ipv4.version_ihl m.Ingress_tmp_3
+	or h.ipv4.version_ihl 0x50
+	LABEL_END_4 :	mov m.Ingress_tmp_0 h.ipv4.version_ihl
+	jmpneq LABEL_END_5 m.Ingress_tmp_0 0x6
+	mov m.Ingress_tmp_4 h.ipv4.version_ihl
+	and m.Ingress_tmp_4 0xf
+	mov h.ipv4.version_ihl m.Ingress_tmp_4
+	or h.ipv4.version_ihl 0x60
+	LABEL_END_5 :	return
+}
+
+table tbl {
+	key {
+		h.ethernet.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.IngressParser_parser_tmp h.ipv4.version_ihl
+	shr m.IngressParser_parser_tmp 0x4
+	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
+	mov m.IngressParser_parser_tmp_1 0x0
+	jmp LABEL_END
+	LABEL_TRUE :	mov m.IngressParser_parser_tmp_1 0x1
+	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_1 0
+	mov m.psa_ingress_input_metadata_parser_error 0x7
+	jmp INGRESSPARSERIMPL_ACCEPT
+	LABEL_END_0 :	mov m.IngressParser_parser_tmp_2 h.ipv4.version_ihl
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
+	jmpneq LABEL_END_1 m.local_metadata_port_out 0x1
+	table tbl
+	regadd counter0_0_packets 0x3ff 1
+	regadd counter0_0_bytes 0x3ff 0x14
+	regadd counter1_0 0x200 1
+	regadd counter2_0 0x3ff 0x40
+	regrd m.local_metadata_port_out reg_0 0x1
+	mov m.Ingress_tmp_1 h.ipv4.version_ihl
+	jmpneq LABEL_END_1 m.Ingress_tmp_1 0x4
+	mov m.Ingress_tmp_5 h.ipv4.hdrChecksum
+	and m.Ingress_tmp_5 0xfff0
+	mov m.Ingress_tmp_6 h.ipv4.version_ihl
+	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	add m.Ingress_tmp_7 0x5
+	mov m.Ingress_tmp_8 m.Ingress_tmp_7
+	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	and m.Ingress_tmp_9 0xf
+	mov h.ipv4.hdrChecksum m.Ingress_tmp_5
+	or h.ipv4.hdrChecksum m.Ingress_tmp_9
+	LABEL_END_1 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	mov h.ipv4.hdrChecksum 0x4
+	emit h.ethernet
+	emit h.ipv4
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-first.p4
@@ -1,0 +1,138 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(32w1024) reg;
+    Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 4w5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {
+            hdr.ipv4.ihl = 4w5;
+        }
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (user_meta.port_out == 32w1) {
+            tbl.apply();
+            counter0.count(12w1023, 32w20);
+            counter1.count(12w512);
+            counter2.count(12w1023, 32w64);
+            user_meta.port_out = reg.read(12w1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum[3:0] = 4w4;
+        hdr.ipv4.version = 4w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-frontend.p4
@@ -1,0 +1,151 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @name("ingress.tmp") bit<32> tmp;
+    @name("ingress.hasReturned") bool hasReturned;
+    @name("ingress.version") bit<4> version_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        if (color_out_0 == PSA_MeterColor_t.GREEN) {
+            tmp = 32w1;
+        } else {
+            tmp = 32w0;
+        }
+        user_meta.port_out = tmp;
+        reg_0.write(index_1, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {
+            hdr.ipv4.ihl = 4w5;
+        }
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+    }
+    @name("ingress.test") action test() {
+        version_0 = hdr.ipv4.version;
+        if (version_0 == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        hasReturned = false;
+        color_in_0 = PSA_MeterColor_t.RED;
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            counter0_0.count(12w1023, 32w20);
+            counter1_0.count(12w512);
+            counter2_0.count(12w1023, 32w64);
+            user_meta.port_out = reg_0.read(12w1);
+            test();
+        } else {
+            hasReturned = true;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum[3:0] = 4w4;
+        hdr.ipv4.version = 4w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-midend.p4
@@ -1,0 +1,166 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
+        hdr.ipv4.ihl = 4w5;
+        hdr.ipv4.ihl = (hdr.ipv4.version == 4w6 ? 4w6 : 4w5);
+    }
+    @name("ingress.test") action test() {
+        hdr.ipv4.hdrChecksum[3:0] = (hdr.ipv4.version == 4w4 ? hdr.ipv4.version + 4w5 : hdr.ipv4.hdrChecksum[3:0]);
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psaexampledpdkbytealignment_2l98() {
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512);
+        counter2_0.count(12w1023, 32w64);
+        user_meta.port_out = reg_0.read(12w1);
+    }
+    @hidden action psaexampledpdkbytealignment_2l69() {
+        color_in_0 = PSA_MeterColor_t.RED;
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_2l69 {
+        actions = {
+            psaexampledpdkbytealignment_2l69();
+        }
+        const default_action = psaexampledpdkbytealignment_2l69();
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_2l98 {
+        actions = {
+            psaexampledpdkbytealignment_2l98();
+        }
+        const default_action = psaexampledpdkbytealignment_2l98();
+    }
+    @hidden table tbl_test {
+        actions = {
+            test();
+        }
+        const default_action = test();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_2l69.apply();
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            tbl_psaexampledpdkbytealignment_2l98.apply();
+            tbl_test.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psaexampledpdkbytealignment_2l122() {
+        hdr.ipv4.hdrChecksum[3:0] = 4w4;
+        hdr.ipv4.version = 4w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_2l122 {
+        actions = {
+            psaexampledpdkbytealignment_2l122();
+        }
+        const default_action = psaexampledpdkbytealignment_2l122();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_2l122.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4
@@ -1,0 +1,137 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6) {
+            hdr.ipv4.ihl = 5;
+        }
+        if (hdr.ipv4.version == 6) {
+            hdr.ipv4.ihl = 6;
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum[3:0] = 4;
+        hdr.ipv4.version = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4-stderr
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4.p4info.txt
@@ -1,0 +1,111 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+  params {
+    id: 1
+    name: "index"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 30967736
+    name: "ingress.test"
+    alias: "test"
+  }
+}
+counters {
+  preamble {
+    id: 314114784
+    name: "ingress.counter0"
+    alias: "counter0"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 318473483
+    name: "ingress.counter1"
+    alias: "counter1"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 313911423
+    name: "ingress.counter2"
+    alias: "counter2"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+meters {
+  preamble {
+    id: 344514043
+    name: "ingress.meter0"
+    alias: "meter0"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+registers {
+  preamble {
+    id: 382856063
+    name: "ingress.reg"
+    alias: "reg"
+  }
+  type_spec {
+    bitstring {
+      bit {
+        bitwidth: 32
+      }
+    }
+  }
+  size: 1024
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-first.p4
@@ -1,0 +1,139 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(32w1024) reg;
+    Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 4w5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {
+            hdr.ipv4.ihl = 4w5;
+        }
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr     : exact @name("hdr.ethernet.srcAddr") ;
+            hdr.ipv4.hdrChecksum[4:0]: exact @name("hdr.ipv4.hdrChecksum[4:0]") ;
+            hdr.ipv4.version         : exact @name("hdr.ipv4.version") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (user_meta.port_out == 32w1) {
+            tbl.apply();
+            counter0.count(12w1023, 32w20);
+            counter1.count(12w512);
+            counter2.count(12w1023, 32w64);
+            user_meta.port_out = reg.read(12w1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-frontend.p4
@@ -1,0 +1,152 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @name("ingress.tmp") bit<32> tmp;
+    @name("ingress.hasReturned") bool hasReturned;
+    @name("ingress.version") bit<4> version_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        if (color_out_0 == PSA_MeterColor_t.GREEN) {
+            tmp = 32w1;
+        } else {
+            tmp = 32w0;
+        }
+        user_meta.port_out = tmp;
+        reg_0.write(index_1, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {
+            hdr.ipv4.ihl = 4w5;
+        }
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+    }
+    @name("ingress.test") action test() {
+        version_0 = hdr.ipv4.version;
+        if (version_0 == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr     : exact @name("hdr.ethernet.srcAddr") ;
+            hdr.ipv4.hdrChecksum[4:0]: exact @name("hdr.ipv4.hdrChecksum[4:0]") ;
+            hdr.ipv4.version         : exact @name("hdr.ipv4.version") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        hasReturned = false;
+        color_in_0 = PSA_MeterColor_t.RED;
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            counter0_0.count(12w1023, 32w20);
+            counter1_0.count(12w512);
+            counter2_0.count(12w1023, 32w64);
+            user_meta.port_out = reg_0.read(12w1);
+            test();
+        } else {
+            hasReturned = true;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-midend.p4
@@ -1,0 +1,167 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
+        hdr.ipv4.ihl = 4w5;
+        hdr.ipv4.ihl = (hdr.ipv4.version == 4w6 ? 4w6 : 4w5);
+    }
+    @name("ingress.test") action test() {
+        hdr.ipv4.hdrChecksum[3:0] = (hdr.ipv4.version == 4w4 ? hdr.ipv4.version + 4w5 : hdr.ipv4.hdrChecksum[3:0]);
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr     : exact @name("hdr.ethernet.srcAddr") ;
+            hdr.ipv4.hdrChecksum[4:0]: exact @name("hdr.ipv4.hdrChecksum[4:0]") ;
+            hdr.ipv4.version         : exact @name("hdr.ipv4.version") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psaexampledpdkbytealignment_3l100() {
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512);
+        counter2_0.count(12w1023, 32w64);
+        user_meta.port_out = reg_0.read(12w1);
+    }
+    @hidden action psaexampledpdkbytealignment_3l69() {
+        color_in_0 = PSA_MeterColor_t.RED;
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_3l69 {
+        actions = {
+            psaexampledpdkbytealignment_3l69();
+        }
+        const default_action = psaexampledpdkbytealignment_3l69();
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_3l100 {
+        actions = {
+            psaexampledpdkbytealignment_3l100();
+        }
+        const default_action = psaexampledpdkbytealignment_3l100();
+    }
+    @hidden table tbl_test {
+        actions = {
+            test();
+        }
+        const default_action = test();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_3l69.apply();
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            tbl_psaexampledpdkbytealignment_3l100.apply();
+            tbl_test.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psaexampledpdkbytealignment_3l124() {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_3l124 {
+        actions = {
+            psaexampledpdkbytealignment_3l124();
+        }
+        const default_action = psaexampledpdkbytealignment_3l124();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_3l124.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4
@@ -1,0 +1,138 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6) {
+            hdr.ipv4.ihl = 5;
+        }
+        if (hdr.ipv4.version == 6) {
+            hdr.ipv4.ihl = 6;
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr     : exact;
+            hdr.ipv4.hdrChecksum[4:0]: exact;
+            hdr.ipv4.version         : exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4-stderr
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.p4info.txt
@@ -1,0 +1,123 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "hdr.ipv4.hdrChecksum[4:0]"
+    bitwidth: 5
+    match_type: EXACT
+  }
+  match_fields {
+    id: 3
+    name: "hdr.ipv4.version"
+    bitwidth: 4
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+  params {
+    id: 1
+    name: "index"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 30967736
+    name: "ingress.test"
+    alias: "test"
+  }
+}
+counters {
+  preamble {
+    id: 314114784
+    name: "ingress.counter0"
+    alias: "counter0"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 318473483
+    name: "ingress.counter1"
+    alias: "counter1"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 313911423
+    name: "ingress.counter2"
+    alias: "counter2"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+meters {
+  preamble {
+    id: 344514043
+    name: "ingress.meter0"
+    alias: "meter0"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+registers {
+  preamble {
+    id: 382856063
+    name: "ingress.reg"
+    alias: "reg"
+  }
+  type_spec {
+    bitstring {
+      bit {
+        bitwidth: 32
+      }
+    }
+  }
+  size: 1024
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4-first.p4
@@ -1,0 +1,150 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+    bit<32> old_srcAddr;
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition select(parsed_hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action drop() {
+        ingress_drop(ostd);
+    }
+    action forward(PortId_t port, bit<32> srcAddr) {
+        user_meta.fwd_metadata.old_srcAddr = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = srcAddr;
+        send_to_port(ostd, port);
+    }
+    table route {
+        key = {
+            hdr.ipv4.dstAddr: lpm @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            forward();
+            drop();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            route.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata user_meta, in psa_ingress_output_metadata_t istd) {
+    InternetChecksum() ck;
+    apply {
+        ck.clear();
+        ck.add<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = ck.get();
+        ck.clear();
+        ck.subtract<tuple<bit<16>>>({ hdr.tcp.checksum });
+        ck.subtract<tuple<bit<32>>>({ user_meta.fwd_metadata.old_srcAddr });
+        ck.add<tuple<bit<32>>>({ hdr.ipv4.srcAddr });
+        hdr.tcp.checksum = ck.get();
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4-frontend.p4
@@ -1,0 +1,166 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+    bit<32> old_srcAddr;
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition select(parsed_hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.meta") psa_ingress_output_metadata_t meta_2;
+    @name("ingress.meta") psa_ingress_output_metadata_t meta_3;
+    @name("ingress.egress_port") PortId_t egress_port_1;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.drop") action drop_1() {
+        @noWarnUnused {
+            meta_2 = ostd;
+            meta_2.drop = true;
+            ostd = meta_2;
+        }
+    }
+    @name("ingress.forward") action forward(@name("port") PortId_t port, @name("srcAddr") bit<32> srcAddr_1) {
+        user_meta.fwd_metadata.old_srcAddr = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = srcAddr_1;
+        @noWarnUnused {
+            meta_3 = ostd;
+            egress_port_1 = port;
+            meta_3.drop = false;
+            meta_3.multicast_group = (MulticastGroup_t)32w0;
+            meta_3.egress_port = egress_port_1;
+            ostd = meta_3;
+        }
+    }
+    @name("ingress.route") table route_0 {
+        key = {
+            hdr.ipv4.dstAddr: lpm @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            forward();
+            drop_1();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            route_0.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata user_meta, in psa_ingress_output_metadata_t istd) {
+    @name("IngressDeparserImpl.ck") InternetChecksum() ck_0;
+    apply {
+        ck_0.clear();
+        ck_0.add<tuple<bit<4>, bit<4>, bit<8>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>>({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = ck_0.get();
+        ck_0.clear();
+        ck_0.subtract<tuple<bit<16>>>({ hdr.tcp.checksum });
+        ck_0.subtract<tuple<bit<32>>>({ user_meta.fwd_metadata.old_srcAddr });
+        ck_0.add<tuple<bit<32>>>({ hdr.ipv4.srcAddr });
+        hdr.tcp.checksum = ck_0.get();
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4-midend.p4
@@ -1,0 +1,198 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+    bit<32> old_srcAddr;
+}
+
+struct metadata {
+    bit<32> _fwd_metadata_old_srcAddr0;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(parsed_hdr.ipv4);
+        transition select(parsed_hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.drop") action drop_1() {
+        @noWarnUnused {
+            ostd.drop = true;
+        }
+    }
+    @name("ingress.forward") action forward(@name("port") PortId_t port, @name("srcAddr") bit<32> srcAddr_1) {
+        user_meta._fwd_metadata_old_srcAddr0 = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = srcAddr_1;
+        @noWarnUnused {
+            ostd.drop = false;
+            ostd.multicast_group = 32w0;
+            ostd.egress_port = port;
+        }
+    }
+    @name("ingress.route") table route_0 {
+        key = {
+            hdr.ipv4.dstAddr: lpm @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            forward();
+            drop_1();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            route_0.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+struct tuple_0 {
+    bit<4>  f0;
+    bit<4>  f1;
+    bit<8>  f2;
+    bit<16> f3;
+    bit<16> f4;
+    bit<3>  f5;
+    bit<13> f6;
+    bit<8>  f7;
+    bit<8>  f8;
+    bit<32> f9;
+    bit<32> f10;
+}
+
+struct tuple_1 {
+    bit<16> f0;
+}
+
+struct tuple_2 {
+    bit<32> f0;
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata user_meta, in psa_ingress_output_metadata_t istd) {
+    @name("IngressDeparserImpl.ck") InternetChecksum() ck_0;
+    @hidden action psaexampledpdkbytealignment_4l171() {
+        ck_0.clear();
+        ck_0.add<tuple_0>((tuple_0){f0 = hdr.ipv4.version,f1 = hdr.ipv4.ihl,f2 = hdr.ipv4.diffserv,f3 = hdr.ipv4.totalLen,f4 = hdr.ipv4.identification,f5 = hdr.ipv4.flags,f6 = hdr.ipv4.fragOffset,f7 = hdr.ipv4.ttl,f8 = hdr.ipv4.protocol,f9 = hdr.ipv4.srcAddr,f10 = hdr.ipv4.dstAddr});
+        hdr.ipv4.hdrChecksum = ck_0.get();
+        ck_0.clear();
+        ck_0.subtract<tuple_1>((tuple_1){f0 = hdr.tcp.checksum});
+        ck_0.subtract<tuple_2>((tuple_2){f0 = user_meta._fwd_metadata_old_srcAddr0});
+        ck_0.add<tuple_2>((tuple_2){f0 = hdr.ipv4.srcAddr});
+        hdr.tcp.checksum = ck_0.get();
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_4l171 {
+        actions = {
+            psaexampledpdkbytealignment_4l171();
+        }
+        const default_action = psaexampledpdkbytealignment_4l171();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_4l171.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action psaexampledpdkbytealignment_4l215() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_4l215 {
+        actions = {
+            psaexampledpdkbytealignment_4l215();
+        }
+        const default_action = psaexampledpdkbytealignment_4l215();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_4l215.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4.p4
@@ -1,0 +1,148 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct fwd_metadata_t {
+    bit<32> old_srcAddr;
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        transition select(parsed_hdr.ipv4.protocol) {
+            6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action drop() {
+        ingress_drop(ostd);
+    }
+    action forward(PortId_t port, bit<32> srcAddr) {
+        user_meta.fwd_metadata.old_srcAddr = hdr.ipv4.srcAddr;
+        hdr.ipv4.srcAddr = srcAddr;
+        send_to_port(ostd, port);
+    }
+    table route {
+        key = {
+            hdr.ipv4.dstAddr: lpm;
+        }
+        actions = {
+            forward;
+            drop;
+        }
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            route.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata user_meta, in psa_ingress_output_metadata_t istd) {
+    InternetChecksum() ck;
+    apply {
+        ck.clear();
+        ck.add({ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv, hdr.ipv4.totalLen, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.fragOffset, hdr.ipv4.ttl, hdr.ipv4.protocol, hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = ck.get();
+        ck.clear();
+        ck.subtract({ hdr.tcp.checksum });
+        ck.subtract({ user_meta.fwd_metadata.old_srcAddr });
+        ck.add({ hdr.ipv4.srcAddr });
+        hdr.tcp.checksum = ck.get();
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4.p4-stderr
@@ -1,0 +1,6 @@
+psa.p4(546): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(575): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4.p4.p4info.txt
@@ -1,0 +1,74 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 40550280
+    name: "ingress.route"
+    alias: "route"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ipv4.dstAddr"
+    bitwidth: 32
+    match_type: LPM
+  }
+  action_refs {
+    id: 26512162
+  }
+  action_refs {
+    id: 33281717
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 33281717
+    name: "ingress.drop"
+    alias: "drop"
+  }
+}
+actions {
+  preamble {
+    id: 26512162
+    name: "ingress.forward"
+    alias: "forward"
+  }
+  params {
+    id: 1
+    name: "port"
+    bitwidth: 32
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  params {
+    id: 2
+    name: "srcAddr"
+    bitwidth: 32
+  }
+}
+type_info {
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-first.p4
@@ -1,0 +1,138 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<17> val;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(32w1024) reg;
+    Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 4w5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {
+            hdr.ipv4.ihl = 4w5;
+        }
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (user_meta.port_out == 32w1) {
+            tbl.apply();
+            counter0.count(12w1023, 32w20);
+            counter1.count(12w512);
+            counter2.count(12w1023, 32w64);
+            user_meta.port_out = reg.read(12w1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-frontend.p4
@@ -1,0 +1,151 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<17> val;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @name("ingress.tmp") bit<32> tmp;
+    @name("ingress.hasReturned") bool hasReturned;
+    @name("ingress.version") bit<4> version_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        if (color_out_0 == PSA_MeterColor_t.GREEN) {
+            tmp = 32w1;
+        } else {
+            tmp = 32w0;
+        }
+        user_meta.port_out = tmp;
+        reg_0.write(index_1, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {
+            hdr.ipv4.ihl = 4w5;
+        }
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+    }
+    @name("ingress.test") action test() {
+        version_0 = hdr.ipv4.version;
+        if (version_0 == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        hasReturned = false;
+        color_in_0 = PSA_MeterColor_t.RED;
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            counter0_0.count(12w1023, 32w20);
+            counter1_0.count(12w512);
+            counter2_0.count(12w1023, 32w64);
+            user_meta.port_out = reg_0.read(12w1);
+            test();
+        } else {
+            hasReturned = true;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-midend.p4
@@ -1,0 +1,166 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<17> val;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
+        hdr.ipv4.ihl = 4w5;
+        hdr.ipv4.ihl = (hdr.ipv4.version == 4w6 ? 4w6 : 4w5);
+    }
+    @name("ingress.test") action test() {
+        hdr.ipv4.hdrChecksum[3:0] = (hdr.ipv4.version == 4w4 ? hdr.ipv4.version + 4w5 : hdr.ipv4.hdrChecksum[3:0]);
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psaexampledpdkbytealignment_5l99() {
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512);
+        counter2_0.count(12w1023, 32w64);
+        user_meta.port_out = reg_0.read(12w1);
+    }
+    @hidden action psaexampledpdkbytealignment_5l70() {
+        color_in_0 = PSA_MeterColor_t.RED;
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_5l70 {
+        actions = {
+            psaexampledpdkbytealignment_5l70();
+        }
+        const default_action = psaexampledpdkbytealignment_5l70();
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_5l99 {
+        actions = {
+            psaexampledpdkbytealignment_5l99();
+        }
+        const default_action = psaexampledpdkbytealignment_5l99();
+    }
+    @hidden table tbl_test {
+        actions = {
+            test();
+        }
+        const default_action = test();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_5l70.apply();
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            tbl_psaexampledpdkbytealignment_5l99.apply();
+            tbl_test.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psaexampledpdkbytealignment_5l123() {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_5l123 {
+        actions = {
+            psaexampledpdkbytealignment_5l123();
+        }
+        const default_action = psaexampledpdkbytealignment_5l123();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_5l123.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4
@@ -1,0 +1,137 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<17> val;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6) {
+            hdr.ipv4.ihl = 5;
+        }
+        if (hdr.ipv4.version == 6) {
+            hdr.ipv4.ihl = 6;
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4-error
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4-stderr
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.bfrt.json
@@ -1,0 +1,272 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "index",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 12
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.ingress.counter0",
+      "id" : 314114784,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65553,
+            "name" : "$COUNTER_SPEC_BYTES",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65554,
+            "name" : "$COUNTER_SPEC_PKTS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.counter1",
+      "id" : 318473483,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65554,
+            "name" : "$COUNTER_SPEC_PKTS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.counter2",
+      "id" : 313911423,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65553,
+            "name" : "$COUNTER_SPEC_BYTES",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.meter0",
+      "id" : 344514043,
+      "table_type" : "Meter",
+      "size" : 1024,
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65555,
+          "name" : "$METER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65545,
+            "name" : "$METER_SPEC_CIR_KBPS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65546,
+            "name" : "$METER_SPEC_PIR_KBPS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65547,
+            "name" : "$METER_SPEC_CBS_KBITS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65548,
+            "name" : "$METER_SPEC_PBS_KBITS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        }
+      ],
+      "supported_operations" : [],
+      "attributes" : ["MeterByteCountAdjust"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.p4info.txt
@@ -1,0 +1,111 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+  params {
+    id: 1
+    name: "index"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 30967736
+    name: "ingress.test"
+    alias: "test"
+  }
+}
+counters {
+  preamble {
+    id: 314114784
+    name: "ingress.counter0"
+    alias: "counter0"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 318473483
+    name: "ingress.counter1"
+    alias: "counter1"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 313911423
+    name: "ingress.counter2"
+    alias: "counter2"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+meters {
+  preamble {
+    id: 344514043
+    name: "ingress.meter0"
+    alias: "meter0"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+registers {
+  preamble {
+    id: 382856063
+    name: "ingress.reg"
+    alias: "reg"
+  }
+  type_spec {
+    bitstring {
+      bit {
+        bitwidth: 32
+      }
+    }
+  }
+  size: 1024
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.spec
@@ -1,0 +1,168 @@
+
+
+
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<32> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct execute_1_arg_t {
+	bit<32> index
+}
+
+struct metadata_t {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<32> local_metadata_port_out
+	bit<32> IngressParser_parser_tmp
+	bit<32> Ingress_tmp
+	bit<32> Ingress_tmp_0
+	bit<32> Ingress_tmp_1
+	bit<8> Ingress_tmp_2
+	bit<8> Ingress_tmp_3
+	bit<8> Ingress_tmp_4
+	bit<16> Ingress_tmp_5
+	bit<32> Ingress_tmp_6
+	bit<32> Ingress_tmp_7
+	bit<16> Ingress_tmp_8
+	bit<16> Ingress_tmp_9
+	bit<32> Ingress_color_out
+	bit<32> Ingress_color_in
+	bit<32> Ingress_tmp_10
+}
+metadata instanceof metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray counter0_0_packets size 0x400 initval 0x0
+
+regarray counter0_0_bytes size 0x400 initval 0x0
+
+regarray counter1_0 size 0x400 initval 0x0
+
+regarray counter2_0 size 0x400 initval 0x0
+
+regarray reg_0 size 0x400 initval 0
+
+metarray meter0_0 size 0x400
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args instanceof execute_1_arg_t {
+	mov m.Ingress_tmp_2 h.ipv4.version_ihl
+	and m.Ingress_tmp_2 0xf
+	mov h.ipv4.version_ihl m.Ingress_tmp_2
+	or h.ipv4.version_ihl 0x50
+	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in m.Ingress_color_out
+	jmpneq LABEL_FALSE_1 m.Ingress_color_out 0x0
+	mov m.Ingress_tmp_10 0x1
+	jmp LABEL_END_1
+	LABEL_FALSE_1 :	mov m.Ingress_tmp_10 0x0
+	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_10
+	regwr reg_0 t.index m.local_metadata_port_out
+	mov m.Ingress_tmp h.ipv4.hdrChecksum
+	jmpneq LABEL_END_2 m.Ingress_tmp 0x6
+	mov m.Ingress_tmp_3 h.ipv4.version_ihl
+	and m.Ingress_tmp_3 0xf
+	mov h.ipv4.version_ihl m.Ingress_tmp_3
+	or h.ipv4.version_ihl 0x50
+	LABEL_END_2 :	mov m.Ingress_tmp_0 h.ipv4.version_ihl
+	jmpneq LABEL_END_3 m.Ingress_tmp_0 0x6
+	mov m.Ingress_tmp_4 h.ipv4.version_ihl
+	and m.Ingress_tmp_4 0xf
+	mov h.ipv4.version_ihl m.Ingress_tmp_4
+	or h.ipv4.version_ihl 0x60
+	LABEL_END_3 :	return
+}
+
+table tbl {
+	key {
+		h.ethernet.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.IngressParser_parser_tmp h.ipv4.version_ihl
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
+	jmpneq LABEL_END m.local_metadata_port_out 0x1
+	table tbl
+	regadd counter0_0_packets 0x3ff 1
+	regadd counter0_0_bytes 0x3ff 0x14
+	regadd counter1_0 0x200 1
+	regadd counter2_0 0x3ff 0x40
+	regrd m.local_metadata_port_out reg_0 0x1
+	mov m.Ingress_tmp_1 h.ipv4.version_ihl
+	jmpneq LABEL_END m.Ingress_tmp_1 0x4
+	mov m.Ingress_tmp_5 h.ipv4.hdrChecksum
+	and m.Ingress_tmp_5 0xfff0
+	mov m.Ingress_tmp_6 h.ipv4.version_ihl
+	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	add m.Ingress_tmp_7 0x5
+	mov m.Ingress_tmp_8 m.Ingress_tmp_7
+	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	and m.Ingress_tmp_9 0xf
+	mov h.ipv4.hdrChecksum m.Ingress_tmp_5
+	or h.ipv4.hdrChecksum m.Ingress_tmp_9
+	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	mov h.ipv4.hdrChecksum 0x4
+	emit h.ethernet
+	emit h.ipv4
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-first.p4
@@ -1,0 +1,147 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<4> f1;
+    bit<4> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    s1_t    s1;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(32w1024) reg;
+    Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 4w5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+        if (user_meta.temp == 4w6) {
+            hdr.ipv4.s1 = (s1_t){f1 = 4w7,f2 = 4w8};
+        } else {
+            hdr.ipv4.s1 = (s1_t){f1 = 4w7,f2 = 4w9};
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (user_meta.port_out == 32w1) {
+            tbl.apply();
+            counter0.count(12w1023, 32w20);
+            counter1.count(12w512);
+            counter2.count(12w1023, 32w64);
+            user_meta.port_out = reg.read(12w1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-frontend.p4
@@ -1,0 +1,160 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<4> f1;
+    bit<4> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    s1_t    s1;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @name("ingress.tmp") bit<32> tmp;
+    @name("ingress.hasReturned") bool hasReturned;
+    @name("ingress.version") bit<4> version_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        if (color_out_0 == PSA_MeterColor_t.GREEN) {
+            tmp = 32w1;
+        } else {
+            tmp = 32w0;
+        }
+        user_meta.port_out = tmp;
+        reg_0.write(index_1, user_meta.port_out);
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+        if (user_meta.temp == 4w6) {
+            hdr.ipv4.s1 = (s1_t){f1 = 4w7,f2 = 4w8};
+        } else {
+            hdr.ipv4.s1 = (s1_t){f1 = 4w7,f2 = 4w9};
+        }
+    }
+    @name("ingress.test") action test() {
+        version_0 = hdr.ipv4.version;
+        if (version_0 == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        hasReturned = false;
+        color_in_0 = PSA_MeterColor_t.RED;
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            counter0_0.count(12w1023, 32w20);
+            counter1_0.count(12w512);
+            counter2_0.count(12w1023, 32w64);
+            user_meta.port_out = reg_0.read(12w1);
+            test();
+        } else {
+            hasReturned = true;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-midend.p4
@@ -1,0 +1,177 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<4> f1;
+    bit<4> f2;
+}
+
+header ipv4_t {
+    bit<4>  _version0;
+    bit<4>  _ihl1;
+    bit<8>  _diffserv2;
+    bit<32> _totalLen3;
+    bit<16> _identification4;
+    bit<3>  _flags5;
+    bit<13> _fragOffset6;
+    bit<8>  _ttl7;
+    bit<8>  _protocol8;
+    bit<16> _hdrChecksum9;
+    bit<32> _srcAddr10;
+    bit<32> _dstAddr11;
+    bit<4>  _s1_f112;
+    bit<4>  _s1_f213;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4._ihl1 == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4._version0) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4._ihl1 = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4._totalLen3);
+        user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
+        hdr.ipv4._ihl1 = (hdr.ipv4._version0 == 4w6 ? 4w6 : 4w5);
+        hdr.ipv4._s1_f112 = (user_meta.temp == 4w6 ? 4w7 : hdr.ipv4._s1_f112);
+        hdr.ipv4._s1_f213 = (user_meta.temp == 4w6 ? 4w8 : hdr.ipv4._s1_f213);
+        hdr.ipv4._s1_f112 = 4w7;
+        hdr.ipv4._s1_f213 = (user_meta.temp == 4w6 ? 4w8 : 4w9);
+    }
+    @name("ingress.test") action test() {
+        hdr.ipv4._hdrChecksum9[3:0] = (hdr.ipv4._version0 == 4w4 ? hdr.ipv4._version0 + 4w5 : hdr.ipv4._hdrChecksum9[3:0]);
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psaexampledpdkbytealignment_6l109() {
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512);
+        counter2_0.count(12w1023, 32w64);
+        user_meta.port_out = reg_0.read(12w1);
+    }
+    @hidden action psaexampledpdkbytealignment_6l77() {
+        color_in_0 = PSA_MeterColor_t.RED;
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_6l77 {
+        actions = {
+            psaexampledpdkbytealignment_6l77();
+        }
+        const default_action = psaexampledpdkbytealignment_6l77();
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_6l109 {
+        actions = {
+            psaexampledpdkbytealignment_6l109();
+        }
+        const default_action = psaexampledpdkbytealignment_6l109();
+    }
+    @hidden table tbl_test {
+        actions = {
+            test();
+        }
+        const default_action = test();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_6l77.apply();
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            tbl_psaexampledpdkbytealignment_6l109.apply();
+            tbl_test.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psaexampledpdkbytealignment_6l133() {
+        hdr.ipv4._hdrChecksum9 = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_6l133 {
+        actions = {
+            psaexampledpdkbytealignment_6l133();
+        }
+        const default_action = psaexampledpdkbytealignment_6l133();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_6l133.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4
@@ -1,0 +1,146 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<4> f1;
+    bit<4> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    s1_t    s1;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.version == 6) {
+            hdr.ipv4.ihl = 6;
+        }
+        if (user_meta.temp == 6) {
+            hdr.ipv4.s1 = { 7, 8 };
+        } else {
+            hdr.ipv4.s1 = { 7, 9 };
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4-error
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4-stderr
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.bfrt.json
@@ -1,0 +1,272 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "index",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 12
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.ingress.counter0",
+      "id" : 314114784,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65553,
+            "name" : "$COUNTER_SPEC_BYTES",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65554,
+            "name" : "$COUNTER_SPEC_PKTS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.counter1",
+      "id" : 318473483,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65554,
+            "name" : "$COUNTER_SPEC_PKTS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.counter2",
+      "id" : 313911423,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65553,
+            "name" : "$COUNTER_SPEC_BYTES",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.meter0",
+      "id" : 344514043,
+      "table_type" : "Meter",
+      "size" : 1024,
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65555,
+          "name" : "$METER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65545,
+            "name" : "$METER_SPEC_CIR_KBPS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65546,
+            "name" : "$METER_SPEC_PIR_KBPS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65547,
+            "name" : "$METER_SPEC_CBS_KBITS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65548,
+            "name" : "$METER_SPEC_PBS_KBITS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        }
+      ],
+      "supported_operations" : [],
+      "attributes" : ["MeterByteCountAdjust"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.p4info.txt
@@ -1,0 +1,111 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+  params {
+    id: 1
+    name: "index"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 30967736
+    name: "ingress.test"
+    alias: "test"
+  }
+}
+counters {
+  preamble {
+    id: 314114784
+    name: "ingress.counter0"
+    alias: "counter0"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 318473483
+    name: "ingress.counter1"
+    alias: "counter1"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 313911423
+    name: "ingress.counter2"
+    alias: "counter2"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+meters {
+  preamble {
+    id: 344514043
+    name: "ingress.meter0"
+    alias: "meter0"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+registers {
+  preamble {
+    id: 382856063
+    name: "ingress.reg"
+    alias: "reg"
+  }
+  type_spec {
+    bitstring {
+      bit {
+        bitwidth: 32
+      }
+    }
+  }
+  size: 1024
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.spec
@@ -1,0 +1,197 @@
+
+
+
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> _version0__ihl1
+	bit<8> _diffserv2
+	bit<32> _totalLen3
+	bit<16> _identification4
+	bit<16> _flags5__fragOffset6
+	bit<8> _ttl7
+	bit<8> _protocol8
+	bit<16> _hdrChecksum9
+	bit<32> _srcAddr10
+	bit<32> _dstAddr11
+	bit<8> _s1_f112__s1_f213
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct execute_1_arg_t {
+	bit<32> index
+}
+
+struct metadata_t {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<32> local_metadata_port_out
+	bit<32> local_metadata_temp
+	bit<8> IngressParser_parser_tmp
+	bit<32> IngressParser_parser_tmp_0
+	bit<8> IngressParser_parser_tmp_1
+	bit<32> IngressParser_parser_tmp_2
+	bit<32> Ingress_tmp
+	bit<32> Ingress_tmp_0
+	bit<8> Ingress_tmp_1
+	bit<8> Ingress_tmp_2
+	bit<8> Ingress_tmp_3
+	bit<8> Ingress_tmp_4
+	bit<8> Ingress_tmp_5
+	bit<8> Ingress_tmp_6
+	bit<16> Ingress_tmp_7
+	bit<32> Ingress_tmp_8
+	bit<32> Ingress_tmp_9
+	bit<16> Ingress_tmp_10
+	bit<16> Ingress_tmp_11
+	bit<32> Ingress_color_out
+	bit<32> Ingress_color_in
+	bit<32> Ingress_tmp_12
+}
+metadata instanceof metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray counter0_0_packets size 0x400 initval 0x0
+
+regarray counter0_0_bytes size 0x400 initval 0x0
+
+regarray counter1_0 size 0x400 initval 0x0
+
+regarray counter2_0 size 0x400 initval 0x0
+
+regarray reg_0 size 0x400 initval 0
+
+metarray meter0_0 size 0x400
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args instanceof execute_1_arg_t {
+	mov m.Ingress_tmp_1 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_1 0xf
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_1
+	or h.ipv4._version0__ihl1 0x50
+	meter meter0_0 t.index h.ipv4._totalLen3 m.Ingress_color_in m.Ingress_color_out
+	jmpneq LABEL_FALSE_2 m.Ingress_color_out 0x0
+	mov m.Ingress_tmp_12 0x1
+	jmp LABEL_END_3
+	LABEL_FALSE_2 :	mov m.Ingress_tmp_12 0x0
+	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_12
+	regwr reg_0 t.index m.local_metadata_port_out
+	mov m.Ingress_tmp h.ipv4._version0__ihl1
+	jmpneq LABEL_END_4 m.Ingress_tmp 0x6
+	mov m.Ingress_tmp_2 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_2 0xf
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_2
+	or h.ipv4._version0__ihl1 0x60
+	LABEL_END_4 :	jmpneq LABEL_FALSE_4 m.local_metadata_temp 0x6
+	mov m.Ingress_tmp_3 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_3 0xf0
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_3
+	or h.ipv4._s1_f112__s1_f213 0x7
+	mov m.Ingress_tmp_4 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_4 0xf
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_4
+	or h.ipv4._s1_f112__s1_f213 0x80
+	jmp LABEL_END_5
+	LABEL_FALSE_4 :	mov m.Ingress_tmp_5 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_5 0xf0
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_5
+	or h.ipv4._s1_f112__s1_f213 0x7
+	mov m.Ingress_tmp_6 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_6 0xf
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_6
+	or h.ipv4._s1_f112__s1_f213 0x90
+	LABEL_END_5 :	return
+}
+
+table tbl {
+	key {
+		h.ethernet.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.IngressParser_parser_tmp h.ipv4._version0__ihl1
+	shr m.IngressParser_parser_tmp 0x4
+	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
+	mov m.IngressParser_parser_tmp_1 0x0
+	jmp LABEL_END
+	LABEL_TRUE :	mov m.IngressParser_parser_tmp_1 0x1
+	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_1 0
+	mov m.psa_ingress_input_metadata_parser_error 0x7
+	jmp INGRESSPARSERIMPL_ACCEPT
+	LABEL_END_0 :	mov m.IngressParser_parser_tmp_2 h.ipv4._version0__ihl1
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
+	jmpneq LABEL_END_1 m.local_metadata_port_out 0x1
+	table tbl
+	regadd counter0_0_packets 0x3ff 1
+	regadd counter0_0_bytes 0x3ff 0x14
+	regadd counter1_0 0x200 1
+	regadd counter2_0 0x3ff 0x40
+	regrd m.local_metadata_port_out reg_0 0x1
+	mov m.Ingress_tmp_0 h.ipv4._version0__ihl1
+	jmpneq LABEL_END_1 m.Ingress_tmp_0 0x4
+	mov m.Ingress_tmp_7 h.ipv4._hdrChecksum9
+	and m.Ingress_tmp_7 0xfff0
+	mov m.Ingress_tmp_8 h.ipv4._version0__ihl1
+	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	add m.Ingress_tmp_9 0x5
+	mov m.Ingress_tmp_10 m.Ingress_tmp_9
+	mov m.Ingress_tmp_11 m.Ingress_tmp_10
+	and m.Ingress_tmp_11 0xf
+	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_7
+	or h.ipv4._hdrChecksum9 m.Ingress_tmp_11
+	LABEL_END_1 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	mov h.ipv4._hdrChecksum9 0x4
+	emit h.ethernet
+	emit h.ipv4
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-first.p4
@@ -1,0 +1,155 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<3> f1;
+    bit<5> f2;
+}
+
+struct s2_t {
+    bit<5> f1;
+    bit<3> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    s1_t    s1;
+    s2_t    s2;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(32w1024) reg;
+    Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 4w5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+        if (user_meta.temp == 4w6) {
+            hdr.ipv4.s1 = (s1_t){f1 = 3w2,f2 = 5w3};
+            hdr.ipv4.s2 = (s2_t){f1 = 5w2,f2 = 3w3};
+        } else {
+            hdr.ipv4.s1 = (s1_t){f1 = 3w3,f2 = 5w2};
+            hdr.ipv4.s2 = (s2_t){f1 = 5w3,f2 = 3w2};
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (user_meta.port_out == 32w1) {
+            tbl.apply();
+            counter0.count(12w1023, 32w20);
+            counter1.count(12w512);
+            counter2.count(12w1023, 32w64);
+            user_meta.port_out = reg.read(12w1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-frontend.p4
@@ -1,0 +1,168 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<3> f1;
+    bit<5> f2;
+}
+
+struct s2_t {
+    bit<5> f1;
+    bit<3> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    s1_t    s1;
+    s2_t    s2;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @name("ingress.tmp") bit<32> tmp;
+    @name("ingress.hasReturned") bool hasReturned;
+    @name("ingress.version") bit<4> version_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        if (color_out_0 == PSA_MeterColor_t.GREEN) {
+            tmp = 32w1;
+        } else {
+            tmp = 32w0;
+        }
+        user_meta.port_out = tmp;
+        reg_0.write(index_1, user_meta.port_out);
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+        if (user_meta.temp == 4w6) {
+            hdr.ipv4.s1 = (s1_t){f1 = 3w2,f2 = 5w3};
+            hdr.ipv4.s2 = (s2_t){f1 = 5w2,f2 = 3w3};
+        } else {
+            hdr.ipv4.s1 = (s1_t){f1 = 3w3,f2 = 5w2};
+            hdr.ipv4.s2 = (s2_t){f1 = 5w3,f2 = 3w2};
+        }
+    }
+    @name("ingress.test") action test() {
+        version_0 = hdr.ipv4.version;
+        if (version_0 == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        hasReturned = false;
+        color_in_0 = PSA_MeterColor_t.RED;
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            counter0_0.count(12w1023, 32w20);
+            counter1_0.count(12w512);
+            counter2_0.count(12w1023, 32w64);
+            user_meta.port_out = reg_0.read(12w1);
+            test();
+        } else {
+            hasReturned = true;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-midend.p4
@@ -1,0 +1,188 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<3> f1;
+    bit<5> f2;
+}
+
+struct s2_t {
+    bit<5> f1;
+    bit<3> f2;
+}
+
+header ipv4_t {
+    bit<4>  _version0;
+    bit<4>  _ihl1;
+    bit<8>  _diffserv2;
+    bit<32> _totalLen3;
+    bit<16> _identification4;
+    bit<3>  _flags5;
+    bit<13> _fragOffset6;
+    bit<8>  _ttl7;
+    bit<8>  _protocol8;
+    bit<16> _hdrChecksum9;
+    bit<32> _srcAddr10;
+    bit<32> _dstAddr11;
+    bit<3>  _s1_f112;
+    bit<5>  _s1_f213;
+    bit<5>  _s2_f114;
+    bit<3>  _s2_f215;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4._ihl1 == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4._version0) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4._ihl1 = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4._totalLen3);
+        user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
+        hdr.ipv4._ihl1 = (hdr.ipv4._version0 == 4w6 ? 4w6 : 4w5);
+        hdr.ipv4._s1_f112 = (user_meta.temp == 4w6 ? 3w2 : hdr.ipv4._s1_f112);
+        hdr.ipv4._s1_f213 = (user_meta.temp == 4w6 ? 5w3 : hdr.ipv4._s1_f213);
+        hdr.ipv4._s2_f114 = (user_meta.temp == 4w6 ? 5w2 : hdr.ipv4._s2_f114);
+        hdr.ipv4._s2_f215 = (user_meta.temp == 4w6 ? 3w3 : hdr.ipv4._s2_f215);
+        hdr.ipv4._s1_f112 = (user_meta.temp == 4w6 ? 3w2 : 3w3);
+        hdr.ipv4._s1_f213 = (user_meta.temp == 4w6 ? 5w3 : 5w2);
+        hdr.ipv4._s2_f114 = (user_meta.temp == 4w6 ? 5w2 : 5w3);
+        hdr.ipv4._s2_f215 = (user_meta.temp == 4w6 ? 3w3 : 3w2);
+    }
+    @name("ingress.test") action test() {
+        hdr.ipv4._hdrChecksum9[3:0] = (hdr.ipv4._version0 == 4w4 ? hdr.ipv4._version0 + 4w5 : hdr.ipv4._hdrChecksum9[3:0]);
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psaexampledpdkbytealignment_7l117() {
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512);
+        counter2_0.count(12w1023, 32w64);
+        user_meta.port_out = reg_0.read(12w1);
+    }
+    @hidden action psaexampledpdkbytealignment_7l83() {
+        color_in_0 = PSA_MeterColor_t.RED;
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_7l83 {
+        actions = {
+            psaexampledpdkbytealignment_7l83();
+        }
+        const default_action = psaexampledpdkbytealignment_7l83();
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_7l117 {
+        actions = {
+            psaexampledpdkbytealignment_7l117();
+        }
+        const default_action = psaexampledpdkbytealignment_7l117();
+    }
+    @hidden table tbl_test {
+        actions = {
+            test();
+        }
+        const default_action = test();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_7l83.apply();
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            tbl_psaexampledpdkbytealignment_7l117.apply();
+            tbl_test.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psaexampledpdkbytealignment_7l141() {
+        hdr.ipv4._hdrChecksum9 = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_7l141 {
+        actions = {
+            psaexampledpdkbytealignment_7l141();
+        }
+        const default_action = psaexampledpdkbytealignment_7l141();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_7l141.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4
@@ -1,0 +1,154 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<3> f1;
+    bit<5> f2;
+}
+
+struct s2_t {
+    bit<5> f1;
+    bit<3> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    s1_t    s1;
+    s2_t    s2;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.version == 6) {
+            hdr.ipv4.ihl = 6;
+        }
+        if (user_meta.temp == 6) {
+            hdr.ipv4.s1 = { 2, 3 };
+            hdr.ipv4.s2 = { 2, 3 };
+        } else {
+            hdr.ipv4.s1 = { 3, 2 };
+            hdr.ipv4.s2 = { 3, 2 };
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4-error
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4-stderr
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.bfrt.json
@@ -1,0 +1,272 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "index",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 12
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.ingress.counter0",
+      "id" : 314114784,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65553,
+            "name" : "$COUNTER_SPEC_BYTES",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65554,
+            "name" : "$COUNTER_SPEC_PKTS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.counter1",
+      "id" : 318473483,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65554,
+            "name" : "$COUNTER_SPEC_PKTS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.counter2",
+      "id" : 313911423,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65553,
+            "name" : "$COUNTER_SPEC_BYTES",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.meter0",
+      "id" : 344514043,
+      "table_type" : "Meter",
+      "size" : 1024,
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65555,
+          "name" : "$METER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65545,
+            "name" : "$METER_SPEC_CIR_KBPS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65546,
+            "name" : "$METER_SPEC_PIR_KBPS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65547,
+            "name" : "$METER_SPEC_CBS_KBITS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65548,
+            "name" : "$METER_SPEC_PBS_KBITS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        }
+      ],
+      "supported_operations" : [],
+      "attributes" : ["MeterByteCountAdjust"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.p4info.txt
@@ -1,0 +1,111 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+  params {
+    id: 1
+    name: "index"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 30967736
+    name: "ingress.test"
+    alias: "test"
+  }
+}
+counters {
+  preamble {
+    id: 314114784
+    name: "ingress.counter0"
+    alias: "counter0"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 318473483
+    name: "ingress.counter1"
+    alias: "counter1"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 313911423
+    name: "ingress.counter2"
+    alias: "counter2"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+meters {
+  preamble {
+    id: 344514043
+    name: "ingress.meter0"
+    alias: "meter0"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+registers {
+  preamble {
+    id: 382856063
+    name: "ingress.reg"
+    alias: "reg"
+  }
+  type_spec {
+    bitstring {
+      bit {
+        bitwidth: 32
+      }
+    }
+  }
+  size: 1024
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.spec
@@ -1,0 +1,218 @@
+
+
+
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> _version0__ihl1
+	bit<8> _diffserv2
+	bit<32> _totalLen3
+	bit<16> _identification4
+	bit<16> _flags5__fragOffset6
+	bit<8> _ttl7
+	bit<8> _protocol8
+	bit<16> _hdrChecksum9
+	bit<32> _srcAddr10
+	bit<32> _dstAddr11
+	bit<8> _s1_f112__s1_f213
+	bit<8> _s2_f114__s2_f215
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct execute_1_arg_t {
+	bit<32> index
+}
+
+struct metadata_t {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<32> local_metadata_port_out
+	bit<32> local_metadata_temp
+	bit<8> IngressParser_parser_tmp
+	bit<32> IngressParser_parser_tmp_0
+	bit<8> IngressParser_parser_tmp_1
+	bit<32> IngressParser_parser_tmp_2
+	bit<32> Ingress_tmp
+	bit<32> Ingress_tmp_0
+	bit<8> Ingress_tmp_1
+	bit<8> Ingress_tmp_2
+	bit<8> Ingress_tmp_3
+	bit<8> Ingress_tmp_4
+	bit<8> Ingress_tmp_5
+	bit<8> Ingress_tmp_6
+	bit<8> Ingress_tmp_7
+	bit<8> Ingress_tmp_8
+	bit<8> Ingress_tmp_9
+	bit<8> Ingress_tmp_10
+	bit<16> Ingress_tmp_11
+	bit<32> Ingress_tmp_12
+	bit<32> Ingress_tmp_13
+	bit<16> Ingress_tmp_14
+	bit<16> Ingress_tmp_15
+	bit<32> Ingress_color_out
+	bit<32> Ingress_color_in
+	bit<32> Ingress_tmp_16
+}
+metadata instanceof metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray counter0_0_packets size 0x400 initval 0x0
+
+regarray counter0_0_bytes size 0x400 initval 0x0
+
+regarray counter1_0 size 0x400 initval 0x0
+
+regarray counter2_0 size 0x400 initval 0x0
+
+regarray reg_0 size 0x400 initval 0
+
+metarray meter0_0 size 0x400
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args instanceof execute_1_arg_t {
+	mov m.Ingress_tmp_1 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_1 0xf
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_1
+	or h.ipv4._version0__ihl1 0x50
+	meter meter0_0 t.index h.ipv4._totalLen3 m.Ingress_color_in m.Ingress_color_out
+	jmpneq LABEL_FALSE_2 m.Ingress_color_out 0x0
+	mov m.Ingress_tmp_16 0x1
+	jmp LABEL_END_3
+	LABEL_FALSE_2 :	mov m.Ingress_tmp_16 0x0
+	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_16
+	regwr reg_0 t.index m.local_metadata_port_out
+	mov m.Ingress_tmp h.ipv4._version0__ihl1
+	jmpneq LABEL_END_4 m.Ingress_tmp 0x6
+	mov m.Ingress_tmp_2 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_2 0xf
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_2
+	or h.ipv4._version0__ihl1 0x60
+	LABEL_END_4 :	jmpneq LABEL_FALSE_4 m.local_metadata_temp 0x6
+	mov m.Ingress_tmp_3 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_3 0xf8
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_3
+	or h.ipv4._s1_f112__s1_f213 0x2
+	mov m.Ingress_tmp_4 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_4 0x7
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_4
+	or h.ipv4._s1_f112__s1_f213 0x18
+	mov m.Ingress_tmp_5 h.ipv4._s2_f114__s2_f215
+	and m.Ingress_tmp_5 0xe0
+	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_5
+	or h.ipv4._s2_f114__s2_f215 0x2
+	mov m.Ingress_tmp_6 h.ipv4._s2_f114__s2_f215
+	and m.Ingress_tmp_6 0x1f
+	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_6
+	or h.ipv4._s2_f114__s2_f215 0x60
+	jmp LABEL_END_5
+	LABEL_FALSE_4 :	mov m.Ingress_tmp_7 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_7 0xf8
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_7
+	or h.ipv4._s1_f112__s1_f213 0x3
+	mov m.Ingress_tmp_8 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_8 0x7
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_8
+	or h.ipv4._s1_f112__s1_f213 0x10
+	mov m.Ingress_tmp_9 h.ipv4._s2_f114__s2_f215
+	and m.Ingress_tmp_9 0xe0
+	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_9
+	or h.ipv4._s2_f114__s2_f215 0x3
+	mov m.Ingress_tmp_10 h.ipv4._s2_f114__s2_f215
+	and m.Ingress_tmp_10 0x1f
+	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_10
+	or h.ipv4._s2_f114__s2_f215 0x40
+	LABEL_END_5 :	return
+}
+
+table tbl {
+	key {
+		h.ethernet.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.IngressParser_parser_tmp h.ipv4._version0__ihl1
+	shr m.IngressParser_parser_tmp 0x4
+	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
+	mov m.IngressParser_parser_tmp_1 0x0
+	jmp LABEL_END
+	LABEL_TRUE :	mov m.IngressParser_parser_tmp_1 0x1
+	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_1 0
+	mov m.psa_ingress_input_metadata_parser_error 0x7
+	jmp INGRESSPARSERIMPL_ACCEPT
+	LABEL_END_0 :	mov m.IngressParser_parser_tmp_2 h.ipv4._version0__ihl1
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
+	jmpneq LABEL_END_1 m.local_metadata_port_out 0x1
+	table tbl
+	regadd counter0_0_packets 0x3ff 1
+	regadd counter0_0_bytes 0x3ff 0x14
+	regadd counter1_0 0x200 1
+	regadd counter2_0 0x3ff 0x40
+	regrd m.local_metadata_port_out reg_0 0x1
+	mov m.Ingress_tmp_0 h.ipv4._version0__ihl1
+	jmpneq LABEL_END_1 m.Ingress_tmp_0 0x4
+	mov m.Ingress_tmp_11 h.ipv4._hdrChecksum9
+	and m.Ingress_tmp_11 0xfff0
+	mov m.Ingress_tmp_12 h.ipv4._version0__ihl1
+	mov m.Ingress_tmp_13 m.Ingress_tmp_12
+	add m.Ingress_tmp_13 0x5
+	mov m.Ingress_tmp_14 m.Ingress_tmp_13
+	mov m.Ingress_tmp_15 m.Ingress_tmp_14
+	and m.Ingress_tmp_15 0xf
+	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_11
+	or h.ipv4._hdrChecksum9 m.Ingress_tmp_15
+	LABEL_END_1 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	mov h.ipv4._hdrChecksum9 0x4
+	emit h.ethernet
+	emit h.ipv4
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-first.p4
@@ -1,0 +1,155 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<8> f1;
+    bit<3> f2;
+}
+
+struct s2_t {
+    bit<5> f1;
+    bit<8> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    s1_t    s1;
+    s2_t    s2;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(32w1024) reg;
+    Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 4w5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+        if (user_meta.temp == 4w6) {
+            hdr.ipv4.s1 = (s1_t){f1 = 8w2,f2 = 3w3};
+            hdr.ipv4.s2 = (s2_t){f1 = 5w2,f2 = 8w3};
+        } else {
+            hdr.ipv4.s1 = (s1_t){f1 = 8w3,f2 = 3w2};
+            hdr.ipv4.s2 = (s2_t){f1 = 5w3,f2 = 8w2};
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (user_meta.port_out == 32w1) {
+            tbl.apply();
+            counter0.count(12w1023, 32w20);
+            counter1.count(12w512);
+            counter2.count(12w1023, 32w64);
+            user_meta.port_out = reg.read(12w1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-frontend.p4
@@ -1,0 +1,168 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<8> f1;
+    bit<3> f2;
+}
+
+struct s2_t {
+    bit<5> f1;
+    bit<8> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    s1_t    s1;
+    s2_t    s2;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @name("ingress.tmp") bit<32> tmp;
+    @name("ingress.hasReturned") bool hasReturned;
+    @name("ingress.version") bit<4> version_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4.totalLen);
+        if (color_out_0 == PSA_MeterColor_t.GREEN) {
+            tmp = 32w1;
+        } else {
+            tmp = 32w0;
+        }
+        user_meta.port_out = tmp;
+        reg_0.write(index_1, user_meta.port_out);
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+        if (user_meta.temp == 4w6) {
+            hdr.ipv4.s1 = (s1_t){f1 = 8w2,f2 = 3w3};
+            hdr.ipv4.s2 = (s2_t){f1 = 5w2,f2 = 8w3};
+        } else {
+            hdr.ipv4.s1 = (s1_t){f1 = 8w3,f2 = 3w2};
+            hdr.ipv4.s2 = (s2_t){f1 = 5w3,f2 = 8w2};
+        }
+    }
+    @name("ingress.test") action test() {
+        version_0 = hdr.ipv4.version;
+        if (version_0 == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        hasReturned = false;
+        color_in_0 = PSA_MeterColor_t.RED;
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            counter0_0.count(12w1023, 32w20);
+            counter1_0.count(12w512);
+            counter2_0.count(12w1023, 32w64);
+            user_meta.port_out = reg_0.read(12w1);
+            test();
+        } else {
+            hasReturned = true;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-midend.p4
@@ -1,0 +1,188 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<8> f1;
+    bit<3> f2;
+}
+
+struct s2_t {
+    bit<5> f1;
+    bit<8> f2;
+}
+
+header ipv4_t {
+    bit<4>  _version0;
+    bit<4>  _ihl1;
+    bit<8>  _diffserv2;
+    bit<32> _totalLen3;
+    bit<16> _identification4;
+    bit<3>  _flags5;
+    bit<13> _fragOffset6;
+    bit<8>  _ttl7;
+    bit<8>  _protocol8;
+    bit<16> _hdrChecksum9;
+    bit<32> _srcAddr10;
+    bit<32> _dstAddr11;
+    bit<8>  _s1_f112;
+    bit<3>  _s1_f213;
+    bit<5>  _s2_f114;
+    bit<8>  _s2_f215;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4._ihl1 == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4._version0) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4._ihl1 = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0, hdr.ipv4._totalLen3);
+        user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
+        hdr.ipv4._ihl1 = (hdr.ipv4._version0 == 4w6 ? 4w6 : 4w5);
+        hdr.ipv4._s1_f112 = (user_meta.temp == 4w6 ? 8w2 : hdr.ipv4._s1_f112);
+        hdr.ipv4._s1_f213 = (user_meta.temp == 4w6 ? 3w3 : hdr.ipv4._s1_f213);
+        hdr.ipv4._s2_f114 = (user_meta.temp == 4w6 ? 5w2 : hdr.ipv4._s2_f114);
+        hdr.ipv4._s2_f215 = (user_meta.temp == 4w6 ? 8w3 : hdr.ipv4._s2_f215);
+        hdr.ipv4._s1_f112 = (user_meta.temp == 4w6 ? 8w2 : 8w3);
+        hdr.ipv4._s1_f213 = (user_meta.temp == 4w6 ? 3w3 : 3w2);
+        hdr.ipv4._s2_f114 = (user_meta.temp == 4w6 ? 5w2 : 5w3);
+        hdr.ipv4._s2_f215 = (user_meta.temp == 4w6 ? 8w3 : 8w2);
+    }
+    @name("ingress.test") action test() {
+        hdr.ipv4._hdrChecksum9[3:0] = (hdr.ipv4._version0 == 4w4 ? hdr.ipv4._version0 + 4w5 : hdr.ipv4._hdrChecksum9[3:0]);
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psaexampledpdkbytealignment_8l117() {
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512);
+        counter2_0.count(12w1023, 32w64);
+        user_meta.port_out = reg_0.read(12w1);
+    }
+    @hidden action psaexampledpdkbytealignment_8l83() {
+        color_in_0 = PSA_MeterColor_t.RED;
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_8l83 {
+        actions = {
+            psaexampledpdkbytealignment_8l83();
+        }
+        const default_action = psaexampledpdkbytealignment_8l83();
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_8l117 {
+        actions = {
+            psaexampledpdkbytealignment_8l117();
+        }
+        const default_action = psaexampledpdkbytealignment_8l117();
+    }
+    @hidden table tbl_test {
+        actions = {
+            test();
+        }
+        const default_action = test();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_8l83.apply();
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            tbl_psaexampledpdkbytealignment_8l117.apply();
+            tbl_test.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psaexampledpdkbytealignment_8l141() {
+        hdr.ipv4._hdrChecksum9 = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_psaexampledpdkbytealignment_8l141 {
+        actions = {
+            psaexampledpdkbytealignment_8l141();
+        }
+        const default_action = psaexampledpdkbytealignment_8l141();
+    }
+    apply {
+        tbl_psaexampledpdkbytealignment_8l141.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4
@@ -1,0 +1,154 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+struct s1_t {
+    bit<8> f1;
+    bit<3> f2;
+}
+
+struct s2_t {
+    bit<5> f1;
+    bit<8> f2;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    s1_t    s1;
+    s2_t    s2;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+    bit<4>  temp;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in, hdr.ipv4.totalLen);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.version == 6) {
+            hdr.ipv4.ihl = 6;
+        }
+        if (user_meta.temp == 6) {
+            hdr.ipv4.s1 = { 2, 3 };
+            hdr.ipv4.s2 = { 2, 3 };
+        } else {
+            hdr.ipv4.s1 = { 3, 2 };
+            hdr.ipv4.s2 = { 3, 2 };
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4-error
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4-stderr
@@ -1,0 +1,6 @@
+psa.p4(534): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+psa.p4(563): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.bfrt.json
@@ -1,0 +1,272 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "index",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 12
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.ingress.counter0",
+      "id" : 314114784,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65553,
+            "name" : "$COUNTER_SPEC_BYTES",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65554,
+            "name" : "$COUNTER_SPEC_PKTS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.counter1",
+      "id" : 318473483,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65554,
+            "name" : "$COUNTER_SPEC_PKTS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.counter2",
+      "id" : 313911423,
+      "table_type" : "Counter",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65556,
+          "name" : "$COUNTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65553,
+            "name" : "$COUNTER_SPEC_BYTES",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 0
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    },
+    {
+      "name" : "ip.ingress.meter0",
+      "id" : 344514043,
+      "table_type" : "Meter",
+      "size" : 1024,
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65555,
+          "name" : "$METER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65545,
+            "name" : "$METER_SPEC_CIR_KBPS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65546,
+            "name" : "$METER_SPEC_PIR_KBPS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65547,
+            "name" : "$METER_SPEC_CBS_KBITS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        },
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65548,
+            "name" : "$METER_SPEC_PBS_KBITS",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "uint64",
+              "default_value" : 18446744073709551615
+            }
+          }
+        }
+      ],
+      "supported_operations" : [],
+      "attributes" : ["MeterByteCountAdjust"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.p4info.txt
@@ -1,0 +1,111 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+  params {
+    id: 1
+    name: "index"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 30967736
+    name: "ingress.test"
+    alias: "test"
+  }
+}
+counters {
+  preamble {
+    id: 314114784
+    name: "ingress.counter0"
+    alias: "counter0"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 318473483
+    name: "ingress.counter1"
+    alias: "counter1"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 313911423
+    name: "ingress.counter2"
+    alias: "counter2"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+meters {
+  preamble {
+    id: 344514043
+    name: "ingress.meter0"
+    alias: "meter0"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+registers {
+  preamble {
+    id: 382856063
+    name: "ingress.reg"
+    alias: "reg"
+  }
+  type_spec {
+    bitstring {
+      bit {
+        bitwidth: 32
+      }
+    }
+  }
+  size: 1024
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.spec
@@ -1,0 +1,203 @@
+
+
+
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> _version0__ihl1
+	bit<8> _diffserv2
+	bit<32> _totalLen3
+	bit<16> _identification4
+	bit<16> _flags5__fragOffset6
+	bit<8> _ttl7
+	bit<8> _protocol8
+	bit<16> _hdrChecksum9
+	bit<32> _srcAddr10
+	bit<32> _dstAddr11
+	bit<8> _s1_f112
+	bit<8> _s1_f213__s2_f114
+	bit<8> _s2_f215
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct execute_1_arg_t {
+	bit<32> index
+}
+
+struct metadata_t {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<32> local_metadata_port_out
+	bit<32> local_metadata_temp
+	bit<8> IngressParser_parser_tmp
+	bit<32> IngressParser_parser_tmp_0
+	bit<8> IngressParser_parser_tmp_1
+	bit<32> IngressParser_parser_tmp_2
+	bit<32> Ingress_tmp
+	bit<32> Ingress_tmp_0
+	bit<8> Ingress_tmp_1
+	bit<8> Ingress_tmp_2
+	bit<8> Ingress_tmp_3
+	bit<8> Ingress_tmp_4
+	bit<8> Ingress_tmp_5
+	bit<8> Ingress_tmp_6
+	bit<16> Ingress_tmp_7
+	bit<32> Ingress_tmp_8
+	bit<32> Ingress_tmp_9
+	bit<16> Ingress_tmp_10
+	bit<16> Ingress_tmp_11
+	bit<32> Ingress_color_out
+	bit<32> Ingress_color_in
+	bit<32> Ingress_tmp_12
+}
+metadata instanceof metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray counter0_0_packets size 0x400 initval 0x0
+
+regarray counter0_0_bytes size 0x400 initval 0x0
+
+regarray counter1_0 size 0x400 initval 0x0
+
+regarray counter2_0 size 0x400 initval 0x0
+
+regarray reg_0 size 0x400 initval 0
+
+metarray meter0_0 size 0x400
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args instanceof execute_1_arg_t {
+	mov m.Ingress_tmp_1 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_1 0xf
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_1
+	or h.ipv4._version0__ihl1 0x50
+	meter meter0_0 t.index h.ipv4._totalLen3 m.Ingress_color_in m.Ingress_color_out
+	jmpneq LABEL_FALSE_2 m.Ingress_color_out 0x0
+	mov m.Ingress_tmp_12 0x1
+	jmp LABEL_END_3
+	LABEL_FALSE_2 :	mov m.Ingress_tmp_12 0x0
+	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_12
+	regwr reg_0 t.index m.local_metadata_port_out
+	mov m.Ingress_tmp h.ipv4._version0__ihl1
+	jmpneq LABEL_END_4 m.Ingress_tmp 0x6
+	mov m.Ingress_tmp_2 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_2 0xf
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_2
+	or h.ipv4._version0__ihl1 0x60
+	LABEL_END_4 :	jmpneq LABEL_FALSE_4 m.local_metadata_temp 0x6
+	mov h.ipv4._s1_f112 0x2
+	mov m.Ingress_tmp_3 h.ipv4._s1_f213__s2_f114
+	and m.Ingress_tmp_3 0xf8
+	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_3
+	or h.ipv4._s1_f213__s2_f114 0x3
+	mov m.Ingress_tmp_4 h.ipv4._s1_f213__s2_f114
+	and m.Ingress_tmp_4 0x7
+	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_4
+	or h.ipv4._s1_f213__s2_f114 0x10
+	mov h.ipv4._s2_f215 0x3
+	jmp LABEL_END_5
+	LABEL_FALSE_4 :	mov h.ipv4._s1_f112 0x3
+	mov m.Ingress_tmp_5 h.ipv4._s1_f213__s2_f114
+	and m.Ingress_tmp_5 0xf8
+	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_5
+	or h.ipv4._s1_f213__s2_f114 0x2
+	mov m.Ingress_tmp_6 h.ipv4._s1_f213__s2_f114
+	and m.Ingress_tmp_6 0x7
+	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_6
+	or h.ipv4._s1_f213__s2_f114 0x18
+	mov h.ipv4._s2_f215 0x2
+	LABEL_END_5 :	return
+}
+
+table tbl {
+	key {
+		h.ethernet.srcAddr exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.IngressParser_parser_tmp h.ipv4._version0__ihl1
+	shr m.IngressParser_parser_tmp 0x4
+	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
+	mov m.IngressParser_parser_tmp_1 0x0
+	jmp LABEL_END
+	LABEL_TRUE :	mov m.IngressParser_parser_tmp_1 0x1
+	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_1 0
+	mov m.psa_ingress_input_metadata_parser_error 0x7
+	jmp INGRESSPARSERIMPL_ACCEPT
+	LABEL_END_0 :	mov m.IngressParser_parser_tmp_2 h.ipv4._version0__ihl1
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
+	jmpneq LABEL_END_1 m.local_metadata_port_out 0x1
+	table tbl
+	regadd counter0_0_packets 0x3ff 1
+	regadd counter0_0_bytes 0x3ff 0x14
+	regadd counter1_0 0x200 1
+	regadd counter2_0 0x3ff 0x40
+	regrd m.local_metadata_port_out reg_0 0x1
+	mov m.Ingress_tmp_0 h.ipv4._version0__ihl1
+	jmpneq LABEL_END_1 m.Ingress_tmp_0 0x4
+	mov m.Ingress_tmp_7 h.ipv4._hdrChecksum9
+	and m.Ingress_tmp_7 0xfff0
+	mov m.Ingress_tmp_8 h.ipv4._version0__ihl1
+	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	add m.Ingress_tmp_9 0x5
+	mov m.Ingress_tmp_10 m.Ingress_tmp_9
+	mov m.Ingress_tmp_11 m.Ingress_tmp_10
+	and m.Ingress_tmp_11 0xf
+	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_7
+	or h.ipv4._hdrChecksum9 m.Ingress_tmp_11
+	LABEL_END_1 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	mov h.ipv4._hdrChecksum9 0x4
+	emit h.ethernet
+	emit h.ipv4
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
@@ -11,13 +11,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<32> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -46,7 +44,7 @@ struct psa_egress_deparser_input_metadata_t {
 }
 
 struct execute_1_arg_t {
-	bit<12> index
+	bit<32> index
 }
 
 struct metadata_t {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
@@ -7,13 +7,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -42,7 +40,7 @@ struct psa_egress_deparser_input_metadata_t {
 }
 
 struct execute_1_arg_t {
-	bit<12> index
+	bit<32> index
 }
 
 struct metadata_t {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
@@ -7,13 +7,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<32> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -42,7 +40,7 @@ struct psa_egress_deparser_input_metadata_t {
 }
 
 struct execute_1_arg_t {
-	bit<12> index
+	bit<32> index
 }
 
 struct metadata_t {

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.spec
@@ -6,13 +6,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -25,10 +23,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -27,10 +25,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -27,10 +25,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.spec
@@ -7,13 +7,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.spec
@@ -7,13 +7,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -26,10 +24,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -27,10 +25,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.spec
@@ -7,13 +7,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -26,10 +24,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.spec
@@ -7,13 +7,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -26,10 +24,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
@@ -6,9 +6,7 @@ struct ethernet_t {
 }
 
 struct vlan_tag_h {
-	bit<3> pcp
-	bit<1> cfi
-	bit<12> vid
+	bit<16> pcp_cfi_vid
 	bit<16> ether_type
 }
 

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
@@ -39,7 +39,7 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> Ingress_tmp
-	bit<1> Ingress_tmp_0
+	bit<32> Ingress_tmp_0
 }
 metadata instanceof metadata_t
 

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.spec
@@ -38,7 +38,7 @@ struct metadata_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<4> Ingress_tmp
+	bit<32> Ingress_tmp
 	bit<48> Ingress_tmp_0
 	bit<32> Ingress_int_packet_path
 }

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.spec
@@ -27,7 +27,7 @@ struct psa_egress_deparser_input_metadata_t {
 }
 
 struct execute_register_arg_t {
-	bit<10> idx
+	bit<32> idx
 }
 
 struct EMPTY {

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.spec
@@ -27,7 +27,7 @@ struct psa_egress_deparser_input_metadata_t {
 }
 
 struct execute_register_arg_t {
-	bit<10> idx
+	bit<32> idx
 }
 
 struct user_meta_t {

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.spec
@@ -27,7 +27,7 @@ struct psa_egress_deparser_input_metadata_t {
 }
 
 struct execute_register_arg_t {
-	bit<10> idx
+	bit<32> idx
 }
 
 struct user_meta_t {

--- a/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4.spec
@@ -8,13 +8,11 @@ struct ethernet_t {
 }
 
 struct ipv4_t {
-	bit<4> version
-	bit<4> ihl
+	bit<8> version_ihl
 	bit<8> diffserv
 	bit<16> totalLen
 	bit<16> identification
-	bit<3> flags
-	bit<13> fragOffset
+	bit<16> flags_fragOffset
 	bit<8> ttl
 	bit<8> protocol
 	bit<16> hdrChecksum
@@ -28,10 +26,7 @@ struct tcp_t {
 	bit<16> dstPort
 	bit<32> seqNo
 	bit<32> ackNo
-	bit<4> dataOffset
-	bit<3> res
-	bit<3> ecn
-	bit<6> ctrl
+	bit<16> dataOffset_res_ecn_ctrl
 	bit<16> window
 	bit<16> checksum
 	bit<16> urgentPtr

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
@@ -39,7 +39,7 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> Ingress_tmp
-	bit<1> Ingress_tmp_0
+	bit<32> Ingress_tmp_0
 }
 metadata instanceof metadata_t
 


### PR DESCRIPTION
DPDK: Implementation for non byte aligned metadata and header fields 
For Example :
 header ipv4_t {
    bit<4>  version;
    bit<4>  ihl;
    bit<8>  diffserv;
    bit<32> totalLen;
    bit<16> identification;
    bit<3>  flags;
    bit<13> fragOffset;
    bit<8>  ttl;
    ...
}
is converted into
header ipv4_t {
    bit<8>  version_ihl;      // "version" and "ihl" combined for 8-bit alignment
                                 resulting into 8 bit "version_ihl" field
    bit<8>  diffserv;
    bit<32> totalLen;
    bit<16> identification;
    bit<16> flags_fragOffset; // "flag" and "fragOffset" combined for 8-bit aligment
                                 resulting into 16-bit "flags_fragOffset" field
    bit<8>  ttl;
    ...
}