### PR TITLE
Fix format of trace messages in EBPF deparser

### DIFF
--- a/backends/ebpf/ebpfDeparser.cpp
+++ b/backends/ebpf/ebpfDeparser.cpp
@@ -185,11 +185,19 @@ void DeparserHdrEmitTranslator::emitField(CodeBuilder* builder, cstring field,
     cstring swap = "", msgStr;
 
     if (widthToEmit <= 64) {
-        cstring tmp = Util::printf_format("(unsigned long long) %s.%s",
-                                          hdrExpr->toString(), field);
-        msgStr = Util::printf_format("Deparser: emitting field %s=0x%%llx (%u bits)",
-                                     field, widthToEmit);
-        builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, tmp.c_str());
+        if (program->options.emitTraceMessages) {
+            builder->emitIndent();
+            builder->blockStart();
+            builder->emitIndent();
+            builder->append("u64 tmp = ");
+            visit(hdrExpr);
+            builder->appendFormat(".%s", field.c_str());
+            builder->endOfStatement(true);
+            msgStr = Util::printf_format("Deparser: emitting field %s=0x%%llx (%u bits)",
+                                         field, widthToEmit);
+            builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, "tmp");
+            builder->blockEnd(true);
+        }
     } else {
         msgStr = Util::printf_format("Deparser: emitting field %s (%u bits)", field, widthToEmit);
         builder->target->emitTraceMessage(builder, msgStr.c_str());

--- a/backends/ebpf/ebpfParser.h
+++ b/backends/ebpf/ebpfParser.h
@@ -59,7 +59,7 @@ class StateTranslationVisitor : public CodeGenInspector {
     bool preorder(const IR::Member* expression) override;
     bool preorder(const IR::MethodCallExpression* expression) override;
     bool preorder(const IR::MethodCallStatement* stat) override
-    { visit(stat->methodCall); return false; }
+    { visit(stat->methodCall); builder->endOfStatement(true); return false; }
     bool preorder(const IR::AssignmentStatement* stat) override;
 };
 


### PR DESCRIPTION
The PR fixes the format of trace messages in EBPF deparser. The header name in the trace message was not substituted to the right value, if eBPF code uses pointer to access headers. Also, adds missing semicolon in EBPF Parser