### PR TITLE
test: Update install_fedora_deps.sh

### DIFF
--- a/tools/install_fedora_deps.sh
+++ b/tools/install_fedora_deps.sh
@@ -72,12 +72,6 @@ cd behavioral-model
 ./configure --with-pdfixed --with-thrift --with-pi --with-stress-tests --enable-debugger
 make
 make install-strip
-
-cd targets/simple_switch_grpc/
-./autogen.sh
-./configure --with-thrift
-make
-make install-strip
 popd
 
 rm -rf "${tmp_dir}"


### PR DESCRIPTION
The simple_switch_grpc target has been integrated with the main `autogen.sh` and `configure.ac` files.

https://github.com/p4lang/behavioral-model/pull/1105

Fixes #3189