### PR TITLE
Use a helper to to define the cpp toolchain type

### DIFF
--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -233,5 +233,5 @@ p4_graphs = rule(
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
     incompatible_use_toolchain_transition = True,
-    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = use_cpp_toolchain(),
 )


### PR DESCRIPTION
Part of bazelbuild/bazel#14727

Missed this in 2645f654add2e0a3f9eaaf2ae294d0677576922d