### PR TITLE
Require generic return types to be specialized

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1188,6 +1188,17 @@ const IR::Node* TypeInference::postorder(IR::Method* method) {
     auto type = getTypeType(method->type);
     if (type == nullptr)
         return method;
+    if (auto mtype = type->to<IR::Type_Method>()) {
+        if (mtype->returnType) {
+            if (auto gen = mtype->returnType->to<IR::IMayBeGenericType>()) {
+                if (gen->getTypeParameters()->size() != 0) {
+                    typeError("%1%: no type parameters supplied for return generic type",
+                              method->type->returnType);
+                    return method;
+                }
+            }
+        }
+    }
     setType(getOriginal(), type);
     setType(method, type);
     return method;

--- a/testdata/p4_16_errors/issue3293.p4
+++ b/testdata/p4_16_errors/issue3293.p4
@@ -1,0 +1,3 @@
+struct t1<t>{}
+
+extern t1 f();

--- a/testdata/p4_16_errors_outputs/issue3293.p4
+++ b/testdata/p4_16_errors_outputs/issue3293.p4
@@ -1,0 +1,4 @@
+struct t1<t> {
+}
+
+extern t1 f();

--- a/testdata/p4_16_errors_outputs/issue3293.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3293.p4-stderr
@@ -1,0 +1,3 @@
+issue3293.p4(3): [--Werror=type-error] error: t1: no type parameters supplied for return generic type
+extern t1 f();
+       ^^


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>

Fixes #3293