### PR TITLE
DPDK Backend: Minor fix to emit target_action_name in context json

### DIFF
--- a/backends/dpdk/DPDK_context_schema.json
+++ b/backends/dpdk/DPDK_context_schema.json
@@ -24,7 +24,11 @@
          "properties": {
             "action_name": {
                "type": "string",
-               "description": "Name of the action"
+               "description": "Name of the action as in P4 file"
+            },
+            "target_action_name": {
+               "type": "string",
+               "description": "Name of the action as in spec file"
             },
             "action_handle": {
                "type": "integer",

--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -221,9 +221,15 @@ DpdkContextGenerator::addMatchAttributes(const IR::P4Table*table, const cstring 
         auto* oneAction = new Util::JsonObject();
         struct actionAttributes attr = ::get(actionAttrMap, action->getName());
         auto actName = toStr(action->expression);
-        if (actName != "NoAction")
+        auto name = action->externalName();
+        if (name != "NoAction") {
             actName = ctrlName + "." + actName;
-        oneAction->emplace("action_name", actName);
+            name = ctrlName + "." + name;
+        } else {
+            actName = name;
+        }
+        oneAction->emplace("action_name", name);
+        oneAction->emplace("target_action_name", actName);
         oneAction->emplace("action_handle", attr.actionHandle);
         auto* immFldArray = new Util::JsonArray();
         if (attr.params) {
@@ -271,7 +277,7 @@ const IR::P4Table * table, const cstring controlName, bool isMatch) {
         // Printing compiler added actions is curently not required
         if (!attr.is_compiler_added_action) {
             auto *act = new Util::JsonObject();
-            auto actName = toStr(action->expression);
+            auto actName = action->externalName();
 
             // NoAction is not prefixed with control block name
             if (actName != "NoAction")


### PR DESCRIPTION
This PR is to add a new field to context json. This field holds the unique internal name of the actions .This name should be same as the action name in output spec file.

Context json would now contain two fields for the action name, one name is the externalName and should be same as in bfrt json file and another name "target_action_name" should be same as the name in the spec file.

NoAction is handled in special manner to always use the externalName().

Note: Context json files are not part of the repo, hence attaching the patch to show the change. Also attaching bfrt.json and spec file for reference.
[pna-example-tunnel.p4.bfrt.json.txt](https://github.com/p4lang/p4c/files/8478943/pna-example-tunnel.p4.bfrt.json.txt)
[pna-example-tunnel.p4.spec.txt](https://github.com/p4lang/p4c/files/8478944/pna-example-tunnel.p4.spec.txt)
[Report.txt](https://github.com/p4lang/p4c/files/8478945/Report.txt)
