### PR TITLE
Add support for LLD linker, cmake options for LLD and Gold

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,25 +217,38 @@ add_cxx_compiler_option ("-Wno-deprecated-declarations")
 # Enable/disable runtime exceptions on nullpointer dereferencing
 # add_cxx_compiler_option ("-fsanitize=null")
 
-# If we're on GCC, use the gold linker if available.
-if(CMAKE_COMPILER_IS_GNUCC)
+# If we're on GCC or Clang, use the prefer LLD or Gold linker if available.
+set(BUILD_LINK_WITH_GOLD ON CACHE BOOL "Use Gold linker for build if available")
+set(BUILD_LINK_WITH_LLD ON CACHE BOOL "Use LLD linker for build if available (overrides BUILD_LINK_WITH_GOLD)")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # We want to optimize the binary size for a static release binary.
     # This only works with modern versions of GCC.
-    if (BUILD_STATIC_RELEASE AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
-      add_cxx_compiler_option ("-flto")
+    if (BUILD_STATIC_RELEASE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
+        add_cxx_compiler_option ("-flto")
     endif ()
-    execute_process(
-            COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version
-            ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
-    if ("${LD_VERSION}" MATCHES "GNU gold")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold")
-        message(STATUS "Using the GNU gold linker.")
-    else ()
-        message(STATUS "Using the default system linker.")
-    endif ()
+    set(_LD_USED "default system")
+    set(_LD_OPT_USED "")
+    macro(check_linker BUILD_LINK_WITH_VAR LINKER_OPT LINKER_NAME)
+        if (${BUILD_LINK_WITH_VAR})
+            execute_process(
+                    COMMAND ${CMAKE_C_COMPILER} -fuse-ld=${LINKER_OPT} -Wl,--version
+                    ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
+            if ("${LD_VERSION}" MATCHES ${LINKER_NAME})
+                set(_LD_USED "${LINKER_NAME}")
+                set(_LD_OPT_USED "-fuse-ld=${LINKER_OPT}")
+            endif()
+        endif()
+    endmacro()
+    check_linker(BUILD_LINK_WITH_GOLD "gold" "GNU gold")
+    check_linker(BUILD_LINK_WITH_LLD "lld" "LLD")
+
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_LD_OPT_USED}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_LD_OPT_USED}")
+    message(STATUS "Using the ${_LD_USED} linker.")
     unset(LD_VERSION)
-endif ()
+    unset(_LD_USED)
+    unset(_LD_OPT_USED)
+endif()
 
 include_directories (
   ${P4C_SOURCE_DIR}/frontends


### PR DESCRIPTION
A somewhat different approach to the same problem as  in #3262, where @grg wrote:



> LLD is much faster than gold in testing, so prefer LLD if it is found.
>
> Test results for a debug build with the Intel Tofino backend after
> touching a single file:
> 
>     gold: 313.410 s (averaged across 10 runs)
>     lld: 151.783 s (averaged across 10 runs)
> 

The difference is mainly in the options to enable/disable lookup for linkers.

Tested with GCC & Clang. Since the detection fails if the `-fuse-ld=???` is not supported by the given gcc/clang version there is no need for version checks.