### PR TITLE
DPDK: Add support for "mirror_packet" PNA extern

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -65,3 +65,15 @@ p4c_add_xfail_reason("dpdk"
   "Non Type_Bits type bool for expression"
   testdata/p4_16_samples/pna-dpdk-parser-state-err.p4
   )
+
+p4c_add_xfail_reason("dpdk"
+  "mirror_packet cannot be used in the"
+  testdata/p4_16_samples/pna-example-mirror-packet-ctxt-error.p4
+  testdata/p4_16_samples/pna-example-mirror-packet-ctxt-error1.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  "Mirror session ID 0 is reserved for use by Architecture"
+  testdata/p4_16_samples/pna-example-mirror-packet-error1.p4
+  )
+

--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -77,3 +77,12 @@ p4c_add_xfail_reason("dpdk"
   testdata/p4_16_samples/pna-example-mirror-packet-error1.p4
   )
 
+p4c_add_xfail_reason("dpdk"
+  "argument used for directionless parameter .* must be a compile-time constant"
+  testdata/p4_16_samples/pna-example-mirror-packet-error2.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  "No argument supplied for parameter"
+  testdata/p4_16_samples/pna-example-mirror-packet-error3.p4
+  )

--- a/backends/dpdk/dbprint-dpdk.cpp
+++ b/backends/dpdk/dbprint-dpdk.cpp
@@ -20,6 +20,10 @@ void IR::DpdkLearnStatement::dbprint(std::ostream& out) const {
     out << "learn " << action << std::endl;
 }
 
+void IR::DpdkMirrorStatement::dbprint(std::ostream& out) const {
+    out << "mirror " << slotId << " " << sessionId << std::endl;
+}
+
 void IR::DpdkEmitStatement::dbprint(std::ostream& out) const {
     out << "emit " << header << std::endl;
 }

--- a/backends/dpdk/dpdk.def
+++ b/backends/dpdk/dpdk.def
@@ -107,6 +107,12 @@ class DpdkLearnStatement : DpdkAsmStatement, IDPDKNode {
     std::ostream& toSpec(std::ostream& out) const override;
 }
 
