### PR TITLE
manage lifetime of Visitor::visited

### DIFF
--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -180,15 +180,15 @@ Visitor::profile_t Visitor::init_apply(const IR::Node *root, const Context *pare
 }
 Visitor::profile_t Modifier::init_apply(const IR::Node *root) {
     auto rv = Visitor::init_apply(root);
-    visited = new ChangeTracker();
+    visited = std::make_shared<ChangeTracker>();
     return rv; }
 Visitor::profile_t Inspector::init_apply(const IR::Node *root) {
     auto rv = Visitor::init_apply(root);
-    visited = new visited_t();
+    visited = std::make_shared<visited_t>();
     return rv; }
 Visitor::profile_t Transform::init_apply(const IR::Node *root) {
     auto rv = Visitor::init_apply(root);
-    visited = new ChangeTracker();
+    visited = std::make_shared<ChangeTracker>();
     return rv; }
 void Visitor::end_apply() {}
 void Visitor::end_apply(const IR::Node*) {}
@@ -305,7 +305,7 @@ const IR::Node *Modifier::apply_visitor(const IR::Node *n, const char *name) {
     if (ctxt)
         ctxt->child_index++;
     else
-        visited = nullptr;
+        visited.reset();
     return n;
 }
 
@@ -330,8 +330,9 @@ const IR::Node *Inspector::apply_visitor(const IR::Node *n, const char *name) {
             vp.first->second.done = true; } }
     if (ctxt)
         ctxt->child_index++;
-    else
-        visited = nullptr;
+    else {
+        visited.reset();
+    }
     return n;
 }
 
@@ -389,7 +390,7 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
     if (ctxt)
         ctxt->child_index++;
     else
-        visited = nullptr;
+        visited.reset();
     return n;
 }
 

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -290,7 +290,7 @@ class Visitor {
 };
 
 class Modifier : public virtual Visitor {
-    ChangeTracker       *visited = nullptr;
+    std::shared_ptr<ChangeTracker> visited;
     void visitor_const_error() override;
     bool check_clone(const Visitor *) override;
  public:
@@ -314,7 +314,7 @@ class Modifier : public virtual Visitor {
 class Inspector : public virtual Visitor {
     struct info_t { bool done, visitOnce; };
     typedef std::unordered_map<const IR::Node *, info_t>       visited_t;
-    visited_t   *visited = nullptr;
+    std::shared_ptr<visited_t> visited;
     bool check_clone(const Visitor *) override;
  public:
     profile_t init_apply(const IR::Node *root) override;
@@ -337,7 +337,7 @@ class Inspector : public virtual Visitor {
 };
 
 class Transform : public virtual Visitor {
-    ChangeTracker       *visited = nullptr;
+    std::shared_ptr<ChangeTracker> visited;
     bool prune_flag = false;
     void visitor_const_error() override;
     bool check_clone(const Visitor *) override;


### PR DESCRIPTION
All three `Visitor` implementations hold a data structure containing information about all visited IR nodes in the `visited` attribute. This attribute is a pointer to an object dynamically allocated in `init_apply`, which is later set to `nullptr` when the visitor no longer needs it. The garbare collector is then supposed to destroy these objects.

This memory management mechanism doesn't work perfectly, however. In our backend implementation, managing lifetime of `visited` objects by refcounting  (as submitted in this PR) leads to  3x (!) peak memory usage decrease on large P4 programs. It seems the garbage collector isn't able to release the `visited` hashtable properly, leaving piles of IR nodes in the memory. This should also bring the codebase closer to proper memory management in ENABLE_GC=OFF builds, although this is only a tiny improvement in this direction.

I'm not sure on the exact reason why libgc doesn't release these objects properly. I've tried various versions including the latest 8.2 with similar results.

This behavior can be also reproduced on small P4 programs from this repository, for example
```
/usr/bin/time -f "%M" ./p4c-dpdk --arch psa ../backends/dpdk/examples/vxlan.p4
```
shows peak memory usage of 46969 bytes before the change, and 40392 after this change.
