### PR TITLE
Require a start state in parsers

### DIFF
--- a/frontends/p4/validateParsedProgram.h
+++ b/frontends/p4/validateParsedProgram.h
@@ -83,6 +83,10 @@ class ValidateParsedProgram final : public Inspector {
                            control->getApplyParameters(),
                            control->getConstructorParameters()); }
     void postorder(const IR::P4Parser* parser) override {
+        auto start = parser->states.getDeclaration("start");
+        if (!start) {
+            ::error(ErrorType::ERR_INVALID, "Parser %1% has no 'start' state", parser);
+        }
         container(parser);
         distinctParameters(parser->getTypeParameters(),
                            parser->getApplyParameters(),

--- a/testdata/p4_16_errors/issue3338.p4
+++ b/testdata/p4_16_errors/issue3338.p4
@@ -1,0 +1,5 @@
+parser MyParser1(){
+    state not_start {
+        transition accept;
+    }
+}

--- a/testdata/p4_16_errors_outputs/accept_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/accept_e.p4-stderr
@@ -1,3 +1,6 @@
 accept_e.p4(18): [--Werror=invalid] error: Invalid parser state: accept should not be implemented, it is built-in
     state accept { // reserved name
           ^^^^^^
+accept_e.p4(16): [--Werror=invalid] error: Parser parser p has no 'start' state
+parser p()
+       ^

--- a/testdata/p4_16_errors_outputs/issue3338.p4
+++ b/testdata/p4_16_errors_outputs/issue3338.p4
@@ -1,0 +1,6 @@
+parser MyParser1() {
+    state not_start {
+        transition accept;
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/issue3338.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3338.p4-stderr
@@ -1,0 +1,3 @@
+issue3338.p4(1): [--Werror=invalid] error: Parser parser MyParser1 has no 'start' state
+parser MyParser1(){
+       ^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/nostart.p4-stderr
+++ b/testdata/p4_16_errors_outputs/nostart.p4-stderr
@@ -1,6 +1,3 @@
-nostart.p4(18): [--Wwarn=parser-transition] warning: next: implicit transition to `reject'
-    state next {}
-          ^^^^
-nostart.p4(17): [--Werror=not-found] error: parser p: parser does not have a `start' state
+nostart.p4(17): [--Werror=invalid] error: Parser parser p has no 'start' state
 parser p() {
        ^


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3338