### PR TITLE
Allow specialized types for direct control/parser invocations

### DIFF
--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -138,13 +138,15 @@ Util::IJson* ExternConverter_clone::convertExternFunction(
     if (ei->name == "I2E") {
         prim = "clone_ingress_pkt_to_egress";
         if (ctxt->blockConverted != BlockConverted::Ingress) {
-            ::error("'clone(I2E, ...) not invoked in ingress %1%", mc);
+            ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
+                    "'clone(I2E, ...) not invoked in ingress %1%", mc);
             return nullptr;
         }
     } else {
         prim = "clone_egress_pkt_to_egress";
         if (ctxt->blockConverted != BlockConverted::Egress) {
-            ::error("'clone(E2E, ...) not invoked in egress %1%", mc);
+            ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
+                    "'clone(E2E, ...) not invoked in egress %1%", mc);
             return nullptr;
         }
     }
@@ -208,13 +210,15 @@ Util::IJson* ExternConverter_clone_preserving_field_list::convertExternFunction(
     if (ei->name == "I2E") {
         prim = "clone_ingress_pkt_to_egress";
         if (ctxt->blockConverted != BlockConverted::Ingress) {
-            ::error("'clone_preserving_field_list(I2E, ...) not invoked in ingress %1%", mc);
+            ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
+                    "'clone_preserving_field_list(I2E, ...) not invoked in ingress %1%", mc);
             return nullptr;
         }
     } else {
         prim = "clone_egress_pkt_to_egress";
         if (ctxt->blockConverted != BlockConverted::Egress) {
-            ::error("'clone_preserving_field_list(E2E, ...) not invoked in egress %1%", mc);
+            ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
+                    "'clone_preserving_field_list(E2E, ...) not invoked in egress %1%", mc);
             return nullptr;
         }
     }
