### PR TITLE
typeChecker: make error message less confusing

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -2935,7 +2935,9 @@ const IR::Node* TypeInference::postorder(IR::Member* expression) {
     }
 
     if (type->is<IR::Type_StructLike>()) {
+        cstring typeStr = "structure ";
         if (type->is<IR::Type_Header>() || type->is<IR::Type_HeaderUnion>()) {
+            typeStr = "";
             if (inMethod && (member == IR::Type_Header::isValid)) {
                 // Built-in method
                 auto type = new IR::Type_Method(
@@ -2968,8 +2970,8 @@ const IR::Node* TypeInference::postorder(IR::Member* expression) {
         auto stb = type->to<IR::Type_StructLike>();
         auto field = stb->getField(member);
         if (field == nullptr) {
-            typeError("Field %1% is not a member of structure %2%",
-                      expression->member, stb);
+            typeError("Field %1% is not a member of %2%%3%",
+                      expression->member, typeStr, stb);
             return expression;
         }
 

--- a/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
@@ -18,7 +18,7 @@ issue561-1.p4(29)
 issue561-1.p4(19)
   header_union U {
                ^
-issue561-1.p4(30): [--Werror=type-error] error: Field setValid is not a member of structure header_union U
+issue561-1.p4(30): [--Werror=type-error] error: Field setValid is not a member of header_union U
         u.setValid(); // no such method
           ^^^^^^^^
 issue561-1.p4(19)


### PR DESCRIPTION
Same error message was used for all struct-like types:
* IR::Type_UnknownStruct
* IR::Type_Struct
* IR::Type_Header
* IR::Type_HeaderUnion

In case of a header or header_union it could result in a message
like this:
"""
Field my_field is not a member of structure header my_header_h
"""
which might have been confusing for a user (why is error message
mentioning structure and header at one place?).

The word "structure" is now omitted in case of IR::Type_Header
and IR::Type_HeaderUnion.
String representation of IR::Type_Header and IR::Type_HeaderUnion
nodes used in this error message already contains also header or
header_union keyword.