### PR TITLE
Add --xdp2tc compiler flag for eBPF backend

### DIFF
--- a/backends/ebpf/ebpfOptions.cpp
+++ b/backends/ebpf/ebpfOptions.cpp
@@ -37,5 +37,6 @@ EbpfOptions::EbpfOptions() {
                    }
                    return true;
                 },
-                "[psa only] Select the mode used to pass metadata from XDP to TC (possible values: meta, head, cpumap).");
+                "[psa only] Select the mode used to pass metadata from XDP to TC "
+                "(possible values: meta, head, cpumap).");
 }

--- a/backends/ebpf/ebpfOptions.cpp
+++ b/backends/ebpf/ebpfOptions.cpp
@@ -37,5 +37,5 @@ EbpfOptions::EbpfOptions() {
                    }
                    return true;
                 },
-                "[psa only] Select the mode used to pass metadata from XDP to TC.");
+                "[psa only] Select the mode used to pass metadata from XDP to TC (possible values: meta, head, cpumap).");
 }

--- a/backends/ebpf/ebpfOptions.cpp
+++ b/backends/ebpf/ebpfOptions.cpp
@@ -26,4 +26,16 @@ EbpfOptions::EbpfOptions() {
         registerOption("--trace", nullptr,
                 [this](const char*) { emitTraceMessages = true; return true; },
                 "Generate tracing messages of packet processing");
+        registerOption("--xdp2tc", "MODE",
+                [this](const char* arg) {
+                   if (!strcmp(arg, "meta")) {
+                       xdp2tcMode = XDP2TC_META;
+                   } else if (!strcmp(arg, "head")) {
+                       xdp2tcMode = XDP2TC_HEAD;
+                   } else if (!strcmp(arg, "cpumap")) {
+                       xdp2tcMode = XDP2TC_CPUMAP;
+                   }
+                   return true;
+                },
+                "[psa only] Select the mode used to pass metadata from XDP to TC.");
 }

--- a/backends/ebpf/ebpfOptions.h
+++ b/backends/ebpf/ebpfOptions.h
@@ -20,6 +20,12 @@ limitations under the License.
 #include <getopt.h>
 #include "frontends/common/options.h"
 
