### PR TITLE
sfinae-protect operator== StringRef overload

### DIFF
--- a/lib/stringref.h
+++ b/lib/stringref.h
@@ -142,17 +142,17 @@ struct StringRef {
 };
 
 template <class T> inline
-    bool operator==(T a, const StringRef &b) { return b == a; }
+    auto operator==(T a, const StringRef &b) -> decltype(b.operator==(a)) { return b == a; }
 template <class T> inline
-    bool operator!=(T a, const StringRef &b) { return b != a; }
+    auto operator!=(T a, const StringRef &b) -> decltype (b.operator!=(a)) { return b != a; }
 template <class T> inline
-    bool operator>=(T a, const StringRef &b) { return b <= a; }
+    auto operator>=(T a, const StringRef &b) -> decltype (b.operator<=(a)) { return b <= a; }
 template <class T> inline
-    bool operator>(T a, const StringRef &b) { return b < a; }
+    auto operator>(T a, const StringRef &b) -> decltype(b.operator<(a)) { return b < a; }
 template <class T> inline
-    bool operator<=(T a, const StringRef &b) { return b >= a; }
+    auto operator<=(T a, const StringRef &b) -> decltype(b.operator>=(a)) { return b >= a; }
 template <class T> inline
-    bool operator<(T a, const StringRef &b) { return b > a; }
+    auto operator<(T a, const StringRef &b) -> decltype(b.operator>(a)) { return b > a; }
 
 inline std::ostream &operator<<(std::ostream &os, const StringRef &a) {
     return a.len ? os.write(a.p, a.len) : os;  }


### PR DESCRIPTION
We encountered a c++ compilation issue when using p4c together with inja (https://github.com/pantor/inja) in one project. Inja headers define:

```
  template <class CharT, class Traits nssv_MSVC_ORDER(1)>
  nssv_constexpr bool operator==(basic_string_view<CharT, Traits> lhs,
                                 nssv_BASIC_STRING_VIEW_I(CharT, Traits) rhs) nssv_noexcept {
```

which is supposed to be called when `basic_string_view<>` is compared to `const char*`. But if p4c sources are also included, such call is ambiguous, because `operator==(T, StringRef)` also participates in overload resolution:
```
inja/include/inja/parser.hpp:207:31: error: ambiguous overload for ‘operator==’ (operand types are ‘nonstd::sv_lite::string_view {aka nonstd::sv_lite::basic_string_view<char>}’ and ‘const char [3]’)
           } else if (tok.text == "in") {
                      ~~~~~~~~~^~~~~~~

p4c/lib/stringref.h:145:10: note: candidate: bool operator==(T, const StringRef&) [with T = nonstd::sv_lite::basic_string_view<char>]
     bool operator==(T a, const StringRef &b) { return b == a; }
          ^~~~~~~~

inja/include/inja/string_view.hpp:1088:18: note: candidate: constexpr bool nonstd::sv_lite::operator==(nonstd::sv_lite::basic_string_view<CharT, Traits>, typename std::decay<nonstd::sv_lite::basic_string_view<CharT, Traits> >::type) [with CharT = char; Traits = std::char_traits<char>; typename std::decay<nonstd::sv_lite::basic_string_view<CharT, Traits> >::type = nonstd::sv_lite::basic_string_view<char>]
   nssv_constexpr bool operator==(basic_string_view<CharT, Traits> lhs,
                  ^~~~~~~~
```

This PR fixes this problem by employing SFINAE to enable `operator==(T a, StringRef b)` only if `a == b` is a valid expression.

