### PR TITLE
Add cmake option to force-enable colors in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,18 @@ if(CMAKE_COMPILER_IS_GNUCC)
     unset(LD_VERSION)
 endif ()
 
+set(BUILD_USE_COLOR OFF CACHE BOOL "Use color in C++ compiler output (even if "
+    "the compiler does not detect terminal, e.g. when using ccache/distcc)")
+if (BUILD_USE_COLOR)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=always")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
+    else()
+        message(WARNING "Colors enabled (BUILD_USE_COLOR=ON) but we don't know "
+                "how to enable them for ${CMAKE_CXX_COMPILER_ID} C++ compiler")
+    endif()
+endif()
+
 include_directories (
   ${P4C_SOURCE_DIR}/frontends
   ${P4C_SOURCE_DIR}/backends


### PR DESCRIPTION
This exposes an option (OFF by default) that can enable color in compiler output. The intended use is in build environments that use distcc/ccache or build tools like Ninja that break direct connection from gcc/clang to the termina, causing the compiler to skip colors.