### PR TITLE
Add support of path expressions for a header stack inside parserUnroll

### DIFF
--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -8,6 +8,8 @@ namespace P4 {
 
 StackVariable::StackVariable(const IR::Expression* expr) : member(nullptr) {
     CHECK_NULL(expr);
+    // Translate PathExpression into Member.
+    expr = pathExprToMember(expr);
     BUG_CHECK(repOk(expr), "Invalid stack variable %1%", expr);
     member = expr->checkedTo<IR::Member>();
 }
@@ -41,6 +43,13 @@ size_t StackVariableHash::operator()(const StackVariable& var) const {
         curMember = curMember->expr->checkedTo<IR::Member>();
     }
     return Util::Hash::fnv1a(h.data(), sizeof(size_t) * h.size());
+}
+
+const IR::Expression* StackVariable::pathExprToMember(const IR::Expression* expr) {
+    if (expr->is<IR::PathExpression>()) {
+        return new IR::Member(expr->srcInfo, expr->type, expr, IR::ID(" "));
+    }
+    return expr;
 }
 
 /// The main class for parsers' states key for visited checking.

--- a/midend/parserUnroll.h
+++ b/midend/parserUnroll.h
@@ -55,6 +55,9 @@ class StackVariable {
     // Implements comparisons so that StateVariables can be used as map keys.
     bool operator==(const StackVariable& other) const;
 
+ protected:
+    const IR::Expression* pathExprToMember(const IR::Expression* expr);
+
  private:
     const IR::Member* member;
 


### PR DESCRIPTION
These small changes allow to support variables for header stacks which represented by `IR::PathExpression` inside `parserUnroll`.
To demonstrate a problem, please run the following commands:
1) p4c-bm2-ss -o "./dmp/uninit-nowarnings.p4" "testdata/p4_16_samples/uninit-nowarnings.p4" --loopsUnroll
2) p4c-bm2-ss -o "./dmp/issue2090.p4" "testdata/p4_16_samples/issue2090.p4" --loopsUnroll