### PR TITLE
Design of the p4c-model compiler

### DIFF
--- a/backends/model/README.md
+++ b/backends/model/README.md
@@ -1,0 +1,36 @@
+# The p4c-model compiler
+
+This is a special backend for the p4c compiler which aids in building
+other backends for the p4c compiler.
+
+The input to this compiler is a *model.p4 file, describing
+capabilities of a P4 target.  The output of this compiler is set of of
+files:
+
+- one *.def file, which defines compiler IR classes that represent the
+  various objects defined in the model: externs, extern functions,
+  controls, parsers, and packages.  Each such object has a custom
+  associated IR class.  For example, when run on v1model.p4 this would
+  produce an IR class named `counter_instance` for `counter` which can
+  be used to represent counter instantiations.
+
+```
+class counter_instance {
+   Type      type_parameter_I;
+   Argument  size_constructor_argument;
+   Argument  type_constructor_argument;
+}
+```
+
+- one *.h/cpp pair of files, defining a Transform class.  The
+  transform class takes a P4 program written for this specific model,
+  validates that the model objects are used correctly (e.g., correct
+  number of type parameters, correct number of arguments, etc), and
+  replaces the general-purpose IR classes (i.e., `Declaration_Instance`
+  for a `counter` extern) with more specific instances (i.e.,
+  the just-defined `counter_instance` ).
+
+The generated code is meant to be included in the backend of a
+compiler for the specific model.  The generated visitor will automate
+checking the correct usage of the model.  The generated IR classes
+will make code generation much simpler and readable.


### PR DESCRIPTION
By reviewing code for multiple backends I have realized that the task of writing a backend is very onerous, and requires many manual checks that could be completely automated. In particular, the backend encodes a lot of information about the model in C++ code that verifies all sorts of well-formedness of the model usage, and extracts information from the model. 

This is an initial PR for a compiler that would automate much of the task of validating a model and would simplify writing a back-end. Similar to the ir-generator compiler, which generate a lot of C++ boilerplate code for p4c, this compiler would generate lots of boilerplate code for a specific model. All backends that compile for that model would be able to reuse this code. For example, this compiler could generate code for psa.p4 which could be used in all backends for PSA, including psa-ebpf and psa-dpdk.

This initial PR only contains a README.md which describes briefly the design. I expect that this compiler will not be too difficult to implement. Migrating existing backends to use this infrastructure may be more complicated, but at least this should make writing new backends singificantly easier.

Please comment on this design @ChrisDodd @osinstom @rst0git @fruffy @hanw et al. Of course, contributions are welcome. 