### PR TITLE
[RFC] Enable Automated Releases

### DIFF
--- a/.github/workflows/ci-auto-release.yml
+++ b/.github/workflows/ci-auto-release.yml
@@ -1,0 +1,87 @@
+name: Automated Release
+
+on:
+  schedule:
+    - cron: '0 12 1 * *'  # At 12:00 on day-of-month 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Check if the event is not triggered by a fork
+    if: ${{ github.repository == 'p4lang/p4c' && github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Fetch all history for all branches and tags
+          fetch-depth: 0
+
+      - name: Increment version number
+        run: perl -i -pe 's/\b(\d+)(?=\D*$)/$1+1/e' Version.txt
+
+      - name: Get changelog
+        id: changelog
+        run: |
+          TAG="$(git describe --tags --abbrev=0)"
+          GIT_LOG="$(git log $TAG..HEAD --oneline --pretty=format:"- %s [%an]")"
+          CHANGELOG=$(cat << EOF
+          Changelog:
+          $GIT_LOG
+          EOF
+          )
+          CHANGELOG="${CHANGELOG//'%'/'%25'}"
+          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+          CHANGELOG="${CHANGELOG//'#'/''}"
+          echo "::set-output name=content::$CHANGELOG"
+
+      - name: Display changelog
+        run: echo "${{ steps.changelog.outputs.content }}"
+
+      - name: Get version
+        run: |
+          VERSION="$(cat Version.txt)"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Get commit message
+        id: message
+        run: |
+          COMMIT_MSG=$(cat << EOF
+          Release v${{ env.VERSION }}
+
+          ${{ steps.changelog.outputs.content }}
+          EOF
+          )
+          COMMIT_MSG="${COMMIT_MSG//'%'/'%25'}"
+          COMMIT_MSG="${COMMIT_MSG//$'\n'/'%0A'}"
+          COMMIT_MSG="${COMMIT_MSG//$'\r'/'%0D'}"
+          echo "::set-output name=content::$COMMIT_MSG"
+
+      - name: Get pull request body message
+        id: body
+        run: |
+          MSG=$(cat << EOF
+          Auto-generated pull request for version ${{ env.VERSION }}.
+
+          Please use **Squash and merge** to include the changelog in the release message.
+
+          ${{ steps.changelog.outputs.content }}
+          EOF
+          )
+          MSG="${MSG//'%'/'%25'}"
+          MSG="${MSG//$'\n'/'%0A'}"
+          MSG="${MSG//$'\r'/'%0D'}"
+          echo "::set-output name=content::$MSG"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          base: main
+          add-paths: Version.txt
+          reviewers: mbudiu-vmw
+          commit-message: ${{ steps.message.outputs.content }}
+          signoff: false
+          branch: v${{ env.VERSION }}
+          delete-branch: true
+          title: Automated Release v${{ env.VERSION }}
+          body: ${{ steps.body.outputs.content }}


### PR DESCRIPTION
This pull request adds a new GitHub action that automatically increments the version of p4c on the first day of every month and creates a pull request. When that pull request is merged, a new GitHub release would be automatically created.

Example: 
- Auto-generated pull request: https://github.com/rst0git/p4c-1/pull/16
- Auto-generated release: https://github.com/rst0git/p4c-1/releases/tag/v1.2.2.3

The change in this pull request was discussed at the P4.org open source developer days meeting on June 7, 2022.