### PR TITLE
Add check of uniqueness of control plane names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ include_directories (
   ${P4C_SOURCE_DIR}/extensions
   ${P4C_SOURCE_DIR}
   ${P4C_SOURCE_DIR}/test/frameworks/gtest/googletest/include
+  ${P4C_SOURCE_DIR}/test/frameworks/gtest/googlemock/include
   ${P4C_BINARY_DIR}
   )
 add_definitions (-DCONFIG_PREFIX="${CMAKE_INSTALL_PREFIX}")

--- a/frontends/p4/hierarchicalNames.cpp
+++ b/frontends/p4/hierarchicalNames.cpp
@@ -27,14 +27,25 @@ const IR::Node* HierarchicalNames::postorder(IR::Annotation* annotation) {
         return annotation;
 
     cstring name = annotation->getName();
-    if (name.startsWith("."))
-        return annotation;
-    cstring newName = "";
-    for (cstring s : stack)
-        newName += s + ".";
-    newName += name;
-    LOG2("Changing " << name << " to " << newName);
-    annotation = new IR::Annotation(annotation->name, newName);
+    if (!name.startsWith(".")) {
+        cstring newName = "";
+        for (cstring s : stack)
+            newName += s + ".";
+        newName += name;
+        LOG2("Changing " << name << " to " << newName);
+        annotation = new IR::Annotation(annotation->name, newName);
+        name = newName;
+    }
+    // The node the annotation belongs to
+    CHECK_NULL(getContext()->parent);
+    auto *annotatedNode = getContext()->parent->node;
+    CHECK_NULL(annotatedNode);
+    if (annotatedNodes.count(name)) {
+        error(ErrorType::ERR_DUPLICATE, "%1%: " ERR_STR_DUPLICATED_NAME ": %2%",
+            annotatedNode, annotatedNodes[name]);
+    } else {
+        annotatedNodes[name] = annotatedNode;
+    }
     return annotation;
 }
 

--- a/frontends/p4/hierarchicalNames.h
+++ b/frontends/p4/hierarchicalNames.h
@@ -21,6 +21,8 @@ limitations under the License.
 
 namespace P4 {
 
+#define ERR_STR_DUPLICATED_NAME "conflicting control plane name"
+
 /**
  * This transform will adjust the @name annotations on objects
  * to reflect their position in the hierarchy.  Only relative names
@@ -53,9 +55,12 @@ control c() {
 This pass should be run after inlining.  It assumes that all
 externally-visible objects already have @name annotations -- this is
 done by the UniqueNames front-end pass.
+The pass also checks the uniqueness of the control plane names.
 */
 class HierarchicalNames : public Transform {
     std::vector<cstring> stack;
+    /// Used for detection of conflicting control plane names
+    std::map<cstring, const IR::Node *> annotatedNodes;
  public:
     cstring getName(const IR::IDeclaration* decl);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/helpers.cpp
   gtest/json_test.cpp
   gtest/midend_test.cpp
+  gtest/name_duplicated.cpp
   gtest/opeq_test.cpp
   gtest/ordered_map.cpp
   gtest/ordered_set.cpp

--- a/test/gtest/name_duplicated.cpp
+++ b/test/gtest/name_duplicated.cpp
@@ -1,0 +1,88 @@
+#include "gtest/gtest.h"
+#include "test/gtest/helpers.h"
+#include "gmock/gmock.h"
+
+#include "frontends/p4/hierarchicalNames.h"
+
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/optional.hpp>
+
+namespace Test {
+
+namespace {
+
+boost::optional<FrontendTestCase>
+createTestCase(const std::string& ingress) {
+    auto source = P4_SOURCE(R"(
+control CC();
+package P(CC cc);
+%INGRESS%
+P(C()) main;
+)");
+    boost::replace_first(source, "%INGRESS%", ingress);
+    return FrontendTestCase::create(source);
+}
+
+class P4C_NameDuplicated : public P4CTest {
+    std::ostream* org;
+ public:
+    std::stringstream err;
+
+    void SetUp() {
+        org = BaseCompileContext::get().errorReporter().getOutputStream();
+        BaseCompileContext::get().errorReporter().setOutputStream(&err);
+    }
+
+    void TearDown() {
+        BaseCompileContext::get().errorReporter().setOutputStream(org);
+        err.clear();
+    }
+};
+
+TEST_F(P4C_NameDuplicated, LocalOk) {
+    auto test = createTestCase(P4_SOURCE(R"(
+control C2() {
+    @name("a") action a2() {}
+    apply { a2(); }
+}
+control C() {
+    @name("a") action a1() {}
+    apply { C2.apply(); a1(); }
+})"));
+
+    EXPECT_TRUE(test);
+    EXPECT_EQ(0u, ::errorCount());
+}
+
+TEST_F(P4C_NameDuplicated, LocalDuplicated) {
+    auto test = createTestCase(P4_SOURCE(R"(
+control C() {
+    @name("a") action a1() {}
+    @name("a") action a2() {}
+    apply { a1(); a2(); }
+})"));
+
+    EXPECT_FALSE(test);
+    EXPECT_EQ(::errorCount(), 1u);
+    EXPECT_THAT(err.str(), testing::HasSubstr(ERR_STR_DUPLICATED_NAME));
+}
+
+TEST_F(P4C_NameDuplicated, GlobalDuplicated) {
+    auto test = createTestCase(P4_SOURCE(R"(
+control C2() {
+    @name(".a") action a2() {}
+    apply { a2(); }
+}
+control C() {
+    @name(".a") action a1() {}
+    apply { C2.apply(); a1(); }
+})"));
+
+    EXPECT_FALSE(test);
+    EXPECT_EQ(::errorCount(), 1u);
+    EXPECT_THAT(err.str(), testing::HasSubstr(ERR_STR_DUPLICATED_NAME));
+}
+
+}
+
+}  // namespace Test


### PR DESCRIPTION
[Control plane names](https://p4.org/p4-spec/docs/P4-16-v1.2.2.html#sec-control-plane-api-annotations) are not checked for uniqueness. It may lead to various issues in subsequent passes when uniqueness is assumed.