### PR TITLE
Inhibit compiler optimizations in GC malloc() implementation

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -130,9 +130,7 @@ jobs:
           # To flush out issues with unified vs. non-unified builds,
           # do a non-unified build before continuing with the rest,
           # which produces a unified build.
-          # On MacOS we have noticed problems with the C++
-          # garbage-collector, so we disable it
-          ./bootstrap.sh -DENABLE_GC=OFF -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_UNIFIED_COMPILATION=${{ matrix.unified }} -DENABLE_GMP=${{ matrix.enable_gmp }} && cd build && make -j2
+          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE -DENABLE_UNIFIED_COMPILATION=${{ matrix.unified }} -DENABLE_GMP=${{ matrix.enable_gmp }} && cd build && make -j2
 
     - name: Run tests (MacOS)
       run: |

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -139,7 +139,15 @@ void *realloc(void *ptr, size_t size) {
         return GC_malloc(size);
     }
 }
-void *malloc(size_t size) { return realloc(nullptr, size); }
+// IMPORTANT: do not simplify this to realloc(nullptr, size)
+// As it could be optimized to malloc(size) call causing
+// infinite loops
+void *malloc(size_t size) {
+    if (!done_init)
+        return realloc(nullptr, size);
+
+    return GC_malloc(size);
+}
 void free(void *ptr) {
     if (done_init && GC_is_heap_ptr(ptr))
         GC_free(ptr);


### PR DESCRIPTION
Apparently, clang could optimize realloc(nullptr, size) down to malloc(size) causing infinite loops. Rearrange the code
a bit to use realloc() code path only when GC is not initialized. This also makes a clean fast-path to GC_malloc() call.