### PR TITLE
p4-ebpf: Fix warnings generated by clang when compiling XDP helper program

### DIFF
--- a/backends/ebpf/psa/xdpHelpProgram.h
+++ b/backends/ebpf/psa/xdpHelpProgram.h
@@ -24,7 +24,7 @@ namespace EBPF {
 class XDPHelpProgram : public EBPFProgram {
     cstring XDPProgUsingMetaForXDP2TC =
             "    void *data_end = (void *)(long)skb->data_end;\n"
-            "    struct ethhdr *eth = (struct ethhdr *) skb->data;\n"
+            "    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;\n"
             "    if ((void *)((struct ethhdr *) eth + 1) > data_end) {\n"
             "        return XDP_ABORTED;\n"
             "    }\n"
@@ -40,7 +40,7 @@ class XDPHelpProgram : public EBPFProgram {
             "    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;\n"
             "    eth = (void *)(long)skb->data;\n"
             "    data_end = (void *)(long)skb->data_end;\n"
-            "    if ((void *) ((struct internal_metadata *) meta + 1) > (void *) skb->data)\n"
+            "    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)\n"
             "        return XDP_ABORTED;\n"
             "    if ((void *)((struct ethhdr *) eth + 1) > data_end) {\n"
             "        return XDP_ABORTED;\n"


### PR DESCRIPTION
Currently, clang generates the following warnings when compiling XDP helper program:

```
out.c:313:26: warning: cast to 'struct ethhdr *' from smaller integer type '__u32' (aka 'unsigned int') [-Wint-to-pointer-cast] 
   struct ethhdr *eth = (struct ethhdr *) skb->data;
                        ^ 
out.c:329:60: warning: cast to 'void *' from smaller integer type '__u32' (aka 'unsigned int') [-Wint-to-void-pointer-cast]                                                                              
   if ((void *) ((struct internal_metadata *) meta + 1) > (void *) skb->data)
                                                          ^ 
2 warnings generated.   
```

They don't impact the functionality, but might be annoying for users. This PR fixes the XDP helper program. 