### PR TITLE
PSA-eBPF PTF tests: update psabpf to the latest version

### DIFF
--- a/backends/ebpf/tests/ptf/common.py
+++ b/backends/ebpf/tests/ptf/common.py
@@ -359,24 +359,24 @@ class P4EbpfTest(BaseTest):
             self.fail("Support for DirectMeter is not implemented yet (psabpf doesn't return internal state of meter if you need it)")
 
     def action_selector_add_action(self, selector, action, data=None):
-        cmd = "psabpf-ctl action-selector add_member pipe {} {} ".format(TEST_PIPELINE_ID, selector)
+        cmd = "psabpf-ctl action-selector add-member pipe {} {} ".format(TEST_PIPELINE_ID, selector)
         cmd = cmd + self._table_create_str_from_action(action)
         if data:
             cmd = cmd + " data"
             for d in data:
                 cmd = cmd + " {}".format(d)
-        _, stdout, _ = self.exec_ns_cmd(cmd, "ActionSelector add_member failed")
+        _, stdout, _ = self.exec_ns_cmd(cmd, "ActionSelector add-member failed")
         return int(stdout)
 
     def action_selector_create_empty_group(self, selector):
-        cmd = "psabpf-ctl action-selector create_group pipe {} {}".format(TEST_PIPELINE_ID, selector)
-        _, stdout, _ = self.exec_ns_cmd(cmd, "ActionSelector create_group failed")
+        cmd = "psabpf-ctl action-selector create-group pipe {} {}".format(TEST_PIPELINE_ID, selector)
+        _, stdout, _ = self.exec_ns_cmd(cmd, "ActionSelector create-group failed")
         return int(stdout)
 
     def action_selector_add_member_to_group(self, selector, group_ref, member_ref):
-        cmd = "psabpf-ctl action-selector add_to_group pipe {} {} {} to {}"\
+        cmd = "psabpf-ctl action-selector add-to-group pipe {} {} {} to {}"\
             .format(TEST_PIPELINE_ID, selector, member_ref, group_ref)
-        self.exec_ns_cmd(cmd, "ActionSelector add_to_group failed")
+        self.exec_ns_cmd(cmd, "ActionSelector add-to-group failed")
 
     def digest_get(self, name):
         cmd = "psabpf-ctl digest get-all pipe {} {}".format(TEST_PIPELINE_ID, name)

--- a/backends/ebpf/tests/ptf/table_implementation.py
+++ b/backends/ebpf/tests/ptf/table_implementation.py
@@ -227,7 +227,7 @@ class ActionSelectorTwoTablesSameInstancePSATest(ActionSelectorTest):
         testutils.verify_packet(self, pkt, PORT2)
 
 
-class ActionSelectorDefaultEmptyGroupActionPSATest(ActionSelectorTest):
+class ActionSelectorEmptyGroupActionPSATest(ActionSelectorTest):
     """
     Tests behaviour of default empty group action, aka table property "psa_empty_group_action".
     """
@@ -245,8 +245,8 @@ class ActionSelectorDefaultEmptyGroupActionPSATest(ActionSelectorTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT1)
 
-        cmd = "psabpf-ctl action-selector default_group_action pipe {} MyIC_as action id 1 data 6".format(TEST_PIPELINE_ID)
-        self.exec_ns_cmd(cmd, "default group action update failed")
+        cmd = "psabpf-ctl action-selector empty-group-action pipe {} MyIC_as action id 1 data 6".format(TEST_PIPELINE_ID)
+        self.exec_ns_cmd(cmd, "empty group action update failed")
 
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet(self, pkt, PORT2)

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -82,7 +82,7 @@ function install_ptf_ebpf_test_deps() (
   git clone --recursive https://github.com/P4-Research/psabpf.git /tmp/psabpf
   cd /tmp/psabpf
   # FIXME: psabpf is under heavy development, later use git tags when it will be ready to use
-  git reset --hard 78445a5
+  git reset --hard 986981c
   ./build_libbpf.sh
   mkdir build
   cd build


### PR DESCRIPTION
New version of `psabpf-ctl`:
- now use `empty_gruop_action` instead of `default_group_action`
- use `-` instead `_` in commands