### PR TITLE
Add support for DirectCounter extern to PSA/eBPF backend

### DIFF
--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -205,6 +205,7 @@ void EBPFTable::emitValueType(CodeBuilder* builder) {
     builder->blockStart();
 
     emitValueStructStructure(builder);
+    emitDirectTypes(builder);
 
     builder->blockEnd(false);
     builder->endOfStatement(true);

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -205,7 +205,7 @@ void EBPFTable::emitValueType(CodeBuilder* builder) {
     builder->blockStart();
 
     emitValueStructStructure(builder);
-    emitDirectTypes(builder);
+    emitDirectValueTypes(builder);
 
     builder->blockEnd(false);
     builder->endOfStatement(true);

--- a/backends/ebpf/ebpfTable.h
+++ b/backends/ebpf/ebpfTable.h
@@ -104,6 +104,7 @@ class EBPFTable : public EBPFTableBase {
     virtual void emitValueType(CodeBuilder* builder);
     virtual void emitValueActionIDNames(CodeBuilder* builder);
     virtual void emitValueStructStructure(CodeBuilder* builder);
+    virtual void emitDirectTypes(CodeBuilder* builder) { (void) builder; }
     virtual void emitAction(CodeBuilder* builder, cstring valueName, cstring actionRunVariable);
     virtual void emitInitializer(CodeBuilder* builder);
     virtual void emitLookup(CodeBuilder* builder, cstring key, cstring value) {

--- a/backends/ebpf/ebpfTable.h
+++ b/backends/ebpf/ebpfTable.h
@@ -104,7 +104,8 @@ class EBPFTable : public EBPFTableBase {
     virtual void emitValueType(CodeBuilder* builder);
     virtual void emitValueActionIDNames(CodeBuilder* builder);
     virtual void emitValueStructStructure(CodeBuilder* builder);
-    virtual void emitDirectTypes(CodeBuilder* builder) { (void) builder; }
+    // Emits value types used by direct externs.
+    virtual void emitDirectValueTypes(CodeBuilder* builder) { (void) builder; }
     virtual void emitAction(CodeBuilder* builder, cstring valueName, cstring actionRunVariable);
     virtual void emitInitializer(CodeBuilder* builder);
     virtual void emitLookup(CodeBuilder* builder, cstring key, cstring value) {

--- a/backends/ebpf/psa/ebpfPsaControl.h
+++ b/backends/ebpf/psa/ebpfPsaControl.h
@@ -33,8 +33,12 @@ class ControlBodyTranslatorPSA : public ControlBodyTranslator {
 
 class ActionTranslationVisitorPSA : public ActionTranslationVisitor,
                                     public ControlBodyTranslatorPSA {
+ protected:
+    const EBPFTablePSA* table;
+
  public:
-    ActionTranslationVisitorPSA(const EBPFProgram* program, cstring valueName);
+    ActionTranslationVisitorPSA(const EBPFProgram* program, cstring valueName,
+                                const EBPFTablePSA* table);
 
     bool preorder(const IR::PathExpression* pe) override;
     bool isActionParameter(const IR::Expression *expression) const;

--- a/backends/ebpf/psa/ebpfPsaGen.cpp
+++ b/backends/ebpf/psa/ebpfPsaGen.cpp
@@ -627,6 +627,9 @@ bool ConvertToEBPFControlPSA::preorder(const IR::ExternBlock* instance) {
     } else if (typeName == "Counter") {
         auto ctr = new EBPFCounterPSA(program, di, name, control->codeGen);
         control->counters.emplace(name, ctr);
+    } else if (typeName == "DirectCounter") {
+        // instance will be created by table
+        return false;
     } else {
         ::error(ErrorType::ERR_UNEXPECTED, "Unexpected block %s nested within control",
                 instance);

--- a/backends/ebpf/psa/ebpfPsaTable.cpp
+++ b/backends/ebpf/psa/ebpfPsaTable.cpp
@@ -223,7 +223,7 @@ void EBPFTablePSA::emitTypes(CodeBuilder* builder) {
  * Order of emitting counters and meters affects generated layout of BPF map value.
  * Do not change this order!
  */
-void EBPFTablePSA::emitDirectTypes(CodeBuilder* builder) {
+void EBPFTablePSA::emitDirectValueTypes(CodeBuilder* builder) {
     for (auto ctr : counters) {
         ctr.second->emitValueType(builder);
     }

--- a/backends/ebpf/psa/ebpfPsaTable.cpp
+++ b/backends/ebpf/psa/ebpfPsaTable.cpp
@@ -123,6 +123,12 @@ void EBPFTablePSA::initDirectCounters() {
         auto decl = program->refMap->getDeclaration(pe->path, true);
         auto di = decl->to<IR::Declaration_Instance>();
         CHECK_NULL(di);
+        auto ts = di->type->to<IR::Type_Specialized>();
+        if (ts == nullptr || ts->baseType->toString() != "DirectCounter") {
+            ::error(ErrorType::ERR_UNEXPECTED,
+                    "%1%: not a DirectCounter, see declaration of %2%", pe, decl);
+            return;
+        }
         auto counterName = EBPFObject::externalName(di);
         auto ctr = new EBPFCounterPSA(program, di, counterName, codeGen);
         this->counters.emplace_back(std::make_pair(counterName, ctr));

--- a/backends/ebpf/psa/ebpfPsaTable.cpp
+++ b/backends/ebpf/psa/ebpfPsaTable.cpp
@@ -84,7 +84,7 @@ void ActionTranslationVisitorPSA::processMethod(const P4::ExternMethod* method) 
             ctr->emitDirectMethodInvocation(builder, method, valueName);
         else
             ::error(ErrorType::ERR_NOT_FOUND,
-                    "%1%: Table %2% do not own DirectCounter named %3%",
+                    "%1%: Table %2% does not own DirectCounter named %3%",
                     method->expr, table->table->container, instanceName);
     } else {
         ControlBodyTranslatorPSA::processMethod(method);
@@ -220,7 +220,7 @@ void EBPFTablePSA::emitTypes(CodeBuilder* builder) {
 }
 
 /**
- * Remember that order of emitting counters and meters affects future access to BPF maps.
+ * Order of emitting counters and meters affects generated layout of BPF map value.
  * Do not change this order!
  */
 void EBPFTablePSA::emitDirectTypes(CodeBuilder* builder) {

--- a/backends/ebpf/psa/ebpfPsaTable.h
+++ b/backends/ebpf/psa/ebpfPsaTable.h
@@ -66,7 +66,7 @@ class EBPFTablePSA : public EBPFTable {
     void emitValueStructStructure(CodeBuilder* builder) override;
     void emitAction(CodeBuilder* builder, cstring valueName, cstring actionRunVariable) override;
     void emitInitializer(CodeBuilder* builder) override;
-    void emitDirectTypes(CodeBuilder* builder) override;
+    void emitDirectValueTypes(CodeBuilder* builder) override;
     void emitLookup(CodeBuilder* builder, cstring key, cstring value) override;
     void emitLookupDefault(CodeBuilder* builder, cstring key, cstring value) override;
     bool dropOnNoMatchingEntryFound() const override;

--- a/backends/ebpf/psa/externs/ebpfPsaCounter.h
+++ b/backends/ebpf/psa/externs/ebpfPsaCounter.h
@@ -27,6 +27,7 @@ class EBPFCounterPSA : public EBPFCounterTable {
  protected:
     EBPFType* dataplaneWidthType;
     EBPFType* indexWidthType;
+    bool isDirect;
 
  public:
     enum CounterType {
@@ -44,9 +45,12 @@ class EBPFCounterPSA : public EBPFCounterTable {
     void emitTypes(CodeBuilder* builder) override;
     virtual void emitKeyType(CodeBuilder* builder);
     virtual void emitValueType(CodeBuilder* builder);
+    void emitInstance(CodeBuilder* builder) override;
 
     void emitMethodInvocation(CodeBuilder* builder, const P4::ExternMethod* method,
                               CodeGenInspector* codeGen);
+    void emitDirectMethodInvocation(CodeBuilder* builder, const P4::ExternMethod* method,
+                                    cstring valuePtr);
     virtual void emitCount(CodeBuilder* builder, const IR::MethodCallExpression *expression,
                            CodeGenInspector* codeGen);
     virtual void emitCounterUpdate(CodeBuilder* builder, cstring target, cstring keyName);


### PR DESCRIPTION
This PR adds the support for DirectCounter extern to PSA/eBPF backend.

Co-authored-by: Tomasz Osiński <tomasz@opennetworking.org>
Co-authored-by: Mateusz Kossakowski <mateusz.kossakowski@orange.com>