+enum XDP2TC {
+    XDP2TC_NONE,
+    XDP2TC_META,
+    XDP2TC_HEAD,
+    XDP2TC_CPUMAP
+};
 
 class EbpfOptions : public CompilerOptions {
  public:
@@ -31,7 +37,23 @@ class EbpfOptions : public CompilerOptions {
     bool emitExterns = false;
     // tracing eBPF code execution
     bool emitTraceMessages = false;
+    // XDP2TC mode for PSA-eBPF
+    enum XDP2TC xdp2tcMode = XDP2TC_NONE;
+
     EbpfOptions();
+
+    void calculateXDP2TCMode() {
+        if (arch != "psa") {
+            return;
+        }
+
+        if (xdp2tcMode == XDP2TC_NONE) {
+            std::cout << "Setting XDP2TC 'meta' mode by default." << std::endl;
+            // Use 'meta' mode by default.
+            xdp2tcMode = XDP2TC_META;
+        }
+        BUG_CHECK(xdp2tcMode != XDP2TC_NONE, "xdp2tc mode should not be set to NONE, bug?");
+    }
 };
 
 using EbpfContext = P4CContextWithOptions<EbpfOptions>;

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -100,6 +100,7 @@ int main(int argc, char *const argv[]) {
     if (::errorCount() > 0)
         exit(1);
 
+    options.calculateXDP2TCMode();
     try {
         compile(options);
     } catch (const std::exception &bug) {

--- a/backends/ebpf/psa/README.md
+++ b/backends/ebpf/psa/README.md
@@ -23,9 +23,9 @@ The TC-based design of PSA for eBPF is depicted in Figure below.
   a packet for further processing in the TC subsystem. Why do we need the XDP helper program? Some eBPF helpers for the TC hook depend on
   the `skb->protocol` type (in particular, IPv4/IPv6 EtherType), which is read by the TC layer before a packet enters the eBPF program.
   This limitation prevents from using TC as a protocol-independent packet processing engine. If a packet arriving at the XDP level isn't
-  an IPv4 packet, the XDP helper replaces it's original EtherType with IPv4 EtherType. The original EtherType is passed to TC in `data_meta` field
-  (injected by `bpf_xdp_adjust_meta()`). The `tc-ingress` program reads original EtherType and puts it back into the packet. We verified that
-  this workaround enables handling other protocols in the TC layer (e.g., MPLS).
+  an IPv4 packet, the XDP helper replaces it's original EtherType with IPv4 EtherType. The original EtherType is passed to TC according to 
+  the XDP2TC mode specified by a user (see XDP2TC metadata section). The `tc-ingress` program reads original EtherType and puts it back into the packet. 
+  We verified that this workaround enables handling other protocols in the TC layer (e.g., MPLS).
 - `tc-ingress` - In the TC Ingress, the PSA Ingress pipeline as well as so-called "Traffic Manager" eBPF program is attached.
   The Ingress pipeline is composed of Parser, Control block and Deparser. The details of Parser, Control block and Deparser implementation
   will be explained further in this document. The same eBPF program in TC contains also the Traffic Manager.
@@ -116,6 +116,27 @@ invoking `bpf_redirect()` to the `PSA_PORT_RECIRCULATE` port with `BPF_F_INGRESS
 
 There are some global metadata defined for the PSA architecture. For example, `packet_path` must be shared among different pipelines.
 To share a global metadata between pipelines we use `skb->cb` (control buffer), which gives us 20B that are free to use.
+
+## XDP2TC mode
+
+The XDP2TC mode determines how the metadata (containing original EtherType) is passed from XDP up to TC.
+By default, PSA-eBPF uses the `bpf_xdp_adjust_meta()` helper to append the original
+EtherType to the `skb`’s `data_meta` field, which is further read by the TC Ingress to restore the original format of the packet.
+The way of passing metadata is determined by the user-configurable `--xdp2tc` compiler flag. We have noticed that some NIC
+drivers does not support the `bpf_xdp_adjust_meta()` BPF helper and the default mode cannot be used. Therefore, we
+come up with a more generic mode called `head`, which uses `bpf_xdp_adjust_head()` instead to prepend a packet with
+metadata. In this mode, the helper must be invoked twice - in the XDP helper program to append the metadata and in
+the TC Ingress to strip the metadata out of a packet. We also introduce the third mode - `cpumap`, which is an experimental features and should be used carefully.
+The `cpumap` assumes that the single CPU core handles a packet in the run-to-completion mode from XDP up to the TC layer
+(in other words, for a given packet, the CPU core running the TC program is the same as the one for XDP). If the above
+condition is met, the `cpumap` mode uses the per-CPU BPF array map to transfer metadata from XDP to TC. Hence, the `cpumap` mode 
+should only be used, if there is a guarantee that the same CPU core handles the packet in both XDP and TC hooks.
+Note that the XDP helper program introduces a constant but noticeable per-packet overhead. Though, it is necessary to implement P4 processing in the TC layer.
+
+To sum up, the `--xdp2tc` compiler flag can take the following values:
+- `meta` (default) - uses the `bpf_xdp_adjust_meta()` BPF helper. It's the most efficient way and should be used wherever possible. 
+- `head` - uses the `bpf_xdp_adjust_head()` BPF helper and should be used if `meta` is not supported by a NIC driver.
+- `cpumap` - uses the BPF per-CPU array map. It should rather be used for testing purposes only. 
 
 ## Control-plane API
 
@@ -259,6 +280,7 @@ with some NICs. So far, we have verified the correct behavior with Intel 82599ES
 - `lookahead()` with bit fields (e.g., `bit<16>`) doesn't work.
 - `@atomic` operation is not supported yet.
 - `psa_idle_timeout` is not supported yet. 
+- The `xdp2tc=head` mode works only for packets larger than 34 bytes (the size of Ethernet and IPv4 header).
 
 # Roadmap
 

--- a/backends/ebpf/psa/ebpfPipeline.cpp
+++ b/backends/ebpf/psa/ebpfPipeline.cpp
@@ -450,7 +450,15 @@ void TCIngressPipeline::emitGlobalMetadataInitializer(CodeBuilder *builder) {
                           compilerGlobalMetadata);
     builder->blockStart();
     builder->emitIndent();
-    emitTCWorkaroundUsingMeta(builder);
+    if (options.xdp2tcMode == XDP2TC_META) {
+        emitTCWorkaroundUsingMeta(builder);
+    } else if (options.xdp2tcMode == XDP2TC_HEAD) {
+        emitTCWorkaroundUsingHead(builder);
+    } else if (options.xdp2tcMode == XDP2TC_CPUMAP) {
+        emitTCWorkaroundUsingCPUMAP(builder);
+    } else {
+        BUG("no xdp2tc mode specified?");
+    }
     builder->blockEnd(true);
 }
 
@@ -492,7 +500,7 @@ void TCIngressPipeline::emitTCWorkaroundUsingCPUMAP(CodeBuilder *builder) {
     builder->append("    void *data = (void *)(long)skb->data;\n"
                     "    void *data_end = (void *)(long)skb->data_end;\n"
                     "    u32 zeroKey = 0;\n"
-                    "    u16 *orig_ethtype = BPF_MAP_LOOKUP_ELEM(workaround_cpumap, &zeroKey);\n"
+                    "    u16 *orig_ethtype = BPF_MAP_LOOKUP_ELEM(xdp2tc_cpumap, &zeroKey);\n"
                     "    if (!orig_ethtype) {\n"
                     "        return TC_ACT_SHOT;\n"
                     "    }\n"

--- a/backends/ebpf/psa/ebpfPsaGen.cpp
+++ b/backends/ebpf/psa/ebpfPsaGen.cpp
@@ -343,6 +343,12 @@ void PSAArchTC::emit(CodeBuilder *builder) const {
 void PSAArchTC::emitInstances(CodeBuilder *builder) const {
     builder->appendLine("REGISTER_START()");
 
+    if (options.xdp2tcMode == XDP2TC_CPUMAP) {
+        builder->target->emitTableDecl(builder, "xdp2tc_cpumap",
+                                       TablePerCPUArray, "u32",
+                                       "u16", 1);
+    }
+
     emitPacketReplicationTables(builder);
     emitPipelineInstances(builder);
 

--- a/backends/ebpf/psa/xdpHelpProgram.h
+++ b/backends/ebpf/psa/xdpHelpProgram.h
@@ -50,6 +50,49 @@ class XDPHelpProgram : public EBPFProgram {
             "\n"
             "    return XDP_PASS;";
 
+    cstring XDPProgUsingHeadForXDP2TC =
+            "    void *data = (void *)(long)skb->data;\n"
+            "    void *data_end = (void *)(long)skb->data_end;\n"
+            "    struct ethhdr *eth = data;\n"
+            "    if ((void *)((struct ethhdr *) eth + 1) > data_end) {\n"
+            "        return XDP_ABORTED;\n"
+            "    }\n"
+            "    __u16 orig_ethtype = eth->h_proto;\n"
+            "    int ret = bpf_xdp_adjust_head(skb, -2);\n"
+            "    if (ret < 0) {\n"
+            "        return XDP_ABORTED;\n"
+            "    }\n"
+            "\n"
+            "    data = (void *)(long)skb->data;\n"
+            "    data_end = (void *)(long)skb->data_end;\n"
+            "\n"
+            "    if ((void *)(data + 16) > data_end) {\n"
+            "        return XDP_ABORTED;\n"
+            "    }\n"
+            "    __builtin_memmove(data, data + 2, 14);\n"
+            "    eth = data;\n"
+            "    if ((void *)((struct ethhdr *) eth + 1) > data_end) {\n"
+            "        return XDP_ABORTED;\n"
+            "    }\n"
+            "    eth->h_proto = bpf_htons(0x0800);\n"
+            "    __builtin_memcpy((char *)data + 14, &orig_ethtype, 2);\n"
+            "    "
+            "\n"
+            "    return XDP_PASS;";
+
+    cstring XDPProgUsingCPUMAPForXDP2TC =
+            "    void *data = (void *)(long)skb->data;\n"
+            "    void *data_end = (void *)(long)skb->data_end;\n"
+            "    struct ethhdr *eth = data;\n"
+            "    if ((void *)((struct ethhdr *) eth + 1) > data_end) {\n"
+            "        return XDP_ABORTED;\n"
+            "    }\n"
+            "    u16 orig_ethtype = eth->h_proto;\n"
+            "    eth->h_proto = bpf_htons(0x0800);\n"
+            "    u32 zero = 0;\n"
+            "    BPF_MAP_UPDATE_ELEM(xdp2tc_cpumap, &zero, &orig_ethtype, BPF_ANY);\n"
+            "    return XDP_PASS;";
+
  public:
     cstring sectionName;
     explicit XDPHelpProgram(const EbpfOptions& options) :
@@ -66,7 +109,14 @@ class XDPHelpProgram : public EBPFProgram {
         builder->spc();
         builder->blockStart();
         builder->emitIndent();
-        builder->appendLine(XDPProgUsingMetaForXDP2TC);
+        // this is static program, so we can just paste a piece of code.
+        if (options.xdp2tcMode == XDP2TC_META) {
+            builder->appendLine(XDPProgUsingMetaForXDP2TC);
+        } else if (options.xdp2tcMode == XDP2TC_HEAD) {
+            builder->appendLine(XDPProgUsingHeadForXDP2TC);
+        } else if (options.xdp2tcMode == XDP2TC_CPUMAP) {
+            builder->appendLine(XDPProgUsingCPUMAPForXDP2TC);
+        }
         builder->blockEnd(true);
     }
 };

--- a/backends/ebpf/tests/ptf/checksum.py
+++ b/backends/ebpf/tests/ptf/checksum.py
@@ -11,6 +11,7 @@ PORT2 = 2
 ALL_PORTS = [PORT0, PORT1, PORT2]
 
 
+@xdp2tc_head_not_supported
 class ChecksumCRC32MultipleUpdatesPSATest(P4EbpfTest):
     p4_file_path = "p4testdata/checksum-updates-crc32.p4"
 
@@ -21,6 +22,7 @@ class ChecksumCRC32MultipleUpdatesPSATest(P4EbpfTest):
         testutils.verify_packet_any_port(self, exp_pkt, ALL_PORTS)
 
 
+@xdp2tc_head_not_supported
 class ChecksumCRC16MultipleUpdatesPSATest(P4EbpfTest):
     p4_file_path = "p4testdata/checksum-updates-crc16.p4"
 

--- a/backends/ebpf/tests/ptf/common.py
+++ b/backends/ebpf/tests/ptf/common.py
@@ -79,6 +79,9 @@ class P4EbpfTest(BaseTest):
         if self.is_trace_logs_enabled():
             p4args += " --trace"
 
+        if "xdp2tc" in testutils.test_params_get():
+            p4args += " --xdp2tc=" + self.xdp2tc_mode()
+
         logger.info("P4ARGS=" + p4args)
         self.exec_cmd("make -f ../runtime/kernel.mk BPFOBJ={output} P4FILE={p4file} "
                       "ARGS=\"{cargs}\" P4C=p4c-ebpf P4ARGS=\"{p4args}\" psa".format(

--- a/backends/ebpf/tests/test.sh
+++ b/backends/ebpf/tests/test.sh
@@ -166,12 +166,15 @@ fi
 TEST_CASE=$@
 xdp_enabled="False"
 
-TEST_PARAMS='interfaces="'"$interface_list"'";namespace="switch";trace="'"$TRACE_LOGS"'"'
-# Start tests
-ptf \
-  --test-dir ptf/ \
-  --test-params="$TEST_PARAMS" \
-  --interface 0@s1-eth0 --interface 1@s1-eth1 --interface 2@s1-eth2 --interface 3@s1-eth3 \
-  --interface 4@s1-eth4 --interface 5@s1-eth5 $TEST_CASE
-exit_on_error
-rm -rf ptf_out
+for xdp2tc_mode in "${XDP2TC_MODE[@]}" ; do
+  TEST_PARAMS='interfaces="'"$interface_list"'";namespace="switch";trace="'"$TRACE_LOGS"'"'
+  TEST_PARAMS+=";xdp2tc='$xdp2tc_mode'"
+  # Start tests
+  ptf \
+    --test-dir ptf/ \
+    --test-params="$TEST_PARAMS" \
+    --interface 0@s1-eth0 --interface 1@s1-eth1 --interface 2@s1-eth2 --interface 3@s1-eth3 \
+    --interface 4@s1-eth4 --interface 5@s1-eth5 $TEST_CASE
+  exit_on_error
+  rm -rf ptf_out
+done


### PR DESCRIPTION
This PR makes the XDP2TC mode configurable. The XDP2TC mode determines how the metadata (containing original EtherType) is passed from XDP up to TC. This is needed because we discovered that the default `meta` mode using `bpf_xdp_adjust_meta()` is not supported by some NIC drivers. In such a case, the entire PSA implementation for eBPF does not work. This PR adds two alternative modes: `head` and `cpumap` that can be used to work around the NIC limitations. 