### PR TITLE
Avoid crash in ebpf backend by checking expected IR node kinds

### DIFF
--- a/backends/ebpf/psa/ebpfPipeline.cpp
+++ b/backends/ebpf/psa/ebpfPipeline.cpp
@@ -27,8 +27,10 @@ bool EBPFPipeline::isEmpty() const {
     }
 
     auto startState = parser->parserBlock->container->states.at(0);
-    auto pathExpr = startState->selectExpression->to<IR::PathExpression>()->path;
-    if (!startState->components.empty() || pathExpr->name.name != IR::ParserState::accept) {
+    auto path = startState->selectExpression->to<IR::PathExpression>();
+    if (!path)
+        return false;
+    if (!startState->components.empty() || path->path->name.name != IR::ParserState::accept) {
         return false;
     }
 


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3426 
Unfortunately there is no test attached since we don't have a simple way to run ebpf tests for the psa architecture.