### PR TITLE
Add support for InternetChecksum extern to eBPF backend

### DIFF
--- a/backends/ebpf/ebpfDeparser.cpp
+++ b/backends/ebpf/ebpfDeparser.cpp
@@ -107,6 +107,7 @@ DeparserHdrEmitTranslator::DeparserHdrEmitTranslator(const EBPFDeparser *deparse
 }
 
 void DeparserHdrEmitTranslator::processMethod(const P4::ExternMethod *method) {
+    // This method handles packet_out.emit() only and is intended to skip other externs
     if (method->method->name.name == p4lib.packetOut.emit.name) {
         auto decl = method->object;
         if (decl == deparser->packet_out) {
@@ -164,8 +165,6 @@ void DeparserHdrEmitTranslator::processMethod(const P4::ExternMethod *method) {
         } else {
             BUG("emit() should only be invoked for packet_out");
         }
-    } else {
-        ::error(ErrorType::ERR_UNSUPPORTED, "Unsupported method invocation %1%", method->method);
     }
 }
 

--- a/backends/ebpf/ebpfObject.h
+++ b/backends/ebpf/ebpfObject.h
@@ -50,6 +50,14 @@ class EBPFObject {
 
         return nullptr;
     }
+
+    static cstring getTypeName(const IR::Declaration_Instance* di) {
+        if (auto typeName = di->type->to<IR::Type_Name>()) {
+            return typeName->path->name.name;
+        }
+
+        return nullptr;
+    }
 };
 
 }  // namespace EBPF

