### PR TITLE
Add old parser state in loopsUnroll if ExpressionEvaluator returns a error

### DIFF
--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -656,6 +656,7 @@ class ParserSymbolicInterpreter {
                 // don't evaluate successors anymore
                 continue;
             }
+            bool notAdded = newStates.count(getNewName(stateInfo)) == 0;
             auto nextStates = evaluateState(stateInfo, newStates);
             if (nextStates.first == nullptr) {
                 if (nextStates.second && stateInfo->predecessor &&
@@ -668,7 +669,9 @@ class ParserSymbolicInterpreter {
                             new IR::Path(outOfBoundsStateName, false)));
                 } else {
                     // save current state
-                    stateInfo->newState = stateInfo->state->clone();
+                    if (notAdded) {
+                        stateInfo->newState = stateInfo->state->clone();
+                    }
                 }
                 LOG1("No next states");
                 continue;

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -184,16 +184,7 @@ class ParserStateRewriter : public Transform {
             if (left->type->is<IR::Type_Stack>())
                 return left->type->to<IR::Type_Stack>()->elementType;
         }
-        auto* currentType = typeMap->getType(element);
-        if (currentType == nullptr) {
-            if (auto* expr = element->to<IR::Expression>()) {
-                if (!expr->type->is<IR::Type_Unknown>()) {
-                    currentType = expr->type;
-                }
-            }
-            BUG_CHECK(currentType != nullptr, "Can't detect type for %1%", element);
-        }
-        return currentType;
+        return typeMap->getType(element, true);
     }
 
     /// Checks if this state was called previously with the same state of header stack indexes.

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -184,7 +184,16 @@ class ParserStateRewriter : public Transform {
             if (left->type->is<IR::Type_Stack>())
                 return left->type->to<IR::Type_Stack>()->elementType;
         }
-        return typeMap->getType(element, true);
+        auto* currentType = typeMap->getType(element);
+        if (currentType == nullptr) {
+            if (auto* expr = element->to<IR::Expression>()) {
+                if (!expr->type->is<IR::Type_Unknown>()) {
+                    currentType = expr->type;
+                }
+            }
+            BUG_CHECK(currentType != nullptr, "Can't detect type for %1%", element);
+        }
+        return currentType;
     }
 
     /// Checks if this state was called previously with the same state of header stack indexes.
@@ -666,6 +675,9 @@ class ParserSymbolicInterpreter {
                         IR::IndexedVector<IR::StatOrDecl>(),
                         new IR::PathExpression(new IR::Type_State(),
                             new IR::Path(outOfBoundsStateName, false)));
+                } else {
+                    // save current state
+                    stateInfo->newState = stateInfo->state->clone();
                 }
                 LOG1("No next states");
                 continue;


### PR DESCRIPTION
These changes allow to save parser state for case where ExpressionEvaluator returns an error, otherwise this state could be eliminated from the result.
To repeat this problem, please, run the following command:
`./p4test -I . /p4include --target bmv2 --std p4-16 --loopsUnroll --arch v1model --dump 11 --top4 End ../testdata/p4_16_samples/issue314.p4`
The parser doesn't have start state after ParserUnroll without these changes. 