### PR TITLE
Improve padding calculation in eBPF parser

### DIFF
--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -401,7 +401,11 @@ StateTranslationVisitor::compileExtract(const IR::Expression* destination) {
         auto etype = EBPFTypeFactory::instance->create(ftype);
         if (etype->is<EBPFScalarType>()) {
             auto scalarType = etype->to<EBPFScalarType>();
-            unsigned padding = scalarType->alignment() * 8 - scalarType->widthInBits();
+            unsigned readWordSize = scalarType->alignment() * 8;
+            unsigned unaligned = scalarType->widthInBits() % readWordSize;
+            unsigned padding = readWordSize - unaligned;
+            if (padding == readWordSize)
+                padding = 0;
             if (scalarType->widthInBits() + padding >= curr_padding) {
                 curr_padding = padding;
             }


### PR DESCRIPTION
This PR improves padding calculation in eBPF parser. 

@mbudiu-vmw please verify if this patch fixes tests for p4c-xdp.

CC: @osinstom @kmateuszssak 