### PR TITLE
Dpdk backend: Add target_name field for tables to context json. 

### DIFF
--- a/backends/dpdk/DPDK_context_schema.json
+++ b/backends/dpdk/DPDK_context_schema.json
@@ -6,7 +6,11 @@
          "properties": {
             "name": {
                "type": "string",
-               "description": "Name of the referenced table."
+               "description": "Name of the referenced table as in the P4 file."
+            },
+            "target_name": {
+               "type": "string",
+               "description": "Name of the referenced table as in the spec file."
             },
             "handle": {
                "type": "integer",
@@ -26,7 +30,7 @@
                "type": "string",
                "description": "Name of the action as in P4 file"
             },
-            "target_action_name": {
+            "target_name": {
                "type": "string",
                "description": "Name of the action as in spec file"
             },

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -1676,8 +1676,6 @@ SplitP4TableCommon::create_match_table(const IR::P4Table *tbl) {
     } else {
         BUG("Unexpected table implementation type");
     }
-    auto hidden = new IR::Annotations();
-    hidden->add(new IR::Annotation(IR::Annotation::hiddenAnnotation, {}));
     IR::Vector<IR::KeyElement> match_keys;
     for (auto key : tbl->getKey()->keyElements) {
         if (key->matchType->toString() != "selector") {
@@ -1697,7 +1695,8 @@ SplitP4TableCommon::create_match_table(const IR::P4Table *tbl) {
     if (tbl->getSizeProperty()) {
         properties.push_back(new IR::Property("size",
                              new IR::ExpressionValue(tbl->getSizeProperty()), false)); }
-    auto match_table = new IR::P4Table(tbl->name, new IR::TableProperties(properties));
+    auto match_table = new IR::P4Table(tbl->name, tbl->annotations,
+                                       new IR::TableProperties(properties));
     return std::make_tuple(match_table, actionName);
 }
 
@@ -1725,6 +1724,10 @@ const IR::P4Table* SplitP4TableCommon::create_member_table(const IR::P4Table* tb
 
     auto hidden = new IR::Annotations();
     hidden->add(new IR::Annotation(IR::Annotation::hiddenAnnotation, {}));
+    auto nameAnnon = tbl->getAnnotation(IR::Annotation::nameAnnotation);
+    cstring nameA = nameAnnon->getSingleString();
+    cstring memName = nameA.replace(nameA.findlast('.'), "." + memberTableName);
+    hidden->addAnnotation(IR::Annotation::nameAnnotation, new IR::StringLiteral(memName), false);
 
     IR::IndexedVector<IR::ActionListElement> memberActionList;
     for (auto action : tbl->getActionList()->actionList)
@@ -1755,6 +1758,10 @@ const IR::P4Table* SplitP4TableCommon::create_group_table(const IR::P4Table* tbl
     }
     auto hidden = new IR::Annotations();
     hidden->add(new IR::Annotation(IR::Annotation::hiddenAnnotation, {}));
+    auto nameAnnon = tbl->getAnnotation(IR::Annotation::nameAnnotation);
+    cstring nameA = nameAnnon->getSingleString();
+    cstring selName = nameA.replace(nameA.findlast('.'), "." + selectorTableName);
+    hidden->addAnnotation(IR::Annotation::nameAnnotation, new IR::StringLiteral(selName), false);
     IR::IndexedVector<IR::Property> selector_properties;
     selector_properties.push_back(new IR::Property("selector", new IR::Key(selector_keys), false));
     selector_properties.push_back(new IR::Property("group_id",

--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -49,6 +49,7 @@ void DpdkContextGenerator::CollectTablesAndSetAttributes() {
                 struct TableAttributes tblAttr;
                 tblAttr.direction = direction;
                 tblAttr.controlName = control->name.originalName;
+                tblAttr.externalName = tbl->controlPlaneName();
                 tblAttr.tableHandle = getNewTableHandle();
                 auto size = tbl->getSizeProperty();
                 tblAttr.size = dpdk_default_table_size;
@@ -139,7 +140,8 @@ Util::JsonObject* DpdkContextGenerator::initTableCommonJson(
     const cstring name, const struct TableAttributes & attr) {
     auto* tableJson = new Util::JsonObject();
     cstring tableName = attr.controlName + "." + name;
-    tableJson->emplace("name", tableName);
+    tableJson->emplace("name", attr.externalName);
+    tableJson->emplace("target_name", tableName);
     tableJson->emplace("direction", attr.direction);
     tableJson->emplace("handle", attr.tableHandle);
     tableJson->emplace("table_type", attr.tableType);

--- a/backends/dpdk/dpdkContext.h
+++ b/backends/dpdk/dpdkContext.h
@@ -48,6 +48,7 @@ struct TableAttributes {
     bool isHidden;
     unsigned size;
     cstring controlName;
+    cstring externalName;
     unsigned default_action_handle;
     /* Non selector table keys from original P4 program */
     std::vector<std::pair<cstring, cstring>> tableKeys;


### PR DESCRIPTION

This PR adds target_name field for tables to context json. This holds the name of the table in spec file.