### PR TITLE
Expand 'emit' calls in the ebpf backend

### DIFF
--- a/backends/ebpf/ebpfDeparser.cpp
+++ b/backends/ebpf/ebpfDeparser.cpp
@@ -83,6 +83,7 @@ void DeparserPrepareBufferTranslator::processMethod(const P4::ExternMethod *meth
             if (headerToEmit == nullptr) {
                 ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
                         "Cannot emit a non-header type %1%", expr);
+                return;
             }
 
             unsigned width = headerToEmit->width_bits();

--- a/backends/ebpf/midend.cpp
+++ b/backends/ebpf/midend.cpp
@@ -32,6 +32,7 @@ limitations under the License.
 #include "midend/convertEnums.h"
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateTuples.h"
+#include "midend/expandEmit.h"
 #include "midend/local_copyprop.h"
 #include "midend/midEndLast.h"
 #include "midend/noMatch.h"
@@ -88,6 +89,7 @@ const IR::ToplevelBlock* MidEnd::run(EbpfOptions& options,
             new P4::RemoveExits(&refMap, &typeMap),
             new P4::ConstantFolding(&refMap, &typeMap),
             new P4::SimplifySelectCases(&refMap, &typeMap, false),  // accept non-constant keysets
+            new P4::ExpandEmit(&refMap, &typeMap),
             new P4::HandleNoMatch(&refMap),
             new P4::SimplifyParsers(&refMap),
             new P4::StrengthReduction(&refMap, &typeMap),


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>

Fixes #3318

There is no attached test because our testsuite does not run tests for the psa ebfp backend in the standard way.