### PR TITLE
Only crash if the error count exceeds the maximum

### DIFF
--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -152,7 +152,7 @@ class ErrorReporter {
         msg = ::error_helper(fmt, msg, args...);
         emit_message(msg);
 
-        if (errorCount >= maxErrorCount)
+        if (errorCount > maxErrorCount)
             FATAL_ERROR("Number of errors exceeded set maximum of %1%", maxErrorCount);
     }
 


### PR DESCRIPTION
This dramatic change achieves unprecedented accuracy of fatal error messages.