### PR TITLE
Add metadata field uses as Member Expression

### DIFF
--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -1013,16 +1013,17 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
             } else if (boolLiteral->value == true) {
                 return false;
             }
-            IR::PathExpression *error_meta_path;
+            IR::Member *error_meta_path;
             if (structure->isPSA()) {
-                error_meta_path = new IR::PathExpression(
-                    IR::ID("m.psa_ingress_input_metadata_parser_error"));
+                error_meta_path = new IR::Member(new IR::PathExpression(
+                    IR::ID("m")), IR::ID("psa_ingress_input_metadata_parser_error"));
             } else if (structure->isPNA()) {
-                error_meta_path = new IR::PathExpression(
-                    IR::ID("m.pna_pre_input_metadata_parser_error"));
+                error_meta_path = new IR::Member( new IR::PathExpression(IR::ID("m")),
+                    IR::ID("pna_pre_input_metadata_parser_error"));
             } else {
                 BUG("Unknown architecture unexpectedly!");
             }
+
             add_instr(new IR::DpdkMovStatement(error_meta_path, error_id->expression));
             add_instr(new IR::DpdkJmpLabelStatement(
                         append_parser_name(parser, IR::ParserState::reject)));

--- a/testdata/p4_16_samples_outputs/pna-example-pass-parser.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-pass-parser.p4.spec
@@ -26,6 +26,7 @@ struct udp_t {
 }
 
 struct main_metadata_t {
+	bit<16> pna_pre_input_metadata_parser_error
 	bit<32> pna_main_parser_input_metadata_pass
 	bit<32> pna_main_input_metadata_pass
 	bit<32> pna_main_input_metadata_input_port

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.spec
@@ -49,6 +49,7 @@ struct execute_1_arg_t {
 
 struct metadata_t {
 	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<16> psa_ingress_input_metadata_parser_error
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_port_out

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.spec
@@ -50,6 +50,7 @@ struct execute_1_arg_t {
 
 struct metadata_t {
 	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<16> psa_ingress_input_metadata_parser_error
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_port_out

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.spec
@@ -51,6 +51,7 @@ struct execute_1_arg_t {
 
 struct metadata_t {
 	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<16> psa_ingress_input_metadata_parser_error
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_port_out

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.spec
@@ -52,6 +52,7 @@ struct execute_1_arg_t {
 
 struct metadata_t {
 	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<16> psa_ingress_input_metadata_parser_error
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_port_out

--- a/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-header-stack.p4.spec
@@ -32,6 +32,7 @@ struct psa_egress_deparser_input_metadata_t {
 
 struct EMPTY_M {
 	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<16> psa_ingress_input_metadata_parser_error
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 }


### PR DESCRIPTION
some of the metadata fields were being removed as unused. Root cause is that some metadata fields are added as Path expressions instead of Member expressions