### PR TITLE
Fixing bug for concat elimination in SimpleSwitch

### DIFF
--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -148,7 +148,7 @@ const IR::Node* LowerExpressions::postorder(IR::Concat* expression) {
     auto sh = new IR::Shl(cast0->srcInfo, cast0, new IR::Constant(sizeofb));
     big_int m = Util::maskFromSlice(sizeofb, 0);
     auto mask = new IR::Constant(expression->right->srcInfo,
-                                 IR::Type_Bits::get(sizeofresult), m, 16);
+                                 resulttype, m, 16);
     auto and0 = new IR::BAnd(expression->right->srcInfo, cast1, mask);
     auto result = new IR::BOr(expression->srcInfo, sh, and0);
     typeMap->setType(cast0, resulttype);


### PR DESCRIPTION
These small changes fix error in type checking for `concat` operation.  The idea is very simple: the type of the `mask` should be the same as for the `cast1`, because in the next line of code contains creation of `BAnd` operation with them and if the `mask` and the `cast1` will have different types then `TypeInference` generates an error for following example:
`./p4c-bm2-ss -o  ./output/strength4.json ../testdata/p4_16_samples/strength4.p4`