### PR TITLE
Enable generation of pointer variables by eBPF CodeGenInspector

### DIFF
--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -200,7 +200,12 @@ bool CodeGenInspector::preorder(const IR::Member* expression) {
     auto ei = P4::EnumInstance::resolve(expression, typeMap);
     if (ei == nullptr) {
         visit(expression->expr);
-        builder->append(".");
+        auto pe = expression->expr->to<IR::PathExpression>();
+        if (pe != nullptr && isPointerVariable(pe->path->name.name)) {
+            builder->append("->");
+        } else {
+            builder->append(".");
+        }
     }
     builder->append(expression->member);
     expressionPrecedence = prec;

--- a/backends/ebpf/codeGen.h
+++ b/backends/ebpf/codeGen.h
@@ -44,6 +44,9 @@ class CodeGenInspector : public Inspector {
     P4::ReferenceMap* refMap;
     P4::TypeMap* typeMap;
     std::map<const IR::Parameter*, const IR::Parameter*> substitution;
+    // asPointerVariables stores the list of string expressions that
+    // should be emitted as pointer variables.
+    std::set<cstring> asPointerVariables;
 
  public:
     int expressionPrecedence;  /// precedence of current IR::Operation
@@ -63,6 +66,18 @@ class CodeGenInspector : public Inspector {
     void copySubstitutions(CodeGenInspector* other) {
         for (auto s : other->substitution)
             substitute(s.first, s.second);
+    }
+
+    void useAsPointerVariable(cstring name) {
+        this->asPointerVariables.insert(name);
+    }
+    void copyPointerVariables(CodeGenInspector *other) {
+        for (auto s : other->asPointerVariables) {
+            this->asPointerVariables.insert(s);
+        }
+    }
+    bool isPointerVariable(cstring name) {
+        return asPointerVariables.count(name) > 0;
     }
 
     bool notSupported(const IR::Expression* expression)

--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -537,7 +537,8 @@ void EBPFControl::emitDeclaration(CodeBuilder* builder, const IR::Declaration* d
         auto vd = decl->to<IR::Declaration_Variable>();
         auto etype = EBPFTypeFactory::instance->create(vd->type);
         builder->emitIndent();
-        etype->declareInit(builder, vd->name, false);
+        bool isPointer = codeGen->isPointerVariable(decl->name.name);
+        etype->declareInit(builder, vd->name, isPointer);
         builder->endOfStatement(true);
         BUG_CHECK(vd->initializer == nullptr,
                   "%1%: declarations with initializers not supported", decl);


### PR DESCRIPTION
This PR enables emitting eBPF fields as pointer variables by eBPF `CodeGenInspector`. So far,  `CodeGenInspector` assumes that eBPF fields (e.g. `Headers`) are on-stack variables. With this change, we can decide whether to access fields' member via `.` or `->`. 

A use case for this change is PSA implementation for eBPF backend. PSA-eBPF uses BPF array map to store the `Headers` structure, instead of an on-stack variable, to avoid BPF stack size limit, see the discussion here https://github.com/vmware/p4c-xdp/issues/43. Using BPF array map to store large piece of data (parsed headers) is a common approach used also by Cilium/Calico eBPF datapaths. We've observed almost no impact on performance when using BPF array map.

Note that `ebpf_model.p4` is not affected by this change, because `useAsPointerVariable` is never called for any eBPF field generated for eBPF model. 

This PR is one from the series of PRs bringing the support for the PSA model to eBPF backend. The goal is to shrink the "main PR" with the full implementation of PSA for eBPF to facilitate review.

Co-authored-by: Mateusz Kossakowski <mateusz.kossakowski@orange.com>
Co-authored-by: Jan Palimąka <jan.palimaka@orange.com>