### PR TITLE
BUILD_USE_COLOR=OFF disables colors for the C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,11 @@ if (BUILD_USE_COLOR)
         message(WARNING "Colors enabled (BUILD_USE_COLOR=ON) but we don't know "
                 "how to enable them for ${CMAKE_CXX_COMPILER_ID} C++ compiler")
     endif()
+else()
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=never")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=never")
+  endif()
 endif()
 
 include_directories (


### PR DESCRIPTION
BUILD_USE_COLOR=OFF currently does not do what I would expect and what I need - it fails to disable colors (ansi control characters) - note, gcc default mode is "auto", not "never".

Either we should proceed with a patch like this one, or rename the original option to something like "BUILD_FORCE_COLORS". I prefer the former as I have an use case for BUILD_USE_COLOR=OFF.