### PR TITLE
remove unused include

### DIFF
--- a/midend/parserUnroll.h
+++ b/midend/parserUnroll.h
@@ -17,7 +17,6 @@ limitations under the License.
 #ifndef _MIDEND_PARSERUNROLL_H_
 #define _MIDEND_PARSERUNROLL_H_
 
-#include <variant>
 #include <unordered_map>
 
 #include "ir/ir.h"


### PR DESCRIPTION
std::variant isn't actually used. This include also prevents gcc-6 based builds as variant is supported only by newer gccs.