### PR TITLE
Add support for atomic annotation for registers

### DIFF
--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -129,6 +129,7 @@ class EBPFTypeName : public EBPFType, public IHasWidth {
 
     template<typename T> bool canonicalTypeIs() const
     { return dynamic_cast<const T*>(this->canonical) != nullptr; }
+    template<typename T> T *toCanonical() { return dynamic_cast<T*>(this->canonical); }
 };
 
 // Also represents headers and unions

--- a/backends/ebpf/psa/ebpfPsaGen.h
+++ b/backends/ebpf/psa/ebpfPsaGen.h
@@ -155,6 +155,8 @@ class ConvertToEBPFControlPSA : public Inspector {
 
     const EbpfOptions &options;
 
+    void processAtomicAnnotation(const IR::BlockStatement* b);
+
  public:
     ConvertToEBPFControlPSA(EBPF::EBPFProgram *program, const IR::Parameter* parserHeaders,
                             P4::ReferenceMap *refmap, P4::TypeMap *typemap,
@@ -169,6 +171,7 @@ class ConvertToEBPFControlPSA : public Inspector {
     bool preorder(const IR::Member *m) override;
     bool preorder(const IR::IfStatement *a) override;
     bool preorder(const IR::ExternBlock* instance) override;
+    bool preorder(const IR::BlockStatement* b) override;
 
     EBPF::EBPFControlPSA *getEBPFControl() { return control; }
 };

--- a/backends/ebpf/psa/externs/ebpfPsaRegister.h
+++ b/backends/ebpf/psa/externs/ebpfPsaRegister.h
@@ -25,6 +25,9 @@ namespace EBPF {
 class ControlBodyTranslatorPSA;
 
 class EBPFRegisterPSA : public EBPFTableBase {
+ private:
+    cstring readValueName;
+
  protected:
     size_t size;
     // initial value for Register cells.
@@ -38,6 +41,8 @@ class EBPFRegisterPSA : public EBPFTableBase {
     bool shouldUseArrayMap();
 
  public:
+    bool isAtomic = false;
+
     EBPFRegisterPSA(const EBPFProgram* program, cstring instanceName,
                     const IR::Declaration_Instance* di,
                     CodeGenInspector* codeGen);

--- a/backends/ebpf/tests/p4testdata/register-structs.p4
+++ b/backends/ebpf/tests/p4testdata/register-structs.p4
@@ -95,13 +95,15 @@ control ingress(inout headers hdr,
          reg_key.port = (PortId_t)5;
          reg_key.srcAddr = 0xffffffffffff;
          reg_value_t tmp;
-         tmp = reg.read(reg_key);
-         if (tmp.srcAddr < (bit<32>) 5) {
-             tmp.srcAddr = (bit<32>) 5;
-         } else {
-             tmp.dstAddr = tmp.dstAddr + 13;
+         @atomic {
+            tmp = reg.read(reg_key);
+            if (tmp.srcAddr < (bit<32>) 5) {
+                tmp.srcAddr = (bit<32>) 5;
+            } else {
+                tmp.dstAddr = tmp.dstAddr + 13;
+            }
+            reg.write(reg_key, tmp);
          }
-         reg.write(reg_key, tmp);
     }
 }
 

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -82,7 +82,7 @@ function install_ptf_ebpf_test_deps() (
   git clone --recursive https://github.com/P4-Research/psabpf.git /tmp/psabpf
   cd /tmp/psabpf
   # FIXME: psabpf is under heavy development, later use git tags when it will be ready to use
-  git reset --hard 986981c
+  git reset --hard 617c567e
   ./build_libbpf.sh
   mkdir build
   cd build


### PR DESCRIPTION
This PR adds support for an atomic annotation for registers.
Due to constrained BPF environment a use of an atomic annotation is limited to cases where one `register.read()` and one `register.write()` operations are perfomed (on the same register index). 