### PR TITLE
Point to PSA/eBPF implementation in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ The code contains five sample backends:
   the BMv2 behavioral model https://github.com/p4lang/behavioral-model,
 * p4c-dpdk: can be used to target the DPDK software switch (SWX) pipeline
   https://doc.dpdk.org/guides/rel_notes/release_20_11.html,
-* p4c-ebpf: can be used to generate C code which can be compiled to eBPF
-  https://en.wikipedia.org/wiki/Berkeley_Packet_Filter and then loaded
-  in the Linux kernel for packet filtering,
+* p4c-ebpf: can be used to generate C code which can be compiled to [eBPF](https://en.wikipedia.org/wiki/Berkeley_Packet_Filter)
+  and then loaded in the Linux kernel. The eBPF backend currently implements two architecture models:
+  [ebpf_model.p4 for packet filtering](./backends/ebpf/README.md) and [the fully-featured PSA (Portable Switch Architecture) model](./backends/ebpf/psa/README.md). 
 * p4test: a source-to-source P4 translator which can be used for
   testing, learning compiler internals and debugging,
 * p4c-graphs: can be used to generate visual representations of a P4 program;
   for now it only supports generating graphs of top-level control flows, and
-* p4c-ubfp: can be used to generate eBPF code that runs in user-space.
+* p4c-ubpf: can be used to generate eBPF code that runs in user-space.
 
 Sample command lines:
 


### PR DESCRIPTION
This PR modifies the main README to point to the PSA implementation for eBPF. 

Also, it fixes a typo in the p4c-ubpf. 