### PR TITLE
Use 0 as action ID for NoAction and refactor eBPF table implementation

### DIFF
--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -464,9 +464,7 @@ bool ControlBodyTranslator::preorder(const IR::SwitchStatement* statement) {
             BUG_CHECK(decl->is<IR::P4Action>(), "%1%: expected an action", pe);
             auto act = decl->to<IR::P4Action>();
             cstring fullActionName = table->p4ActionToActionIDName(act);
-            act->name.originalName == P4::P4CoreLibrary::instance.noAction.name ?
-                builder->append("0") :
-                builder->append(fullActionName);
+            builder->append(fullActionName);
         }
         builder->append(":");
         builder->newline();

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -374,7 +374,12 @@ void EBPFTable::emitKey(CodeBuilder* builder, cstring keyName) {
                 swap = "bpf_htonl";
             } else if (width <= 64) {
                 swap = "bpf_htonll";
-            }  // TODO: handle width > 64 bits
+            } else {
+                // TODO: handle width > 64 bits
+                ::error(ErrorType::ERR_UNSUPPORTED,
+                        "%1%: fields wider than 64 bits are not supported yet",
+                        fieldName);
+            }
         }
 
         bool isLPMKeyBigEndian = false;

--- a/backends/ebpf/targets/ebpfstf.py
+++ b/backends/ebpf/targets/ebpfstf.py
@@ -62,7 +62,11 @@ def _generate_control_actions(cmds):
                       " exit(1); }\n\t" % tbl_name)
         generated += ("struct %s_value %s = {\n\t\t" % (
             cmd.table, value_name))
-        generated += ".action = %s,\n\t\t" % (cmd.action[0])
+        if cmd.action[0] == "_NoAction":
+            generated += ".action = 0,\n\t\t"
+        else:
+            action_full_name = "{}_ACT_{}".format(cmd.table.upper(), cmd.action[0].upper())
+            generated += ".action = %s,\n\t\t" % action_full_name
         generated += ".u = {.%s = {" % cmd.action[0]
         for val_num, val_field in enumerate(cmd.action[1]):
             generated += "%s," % val_field[1]


### PR DESCRIPTION
This PR changes the way of handling `NoAction` in eBPF tables. With this change, `NoAction` will always be allocated with actionID = 0 regardless of its position in the action list. User-defined actions are enumerated starting from index=1. 

Additionally, this PR introduces modifications to the format of the ActionIDs list. We get rid of `enum` to store action IDs and implement new naming format: `<TABLE_NAME>_ACT_<ACTION_NAME>`. 

Also, this PR refactors eBPF table implementation, so that it's easier to inherit from the base eBPF table. 

This PR is one from the series of PRs bringing the support for the PSA model to eBPF backend. The goal is to shrink the "main PR" with the full implementation of PSA for eBPF to facilitate review.

Co-authored-by: Mateusz Kossakowski <mateusz.kossakowski@orange.com>
Co-authored-by: Jan Palimąka <jan.palimaka@orange.com>