### PR TITLE
ordered_set: operator<: Fix for a case of strict inclusion.

### DIFF
--- a/lib/ordered_set.h
+++ b/lib/ordered_set.h
@@ -99,11 +99,11 @@ class ordered_set {
         // have a set of ordered_sets (or use ordered_set as a map key).
         auto it = a.data_map.begin();
         for (auto &el : data_map) {
-            if (it == a.data_map.end()) return true;
+            if (it == a.data_map.end()) return false;
             if (mapcmp()(el.first, it->first)) return true;
             if (mapcmp()(it->first, el.first)) return false;
             ++it; }
-        return false; }
+        return it != a.data_map.end(); }
 
     // FIXME add allocator and comparator ctors...
 

--- a/test/gtest/ordered_set.cpp
+++ b/test/gtest/ordered_set.cpp
@@ -93,4 +93,18 @@ TEST(ordered_set, set_intersect) {
     EXPECT_EQ(res, expect);
 }
 
+TEST(ordered_set, x_is_strict_prefix_of_y) {
+    ordered_set<unsigned> x;
+    x.insert(1);
+
+    ordered_set<unsigned> y;
+    y.insert(1);
+    EXPECT_FALSE(x < y);
+    EXPECT_FALSE(y < x);
+
+    y.insert(2);
+    EXPECT_TRUE(x < y);
+    EXPECT_FALSE(y < x);
+}
+
 }  // namespace Test


### PR DESCRIPTION
When all elements compared so far in sets `x` and `y` have been equivalent
and one of the sets (`x`) ends, but the other one (`y`) does not end
(i.e. `x` is a strict prefix of `y`),
we used to get `y < x`, but with this changeset we are going to get `x < y`.

Example (in pseudocode) (with case-insensitive comparison):
  we used to get `{'A', 'b'} > {'a', 'B', 'c'}`,
  now fixed to   `{'A', 'b'} < {'a', 'B', 'c'}`.
This is similar to how `std::lexicographical_compare` behaves.