### PR TITLE
Fixed start state renaming for p4-14 translation using @packet_entry

### DIFF
--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -769,7 +769,7 @@ class InsertCompilerGeneratedStartState: public Transform {
         if (path->name.name != IR::ParserState::start)
             return path;
         // Just to make sure we can also check it explicitly
-        auto pe = getContext()->node->to<IR::PathExpression>();;
+        auto pe = getContext()->node->to<IR::PathExpression>();
         auto sc = findContext<IR::SelectCase>();
         auto ps = findContext<IR::ParserState>();
         // Either the path is within SelectCase->state<PathExpression>->path

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -764,6 +764,8 @@ class InsertCompilerGeneratedStartState: public Transform {
         // At this point any identifier called start should have been renamed
         // to unique name (e.g. start_1) => we can safely assume that any
         // "start" refers to the parser state
+        if (!structure->parserEntryPoints.size())
+            return path;
         if (path->name.name == IR::ParserState::start)
             path->name = newStartState;
         return path;

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -737,9 +737,9 @@ class InsertCompilerGeneratedStartState: public Transform {
  public:
     explicit InsertCompilerGeneratedStartState(ProgramStructure* structure) : structure(structure) {
         setName("InsertCompilerGeneratedStartState");
-        structure->allNames.emplace("start");
+        structure->allNames.emplace(IR::ParserState::start);
         structure->allNames.emplace("InstanceType");
-        newStartState = structure->makeUniqueName("start");
+        newStartState = structure->makeUniqueName(IR::ParserState::start);
         newInstanceType = structure->makeUniqueName("InstanceType");
     }
 
@@ -757,6 +757,16 @@ class InsertCompilerGeneratedStartState: public Transform {
             state->name = newStartState;
         }
         return state;
+    }
+
+    // Rename any path refering to original start state
+    const IR::Node* postorder(IR::Path* path) override {
+        // At this point any identifier called start should have been renamed
+        // to unique name (e.g. start_1) => we can safely assume that any
+        // "start" refers to the parser state
+        if (path->name.name == IR::ParserState::start)
+            path->name = newStartState;
+        return path;
     }
 
     const IR::Node* postorder(IR::P4Parser* parser) override {

--- a/testdata/p4_14_samples/packet_entry_to_start.p4
+++ b/testdata/p4_14_samples/packet_entry_to_start.p4
@@ -1,0 +1,49 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc. 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@pragma packet_entry
+parser start_i2e_mirrored {
+    return start;
+}
+
+parser start {
+    return ingress;
+}
+
+header_type start {
+    fields {
+        f1 : 32;
+    }
+}
+
+metadata start m;
+
+action a1() {
+    modify_field(m.f1, 1);
+}
+
+table t1 {
+    actions {
+        a1;
+    }
+}
+
+control ingress {
+    apply(t1);
+}
+
+control egress {
+}

--- a/testdata/p4_14_samples_outputs/packet_entry_to_start-first.p4
+++ b/testdata/p4_14_samples_outputs/packet_entry_to_start-first.p4
@@ -1,0 +1,74 @@
+@name(".$InstanceType") enum bit<32> InstanceType_0 {
+    START = 32w0,
+    start_i2e_mirrored = 32w1
+}
+
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+@name("start") struct start_1 {
+    bit<32> f1;
+}
+
+struct metadata {
+    @name(".m") 
+    start_1 m;
+}
+
+struct headers {
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start_0 {
+        transition accept;
+    }
+    @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
+        transition start_0;
+    }
+    @name(".$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
+        }
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".a1") action a1() {
+        meta.m.f1 = 32w1;
+    }
+    @name(".t1") table t1 {
+        actions = {
+            a1();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        t1.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/packet_entry_to_start-frontend.p4
+++ b/testdata/p4_14_samples_outputs/packet_entry_to_start-frontend.p4
@@ -1,0 +1,76 @@
+@name(".$InstanceType") enum bit<32> InstanceType_0 {
+    START = 32w0,
+    start_i2e_mirrored = 32w1
+}
+
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+@name("start") struct start_1 {
+    bit<32> f1;
+}
+
+struct metadata {
+    @name(".m") 
+    start_1 m;
+}
+
+struct headers {
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start_0 {
+        transition accept;
+    }
+    @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
+        transition start_0;
+    }
+    @name(".$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
+        }
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name(".a1") action a1() {
+        meta.m.f1 = 32w1;
+    }
+    @name(".t1") table t1_0 {
+        actions = {
+            a1();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        t1_0.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/packet_entry_to_start-midend.p4
+++ b/testdata/p4_14_samples_outputs/packet_entry_to_start-midend.p4
@@ -1,0 +1,75 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+@name("start") struct start_1 {
+    bit<32> f1;
+}
+
+struct metadata {
+    bit<32> _m_f10;
+}
+
+struct headers {
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start_0 {
+        transition accept;
+    }
+    @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
+        transition start_0;
+    }
+    @name(".$start") state start {
+        transition select((bit<32>)standard_metadata.instance_type) {
+            32w0: start_0;
+            32w1: start_i2e_mirrored;
+            default: noMatch;
+        }
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name(".a1") action a1() {
+        meta._m_f10 = 32w1;
+    }
+    @name(".t1") table t1_0 {
+        actions = {
+            a1();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        t1_0.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+

--- a/testdata/p4_14_samples_outputs/packet_entry_to_start.p4
+++ b/testdata/p4_14_samples_outputs/packet_entry_to_start.p4
@@ -1,0 +1,72 @@
+@name(".$InstanceType") enum bit<32> InstanceType_0 {
+    START = 0,
+    start_i2e_mirrored = 1
+}
+
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+@name("start") struct start_1 {
+    bit<32> f1;
+}
+
+struct metadata {
+    @name(".m") 
+    start_1 m;
+}
+
+struct headers {
+}
+
+parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".start") state start_0 {
+        transition accept;
+    }
+    @packet_entry @name(".start_i2e_mirrored") state start_i2e_mirrored {
+        transition start_0;
+    }
+    @name(".$start") state start {
+        transition select((InstanceType_0)standard_metadata.instance_type) {
+            InstanceType_0.START: start_0;
+            InstanceType_0.start_i2e_mirrored: start_i2e_mirrored;
+        }
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name(".a1") action a1() {
+        meta.m.f1 = 32w1;
+    }
+    @name(".t1") table t1 {
+        actions = {
+            a1;
+        }
+    }
+    apply {
+        t1.apply();
+    }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+    }
+}
+
+control verifyChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
+


### PR DESCRIPTION
The issue was that if there was a transition into the start state (for example from one of the @packet_entry states) and @packet_entry used, the compiler renamed the original start state to replace it with a new one. However these transitions into the original start state were not renamed.