@@ -321,7 +325,8 @@ Util::IJson* ExternConverter_resubmit_preserving_field_list::convertExternFuncti
     const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
     UNUSED const bool emitExterns) {
     if (ctxt->blockConverted != BlockConverted::Ingress) {
-        ::error("'resubmit' can only be invoked in ingress %1%", mc);
+        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
+                "'resubmit' can only be invoked in ingress %1%", mc);
         return nullptr;
     }
     if (mc->arguments->size() == 1) {
@@ -351,7 +356,8 @@ Util::IJson* ExternConverter_recirculate_preserving_field_list::convertExternFun
     const IR::MethodCallExpression* mc, UNUSED const IR::StatOrDecl* s,
     UNUSED const bool emitExterns) {
     if (ctxt->blockConverted != BlockConverted::Egress) {
-        ::error("'resubmit' can only be invoked in egress %1%", mc);
+        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
+                "'resubmit' can only be invoked in egress %1%", mc);
         return nullptr;
     }
     if (mc->arguments->size() == 1) {
@@ -1034,7 +1040,8 @@ SimpleSwitchBackend::createRecirculateFieldsList(
         for (auto e : anno->expr) {
             auto cst = e->to<IR::Constant>();
             if (cst == nullptr) {
-                ::error("%1%: Annotation must be a constant integer", e);
+                ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
+                        "%1%: Annotation must be a constant integer", e);
                 continue;
             }
 

--- a/backends/dpdk/control-plane/bfruntime_arch_handler.h
+++ b/backends/dpdk/control-plane/bfruntime_arch_handler.h
@@ -96,7 +96,8 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
     void forAllPipeBlocks(const IR::ToplevelBlock* evaluatedProgram, Func function) {
         auto main = evaluatedProgram->getMain();
         if (!main)
-            ::error("Program does not contain a `main` module");
+            ::error(ErrorType::ERR_NOT_FOUND,
+                    "Program does not contain a `main` module");
         auto cparams = main->getConstructorParameters();
         int index = -1;
         for (auto param : main->constantValue) {

--- a/backends/dpdk/control-plane/bfruntime_ext.cpp
+++ b/backends/dpdk/control-plane/bfruntime_ext.cpp
@@ -35,7 +35,8 @@ struct BFRuntimeSchemaGenerator::ActionSelector {
         const auto& pre = externInstance.preamble();
         ::dpdk::ActionSelector actionSelector;
         if (!externInstance.info().UnpackTo(&actionSelector)) {
-            ::error("Extern instance %1% does not pack an ActionSelector object", pre.name());
+            ::error(ErrorType::ERR_NOT_FOUND,
+                    "Extern instance %1% does not pack an ActionSelector object", pre.name());
             return boost::none;
         }
         auto selectorId = makeBFRuntimeId(pre.id(), ::dpdk::P4Ids::ACTION_SELECTOR);
@@ -167,7 +168,8 @@ BFRuntimeSchemaGenerator::addActionProfIds(const p4configv1::Table& table,
     if (implementationId > 0) {
         auto hasSelector = actProfHasSelector(implementationId);
         if (hasSelector == boost::none) {
-            ::error("Invalid implementation id in p4info: %1%", implementationId);
+            ::error(ErrorType::ERR_INVALID,
+                    "Invalid implementation id in p4info: %1%", implementationId);
             return false;
         }
         cstring tableType = "";

--- a/backends/dpdk/control-plane/bfruntime_ext.h
+++ b/backends/dpdk/control-plane/bfruntime_ext.h
@@ -77,7 +77,8 @@ class BFRuntimeSchemaGenerator : public BFRuntimeGenerator {
         const auto& pre = externInstance.preamble();
         p4configv1::ActionProfile actionProfile;
         if (!externInstance.info().UnpackTo(&actionProfile)) {
-            ::error("Extern instance %1% does not pack an ActionProfile object", pre.name());
+            ::error(ErrorType::ERR_NOT_FOUND,
+                    "Extern instance %1% does not pack an ActionProfile object", pre.name());
             return boost::none;
         }
         auto tableIds = collectTableIds(

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -655,7 +655,8 @@ class CollectExternDeclaration : public Inspector {
             auto externTypeName = type->baseType->path->name.name;
             if (externTypeName == "Meter") {
                 if (d->arguments->size() != 2) {
-                    ::error("%1%: expected number of meters and type of meter as arguments", d);
+                    ::error(ErrorType::ERR_EXPECTED,
+                            "%1%: expected number of meters and type of meter as arguments", d);
                 } else {
                     /* Check if the meter is of PACKETS (0) type */
                     if (d->arguments->at(1)->expression->to<IR::Constant>()->asUnsigned() == 0)
@@ -665,11 +666,13 @@ class CollectExternDeclaration : public Inspector {
                 }
             } else if (externTypeName == "Counter") {
                 if (d->arguments->size() != 2) {
-                    ::error("%1%: expected number of_counters and type of counter as arguments", d);
+                    ::error(ErrorType::ERR_EXPECTED,
+                            "%1%: expected number of_counters and type of counter as arguments", d);
                 }
             } else if (externTypeName == "Register") {
                 if (d->arguments->size() != 1 && d->arguments->size() != 2) {
-                    ::error("%1%: expected size and optionally init_val as arguments", d);
+                    ::error(ErrorType::ERR_EXPECTED,
+                            "%1%: expected size and optionally init_val as arguments", d);
                 }
             } else {
                 // unsupported extern type

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -667,7 +667,7 @@ class CollectExternDeclaration : public Inspector {
             } else if (externTypeName == "Counter") {
                 if (d->arguments->size() != 2) {
                     ::error(ErrorType::ERR_EXPECTED,
-                            "%1%: expected number of_counters and type of counter as arguments", d);
+                            "%1%: expected number of counters and type of counter as arguments", d);
                 }
             } else if (externTypeName == "Register") {
                 if (d->arguments->size() != 1 && d->arguments->size() != 2) {

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -734,13 +734,13 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                 add_instr(new IR::DpdkRegisterWriteStatement(reg, index, src));
             }
         } else {
-            ::error("%1%: Unknown extern function.", s);
+            ::error(ErrorType::ERR_UNKNOWN, "%1%: Unknown extern function.", s);
         }
     } else if (auto a = mi->to<P4::ExternFunction>()) {
         LOG3("extern function: " << dbp(s) << std::endl << s);
         if (a->method->name == "verify") {
             if (parser == nullptr)
-                ::error("%1%: verify must be used in parser", s);
+                ::error(ErrorType::ERR_INVALID, "%1%: verify must be used in parser", s);
             auto args = a->expr->arguments;
             auto condition = args->at(0);
             auto error_id = args->at(1);
@@ -786,7 +786,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                 add_instr(new IR::DpdkMovStatement(learnMember, param));
                 add_instr(new IR::DpdkLearnStatement(action_name, learnMember));
             } else {
-                ::error("%1%: unhandled function", s);
+                ::error(ErrorType::ERR_UNEXPECTED, "%1%: unhandled function", s);
             }
         } else if (a->method->name == "mirror_packet") {
             auto args = a->expr->arguments;
@@ -804,7 +804,8 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                       "Expected a constant for session_id param of %1%", a->method->name);
             unsigned value =  session_id->to<IR::Constant>()->asUnsigned();
             if (value == 0) {
-                ::error("Mirror session ID 0 is reserved for use by Architecture");
+                ::error(ErrorType::ERR_INVALID,
+                        "Mirror session ID 0 is reserved for use by Architecture");
                 return false;
             }
 
@@ -831,7 +832,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
         } else if (a->method->name == "drop_packet") {
             add_instr(new IR::DpdkDropStatement());
         } else {
-            ::error("%1%: Unknown extern function", s);
+            ::error(ErrorType::ERR_UNKNOWN, "%1%: Unknown extern function", s);
         }
     } else if (auto a = mi->to<P4::BuiltInMethod>()) {
         LOG3("builtin method: " << dbp(s) << std::endl << s);

--- a/backends/dpdk/dpdkProgramStructure.cpp
+++ b/backends/dpdk/dpdkProgramStructure.cpp
@@ -15,7 +15,8 @@ void ParseDpdkArchitecture::parse_pna_block(const IR::PackageBlock *block) {
     structure->p4arch = "pna";
     auto p = block->findParameterValue("main_parser");
     if (p == nullptr) {
-        ::error("Package %1% has no parameter named 'main_parser'", block);
+        ::error(ErrorType::ERR_MODEL,
+                "Package %1% has no parameter named 'main_parser'", block);
         return;
     }
     auto parser = p->to<IR::ParserBlock>();
@@ -37,20 +38,23 @@ void ParseDpdkArchitecture::parse_psa_block(const IR::PackageBlock *block) {
     structure->p4arch = "psa";
     auto pkg = block->findParameterValue("ingress");
     if (pkg == nullptr) {
-        ::error("Package %1% has no parameter named 'ingress'", block);
+        ::error(ErrorType::ERR_MODEL,
+                "Package %1% has no parameter named 'ingress'", block);
         return;
     }
     if (auto ingress = pkg->to<IR::PackageBlock>()) {
         auto p = ingress->findParameterValue("ip");
         if (!p) {
-            ::error("'ingress' package %1% has no parameter named 'ip'", block);
+            ::error(ErrorType::ERR_MODEL,
+                    "'ingress' package %1% has no parameter named 'ip'", block);
             return;
         }
         auto parser = p->to<IR::ParserBlock>();
         structure->parsers.emplace("IngressParser", parser->container);
         p = ingress->findParameterValue("ig");
         if (!p) {
-            ::error("'ingress' package %1% has no parameter named 'ig'", block);
+            ::error(ErrorType::ERR_MODEL,
+                    "'ingress' package %1% has no parameter named 'ig'", block);
             return;
         }
         auto pipeline = p->to<IR::ControlBlock>();
@@ -58,7 +62,8 @@ void ParseDpdkArchitecture::parse_psa_block(const IR::PackageBlock *block) {
         structure->pipeline_controls.emplace(pipeline->container->name);
         p = ingress->findParameterValue("id");
         if (!p) {
-            ::error("'ingress' package %1% has no parameter named 'id'", block);
+            ::error(ErrorType::ERR_MODEL,
+                    "'ingress' package %1% has no parameter named 'id'", block);
             return;
         }
         auto deparser = p->to<IR::ControlBlock>();
@@ -69,14 +74,16 @@ void ParseDpdkArchitecture::parse_psa_block(const IR::PackageBlock *block) {
     if (auto egress = pkg->to<IR::PackageBlock>()) {
         auto p = egress->findParameterValue("ep");
         if (!p) {
-            ::error("'egress' package %1% has no parameter named 'ep'", block);
+            ::error(ErrorType::ERR_MODEL,
+                    "'egress' package %1% has no parameter named 'ep'", block);
             return;
         }
         auto parser = p->to<IR::ParserBlock>();
         structure->parsers.emplace("EgressParser", parser->container);
         p = egress->findParameterValue("eg");
         if (!p) {
-            ::error("'egress' package %1% has no parameter named 'eg'", block);
+            ::error(ErrorType::ERR_MODEL,
+                    "'egress' package %1% has no parameter named 'eg'", block);
             return;
         }
         auto pipeline = p->to<IR::ControlBlock>();
@@ -84,7 +91,8 @@ void ParseDpdkArchitecture::parse_psa_block(const IR::PackageBlock *block) {
         structure->pipeline_controls.emplace(pipeline->container->name);
         p = egress->findParameterValue("ed");
         if (!p) {
-            ::error("'egress' package %1% has no parameter named 'ed'", block);
+            ::error(ErrorType::ERR_MODEL,
+                    "'egress' package %1% has no parameter named 'ed'", block);
             return;
         }
         auto deparser = p->to<IR::ControlBlock>();
@@ -102,7 +110,8 @@ bool ParseDpdkArchitecture::preorder(const IR::PackageBlock* block) {
         block->instanceType->to<IR::Type_Package>()->name == "PNA_NIC") {
         parse_pna_block(block);
     } else {
-        ::error("Unknown architecture %1%", options.arch);
+        ::error(ErrorType::ERR_MODEL,
+                "Unknown architecture %1%", options.arch);
     }
     return false;
 }

--- a/backends/dpdk/main.cpp
+++ b/backends/dpdk/main.cpp
@@ -80,13 +80,14 @@ int main(int argc, char *const argv[]) {
     } else {
         std::filebuf fb;
         if (fb.open(options.file, std::ios::in) == nullptr) {
-            ::error("%s: No such file or directory.", options.file);
+            ::error(ErrorType::ERR_NOT_FOUND,
+                    "%s: No such file or directory.", options.file);
             return 1;
         }
         std::istream inJson(&fb);
         JSONLoader jsonFileLoader(inJson);
         if (jsonFileLoader.json == nullptr) {
-            ::error("Not valid input file");
+            ::error(ErrorType::ERR_INVALID, "Not valid input file");
             return 1;
         }
         program = new IR::P4Program(jsonFileLoader);
@@ -109,7 +110,8 @@ int main(int argc, char *const argv[]) {
         auto p4rt = new P4::BFRT::BFRuntimeSchemaGenerator(*p4Runtime.p4Info);
         std::ostream* out = openFile(options.bfRtSchema, false);
         if (!out) {
-            ::error("Could not open BF-RT schema file: %1%", options.bfRtSchema);
+            ::error(ErrorType::ERR_IO,
+                    "Could not open BF-RT schema file: %1%", options.bfRtSchema);
             return 1;
         }
         p4rt->serializeBFRuntimeSchema(out);

--- a/backends/dpdk/printUtils.cpp
+++ b/backends/dpdk/printUtils.cpp
@@ -53,7 +53,11 @@ bool ConvertToString::preorder(const IR::PathExpression *e) {
 }
 
 bool ConvertToString::preorder(const IR::TypeNameExpression *e) {
-    out << e->typeName->path->name;
+    if (auto tn = e->typeName->to<IR::Type_Name>()) {
+        out << tn->path->name;
+    } else {
+        BUG("%1%: unexpected typeNameExpression", e);
+    }
     return false;
 }
 
@@ -62,7 +66,8 @@ bool ConvertToString::preorder(const IR::MethodCallExpression *e) {
     if (auto path = e->method->to<IR::PathExpression>()) {
         out << path->path->name.name;
     } else {
-        ::error("%1% is not a PathExpression", e->toString());
+        ::error(ErrorType::ERR_INVALID,
+                "%1% is not a PathExpression", e->toString());
     }
     return false;
 }
@@ -76,7 +81,7 @@ bool ConvertToString::preorder(const IR::ArrayIndex *e) {
     if (auto cst = e->right->to<IR::Constant>()) {
         out << toStr(e->left) <<  "_" << cst->value;
     } else {
-        ::error("%1% is not a constant", e->right);
+        ::error(ErrorType::ERR_INVALID, "%1% is not a constant", e->right);
     }
     return false;
 }

--- a/backends/dpdk/spec.cpp
+++ b/backends/dpdk/spec.cpp
@@ -72,7 +72,8 @@ std::ostream &IR::DpdkExternDeclaration::toSpec(std::ostream &out) const {
     if (DPDK::toStr(this->getType()) == "Register") {
         auto args = this->arguments;
         if (args->size() == 0) {
-            ::error("Register extern declaration %1% must contain a size parameter\n",
+            ::error(ErrorType::ERR_INVALID,
+                    "Register extern declaration %1% must contain a size parameter\n",
                 this->Name());
         } else {
             auto size = args->at(0)->expression;
@@ -84,7 +85,8 @@ std::ostream &IR::DpdkExternDeclaration::toSpec(std::ostream &out) const {
         auto args = this->arguments;
         unsigned value = 0;
         if (args->size() < 2) {
-            ::error("Counter extern declaration %1% must contain 2 parameters\n", this->Name());
+            ::error(ErrorType::ERR_INVALID,
+                    "Counter extern declaration %1% must contain 2 parameters\n", this->Name());
         } else {
             auto n_counters = args->at(0)->expression;
             auto counter_type = args->at(1)->expression;
@@ -108,7 +110,8 @@ std::ostream &IR::DpdkExternDeclaration::toSpec(std::ostream &out) const {
     } else if (DPDK::toStr(this->getType()) == "Meter") {
         auto args = this->arguments;
         if (args->size() < 2) {
-            ::error("Meter extern declaration %1% must contain a size parameter"
+            ::error(ErrorType::ERR_INVALID,
+                    "Meter extern declaration %1% must contain a size parameter"
                     " and meter type parameter", this->Name());
         } else {
             auto n_meters = args->at(0)->expression;
@@ -500,7 +503,8 @@ std::ostream &IR::DpdkGetHashStatement::toSpec(std::ostream &out) const {
             out << " " << DPDK::toStr(c);
         }
     } else {
-        ::error("get_hash's arg is not a ListExpression.");
+        ::error(ErrorType::ERR_INVALID,
+                "%1%: get_hash's arg is not a ListExpression.", this);
     }
     out << ")";
     return out;
@@ -583,4 +587,3 @@ std::ostream& IR::DpdkDropStatement::toSpec(std::ostream& out) const {
     out << "drop";
     return out;
 }
-

--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -197,8 +197,10 @@ bool CodeGenInspector::preorder(const IR::Cast* c) {
 bool CodeGenInspector::preorder(const IR::Member* expression) {
     bool isErrorAccess = false;
     if (auto tne = expression->expr->to<IR::TypeNameExpression>()) {
-        if (tne->typeName->path->name.name == IR::Type_Error::error)
-            isErrorAccess = true;
+        if (auto tn = tne->typeName->to<IR::Type_Name>()) {
+            if (tn->path->name.name == IR::Type_Error::error)
+                isErrorAccess = true;
+        }
     }
 
     int prec = expressionPrecedence;

--- a/backends/ebpf/psa/ebpfPipeline.cpp
+++ b/backends/ebpf/psa/ebpfPipeline.cpp
@@ -67,7 +67,7 @@ void EBPFPipeline::emitUserMetadataInstance(CodeBuilder *builder) {
     builder->emitIndent();
     auto user_md_type = typeMap->getType(control->user_metadata);
     if (user_md_type == nullptr) {
-        ::error("cannot emit user metadata");
+        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET, "cannot emit user metadata");
     }
     auto userMetadataType = EBPFTypeFactory::instance->create(user_md_type);
     userMetadataType->declare(builder, control->user_metadata->name.name, true);

--- a/control-plane/bfruntime.cpp
+++ b/control-plane/bfruntime.cpp
@@ -41,7 +41,8 @@ TypeSpecParser TypeSpecParser::make(const p4configv1::P4Info& p4info,
             auto e = fSpec.serializable_enum().name();
             auto typeEnum = enums.find(e);
             if (typeEnum == enums.end()) {
-                ::error("Enum type '%1%' not found in typeInfo for '%2%' '%3%'",
+                ::error(ErrorType::ERR_NOT_FOUND,
+                        "Enum type '%1%' not found in typeInfo for '%2%' '%3%'",
                         e, instanceType, instanceName);
                 return;
             }
@@ -60,7 +61,8 @@ TypeSpecParser TypeSpecParser::make(const p4configv1::P4Info& p4info,
             auto typeName = fSpec.new_type().name();
             auto newType = newtypes.find(typeName);
             if (newType == newtypes.end()) {
-                ::error("New type '%1%' not found in typeInfo for '%2%' '%3%'",
+                ::error(ErrorType::ERR_NOT_FOUND,
+                        "New type '%1%' not found in typeInfo for '%2%' '%3%'",
                         typeName, instanceType, instanceName);
                 return;
             }
@@ -68,7 +70,8 @@ TypeSpecParser TypeSpecParser::make(const p4configv1::P4Info& p4info,
         }
 
         if (!type) {
-            ::error("Error when generating BF-RT info for '%1%' '%2%': "
+            ::error(ErrorType::ERR_UNSUPPORTED,
+                    "Error when generating BF-RT info for '%1%' '%2%': "
                     "packed type is too complex",
                     instanceType, instanceName);
             return;
@@ -134,7 +137,8 @@ TypeSpecParser TypeSpecParser::make(const p4configv1::P4Info& p4info,
             fields.push_back({prefix + member.name() + suffix, id++, type});
         }
     } else {
-        ::error("Error when generating BF-RT info for '%1%' '%2%': "
+        ::error(ErrorType::ERR_UNSUPPORTED,
+                "Error when generating BF-RT info for '%1%' '%2%': "
                 "only structs, headers, tuples, bitstrings and "
                 "serializable enums are currently supported types",
                 instanceType, instanceName);
@@ -566,7 +570,8 @@ BFRuntimeGenerator::makeActionSpecs(const p4configv1::Table& table,
     for (const auto& action_ref : table.action_refs()) {
         auto* action = Standard::findAction(p4info, action_ref.id());
         if (action == nullptr) {
-            ::error("Invalid action id '%1%'", action_ref.id());
+            ::error(ErrorType::ERR_INVALID,
+                    "Invalid action id '%1%'", action_ref.id());
             continue;
         }
         auto* spec = new Util::JsonObject();
@@ -584,7 +589,8 @@ BFRuntimeGenerator::makeActionSpecs(const p4configv1::Table& table,
                 spec->emplace("action_scope", "DefaultOnly");
                 break;
             default:
-                ::error("Invalid action ref scope '%1%' in P4Info", int(action_ref.scope()));
+                ::error(ErrorType::ERR_INVALID,
+                        "Invalid action ref scope '%1%' in P4Info", int(action_ref.scope()));
                 break;
         }
         auto* annotations = transformAnnotations(
@@ -643,7 +649,8 @@ void BFRuntimeGenerator::addDirectResources(const p4configv1::Table& table,
             addMeterDataFields(dataJson, *meter);
             attributesJson->append("MeterByteCountAdjust");
         } else {
-            ::error("Unknown direct resource id '%1%'", directResId);
+            ::error(ErrorType::ERR_UNKNOWN,
+                    "Unknown direct resource id '%1%'", directResId);
             continue;
         }
     }
@@ -694,7 +701,8 @@ BFRuntimeGenerator::addMatchTables(Util::JsonArray* tablesJson) const {
                     break;
             }
             if (matchType == boost::none) {
-                ::error("Unsupported match type for BF-RT: %1%", int(mf.match_type()));
+                ::error(ErrorType::ERR_UNSUPPORTED,
+                        "Unsupported match type for BF-RT: %1%", int(mf.match_type()));
                 continue;
             }
             if (*matchType == "Ternary" || *matchType == "Range" || *matchType == "Optional")
@@ -730,8 +738,9 @@ BFRuntimeGenerator::addMatchTables(Util::JsonArray* tablesJson) const {
 
             // Control plane requires there's no duplicate key in one table.
             if (dupKey.count(keyName) != 0) {
-              ::error("Key \"%s\" is duplicate in Table \"%s\". It doesn't meet BFRT's "
-              "requirements.\n" "Please using @name annotation for the duplicate key names",
+                ::error(ErrorType::ERR_DUPLICATE,
+                      "Key \"%s\" is duplicate in Table \"%s\". It doesn't meet BFRT's "
+                      "requirements.\n" "Please using @name annotation for the duplicate key names",
               keyName, pre.name());
               return;
             } else {

--- a/control-plane/bfruntime.h
+++ b/control-plane/bfruntime.h
@@ -239,7 +239,7 @@ static std::vector<P4Id> collectTableIds(const p4configv1::P4Info& p4info,
     for (auto it = first; it != last; it++) {
         auto* table = Standard::findTable(p4info, *it);
         if (table == nullptr) {
-            ::error("Invalid table id '%1%'", *it);
+            ::error(ErrorType::ERR_INVALID, "Invalid table id '%1%'", *it);
             continue;
         }
         tableIds.push_back(*it);

--- a/frontends/p4/directCalls.cpp
+++ b/frontends/p4/directCalls.cpp
@@ -25,14 +25,21 @@ const IR::Node* DoInstantiateCalls::postorder(IR::MethodCallExpression* expressi
     if (tn == nullptr)
         return expression;
 
-    auto ref = refMap->getDeclaration(tn->typeName->path, true);
+    const IR::Type_Name* tname;
+    if (auto ts = tn->typeName->to<IR::Type_Specialized>()) {
+        tname = ts->baseType;
+    } else {
+        tname = tn->typeName->to<IR::Type_Name>();
+    }
+    CHECK_NULL(tname);
+    auto ref = refMap->getDeclaration(tname->path, true);
     if (!ref->is<IR::P4Control>() && !ref->is<IR::P4Parser>())
         return expression;
 
-    auto name = refMap->newName(tn->typeName->path->name + "_inst");
+    auto name = refMap->newName(tname->path->name + "_inst");
     LOG3("Inserting instance " << name);
     auto annos = new IR::Annotations();
-    annos->add(new IR::Annotation(IR::Annotation::nameAnnotation, tn->typeName->path->toString()));
+    annos->add(new IR::Annotation(IR::Annotation::nameAnnotation, tname->path->toString()));
     auto inst = new IR::Declaration_Instance(
         expression->srcInfo, IR::ID(name), annos,
         tn->typeName->clone(), new IR::Vector<IR::Argument>());

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -937,13 +937,13 @@ class FindRecirculated : public Inspector {
         }
         auto expression = primitive->operands.at(operand);
         if (!expression->is<IR::PathExpression>()) {
-            ::error("%1%: expected a field list", expression);
+            ::error(ErrorType::ERR_EXPECTED, "%1%: expected a field list", expression);
             return;
         }
         auto nr = expression->to<IR::PathExpression>();
         auto fl = structure->field_lists.get(nr->path->name);
         if (fl == nullptr) {
-            ::error("%1%: Expected a field list", expression);
+            ::error(ErrorType::ERR_EXPECTED, "%1%: Expected a field list", expression);
             return;
         }
         LOG3("Recirculated " << nr->path->name);

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -164,7 +164,8 @@ const IR::Vector<IR::Expression>* ProgramStructure::listIndexes(cstring type, cs
 const IR::Expression* ProgramStructure::listIndex(const IR::Expression* expression) const {
     auto pe = expression->to<IR::PathExpression>();
     if (pe == nullptr) {
-        ::error("%1%: Expected a field list", expression);
+        ::error(ErrorType::ERR_EXPECTED,
+                "%1%: Expected a field list", expression);
         return 0;
     }
 

--- a/frontends/p4/typeChecking/syntacticEquivalence.cpp
+++ b/frontends/p4/typeChecking/syntacticEquivalence.cpp
@@ -82,9 +82,9 @@ bool SameExpression::sameExpression(const IR::Expression* left, const IR::Expres
         auto rd = refMap->getDeclaration(right->to<IR::PathExpression>()->path, true);
         return ld == rd;
     } else if (left->is<IR::TypeNameExpression>()) {
-        auto ld = refMap->getDeclaration(left->to<IR::TypeNameExpression>()->typeName->path, true);
-        auto rd = refMap->getDeclaration(right->to<IR::TypeNameExpression>()->typeName->path, true);
-        return ld == rd;
+        auto lt = left->to<IR::TypeNameExpression>()->typeName;
+        auto rt = right->to<IR::TypeNameExpression>()->typeName;
+        return sameType(lt, rt);
     } else if (left->is<IR::ListExpression>()) {
         auto ll = left->to<IR::ListExpression>();
         auto rl = right->to<IR::ListExpression>();

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1180,6 +1180,11 @@ directApplication
                                       @1 + @3, new IR::TypeNameExpression($1), IR::ID(@3, "apply"));
                                   auto mce = new IR::MethodCallExpression(@1 + @6, method, $5);
                                   $$ = new IR::MethodCallStatement(@1 + @6, mce); }
+    | specializedType "." APPLY "(" argumentList ")" ";" {
+                                  auto method = new IR::Member(
+                                      @1 + @3, new IR::TypeNameExpression($1), IR::ID(@3, "apply"));
+                                  auto mce = new IR::MethodCallExpression(@1 + @6, method, $5);
+                                  $$ = new IR::MethodCallStatement(@1 + @6, mce); }
     ;
 
 statement

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -261,12 +261,14 @@ class PathExpression : Expression {
 // X.a
 // The 'X' portion is a TypeNameExpression
 class TypeNameExpression : Expression {
-    Type_Name typeName;
+    Type typeName;
     TypeNameExpression { if (!srcInfo && typeName) srcInfo = typeName->srcInfo; }
     TypeNameExpression(ID id) : Expression(id.srcInfo),
                                 typeName(new IR::Type_Name(new IR::Path(id))) {}
     dbprint{ out << typeName; }
     toString { return typeName->toString(); }
+    validate { BUG_CHECK(typeName->is<Type_Name>() || typeName->is<Type_Specialized>(),
+                         "%1 unexpected type in TypeNameExpression", typeName); }
 }
 
 class Slice : Operation_Ternary {

--- a/midend/checkExternInvocationCommon.h
+++ b/midend/checkExternInvocationCommon.h
@@ -137,10 +137,12 @@ class CheckExternInvocationCommon : public Inspector {
         auto constraint = pipeConstraints.at(extType) & bv;
         if (!bv.empty() && constraint.empty()) {
             if (extName != "")
-                ::error("%s %s %s cannot be used in the %s %s", expr->srcInfo,
+                ::error(ErrorType::ERR_UNSUPPORTED,
+                        "%s %s %s cannot be used in the %s %s", expr->srcInfo,
                         extType, extName, pipe, extractBlock(bv));
             else
-                ::error("%s %s cannot be used in the %s %s", expr->srcInfo,
+                ::error(ErrorType::ERR_UNSUPPORTED,
+                        "%s %s cannot be used in the %s %s", expr->srcInfo,
                         extType, pipe, extractBlock(bv));
         }
     }

--- a/midend/singleArgumentSelect.cpp
+++ b/midend/singleArgumentSelect.cpp
@@ -66,7 +66,8 @@ void DoSingleArgumentSelect::checkExpressionType(const IR::Expression* expressio
             checkExpressionType(c);
         }
     } else {
-        ::error("%1%: expression type %2% not supported in select expression",
+        ::error(ErrorType::ERR_UNSUPPORTED,
+                "%1%: expression type %2% not supported in select expression",
                 expression, type);
     }
 }

--- a/testdata/p4_14_errors_outputs/issue747.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue747.p4-stderr
@@ -1,4 +1,4 @@
-issue747.p4(31): [--Werror=legacy] error: local_port: expected a field list
+issue747.p4(31): [--Werror=expected] error: local_port: expected a field list
 action local_recirc(local_port) {
                     ^^^^^^^^^^
 [--Werror=overlimit] error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_samples/spec-issue1068.p4
+++ b/testdata/p4_16_samples/spec-issue1068.p4
@@ -1,0 +1,12 @@
+parser MyParser<t>(t tt) {
+    state start {
+        transition accept;
+    }
+}
+
+parser MyParser1() {
+    state start {
+        MyParser<bit>.apply(1);
+        transition accept;
+    }
+}

--- a/testdata/p4_16_samples_outputs/spec-issue1068-first.p4
+++ b/testdata/p4_16_samples_outputs/spec-issue1068-first.p4
@@ -1,0 +1,14 @@
+parser MyParser<t>(t tt) {
+    state start {
+        transition accept;
+    }
+}
+
+parser MyParser1() {
+    @name("MyParser") MyParser<bit<1>>() MyParser_inst;
+    state start {
+        MyParser_inst.apply(1w1);
+        transition accept;
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/spec-issue1068.p4
+++ b/testdata/p4_16_samples_outputs/spec-issue1068.p4
@@ -1,0 +1,13 @@
+parser MyParser<t>(t tt) {
+    state start {
+        transition accept;
+    }
+}
+
+parser MyParser1() {
+    state start {
+        MyParser<bit<1>>.apply(1);
+        transition accept;
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/spec-issue1068.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-issue1068.p4-stderr
@@ -1,0 +1,1 @@
+[--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
Fixes https://github.com/p4lang/p4-spec/issues/1068
It also fixes many calls to ::error that were not using the appropriate API.