### PR TITLE
Add support for Checksum extern and CRC16/32 algorithms to eBPF backend

### DIFF
--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -44,7 +44,9 @@ set (P4C_EBPF_SRCS
   psa/ebpfPsaControl.cpp
   psa/ebpfPsaTable.cpp
   psa/backend.cpp
-  psa/externs/ebpfPsaCounter.cpp)
+  psa/externs/ebpfPsaCounter.cpp
+  psa/externs/ebpfPsaChecksum.cpp
+  psa/externs/ebpfPsaHashAlgorithm.cpp)
 
 set (P4C_EBPF_HDRS
   codeGen.h
@@ -73,6 +75,8 @@ set (P4C_EBPF_HDRS
   psa/ebpfPsaControl.h
   psa/ebpfPsaTable.h
   psa/externs/ebpfPsaCounter.h
+  psa/externs/ebpfPsaChecksum.h
+  psa/externs/ebpfPsaHashAlgorithm.h
 )
 
 add_cpplint_files(${CMAKE_CURRENT_SOURCE_DIR} "${P4C_EBPF_SRCS};${P4C_EBPF_HDRS}")

--- a/backends/ebpf/ebpfObject.h
+++ b/backends/ebpf/ebpfObject.h
@@ -40,6 +40,16 @@ class EBPFObject {
         cstring name = declaration->externalName();
         return name.replace('.', '_');
     }
+
+    static cstring getSpecializedTypeName(const IR::Declaration_Instance* di) {
+        if (auto typeSpec = di->type->to<IR::Type_Specialized>()) {
+            if (auto typeName = typeSpec->baseType->to<IR::Type_Name>()) {
+                return typeName->path->name.name;
+            }
+        }
+
+        return nullptr;
+    }
 };
 
 }  // namespace EBPF

--- a/backends/ebpf/psa/ebpfPsaDeparser.h
+++ b/backends/ebpf/psa/ebpfPsaDeparser.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "backends/ebpf/ebpfDeparser.h"
 #include "ebpfPsaControl.h"
 #include "backends/ebpf/psa/ebpfPsaParser.h"