+class DpdkMirrorStatement : DpdkAsmStatement, IDPDKNode {
+    Expression slotId;
+    Expression sessionId;
+    std::ostream& toSpec(std::ostream& out) const override;
+}
+
 class DpdkEmitStatement : DpdkAsmStatement, IDPDKNode {
     Expression header;
     std::ostream& toSpec(std::ostream& out) const override;

--- a/backends/dpdk/dpdkCheckExternInvocation.h
+++ b/backends/dpdk/dpdkCheckExternInvocation.h
@@ -48,6 +48,7 @@ class CheckPNAExternInvocation : public P4::CheckExternInvocationCommon {
         bitvec validInMainControl;
         validInMainControl.setbit(MAIN_CONTROL);
         setPipeConstraints("send_to_port", validInMainControl);
+        setPipeConstraints("mirror_packet", validInMainControl);
         // Add new constraints here
     }
 

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -770,6 +770,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
             if (args->size() != 2) {
                 ::error(ErrorType::ERR_UNEXPECTED, "Expected 2 arguments for %1%",
                             a->method->name);
+                return false;
             }
             auto slot_id = a->expr->arguments->at(0)->expression;
             auto session_id = a->expr->arguments->at(1)->expression;
@@ -779,8 +780,10 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
             BUG_CHECK(session_id->is<IR::Constant>(),
                       "Expected a constant for session_id param of %1%", a->method->name);
             unsigned value =  session_id->to<IR::Constant>()->asUnsigned();
-            if (value == 0)
+            if (value == 0) {
                 ::error("Mirror session ID 0 is reserved for use by Architecture");
+                return false;
+            }
 
             // Mov slot id and session id to metadata fields as DPDK expects these parameters
             // to be in metadata

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -766,32 +766,34 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                 ::error("%1%: unhandled function", s);
             }
         } else if (a->method->name == "mirror_packet") {
+            auto args = a->expr->arguments;
+            if (args->size() != 2) {
+                ::error(ErrorType::ERR_UNEXPECTED, "Expected 2 arguments for %1%",
+                            a->method->name);
+            }
             auto slot_id = a->expr->arguments->at(0)->expression;
             auto session_id = a->expr->arguments->at(1)->expression;
-            const IR::Expression *slot_idexpr = slot_id;
-            const IR::Expression *session_idexpr = session_id;
-            // mirror instruction supports only metadata as operands, move any constant arguments
-            // to metadata fields
-            if (slot_id->is<IR::Constant>()){
-                IR::ID tmpName(refmap->newName("mirrorSlot"));
-                BUG_CHECK(metadataStruct, "Metadata structure missing unexpectedly!");
-                metadataStruct->fields.push_back(new IR::StructField(tmpName, slot_id->type));
-                auto tmpMember = new IR::Member(new IR::PathExpression("m"), tmpName);
-                add_instr(new IR::DpdkMovStatement(tmpMember, slot_id));
-                slot_idexpr = tmpMember;
-            }
-            if (session_id->is<IR::Constant>()){
-                unsigned value =  session_id->to<IR::Constant>()->asUnsigned();
-                if (value == 0)
-                    ::error("Mirror session ID 0 is reserved for use by Architecture");
-                IR::ID tmpName(refmap->newName("mirrorSession"));
-                BUG_CHECK(metadataStruct, "Metadata structure missing unexpectedly!");
-                metadataStruct->fields.push_back(new IR::StructField(tmpName, session_id->type));
-                auto tmpMember = new IR::Member(new IR::PathExpression("m"), tmpName);
-                add_instr(new IR::DpdkMovStatement(tmpMember, session_id));
-                session_idexpr = tmpMember;
-            }
-            add_instr(new IR::DpdkMirrorStatement(slot_idexpr, session_idexpr));
+            // Frontend rejects programs which have non-constant arguments for mirror_packet()
+            BUG_CHECK(slot_id->is<IR::Constant>(), "Expected a constant for slot_id param of %1%",
+                                                   a->method->name);
+            BUG_CHECK(session_id->is<IR::Constant>(),
+                      "Expected a constant for session_id param of %1%", a->method->name);
+            unsigned value =  session_id->to<IR::Constant>()->asUnsigned();
+            if (value == 0)
+                ::error("Mirror session ID 0 is reserved for use by Architecture");
+
+            // Mov slot id and session id to metadata fields as DPDK expects these parameters
+            // to be in metadata
+            BUG_CHECK(metadataStruct, "Metadata structure missing unexpectedly!");
+            IR::ID slotName(refmap->newName("mirrorSlot"));
+            IR::ID sessionName(refmap->newName("mirrorSession"));
+            metadataStruct->fields.push_back(new IR::StructField(slotName, slot_id->type));
+            metadataStruct->fields.push_back(new IR::StructField(sessionName, session_id->type));
+            auto slotMember = new IR::Member(new IR::PathExpression("m"), slotName);
+            auto sessionMember = new IR::Member(new IR::PathExpression("m"), sessionName);
+            add_instr(new IR::DpdkMovStatement(slotMember, slot_id));
+            add_instr(new IR::DpdkMovStatement(sessionMember, session_id));
+            add_instr(new IR::DpdkMirrorStatement(slotMember, sessionMember));
         } else if (a->method->name == "send_to_port") {
             BUG_CHECK(a->expr->arguments->size() == 1,
                 "%1%: expected one argument for send_to_port extern", a);

--- a/backends/dpdk/dpdkProgram.cpp
+++ b/backends/dpdk/dpdkProgram.cpp
@@ -122,9 +122,9 @@ const IR::DpdkAsmProgram *ConvertToDpdkProgram::create(IR::P4Program *prog) {
             BUG("Unknown parser %s", kv.second->name);
     }
     auto ingress_converter =
-        new ConvertToDpdkControl(refmap, typemap, structure);
+        new ConvertToDpdkControl(refmap, typemap, structure, metadataStruct);
     auto egress_converter =
-        new ConvertToDpdkControl(refmap, typemap, structure);
+        new ConvertToDpdkControl(refmap, typemap, structure, metadataStruct);
     for (auto kv : structure->pipelines) {
         if (kv.first == "Ingress")
             kv.second->apply(*ingress_converter);
@@ -139,9 +139,9 @@ const IR::DpdkAsmProgram *ConvertToDpdkProgram::create(IR::P4Program *prog) {
             BUG("Unknown control block %s", kv.second->name);
     }
     auto ingress_deparser_converter =
-        new ConvertToDpdkControl(refmap, typemap, structure, true);
+        new ConvertToDpdkControl(refmap, typemap, structure, metadataStruct, true);
     auto egress_deparser_converter =
-        new ConvertToDpdkControl(refmap, typemap, structure);
+        new ConvertToDpdkControl(refmap, typemap, structure, metadataStruct);
     for (auto kv : structure->deparsers) {
         if (kv.first == "IngressDeparser")
             kv.second->apply(*ingress_deparser_converter);
@@ -501,7 +501,7 @@ bool ConvertToDpdkParser::preorder(const IR::ParserState *) { return false; }
 
 // =====================Control=============================
 bool ConvertToDpdkControl::preorder(const IR::P4Action *a) {
-    auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure);
+    auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure, metadataStruct);
     helper->setCalledBy(this);
     a->body->apply(*helper);
     auto stmt_list = new IR::IndexedVector<IR::DpdkAsmStatement>();
@@ -641,7 +641,7 @@ bool ConvertToDpdkControl::preorder(const IR::P4Control *c) {
             structure->push_variable(new IR::DpdkDeclaration(l));
         }
     }
-    auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure);
+    auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure, metadataStruct);
     helper->setCalledBy(this);
     c->body->apply(*helper);
     if (deparser && structure->isPSA()) {

--- a/backends/dpdk/dpdkProgram.h
+++ b/backends/dpdk/dpdkProgram.h
@@ -95,6 +95,7 @@ class ConvertToDpdkControl : public Inspector {
     P4::TypeMap *typemap;
     P4::ReferenceMap *refmap;
     DpdkProgramStructure *structure;
+    IR::Type_Struct *metadataStruct;
     IR::IndexedVector<IR::DpdkAsmStatement> instructions;
     IR::IndexedVector<IR::DpdkTable> tables;
     IR::IndexedVector<IR::DpdkSelector> selectors;
@@ -107,8 +108,10 @@ class ConvertToDpdkControl : public Inspector {
     ConvertToDpdkControl(
         P4::ReferenceMap *refmap, P4::TypeMap *typemap,
         DpdkProgramStructure *structure,
+        IR::Type_Struct *metadataStruct,
         bool deparser = false)
-        : typemap(typemap), refmap(refmap), structure(structure), deparser(deparser) {}
+        : typemap(typemap), refmap(refmap), structure(structure),
+          metadataStruct(metadataStruct), deparser(deparser) {}
 
     IR::IndexedVector<IR::DpdkTable> &getTables() { return tables; }
     IR::IndexedVector<IR::DpdkSelector> &getSelectors() { return selectors; }

--- a/backends/dpdk/spec.cpp
+++ b/backends/dpdk/spec.cpp
@@ -193,6 +193,11 @@ std::ostream &IR::DpdkApplyStatement::toSpec(std::ostream &out) const {
     return out;
 }
 
+std::ostream &IR::DpdkMirrorStatement::toSpec(std::ostream &out) const {
+    out << "mirror " << DPDK::toStr(slotId) << " " << DPDK::toStr(sessionId);
+    return out;
+}
+
 std::ostream &IR::DpdkLearnStatement::toSpec(std::ostream &out) const {
     out << "learn " << action << " " << DPDK::toStr(argument);
     return out;

--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -108,6 +108,10 @@ set (P4_XFAIL_TESTS
   # This program uses conditional execution inside action body which is currently
   # unsupported
   testdata/p4_16_samples/psa-dpdk-action-jumpOpt.p4
+  # These tests are added to check mirror_packet extern invocation with non-constant
+  # arguments and with incorrect number of arguments
+  testdata/p4_16_samples/pna-example-mirror-packet-error2.p4
+  testdata/p4_16_samples/pna-example-mirror-packet-error3.p4
   )
 # we invoke p4c with --p4runtime-files even for programs in p4_16_errors. This
 # enables us to use p4_16_errors even for programs which pass compilation but

--- a/testdata/p4_16_samples/pna-example-mirror-packet-ctxt-error.p4
+++ b/testdata/p4_16_samples/pna-example-mirror-packet-ctxt-error.p4
@@ -1,0 +1,125 @@
+#include <core.p4>
+#include "pna.p4"
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t) 3;
+
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t) 58;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t) 62;
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select (hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(
+    inout headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action send_with_mirror (PortId_t vport) {
+	send_to_port(vport);
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION1);
+    }
+
+    action drop_with_mirror() {
+	drop_packet();
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+    }
+
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.protocol : exact;
+        }
+        actions = {
+            send_with_mirror;
+            drop_with_mirror;
+            NoAction;
+        }
+        const default_action = NoAction();
+    }
+
+    apply {
+                flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,
+    in    main_metadata_t user_meta,
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    ) main;
+

