### PR TITLE
Extend eBPF kernel target with support for additional BPF helpers and more types of BPF maps

### DIFF
--- a/backends/ebpf/ebpfProgram.cpp
+++ b/backends/ebpf/ebpfProgram.cpp
@@ -78,7 +78,7 @@ void EBPFProgram::emitC(CodeBuilder* builder, cstring header) {
     builder->append("REGISTER_END()\n");
     builder->newline();
     builder->emitIndent();
-    builder->target->emitCodeSection(builder, functionName);
+    builder->target->emitCodeSection(builder, "prog");
     builder->emitIndent();
     builder->target->emitMain(builder, functionName, model.CPacketName.str());
     builder->blockStart();

--- a/backends/ebpf/runtime/ebpf_kernel.h
+++ b/backends/ebpf/runtime/ebpf_kernel.h
@@ -33,6 +33,9 @@ limitations under the License.
 #define htonl(d) bpf_htonl(d)
 #define htonll(d) bpf_cpu_to_be64(d)
 #define ntohll(x) bpf_be64_to_cpu(x)
+#ifndef bpf_htonll
+#define bpf_htonll(x) htonll(x)
+#endif
 
 #define load_byte(data, b) (*(((u8*)(data)) + (b)))
 #define load_half(data, b) bpf_ntohs(*(u16 *)((u8*)(data) + (b)))
@@ -61,7 +64,6 @@ limitations under the License.
 // This file contains the definitions of all the kernel bpf essentials
 #include <bpf/bpf_helpers.h>
 
-
 /* a helper structure used by an eBPF C program
  * to describe map attributes for the elf_bpf loader
  * FIXME: We only need this because we are loading with iproute2
@@ -74,22 +76,108 @@ struct bpf_elf_map {
     __u32 flags;
     __u32 id;
     __u32 pinning;
+    __u32 inner_id;
+    __u32 inner_idx;
 };
 
 /* simple descriptor which replaces the kernel sk_buff structure */
 #define SK_BUFF struct __sk_buff
 
+/* from iproute2, annotate table with BTF which allows to read types at runtime */
+#define BPF_ANNOTATE_KV_PAIR(name, type_key, type_val)  \
+    struct ____btf_map_##name {                         \
+        type_key key;                                   \
+        type_val value;                                 \
+    };                                                  \
+    struct ____btf_map_##name                           \
+        __attribute__ ((section(".maps." #name), used)) \
+        ____btf_map_##name = {};
+
 #define REGISTER_START()
+#ifndef BTF
 /* Note: pinning exports the table name globally, do not remove */
-#define REGISTER_TABLE(NAME, TYPE, KEY_SIZE, VALUE_SIZE, MAX_ENTRIES) \
+#define REGISTER_TABLE(NAME, TYPE, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES) \
 struct bpf_elf_map SEC("maps") NAME = {          \
-    .type        = TYPE,             \
-    .size_key    = KEY_SIZE,         \
-    .size_value  = VALUE_SIZE,       \
-    .max_elem    = MAX_ENTRIES,      \
-    .pinning     = 2,                \
-    .flags       = 0,                \
+    .type        = TYPE,               \
+    .size_key    = sizeof(KEY_TYPE),   \
+    .size_value  = sizeof(VALUE_TYPE), \
+    .max_elem    = MAX_ENTRIES,        \
+    .pinning     = 2,                  \
+    .flags       = 0,                  \
 };
+#define REGISTER_TABLE_INNER(NAME, TYPE, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES, ID, INNER_IDX) \
+struct bpf_elf_map SEC("maps") NAME = {          \
+    .type        = TYPE,               \
+    .size_key    = sizeof(KEY_TYPE),   \
+    .size_value  = sizeof(VALUE_TYPE), \
+    .max_elem    = MAX_ENTRIES,        \
+    .pinning     = 2,                  \
+    .flags       = 0,                  \
+    .id          = ID,                 \
+    .inner_idx   = INNER_IDX,          \
+};
+#define REGISTER_TABLE_OUTER(NAME, TYPE, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES, INNER_ID, INNER_NAME) \
+struct bpf_elf_map SEC("maps") NAME = {          \
+    .type        = TYPE,               \
+    .size_key    = sizeof(KEY_TYPE),   \
+    .size_value  = sizeof(VALUE_TYPE), \
+    .max_elem    = MAX_ENTRIES,        \
+    .pinning     = 2,                  \
+    .flags       = 0,                  \
+    .inner_id    = INNER_ID,           \
+};
+#define REGISTER_TABLE_FLAGS(NAME, TYPE, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES, FLAGS) \
+struct bpf_elf_map SEC("maps") NAME = {          \
+    .type        = TYPE,               \
+    .size_key    = sizeof(KEY_TYPE),   \
+    .size_value  = sizeof(VALUE_TYPE), \
+    .max_elem    = MAX_ENTRIES,        \
+    .pinning     = 2,                  \
+    .flags       = FLAGS,              \
+};
+#else
+#define REGISTER_TABLE(NAME, TYPE, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES) \
+struct {                                 \
+    __uint(type, TYPE);                  \
+    KEY_TYPE *key;                       \
+    VALUE_TYPE *value;                   \
+    __uint(max_entries, MAX_ENTRIES);    \
+    __uint(pinning, LIBBPF_PIN_BY_NAME); \
+} NAME SEC(".maps");
+#define REGISTER_TABLE_FLAGS(NAME, TYPE, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES, FLAGS) \
+struct {                                 \
+    __uint(type, TYPE);                  \
+    KEY_TYPE *key;                       \
+    VALUE_TYPE *value;                   \
+    __uint(max_entries, MAX_ENTRIES);    \
+    __uint(pinning, LIBBPF_PIN_BY_NAME); \
+    __uint(map_flags, FLAGS);            \
+} NAME SEC(".maps");
+#define REGISTER_TABLE_INNER(NAME, TYPE, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES, ID, INNER_IDX) \
+struct NAME {                            \
+    __uint(type, TYPE);                  \
+    KEY_TYPE *key;                       \
+    VALUE_TYPE *value;                   \
+    __uint(max_entries, MAX_ENTRIES);    \
+} NAME SEC(".maps");
+#define REGISTER_TABLE_OUTER(NAME, TYPE, KEY_TYPE, VALUE_TYPE, MAX_ENTRIES, INNER_ID, INNER_NAME) \
+struct {                                 \
+    __uint(type, TYPE);                  \
+    KEY_TYPE *key;                       \
+    VALUE_TYPE *value;                   \
+    __uint(max_entries, MAX_ENTRIES);    \
+    __uint(pinning, LIBBPF_PIN_BY_NAME); \
+    __array(values, struct INNER_NAME);  \
+} NAME SEC(".maps");
+#define REGISTER_TABLE_NO_KEY_TYPE(NAME, TYPE, KEY_SIZE, VALUE_TYPE, MAX_ENTRIES) \
+struct {                                 \
+    __uint(type, TYPE);                  \
+    __uint(key_size, KEY_SIZE);          \
+    VALUE_TYPE *value;                   \
+    __uint(max_entries, MAX_ENTRIES);    \
+    __uint(pinning, LIBBPF_PIN_BY_NAME); \
+} NAME SEC(".maps");
+#endif
 #define REGISTER_END()
 
 #define BPF_MAP_LOOKUP_ELEM(table, key) \

--- a/backends/ebpf/runtime/ebpf_kernel.h
+++ b/backends/ebpf/runtime/ebpf_kernel.h
@@ -33,9 +33,6 @@ limitations under the License.
 #define htonl(d) bpf_htonl(d)
 #define htonll(d) bpf_cpu_to_be64(d)
 #define ntohll(x) bpf_be64_to_cpu(x)
-#ifndef bpf_htonll
-#define bpf_htonll(x) htonll(x)
-#endif
 
 #define load_byte(data, b) (*(((u8*)(data)) + (b)))
 #define load_half(data, b) bpf_ntohs(*(u16 *)((u8*)(data) + (b)))
@@ -63,6 +60,7 @@ limitations under the License.
 #include "linux/bpf.h"  // types, and general bpf definitions
 // This file contains the definitions of all the kernel bpf essentials
 #include <bpf/bpf_helpers.h>
+
 
 /* a helper structure used by an eBPF C program
  * to describe map attributes for the elf_bpf loader

--- a/backends/ebpf/runtime/kernel.mk
+++ b/backends/ebpf/runtime/kernel.mk
@@ -6,7 +6,7 @@ CLANG ?= clang
 override INCLUDES+= -I$(ROOT_DIR) -I$(ROOT_DIR)usr/include/ -I$(ROOT_DIR)contrib/libbpf/include/uapi/
 override LIBS+=
 # Optimization flags to save space
-override CFLAGS+= -O2 -g -D__KERNEL__ -D__ASM_SYSREG_H \
+override CFLAGS+= -O2 -g -c -D__KERNEL__ -D__ASM_SYSREG_H \
 		-Wno-unused-value  -Wno-pointer-sign \
 		-Wno-compare-distinct-pointer-types \
 		-Wno-gnu-variable-sized-type-not-at-end \

--- a/backends/ebpf/target.cpp
+++ b/backends/ebpf/target.cpp
@@ -76,13 +76,20 @@ void KernelSamplesTarget::emitTableDecl(Util::SourceCodeBuilder* builder,
 
     kind = getBPFMapType(tableKind);
 
-    if (tableKind == TablePerCPUArray || tableKind == TableArray) {
+    if (keyType != "u32" && (tableKind == TablePerCPUArray || tableKind == TableArray)) {
         // it's more safe to overwrite user-provided key type,
         // as array map must have u32 key type.
         keyType = "u32";
-    } else if (tableKind == TableProgArray) {
+        ::warning(ErrorType::WARN_INVALID,
+                  "Invalid key type (%1%) for table kind %2%, replacing with u32",
+                  keyType, kind);
+    } else if (tableKind == TableProgArray && (keyType != "u32" || valueType != "u32")) {
         keyType = "u32";
         valueType = "u32";
+        ::warning(ErrorType::WARN_INVALID,
+                  "Invalid key type (%1%) or value type (%2%) for table kind %3%, "
+                  "replacing with u32",
+                  keyType, valueType, kind);
     }
 
     if (tableKind == TableLPMTrie) {

--- a/backends/ebpf/target.cpp
+++ b/backends/ebpf/target.cpp
@@ -40,10 +40,18 @@ void KernelSamplesTarget::emitIncludes(Util::SourceCodeBuilder* builder) const {
     builder->newline();
 }
 
+void KernelSamplesTarget::emitResizeBuffer(Util::SourceCodeBuilder *builder,
+                                           cstring buffer, cstring offsetVar) const {
+    builder->appendFormat("bpf_skb_adjust_room(%s, %s, 1, 0)",
+                          buffer, offsetVar);
+}
+
 void KernelSamplesTarget::emitTableLookup(Util::SourceCodeBuilder* builder, cstring tblName,
                                           cstring key, cstring value) const {
-    builder->appendFormat("%s = BPF_MAP_LOOKUP_ELEM(%s, &%s)",
-                          value.c_str(), tblName.c_str(), key.c_str());
+    if (!value.isNullOrEmpty())
+        builder->appendFormat("%s = ", value.c_str());
+    builder->appendFormat("BPF_MAP_LOOKUP_ELEM(%s, &%s)",
+                          tblName.c_str(), key.c_str());
 }
 
 void KernelSamplesTarget::emitTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
@@ -62,19 +70,79 @@ void KernelSamplesTarget::emitTableDecl(Util::SourceCodeBuilder* builder,
                                         cstring tblName, TableKind tableKind,
                                         cstring keyType, cstring valueType,
                                         unsigned size) const {
-    cstring kind;
-    if (tableKind == TableHash)
-        kind = "BPF_MAP_TYPE_HASH";
-    else if (tableKind == TableArray)
-        kind = "BPF_MAP_TYPE_ARRAY";
-    else if (tableKind == TableLPMTrie)
-        kind = "BPF_MAP_TYPE_LPM_TRIE";
-    else
-        BUG("%1%: unsupported table kind", tableKind);
-    builder->appendFormat("REGISTER_TABLE(%s, %s, ", tblName.c_str(), kind.c_str());
-    builder->appendFormat("sizeof(%s), sizeof(%s), %d)",
-                          keyType.c_str(), valueType.c_str(), size);
+    cstring kind, flags;
+    cstring registerTable = "REGISTER_TABLE(%s, %s, %s, %s, %d)";
+    cstring registerTableWithFlags = "REGISTER_TABLE_FLAGS(%s, %s, %s, %s, %d, %s)";
+
+    kind = getBPFMapType(tableKind);
+
+    if (tableKind == TablePerCPUArray || tableKind == TableArray) {
+        // it's more safe to overwrite user-provided key type,
+        // as array map must have u32 key type.
+        keyType = "u32";
+    } else if (tableKind == TableProgArray) {
+        keyType = "u32";
+        valueType = "u32";
+    }
+
+    if (tableKind == TableLPMTrie) {
+        flags = "BPF_F_NO_PREALLOC";
+    }
+
+    if (flags.isNullOrEmpty()) {
+        builder->appendFormat(registerTable, tblName.c_str(),
+                              kind.c_str(), keyType.c_str(),
+                              valueType.c_str(), size);
+    } else {
+        builder->appendFormat(registerTableWithFlags, tblName.c_str(),
+                              kind.c_str(), keyType.c_str(),
+                              valueType.c_str(), size, flags);
+    }
     builder->newline();
+    annotateTableWithBTF(builder, tblName, keyType, valueType);
+}
+
+void KernelSamplesTarget::emitTableDeclSpinlock(Util::SourceCodeBuilder* builder,
+                                                cstring tblName, TableKind tableKind,
+                                                cstring keyType, cstring valueType,
+                                                unsigned size) const {
+    if (tableKind == TableHash || tableKind == TableArray) {
+        emitTableDecl(builder, tblName, tableKind, keyType, valueType, size);
+    } else {
+        BUG("%1%: unsupported table kind with spinlock", tableKind);
+    }
+}
+
+void
+KernelSamplesTarget::emitMapInMapDecl(Util::SourceCodeBuilder *builder, cstring innerName,
+                                      TableKind innerTableKind, cstring innerKeyType,
+                                      cstring innerValueType, unsigned int innerSize,
+                                      cstring outerName, TableKind outerTableKind,
+                                      cstring outerKeyType, unsigned int outerSize) const {
+    if (outerTableKind != TableArray && outerTableKind != TableHash) {
+        BUG("Unsupported type of outer map for map-in-map");
+    }
+
+    cstring registerOuterTable = "REGISTER_TABLE_OUTER(%s, %s_OF_MAPS, %s, %s, %d, %d, %s)";
+    cstring registerInnerTable = "REGISTER_TABLE_INNER(%s, %s, %s, %s, %d, %d, %d)";
+
+    innerMapIndex++;
+
+    cstring kind = getBPFMapType(innerTableKind);
+    builder->appendFormat(registerInnerTable, innerName,
+                          kind, innerKeyType, innerValueType,
+                          innerSize, innerMapIndex, innerMapIndex);
+    builder->newline();
+    annotateTableWithBTF(builder, innerName, innerKeyType, innerValueType);
+
+    kind = getBPFMapType(outerTableKind);
+    cstring keyType = outerTableKind == TableArray ? "__u32" : outerKeyType;
+    builder->appendFormat(registerOuterTable, outerName,
+                          kind, keyType,
+                          "__u32", outerSize, innerMapIndex,
+                          innerName);
+    builder->newline();
+    annotateTableWithBTF(builder, outerName, keyType, "__u32");
 }
 
 void KernelSamplesTarget::emitLicense(Util::SourceCodeBuilder* builder, cstring license) const {
@@ -85,7 +153,7 @@ void KernelSamplesTarget::emitLicense(Util::SourceCodeBuilder* builder, cstring 
 
 void KernelSamplesTarget::emitCodeSection(
     Util::SourceCodeBuilder* builder, cstring sectionName) const {
-    builder->appendFormat("SEC(\"prog\")\n", sectionName.c_str());
+    builder->appendFormat("SEC(\"%s\")\n", sectionName.c_str());
 }
 
 void KernelSamplesTarget::emitMain(Util::SourceCodeBuilder* builder,
@@ -127,6 +195,7 @@ void KernelSamplesTarget::emitTraceMessage(Util::SourceCodeBuilder* builder, con
         msg = msg + "\\n";
 
     msg = cstring("\"") + msg + "\"";
+
     va_start(ap, argc);
     for (int i = 0; i < argc; ++i) {
         auto arg = va_arg(ap, const char *);
@@ -138,6 +207,13 @@ void KernelSamplesTarget::emitTraceMessage(Util::SourceCodeBuilder* builder, con
 
     builder->emitIndent();
     builder->appendFormat("bpf_trace_message(%s);", msg);
+    builder->newline();
+}
+
+void KernelSamplesTarget::annotateTableWithBTF(Util::SourceCodeBuilder* builder, cstring name,
+                                               cstring keyType, cstring valueType) const {
+    builder->appendFormat("BPF_ANNOTATE_KV_PAIR(%s, %s, %s)",
+                          name.c_str(), keyType.c_str(), valueType.c_str());
     builder->newline();
 }
 
@@ -162,8 +238,10 @@ void TestTarget::emitTableDecl(Util::SourceCodeBuilder* builder,
 
 void BccTarget::emitTableLookup(Util::SourceCodeBuilder* builder, cstring tblName,
                                 cstring key, cstring value) const {
-    builder->appendFormat("%s = %s.lookup(&%s)",
-                          value.c_str(), tblName.c_str(), key.c_str());
+    if (!value.isNullOrEmpty())
+        builder->appendFormat("%s = ", value.c_str());
+    builder->appendFormat("%s.lookup(&%s)",
+                          tblName.c_str(), key.c_str());
 }
 
 void BccTarget::emitTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,

--- a/backends/ebpf/target.cpp
+++ b/backends/ebpf/target.cpp
@@ -195,7 +195,6 @@ void KernelSamplesTarget::emitTraceMessage(Util::SourceCodeBuilder* builder, con
         msg = msg + "\\n";
 
     msg = cstring("\"") + msg + "\"";
-
     va_start(ap, argc);
     for (int i = 0; i < argc; ++i) {
         auto arg = va_arg(ap, const char *);

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define _BACKENDS_EBPF_TARGET_H_
 
 #include "lib/cstring.h"
+#include "lib/error.h"
 #include "lib/sourceCodeBuilder.h"
 #include "lib/exceptions.h"
 
@@ -68,6 +69,9 @@ class Target {
         (void) keyType;
         (void) valueType;
         (void) size;
+        ::error(ErrorType::ERR_UNSUPPORTED,
+                "emitTableDeclSpinlock is not supported on %1% target",
+                name);
     }
     // map-in-map requires declaration of both inner and outer map,
     // thus we define them together in a single method.
@@ -86,6 +90,9 @@ class Target {
         (void) outerTableKind;
         (void) outerKeyType;
         (void) outerSize;
+        ::error(ErrorType::ERR_UNSUPPORTED,
+                "emitMapInMapDecl is not supported on %1% target",
+                name);
     }
     virtual void emitMain(Util::SourceCodeBuilder* builder,
                           cstring functionName,

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -29,7 +29,11 @@ namespace EBPF {
 enum TableKind {
     TableHash,
     TableArray,
-    TableLPMTrie  // longest prefix match trie
+    TablePerCPUArray,
+    TableProgArray,
+    TableLPMTrie,  // longest prefix match trie
+    TableHashLRU,
+    TableDevmap
 };
 
 class Target {
@@ -44,6 +48,8 @@ class Target {
     virtual void emitLicense(Util::SourceCodeBuilder* builder, cstring license) const = 0;
     virtual void emitCodeSection(Util::SourceCodeBuilder* builder, cstring sectionName) const = 0;
     virtual void emitIncludes(Util::SourceCodeBuilder* builder) const = 0;
+    virtual void emitResizeBuffer(Util::SourceCodeBuilder* builder, cstring buffer,
+                                  cstring offsetVar) const = 0;
     virtual void emitTableLookup(Util::SourceCodeBuilder* builder, cstring tblName,
                                  cstring key, cstring value) const = 0;
     virtual void emitTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
@@ -53,6 +59,34 @@ class Target {
     virtual void emitTableDecl(Util::SourceCodeBuilder* builder,
                                cstring tblName, TableKind tableKind,
                                cstring keyType, cstring valueType, unsigned size) const = 0;
+    virtual void emitTableDeclSpinlock(Util::SourceCodeBuilder* builder,
+                               cstring tblName, TableKind tableKind,
+                               cstring keyType, cstring valueType, unsigned size) const {
+        (void) builder;
+        (void) tblName;
+        (void) tableKind;
+        (void) keyType;
+        (void) valueType;
+        (void) size;
+    }
+    // map-in-map requires declaration of both inner and outer map,
+    // thus we define them together in a single method.
+    virtual void emitMapInMapDecl(Util::SourceCodeBuilder* builder,
+                          cstring innerName, TableKind innerTableKind,
+                          cstring innerKeyType, cstring innerValueType, unsigned innerSize,
+                          cstring outerName, TableKind outerTableKind,
+                          cstring outerKeyType, unsigned outerSize) const {
+        (void) builder;
+        (void) innerName;
+        (void) innerTableKind;
+        (void) innerKeyType;
+        (void) innerValueType;
+        (void) innerSize;
+        (void) outerName;
+        (void) outerTableKind;
+        (void) outerKeyType;
+        (void) outerSize;
+    }
     virtual void emitMain(Util::SourceCodeBuilder* builder,
                           cstring functionName,
                           cstring argName) const = 0;
@@ -63,6 +97,7 @@ class Target {
     virtual cstring abortReturnCode() const = 0;
     // Path on /sys filesystem where maps are stored
     virtual cstring sysMapPath() const = 0;
+    virtual cstring packetDescriptorType() const = 0;
 
     virtual void emitPreamble(Util::SourceCodeBuilder* builder) const;
     /// Emit trace message which will be printed during packet processing (if enabled).
@@ -84,15 +119,40 @@ class Target {
 // Represents a target that is compiled within the kernel
 // source tree samples folder and which attaches to a socket
 class KernelSamplesTarget : public Target {
+ private:
+    mutable unsigned int innerMapIndex;
+
+    cstring getBPFMapType(TableKind kind) const {
+        if (kind == TableHash) {
+            return "BPF_MAP_TYPE_HASH";
+        } else if (kind == TableArray) {
+            return "BPF_MAP_TYPE_ARRAY";
+        } else if (kind == TablePerCPUArray) {
+            return "BPF_MAP_TYPE_PERCPU_ARRAY";
+        } else if (kind == TableLPMTrie) {
+            return "BPF_MAP_TYPE_LPM_TRIE";
+        } else if (kind == TableHashLRU) {
+            return "BPF_MAP_TYPE_LRU_HASH";
+        } else if (kind == TableProgArray) {
+            return "BPF_MAP_TYPE_PROG_ARRAY";
+        } else if (kind == TableDevmap) {
+            return "BPF_MAP_TYPE_DEVMAP";
+        }
+        BUG("Unknown table kind");
+    }
+
  protected:
     bool emitTraceMessages;
 
  public:
     explicit KernelSamplesTarget(bool emitTrace = false, cstring name = "Linux kernel")
-        : Target(name), emitTraceMessages(emitTrace) {}
+        : Target(name), innerMapIndex(0), emitTraceMessages(emitTrace) {}
+
     void emitLicense(Util::SourceCodeBuilder* builder, cstring license) const override;
     void emitCodeSection(Util::SourceCodeBuilder* builder, cstring sectionName) const override;
     void emitIncludes(Util::SourceCodeBuilder* builder) const override;
+    void emitResizeBuffer(Util::SourceCodeBuilder* builder, cstring buffer,
+                          cstring offsetVar) const override;
     void emitTableLookup(Util::SourceCodeBuilder* builder, cstring tblName,
                          cstring key, cstring value) const override;
     void emitTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
@@ -102,9 +162,20 @@ class KernelSamplesTarget : public Target {
     void emitTableDecl(Util::SourceCodeBuilder* builder,
                        cstring tblName, TableKind tableKind,
                        cstring keyType, cstring valueType, unsigned size) const override;
+    void emitTableDeclSpinlock(Util::SourceCodeBuilder* builder,
+                               cstring tblName, TableKind tableKind,
+                               cstring keyType, cstring valueType, unsigned size) const override;
+    void emitMapInMapDecl(Util::SourceCodeBuilder* builder,
+                          cstring innerName, TableKind innerTableKind,
+                          cstring innerKeyType, cstring innerValueType, unsigned innerSize,
+                          cstring outerName, TableKind outerTableKind,
+                          cstring outerKeyType, unsigned outerSize) const override;
     void emitMain(Util::SourceCodeBuilder* builder,
                   cstring functionName,
                   cstring argName) const override;
+    void emitPreamble(Util::SourceCodeBuilder* builder) const override;
+    void emitTraceMessage(Util::SourceCodeBuilder* builder, const char* format,
+                          int argc = 0, ...) const override;
     cstring dataOffset(cstring base) const override
     { return cstring("((void*)(long)")+ base + "->data)"; }
     cstring dataEnd(cstring base) const override
@@ -114,9 +185,10 @@ class KernelSamplesTarget : public Target {
     cstring abortReturnCode() const override { return "TC_ACT_SHOT"; }
     cstring sysMapPath() const override { return "/sys/fs/bpf/tc/globals"; }
 
-    void emitPreamble(Util::SourceCodeBuilder* builder) const override;
-    void emitTraceMessage(Util::SourceCodeBuilder* builder,
-                          const char* format, int argc, ...) const override;
+    cstring packetDescriptorType() const override { return "struct __sk_buff"; }
+
+    void annotateTableWithBTF(Util::SourceCodeBuilder* builder, cstring name,
+                              cstring keyType, cstring valueType) const;
 };
 
 // Represents a target compiled by bcc that uses the TC
@@ -126,6 +198,7 @@ class BccTarget : public Target {
     void emitLicense(Util::SourceCodeBuilder*, cstring) const override {};
     void emitCodeSection(Util::SourceCodeBuilder*, cstring) const override {}
     void emitIncludes(Util::SourceCodeBuilder* builder) const override;
+    void emitResizeBuffer(Util::SourceCodeBuilder*, cstring, cstring) const override {};
     void emitTableLookup(Util::SourceCodeBuilder* builder, cstring tblName,
                          cstring key, cstring value) const override;
     void emitTableUpdate(Util::SourceCodeBuilder* builder, cstring tblName,
@@ -145,6 +218,7 @@ class BccTarget : public Target {
     cstring dropReturnCode() const override { return "1"; }
     cstring abortReturnCode() const override { return "1"; }
     cstring sysMapPath() const override { return "/sys/fs/bpf"; }
+    cstring packetDescriptorType() const override { return "struct __sk_buff"; }
 };
 
 // A userspace test version with functionality equivalent to the kernel
@@ -152,6 +226,8 @@ class BccTarget : public Target {
 class TestTarget : public EBPF::KernelSamplesTarget {
  public:
     TestTarget() : KernelSamplesTarget(false, "Userspace Test") {}
+
+    void emitResizeBuffer(Util::SourceCodeBuilder*, cstring, cstring) const override {};
     void emitIncludes(Util::SourceCodeBuilder* builder) const override;
     void emitTableDecl(Util::SourceCodeBuilder* builder,
                        cstring tblName, TableKind tableKind,
@@ -164,6 +240,7 @@ class TestTarget : public EBPF::KernelSamplesTarget {
     cstring dropReturnCode() const override { return "false"; }
     cstring abortReturnCode() const override { return "false"; }
     cstring sysMapPath() const override { return "/sys/fs/bpf"; }
+    cstring packetDescriptorType() const override { return "struct __sk_buff"; }
 };
 
 }  // namespace EBPF

--- a/backends/ubpf/target.cpp
+++ b/backends/ubpf/target.cpp
@@ -35,6 +35,12 @@ namespace UBPF {
                               functionName.c_str(), argName.c_str(), standardMetdata.c_str());
     }
 
+    void UbpfTarget::emitResizeBuffer(Util::SourceCodeBuilder *builder,
+                                      cstring buffer, cstring offsetVar) const {
+        builder->appendFormat("ubpf_adjust_head(%s, %s)",
+                              buffer.c_str(), offsetVar.c_str());
+    }
+
     void UbpfTarget::emitTableLookup(Util::SourceCodeBuilder *builder,
                                      cstring tblName,
                                      cstring key,

--- a/backends/ubpf/target.h
+++ b/backends/ubpf/target.h
@@ -32,6 +32,7 @@ namespace UBPF {
         void emitLicense(Util::SourceCodeBuilder *, cstring) const override {};
         void emitCodeSection(Util::SourceCodeBuilder *, cstring) const override {};
         void emitIncludes(Util::SourceCodeBuilder *builder) const override;
+        void emitResizeBuffer(Util::SourceCodeBuilder* builder, cstring buffer, cstring offsetVar) const override;
         void emitTableLookup(Util::SourceCodeBuilder *builder, cstring tblName,
                              cstring key, cstring value) const override;
         void emitTableUpdate(Util::SourceCodeBuilder *builder, cstring tblName,
@@ -61,6 +62,7 @@ namespace UBPF {
         cstring abortReturnCode() const override { return "1"; }
         cstring forwardReturnCode() const override { return "1"; }
         cstring sysMapPath() const override { return ""; }
+        cstring packetDescriptorType() const override { return "void"; }
     };
 
 }


### PR DESCRIPTION
This PR extends the eBPF kernel target with:
- support for defining other BPF map types
- support for BPF map-in-maps
- support for BPF maps using BPF spinlocks
- method to generate packet descriptor type (e.g. `__sk_buff`) depending on the eBPF hook type. It's required to support mixed deployments leveraging both TC and XDP programs.
- method to generate packet buffer's size adjustment
- BTF annotation of BPF maps, so that BPF types can be read at runtime

This PR is one from the series of PRs bringing the support for the PSA model to eBPF backend. The goal is to shrink the "main PR" with the full implementation of PSA for eBPF to facilitate review. 