### PR TITLE
DPDK Backend: Update reference outputs for tests failing after dynamic header stack index merge

### DIFF
--- a/testdata/p4_16_samples_outputs/pna-example-varIndex-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex-1.p4.spec
@@ -16,6 +16,7 @@ header vlan_tag_1 instanceof vlan_tag_h
 
 
 struct main_metadata_t {
+	bit<16> pna_pre_input_metadata_parser_error
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> local_metadata_depth
 	bit<32> pna_main_output_metadata_output_port

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex-2.p4.spec
@@ -16,6 +16,7 @@ header vlan_tag_1 instanceof vlan_tag_h
 
 
 struct main_metadata_t {
+	bit<16> pna_pre_input_metadata_parser_error
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> local_metadata_depth
 	bit<32> pna_main_output_metadata_output_port

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex.p4.spec
@@ -16,6 +16,7 @@ header vlan_tag_1 instanceof vlan_tag_h
 
 
 struct main_metadata_t {
+	bit<16> pna_pre_input_metadata_parser_error
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> local_metadata_depth
 	bit<16> local_metadata_ethType

--- a/testdata/p4_16_samples_outputs/psa-variable-index.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-variable-index.p4.spec
@@ -32,6 +32,7 @@ struct psa_egress_deparser_input_metadata_t {
 
 struct EMPTY_M {
 	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<16> psa_ingress_input_metadata_parser_error
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_depth


### PR DESCRIPTION
Merging #3387  and #3375 is causing some tests to fail on the main branch.
Updating the reference outputs for tests added by #3375 affected by both PRs.