### PR TITLE
Compile the P4 compiler tools in host configuration

### DIFF
--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -143,7 +143,7 @@ p4_library = rule(
         "_p4c": attr.label(
             default = Label("@com_github_p4lang_p4c//:p4c_bmv2"),
             executable = True,
-            cfg = "target",
+            cfg = "host",
         ),
         "_p4include": attr.label(
             default = Label("@com_github_p4lang_p4c//:p4include"),
@@ -224,7 +224,7 @@ p4_graphs = rule(
         "_p4c": attr.label(
             default = Label("@com_github_p4lang_p4c//:p4c_graphs"),
             executable = True,
-            cfg = "target",
+            cfg = "host",
         ),
         "_p4include": attr.label(
             default = Label("@com_github_p4lang_p4c//:p4include"),


### PR DESCRIPTION
There's no reason I'm aware of to compile the compilers for the target architecture.

As a side benefit, this may improve the build system's cache hit rate slightly because these tools don't need to be recompiled for Tsan/Asan/Msan/etc let alone x86 vs. ARM vs. etc.

Signed-off-by: Chris Dolan <chrisdolan@google.com>