--- a/testdata/p4_16_samples/pna-example-mirror-packet-ctxt-error1.p4
+++ b/testdata/p4_16_samples/pna-example-mirror-packet-ctxt-error1.p4
@@ -1,0 +1,126 @@
+#include <core.p4>
+#include "pna.p4"
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t) 3;
+
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t) 58;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t) 62;
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select (hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(
+    inout headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action send_with_mirror (PortId_t vport) {
+	send_to_port(vport);
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION1);
+    }
+
+    action drop_with_mirror() {
+	drop_packet();
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+    }
+
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.protocol : exact;
+        }
+        actions = {
+            send_with_mirror;
+            drop_with_mirror;
+            NoAction;
+        }
+        const default_action = NoAction();
+    }
+
+    apply {
+                flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,
+    in    main_metadata_t user_meta,
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    ) main;
+

--- a/testdata/p4_16_samples/pna-example-mirror-packet-error1.p4
+++ b/testdata/p4_16_samples/pna-example-mirror-packet-error1.p4
@@ -1,0 +1,125 @@
+#include <core.p4>
+#include "pna.p4"
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t) 3;
+
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t) 0;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t) 62;
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select (hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(
+    inout headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action send_with_mirror (PortId_t vport) {
+	send_to_port(vport);
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION1);
+    }
+
+    action drop_with_mirror() {
+	drop_packet();
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+    }
+
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.protocol : exact;
+        }
+        actions = {
+            send_with_mirror;
+            drop_with_mirror;
+            NoAction;
+        }
+        const default_action = NoAction();
+    }
+
+    apply {
+                flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,
+    in    main_metadata_t user_meta,
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    ) main;
+

