### PR TITLE
Add generic structs to P4Runtime digest example

### DIFF
--- a/testdata/p4_16_samples/p4rt_digest_complex.p4
+++ b/testdata/p4_16_samples/p4rt_digest_complex.p4
@@ -8,6 +8,18 @@ struct s_t {
     bit<16> f16;
 }
 
+// generic struct without @name annotation
+struct s2_t<T> {
+    bit<16> f16;
+    T f;
+}
+
+// generic struct with @name annotation
+@name("s3_t")
+struct s3_t<T> {
+    T f;
+}
+
 header h_t {
     s_t s;
     bit<32> f32;
@@ -63,6 +75,8 @@ control MyEC(
 struct digest_t {
     h_t h;
     PortId_t port;
+    s2_t<bit<32> > s2;
+    s3_t<bit<64> > s3;
 }
 
 control MyID(
@@ -75,7 +89,7 @@ control MyID(
     in psa_ingress_output_metadata_t f) {
     Digest<digest_t>() digest;
     apply {
-        digest.pack({hdr.h, f.egress_port});
+        digest.pack({hdr.h, f.egress_port, {16w10, 32w20}, {64w30}});
     }
 }
 

--- a/testdata/p4_16_samples_outputs/p4rt_digest_complex-first.p4
+++ b/testdata/p4_16_samples_outputs/p4rt_digest_complex-first.p4
@@ -9,6 +9,15 @@ struct s_t {
     bit<16> f16;
 }
 
+struct s2_t<T> {
+    bit<16> f16;
+    T       f;
+}
+
+@name("s3_t") struct s3_t<T> {
+    T f;
+}
+
 header h_t {
     s_t     s;
     bit<32> f32;
@@ -42,15 +51,26 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
+struct s2_t_0 {
+    bit<16> f16;
+    bit<32> f;
+}
+
+@name("s3_t") struct s3_t_0 {
+    bit<64> f;
+}
+
 struct digest_t {
     h_t      h;
     PortId_t port;
+    s2_t_0   s2;
+    s3_t_0   s3;
 }
 
 control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     Digest<digest_t>() digest;
     apply {
-        digest.pack((digest_t){h = hdr.h,port = f.egress_port});
+        digest.pack((digest_t){h = hdr.h,port = f.egress_port,s2 = (s2_t_0){f16 = 16w10,f = 32w20},s3 = (s3_t_0){f = 64w30}});
     }
 }
 

--- a/testdata/p4_16_samples_outputs/p4rt_digest_complex-frontend.p4
+++ b/testdata/p4_16_samples_outputs/p4rt_digest_complex-frontend.p4
@@ -9,6 +9,15 @@ struct s_t {
     bit<16> f16;
 }
 
+struct s2_t<T> {
+    bit<16> f16;
+    T       f;
+}
+
+@name("s3_t") struct s3_t<T> {
+    T f;
+}
+
 header h_t {
     s_t     s;
     bit<32> f32;
@@ -42,16 +51,27 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
+struct s2_t_0 {
+    bit<16> f16;
+    bit<32> f;
+}
+
+@name("s3_t") struct s3_t_0 {
+    bit<64> f;
+}
+
 struct digest_t {
     h_t      h;
     PortId_t port;
+    s2_t_0   s2;
+    s3_t_0   s3;
 }
 
 control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     @name("MyID.tmp") digest_t tmp;
     @name("MyID.digest") Digest<digest_t>() digest_0;
     apply {
-        tmp = (digest_t){h = hdr.h,port = f.egress_port};
+        tmp = (digest_t){h = hdr.h,port = f.egress_port,s2 = (s2_t_0){f16 = 16w10,f = 32w20},s3 = (s3_t_0){f = 64w30}};
         digest_0.pack(tmp);
     }
 }

--- a/testdata/p4_16_samples_outputs/p4rt_digest_complex-midend.p4
+++ b/testdata/p4_16_samples_outputs/p4rt_digest_complex-midend.p4
@@ -9,6 +9,15 @@ struct s_t {
     bit<16> f16;
 }
 
+struct s2_t<T> {
+    bit<16> f16;
+    T       f;
+}
+
+@name("s3_t") struct s3_t<T> {
+    T f;
+}
+
 header h_t {
     bit<8>  _s_f80;
     bit<16> _s_f161;
@@ -33,17 +42,17 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 }
 
 control MyIC(inout headers hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
-    @hidden action p4rt_digest_complex51() {
+    @hidden action p4rt_digest_complex63() {
         d.egress_port = c.ingress_port;
     }
-    @hidden table tbl_p4rt_digest_complex51 {
+    @hidden table tbl_p4rt_digest_complex63 {
         actions = {
-            p4rt_digest_complex51();
+            p4rt_digest_complex63();
         }
-        const default_action = p4rt_digest_complex51();
+        const default_action = p4rt_digest_complex63();
     }
     apply {
-        tbl_p4rt_digest_complex51.apply();
+        tbl_p4rt_digest_complex63.apply();
     }
 }
 
@@ -52,24 +61,40 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
     }
 }
 
+struct s2_t_0 {
+    bit<16> f16;
+    bit<32> f;
+}
+
+@name("s3_t") struct s3_t_0 {
+    bit<64> f;
+}
+
 struct digest_t {
     h_t      h;
     PortId_t port;
+    s2_t_0   s2;
+    s3_t_0   s3;
 }
 
 control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
+    s2_t_0 tmp_s2;
+    s3_t_0 tmp_s3;
     @name("MyID.digest") Digest<digest_t>() digest_0;
-    @hidden action p4rt_digest_complex78() {
-        digest_0.pack((digest_t){h = hdr.h,port = f.egress_port});
+    @hidden action p4rt_digest_complex92() {
+        tmp_s2.f16 = 16w10;
+        tmp_s2.f = 32w20;
+        tmp_s3.f = 64w30;
+        digest_0.pack((digest_t){h = hdr.h,port = f.egress_port,s2 = tmp_s2,s3 = tmp_s3});
     }
-    @hidden table tbl_p4rt_digest_complex78 {
+    @hidden table tbl_p4rt_digest_complex92 {
         actions = {
-            p4rt_digest_complex78();
+            p4rt_digest_complex92();
         }
-        const default_action = p4rt_digest_complex78();
+        const default_action = p4rt_digest_complex92();
     }
     apply {
-        tbl_p4rt_digest_complex78.apply();
+        tbl_p4rt_digest_complex92.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/p4rt_digest_complex.p4
+++ b/testdata/p4_16_samples_outputs/p4rt_digest_complex.p4
@@ -9,6 +9,15 @@ struct s_t {
     bit<16> f16;
 }
 
+struct s2_t<T> {
+    bit<16> f16;
+    T       f;
+}
+
+@name("s3_t") struct s3_t<T> {
+    T f;
+}
+
 header h_t {
     s_t     s;
     bit<32> f32;
@@ -43,14 +52,16 @@ control MyEC(inout EMPTY a, inout EMPTY b, in psa_egress_input_metadata_t c, ino
 }
 
 struct digest_t {
-    h_t      h;
-    PortId_t port;
+    h_t           h;
+    PortId_t      port;
+    s2_t<bit<32>> s2;
+    s3_t<bit<64>> s3;
 }
 
 control MyID(packet_out buffer, out EMPTY a, out EMPTY b, out EMPTY c, inout headers hdr, in EMPTY e, in psa_ingress_output_metadata_t f) {
     Digest<digest_t>() digest;
     apply {
-        digest.pack({ hdr.h, f.egress_port });
+        digest.pack({ hdr.h, f.egress_port, { 16w10, 32w20 }, { 64w30 } });
     }
 }
 

--- a/testdata/p4_16_samples_outputs/p4rt_digest_complex.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/p4rt_digest_complex.p4.p4info.txt
@@ -33,6 +33,62 @@ type_info {
           }
         }
       }
+      members {
+        name: "s2"
+        type_spec {
+          struct {
+            name: "s2_t_0"
+          }
+        }
+      }
+      members {
+        name: "s3"
+        type_spec {
+          struct {
+            name: "s3_t"
+          }
+        }
+      }
+    }
+  }
+  structs {
+    key: "s2_t_0"
+    value {
+      members {
+        name: "f16"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 16
+            }
+          }
+        }
+      }
+      members {
+        name: "f"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 32
+            }
+          }
+        }
+      }
+    }
+  }
+  structs {
+    key: "s3_t"
+    value {
+      members {
+        name: "f"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 64
+            }
+          }
+        }
+      }
     }
   }
   headers {


### PR DESCRIPTION
To show how they are represented in the P4Info.