### PR TITLE
Do not allow variables with type Type_Parser/Control

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -674,8 +674,9 @@ const IR::Node* TypeInference::postorder(IR::Declaration_Variable* decl) {
     const IR::Type* baseType = type;
     if (auto sc = type->to<IR::Type_SpecializedCanonical>())
         baseType = sc->baseType;
-    if (baseType->is<IR::IContainer>() || baseType->is<IR::Type_Extern>()) {
-        typeError("%1%: cannot declare variables of type %2% (consider using an instantiation)",
+    if (baseType->is<IR::IContainer>() || baseType->is<IR::Type_Extern>() ||
+        baseType->is<IR::Type_Parser>() || baseType->is<IR::Type_Control>()) {
+        typeError("%1%: cannot declare variables of type '%2%' (consider using an instantiation)",
                   decl, type);
         return decl;
     }

--- a/testdata/p4_16_errors/issue3359.p4
+++ b/testdata/p4_16_errors/issue3359.p4
@@ -1,0 +1,36 @@
+parser mypt(in bit tt);
+package mypack(mypt t);
+
+parser MyParser(in bit tt) {
+    state start {
+        transition select(tt) {
+            0: accept;
+            _: reject;
+        }
+    }
+}
+
+parser MyParser1(in bit tt) {
+    mypt t = MyParser();
+    state start {
+        t.apply(tt);
+        transition select(tt) {
+            0: accept;
+            _: reject;
+        }
+    }
+}
+
+parser MyParser2(in bit tt) {
+    mypt t;
+    state start {
+        t = MyParser();
+        t.apply(tt);
+        transition select(tt) {
+            0: accept;
+            _: reject;
+        }
+    }
+}
+
+mypack(MyParser1()) main;

--- a/testdata/p4_16_errors_outputs/issue3359.p4
+++ b/testdata/p4_16_errors_outputs/issue3359.p4
@@ -1,0 +1,36 @@
+parser mypt(in bit<1> tt);
+package mypack(mypt t);
+parser MyParser(in bit<1> tt) {
+    state start {
+        transition select(tt) {
+            0: accept;
+            default: reject;
+        }
+    }
+}
+
+parser MyParser1(in bit<1> tt) {
+    mypt t = MyParser();
+    state start {
+        t.apply(tt);
+        transition select(tt) {
+            0: accept;
+            default: reject;
+        }
+    }
+}
+
+parser MyParser2(in bit<1> tt) {
+    mypt t;
+    state start {
+        t = MyParser();
+        t.apply(tt);
+        transition select(tt) {
+            0: accept;
+            default: reject;
+        }
+    }
+}
+
+mypack(MyParser1()) main;
+

--- a/testdata/p4_16_errors_outputs/issue3359.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3359.p4-stderr
@@ -1,0 +1,12 @@
+issue3359.p4(14): [--Werror=type-error] error: t: cannot declare variables of type 'parser mypt' (consider using an instantiation)
+    mypt t = MyParser();
+    ^^^^^^^^^^^^^^^^^^^^
+issue3359.p4(1)
+parser mypt(in bit tt);
+       ^^^^
+issue3359.p4(25): [--Werror=type-error] error: t: cannot declare variables of type 'parser mypt' (consider using an instantiation)
+    mypt t;
+    ^^^^^^^
+issue3359.p4(1)
+parser mypt(in bit tt);
+       ^^^^

--- a/testdata/p4_16_errors_outputs/issue394.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue394.p4-stderr
@@ -1,4 +1,4 @@
-issue394.p4(19): [--Werror=type-error] error: c: cannot declare variables of type C (consider using an instantiation)
+issue394.p4(19): [--Werror=type-error] error: c: cannot declare variables of type 'C' (consider using an instantiation)
     C c;
     ^^^^
 issue394.p4(16)

--- a/testdata/p4_16_errors_outputs/issue807.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue807.p4-stderr
@@ -4,9 +4,21 @@ issue807.p4(20): [--Werror=type-error] error: e.get2: illegal return type contro
 issue807.p4(5)
 control C2();
         ^^
+issue807.p4(20): [--Werror=type-error] error: c2: cannot declare variables of type 'control C2' (consider using an instantiation)
+    C2 c2 = e.get2();
+    ^^^^^^^^^^^^^^^^^
+issue807.p4(5)
+control C2();
+        ^^
 issue807.p4(26): [--Werror=type-error] error: e.get1: illegal return type control C1
     C1 c1 = e.get1();
             ^^^^^^^^
+issue807.p4(4)
+control C1();
+        ^^
+issue807.p4(26): [--Werror=type-error] error: c1: cannot declare variables of type 'control C1' (consider using an instantiation)
+    C1 c1 = e.get1();
+    ^^^^^^^^^^^^^^^^^
 issue807.p4(4)
 control C1();
         ^^

--- a/testdata/p4_16_errors_outputs/issue816-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue816-1.p4-stderr
@@ -1,6 +1,18 @@
 issue816-1.p4(14): [--Werror=type-error] error: p: parameter cannot be a package
 control MyC1()(P p) {
                  ^
+issue816-1.p4(25): [--Werror=type-error] error: c1: cannot declare variables of type 'control C' (consider using an instantiation)
+  C c1 = MyC1(p);
+  ^^^^^^^^^^^^^^^
+issue816-1.p4(4)
+control C();
+        ^
 issue816-1.p4(18): [--Werror=type-error] error: p: parameter cannot be a package
 control MyC2()(P p) {
                  ^
+issue816-1.p4(26): [--Werror=type-error] error: c2: cannot declare variables of type 'control C' (consider using an instantiation)
+  C c2 = MyC2(p);
+  ^^^^^^^^^^^^^^^
+issue816-1.p4(4)
+control C();
+        ^


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3359