--- a/testdata/p4_16_samples/pna-example-mirror-packet-error2.p4
+++ b/testdata/p4_16_samples/pna-example-mirror-packet-error2.p4
@@ -1,0 +1,133 @@
+#include <core.p4>
+#include "pna.p4"
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t) 3;
+
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t) 58;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t) 62;
+const MirrorSessionId_t MIRROR_SESSION3 = (MirrorSessionId_t) 6;
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select (hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(
+    inout headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    MirrorSessionId_t mirror_session;
+    MirrorSlotId_t mirror_slot; 
+    action send_with_mirror (PortId_t vport) {
+	send_to_port(vport);
+	mirror_packet(mirror_slot, mirror_session);
+    }
+
+    action drop_with_mirror() {
+	drop_packet();
+	mirror_packet(mirror_slot, mirror_session);
+    }
+
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.protocol : exact;
+        }
+        actions = {
+            send_with_mirror;
+            drop_with_mirror;
+            NoAction;
+        }
+        const default_action = NoAction();
+    }
+
+    apply {
+                mirror_slot = MIRROR_SLOT_ID;
+                switch (flowTable.apply().action_run){
+                    send_with_mirror: { mirror_session = MIRROR_SESSION1;}
+                    drop_with_mirror: { mirror_session = MIRROR_SESSION2;}
+                    default: {mirror_session = MIRROR_SESSION3;}
+                }
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,
+    in    main_metadata_t user_meta,
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    ) main;
+

