### PR TITLE
DPDK Backend: Fix missing key initialization when header/metadata fields used as table keys

### DIFF
--- a/backends/dpdk/dpdkHelpers.h
+++ b/backends/dpdk/dpdkHelpers.h
@@ -166,11 +166,12 @@ class ConvertStatementToDpdk : public Inspector {
     ConvertStatementToDpdk(
         P4::ReferenceMap *refmap, P4::TypeMap *typemap,
         DpdkProgramStructure *structure)
-        : typemap(typemap), refmap(refmap), structure(structure) {}
+        : typemap(typemap), refmap(refmap), structure(structure) {visitDagOnce = false;}
     ConvertStatementToDpdk(
         P4::ReferenceMap *refmap, P4::TypeMap *typemap,
         DpdkProgramStructure *structure, IR::Type_Struct *metadataStruct)
-        : typemap(typemap), refmap(refmap), structure(structure), metadataStruct(metadataStruct) {}
+        : typemap(typemap), refmap(refmap), structure(structure),
+          metadataStruct(metadataStruct) {visitDagOnce = false;}
     IR::IndexedVector<IR::DpdkAsmStatement> getInstructions() {
         return instructions;
     }

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex-2.p4.spec
@@ -138,11 +138,14 @@ apply {
 	shr m.MainControlT_tmp_1 0x4
 	mov m.MainControlT_tmp_2 m.MainControlT_tmp_1
 	jmpeq LABEL_SWITCH_1 m.MainControlT_tmp_2 0x1
-	jmpeq LABEL_END_0 m.MainControlT_tmp_2 0x2
+	jmpeq LABEL_SWITCH_2 m.MainControlT_tmp_2 0x2
 	jmp LABEL_END_0
 	LABEL_SWITCH_1 :	mov m.MainControlT_tmp_16 h.vlan_tag_1.pcp_cfi_vid
 	shr m.MainControlT_tmp_16 0x4
 	mov m.MainControlT_key m.MainControlT_tmp_16
+	table stub
+	jmp LABEL_END_0
+	LABEL_SWITCH_2 :	table stub1
 	LABEL_END_0 :	emit h.ethernet
 	emit h.vlan_tag_0
 	emit h.vlan_tag_1

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex.p4.spec
@@ -183,6 +183,7 @@ apply {
 	mov m.MainControlT_tmp_31 h.vlan_tag_1.pcp_cfi_vid
 	shr m.MainControlT_tmp_31 0x4
 	mov m.MainControlT_key m.MainControlT_tmp_31
+	table stub
 	LABEL_END_0 :	emit h.ethernet
 	emit h.vlan_tag_0
 	emit h.vlan_tag_1

--- a/testdata/p4_16_samples_outputs/psa-action-selector4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-action-selector4.p4.spec
@@ -134,21 +134,29 @@ apply {
 	jmpnh LABEL_END_2
 	table foo
 	LABEL_END_2 :	table tbl
-	jmpnh LABEL_END_5
+	jmpnh LABEL_FALSE_5
 	table as_sel
-	jmpnh LABEL_END_5
+	jmpnh LABEL_FALSE_6
 	table as
 	jmpnh LABEL_FALSE_7
 	jmp LABEL_END_5
 	LABEL_FALSE_7 :	table foo
+	jmp LABEL_END_5
+	LABEL_FALSE_6 :	table foo
+	jmp LABEL_END_5
+	LABEL_FALSE_5 :	table foo
 	LABEL_END_5 :	table tbl
-	jmpnh LABEL_END_8
+	jmpnh LABEL_FALSE_8
 	table as_sel
-	jmpnh LABEL_END_8
+	jmpnh LABEL_FALSE_9
 	table as
 	jmpnh LABEL_FALSE_10
 	jmp LABEL_END_8
 	LABEL_FALSE_10 :	table foo
+	jmp LABEL_END_8
+	LABEL_FALSE_9 :	table foo
+	jmp LABEL_END_8
+	LABEL_FALSE_8 :	table foo
 	LABEL_END_8 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.spec
@@ -168,14 +168,18 @@ apply {
 	jmpnh LABEL_END
 	mov m.MyIC_foo_ethernet_dstAddr h.ethernet.dstAddr
 	table foo
-	LABEL_END :	table tbl
+	LABEL_END :	mov m.MyIC_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
 	jmpnh LABEL_END_0
+	mov m.MyIC_foo_ethernet_dstAddr h.ethernet.dstAddr
 	table foo
-	LABEL_END_0 :	table tbl
+	LABEL_END_0 :	mov m.MyIC_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
 	jmpnh LABEL_FALSE_1
 	jmp LABEL_END_1
 	LABEL_FALSE_1 :	table bar
-	LABEL_END_1 :	table tbl
+	LABEL_END_1 :	mov m.MyIC_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
 	jmpnh LABEL_FALSE_2
 	jmp LABEL_END_2
 	LABEL_FALSE_2 :	table bar

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.spec
@@ -141,14 +141,17 @@ apply {
 	table tbl
 	jmpnh LABEL_END
 	table foo
-	LABEL_END :	table tbl
+	LABEL_END :	mov m.MyIC_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
 	jmpnh LABEL_END_0
 	table foo
-	LABEL_END_0 :	table tbl
+	LABEL_END_0 :	mov m.MyIC_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
 	jmpnh LABEL_FALSE_1
 	jmp LABEL_END_1
 	LABEL_FALSE_1 :	table bar
-	LABEL_END_1 :	table tbl
+	LABEL_END_1 :	mov m.MyIC_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
 	jmpnh LABEL_FALSE_2
 	jmp LABEL_END_2
 	LABEL_FALSE_2 :	table bar


### PR DESCRIPTION
DPDK target does not accept table keys from different structures, hence compiler moves the keys coming from different structures to metadata.
Each table apply statement should be preceded with mov instructions corresponding to the assignment statements for moving the key fields to metadata(Example below)

```
table table1 {
   key = {
      hdr.ipv4.srcAddr : exact;
      hdr.ipv4.dstAddr : exact;
      hdr.ipv4.protocol : exact;
      hdr.tcp.srcPort : exact;    
      hdr.tcp.dstPort : exact;
  }
  ....
}
apply {
      if (cond){
               table.apply();
               flag = true;
               table1.apply();
      } else {
               flag = false;
               table1.apply();
     }
}
```
is translated into

```
 table table1 {
       key = {
           m.MainControlImpl_table1_ipv4_srcAddr : exact @name("hdr.ipv4.srcAddr") ;
           m.MainControlImpl_table1_ipv4_dstAddr : exact @name("hdr.ipv4.dstAddr") ;
           m.MainControlImpl_table1_ipv4_protocol: exact @name("hdr.ipv4.protocol") ;
           m.MainControlImpl_table1_tcp_srcPort  : exact @name("hdr.tcp.srcPort") ;
           m.MainControlImpl_table1_tcp_dstPort  : exact @name("hdr.tcp.dstPort") ;
       }
        ...
 }
apply { ....
                   if (cond == 1w1) {                     
                         table.apply()
                         flag = true;
                         {
                           m.MainControlImpl_table1_ipv4_srcAddr = h.ipv4.srcAddr;
                           m.MainControlImpl_table1_ipv4_dstAddr = h.ipv4.dstAddr;
                           m.MainControlImpl_table1_ipv4_protocol = h.ipv4.protocol;
                           m.MainControlImpl_table1_tcp_srcPort = h.tcp.srcPort;
                           m.MainControlImpl_table1_tcp_dstPort = h.tcp.dstPort;
                           table1.apply();
                         }
                   } else {
                       flag = false;
                       {
                           **m.MainControlImpl_table1_ipv4_srcAddr = h.ipv4.srcAddr;
                           m.MainControlImpl_table1_ipv4_dstAddr = h.ipv4.dstAddr;
                           m.MainControlImpl_table1_ipv4_protocol = h.ipv4.protocol;
                           m.MainControlImpl_table1_tcp_srcPort = h.tcp.srcPort;
                           m.MainControlImpl_table1_tcp_dstPort = h.tcp.dstPort;**
                           table1.apply();
                       }
                   }
...
}
```
When the same table is applied in both if and else, the **set of mov instructions for else block are missing** because the DAG is same for the block of mov statements and is visited only once while conversion to assembly.

Setting  the visitDagOnce to false fixes this issue.