--- a/backends/ebpf/psa/ebpfPsaDeparser.cpp
+++ b/backends/ebpf/psa/ebpfPsaDeparser.cpp
@@ -38,7 +38,7 @@ void DeparserBodyTranslatorPSA::processMethod(const P4::ExternMethod *method) {
     auto dprs = deparser->to<EBPFDeparserPSA>();
     CHECK_NULL(dprs);
     auto externName = method->originalExternType->name.name;
-    if (externName == "Checksum") {
+    if (externName == "Checksum" || externName == "InternetChecksum") {
         auto instance = method->object->getName().name;
         auto methodName = method->method->getName().name;
         dprs->getChecksum(instance)->processMethod(builder, methodName, method->expr, this);
@@ -75,6 +75,11 @@ void EBPFDeparserPSA::emitDeclaration(CodeBuilder* builder, const IR::Declaratio
 
         if (EBPFObject::getSpecializedTypeName(di) == "Checksum") {
             auto instance = new EBPFChecksumPSA(program, di, name);
+            checksums.emplace(name, instance);
+            instance->emitVariables(builder);
+            return;
+        } else if (EBPFObject::getTypeName(di) == "InternetChecksum") {
+            auto instance = new EBPFInternetChecksumPSA(program, di, name);
             checksums.emplace(name, instance);
             instance->emitVariables(builder);
             return;

--- a/backends/ebpf/psa/externs/ebpfPsaChecksum.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaChecksum.cpp
@@ -23,8 +23,7 @@ void EBPFChecksumPSA::init(const EBPFProgram* program, cstring name, int type) {
     engine = EBPFHashAlgorithmTypeFactoryPSA::instance()->create(type, program, name);
 
     if (engine == nullptr) {
-        ::error(ErrorType::ERR_UNSUPPORTED, "Hash algorithm not yet implemented: %1%",
-                declaration->arguments->at(0));
+        ::error(ErrorType::ERR_UNSUPPORTED, "Hash algorithm not yet implemented");
     }
 }
 
@@ -61,6 +60,24 @@ void EBPFChecksumPSA::processMethod(CodeBuilder* builder, cstring method,
         engine->emitGet(builder);
     } else {
         ::error(ErrorType::ERR_UNEXPECTED, "Unexpected method call %1%", expr);
+    }
+}
+
+void EBPFInternetChecksumPSA::processMethod(CodeBuilder* builder, cstring method,
+                                            const IR::MethodCallExpression * expr,
+                                            Visitor * visitor) {
+    engine->setVisitor(visitor);
+
+    if (method == "add") {
+        engine->emitAddData(builder, 0, expr);
+    } else if (method == "subtract") {
+        engine->emitSubtractData(builder, 0, expr);
+    } else if (method == "get_state") {
+        engine->emitGetInternalState(builder);
+    } else if (method == "set_state") {
+        engine->emitSetInternalState(builder, expr);
+    } else {
+        EBPFChecksumPSA::processMethod(builder, method, expr, visitor);
     }
 }
 

--- a/backends/ebpf/psa/externs/ebpfPsaChecksum.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaChecksum.cpp
@@ -23,7 +23,11 @@ void EBPFChecksumPSA::init(const EBPFProgram* program, cstring name, int type) {
     engine = EBPFHashAlgorithmTypeFactoryPSA::instance()->create(type, program, name);
 
     if (engine == nullptr) {
-        ::error(ErrorType::ERR_UNSUPPORTED, "Hash algorithm not yet implemented");
+        if (declaration->arguments->empty())
+            ::error(ErrorType::ERR_UNSUPPORTED, "InternetChecksum not yet implemented");
+        else
+            ::error(ErrorType::ERR_UNSUPPORTED, "Hash algorithm not yet implemented: %1%",
+                    declaration->arguments->at(0));
     }
 }
 

--- a/backends/ebpf/psa/externs/ebpfPsaChecksum.h
+++ b/backends/ebpf/psa/externs/ebpfPsaChecksum.h
@@ -45,6 +45,17 @@ class EBPFChecksumPSA : public EBPFObject {
                                const IR::MethodCallExpression * expr, Visitor * visitor);
 };
 
+class EBPFInternetChecksumPSA : public EBPFChecksumPSA {
+ public:
+    EBPFInternetChecksumPSA(const EBPFProgram* program, const IR::Declaration_Instance* block,
+                            cstring name)
+            : EBPFChecksumPSA(program, block, name,
+                              EBPFHashAlgorithmPSA::HashAlgorithm::ONES_COMPLEMENT16) {}
+
+    void processMethod(CodeBuilder* builder, cstring method,
+                       const IR::MethodCallExpression * expr, Visitor * visitor) override;
+};
+
 }  // namespace EBPF
 
 #endif  /* BACKENDS_EBPF_PSA_EXTERNS_EBPFPSACHECKSUM_H_ */

--- a/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 
 namespace EBPF {
 
-EBPFHashAlgorithmPSA::argumentsList EBPFHashAlgorithmPSA::unpackArguments(
+EBPFHashAlgorithmPSA::ArgumentsList EBPFHashAlgorithmPSA::unpackArguments(
         const IR::MethodCallExpression * expr, int dataPos) {
     BUG_CHECK(expr->arguments->size() > ((size_t) dataPos),
               "Data position %1% is outside of the arguments: %2%", dataPos, expr);
@@ -129,7 +129,7 @@ void CRCChecksumAlgorithm::emitClear(CodeBuilder* builder) {
  * 0xEDB88320 - a polynomial in a reflected bit order.
  */
 void CRCChecksumAlgorithm::emitAddData(CodeBuilder* builder,
-                                       const argumentsList & arguments) {
+                                       const ArgumentsList & arguments) {
     cstring tmpVar = program->refMap->newName(baseName + "_tmp");
 
     builder->emitIndent();
@@ -213,7 +213,7 @@ void CRCChecksumAlgorithm::emitGet(CodeBuilder* builder) {
 }
 
 void CRCChecksumAlgorithm::emitSubtractData(CodeBuilder* builder,
-                                            const argumentsList & arguments) {
+                                            const ArgumentsList & arguments) {
     (void) builder; (void) arguments;
     BUG("Not implementable");
 }
@@ -256,7 +256,7 @@ void CRC32ChecksumAlgorithm::emitGlobals(CodeBuilder* builder) {
 // ===========================InternetChecksumAlgorithm===========================
 
 void InternetChecksumAlgorithm::updateChecksum(CodeBuilder* builder,
-                                               const argumentsList & arguments,
+                                               const ArgumentsList & arguments,
                                                bool addData) {
     cstring tmpVar = program->refMap->newName(baseName + "_tmp");
 
@@ -271,7 +271,7 @@ void InternetChecksumAlgorithm::updateChecksum(CodeBuilder* builder,
     for (auto field : arguments) {
         auto fieldType = field->type->to<IR::Type_Bits>();
         if (fieldType == nullptr) {
-            ::error(ErrorType::ERR_UNSUPPORTED, "Only bits types are supported %1%", field);
+            ::error(ErrorType::ERR_UNSUPPORTED, "Unsupported field type: %1%", field->type);
             return;
         }
         const int width = fieldType->width_bits();
@@ -360,7 +360,7 @@ void InternetChecksumAlgorithm::emitClear(CodeBuilder* builder) {
 }
 
 void InternetChecksumAlgorithm::emitAddData(CodeBuilder* builder,
-                                            const argumentsList & arguments) {
+                                            const ArgumentsList & arguments) {
     updateChecksum(builder, arguments, true);
 }
 
@@ -369,7 +369,7 @@ void InternetChecksumAlgorithm::emitGet(CodeBuilder* builder) {
 }
 
 void InternetChecksumAlgorithm::emitSubtractData(CodeBuilder* builder,
-                                                 const argumentsList & arguments) {
+                                                 const ArgumentsList & arguments) {
     updateChecksum(builder, arguments, false);
 }
 
@@ -377,7 +377,6 @@ void InternetChecksumAlgorithm::emitGetInternalState(CodeBuilder* builder) {
     builder->append(stateVar);
 }
 
-// FIXME: works for constant value, but might not for other cases
 void InternetChecksumAlgorithm::emitSetInternalState(CodeBuilder* builder,
                                                      const IR::MethodCallExpression * expr) {
     if (expr->arguments->size() != 1) {

--- a/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.h
+++ b/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.h
@@ -64,6 +64,8 @@ class EBPFHashAlgorithmPSA : public EBPFObject {
     virtual void emitAddData(CodeBuilder* builder, const argumentsList & arguments) = 0;
     virtual void emitGet(CodeBuilder* builder) = 0;
 
+    virtual void emitSubtractData(CodeBuilder* builder, int dataPos,
+                                  const IR::MethodCallExpression * expr);
     virtual void emitSubtractData(CodeBuilder* builder, const argumentsList & arguments) = 0;
 
     virtual void emitGetInternalState(CodeBuilder* builder) = 0;
@@ -149,6 +151,34 @@ class CRC32ChecksumAlgorithm : public CRCChecksumAlgorithm {
     static void emitGlobals(CodeBuilder* builder);
 };
 
+class InternetChecksumAlgorithm : public EBPFHashAlgorithmPSA {
+ protected:
+    cstring stateVar;
+
+    void updateChecksum(CodeBuilder* builder, const argumentsList & arguments, bool addData);
+
+ public:
+    InternetChecksumAlgorithm(const EBPFProgram* program, cstring name)
+            : EBPFHashAlgorithmPSA(program, name) {}
+
+    unsigned getOutputWidth() const override
+    { return 16; }
+
+    static void emitGlobals(CodeBuilder* builder);
+
+    void emitVariables(CodeBuilder* builder, const IR::Declaration_Instance* decl) override;
+
+    void emitClear(CodeBuilder* builder) override;
+    void emitAddData(CodeBuilder* builder, const argumentsList & arguments) override;
+    void emitGet(CodeBuilder* builder) override;
+
+    void emitSubtractData(CodeBuilder* builder, const argumentsList & arguments) override;
+
+    void emitGetInternalState(CodeBuilder* builder) override;
+    void emitSetInternalState(CodeBuilder* builder,
+                              const IR::MethodCallExpression * expr) override;
+};
+
 class EBPFHashAlgorithmTypeFactoryPSA {
  public:
     static EBPFHashAlgorithmTypeFactoryPSA * instance() {
@@ -161,6 +191,9 @@ class EBPFHashAlgorithmTypeFactoryPSA {
             return new CRC32ChecksumAlgorithm(program, name);
         else if (type == EBPFHashAlgorithmPSA::HashAlgorithm::CRC16)
             return new CRC16ChecksumAlgorithm(program, name);
+        else if (type == EBPFHashAlgorithmPSA::HashAlgorithm::ONES_COMPLEMENT16 ||
+                type == EBPFHashAlgorithmPSA::HashAlgorithm::TARGET_DEFAULT)
+            return new InternetChecksumAlgorithm(program, name);
 
         return nullptr;
     }
@@ -168,6 +201,7 @@ class EBPFHashAlgorithmTypeFactoryPSA {
     void emitGlobals(CodeBuilder* builder) {
         CRC16ChecksumAlgorithm::emitGlobals(builder);
         CRC32ChecksumAlgorithm::emitGlobals(builder);
+        InternetChecksumAlgorithm::emitGlobals(builder);
     }
 };
 

--- a/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.h
+++ b/backends/ebpf/psa/externs/ebpfPsaHashAlgorithm.h
@@ -25,14 +25,14 @@ class EBPFProgram;
 
 class EBPFHashAlgorithmPSA : public EBPFObject {
  public:
-    typedef std::vector<const IR::Expression *> argumentsList;
+    typedef std::vector<const IR::Expression *> ArgumentsList;
 
  protected:
     cstring baseName;
     const EBPFProgram* program;
     Visitor * visitor;
 
-    argumentsList unpackArguments(const IR::MethodCallExpression * expr, int dataPos);
+    ArgumentsList unpackArguments(const IR::MethodCallExpression * expr, int dataPos);
 
  public:
     // keep this enum in sync with psa.p4 file
@@ -61,12 +61,12 @@ class EBPFHashAlgorithmPSA : public EBPFObject {
     virtual void emitClear(CodeBuilder* builder) = 0;
     virtual void emitAddData(CodeBuilder* builder, int dataPos,
                              const IR::MethodCallExpression * expr);
-    virtual void emitAddData(CodeBuilder* builder, const argumentsList & arguments) = 0;
+    virtual void emitAddData(CodeBuilder* builder, const ArgumentsList & arguments) = 0;
     virtual void emitGet(CodeBuilder* builder) = 0;
 
     virtual void emitSubtractData(CodeBuilder* builder, int dataPos,
                                   const IR::MethodCallExpression * expr);
-    virtual void emitSubtractData(CodeBuilder* builder, const argumentsList & arguments) = 0;
+    virtual void emitSubtractData(CodeBuilder* builder, const ArgumentsList & arguments) = 0;
 
     virtual void emitGetInternalState(CodeBuilder* builder) = 0;
     virtual void emitSetInternalState(CodeBuilder* builder,
@@ -94,10 +94,10 @@ class CRCChecksumAlgorithm : public EBPFHashAlgorithmPSA {
     void emitVariables(CodeBuilder* builder, const IR::Declaration_Instance* decl) override;
 
     void emitClear(CodeBuilder* builder) override;
-    void emitAddData(CodeBuilder* builder, const argumentsList & arguments) override;
+    void emitAddData(CodeBuilder* builder, const ArgumentsList & arguments) override;
     void emitGet(CodeBuilder* builder) override;
 
-    void emitSubtractData(CodeBuilder* builder, const argumentsList & arguments) override;
+    void emitSubtractData(CodeBuilder* builder, const ArgumentsList & arguments) override;
 
     void emitGetInternalState(CodeBuilder* builder) override;
     void emitSetInternalState(CodeBuilder* builder,
@@ -155,7 +155,7 @@ class InternetChecksumAlgorithm : public EBPFHashAlgorithmPSA {
  protected:
     cstring stateVar;
 
-    void updateChecksum(CodeBuilder* builder, const argumentsList & arguments, bool addData);
+    void updateChecksum(CodeBuilder* builder, const ArgumentsList & arguments, bool addData);
 
  public:
     InternetChecksumAlgorithm(const EBPFProgram* program, cstring name)
@@ -169,10 +169,10 @@ class InternetChecksumAlgorithm : public EBPFHashAlgorithmPSA {
     void emitVariables(CodeBuilder* builder, const IR::Declaration_Instance* decl) override;
 
     void emitClear(CodeBuilder* builder) override;
-    void emitAddData(CodeBuilder* builder, const argumentsList & arguments) override;
+    void emitAddData(CodeBuilder* builder, const ArgumentsList & arguments) override;
     void emitGet(CodeBuilder* builder) override;
 
-    void emitSubtractData(CodeBuilder* builder, const argumentsList & arguments) override;
+    void emitSubtractData(CodeBuilder* builder, const ArgumentsList & arguments) override;
 
     void emitGetInternalState(CodeBuilder* builder) override;
     void emitSetInternalState(CodeBuilder* builder,

--- a/backends/ebpf/tests/p4testdata/common_headers.p4
+++ b/backends/ebpf/tests/p4testdata/common_headers.p4
@@ -48,3 +48,11 @@ header mpls_t {
     bit<8>  ttl;
 }
 
+header udp_t
+{
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<16> length;
+    bit<16> checksum;
+}
+

--- a/backends/ebpf/tests/p4testdata/internet-checksum.p4
+++ b/backends/ebpf/tests/p4testdata/internet-checksum.p4
@@ -1,0 +1,194 @@
+/*
+Copyright 2022-present Orange
+Copyright 2022-present Open Networking Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+header clone_i2e_metadata_t {
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> checksum;
+    bit<16> state;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    udp_t      udp;
+}
+
+parser IngressParserImpl(
+    packet_in buffer,
+    out headers parsed_hdr,
+    inout metadata user_meta,
+    in psa_ingress_parser_input_metadata_t istd,
+    in empty_metadata_t resubmit_meta,
+    in empty_metadata_t recirculate_meta)
+{
+    InternetChecksum() ck;
+
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        ck.clear();
+        ck.add({
+            /* 16-bit word 0 */     parsed_hdr.ipv4.version, parsed_hdr.ipv4.ihl, parsed_hdr.ipv4.diffserv,
+            /* 16-bit word 1 */     parsed_hdr.ipv4.totalLen,
+            /* 16-bit word 2 */     parsed_hdr.ipv4.identification,
+            /* 16-bit word 3 */     parsed_hdr.ipv4.flags, parsed_hdr.ipv4.fragOffset,
+            /* 16-bit word 4 */     parsed_hdr.ipv4.ttl, parsed_hdr.ipv4.protocol,
+            /* 16-bit word 5 skip parsed_hdr.ipv4.hdrChecksum, */
+            /* 16-bit words 6-7 */  parsed_hdr.ipv4.srcAddr,
+            /* 16-bit words 8-9 */  parsed_hdr.ipv4.dstAddr
+            });
+        parsed_hdr.ipv4.hdrChecksum = ck.get_state();
+        transition accept;
+    }
+}
+
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in  psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    apply {
+        send_to_port(ostd, (PortId_t) 5);
+    }
+}
+
+control IngressDeparserImpl(
+    packet_out packet,
+    out clone_i2e_metadata_t clone_i2e_meta,
+    out empty_metadata_t resubmit_meta,
+    out metadata normal_meta,
+    inout headers parsed_hdr,
+    in metadata meta,
+    in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(parsed_hdr.ethernet);
+        packet.emit(parsed_hdr.ipv4);
+    }
+}
+
+parser EgressParserImpl(
+    packet_in buffer,
+    out headers parsed_hdr,
+    inout metadata user_meta,
+    in psa_egress_parser_input_metadata_t istd,
+    in metadata normal_meta,
+    in clone_i2e_metadata_t clone_i2e_meta,
+    in empty_metadata_t clone_e2e_meta)
+{
+    InternetChecksum() ck;
+
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        buffer.extract(parsed_hdr.ethernet);
+        transition parse_ipv4;
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+
+        ck.set_state(parsed_hdr.ipv4.hdrChecksum);
+        ck.subtract({/* 16-bit word 4 */    parsed_hdr.ipv4.ttl, parsed_hdr.ipv4.protocol,
+                     /* 16-bit words 6-7 */ parsed_hdr.ipv4.srcAddr});
+        parsed_hdr.ipv4.hdrChecksum = ck.get_state();
+
+        transition select(parsed_hdr.ipv4.protocol) {
+            0x11: parse_udp;
+            default: accept;
+        }
+    }
+    state parse_udp {
+        buffer.extract(parsed_hdr.udp);
+        ck.clear();
+        ck.subtract(parsed_hdr.udp.checksum);
+        // remove fields from IP pseudo-header (protocol or packet length will not be changed)
+        ck.subtract({parsed_hdr.ipv4.srcAddr, parsed_hdr.ipv4.dstAddr});
+        parsed_hdr.udp.checksum = ck.get();
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in  psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply {
+        ostd.drop = false;
+        hdr.ipv4.ttl = hdr.ipv4.ttl - 2;
+
+        if (hdr.udp.isValid()){
+            hdr.ipv4.srcAddr = 32w0x0a_00_00_01;
+        }
+    }
+}
+
+control EgressDeparserImpl(
+    packet_out packet,
+    out empty_metadata_t clone_e2e_meta,
+    out empty_metadata_t recirculate_meta,
+    inout headers parsed_hdr,
+    in metadata meta,
+    in psa_egress_output_metadata_t istd,
+    in psa_egress_deparser_input_metadata_t edstd)
+{
+    InternetChecksum() ck;
+    apply {
+        ck.set_state(parsed_hdr.ipv4.hdrChecksum);
+        ck.add({/* 16-bit word 4 */    parsed_hdr.ipv4.ttl, parsed_hdr.ipv4.protocol,
+                /* 16-bit words 6-7 */ parsed_hdr.ipv4.srcAddr});
+        parsed_hdr.ipv4.hdrChecksum = ck.get();
+
+        ck.clear();
+        ck.subtract(parsed_hdr.udp.checksum);
+        ck.add({parsed_hdr.ipv4.srcAddr, parsed_hdr.ipv4.dstAddr});
+        parsed_hdr.udp.checksum = ck.get();
+
+        packet.emit(parsed_hdr.ethernet);
+        packet.emit(parsed_hdr.ipv4);
+        packet.emit(parsed_hdr.udp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/ptf/checksum.py
+++ b/backends/ebpf/tests/ptf/checksum.py
@@ -29,3 +29,36 @@ class ChecksumCRC16MultipleUpdatesPSATest(P4EbpfTest):
         exp_pkt = Ether() / bytes.fromhex('313233343536373839 BB3D')
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet_any_port(self, exp_pkt, ALL_PORTS)
+
+
+class InternetChecksumPSATest(P4EbpfTest):
+    """
+    Test if checksum in IP header (or any other using Ones Complement algorithm)
+    is computed correctly.
+    1. Generate IP packet with random values in header.
+    2. Verify that packet is forwarded. Data plane will decrement TTL twice and change
+     source IP address.
+    """
+
+    p4_file_path = "p4testdata/internet-checksum.p4"
+
+    def random_ip(self):
+        return ".".join(str(random.randint(0, 255)) for _ in range(4))
+
+    def runTest(self):
+        for _ in range(1):
+            # test checksum computation
+            pkt = testutils.simple_udp_packet(pktlen=random.randint(100, 512),
+                                              ip_src=self.random_ip(),
+                                              ip_dst=self.random_ip(),
+                                              ip_ttl=random.randint(3, 255),
+                                              ip_id=random.randint(0, 0xFFFF))
+
+            pkt[IP].flags = random.randint(0, 7)
+            pkt[IP].frag = random.randint(0, 0x1FFF)
+            testutils.send_packet(self, PORT0, pkt)
+            pkt[IP].ttl = pkt[IP].ttl - 2
+            pkt[IP].src = '10.0.0.1'
+            pkt[IP].chksum = None
+            pkt[UDP].chksum = None
+            testutils.verify_packet_any_port(self, pkt, ALL_PORTS)


### PR DESCRIPTION
This PR adds InternetChecksum extern.

Co-authored-by: Tomasz Osiński <tomasz@opennetworking.org>
Co-authored-by: Jan Palimąka <jan.palimaka@orange.com>