--- a/testdata/p4_16_samples/pna-example-mirror-packet-error3.p4
+++ b/testdata/p4_16_samples/pna-example-mirror-packet-error3.p4
@@ -1,0 +1,124 @@
+#include <core.p4>
+#include "pna.p4"
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t) 3;
+
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t) 58;
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select (hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(
+    inout headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action send_with_mirror (PortId_t vport) {
+	send_to_port(vport);
+	mirror_packet(MIRROR_SLOT_ID);
+    }
+
+    action drop_with_mirror() {
+	drop_packet();
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION1);
+    }
+
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.protocol : exact;
+        }
+        actions = {
+            send_with_mirror;
+            drop_with_mirror;
+            NoAction;
+        }
+        const default_action = NoAction();
+    }
+
+    apply {
+                flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,
+    in    main_metadata_t user_meta,
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    ) main;
+

--- a/testdata/p4_16_samples/pna-example-mirror-packet.p4
+++ b/testdata/p4_16_samples/pna-example-mirror-packet.p4
@@ -1,0 +1,125 @@
+#include <core.p4>
+#include "pna.p4"
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t) 3;
+
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t) 58;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t) 62;
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select (hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(
+    inout headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action send_with_mirror (PortId_t vport) {
+	send_to_port(vport);
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION1);
+    }
+
+    action drop_with_mirror() {
+	drop_packet();
+	mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+    }
+
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.protocol : exact;
+        }
+        actions = {
+            send_with_mirror;
+            drop_with_mirror;
+            NoAction;
+        }
+        const default_action = NoAction();
+    }
+
+    apply {
+                flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,
+    in    main_metadata_t user_meta,
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    ) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error-first.p4
@@ -1,0 +1,94 @@
+#include <core.p4>
+#include <pna.p4>
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t)8w3;
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t)16w58;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t)16w62;
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action send_with_mirror(PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w58);
+    }
+    action drop_with_mirror() {
+        drop_packet();
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+    }
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction();
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error-frontend.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.send_with_mirror") action send_with_mirror(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w58);
+    }
+    @name("MainControlImpl.drop_with_mirror") action drop_with_mirror() {
+        drop_packet();
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+    }
+    @name("MainControlImpl.flowTable") table flowTable_0 {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        flowTable_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error-midend.p4
@@ -1,0 +1,111 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    @hidden action pnaexamplemirrorpacketctxterror47() {
+        mirror_packet(8w3, 16w62);
+    }
+    @hidden table tbl_pnaexamplemirrorpacketctxterror47 {
+        actions = {
+            pnaexamplemirrorpacketctxterror47();
+        }
+        const default_action = pnaexamplemirrorpacketctxterror47();
+    }
+    apply {
+        tbl_pnaexamplemirrorpacketctxterror47.apply();
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.send_with_mirror") action send_with_mirror(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet(8w3, 16w58);
+    }
+    @name("MainControlImpl.drop_with_mirror") action drop_with_mirror() {
+        drop_packet();
+        mirror_packet(8w3, 16w62);
+    }
+    @name("MainControlImpl.flowTable") table flowTable_0 {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        flowTable_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnaexamplemirrorpacketctxterror114() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnaexamplemirrorpacketctxterror114 {
+        actions = {
+            pnaexamplemirrorpacketctxterror114();
+        }
+        const default_action = pnaexamplemirrorpacketctxterror114();
+    }
+    apply {
+        tbl_pnaexamplemirrorpacketctxterror114.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error.p4
@@ -1,0 +1,94 @@
+#include <core.p4>
+#include <pna.p4>
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t)3;
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t)58;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t)62;
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+        mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action send_with_mirror(PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION1);
+    }
+    action drop_with_mirror() {
+        drop_packet();
+        mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+    }
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.protocol: exact;
+        }
+        actions = {
+            send_with_mirror;
+            drop_with_mirror;
+            NoAction;
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error.p4-stderr
@@ -1,0 +1,12 @@
+pna.p4(373): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+pna.p4(380): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^
+pna.p4(673): [--Wwarn=unused] warning: 'PM' is unused
+parser MainParserT<PM, MH, MM>(
+                   ^^
+pna.p4(680): [--Wwarn=unused] warning: 'PM' is unused
+control MainControlT<PM, MH, MM>(
+                     ^^

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error1-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error1-first.p4
@@ -1,0 +1,94 @@
+#include <core.p4>
+#include <pna.p4>
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t)8w3;
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t)16w58;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t)16w62;
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action send_with_mirror(PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w58);
+    }
+    action drop_with_mirror() {
+        drop_packet();
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+    }
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction();
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error1-frontend.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.send_with_mirror") action send_with_mirror(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w58);
+    }
+    @name("MainControlImpl.drop_with_mirror") action drop_with_mirror() {
+        drop_packet();
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+    }
+    @name("MainControlImpl.flowTable") table flowTable_0 {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        flowTable_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error1-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error1-midend.p4
@@ -1,0 +1,102 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.send_with_mirror") action send_with_mirror(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet(8w3, 16w58);
+    }
+    @name("MainControlImpl.drop_with_mirror") action drop_with_mirror() {
+        drop_packet();
+        mirror_packet(8w3, 16w62);
+    }
+    @name("MainControlImpl.flowTable") table flowTable_0 {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        flowTable_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnaexamplemirrorpacketctxterror1l114() {
+        mirror_packet(8w3, 16w62);
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnaexamplemirrorpacketctxterror1l114 {
+        actions = {
+            pnaexamplemirrorpacketctxterror1l114();
+        }
+        const default_action = pnaexamplemirrorpacketctxterror1l114();
+    }
+    apply {
+        tbl_pnaexamplemirrorpacketctxterror1l114.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error1.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error1.p4
@@ -1,0 +1,94 @@
+#include <core.p4>
+#include <pna.p4>
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t)3;
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t)58;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t)62;
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action send_with_mirror(PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION1);
+    }
+    action drop_with_mirror() {
+        drop_packet();
+        mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+    }
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.protocol: exact;
+        }
+        actions = {
+            send_with_mirror;
+            drop_with_mirror;
+            NoAction;
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-ctxt-error1.p4-stderr
@@ -1,0 +1,12 @@
+pna.p4(373): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+pna.p4(380): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^
+pna.p4(673): [--Wwarn=unused] warning: 'PM' is unused
+parser MainParserT<PM, MH, MM>(
+                   ^^
+pna.p4(680): [--Wwarn=unused] warning: 'PM' is unused
+control MainControlT<PM, MH, MM>(
+                     ^^

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-error1-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-error1-first.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#include <pna.p4>
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t)8w3;
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t)16w0;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t)16w62;
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action send_with_mirror(PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w0);
+    }
+    action drop_with_mirror() {
+        drop_packet();
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+    }
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction();
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-error1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-error1-frontend.p4
@@ -1,0 +1,92 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.send_with_mirror") action send_with_mirror(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w0);
+    }
+    @name("MainControlImpl.drop_with_mirror") action drop_with_mirror() {
+        drop_packet();
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+    }
+    @name("MainControlImpl.flowTable") table flowTable_0 {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        flowTable_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-error1-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-error1-midend.p4
@@ -1,0 +1,101 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.send_with_mirror") action send_with_mirror(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet(8w3, 16w0);
+    }
+    @name("MainControlImpl.drop_with_mirror") action drop_with_mirror() {
+        drop_packet();
+        mirror_packet(8w3, 16w62);
+    }
+    @name("MainControlImpl.flowTable") table flowTable_0 {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        flowTable_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnaexamplemirrorpacketerror1l114() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnaexamplemirrorpacketerror1l114 {
+        actions = {
+            pnaexamplemirrorpacketerror1l114();
+        }
+        const default_action = pnaexamplemirrorpacketerror1l114();
+    }
+    apply {
+        tbl_pnaexamplemirrorpacketerror1l114.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-error1.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-error1.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#include <pna.p4>
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t)3;
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t)0;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t)62;
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action send_with_mirror(PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION1);
+    }
+    action drop_with_mirror() {
+        drop_packet();
+        mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+    }
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.protocol: exact;
+        }
+        actions = {
+            send_with_mirror;
+            drop_with_mirror;
+            NoAction;
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-error1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-error1.p4-stderr
@@ -1,0 +1,12 @@
+pna.p4(373): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+pna.p4(380): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^
+pna.p4(673): [--Wwarn=unused] warning: 'PM' is unused
+parser MainParserT<PM, MH, MM>(
+                   ^^
+pna.p4(680): [--Wwarn=unused] warning: 'PM' is unused
+control MainControlT<PM, MH, MM>(
+                     ^^

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-first.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#include <pna.p4>
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t)8w3;
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t)16w58;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t)16w62;
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action send_with_mirror(PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w58);
+    }
+    action drop_with_mirror() {
+        drop_packet();
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+    }
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction();
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-frontend.p4
@@ -1,0 +1,92 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.send_with_mirror") action send_with_mirror(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w58);
+    }
+    @name("MainControlImpl.drop_with_mirror") action drop_with_mirror() {
+        drop_packet();
+        mirror_packet((MirrorSlotId_t)8w3, (MirrorSessionId_t)16w62);
+    }
+    @name("MainControlImpl.flowTable") table flowTable_0 {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        flowTable_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-midend.p4
@@ -1,0 +1,101 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.send_with_mirror") action send_with_mirror(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet(8w3, 16w58);
+    }
+    @name("MainControlImpl.drop_with_mirror") action drop_with_mirror() {
+        drop_packet();
+        mirror_packet(8w3, 16w62);
+    }
+    @name("MainControlImpl.flowTable") table flowTable_0 {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol") ;
+        }
+        actions = {
+            send_with_mirror();
+            drop_with_mirror();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+    }
+    apply {
+        flowTable_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnaexamplemirrorpacket114() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnaexamplemirrorpacket114 {
+        actions = {
+            pnaexamplemirrorpacket114();
+        }
+        const default_action = pnaexamplemirrorpacket114();
+    }
+    apply {
+        tbl_pnaexamplemirrorpacket114.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#include <pna.p4>
+
+const MirrorSlotId_t MIRROR_SLOT_ID = (MirrorSlotId_t)3;
+const MirrorSessionId_t MIRROR_SESSION1 = (MirrorSessionId_t)58;
+const MirrorSessionId_t MIRROR_SESSION2 = (MirrorSessionId_t)62;
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            default: accept;
+        }
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action send_with_mirror(PortId_t vport) {
+        send_to_port(vport);
+        mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION1);
+    }
+    action drop_with_mirror() {
+        drop_packet();
+        mirror_packet(MIRROR_SLOT_ID, MIRROR_SESSION2);
+    }
+    table flowTable {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.protocol: exact;
+        }
+        actions = {
+            send_with_mirror;
+            drop_with_mirror;
+            NoAction;
+        }
+        const default_action = NoAction();
+    }
+    apply {
+        flowTable.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4-error
@@ -1,0 +1,12 @@
+pna.p4(373): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+pna.p4(380): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^
+pna.p4(673): [--Wwarn=unused] warning: 'PM' is unused
+parser MainParserT<PM, MH, MM>(
+                   ^^
+pna.p4(680): [--Wwarn=unused] warning: 'PM' is unused
+control MainControlT<PM, MH, MM>(
+                     ^^

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4-stderr
@@ -1,0 +1,12 @@
+pna.p4(373): [--Wwarn=unused] warning: 'W' is unused
+extern Counter<W, S> {
+               ^
+pna.p4(380): [--Wwarn=unused] warning: 'W' is unused
+extern DirectCounter<W> {
+                     ^
+pna.p4(673): [--Wwarn=unused] warning: 'PM' is unused
+parser MainParserT<PM, MH, MM>(
+                   ^^
+pna.p4(680): [--Wwarn=unused] warning: 'PM' is unused
+control MainControlT<PM, MH, MM>(
+                     ^^

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4.bfrt.json
@@ -1,0 +1,92 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.flowTable",
+      "id" : 50149889,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.ipv4.protocol",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 8
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 23308017,
+          "name" : "MainControlImpl.send_with_mirror",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 20972178,
+          "name" : "MainControlImpl.drop_with_mirror",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4.spec
@@ -1,0 +1,88 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<4> version
+	bit<4> ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<3> flags
+	bit<13> fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct send_with_mirror_arg_t {
+	bit<32> vport
+}
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<32> pna_main_output_metadata_output_port
+	bit<8> mirrorSlot
+	bit<16> mirrorSession
+	bit<8> mirrorSlot_0
+	bit<16> mirrorSession_0
+}
+metadata instanceof main_metadata_t
+
+action NoAction args none {
+	return
+}
+
+action send_with_mirror args instanceof send_with_mirror_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov m.mirrorSlot 0x3
+	mov m.mirrorSession 0x3a
+	mirror m.mirrorSlot m.mirrorSession
+	return
+}
+
+action drop_with_mirror args none {
+	drop
+	mov m.mirrorSlot_0 0x3
+	mov m.mirrorSession_0 0x3e
+	mirror m.mirrorSlot_0 m.mirrorSession_0
+	return
+}
+
+table flowTable {
+	key {
+		h.ipv4.srcAddr exact
+		h.ipv4.dstAddr exact
+		h.ipv4.protocol exact
+	}
+	actions {
+		send_with_mirror
+		drop_with_mirror
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	table flowTable
+	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-example-tunnel.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-example-tunnel.p4.bfrt.json
@@ -1,0 +1,148 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.main_control.tunnel_decap.ipv4_tunnel_term_table",
+      "id" : 36845502,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "ipv4_src",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "ipv4_dst",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "local_metadata.tunnel.tun_type",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 4
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 28702285,
+          "name" : "main_control.tunnel_decap.decap_outer_ipv4",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "tunnel_id",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 24
+              }
+            }
+          ]
+        },
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.main_control.tunnel_encap.set_tunnel_encap",
+      "id" : 41264220,
+      "table_type" : "MatchAction_Direct",
+      "size" : 256,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "istd.input_port",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 32874118,
+          "name" : "main_control.tunnel_encap.set_tunnel",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "dst_addr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}


### PR DESCRIPTION
This PR adds support for PNA extern "mirror_packet"

```
extern void mirror_packet(MirrorSlotId_t mirror_slot_id,
                          MirrorSessionId_t mirror_session_id);
```

This translates to mirror instruction in dpdk
`mirror <SLOT_ID> <SESSON_ID>`
If the arguments are constants, they should be moved to Metadata as the mirror instruction in dpdk does not support immediate values as operands.

Added a valid test and a few negative tests.
Negative tests are added for the following:
- Mirror session id 0 is reserved by the architecture, and must not be used by a P4 developer
- Invoking mirror_packet(x) is supported from control blocks other than Main control
- Passing incorrect number of arguments
- Passing non-constant arguments