+#include "backends/ebpf/psa/externs/ebpfPsaChecksum.h"
 
 namespace EBPF {
 
@@ -43,7 +44,7 @@ class EBPFDeparserPSA : public EBPFDeparser {
     const IR::Parameter* user_metadata;
     const IR::Parameter* istd;
     const IR::Parameter* resubmit_meta;
-
+    std::map<cstring, EBPFChecksumPSA*> checksums;
     std::map<cstring, const IR::Type *> digests;
 
     EBPFDeparserPSA(const EBPFProgram* program, const IR::ControlBlock* control,
@@ -54,6 +55,12 @@ class EBPFDeparserPSA : public EBPFDeparser {
 
     void emitDigestInstances(CodeBuilder* builder) const;
     void emitDeclaration(CodeBuilder* builder, const IR::Declaration* decl) override;
+
+    EBPFChecksumPSA* getChecksum(cstring name) const {
+        auto result = ::get(checksums, name);
+        BUG_CHECK(result != nullptr, "No checksum named %1%", name);
+        return result;
+    }
 };
 
 class IngressDeparserPSA : public EBPFDeparserPSA {

--- a/backends/ebpf/psa/ebpfPsaGen.cpp
+++ b/backends/ebpf/psa/ebpfPsaGen.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "ebpfPsaControl.h"
 #include "xdpHelpProgram.h"
 #include "externs/ebpfPsaCounter.h"
+#include "externs/ebpfPsaHashAlgorithm.h"
 
 namespace EBPF {
 
@@ -163,6 +164,8 @@ void PSAEbpfGenerator::emitInitializer(CodeBuilder *builder) const {
 }
 
 void PSAEbpfGenerator::emitHelperFunctions(CodeBuilder *builder) const {
+    EBPFHashAlgorithmTypeFactoryPSA::instance()->emitGlobals(builder);
+
     cstring forEachFunc =
             "static __always_inline\n"
             "int do_for_each(SK_BUFF *skb, void *map, "

--- a/backends/ebpf/psa/ebpfPsaParser.cpp
+++ b/backends/ebpf/psa/ebpfPsaParser.cpp
@@ -117,14 +117,10 @@ EBPFPsaParser::EBPFPsaParser(const EBPFProgram* program, const IR::ParserBlock* 
 }
 
 void EBPFPsaParser::emitDeclaration(CodeBuilder* builder, const IR::Declaration* decl) {
-    if (decl->is<IR::Declaration_Instance>()) {
-        auto di = decl->to<IR::Declaration_Instance>();
-        auto type = di->type->to<IR::Type_Name>();
-        auto typeSpec = di->type->to<IR::Type_Specialized>();
+    if (auto di = decl->to<IR::Declaration_Instance>()) {
         cstring name = di->name.name;
 
-        if (typeSpec != nullptr &&
-                typeSpec->baseType->to<IR::Type_Name>()->path->name.name == "Checksum") {
+        if (EBPFObject::getSpecializedTypeName(di) == "Checksum") {
             auto instance = new EBPFChecksumPSA(program, di, name);
             checksums.emplace(name, instance);
             instance->emitVariables(builder);

--- a/backends/ebpf/psa/ebpfPsaParser.cpp
+++ b/backends/ebpf/psa/ebpfPsaParser.cpp
@@ -65,7 +65,15 @@ void PsaStateTranslationVisitor::processFunction(const P4::ExternFunction* funct
 }
 
 void PsaStateTranslationVisitor::processMethod(const P4::ExternMethod* ext) {
-    // TODO: placeholder for handling value sets and checksums
+    auto externName = ext->originalExternType->name.name;
+
+    if (externName == "Checksum") {
+        auto instance = ext->object->getName().name;
+        auto method = ext->method->getName().name;
+        parser->getChecksum(instance)->processMethod(builder, method, ext->expr, this);
+        return;
+    }
+
     StateTranslationVisitor::processMethod(ext);
 }
 
@@ -106,6 +114,25 @@ void PsaStateTranslationVisitor::compileVerify(const IR::MethodCallExpression * 
 EBPFPsaParser::EBPFPsaParser(const EBPFProgram* program, const IR::ParserBlock* block,
                              const P4::TypeMap* typeMap) : EBPFParser(program, block, typeMap) {
     visitor = new PsaStateTranslationVisitor(program->refMap, program->typeMap, this);
+}
+
+void EBPFPsaParser::emitDeclaration(CodeBuilder* builder, const IR::Declaration* decl) {
+    if (decl->is<IR::Declaration_Instance>()) {
+        auto di = decl->to<IR::Declaration_Instance>();
+        auto type = di->type->to<IR::Type_Name>();
+        auto typeSpec = di->type->to<IR::Type_Specialized>();
+        cstring name = di->name.name;
+
+        if (typeSpec != nullptr &&
+                typeSpec->baseType->to<IR::Type_Name>()->path->name.name == "Checksum") {
+            auto instance = new EBPFChecksumPSA(program, di, name);
+            checksums.emplace(name, instance);
+            instance->emitVariables(builder);
+            return;
+        }
+    }
+
+    EBPFParser::emitDeclaration(builder, decl);
 }
 
 void EBPFPsaParser::emitRejectState(CodeBuilder* builder) {

--- a/backends/ebpf/psa/ebpfPsaParser.h
+++ b/backends/ebpf/psa/ebpfPsaParser.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "backends/ebpf/ebpfType.h"
 #include "backends/ebpf/ebpfParser.h"
 #include "backends/ebpf/psa/ebpfPsaTable.h"
+#include "backends/ebpf/psa/externs/ebpfPsaChecksum.h"
 
 namespace EBPF {
 
@@ -46,10 +47,19 @@ class PsaStateTranslationVisitor : public StateTranslationVisitor {
 
 class EBPFPsaParser : public EBPFParser {
  public:
+    std::map<cstring, EBPFChecksumPSA*> checksums;
+
     EBPFPsaParser(const EBPFProgram* program, const IR::ParserBlock* block,
                   const P4::TypeMap* typeMap);
 
+    void emitDeclaration(CodeBuilder* builder, const IR::Declaration* decl) override;
     void emitRejectState(CodeBuilder* builder) override;
+
+    EBPFChecksumPSA* getChecksum(cstring name) const {
+        auto result = ::get(checksums, name);
+        BUG_CHECK(result != nullptr, "No checksum named %1%", name);
+        return result;
+    }
 };
 
 }  // namespace EBPF

--- a/backends/ebpf/psa/externs/ebpfPsaChecksum.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaChecksum.cpp
@@ -1,0 +1,67 @@
+/*
+Copyright 2022-present Orange
+Copyright 2022-present Open Networking Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "ebpfPsaChecksum.h"
+#include "ebpfPsaHashAlgorithm.h"
+
+namespace EBPF {
+
+void EBPFChecksumPSA::init(const EBPFProgram* program, cstring name, int type) {
+    engine = EBPFHashAlgorithmTypeFactoryPSA::instance()->create(type, program, name);
+
+    if (engine == nullptr) {
+        ::error(ErrorType::ERR_UNSUPPORTED, "Hash algorithm not yet implemented: %1%",
+                declaration->arguments->at(0));
+    }
+}
+
+EBPFChecksumPSA::EBPFChecksumPSA(const EBPFProgram* program, const IR::Declaration_Instance* block,
+                                 cstring name) :
+        engine(nullptr), declaration(block) {
+    auto di = block->to<IR::Declaration_Instance>();
+    if (di->arguments->size() != 1) {
+        ::error(ErrorType::ERR_UNEXPECTED, "Expected exactly 1 argument %1%", block);
+        return;
+    }
+    int type = di->arguments->at(0)->expression->to<IR::Constant>()->asInt();
+    init(program, name, type);
+}
+
+EBPFChecksumPSA::EBPFChecksumPSA(const EBPFProgram* program, const IR::Declaration_Instance* block,
+                                 cstring name, int type) :
+        engine(nullptr), declaration(block) {
+    init(program, name, type);
+}
+
+void EBPFChecksumPSA::processMethod(CodeBuilder* builder, cstring method,
+                                    const IR::MethodCallExpression * expr, Visitor * visitor) {
+    if (engine == nullptr)
+        return;
+
+    engine->setVisitor(visitor);
+
+    if (method == "clear") {
+        engine->emitClear(builder);
+    } else if (method == "update") {
+        engine->emitAddData(builder, 0, expr);
+    } else if (method == "get") {
+        engine->emitGet(builder);
+    } else {
+        ::error(ErrorType::ERR_UNEXPECTED, "Unexpected method call %1%", expr);
+    }
+}
+
+}  // namespace EBPF

--- a/backends/ebpf/psa/externs/ebpfPsaChecksum.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaChecksum.cpp
@@ -36,7 +36,7 @@ EBPFChecksumPSA::EBPFChecksumPSA(const EBPFProgram* program, const IR::Declarati
         ::error(ErrorType::ERR_UNEXPECTED, "Expected exactly 1 argument %1%", block);
         return;
     }
-    int type = di->arguments->at(0)->expression->to<IR::Constant>()->asInt();
+    int type = di->arguments->at(0)->expression->checkedTo<IR::Constant>()->asInt();
     init(program, name, type);
 }
 

--- a/backends/ebpf/psa/externs/ebpfPsaChecksum.h
+++ b/backends/ebpf/psa/externs/ebpfPsaChecksum.h
@@ -1,0 +1,50 @@
+/*
+Copyright 2022-present Orange
+Copyright 2022-present Open Networking Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef BACKENDS_EBPF_PSA_EXTERNS_EBPFPSACHECKSUM_H_
+#define BACKENDS_EBPF_PSA_EXTERNS_EBPFPSACHECKSUM_H_
+
+#include "backends/ebpf/ebpfObject.h"
+#include "ebpfPsaHashAlgorithm.h"
+
+namespace EBPF {
+
+class EBPFChecksumPSA : public EBPFObject {
+ protected:
+    EBPFHashAlgorithmPSA * engine;
+    const IR::Declaration_Instance * declaration;
+
+    void init(const EBPFProgram* program, cstring name, int type);
+
+ public:
+    EBPFChecksumPSA(const EBPFProgram* program, const IR::Declaration_Instance* block,
+                    cstring name);
+
+    EBPFChecksumPSA(const EBPFProgram* program, const IR::Declaration_Instance* block,
+                    cstring name, int type);
+
+    void emitVariables(CodeBuilder* builder) {
+        if (engine)
+            engine->emitVariables(builder, declaration);
+    }
+
+    virtual void processMethod(CodeBuilder* builder, cstring method,
+                               const IR::MethodCallExpression * expr, Visitor * visitor);
+};
+
+}  // namespace EBPF
+
+#endif  /* BACKENDS_EBPF_PSA_EXTERNS_EBPFPSACHECKSUM_H_ */

--- a/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.cpp
@@ -27,8 +27,7 @@ EBPFHashAlgorithmPSA::argumentsList EBPFHashAlgorithmPSA::unpackArguments(
 
     std::vector<const IR::Expression *> arguments;
 
-    if (expr->arguments->at(dataPos)->expression->is<IR::StructExpression>()) {
-        auto argList = expr->arguments->at(dataPos)->expression->to<IR::StructExpression>();
+    if (auto argList = expr->arguments->at(dataPos)->expression->to<IR::StructExpression>()) {
         for (auto field : argList->components)
             arguments.push_back(field->expression);
     } else {

--- a/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.cpp
@@ -1,0 +1,251 @@
+/*
+Copyright 2022-present Orange
+Copyright 2022-present Open Networking Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "ebpfPsaHashAlgorithm.h"
+#include "backends/ebpf/ebpfProgram.h"
+#include "backends/ebpf/ebpfType.h"
+
+namespace EBPF {
+
+EBPFHashAlgorithmPSA::argumentsList EBPFHashAlgorithmPSA::unpackArguments(
+        const IR::MethodCallExpression * expr, int dataPos) {
+    BUG_CHECK(expr->arguments->size() > ((size_t) dataPos),
+              "Data position %1% is outside of the arguments: %2%", dataPos, expr);
+
+    std::vector<const IR::Expression *> arguments;
+
+    if (expr->arguments->at(dataPos)->expression->is<IR::StructExpression>()) {
+        auto argList = expr->arguments->at(dataPos)->expression->to<IR::StructExpression>();
+        for (auto field : argList->components)
+            arguments.push_back(field->expression);
+    } else {
+        arguments.push_back(expr->arguments->at(dataPos)->expression);
+    }
+
+    return arguments;
+}
+
+void EBPFHashAlgorithmPSA::emitAddData(CodeBuilder *builder, int dataPos,
+                                       const IR::MethodCallExpression *expr) {
+    emitAddData(builder, unpackArguments(expr, dataPos));
+}
+
+// ===========================CRCChecksumAlgorithm===========================
+
+cstring CRCChecksumAlgorithm::reflect(cstring str) {
+    BUG_CHECK(crcWidth <= 64, "CRC checksum width up to 64 bits is supported");
+    unsigned long long poly = std::stoull(str.c_str(), nullptr, 16);
+    unsigned long long result, i, j;
+
+    result = 0;
+    i = 1ull << (crcWidth - 1);
+    j = 1;
+
+    for (; i != 0; i >>=1, j <<= 1) {
+        if (i & poly)
+            result |= j;
+    }
+
+    return Util::printf_format("%llu", result);
+}
+
+void CRCChecksumAlgorithm::emitUpdateMethod(CodeBuilder* builder, int crcWidth) {
+    // Note that this update method is optimized for our CRC16 and CRC32, custom
+    // version may require other method of update. To deal with byte order data
+    // is read from the end of buffer.
+    cstring code = "static __always_inline\n"
+                   "void crc%w%_update(u%w% * reg, const u8 * data, "
+                   "u16 data_size, const u%w% poly) {\n"
+                   "    data += data_size - 1;\n"
+                   "    #pragma clang loop unroll(full)\n"
+                   "    for (u16 i = 0; i < data_size; i++) {\n"
+                   "        bpf_trace_message(\"CRC%w%: data byte: %x\\n\", *data);\n"
+                   "        *reg ^= *data;\n"
+                   "        for (u8 bit = 0; bit < 8; bit++) {\n"
+                   "            *reg = (*reg) & 1 ? ((*reg) >> 1) ^ poly : (*reg) >> 1;\n"
+                   "        }\n"
+                   "        data--;\n"
+                   "    }\n"
+                   "}";
+    code = code.replace("%w%", Util::printf_format("%d", crcWidth));
+    builder->appendLine(code);
+}
+
+void CRCChecksumAlgorithm::emitVariables(CodeBuilder* builder,
+                                         const IR::Declaration_Instance* decl) {
+    registerVar = program->refMap->newName(baseName + "_reg");
+
+    builder->emitIndent();
+
+    if (decl != nullptr) {
+        BUG_CHECK(decl->type->is<IR::Type_Specialized>(), "Must be a specialized type %1%", decl);
+        auto ts = decl->type->to<IR::Type_Specialized>();
+        BUG_CHECK(ts->arguments->size() == 1, "Expected 1 specialized type %1%", decl);
+
+        auto otype = ts->arguments->at(0);
+        if (!otype->is<IR::Type_Bits>()) {
+            ::error(ErrorType::ERR_UNSUPPORTED, "Must be bit or int type: %1%", ts);
+            return;
+        }
+        if (otype->width_bits() != crcWidth) {
+            ::error(ErrorType::ERR_TYPE_ERROR, "Must be %1%-bits width: %2%", crcWidth, ts);
+            return;
+        }
+
+        auto registerType = EBPFTypeFactory::instance->create(otype);
+        registerType->emit(builder);
+    } else {
+        if (crcWidth == 16)
+            builder->append("u16");
+        else if (crcWidth == 32)
+            builder->append("u32");
+        else
+            BUG("Unsupported CRC width %1%", crcWidth);
+    }
+
+    builder->appendFormat(" %s = %s", registerVar.c_str(), initialValue.c_str());
+    builder->endOfStatement(true);
+}
+
+void CRCChecksumAlgorithm::emitClear(CodeBuilder* builder) {
+    builder->emitIndent();
+    builder->appendFormat("%s = %s", registerVar.c_str(), initialValue.c_str());
+    builder->endOfStatement(true);
+}
+
+void CRCChecksumAlgorithm::emitAddData(CodeBuilder* builder,
+                                       const argumentsList & arguments) {
+    cstring tmpVar = program->refMap->newName(baseName + "_tmp");
+
+    builder->emitIndent();
+    builder->blockStart();
+
+    builder->emitIndent();
+    builder->appendFormat("u8 %s = 0", tmpVar.c_str());
+    builder->endOfStatement(true);
+
+    bool concatenateBits = false;
+    int remainingBits = 8;
+    for (auto field : arguments) {
+        auto fieldType = field->type->to<IR::Type_Bits>();
+        if (fieldType == nullptr) {
+            ::error(ErrorType::ERR_UNSUPPORTED, "Only bits types are supported %1%", field);
+            return;
+        }
+        const int width = fieldType->width_bits();
+
+        if (width < 8 || concatenateBits) {
+            concatenateBits = true;
+            if (width > remainingBits) {
+                ::error(ErrorType::ERR_UNSUPPORTED,
+                        "Sub-byte fields have to be aligned to bytes %1%", field);
+                return;
+            }
+            if (remainingBits == 8) {
+                // start processing sub-byte fields
+                builder->emitIndent();
+                builder->appendFormat("%s = ", tmpVar.c_str());
+            } else {
+                builder->append(" | ");
+            }
+
+            remainingBits -= width;
+            builder->append("(");
+            visitor->visit(field);
+            builder->appendFormat(" << %d)", remainingBits);
+
+            if (remainingBits == 0) {
+                // last bit, update the crc
+                concatenateBits = false;
+                builder->endOfStatement(true);
+                builder->emitIndent();
+                builder->appendFormat("%s(&%s, &%s, 1, %s)", updateMethod.c_str(),
+                                      registerVar.c_str(), tmpVar.c_str(), polynomial.c_str());
+                builder->endOfStatement(true);
+            }
+        } else {
+            // fields larger than 8 bits
+            if (width % 8 != 0) {
+                ::error(ErrorType::ERR_UNSUPPORTED,
+                        "Fields larger than 8 bits have to be aligned to bytes %1%", field);
+                return;
+            }
+            builder->emitIndent();
+            builder->appendFormat("%s(&%s, (u8 *) &(", updateMethod.c_str(), registerVar.c_str());
+            visitor->visit(field);
+            builder->appendFormat("), %d, %s)", width / 8, polynomial.c_str());
+            builder->endOfStatement(true);
+        }
+    }
+
+    cstring varStr = Util::printf_format("(u64) %s", registerVar.c_str());
+    builder->target->emitTraceMessage(builder, "CRC: checksum state: %llx", 1, varStr.c_str());
+
+    cstring final_crc = Util::printf_format("(u64) %s(%s, %s)", finalizeMethod.c_str(),
+                                            registerVar.c_str(), polynomial.c_str());
+    builder->target->emitTraceMessage(builder, "CRC: final checksum: %llx", 1, final_crc.c_str());
+
+    builder->blockEnd(true);
+}
+
+void CRCChecksumAlgorithm::emitGet(CodeBuilder* builder) {
+    builder->appendFormat("%s(%s, %s)", finalizeMethod.c_str(),
+                          registerVar.c_str(), polynomial.c_str());
+}
+
+void CRCChecksumAlgorithm::emitSubtractData(CodeBuilder* builder,
+                                            const argumentsList & arguments) {
+    (void) builder; (void) arguments;
+    BUG("Not implementable");
+}
+
+void CRCChecksumAlgorithm::emitGetInternalState(CodeBuilder* builder) {
+    (void) builder;
+    BUG("Not implemented");
+}
+
+void CRCChecksumAlgorithm::emitSetInternalState(CodeBuilder* builder,
+                                                const IR::MethodCallExpression * expr) {
+    (void) builder; (void) expr;
+    BUG("Not implemented");
+}
+
+// ===========================CRC16ChecksumAlgorithm===========================
+
+void CRC16ChecksumAlgorithm::emitGlobals(CodeBuilder* builder) {
+    CRCChecksumAlgorithm::emitUpdateMethod(builder, 16);
+
+    cstring code ="static __always_inline "
+                  "u16 crc16_finalize(u16 reg, const u16 poly) {\n"
+                  "    return reg;\n"
+                  "}";
+    builder->appendLine(code);
+}
+
+// ===========================CRC32ChecksumAlgorithm===========================
+
+void CRC32ChecksumAlgorithm::emitGlobals(CodeBuilder* builder) {
+    CRCChecksumAlgorithm::emitUpdateMethod(builder, 32);
+
+    cstring code = "static __always_inline "
+                   "u32 crc32_finalize(u32 reg, const u32 poly) {\n"
+                   "    return reg ^ 0xFFFFFFFF;\n"
+                   "}";
+    builder->appendLine(code);
+}
+
+
+}  // namespace EBPF

--- a/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.h
+++ b/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.h
@@ -80,8 +80,6 @@ class CRCChecksumAlgorithm : public EBPFHashAlgorithmPSA {
     cstring polynomial;
     const int crcWidth;
 
-    cstring reflect(cstring str);
-
  public:
     CRCChecksumAlgorithm(const EBPFProgram* program, cstring name, int width)
             : EBPFHashAlgorithmPSA(program, name), crcWidth(width) {}
@@ -104,12 +102,22 @@ class CRCChecksumAlgorithm : public EBPFHashAlgorithmPSA {
                               const IR::MethodCallExpression * expr) override;
 };
 
+/**
+ * For CRC16 calculation we use a polynomial 0x8005.
+ * - updateMethod adds a data to the checksum
+ * and performs a CRC16 calculation
+ * - finalizeMethod returns the CRC16 result
+ *
+ * Above C functions are emitted via emitGlobals.
+ */
 class CRC16ChecksumAlgorithm : public CRCChecksumAlgorithm {
  public:
     CRC16ChecksumAlgorithm(const EBPFProgram* program, cstring name)
             : CRCChecksumAlgorithm(program, name, 16) {
         initialValue = "0";
-        polynomial = reflect("0x8005");
+        // We use a 0x8005 polynomial.
+        // 0xA001 comes from 0x8005 value bits reflection.
+        polynomial = "0xA001";
         updateMethod = "crc16_update";
         finalizeMethod = "crc16_finalize";
     }
@@ -117,12 +125,23 @@ class CRC16ChecksumAlgorithm : public CRCChecksumAlgorithm {
     static void emitGlobals(CodeBuilder* builder);
 };
 
+/**
+ * For CRC32 calculation we use a polynomial 0x04C11DB7.
+ * - updateMethod adds a data to the checksum
+ * and performs a CRC32 calculation
+ * - finalizeMethod finalizes a CRC32 calculation
+ * and returns the CRC32 result
+ *
+ * Above C functions are emitted via emitGlobals.
+ */
 class CRC32ChecksumAlgorithm : public CRCChecksumAlgorithm {
  public:
     CRC32ChecksumAlgorithm(const EBPFProgram* program, cstring name)
             : CRCChecksumAlgorithm(program, name, 32) {
         initialValue = "0xffffffff";
-        polynomial = reflect("0x04c11db7");
+        // We use a 0x04C11DB7 polynomial.
+        // 0xEDB88320 comes from 0x04C11DB7 value bits reflection.
+        polynomial = "0xEDB88320";
         updateMethod = "crc32_update";
         finalizeMethod = "crc32_finalize";
     }

--- a/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.h
+++ b/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.h
@@ -1,0 +1,157 @@
+/*
+Copyright 2022-present Orange
+Copyright 2022-present Open Networking Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef BACKENDS_EBPF_PSA_EXTERNS_EBPFPSAHASHALGORITHM_H_
+#define BACKENDS_EBPF_PSA_EXTERNS_EBPFPSAHASHALGORITHM_H_
+
+#include "backends/ebpf/ebpfObject.h"
+
+namespace EBPF {
+
+class EBPFProgram;
+
+class EBPFHashAlgorithmPSA : public EBPFObject {
+ public:
+    typedef std::vector<const IR::Expression *> argumentsList;
+
+ protected:
+    cstring baseName;
+    const EBPFProgram* program;
+    Visitor * visitor;
+
+    argumentsList unpackArguments(const IR::MethodCallExpression * expr, int dataPos);
+
+ public:
+    // keep this enum in sync with psa.p4 file
+    enum HashAlgorithm {
+        IDENTITY,
+        CRC32,
+        CRC32_CUSTOM,
+        CRC16,
+        CRC16_CUSTOM,
+        ONES_COMPLEMENT16,  // aka InternetChecksum
+        TARGET_DEFAULT
+    };
+
+    EBPFHashAlgorithmPSA(const EBPFProgram* program, cstring name)
+            : baseName(name), program(program), visitor(nullptr) {}
+
+    void setVisitor(Visitor * instance)
+    { this->visitor = instance; }
+
+    virtual unsigned getOutputWidth() const
+    { return 0; }
+
+    // decl might be a null pointer
+    virtual void emitVariables(CodeBuilder* builder, const IR::Declaration_Instance* decl) = 0;
+
+    virtual void emitClear(CodeBuilder* builder) = 0;
+    virtual void emitAddData(CodeBuilder* builder, int dataPos,
+                             const IR::MethodCallExpression * expr);
+    virtual void emitAddData(CodeBuilder* builder, const argumentsList & arguments) = 0;
+    virtual void emitGet(CodeBuilder* builder) = 0;
+
+    virtual void emitSubtractData(CodeBuilder* builder, const argumentsList & arguments) = 0;
+
+    virtual void emitGetInternalState(CodeBuilder* builder) = 0;
+    virtual void emitSetInternalState(CodeBuilder* builder,
+                                      const IR::MethodCallExpression * expr) = 0;
+};
+
+class CRCChecksumAlgorithm : public EBPFHashAlgorithmPSA {
+ protected:
+    cstring registerVar;
+    cstring initialValue;
+    cstring updateMethod;
+    cstring finalizeMethod;
+    cstring polynomial;
+    const int crcWidth;
+
+    cstring reflect(cstring str);
+
+ public:
+    CRCChecksumAlgorithm(const EBPFProgram* program, cstring name, int width)
+            : EBPFHashAlgorithmPSA(program, name), crcWidth(width) {}
+
+    unsigned getOutputWidth() const override
+    { return crcWidth; }
+
+    static void emitUpdateMethod(CodeBuilder* builder, int crcWidth);
+
+    void emitVariables(CodeBuilder* builder, const IR::Declaration_Instance* decl) override;
+
+    void emitClear(CodeBuilder* builder) override;
+    void emitAddData(CodeBuilder* builder, const argumentsList & arguments) override;
+    void emitGet(CodeBuilder* builder) override;
+
+    void emitSubtractData(CodeBuilder* builder, const argumentsList & arguments) override;
+
+    void emitGetInternalState(CodeBuilder* builder) override;
+    void emitSetInternalState(CodeBuilder* builder,
+                              const IR::MethodCallExpression * expr) override;
+};
+
+class CRC16ChecksumAlgorithm : public CRCChecksumAlgorithm {
+ public:
+    CRC16ChecksumAlgorithm(const EBPFProgram* program, cstring name)
+            : CRCChecksumAlgorithm(program, name, 16) {
+        initialValue = "0";
+        polynomial = reflect("0x8005");
+        updateMethod = "crc16_update";
+        finalizeMethod = "crc16_finalize";
+    }
+
+    static void emitGlobals(CodeBuilder* builder);
+};
+
+class CRC32ChecksumAlgorithm : public CRCChecksumAlgorithm {
+ public:
+    CRC32ChecksumAlgorithm(const EBPFProgram* program, cstring name)
+            : CRCChecksumAlgorithm(program, name, 32) {
+        initialValue = "0xffffffff";
+        polynomial = reflect("0x04c11db7");
+        updateMethod = "crc32_update";
+        finalizeMethod = "crc32_finalize";
+    }
+
+    static void emitGlobals(CodeBuilder* builder);
+};
+
+class EBPFHashAlgorithmTypeFactoryPSA {
+ public:
+    static EBPFHashAlgorithmTypeFactoryPSA * instance() {
+        static EBPFHashAlgorithmTypeFactoryPSA factory;
+        return &factory;
+    }
+
+    EBPFHashAlgorithmPSA * create(int type, const EBPFProgram* program, cstring name) {
+        if (type == EBPFHashAlgorithmPSA::HashAlgorithm::CRC32)
+            return new CRC32ChecksumAlgorithm(program, name);
+        else if (type == EBPFHashAlgorithmPSA::HashAlgorithm::CRC16)
+            return new CRC16ChecksumAlgorithm(program, name);
+
+        return nullptr;
+    }
+
+    void emitGlobals(CodeBuilder* builder) {
+        CRC16ChecksumAlgorithm::emitGlobals(builder);
+        CRC32ChecksumAlgorithm::emitGlobals(builder);
+    }
+};
+
+}  // namespace EBPF
+
+#endif  /* BACKENDS_EBPF_PSA_EXTERNS_EBPFPSAHASHALGORITHM_H_ */

--- a/backends/ebpf/tests/p4testdata/checksum-updates-crc16.p4
+++ b/backends/ebpf/tests/p4testdata/checksum-updates-crc16.p4
@@ -1,0 +1,133 @@
+/*
+Copyright 2022-present Orange
+Copyright 2022-present Open Networking Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+header crc_t {
+    bit<40> f1;
+    bit<32> f2;
+
+    bit<16> crc;
+}
+
+header clone_i2e_metadata_t {
+}
+
+struct metadata {
+}
+
+struct headers {
+    ethernet_t ethernet;
+    crc_t     crc;
+}
+
+parser IngressParserImpl(
+    packet_in buffer,
+    out headers parsed_hdr,
+    inout metadata user_meta,
+    in psa_ingress_parser_input_metadata_t istd,
+    in empty_t resubmit_meta,
+    in empty_t recirculate_meta)
+{
+    Checksum<bit<16>>(PSA_HashAlgorithm_t.CRC16) c;
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        buffer.extract(parsed_hdr.ethernet);
+        transition parse_crc;
+    }
+    state parse_crc {
+        buffer.extract(parsed_hdr.crc);
+        c.update(parsed_hdr.crc.f1);
+        c.update(parsed_hdr.crc.f2);
+        parsed_hdr.crc.crc = c.get();
+        transition accept;
+    }
+}
+
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in  psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+
+    apply {
+        send_to_port(ostd, (PortId_t) 5);
+    }
+}
+
+control IngressDeparserImpl(
+    packet_out packet,
+    out clone_i2e_metadata_t clone_i2e_meta,
+    out empty_t resubmit_meta,
+    out metadata normal_meta,
+    inout headers parsed_hdr,
+    in metadata meta,
+    in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(parsed_hdr.ethernet);
+        packet.emit(parsed_hdr.crc);
+    }
+}
+
+parser EgressParserImpl(
+    packet_in buffer,
+    out headers parsed_hdr,
+    inout metadata user_meta,
+    in psa_egress_parser_input_metadata_t istd,
+    in metadata normal_meta,
+    in clone_i2e_metadata_t clone_i2e_meta,
+    in empty_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in  psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply {}
+}
+
+control EgressDeparserImpl(
+    packet_out packet,
+    out empty_t clone_e2e_meta,
+    out empty_t recirculate_meta,
+    inout headers parsed_hdr,
+    in metadata meta,
+    in psa_egress_output_metadata_t istd,
+    in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {}
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/p4testdata/checksum-updates-crc32.p4
+++ b/backends/ebpf/tests/p4testdata/checksum-updates-crc32.p4
@@ -1,0 +1,133 @@
+/*
+Copyright 2022-present Orange
+Copyright 2022-present Open Networking Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+header crc_t {
+    bit<40> f1;
+    bit<32> f2;
+
+    bit<32> crc;
+}
+
+header clone_i2e_metadata_t {
+}
+
+struct metadata {
+}
+
+struct headers {
+    ethernet_t ethernet;
+    crc_t     crc;
+}
+
+parser IngressParserImpl(
+    packet_in buffer,
+    out headers parsed_hdr,
+    inout metadata user_meta,
+    in psa_ingress_parser_input_metadata_t istd,
+    in empty_t resubmit_meta,
+    in empty_t recirculate_meta)
+{
+    Checksum<bit<32>>(PSA_HashAlgorithm_t.CRC32) c;
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        buffer.extract(parsed_hdr.ethernet);
+        transition parse_crc;
+    }
+    state parse_crc {
+        buffer.extract(parsed_hdr.crc);
+        c.update(parsed_hdr.crc.f1);
+        c.update(parsed_hdr.crc.f2);
+        parsed_hdr.crc.crc = c.get();
+        transition accept;
+    }
+}
+
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in  psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+
+    apply {
+        send_to_port(ostd, (PortId_t) 5);
+    }
+}
+
+control IngressDeparserImpl(
+    packet_out packet,
+    out clone_i2e_metadata_t clone_i2e_meta,
+    out empty_t resubmit_meta,
+    out metadata normal_meta,
+    inout headers parsed_hdr,
+    in metadata meta,
+    in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(parsed_hdr.ethernet);
+        packet.emit(parsed_hdr.crc);
+    }
+}
+
+parser EgressParserImpl(
+    packet_in buffer,
+    out headers parsed_hdr,
+    inout metadata user_meta,
+    in psa_egress_parser_input_metadata_t istd,
+    in metadata normal_meta,
+    in clone_i2e_metadata_t clone_i2e_meta,
+    in empty_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in  psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply {}
+}
+
+control EgressDeparserImpl(
+    packet_out packet,
+    out empty_t clone_e2e_meta,
+    out empty_t recirculate_meta,
+    inout headers parsed_hdr,
+    in metadata meta,
+    in psa_egress_output_metadata_t istd,
+    in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {}
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/ptf/checksum.py
+++ b/backends/ebpf/tests/ptf/checksum.py
@@ -1,0 +1,31 @@
+from common import *
+
+import random
+
+from scapy.layers.l2 import Ether
+from scapy.layers.inet import IP, UDP
+
+PORT0 = 0
+PORT1 = 1
+PORT2 = 2
+ALL_PORTS = [PORT0, PORT1, PORT2]
+
+
+class ChecksumCRC32MultipleUpdatesPSATest(P4EbpfTest):
+    p4_file_path = "p4testdata/checksum-updates-crc32.p4"
+
+    def runTest(self):
+        pkt = Ether() / "1234567890000"
+        exp_pkt = Ether() / bytes.fromhex('313233343536373839 cbf43926')
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_packet_any_port(self, exp_pkt, ALL_PORTS)
+
+
+class ChecksumCRC16MultipleUpdatesPSATest(P4EbpfTest):
+    p4_file_path = "p4testdata/checksum-updates-crc16.p4"
+
+    def runTest(self):
+        pkt = Ether() / "1234567890000"
+        exp_pkt = Ether() / bytes.fromhex('313233343536373839 BB3D')
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_packet_any_port(self, exp_pkt, ALL_PORTS)


### PR DESCRIPTION
This PR adds Checksum extern and adds support for CRC16 and CRC32 algorithms.

Co-authored-by: Tomasz Osiński <tomasz@opennetworking.org>
Co-authored-by: Jan Palimąka <jan.palimaka@orange.com>