### PR TITLE
Store annotations after parser unroll application

### DIFF
--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -649,7 +649,9 @@ class ParserSymbolicInterpreter {
         auto result = evaluateSelect(state, valueMap);
         if (unroll) {
             BUG_CHECK(result.second, "Can't generate new selection %1%", state);
-            state->newState = new IR::ParserState(newName, components, result.second);
+            state->newState = new IR::ParserState(state->state->srcInfo, newName,
+                                                  state->state->annotations, components,
+                                                  result.second);
         }
         return EvaluationStateResult(result.first, true);
     }

--- a/testdata/p4_16_samples/parser-unroll-test1.p4
+++ b/testdata/p4_16_samples/parser-unroll-test1.p4
@@ -60,7 +60,7 @@ parser MyParser(packet_in packet,
     
     int<32>                 index;
 
-    state start {
+    @name (".start") state start {
         transition parse_ethernet;
     }
 

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1-first.p4
@@ -45,7 +45,7 @@ struct headers {
 
 parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     int<32> index;
-    state start {
+    @name(".start") state start {
         transition parse_ethernet;
     }
     state parse_ethernet {

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1-frontend.p4
@@ -42,7 +42,7 @@ struct headers {
 parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("MyParser.index") int<32> index_0;
     @name("MyParser.tmp") int<32> tmp;
-    state start {
+    @name(".start") state start {
         index_0 = 32s0;
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1-midend.p4
@@ -41,7 +41,7 @@ struct headers {
 
 parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("MyParser.index") int<32> index_0;
-    state start {
+    @name(".start") state start {
         index_0 = 32s0;
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1.p4
@@ -45,7 +45,7 @@ struct headers {
 
 parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     int<32> index;
-    state start {
+    @name(".start") state start {
         transition parse_ethernet;
     }
     state parse_ethernet {

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-first.p4
@@ -45,7 +45,7 @@ struct headers {
 
 parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     int<32> index;
-    state start {
+    @name(".start") state start {
         transition parse_ethernet;
     }
     state parse_ethernet {

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-frontend.p4
@@ -42,7 +42,7 @@ struct headers {
 parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     @name("MyParser.index") int<32> index_0;
     @name("MyParser.tmp") int<32> tmp;
-    state start {
+    @name(".start") state start {
         index_0 = 32s0;
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-midend.p4
@@ -76,7 +76,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
     state parse_srcRouting3 {
         transition stateOutOfBound;
     }
-    state start {
+    @name(".start") state start {
         index_0 = 32s0;
         packet.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1.p4
@@ -45,7 +45,7 @@ struct headers {
 
 parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     int<32> index;
-    state start {
+    @name(".start") state start {
         transition parse_ethernet;
     }
     state parse_ethernet {


### PR DESCRIPTION
These small changes allow to store annotations of the parsers states after application of loops unrolling.