### PR TITLE
Implement Redundant Copy Elimination

### DIFF
--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -137,6 +137,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
     PassManager post_code_gen = {
         new EliminateUnusedAction(),
         new DpdkAsmOptimization,
+        new CopyPropagationAndElimination(typeMap),
         new CollectUsedMetadataField(used_fields),
         new RemoveUnusedMetadataFields(used_fields),
         new ValidateTableKeys(),

--- a/backends/dpdk/dpdkAsmOpt.h
+++ b/backends/dpdk/dpdkAsmOpt.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "ir/ir.h"
 #include "lib/gmputil.h"
 #include "lib/json.h"
+#include "dpdkUtils.h"
 
 #define DPDK_TABLE_MAX_KEY_SIZE 64*8
 
@@ -289,6 +290,232 @@ class ShortenTokenLength : public Transform {
         return as;
     }
 };
+
+/// This pass collect use def info by analysing all possible
+/// source and destinations, this info will be used by copy elimination pass
+class CollectUseDefInfo : public Inspector {
+    P4::TypeMap* typeMap;
+
+ public:
+    // Member expression as string considered key for all below maps, and value contains
+    // number of occurences either at use or def point.
+    // And this point it's assumed all keys are unique.
+    std::unordered_map<cstring /*member expresion as string */, int> usesInfo;
+    std::unordered_map<cstring, int> defInfo;
+    std::unordered_map<cstring /*def*/, const IR::Expression* /*use*/> replacementMap;
+    std::set<cstring> dontEliminate;
+
+    explicit CollectUseDefInfo(P4::TypeMap* typeMap) : typeMap(typeMap) {
+        dontEliminate.insert("m.pna_main_output_metadata_output_port");
+        dontEliminate.insert("m.psa_ingress_output_metadata_drop");
+        dontEliminate.insert("m.psa_ingress_output_metadata_egress_port");
+    }
+
+    bool preorder(const IR::DpdkJmpCondStatement *b) override {
+        usesInfo[b->src1->toString()]++;
+        usesInfo[b->src2->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkLearnStatement *b) override {
+        usesInfo[b->timeout->toString()]++;
+        if (b->argument)
+            usesInfo[b->argument->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkUnaryStatement *u) override {
+        usesInfo[u->src->toString()]++;
+        defInfo[u->dst->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkBinaryStatement *b) override {
+        usesInfo[b->src1->toString()]++;
+        usesInfo[b->src2->toString()]++;
+        defInfo[b->dst->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkMovStatement *mv) override{
+        defInfo[mv->dst->toString()]++;
+        usesInfo[mv->src->toString()]++;
+        replacementMap[mv->dst->toString()] = mv->src;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkCastStatement *c) override {
+        usesInfo[c->src->toString()]++;
+        defInfo[c->dst->toString()]++;
+        replacementMap[c->dst->toString()] = c->src;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkEmitStatement* e) override {
+        auto type = typeMap->getType(e->header)->to<IR::Type_Header>();
+        if (type)
+            for (auto f : type->fields) {
+                cstring name = e->header->toString() + "." + f->name.toString();
+                usesInfo[name]++;
+            }
+        return false;
+    }
+
+    bool preorder(const IR::DpdkExtractStatement* e) override {
+        auto type = typeMap->getType(e->header)->to<IR::Type_Header>();
+        if (type)
+            for (auto f : type->fields) {
+                cstring name = e->header->toString() + "." + f->name.toString();
+                defInfo[name]++;
+            }
+        if (e->length)
+            usesInfo[e->length->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkLookaheadStatement* l) override {
+        auto type = typeMap->getType(l->header)->to<IR::Type_Header>();
+        if (type)
+            for (auto f : type->fields) {
+                cstring name = l->header->toString() + "." +f->name.toString();
+                defInfo[name]++;
+            }
+        return false;
+    }
+
+    bool preorder(const IR::DpdkRxStatement* r) override {
+        usesInfo[r->port->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkTxStatement* t) override {
+        usesInfo[t->port->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkRecircidStatement* t) override {
+        usesInfo[t->pass->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkRearmStatement* r) override {
+        if (r->timeout)
+            usesInfo[r->timeout->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkChecksumAddStatement* c) override {
+        usesInfo[c->field->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkChecksumSubStatement* c) override {
+        usesInfo[c->field->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkGetHashStatement* c) override {
+        usesInfo[c->dst->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkVerifyStatement* v) override {
+        usesInfo[v->condition->toString()]++;
+        usesInfo[v->error->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkMeterDeclStatement* c) override {
+        usesInfo[c->size->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkMeterExecuteStatement* e) override {
+        usesInfo[e->index->toString()]++;
+        if (e->length)
+            usesInfo[e->length->toString()]++;
+        usesInfo[e->color_in->toString()]++;
+        usesInfo[e->color_out->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkCounterCountStatement* c) override {
+        usesInfo[c->index->toString()]++;
+        if (c->incr)
+            usesInfo[c->incr->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkRegisterDeclStatement* r) override {
+        usesInfo[r->size->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkRegisterReadStatement* r) override {
+        usesInfo[r->index->toString()]++;
+        defInfo[r->dst->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkRegisterWriteStatement* r) override {
+        usesInfo[r->index->toString()]++;
+        return false;
+    }
+
+    bool preorder(const IR::DpdkTable *t) override {
+        auto keys = t->match_keys;
+        if (keys)
+        for (auto ke : keys->keyElements) {
+            dontEliminate.insert(ke->expression->toString());
+        }
+        return false;
+    }
+
+    bool haveSingleUseDef(cstring str) {
+        return defInfo[str] == 1 && usesInfo[str] == 1;
+    }
+};
+
+// This pass identifies redundant copies/moves and eliminates them.
+class CopyPropagationAndElimination : public Transform {
+    std::unordered_map<cstring, int> newUsesInfo;
+    P4::TypeMap* typeMap;
+    CollectUseDefInfo* collectUseDef;
+
+ public:
+    explicit CopyPropagationAndElimination(P4::TypeMap* typeMap) : typeMap(typeMap) {
+    }
+
+    const IR::Expression* getIrreplaceableExpr(cstring str, bool allowConst);
+    const IR::Expression* replaceIfCopy(const IR::Expression *expr, bool allowConst = true);
+    const IR::DpdkAsmStatement* elimCastOrMov(const IR::DpdkAsmStatement* stmt);
+    IR::IndexedVector<IR::DpdkAsmStatement> copyPropAndDeadCodeElim(
+                                                IR::IndexedVector<IR::DpdkAsmStatement> stmts);
+
+    const IR::Node* preorder(IR::DpdkAction* a) override {
+        collectUseDef = new CollectUseDefInfo(typeMap);
+        collectUseDef->setCalledBy(this);
+        a->apply(*collectUseDef);
+        return a;
+    }
+
+    const IR::Node* preorder(IR::DpdkListStatement *l) override {
+        collectUseDef = new CollectUseDefInfo(typeMap);
+        collectUseDef->setCalledBy(this);
+        l->apply(*collectUseDef);
+        return l;
+    }
+
+    const IR::Node* postorder(IR::DpdkAction* a) override {
+        a->statements = copyPropAndDeadCodeElim(a->statements);
+        return a;
+    }
+
+    const IR::Node* postorder(IR::DpdkListStatement *l) override {
+        return new IR::DpdkListStatement(copyPropAndDeadCodeElim(l->statements));
+    }
+};
+
 
 // Instructions can only appear in actions and apply block of .spec file.
 // All these individual passes work on the actions and apply block of .spec file.

--- a/testdata/p4_16_samples_outputs/pna-example-SelectByDirection2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-SelectByDirection2.p4.spec
@@ -71,8 +71,7 @@ apply {
 	mov m.MainControlT_addr h.ipv4.dstAddr
 	jmp LABEL_END_0
 	LABEL_TRUE_0 :	mov m.MainControlT_addr h.ipv4.srcAddr
-	LABEL_END_0 :	mov m.local_metadata_meta m.MainControlT_addr
-	jmpneq LABEL_END m.local_metadata_meta h.ipv4.dstAddr
+	LABEL_END_0 :	jmpneq LABEL_END m.MainControlT_addr h.ipv4.dstAddr
 	table ipv4_da_lpm
 	LABEL_END :	emit h.ethernet
 	emit h.ipv4

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4.spec
@@ -44,10 +44,8 @@ struct a2_arg_t {
 struct main_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> pna_main_output_metadata_output_port
-	bit<32> MainParserT_parser_tmp
 	bit<32> MainParserT_parser_tmp_0
 	bit<32> MainParserT_parser_tmp_1
-	bit<8> MainParserT_parser_tmp_2
 	bit<32> MainParserT_parser_tmp_1_extract_tmp
 }
 metadata instanceof main_metadata_t
@@ -109,12 +107,10 @@ apply {
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4_base
 	jmpeq MAINPARSERIMPL_ACCEPT h.ipv4_base.version_ihl 0x45
 	lookahead h.MainParserT_parser_lookahead_0
-	mov m.MainParserT_parser_tmp_2 h.MainParserT_parser_lookahead_0.f
-	jmpeq MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP m.MainParserT_parser_tmp_2 0x44
+	jmpeq MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP h.MainParserT_parser_lookahead_0.f 0x44
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP :	lookahead h.MainParserT_parser_tmp_hdr
-	mov m.MainParserT_parser_tmp h.MainParserT_parser_tmp_hdr.len
-	mov m.MainParserT_parser_tmp_0 m.MainParserT_parser_tmp
+	mov m.MainParserT_parser_tmp_0 h.MainParserT_parser_tmp_hdr.len
 	shl m.MainParserT_parser_tmp_0 0x3
 	mov m.MainParserT_parser_tmp_1 m.MainParserT_parser_tmp_0
 	add m.MainParserT_parser_tmp_1 0xfffffff0

--- a/testdata/p4_16_samples_outputs/pna-example-pass-3.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-pass-3.p4.spec
@@ -31,8 +31,6 @@ struct main_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
 	bit<16> local_metadata_port
 	bit<32> pna_main_output_metadata_output_port
-	bit<32> MainControlT_tmp
-	bit<8> MainControlT_tmp_0
 }
 metadata instanceof main_metadata_t
 
@@ -54,9 +52,7 @@ apply {
 	mov m.local_metadata_port h.udp.src_port
 	recirculate
 	LABEL_END :	recircid m.pna_main_input_metadata_pass
-	mov m.MainControlT_tmp m.pna_main_input_metadata_pass
-	mov m.MainControlT_tmp_0 m.MainControlT_tmp
-	jmpgt LABEL_END_0 m.MainControlT_tmp_0 0x4
+	jmpgt LABEL_END_0 m.pna_main_input_metadata_pass 0x4
 	add h.udp.src_port 0x1
 	recirculate
 	LABEL_END_0 :	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/pna-example-pass-parser.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-pass-parser.p4.spec
@@ -33,8 +33,6 @@ struct main_metadata_t {
 	bit<16> local_metadata_port
 	bit<32> pna_main_output_metadata_output_port
 	bit<32> MainParserT_parser_tmp
-	bit<32> MainControlT_tmp
-	bit<8> MainControlT_tmp_0
 }
 metadata instanceof main_metadata_t
 
@@ -63,9 +61,7 @@ apply {
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_NOMATCH :	mov m.pna_pre_input_metadata_parser_error 0x2
 	MAINPARSERIMPL_ACCEPT :	recircid m.pna_main_input_metadata_pass
-	mov m.MainControlT_tmp m.pna_main_input_metadata_pass
-	mov m.MainControlT_tmp_0 m.MainControlT_tmp
-	jmpgt LABEL_END_1 m.MainControlT_tmp_0 0x4
+	jmpgt LABEL_END_1 m.pna_main_input_metadata_pass 0x4
 	add h.udp.src_port 0x1
 	LABEL_END_1 :	emit h.ethernet
 	emit h.ipv4

--- a/testdata/p4_16_samples_outputs/pna-example-pass.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-pass.p4.spec
@@ -29,8 +29,6 @@ struct main_metadata_t {
 	bit<32> pna_main_input_metadata_pass
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> pna_main_output_metadata_output_port
-	bit<32> MainControlT_tmp
-	bit<8> MainControlT_tmp_0
 }
 metadata instanceof main_metadata_t
 
@@ -48,9 +46,7 @@ apply {
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	extract h.udp
 	MAINPARSERIMPL_ACCEPT :	recircid m.pna_main_input_metadata_pass
-	mov m.MainControlT_tmp m.pna_main_input_metadata_pass
-	mov m.MainControlT_tmp_0 m.MainControlT_tmp
-	jmpgt LABEL_END m.MainControlT_tmp_0 0x4
+	jmpgt LABEL_END m.pna_main_input_metadata_pass 0x4
 	add h.udp.src_port 0x1
 	recirculate
 	LABEL_END :	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex-1.p4.spec
@@ -28,22 +28,16 @@ struct main_metadata_t {
 	bit<32> MainControlT_tmp_4
 	bit<16> MainControlT_tmp_5
 	bit<16> MainControlT_tmp_6
-	bit<32> MainControlT_tmp_7
-	bit<16> MainControlT_tmp_8
 	bit<16> MainControlT_tmp_9
 	bit<16> MainControlT_tmp_10
 	bit<16> MainControlT_tmp_11
-	bit<16> MainControlT_tmp_12
 	bit<16> MainControlT_tmp_13
 	bit<16> MainControlT_tmp_14
 	bit<16> MainControlT_tmp_15
 	bit<16> MainControlT_tmp_16
-	bit<32> MainControlT_tmp_17
-	bit<16> MainControlT_tmp_18
 	bit<16> MainControlT_tmp_19
 	bit<16> MainControlT_tmp_20
 	bit<16> MainControlT_tmp_21
-	bit<16> MainControlT_tmp_22
 	bit<16> MainControlT_tmp_23
 	bit<16> MainControlT_tmp_24
 	bit<16> MainControlT_tmp_25
@@ -68,9 +62,7 @@ action execute_1 args none {
 	and m.MainControlT_tmp_5 0xf
 	mov m.MainControlT_tmp_6 h.vlan_tag_1.pcp_cfi_vid
 	shr m.MainControlT_tmp_6 0x4
-	mov m.MainControlT_tmp_7 m.MainControlT_tmp_6
-	mov m.MainControlT_tmp_8 m.MainControlT_tmp_7
-	mov m.MainControlT_tmp_9 m.MainControlT_tmp_8
+	mov m.MainControlT_tmp_9 m.MainControlT_tmp_6
 	shl m.MainControlT_tmp_9 0x4
 	mov m.MainControlT_tmp_10 m.MainControlT_tmp_9
 	and m.MainControlT_tmp_10 0xfff0
@@ -82,8 +74,7 @@ action execute_1 args none {
 	jmplt LABEL_END_3 m.MainControlT_tmp 0x1
 	mov m.MainControlT_tmp_11 h.vlan_tag_0.pcp_cfi_vid
 	and m.MainControlT_tmp_11 0xf
-	mov m.MainControlT_tmp_12 m.MainControlT_hsVar
-	mov m.MainControlT_tmp_13 m.MainControlT_tmp_12
+	mov m.MainControlT_tmp_13 m.MainControlT_hsVar
 	shl m.MainControlT_tmp_13 0x4
 	mov m.MainControlT_tmp_14 m.MainControlT_tmp_13
 	and m.MainControlT_tmp_14 0xfff0
@@ -98,9 +89,7 @@ action execute_1 args none {
 	and m.MainControlT_tmp_15 0xf
 	mov m.MainControlT_tmp_16 h.vlan_tag_0.pcp_cfi_vid
 	shr m.MainControlT_tmp_16 0x4
-	mov m.MainControlT_tmp_17 m.MainControlT_tmp_16
-	mov m.MainControlT_tmp_18 m.MainControlT_tmp_17
-	mov m.MainControlT_tmp_19 m.MainControlT_tmp_18
+	mov m.MainControlT_tmp_19 m.MainControlT_tmp_16
 	shl m.MainControlT_tmp_19 0x4
 	mov m.MainControlT_tmp_20 m.MainControlT_tmp_19
 	and m.MainControlT_tmp_20 0xfff0
@@ -116,8 +105,7 @@ action execute_1 args none {
 	jmplt LABEL_END_3 m.MainControlT_tmp_2 0x1
 	mov m.MainControlT_tmp_21 h.vlan_tag_1.pcp_cfi_vid
 	and m.MainControlT_tmp_21 0xf
-	mov m.MainControlT_tmp_22 m.MainControlT_hsVar
-	mov m.MainControlT_tmp_23 m.MainControlT_tmp_22
+	mov m.MainControlT_tmp_23 m.MainControlT_hsVar
 	shl m.MainControlT_tmp_23 0x4
 	mov m.MainControlT_tmp_24 m.MainControlT_tmp_23
 	and m.MainControlT_tmp_24 0xfff0

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex-2.p4.spec
@@ -26,14 +26,10 @@ struct main_metadata_t {
 	bit<32> MainControlT_tmp_2
 	bit<16> MainControlT_tmp_3
 	bit<16> MainControlT_tmp_4
-	bit<32> MainControlT_tmp_5
-	bit<16> MainControlT_tmp_6
 	bit<16> MainControlT_tmp_7
 	bit<16> MainControlT_tmp_8
 	bit<16> MainControlT_tmp_9
 	bit<16> MainControlT_tmp_10
-	bit<32> MainControlT_tmp_11
-	bit<16> MainControlT_tmp_12
 	bit<16> MainControlT_tmp_13
 	bit<16> MainControlT_tmp_14
 	bit<16> MainControlT_tmp_15
@@ -50,9 +46,7 @@ action execute_1 args none {
 	and m.MainControlT_tmp_3 0xf
 	mov m.MainControlT_tmp_4 h.vlan_tag_0.pcp_cfi_vid
 	shr m.MainControlT_tmp_4 0x4
-	mov m.MainControlT_tmp_5 m.MainControlT_tmp_4
-	mov m.MainControlT_tmp_6 m.MainControlT_tmp_5
-	mov m.MainControlT_tmp_7 m.MainControlT_tmp_6
+	mov m.MainControlT_tmp_7 m.MainControlT_tmp_4
 	shl m.MainControlT_tmp_7 0x4
 	mov m.MainControlT_tmp_8 m.MainControlT_tmp_7
 	and m.MainControlT_tmp_8 0xfff0
@@ -64,9 +58,7 @@ action execute_1 args none {
 	and m.MainControlT_tmp_9 0xf
 	mov m.MainControlT_tmp_10 h.vlan_tag_0.pcp_cfi_vid
 	shr m.MainControlT_tmp_10 0x4
-	mov m.MainControlT_tmp_11 m.MainControlT_tmp_10
-	mov m.MainControlT_tmp_12 m.MainControlT_tmp_11
-	mov m.MainControlT_tmp_13 m.MainControlT_tmp_12
+	mov m.MainControlT_tmp_13 m.MainControlT_tmp_10
 	shl m.MainControlT_tmp_13 0x4
 	mov m.MainControlT_tmp_14 m.MainControlT_tmp_13
 	and m.MainControlT_tmp_14 0xfff0

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex.p4.spec
@@ -28,28 +28,18 @@ struct main_metadata_t {
 	bit<32> MainControlT_tmp_3
 	bit<16> MainControlT_tmp_4
 	bit<16> MainControlT_tmp_5
-	bit<32> MainControlT_tmp_6
-	bit<32> MainControlT_tmp_7
-	bit<16> MainControlT_tmp_8
 	bit<16> MainControlT_tmp_9
 	bit<16> MainControlT_tmp_10
 	bit<16> MainControlT_tmp_11
 	bit<16> MainControlT_tmp_12
-	bit<32> MainControlT_tmp_13
-	bit<32> MainControlT_tmp_14
-	bit<16> MainControlT_tmp_15
 	bit<16> MainControlT_tmp_16
 	bit<16> MainControlT_tmp_17
 	bit<16> MainControlT_tmp_18
 	bit<16> MainControlT_tmp_19
-	bit<32> MainControlT_tmp_20
-	bit<16> MainControlT_tmp_21
 	bit<16> MainControlT_tmp_22
 	bit<16> MainControlT_tmp_23
 	bit<16> MainControlT_tmp_24
 	bit<16> MainControlT_tmp_25
-	bit<32> MainControlT_tmp_26
-	bit<16> MainControlT_tmp_27
 	bit<16> MainControlT_tmp_28
 	bit<16> MainControlT_tmp_29
 	bit<16> MainControlT_tmp_30
@@ -90,10 +80,7 @@ action execute_1 args none {
 	and m.MainControlT_tmp_4 0xf
 	mov m.MainControlT_tmp_5 h.vlan_tag_0.pcp_cfi_vid
 	shr m.MainControlT_tmp_5 0x3
-	mov m.MainControlT_tmp_6 m.MainControlT_tmp_5
-	mov m.MainControlT_tmp_7 m.MainControlT_tmp_6
-	mov m.MainControlT_tmp_8 m.MainControlT_tmp_7
-	mov m.MainControlT_tmp_9 m.MainControlT_tmp_8
+	mov m.MainControlT_tmp_9 m.MainControlT_tmp_5
 	shl m.MainControlT_tmp_9 0x4
 	mov m.MainControlT_tmp_10 m.MainControlT_tmp_9
 	and m.MainControlT_tmp_10 0xfff0
@@ -105,10 +92,7 @@ action execute_1 args none {
 	and m.MainControlT_tmp_11 0xf
 	mov m.MainControlT_tmp_12 h.vlan_tag_1.pcp_cfi_vid
 	shr m.MainControlT_tmp_12 0x3
-	mov m.MainControlT_tmp_13 m.MainControlT_tmp_12
-	mov m.MainControlT_tmp_14 m.MainControlT_tmp_13
-	mov m.MainControlT_tmp_15 m.MainControlT_tmp_14
-	mov m.MainControlT_tmp_16 m.MainControlT_tmp_15
+	mov m.MainControlT_tmp_16 m.MainControlT_tmp_12
 	shl m.MainControlT_tmp_16 0x4
 	mov m.MainControlT_tmp_17 m.MainControlT_tmp_16
 	and m.MainControlT_tmp_17 0xfff0
@@ -119,9 +103,7 @@ action execute_1 args none {
 	and m.MainControlT_tmp_18 0xf
 	mov m.MainControlT_tmp_19 h.vlan_tag_1.pcp_cfi_vid
 	shr m.MainControlT_tmp_19 0x4
-	mov m.MainControlT_tmp_20 m.MainControlT_tmp_19
-	mov m.MainControlT_tmp_21 m.MainControlT_tmp_20
-	mov m.MainControlT_tmp_22 m.MainControlT_tmp_21
+	mov m.MainControlT_tmp_22 m.MainControlT_tmp_19
 	shl m.MainControlT_tmp_22 0x4
 	mov m.MainControlT_tmp_23 m.MainControlT_tmp_22
 	and m.MainControlT_tmp_23 0xfff0
@@ -133,9 +115,7 @@ action execute_1 args none {
 	and m.MainControlT_tmp_24 0xf
 	mov m.MainControlT_tmp_25 h.vlan_tag_1.pcp_cfi_vid
 	shr m.MainControlT_tmp_25 0x4
-	mov m.MainControlT_tmp_26 m.MainControlT_tmp_25
-	mov m.MainControlT_tmp_27 m.MainControlT_tmp_26
-	mov m.MainControlT_tmp_28 m.MainControlT_tmp_27
+	mov m.MainControlT_tmp_28 m.MainControlT_tmp_25
 	shl m.MainControlT_tmp_28 0x4
 	mov m.MainControlT_tmp_29 m.MainControlT_tmp_28
 	and m.MainControlT_tmp_29 0xfff0

--- a/testdata/p4_16_samples_outputs/pna-issue3041.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-issue3041.p4.spec
@@ -41,9 +41,7 @@ struct main_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> pna_main_output_metadata_output_port
 	bit<8> MainParserT_parser_tmp
-	bit<32> MainParserT_parser_tmp_0
 	bit<32> MainParserT_parser_tmp_1
-	bit<32> MainParserT_parser_tmp_2
 	bit<32> MainParserT_parser_tmp_3
 	bit<32> MainParserT_parser_tmp_3_extract_tmp
 }
@@ -104,13 +102,11 @@ apply {
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4_base
 	mov m.MainParserT_parser_tmp h.ipv4_base.version_ihl
 	shr m.MainParserT_parser_tmp 0x4
-	mov m.MainParserT_parser_tmp_2 m.MainParserT_parser_tmp
-	jmpeq MAINPARSERIMPL_ACCEPT m.MainParserT_parser_tmp_2 0x5
+	jmpeq MAINPARSERIMPL_ACCEPT m.MainParserT_parser_tmp 0x5
 	lookahead h.option
 	jmpeq MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP h.option.type 0x44
 	jmp MAINPARSERIMPL_ACCEPT
-	MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP :	mov m.MainParserT_parser_tmp_0 h.option.len
-	mov m.MainParserT_parser_tmp_1 m.MainParserT_parser_tmp_0
+	MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP :	mov m.MainParserT_parser_tmp_1 h.option.len
 	shl m.MainParserT_parser_tmp_1 0x3
 	mov m.MainParserT_parser_tmp_3 m.MainParserT_parser_tmp_1
 	add m.MainParserT_parser_tmp_3 0xfffffff0

--- a/testdata/p4_16_samples_outputs/pna-lookahead-structure.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-lookahead-structure.p4.spec
@@ -20,9 +20,6 @@ struct main_metadata_t {
 	bit<32> pna_main_output_metadata_output_port
 	bit<24> MainParserT_parser_tmp
 	bit<24> MainParserT_parser_tmp_0
-	bit<8> MainParserT_parser_tmp_1
-	bit<16> MainParserT_parser_tmp_2
-	bit<24> MainParserT_parser_tmp_3
 	bit<24> MainParserT_parser_tmp_4
 }
 metadata instanceof main_metadata_t
@@ -39,11 +36,9 @@ regarray direction size 0x100 initval 0
 apply {
 	rx m.pna_main_input_metadata_input_port
 	lookahead h.MainParserT_parser_lookahead_1
-	mov m.MainParserT_parser_tmp_3 h.MainParserT_parser_lookahead_1.f
-	mov m.MainParserT_parser_tmp_0 m.MainParserT_parser_tmp_3
+	mov m.MainParserT_parser_tmp_0 h.MainParserT_parser_lookahead_1.f
 	shr m.MainParserT_parser_tmp_0 0x8
-	mov m.MainParserT_parser_tmp_2 m.MainParserT_parser_tmp_0
-	jmpeq MAINPARSERIMPL_PARSE_H1 m.MainParserT_parser_tmp_2 0x1234
+	jmpeq MAINPARSERIMPL_PARSE_H1 m.MainParserT_parser_tmp_0 0x1234
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_H1 :	extract h.h1
 	lookahead h.MainParserT_parser_lookahead_0
@@ -52,8 +47,7 @@ apply {
 	shr m.MainParserT_parser_tmp 0x8
 	mov m.local_metadata__s1_type10 m.MainParserT_parser_tmp
 	mov m.local_metadata__s1_type21 m.MainParserT_parser_tmp_4
-	mov m.MainParserT_parser_tmp_1 m.MainParserT_parser_tmp_4
-	jmpeq MAINPARSERIMPL_PARSE_H2 m.MainParserT_parser_tmp_1 0x1
+	jmpeq MAINPARSERIMPL_PARSE_H2 m.MainParserT_parser_tmp_4 0x1
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_H2 :	extract h.h2
 	MAINPARSERIMPL_ACCEPT :	tx m.pna_main_output_metadata_output_port

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-01.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-01.p4.spec
@@ -37,7 +37,6 @@ struct user_meta_data_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> local_metadata_addr
-	bit<32> Ingress_tmp
 }
 metadata instanceof user_meta_data_t
 
@@ -73,8 +72,7 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	mov m.Ingress_tmp m.psa_ingress_input_metadata_ingress_port
-	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
+	mov m.psa_ingress_output_metadata_egress_port m.psa_ingress_input_metadata_ingress_port
 	xor m.psa_ingress_output_metadata_egress_port 0x1
 	table stub
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-02.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-02.p4.spec
@@ -37,7 +37,6 @@ struct user_meta_data_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> local_metadata_addr
-	bit<32> Ingress_tmp
 }
 metadata instanceof user_meta_data_t
 
@@ -73,8 +72,7 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	mov m.Ingress_tmp m.psa_ingress_input_metadata_ingress_port
-	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
+	mov m.psa_ingress_output_metadata_egress_port m.psa_ingress_input_metadata_ingress_port
 	xor m.psa_ingress_output_metadata_egress_port 0x1
 	table stub
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-03.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-03.p4.spec
@@ -32,7 +32,6 @@ struct user_meta_data_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> local_metadata_addr
-	bit<32> Ingress_tmp
 }
 metadata instanceof user_meta_data_t
 
@@ -66,8 +65,7 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	mov m.Ingress_tmp m.psa_ingress_input_metadata_ingress_port
-	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
+	mov m.psa_ingress_output_metadata_egress_port m.psa_ingress_input_metadata_ingress_port
 	xor m.psa_ingress_output_metadata_egress_port 0x1
 	table stub
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-04.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-04.p4.spec
@@ -32,7 +32,6 @@ struct user_meta_data_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> local_metadata_addr
-	bit<32> Ingress_tmp
 }
 metadata instanceof user_meta_data_t
 
@@ -66,8 +65,7 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	mov m.Ingress_tmp m.psa_ingress_input_metadata_ingress_port
-	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
+	mov m.psa_ingress_output_metadata_egress_port m.psa_ingress_input_metadata_ingress_port
 	xor m.psa_ingress_output_metadata_egress_port 0x1
 	table stub
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-05.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-05.p4.spec
@@ -37,7 +37,6 @@ struct user_meta_data_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> local_metadata_addr
-	bit<32> Ingress_tmp
 }
 metadata instanceof user_meta_data_t
 
@@ -78,8 +77,7 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	mov m.Ingress_tmp m.psa_ingress_input_metadata_ingress_port
-	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
+	mov m.psa_ingress_output_metadata_egress_port m.psa_ingress_input_metadata_ingress_port
 	xor m.psa_ingress_output_metadata_egress_port 0x1
 	table stub
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-06.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-06.p4.spec
@@ -37,7 +37,6 @@ struct user_meta_data_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> local_metadata_addr
-	bit<32> Ingress_tmp
 }
 metadata instanceof user_meta_data_t
 
@@ -78,8 +77,7 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	mov m.Ingress_tmp m.psa_ingress_input_metadata_ingress_port
-	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
+	mov m.psa_ingress_output_metadata_egress_port m.psa_ingress_input_metadata_ingress_port
 	xor m.psa_ingress_output_metadata_egress_port 0x1
 	table stub
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-07.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-07.p4.spec
@@ -37,7 +37,6 @@ struct user_meta_data_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> local_metadata_addr
-	bit<32> Ingress_tmp
 }
 metadata instanceof user_meta_data_t
 
@@ -78,8 +77,7 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	mov m.Ingress_tmp m.psa_ingress_input_metadata_ingress_port
-	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
+	mov m.psa_ingress_output_metadata_egress_port m.psa_ingress_input_metadata_ingress_port
 	xor m.psa_ingress_output_metadata_egress_port 0x1
 	table stub
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-08.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-08.p4.spec
@@ -36,7 +36,6 @@ struct user_meta_data_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> local_metadata_addr
-	bit<32> Ingress_tmp
 	bit<48> Ingress_tmp1
 }
 metadata instanceof user_meta_data_t
@@ -75,8 +74,7 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	mov m.Ingress_tmp m.psa_ingress_input_metadata_ingress_port
-	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
+	mov m.psa_ingress_output_metadata_egress_port m.psa_ingress_input_metadata_ingress_port
 	xor m.psa_ingress_output_metadata_egress_port 0x1
 	table stub
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-09.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-09.p4.spec
@@ -37,7 +37,6 @@ struct user_meta_data_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> local_metadata_addr
-	bit<32> Ingress_tmp
 }
 metadata instanceof user_meta_data_t
 
@@ -73,8 +72,7 @@ apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	mov m.Ingress_tmp m.psa_ingress_input_metadata_ingress_port
-	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
+	mov m.psa_ingress_output_metadata_egress_port m.psa_ingress_input_metadata_ingress_port
 	xor m.psa_ingress_output_metadata_egress_port 0x1
 	table stub
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error.p4.bfrt.json
@@ -1,0 +1,84 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "user_meta.data1",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ethernet.$valid",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 1
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.tcp.$valid",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 1
+          }
+        },
+        {
+          "id" : 4,
+          "name" : "hdr.ipv4.$valid",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 1
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error.p4.spec
@@ -1,5 +1,6 @@
 
 
+
 struct ethernet_t {
 	bit<48> dstAddr
 	bit<48> srcAddr
@@ -17,6 +18,18 @@ struct ipv4_t {
 	bit<16> hdrChecksum
 	bit<32> srcAddr
 	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<16> dataOffset_res_ecn_ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
 }
 
 struct psa_ingress_output_metadata_t {
@@ -39,43 +52,35 @@ struct psa_egress_deparser_input_metadata_t {
 	bit<32> egress_port
 }
 
-struct execute_1_arg_t {
-	bit<32> index
-}
-
-struct metadata_t {
+struct metadata {
 	bit<32> psa_ingress_input_metadata_ingress_port
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<32> local_metadata_port_out
-	bit<32> Ingress_color_out
-	bit<32> Ingress_color_in
-	bit<32> Ingress_tmp_0
+	bit<48> local_metadata_data1
+	bit<8> ingress_tbl_ethernet_isValid
+	bit<8> ingress_tbl_tcp_isValid
+	bit<8> ingress_tbl_ipv4_isValid
 }
-metadata instanceof metadata_t
+metadata instanceof metadata
 
 header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
-
-metarray meter0_0 size 0x400
+header tcp instanceof tcp_t
 
 action NoAction args none {
 	return
 }
 
-action execute_1 args instanceof execute_1_arg_t {
-	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in m.Ingress_color_out
-	jmpneq LABEL_FALSE_0 m.Ingress_color_out 0x0
-	mov m.Ingress_tmp_0 0x1
-	jmp LABEL_END_0
-	LABEL_FALSE_0 :	mov m.Ingress_tmp_0 0x0
-	LABEL_END_0 :	mov m.local_metadata_port_out m.Ingress_tmp_0
+action execute_1 args none {
 	return
 }
 
 table tbl {
 	key {
-		h.ethernet.srcAddr exact
+		m.local_metadata_data1 exact
+		m.ingress_tbl_ethernet_isValid exact
+		m.ingress_tbl_tcp_isValid exact
+		m.ingress_tbl_ipv4_isValid exact
 	}
 	actions {
 		NoAction
@@ -88,17 +93,24 @@ table tbl {
 
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
-	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
-	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
-	jmpneq LABEL_END m.local_metadata_port_out 0x1
-	table tbl
-	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	jmpv LABEL_END h.ethernet
+	LABEL_END :	jmpv LABEL_END_0 h.tcp
+	LABEL_END_0 :	jmpv LABEL_END_1 h.ipv4
+	LABEL_END_1 :	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4
+	emit h.tcp
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-token-too-big.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-token-too-big.p4.spec
@@ -129,8 +129,6 @@ action vxlan_encap_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dp5 args instanc
 	mov h.vxlan.vni t.vxlan_vni
 	mov h.vxlan.reserved2 t.vxlan_reserved2
 	mov m.psa_ingress_output_metadata_egress_port t.port_out
-	mov m.Ingress_tmp h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.hdr_checksum
-	mov m.Ingress_tmp_0 h.ipv4.total_len
 	ckadd h.cksum_state.state_0 m.Ingress_tmp
 	ckadd h.cksum_state.state_0 m.Ingress_tmp_0
 	mov h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.hdr_checksum h.cksum_state.state_0

--- a/testdata/p4_16_samples_outputs/psa-end-of-ingress-test-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-end-of-ingress-test-bmv2.p4.spec
@@ -40,12 +40,8 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> Ingress_tmp
-	bit<32> Ingress_tmp_0
 	bit<48> Ingress_tmp_1
-	bit<32> Ingress_tmp_2
 	bit<48> Ingress_tmp_3
-	bit<16> Ingress_tmp_4
-	bit<16> Ingress_tmp_5
 }
 metadata instanceof metadata_t
 
@@ -61,8 +57,7 @@ apply {
 	extract h.output_data
 	mov m.Ingress_tmp h.ethernet.dstAddr
 	shr m.Ingress_tmp 0x28
-	mov m.Ingress_tmp_0 m.Ingress_tmp
-	jmpneq LABEL_TRUE m.Ingress_tmp_0 0x0
+	jmpneq LABEL_TRUE m.Ingress_tmp 0x0
 	mov m.psa_ingress_output_metadata_drop 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.psa_ingress_output_metadata_drop 0x1
@@ -70,17 +65,14 @@ apply {
 	jmp LABEL_END_0
 	LABEL_FALSE_0 :	mov m.Ingress_tmp_1 h.ethernet.dstAddr
 	shr m.Ingress_tmp_1 0x20
-	mov m.Ingress_tmp_2 m.Ingress_tmp_1
-	jmpneq LABEL_TRUE_1 m.Ingress_tmp_2 0x0
+	jmpneq LABEL_TRUE_1 m.Ingress_tmp_1 0x0
 	mov m.psa_ingress_output_metadata_resubmit 0x0
 	jmp LABEL_END_0
 	LABEL_TRUE_1 :	mov m.psa_ingress_output_metadata_resubmit 0x1
 	LABEL_END_0 :	mov m.Ingress_tmp_3 h.ethernet.dstAddr
 	shr m.Ingress_tmp_3 0x10
-	mov m.Ingress_tmp_4 m.Ingress_tmp_3
-	mov m.psa_ingress_output_metadata_multicast_group m.Ingress_tmp_4
-	mov m.Ingress_tmp_5 h.ethernet.dstAddr
-	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp_5
+	mov m.psa_ingress_output_metadata_multicast_group m.Ingress_tmp_3
+	mov m.psa_ingress_output_metadata_egress_port h.ethernet.dstAddr
 	mov h.output_data.word0 0x8
 	jmpneq LABEL_FALSE_2 m.psa_ingress_input_metadata_packet_path 0x0
 	mov h.output_data.word0 0x1

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.spec
@@ -54,19 +54,13 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_port_out
 	bit<8> IngressParser_parser_tmp
-	bit<32> IngressParser_parser_tmp_0
 	bit<8> IngressParser_parser_tmp_1
 	bit<32> IngressParser_parser_tmp_2
-	bit<32> Ingress_tmp
-	bit<32> Ingress_tmp_0
-	bit<32> Ingress_tmp_1
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
 	bit<8> Ingress_tmp_4
 	bit<16> Ingress_tmp_5
-	bit<32> Ingress_tmp_6
 	bit<32> Ingress_tmp_7
-	bit<16> Ingress_tmp_8
 	bit<16> Ingress_tmp_9
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
@@ -105,14 +99,12 @@ action execute_1 args instanceof execute_1_arg_t {
 	LABEL_FALSE_2 :	mov m.Ingress_tmp_10 0x0
 	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_10
 	regwr reg_0 t.index m.local_metadata_port_out
-	mov m.Ingress_tmp h.ipv4.hdrChecksum
-	jmpneq LABEL_END_4 m.Ingress_tmp 0x6
+	jmpneq LABEL_END_4 h.ipv4.hdrChecksum 0x6
 	mov m.Ingress_tmp_3 h.ipv4.version_ihl
 	and m.Ingress_tmp_3 0xf
 	mov h.ipv4.version_ihl m.Ingress_tmp_3
 	or h.ipv4.version_ihl 0x50
-	LABEL_END_4 :	mov m.Ingress_tmp_0 h.ipv4.version_ihl
-	jmpneq LABEL_END_5 m.Ingress_tmp_0 0x6
+	LABEL_END_4 :	jmpneq LABEL_END_5 h.ipv4.version_ihl 0x6
 	mov m.Ingress_tmp_4 h.ipv4.version_ihl
 	and m.Ingress_tmp_4 0xf
 	mov h.ipv4.version_ihl m.Ingress_tmp_4
@@ -142,8 +134,7 @@ apply {
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4.version_ihl
 	shr m.IngressParser_parser_tmp 0x4
-	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
-	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp 0x5
 	mov m.IngressParser_parser_tmp_1 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.IngressParser_parser_tmp_1 0x1
@@ -159,15 +150,12 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3ff 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_1 h.ipv4.version_ihl
-	jmpneq LABEL_END_1 m.Ingress_tmp_1 0x4
+	jmpneq LABEL_END_1 h.ipv4.version_ihl 0x4
 	mov m.Ingress_tmp_5 h.ipv4.hdrChecksum
 	and m.Ingress_tmp_5 0xfff0
-	mov m.Ingress_tmp_6 h.ipv4.version_ihl
-	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	mov m.Ingress_tmp_7 h.ipv4.version_ihl
 	add m.Ingress_tmp_7 0x5
-	mov m.Ingress_tmp_8 m.Ingress_tmp_7
-	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	mov m.Ingress_tmp_9 m.Ingress_tmp_7
 	and m.Ingress_tmp_9 0xf
 	mov h.ipv4.hdrChecksum m.Ingress_tmp_5
 	or h.ipv4.hdrChecksum m.Ingress_tmp_9

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.spec
@@ -54,16 +54,11 @@ struct metadata_t {
 	bit<32> local_metadata_port_out
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<32> IngressParser_parser_tmp
-	bit<32> Ingress_tmp
-	bit<32> Ingress_tmp_0
-	bit<32> Ingress_tmp_1
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
 	bit<8> Ingress_tmp_4
 	bit<16> Ingress_tmp_5
-	bit<32> Ingress_tmp_6
 	bit<32> Ingress_tmp_7
-	bit<16> Ingress_tmp_8
 	bit<16> Ingress_tmp_9
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
@@ -104,14 +99,12 @@ action execute_1 args instanceof execute_1_arg_t {
 	LABEL_FALSE_1 :	mov m.Ingress_tmp_10 0x0
 	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_10
 	regwr reg_0 t.index m.local_metadata_port_out
-	mov m.Ingress_tmp h.ipv4.hdrChecksum
-	jmpneq LABEL_END_2 m.Ingress_tmp 0x6
+	jmpneq LABEL_END_2 h.ipv4.hdrChecksum 0x6
 	mov m.Ingress_tmp_3 h.ipv4.version_ihl
 	and m.Ingress_tmp_3 0xf
 	mov h.ipv4.version_ihl m.Ingress_tmp_3
 	or h.ipv4.version_ihl 0x50
-	LABEL_END_2 :	mov m.Ingress_tmp_0 h.ipv4.version_ihl
-	jmpneq LABEL_END_3 m.Ingress_tmp_0 0x6
+	LABEL_END_2 :	jmpneq LABEL_END_3 h.ipv4.version_ihl 0x6
 	mov m.Ingress_tmp_4 h.ipv4.version_ihl
 	and m.Ingress_tmp_4 0xf
 	mov h.ipv4.version_ihl m.Ingress_tmp_4
@@ -153,15 +146,12 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3ff 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_1 h.ipv4.version_ihl
-	jmpneq LABEL_END m.Ingress_tmp_1 0x4
+	jmpneq LABEL_END h.ipv4.version_ihl 0x4
 	mov m.Ingress_tmp_5 h.ipv4.hdrChecksum
 	and m.Ingress_tmp_5 0xfff0
-	mov m.Ingress_tmp_6 h.ipv4.version_ihl
-	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	mov m.Ingress_tmp_7 h.ipv4.version_ihl
 	add m.Ingress_tmp_7 0x5
-	mov m.Ingress_tmp_8 m.Ingress_tmp_7
-	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	mov m.Ingress_tmp_9 m.Ingress_tmp_7
 	and m.Ingress_tmp_9 0xf
 	mov h.ipv4.hdrChecksum m.Ingress_tmp_5
 	or h.ipv4.hdrChecksum m.Ingress_tmp_9

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.spec
@@ -53,16 +53,11 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_port_out
 	bit<32> IngressParser_parser_tmp
-	bit<32> Ingress_tmp
-	bit<32> Ingress_tmp_0
-	bit<32> Ingress_tmp_1
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
 	bit<8> Ingress_tmp_4
 	bit<16> Ingress_tmp_5
-	bit<32> Ingress_tmp_6
 	bit<32> Ingress_tmp_7
-	bit<16> Ingress_tmp_8
 	bit<16> Ingress_tmp_9
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
@@ -101,14 +96,12 @@ action execute_1 args instanceof execute_1_arg_t {
 	LABEL_FALSE_1 :	mov m.Ingress_tmp_10 0x0
 	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_10
 	regwr reg_0 t.index m.local_metadata_port_out
-	mov m.Ingress_tmp h.ipv4.hdrChecksum
-	jmpneq LABEL_END_2 m.Ingress_tmp 0x6
+	jmpneq LABEL_END_2 h.ipv4.hdrChecksum 0x6
 	mov m.Ingress_tmp_3 h.ipv4.version_ihl
 	and m.Ingress_tmp_3 0xf
 	mov h.ipv4.version_ihl m.Ingress_tmp_3
 	or h.ipv4.version_ihl 0x50
-	LABEL_END_2 :	mov m.Ingress_tmp_0 h.ipv4.version_ihl
-	jmpneq LABEL_END_3 m.Ingress_tmp_0 0x6
+	LABEL_END_2 :	jmpneq LABEL_END_3 h.ipv4.version_ihl 0x6
 	mov m.Ingress_tmp_4 h.ipv4.version_ihl
 	and m.Ingress_tmp_4 0xf
 	mov h.ipv4.version_ihl m.Ingress_tmp_4
@@ -145,15 +138,12 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3ff 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_1 h.ipv4.version_ihl
-	jmpneq LABEL_END m.Ingress_tmp_1 0x4
+	jmpneq LABEL_END h.ipv4.version_ihl 0x4
 	mov m.Ingress_tmp_5 h.ipv4.hdrChecksum
 	and m.Ingress_tmp_5 0xfff0
-	mov m.Ingress_tmp_6 h.ipv4.version_ihl
-	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	mov m.Ingress_tmp_7 h.ipv4.version_ihl
 	add m.Ingress_tmp_7 0x5
-	mov m.Ingress_tmp_8 m.Ingress_tmp_7
-	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	mov m.Ingress_tmp_9 m.Ingress_tmp_7
 	and m.Ingress_tmp_9 0xf
 	mov h.ipv4.hdrChecksum m.Ingress_tmp_5
 	or h.ipv4.hdrChecksum m.Ingress_tmp_9

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.spec
@@ -56,11 +56,8 @@ struct metadata_t {
 	bit<32> local_metadata_port_out
 	bit<32> local_metadata_temp
 	bit<8> IngressParser_parser_tmp
-	bit<32> IngressParser_parser_tmp_0
 	bit<8> IngressParser_parser_tmp_1
 	bit<32> IngressParser_parser_tmp_2
-	bit<32> Ingress_tmp
-	bit<32> Ingress_tmp_0
 	bit<8> Ingress_tmp_1
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
@@ -68,9 +65,7 @@ struct metadata_t {
 	bit<8> Ingress_tmp_5
 	bit<8> Ingress_tmp_6
 	bit<16> Ingress_tmp_7
-	bit<32> Ingress_tmp_8
 	bit<32> Ingress_tmp_9
-	bit<16> Ingress_tmp_10
 	bit<16> Ingress_tmp_11
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
@@ -109,8 +104,7 @@ action execute_1 args instanceof execute_1_arg_t {
 	LABEL_FALSE_2 :	mov m.Ingress_tmp_12 0x0
 	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_12
 	regwr reg_0 t.index m.local_metadata_port_out
-	mov m.Ingress_tmp h.ipv4._version0__ihl1
-	jmpneq LABEL_END_4 m.Ingress_tmp 0x6
+	jmpneq LABEL_END_4 h.ipv4._version0__ihl1 0x6
 	mov m.Ingress_tmp_2 h.ipv4._version0__ihl1
 	and m.Ingress_tmp_2 0xf
 	mov h.ipv4._version0__ihl1 m.Ingress_tmp_2
@@ -158,8 +152,7 @@ apply {
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4._version0__ihl1
 	shr m.IngressParser_parser_tmp 0x4
-	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
-	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp 0x5
 	mov m.IngressParser_parser_tmp_1 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.IngressParser_parser_tmp_1 0x1
@@ -175,15 +168,12 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3ff 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_0 h.ipv4._version0__ihl1
-	jmpneq LABEL_END_1 m.Ingress_tmp_0 0x4
+	jmpneq LABEL_END_1 h.ipv4._version0__ihl1 0x4
 	mov m.Ingress_tmp_7 h.ipv4._hdrChecksum9
 	and m.Ingress_tmp_7 0xfff0
-	mov m.Ingress_tmp_8 h.ipv4._version0__ihl1
-	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	mov m.Ingress_tmp_9 h.ipv4._version0__ihl1
 	add m.Ingress_tmp_9 0x5
-	mov m.Ingress_tmp_10 m.Ingress_tmp_9
-	mov m.Ingress_tmp_11 m.Ingress_tmp_10
+	mov m.Ingress_tmp_11 m.Ingress_tmp_9
 	and m.Ingress_tmp_11 0xf
 	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_7
 	or h.ipv4._hdrChecksum9 m.Ingress_tmp_11

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.spec
@@ -57,11 +57,8 @@ struct metadata_t {
 	bit<32> local_metadata_port_out
 	bit<32> local_metadata_temp
 	bit<8> IngressParser_parser_tmp
-	bit<32> IngressParser_parser_tmp_0
 	bit<8> IngressParser_parser_tmp_1
 	bit<32> IngressParser_parser_tmp_2
-	bit<32> Ingress_tmp
-	bit<32> Ingress_tmp_0
 	bit<8> Ingress_tmp_1
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
@@ -73,9 +70,7 @@ struct metadata_t {
 	bit<8> Ingress_tmp_9
 	bit<8> Ingress_tmp_10
 	bit<16> Ingress_tmp_11
-	bit<32> Ingress_tmp_12
 	bit<32> Ingress_tmp_13
-	bit<16> Ingress_tmp_14
 	bit<16> Ingress_tmp_15
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
@@ -114,8 +109,7 @@ action execute_1 args instanceof execute_1_arg_t {
 	LABEL_FALSE_2 :	mov m.Ingress_tmp_16 0x0
 	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_16
 	regwr reg_0 t.index m.local_metadata_port_out
-	mov m.Ingress_tmp h.ipv4._version0__ihl1
-	jmpneq LABEL_END_4 m.Ingress_tmp 0x6
+	jmpneq LABEL_END_4 h.ipv4._version0__ihl1 0x6
 	mov m.Ingress_tmp_2 h.ipv4._version0__ihl1
 	and m.Ingress_tmp_2 0xf
 	mov h.ipv4._version0__ihl1 m.Ingress_tmp_2
@@ -179,8 +173,7 @@ apply {
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4._version0__ihl1
 	shr m.IngressParser_parser_tmp 0x4
-	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
-	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp 0x5
 	mov m.IngressParser_parser_tmp_1 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.IngressParser_parser_tmp_1 0x1
@@ -196,15 +189,12 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3ff 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_0 h.ipv4._version0__ihl1
-	jmpneq LABEL_END_1 m.Ingress_tmp_0 0x4
+	jmpneq LABEL_END_1 h.ipv4._version0__ihl1 0x4
 	mov m.Ingress_tmp_11 h.ipv4._hdrChecksum9
 	and m.Ingress_tmp_11 0xfff0
-	mov m.Ingress_tmp_12 h.ipv4._version0__ihl1
-	mov m.Ingress_tmp_13 m.Ingress_tmp_12
+	mov m.Ingress_tmp_13 h.ipv4._version0__ihl1
 	add m.Ingress_tmp_13 0x5
-	mov m.Ingress_tmp_14 m.Ingress_tmp_13
-	mov m.Ingress_tmp_15 m.Ingress_tmp_14
+	mov m.Ingress_tmp_15 m.Ingress_tmp_13
 	and m.Ingress_tmp_15 0xf
 	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_11
 	or h.ipv4._hdrChecksum9 m.Ingress_tmp_15

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.spec
@@ -58,11 +58,8 @@ struct metadata_t {
 	bit<32> local_metadata_port_out
 	bit<32> local_metadata_temp
 	bit<8> IngressParser_parser_tmp
-	bit<32> IngressParser_parser_tmp_0
 	bit<8> IngressParser_parser_tmp_1
 	bit<32> IngressParser_parser_tmp_2
-	bit<32> Ingress_tmp
-	bit<32> Ingress_tmp_0
 	bit<8> Ingress_tmp_1
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
@@ -70,9 +67,7 @@ struct metadata_t {
 	bit<8> Ingress_tmp_5
 	bit<8> Ingress_tmp_6
 	bit<16> Ingress_tmp_7
-	bit<32> Ingress_tmp_8
 	bit<32> Ingress_tmp_9
-	bit<16> Ingress_tmp_10
 	bit<16> Ingress_tmp_11
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
@@ -111,8 +106,7 @@ action execute_1 args instanceof execute_1_arg_t {
 	LABEL_FALSE_2 :	mov m.Ingress_tmp_12 0x0
 	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_12
 	regwr reg_0 t.index m.local_metadata_port_out
-	mov m.Ingress_tmp h.ipv4._version0__ihl1
-	jmpneq LABEL_END_4 m.Ingress_tmp 0x6
+	jmpneq LABEL_END_4 h.ipv4._version0__ihl1 0x6
 	mov m.Ingress_tmp_2 h.ipv4._version0__ihl1
 	and m.Ingress_tmp_2 0xf
 	mov h.ipv4._version0__ihl1 m.Ingress_tmp_2
@@ -164,8 +158,7 @@ apply {
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4._version0__ihl1
 	shr m.IngressParser_parser_tmp 0x4
-	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
-	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp 0x5
 	mov m.IngressParser_parser_tmp_1 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.IngressParser_parser_tmp_1 0x1
@@ -181,15 +174,12 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3ff 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_0 h.ipv4._version0__ihl1
-	jmpneq LABEL_END_1 m.Ingress_tmp_0 0x4
+	jmpneq LABEL_END_1 h.ipv4._version0__ihl1 0x4
 	mov m.Ingress_tmp_7 h.ipv4._hdrChecksum9
 	and m.Ingress_tmp_7 0xfff0
-	mov m.Ingress_tmp_8 h.ipv4._version0__ihl1
-	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	mov m.Ingress_tmp_9 h.ipv4._version0__ihl1
 	add m.Ingress_tmp_9 0x5
-	mov m.Ingress_tmp_10 m.Ingress_tmp_9
-	mov m.Ingress_tmp_11 m.Ingress_tmp_10
+	mov m.Ingress_tmp_11 m.Ingress_tmp_9
 	and m.Ingress_tmp_11 0xf
 	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_7
 	or h.ipv4._hdrChecksum9 m.Ingress_tmp_11

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.spec
@@ -55,16 +55,11 @@ struct metadata_t {
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<16> ingress_tbl_ipv4_hdrChecksum
 	bit<32> IngressParser_parser_tmp
-	bit<32> Ingress_tmp
-	bit<32> Ingress_tmp_0
-	bit<32> Ingress_tmp_1
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
 	bit<8> Ingress_tmp_4
 	bit<16> Ingress_tmp_5
-	bit<32> Ingress_tmp_6
 	bit<32> Ingress_tmp_7
-	bit<16> Ingress_tmp_8
 	bit<16> Ingress_tmp_9
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
@@ -104,14 +99,12 @@ action execute_1 args instanceof execute_1_arg_t {
 	LABEL_FALSE_1 :	mov m.Ingress_tmp_10 0x0
 	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_10
 	regwr reg_0 t.index m.local_metadata_port_out
-	mov m.Ingress_tmp h.ipv4.hdrChecksum
-	jmpneq LABEL_END_2 m.Ingress_tmp 0x6
+	jmpneq LABEL_END_2 h.ipv4.hdrChecksum 0x6
 	mov m.Ingress_tmp_3 h.ipv4.version_ihl
 	and m.Ingress_tmp_3 0xf
 	mov h.ipv4.version_ihl m.Ingress_tmp_3
 	or h.ipv4.version_ihl 0x50
-	LABEL_END_2 :	mov m.Ingress_tmp_0 h.ipv4.version_ihl
-	jmpneq LABEL_END_3 m.Ingress_tmp_0 0x6
+	LABEL_END_2 :	jmpneq LABEL_END_3 h.ipv4.version_ihl 0x6
 	mov m.Ingress_tmp_4 h.ipv4.version_ihl
 	and m.Ingress_tmp_4 0xf
 	mov h.ipv4.version_ihl m.Ingress_tmp_4
@@ -153,15 +146,12 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3ff 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_1 h.ipv4.version_ihl
-	jmpneq LABEL_END m.Ingress_tmp_1 0x4
+	jmpneq LABEL_END h.ipv4.version_ihl 0x4
 	mov m.Ingress_tmp_5 h.ipv4.hdrChecksum
 	and m.Ingress_tmp_5 0xfff0
-	mov m.Ingress_tmp_6 h.ipv4.version_ihl
-	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	mov m.Ingress_tmp_7 h.ipv4.version_ihl
 	add m.Ingress_tmp_7 0x5
-	mov m.Ingress_tmp_8 m.Ingress_tmp_7
-	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	mov m.Ingress_tmp_9 m.Ingress_tmp_7
 	and m.Ingress_tmp_9 0xf
 	mov h.ipv4.hdrChecksum m.Ingress_tmp_5
 	or h.ipv4.hdrChecksum m.Ingress_tmp_9

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2.p4.spec
@@ -82,12 +82,8 @@ struct EMPTY {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<8> IngressParser_parser_tmp
-	bit<32> IngressParser_parser_tmp_0
 	bit<32> IngressParser_parser_tmp_1
 	bit<32> IngressParser_parser_tmp_2
-	bit<16> IngressParser_parser_tmp16
-	bit<8> IngressParser_parser_tmp_3
 	bit<32> Ingress_ap_member_id
 	bit<32> IngressParser_parser_tmp_2_extract_tmp
 }
@@ -160,14 +156,10 @@ apply {
 	MYIP_PARSE_IPV4 :	extract h.ipv4_base
 	jmpeq MYIP_ACCEPT h.ipv4_base.version_ihl 0x45
 	lookahead h.IngressParser_parser_lookahea1
-	mov m.IngressParser_parser_tmp_3 h.IngressParser_parser_lookahea1.f
-	jmpeq MYIP_PARSE_IPV4_OPTION_TIMESTAMP m.IngressParser_parser_tmp_3 0x44
+	jmpeq MYIP_PARSE_IPV4_OPTION_TIMESTAMP h.IngressParser_parser_lookahea1.f 0x44
 	jmp MYIP_ACCEPT
 	MYIP_PARSE_IPV4_OPTION_TIMESTAMP :	lookahead h.IngressParser_parser_lookahea0
-	mov m.IngressParser_parser_tmp16 h.IngressParser_parser_lookahea0.f
-	mov m.IngressParser_parser_tmp m.IngressParser_parser_tmp16
-	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
-	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
+	mov m.IngressParser_parser_tmp_1 h.IngressParser_parser_lookahea0.f
 	shl m.IngressParser_parser_tmp_1 0x3
 	mov m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_1
 	add m.IngressParser_parser_tmp_2 0xfffffff0

--- a/testdata/p4_16_samples_outputs/psa-hash-08.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-hash-08.p4.spec
@@ -44,7 +44,6 @@ struct user_meta_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
-	bit<16> Ingress_tmp
 	bit<16> user_meta_t_Ingress_tmp
 	bit<8> ipv4_t_version_ihl
 	bit<8> ipv4_t_diffserv
@@ -68,8 +67,7 @@ action NoAction args none {
 }
 
 action a1 args none {
-	mov m.Ingress_tmp h.ethernet.srcAddr
-	mov m.user_meta_t_Ingress_tmp m.Ingress_tmp
+	mov m.user_meta_t_Ingress_tmp h.ethernet.srcAddr
 	mov m.ipv4_t_version_ihl h.Ingress_tmp_0.version_ihl
 	mov m.ipv4_t_diffserv h.Ingress_tmp_0.diffserv
 	mov m.ipv4_t_totalLen h.Ingress_tmp_0.totalLen

--- a/testdata/p4_16_samples_outputs/psa-hash-09.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-hash-09.p4.spec
@@ -44,8 +44,6 @@ struct user_meta_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
-	bit<48> Ingress_tmp
-	bit<16> Ingress_tmp_0
 	bit<48> user_meta_t_Ingress_tmp
 	bit<16> user_meta_t_Ingress_tmp_0
 	bit<8> ipv4_t_version_ihl
@@ -70,10 +68,8 @@ action NoAction args none {
 }
 
 action a1 args none {
-	mov m.Ingress_tmp h.ethernet.srcAddr
-	mov m.Ingress_tmp_0 h.ethernet.etherType
-	mov m.user_meta_t_Ingress_tmp m.Ingress_tmp
-	mov m.user_meta_t_Ingress_tmp_0 m.Ingress_tmp_0
+	mov m.user_meta_t_Ingress_tmp h.ethernet.srcAddr
+	mov m.user_meta_t_Ingress_tmp_0 h.ethernet.etherType
 	mov m.ipv4_t_version_ihl h.Ingress_tmp_1.version_ihl
 	mov m.ipv4_t_diffserv h.Ingress_tmp_1.diffserv
 	mov m.ipv4_t_totalLen h.Ingress_tmp_1.totalLen

--- a/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-multicast-basic-2-bmv2.p4.spec
@@ -39,7 +39,6 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> Ingress_tmp
-	bit<32> Ingress_tmp_0
 }
 metadata instanceof metadata_t
 
@@ -55,8 +54,7 @@ apply {
 	mov m.Ingress_tmp h.ethernet.dstAddr
 	and m.Ingress_tmp 0xffffffff
 	mov m.psa_ingress_output_metadata_multicast_group m.Ingress_tmp
-	mov m.Ingress_tmp_0 h.ethernet.srcAddr
-	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp_0
+	mov m.psa_ingress_output_metadata_class_of_service h.ethernet.srcAddr
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.spec
@@ -38,7 +38,6 @@ struct metadata_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<32> Ingress_tmp
 	bit<48> Ingress_tmp_0
 	bit<32> Ingress_int_packet_path
 }
@@ -52,8 +51,7 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x0
 	extract h.ethernet
 	extract h.output_data
-	mov m.Ingress_tmp h.ethernet.dstAddr
-	jmplt LABEL_FALSE m.Ingress_tmp 0x4
+	jmplt LABEL_FALSE h.ethernet.dstAddr 0x4
 	mov h.output_data.word1 m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0
 	mov m.psa_ingress_output_metadata_multicast_group 0x0

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4.spec
@@ -42,15 +42,10 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> Ingress_tmp
-	bit<8> Ingress_tmp_0
 	bit<48> Ingress_tmp_1
-	bit<8> Ingress_tmp_2
 	bit<48> Ingress_tmp_3
-	bit<8> Ingress_tmp_4
 	bit<48> Ingress_tmp_5
-	bit<8> Ingress_tmp_6
 	bit<48> Ingress_tmp_7
-	bit<8> Ingress_tmp_8
 	bit<48> Ingress_tmp_9
 	bit<8> Ingress_idx
 	bit<16> Ingress_orig_data
@@ -69,31 +64,26 @@ apply {
 	mov m.Ingress_idx h.ethernet.dstAddr
 	mov m.Ingress_tmp h.ethernet.dstAddr
 	shr m.Ingress_tmp 0x8
-	mov m.Ingress_tmp_0 m.Ingress_tmp
 	mov m.Ingress_tmp_1 h.ethernet.dstAddr
 	shr m.Ingress_tmp_1 0x8
-	mov m.Ingress_tmp_2 m.Ingress_tmp_1
-	jmplt LABEL_END_0 m.Ingress_tmp_0 0x1
-	jmpgt LABEL_END_0 m.Ingress_tmp_2 0x3
+	jmplt LABEL_END_0 m.Ingress_tmp 0x1
+	jmpgt LABEL_END_0 m.Ingress_tmp_1 0x3
 	regrd m.Ingress_orig_data reg_0 m.Ingress_idx
 	LABEL_END_0 :	mov m.Ingress_tmp_7 h.ethernet.dstAddr
 	shr m.Ingress_tmp_7 0x8
-	mov m.Ingress_tmp_8 m.Ingress_tmp_7
-	jmpneq LABEL_FALSE_1 m.Ingress_tmp_8 0x1
+	jmpneq LABEL_FALSE_1 m.Ingress_tmp_7 0x1
 	mov m.Ingress_tmp_9 h.ethernet.dstAddr
 	shr m.Ingress_tmp_9 0x20
 	mov m.Ingress_next_data m.Ingress_tmp_9
 	jmp LABEL_END_1
 	LABEL_FALSE_1 :	mov m.Ingress_tmp_5 h.ethernet.dstAddr
 	shr m.Ingress_tmp_5 0x8
-	mov m.Ingress_tmp_6 m.Ingress_tmp_5
-	jmpneq LABEL_FALSE_2 m.Ingress_tmp_6 0x2
+	jmpneq LABEL_FALSE_2 m.Ingress_tmp_5 0x2
 	mov m.Ingress_next_data m.Ingress_orig_data
 	jmp LABEL_END_1
 	LABEL_FALSE_2 :	mov m.Ingress_tmp_3 h.ethernet.dstAddr
 	shr m.Ingress_tmp_3 0x8
-	mov m.Ingress_tmp_4 m.Ingress_tmp_3
-	jmpneq LABEL_FALSE_3 m.Ingress_tmp_4 0x3
+	jmpneq LABEL_FALSE_3 m.Ingress_tmp_3 0x3
 	mov m.Ingress_next_data m.Ingress_orig_data
 	add m.Ingress_next_data 0x1
 	jmp LABEL_END_1

--- a/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-unicast-or-drop-bmv2.p4.spec
@@ -39,7 +39,6 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_multicast_group
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<48> Ingress_tmp
-	bit<32> Ingress_tmp_0
 }
 metadata instanceof metadata_t
 
@@ -58,8 +57,7 @@ apply {
 	mov m.psa_ingress_output_metadata_egress_port m.Ingress_tmp
 	jmpneq LABEL_END h.ethernet.dstAddr 0x0
 	mov m.psa_ingress_output_metadata_drop 1
-	LABEL_END :	mov m.Ingress_tmp_0 h.ethernet.srcAddr
-	mov m.psa_ingress_output_metadata_class_of_service m.Ingress_tmp_0
+	LABEL_END :	mov m.psa_ingress_output_metadata_class_of_service h.ethernet.srcAddr
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.output_data

--- a/testdata/p4_16_samples_outputs/psa-variable-index.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-variable-index.p4.spec
@@ -38,12 +38,9 @@ struct EMPTY_M {
 	bit<32> local_metadata_depth
 	bit<16> local_metadata_ret
 	bit<16> Ingress_tmp
-	bit<32> Ingress_tmp_0
 	bit<16> Ingress_tmp_1
-	bit<32> Ingress_tmp_2
 	bit<16> Ingress_tmp_3
 	bit<16> Ingress_tmp_4
-	bit<16> Ingress_tmp_5
 	bit<16> Ingress_hsVar
 	bit<32> Ingress_hsVar_0
 	bit<32> Ingress_vid
@@ -90,14 +87,12 @@ apply {
 	MYIP_ACCEPT :	jmpneq LABEL_FALSE m.local_metadata_depth 0x0
 	mov m.Ingress_tmp h.vlan_tag_0.pcp_cfi_vid
 	shr m.Ingress_tmp 0x4
-	mov m.Ingress_tmp_0 m.Ingress_tmp
-	mov m.local_metadata_ret m.Ingress_tmp_0
+	mov m.local_metadata_ret m.Ingress_tmp
 	jmp LABEL_END_0
 	LABEL_FALSE :	jmpneq LABEL_FALSE_0 m.local_metadata_depth 0x1
 	mov m.Ingress_tmp_1 h.vlan_tag_1.pcp_cfi_vid
 	shr m.Ingress_tmp_1 0x4
-	mov m.Ingress_tmp_2 m.Ingress_tmp_1
-	mov m.local_metadata_ret m.Ingress_tmp_2
+	mov m.local_metadata_ret m.Ingress_tmp_1
 	jmp LABEL_END_0
 	LABEL_FALSE_0 :	jmplt LABEL_END_0 m.local_metadata_depth 0x1
 	mov m.local_metadata_ret m.Ingress_hsVar
@@ -115,8 +110,7 @@ apply {
 	jmp LABEL_END_4
 	LABEL_FALSE_4 :	jmplt LABEL_END_4 m.local_metadata_depth 0x1
 	mov m.Ingress_vid m.Ingress_hsVar_0
-	LABEL_END_4 :	mov m.Ingress_tmp_5 m.Ingress_vid
-	mov m.local_metadata_ret m.Ingress_tmp_5
+	LABEL_END_4 :	mov m.local_metadata_ret m.Ingress_vid
 	add m.local_metadata_ret 0x5
 	table tbl
 	LABEL_END_3 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0


### PR DESCRIPTION
algorithm:

1)collect all used, copied and defined variables in all statements in a block
2)iterate over list of statements in a block in reverse order
3)if a statement is mov/cast, check if destination variable is a single definition, has single use, and also is a single copy
4) then drop that statement and update all use point of destintation with source of mov/cast operation.
else copy statement and push to the to the list.
5)create the list in original order and return.