### PR TITLE
Do not remove externs which are defined not in system files.

### DIFF
--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -28,7 +28,6 @@ Visitor::profile_t RemoveUnusedDeclarations::init_apply(const IR::Node* node) {
 bool RemoveUnusedDeclarations::giveWarning(const IR::Node* node) {
     if (warned == nullptr)
         return false;
-    std::cout << "wrn:" << node << std::endl;
     auto p = warned->emplace(node);
     LOG3("Warn about " << dbp(node) << " " << p.second);
     return p.second;

--- a/frontends/p4/unusedDeclarations.h
+++ b/frontends/p4/unusedDeclarations.h
@@ -104,7 +104,6 @@ class RemoveUnusedDeclarations : public Transform {
     const IR::Node* preorder(IR::Declaration_Variable* decl)  override;
     const IR::Node* preorder(IR::Declaration* decl) override { return process(decl); }
     const IR::Node* preorder(IR::Type_Declaration* decl) override { return process(decl); }
-    bool isSystemFile(cstring file);
     cstring ifSystemFile(const IR::Node* node);  // return file containing node if system file
 };
 

--- a/testdata/p4_16_samples_outputs/annotations-frontend.p4
+++ b/testdata/p4_16_samples_outputs/annotations-frontend.p4
@@ -3,3 +3,4 @@
     @name("exe") void execute(bit<8> index);
 }
 
+@cycles(10) extern bit<32> log(in bit<32> data);

--- a/testdata/p4_16_samples_outputs/cast-call-frontend.p4
+++ b/testdata/p4_16_samples_outputs/cast-call-frontend.p4
@@ -1,0 +1,1 @@
+extern T f<T>(T x);

--- a/testdata/p4_16_samples_outputs/crash-typechecker-frontend.p4
+++ b/testdata/p4_16_samples_outputs/crash-typechecker-frontend.p4
@@ -1,3 +1,4 @@
+extern bit<16> get<D>(in D data);
 header H {
     bit<8>      len;
     @length(((bit<32>)len << 3) + 32w4294967280) 

--- a/testdata/p4_16_samples_outputs/generic-frontend.p4
+++ b/testdata/p4_16_samples_outputs/generic-frontend.p4
@@ -5,6 +5,7 @@ extern Checksum16 {
     void initialize<T>();
 }
 
+extern void f<T>(in T dt);
 extern X<D> {
     T f<T>(in D d, in T t);
 }

--- a/testdata/p4_16_samples_outputs/hashext-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hashext-frontend.p4
@@ -2,6 +2,7 @@ extern hash_function<O, T> {
     O hash(in T data);
 }
 
+extern hash_function<O, T> crc_poly<O, T>(O poly);
 header h1_t {
     bit<32> f1;
     bit<32> f2;

--- a/testdata/p4_16_samples_outputs/initializer-frontend.p4
+++ b/testdata/p4_16_samples_outputs/initializer-frontend.p4
@@ -1,0 +1,1 @@
+extern bit<32> random(bit<5> logRange);

--- a/testdata/p4_16_samples_outputs/issue1172-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1172-frontend.p4
@@ -1,3 +1,4 @@
+extern T max<T>(T t1, T t2);
 extern Register<W> {
     void write(in W max);
 }

--- a/testdata/p4_16_samples_outputs/issue1586-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1586-frontend.p4
@@ -1,0 +1,1 @@
+extern void random<T>(out T result, in T lo);

--- a/testdata/p4_16_samples_outputs/issue2036-3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2036-3-frontend.p4
@@ -2,3 +2,4 @@ struct s {
     bit<8> x;
 }
 
+extern void f(in tuple<bit<8>> a, in s sarg);

--- a/testdata/p4_16_samples_outputs/issue2265-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2265-1-frontend.p4
@@ -1,0 +1,1 @@
+extern void f<T>(in tuple<T> x);

--- a/testdata/p4_16_samples_outputs/issue3292-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue3292-frontend.p4
@@ -2,3 +2,4 @@ header h<t> {
     t f;
 }
 
+extern void e<t>(in h<t> p);

--- a/testdata/p4_16_samples_outputs/issue940-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue940-frontend.p4
@@ -2,5 +2,6 @@
     Checksum16();
 }
 
+@deprecated("Please don't use this function.") extern bit<6> wrong();
 Checksum16() instance;
 

--- a/testdata/p4_16_samples_outputs/pragma-deprecated-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pragma-deprecated-frontend.p4
@@ -2,5 +2,6 @@
     Checksum16();
 }
 
+@deprecated("Please don't use this function.") extern bit<6> wrong();
 Checksum16() instance;
 

--- a/testdata/p4_16_samples_outputs/pragmas-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pragmas-frontend.p4
@@ -3,3 +3,4 @@
     @name("exe") void execute(bit<8> index);
 }
 
+@cycles(10) extern bit<32> log(in bit<32> data);

--- a/testdata/p4_16_samples_outputs/precedence-frontend.p4
+++ b/testdata/p4_16_samples_outputs/precedence-frontend.p4
@@ -8,3 +8,4 @@ struct t {
     s s2;
 }
 
+extern bit<1> fct(in bit<1> a, in bit<1> b);

--- a/testdata/p4_16_samples_outputs/spec-ex06-frontend.p4
+++ b/testdata/p4_16_samples_outputs/spec-ex06-frontend.p4
@@ -1,0 +1,1 @@
+extern void f(in int<9> x, in int<9> y);

--- a/testdata/p4_16_samples_outputs/specialization-frontend.p4
+++ b/testdata/p4_16_samples_outputs/specialization-frontend.p4
@@ -1,3 +1,4 @@
+extern void f<T>(in T data);
 struct S {
     bit<32> f;
 }

--- a/testdata/p4_16_samples_outputs/template-frontend.p4
+++ b/testdata/p4_16_samples_outputs/template-frontend.p4
@@ -1,0 +1,1 @@
+extern bit<32> f<T>(in T data);


### PR DESCRIPTION
Nodes of extern methods calls could be created by different paths (for example, verify in loopsUnroll, noMatch).  These extern methods could be defined not just in "system" files and this class can't remove them in that case. All extern methods represented by IR::Method class. To leave extern method as is we need to remove content of the preorder(IR::Method* method).  