### PR TITLE
ordered_set: Leaner, faster, richer, safer.

### DIFF
--- a/lib/ordered_set.h
+++ b/lib/ordered_set.h
@@ -17,234 +17,540 @@ limitations under the License.
 #ifndef _LIB_ORDERED_SET_H_
 #define _LIB_ORDERED_SET_H_
 
+#include <boost/container/set.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/tuple/tuple.hpp>
+
+#include <algorithm>
 #include <functional>
 #include <initializer_list>
-#include <list>
-#include <map>
-#include <set>
 #include <utility>
+#include <iterator>
 
-// Remembers items in insertion order
-template <class T, class COMP = std::less<T>, class ALLOC = std::allocator<T>>
-class ordered_set {
- public:
-    typedef T                   key_type;
-    typedef T                   value_type;
-    typedef COMP                key_compare;
-    typedef COMP                value_compare;
-    typedef ALLOC               allocator_type;
-    typedef const T             &reference;
-    typedef const T             &const_reference;
 
- private:
-    typedef std::list<T, ALLOC> list_type;
-    list_type                   data;
+//============================================================================
+// EnlistedNode <T>:
+//
+//   An object of this type holds:
+//     - two pointers (to the previous node and to the next node);
+//     - a payload of type T.
+//============================================================================
 
- public:
-    typedef typename list_type::iterator                iterator;
-    typedef typename list_type::const_iterator          const_iterator;
-    typedef std::reverse_iterator<iterator>             reverse_iterator;
-    typedef std::reverse_iterator<const_iterator>       const_reverse_iterator;
+struct MyTag1;
 
- private:
-    struct mapcmp : std::binary_function<const T *, const T *, bool> {
-        COMP    comp;
-        bool operator()(const T *a, const T *b) const { return comp(*a, *b); } };
-    using map_alloc = typename ALLOC::template rebind<std::pair<const T * const, iterator>>::other;
-    typedef std::map<const T *, iterator, mapcmp, map_alloc>    map_type;
-    map_type                            data_map;
-    void init_data_map() {
-        data_map.clear();
-        for (auto it = data.begin(); it != data.end(); it++)
-            data_map.emplace(&*it, it); }
-    iterator tr_iter(typename map_type::iterator i) {
-        if (i == data_map.end())
-            return data.end();
-        return i->second; }
-    const_iterator tr_iter(typename map_type::const_iterator i) const {
-        if (i == data_map.end())
-            return data.end();
-        return i->second; }
+template <typename T>
+class EnlistedNode:
+    public boost::intrusive::list_base_hook <boost::intrusive::tag <MyTag1>>
+{
+private:
+    T _t;
 
- public:
-    typedef typename map_type::size_type        size_type;
-    class sorted_iterator : public std::iterator<std::bidirectional_iterator_tag, T> {
-        friend class ordered_set;
-        typename map_type::const_iterator       iter;
-        sorted_iterator(typename map_type::const_iterator it)    // NOLINT(runtime/explicit)
-        : iter(it) {}
-     public:
-        const T &operator*() const { return *iter->first; }
-        const T *operator->() const { return iter->first; }
-        sorted_iterator operator++() { ++iter; return *this; }
-        sorted_iterator operator--() { --iter; return *this; }
-        sorted_iterator operator++(int) { auto copy = *this; ++iter; return copy; }
-        sorted_iterator operator--(int) { auto copy = *this; --iter; return copy; }
-        bool operator==(const sorted_iterator i) const { return iter == i.iter; }
-        bool operator!=(const sorted_iterator i) const { return iter != i.iter; }
-    };
+public:
+    explicit EnlistedNode (T &&t):
+        _t {std::forward <T> (t)}
+    {}
 
-    ordered_set() {}
-    ordered_set(const ordered_set &a) : data(a.data) { init_data_map(); }
-    ordered_set(std::initializer_list<T> init) : data(init) { init_data_map(); }
-    ordered_set(ordered_set &&a) = default; /* move is ok? */
-    ordered_set &operator=(const ordered_set &a) { data = a.data; init_data_map(); return *this; }
-    ordered_set &operator=(ordered_set &&a) = default; /* move is ok? */
-    bool operator==(const ordered_set &a) const { return data == a.data; }
-    bool operator!=(const ordered_set &a) const { return data != a.data; }
-    bool operator<(const ordered_set &a) const {
-        // we define this to work INDEPENDENT of the order -- so it is possible to have
-        // two ordered_sets where !(a < b) && !(b < a) && !(a == b) -- such sets have the
-        // same elements but in a different order.  This is generally what you want if you
-        // have a set of ordered_sets (or use ordered_set as a map key).
-        auto it = a.data_map.begin();
-        for (auto &el : data_map) {
-            if (it == a.data_map.end()) return true;
-            if (mapcmp()(el.first, it->first)) return true;
-            if (mapcmp()(it->first, el.first)) return false;
-            ++it; }
-        return false; }
+          T *adr_payload ()       noexcept { return &_t; }
+    const T *adr_payload () const noexcept { return &_t; }
 
-    // FIXME add allocator and comparator ctors...
+          T &ref_payload ()       noexcept { return _t; }
+    const T &ref_payload () const noexcept { return _t; }
 
-    iterator                    begin() noexcept { return data.begin(); }
-    const_iterator              begin() const noexcept { return data.begin(); }
-    iterator                    end() noexcept { return data.end(); }
-    const_iterator              end() const noexcept { return data.end(); }
-    reverse_iterator            rbegin() noexcept { return data.rbegin(); }
-    const_reverse_iterator      rbegin() const noexcept { return data.rbegin(); }
-    reverse_iterator            rend() noexcept { return data.rend(); }
-    const_reverse_iterator      rend() const noexcept { return data.rend(); }
-    const_iterator              cbegin() const noexcept { return data.cbegin(); }
-    const_iterator              cend() const noexcept { return data.cend(); }
-    const_reverse_iterator      crbegin() const noexcept { return data.crbegin(); }
-    const_reverse_iterator      crend() const noexcept { return data.crend(); }
-    sorted_iterator             sorted_begin() const noexcept { return data_map.begin(); }
-    sorted_iterator             sorted_end() const noexcept { return data_map.end(); }
-
-    reference front() const noexcept { return *data.begin(); }
-    reference back() const noexcept { return *data.rbegin(); }
-
-    bool        empty() const noexcept { return data.empty(); }
-    size_type   size() const noexcept { return data_map.size(); }
-    size_type   max_size() const noexcept { return data_map.max_size(); }
-    void        clear() { data.clear(); data_map.clear(); }
-
-    iterator        find(const T &a) { return tr_iter(data_map.find(&a)); }
-    const_iterator  find(const T &a) const { return tr_iter(data_map.find(&a)); }
-    size_type       count(const T &a) const { return data_map.count(&a); }
-    iterator        upper_bound(const T &a) { return tr_iter(data_map.upper_bound(&a)); }
-    const_iterator  upper_bound(const T &a) const { return tr_iter(data_map.upper_bound(&a)); }
-    iterator        lower_bound(const T &a) { return tr_iter(data_map.lower_bound(&a)); }
-    const_iterator  lower_bound(const T &a) const { return tr_iter(data_map.lower_bound(&a)); }
-
-    std::pair<iterator, bool> insert(const T &v) {
-        auto it = find(v);
-        if (it == data.end()) {
-            it = data.insert(data.end(), v);
-            data_map.emplace(&*it, it);
-            return std::make_pair(it, true); }
-        return std::make_pair(it, false); }
-    std::pair<iterator, bool> insert(T &&v) {
-        auto it = find(v);
-        if (it == data.end()) {
-            it = data.insert(data.end(), std::move(v));
-            data_map.emplace(&*it, it);
-            return std::make_pair(it, true); }
-        return std::make_pair(it, false); }
-    void insert(ordered_set::const_iterator begin, ordered_set::const_iterator end) {
-        for (auto it = begin; it != end; ++it)
-            insert(*it);
-    }
-    iterator insert(const_iterator pos, const T &v) {
-        auto it = find(v);
-        if (it == data.end()) {
-            it = data.insert(pos, v);
-            data_map.emplace(&*it, it);
-            return it; }
-        return it;
-    }
-    iterator insert(const_iterator pos, T &&v) {
-        auto it = find(v);
-        if (it == data.end()) {
-            it = data.insert(pos, std::move(v));
-            data_map.emplace(&*it, it);
-            return it; }
-        return it;
-    }
-
-    void push_back(const T &v) {
-        auto it = find(v);
-        if (it == data.end()) {
-            it = data.insert(data.end(), v);
-            data_map.emplace(&*it, it);
-        } else {
-            data.splice(data.end(), data, it); } }
-    void push_back(T &&v) {
-        auto it = find(v);
-        if (it == data.end()) {
-            it = data.insert(data.end(), std::move(v));
-            data_map.emplace(&*it, it);
-        } else {
-            data.splice(data.end(), data, it); } }
-
-    template <class... Args>
-    std::pair<iterator, bool> emplace(Args &&... args) {
-        auto it = data.emplace(data.end(), std::forward<Args>(args)...);
-        auto old = find(*it);
-        if (old == data.end()) {
-            data_map.emplace(&*it, it);
-            return std::make_pair(it, true);
-        } else {
-            data.erase(it);
-            return std::make_pair(old, false); } }
-
-    template <class... Args>
-    std::pair<iterator, bool> emplace_back(Args &&... args) {
-        auto it = data.emplace(data.end(), std::forward<Args>(args)...);
-        auto old = find(*it);
-        if (old != data.end()) {
-            data.erase(old); }
-        data_map.emplace(&*it, it);
-        return std::make_pair(it, true); }
-
-    /* should be erase(const_iterator), but glibc++ std::list::erase is broken */
-    iterator erase(iterator pos) {
-        data_map.erase(&*pos);
-        return data.erase(pos); }
-    size_type erase(const T &v) {
-        auto it = find(v);
-        if (it != data.end()) {
-            data_map.erase(&v);
-            data.erase(it);
-            return 1; }
-        return 0; }
+          T  get_payload () const          { return _t; }
 };
 
-template<class T, class C1, class A1, class U> inline
-auto operator|=(ordered_set<T, C1, A1> &a, const U &b) -> decltype(b.begin(), a) {
-    for (auto &el : b) a.insert(el);
-    return a; }
-template<class T, class C1, class A1, class U> inline
-auto operator-=(ordered_set<T, C1, A1> &a, const U &b) -> decltype(b.begin(), a) {
-    for (auto &el : b) a.erase(el);
-    return a; }
-template<class T, class C1, class A1, class U> inline
-auto operator&=(ordered_set<T, C1, A1> &a, const U &b) -> decltype(b.begin(), a) {
-    for (auto it = a.begin(); it != a.end();) {
-        if (b.count(*it))
-            ++it;
-        else
-            it = a.erase(it); }
-    return a; }
+/*
+template <typename T>
+bool operator== (const EnlistedNode <T> &x, const EnlistedNode <T> &y)
+noexcept (noexcept (x.ref_payload () == y.ref_payload ()))
+{
+    return x.ref_payload () == y.ref_payload ();
+}
 
-template<class T, class C1, class A1, class U> inline
-auto contains(const ordered_set<T, C1, A1> &a, const U &b) -> decltype(b.begin(), true) {
-    for (auto &el : b) if (!a.count(el)) return false;
-    return true; }
-template<class T, class C1, class A1, class U> inline
-auto intersects(const ordered_set<T, C1, A1> &a, const U &b) -> decltype(b.begin(), true) {
-    for (auto &el : b) if (a.count(el)) return true;
-    return false; }
+template <typename T>
+bool operator!= (const EnlistedNode <T> &x, const EnlistedNode <T> &y)
+noexcept (noexcept (x.ref_payload () != y.ref_payload ()))
+{
+    return x.ref_payload () != y.ref_payload ();
+}
+
+template <typename T>
+bool operator<  (const EnlistedNode <T> &x, const EnlistedNode <T> &y)
+noexcept (noexcept (x.ref_payload () <  y.ref_payload ()))
+{
+    return x.ref_payload () <  y.ref_payload ();
+}
+
+template <typename T>
+bool operator>  (const EnlistedNode <T> &x, const EnlistedNode <T> &y)
+noexcept (noexcept (x.ref_payload () >  y.ref_payload ()))
+{
+    return x.ref_payload () >  y.ref_payload ();
+}
+
+template <typename T>
+bool operator<= (const EnlistedNode <T> &x, const EnlistedNode <T> &y)
+noexcept (noexcept (x.ref_payload () <= y.ref_payload ()))
+{
+    return x.ref_payload () <= y.ref_payload ();
+}
+
+template <typename T>
+bool operator>= (const EnlistedNode <T> &x, const EnlistedNode <T> &y)
+noexcept (noexcept (x.ref_payload () >= y.ref_payload ()))
+{
+    return x.ref_payload () >= y.ref_payload ();
+}
+*/
+
+
+//============================================================================
+// EnlistedComp <Comp>:
+//
+// If Comp is a Strict Weak Ordering
+// for comparing objects of type T,
+// then EnlistedComp <Comp> is a Strict Weak Ordering
+// for comparing object of type EnlistedNode <T>.
+//============================================================================
+
+template <typename Comp>
+class EnlistedComp
+{
+public:
+    typedef EnlistedNode <typename Comp::first_argument_type>  first_argument_type;
+    typedef EnlistedNode <typename Comp::second_argument_type> second_argument_type;
+    typedef               typename Comp::result_type           result_type;
+
+private:
+    Comp _comp;
+
+public:
+    EnlistedComp () = default;
+
+    explicit EnlistedComp (const Comp &comp):
+        _comp (comp)
+    {}
+
+    result_type operator() (const first_argument_type &x, const second_argument_type &y) const
+    noexcept (noexcept (_comp (x.ref_payload (), y.ref_payload ())))
+    {
+        return _comp (x.ref_payload (), y.ref_payload ());
+    }
+};
+
+
+//============================================================================
+// ordered_set:
+//============================================================================
+
+template
+<
+    typename T,
+    class    Comp  = std::less <T>,
+    class    Alloc = std::allocator <T>
+>
+class ordered_set
+{
+// The (non-intrusive) tree:
+
+private:
+    typedef
+        EnlistedNode <T>
+        MyEnlistedNode;
+
+    typedef
+        EnlistedComp <Comp>
+        MyEnlistedComp;
+
+    typedef
+        typename Alloc::template rebind <MyEnlistedNode>::other
+        MyEnlistedAlloc;
+
+public:
+    typedef
+        boost::container::set <MyEnlistedNode, MyEnlistedComp, MyEnlistedAlloc>
+        MyEnlistedTree,
+        tree_type;
+
+private:
+    tree_type _tree;
+
+
+// The (intrusive) list:
+
+private:
+    typedef
+        boost::intrusive::list_base_hook<boost::intrusive::tag <MyTag1>>
+        BaseHook1;
+
+public:
+    typedef
+        boost::intrusive::list
+        <
+            MyEnlistedNode,
+            boost::intrusive::base_hook <BaseHook1>,
+            boost::intrusive::constant_time_size <false>
+        >
+        MyList,
+        list_type;
+
+private:
+    list_type _list;
+
+
+// Typedefs related to the tree type:
+
+public:
+    typedef typename tree_type::key_type               tree_key_type;
+    typedef typename tree_type::value_type             tree_value_type;
+    typedef typename tree_type::key_compare            tree_key_compare;
+    typedef typename tree_type::value_compare          tree_value_compare;
+    typedef typename tree_type::size_type              tree_size_type;
+    typedef typename tree_type::difference_type        tree_difference_type;
+    typedef typename tree_type::pointer                tree_pointer;
+    typedef typename tree_type::const_pointer          tree_const_pointer;
+    typedef typename tree_type::reference              tree_reference;
+    typedef typename tree_type::const_reference        tree_const_reference;
+    typedef typename tree_type::iterator               tree_iterator;
+    typedef typename tree_type::const_iterator         tree_const_iterator;
+    typedef typename tree_type::reverse_iterator       tree_reverse_iterator;
+    typedef typename tree_type::const_reverse_iterator tree_const_reverse_iterator;
+
+
+// Typedefs related to the list type:
+
+public:
+    typedef typename list_type::value_type             list_value_type;
+    typedef typename list_type::size_type              list_size_type;
+    typedef typename list_type::difference_type        list_difference_type;
+    typedef typename list_type::pointer                list_pointer;
+    typedef typename list_type::const_pointer          list_const_pointer;
+    typedef typename list_type::reference              list_reference;
+    typedef typename list_type::const_reference        list_const_reference;
+    typedef typename list_type::iterator               list_iterator;
+    typedef typename list_type::const_iterator         list_const_iterator;
+    typedef typename list_type::reverse_iterator       list_reverse_iterator;
+    typedef typename list_type::const_reverse_iterator list_const_reverse_iterator;
+
+
+// Typedefs related to the tree type, published without prefix:
+
+public:
+    typedef tree_key_type                              key_type;
+    typedef tree_value_type                            value_type;
+    typedef tree_key_compare                           key_compare;
+    typedef tree_value_compare                         value_compare;
+
+
+// Typedefs related to the list type, published without prefix:
+
+public:
+    typedef list_size_type                             size_type;
+    typedef list_difference_type                       difference_type;
+    typedef list_pointer                               pointer;
+    typedef list_const_pointer                         const_pointer;
+    typedef list_reference                             reference;
+    typedef list_const_reference                       const_reference;
+    typedef list_iterator                              iterator;
+    typedef list_const_iterator                        const_iterator;
+    typedef list_reverse_iterator                      reverse_iterator;
+    typedef list_const_reverse_iterator                const_reverse_iterator;
+
+
+// Conversion from tree_iterator to list_iterator:
+
+private:
+    list_iterator       t2l_iterator (tree_iterator       titer)       noexcept
+    {
+        if (titer == _tree.end ())
+            return _list.end ();
+        else
+            return _list.iterator_to (*titer);
+    }
+
+    list_const_iterator t2l_iterator (tree_const_iterator titer) const noexcept
+    {
+        if (titer == _tree.end ())
+            return _list.end ();
+        else
+            return _list.iterator_to (*titer);
+    }
+
+
+// Conversion from list_iterator to tree_iterator:
+
+private:
+    tree_iterator        l2t_iterator (list_iterator       liter)       noexcept
+    {
+         if (liter == _list.end ())
+             return _tree.end ();
+         else
+             return _tree.find (*liter);
+    }
+
+    tree_const_iterator l2t_iterator (list_const_iterator liter) const noexcept
+    {
+        if (liter == _list.end ())
+            return _tree.end ();
+        else
+            return _tree.find (*liter);
+    }
+
+
+// init_tree:
+
+private:
+    void init_list () noexcept
+    {
+        BOOST_ASSERT (_list.empty ());
+        std::copy (_tree.begin (), _tree.end (), std::back_inserter (_list));
+    }
+
+
+// sorted_iterator:
+
+public:
+    class sorted_iterator
+    {
+    public:
+        typedef       std::bidirectional_iterator_tag  iterator_category;
+        typedef       T                                value_type;
+        typedef       tree_difference_type             difference_type;
+        typedef const T                               *pointer;
+        typedef const T                               &reference;
+
+    private:
+        tree_iterator _titer;
+
+    private:
+        friend class ordered_set;
+        explicit sorted_iterator (tree_iterator titer) noexcept:
+            _titer (titer)
+        {}
+
+    public:
+        const T &operator*  () const noexcept { return *_titer->adr_payload (); }
+        const T *operator-> () const noexcept { return  _titer->adr_payload (); }
+
+        sorted_iterator &operator++ ()    noexcept { ++_titer; }
+        sorted_iterator &operator-- ()    noexcept { --_titer; }
+        sorted_iterator  operator++ (int) noexcept { const sorted_iterator saved {*this}; ++*this; return saved; }
+        sorted_iterator  operator-- (int) noexcept { const sorted_iterator saved {*this}; --*this; return saved; }
+
+        bool operator== (sorted_iterator other) noexcept { return _titer == other._titer; }
+        bool operator!= (sorted_iterator other) noexcept { return ! (*this == other); }
+    };
+
+    typedef                        sorted_iterator        sorted_const_iterator;
+    typedef std::reverse_iterator <sorted_iterator>       sorted_reverse_iterator;
+    typedef std::reverse_iterator <sorted_const_iterator> sorted_const_reverse_iterator;
+
+
+// Tree ranges:
+
+    sorted_iterator               sorted_begin   ()       noexcept { return sorted_iterator               {_tree.begin   ()}; }
+    sorted_const_iterator         sorted_begin   () const noexcept { return sorted_const_iterator         {_tree.begin   ()}; }
+    sorted_const_iterator         sorted_cbegin  () const noexcept { return sorted_const_iterator         {_tree.cbegin  ()}; }
+    sorted_iterator               sorted_end     ()       noexcept { return sorted_iterator               {_tree.end     ()}; }
+    sorted_const_iterator         sorted_end     () const noexcept { return sorted_const_iterator         {_tree.end     ()}; }
+    sorted_const_iterator         sorted_cend    () const noexcept { return sorted_const_iterator         {_tree.cend    ()}; }
+
+    sorted_reverse_iterator       sorted_rbegin  ()       noexcept { return sorted_reverse_iterator       {_tree.rbegin  ()}; }
+    sorted_const_reverse_iterator sorted_rbegin  () const noexcept { return sorted_const_reverse_iterator {_tree.rbegin  ()}; }
+    sorted_const_reverse_iterator sorted_crbegin () const noexcept { return sorted_const_reverse_iterator {_tree.crbegin ()}; }
+    sorted_reverse_iterator       sorted_rend    ()       noexcept { return sorted_reverse_iterator       {_tree.rend    ()}; }
+    sorted_const_reverse_iterator sorted_rend    () const noexcept { return sorted_const_reverse_iterator {_tree.rend    ()}; }
+    sorted_const_reverse_iterator sorted_crend   () const noexcept { return sorted_const_reverse_iterator {_tree.crend   ()}; }
+
+
+// List ranges:
+
+    list_iterator                 list_begin     ()       noexcept { return                                _list.begin   () ; }
+    list_const_iterator           list_begin     () const noexcept { return                                _list.begin   () ; }
+    list_const_iterator           list_cbegin    () const noexcept { return                                _list.cbegin  () ; }
+    list_iterator                 list_end       ()       noexcept { return                                _list.end     () ; }
+    list_const_iterator           list_end       () const noexcept { return                                _list.end     () ; }
+    list_const_iterator           list_cend      () const noexcept { return                                _list.cend    () ; }
+
+    list_reverse_iterator         list_rbegin    ()       noexcept { return                                _list.rbegin  () ; }
+    list_const_reverse_iterator   list_rbegin    () const noexcept { return                                _list.rbegin  () ; }
+    list_const_reverse_iterator   list_crbegin   () const noexcept { return                                _list.crbegin () ; }
+    list_reverse_iterator         list_rend      ()       noexcept { return                                _list.rend    () ; }
+    list_const_reverse_iterator   list_rend      () const noexcept { return                                _list.rend    () ; }
+    list_const_reverse_iterator   list_crend     () const noexcept { return                                _list.crend   () ; }
+
+
+
+// find_ex:
+
+public:
+    std::pair <sorted_iterator, list_iterator> find_ex (const T &t)
+    {
+        const tree_iterator titerFound = _tree.find (t);
+        if (titerFound != _tree.end ())
+            return std::make_pair (sorted_iterator {titerFound}, t2l_iterator (titerFound));
+        else
+            return std::make_pair (sorted_iterator {titerFound}, _list.end ());
+    }
+
+
+// find_sorted:
+
+public:
+    sorted_iterator find_sorted (const T &t)
+    {
+        const auto result = find_ex (t);
+        return result.first;
+    }
+
+
+// find_list:
+
+public:
+    list_iterator find_list (const T &t)
+    {
+        const auto result = find_ex (t);
+        return result.second;
+    }
+
+
+// insert_ex:
+
+public:
+    typedef boost::tuple <sorted_iterator, list_iterator, bool> insert_ex_result_type;
+
+    insert_ex_result_type insert_ex (sorted_iterator siter_hint, list_iterator liter_pos, T &&t)
+    {
+        tree_value_type tt {std::forward <T> (t)};
+        const tree_iterator titerFound = _tree.find (tt);
+        if (titerFound == _tree.end ())
+        {
+            const tree_iterator tresult = _tree.insert (siter_hint._titer, std::move (tt));
+            const list_iterator lresult = _list.insert (liter_pos        , *tresult);
+            return boost::make_tuple (sorted_iterator {tresult}, lresult, true);
+        }
+        else
+            return boost::make_tuple (sorted_iterator {titerFound}, t2l_iterator (titerFound), false);
+    }
+
+    insert_ex_result_type insert_ex (sorted_iterator siter_hint, T &&t)
+    {
+        return insert_ex (siter_hint, _list.end (), std::forward <T> (t));
+    }
+
+    insert_ex_result_type insert_ex (list_iterator iter_pos, T &&t)
+    {
+        return insert_ex (sorted_end (), iter_pos, std::forward <T> (t));
+    }
+
+    insert_ex_result_type insert_ex (T &&t)
+    {
+        return insert_ex (sorted_end (), list_end (), std::forward <T> (t));
+    }
+
+
+// insert_sorted:
+
+public:
+    typedef std::pair <sorted_iterator, bool> insert_sorted_result_type;
+
+    insert_sorted_result_type insert_sorted (sorted_iterator siter_hint, list_iterator liter_pos, T &&t)
+    {
+        const auto result = insert_ex (siter_hint, liter_pos, std::forward <T> (t));
+        return std::make_pair (boost::get <0> (result), boost::get <2> (result));
+    }
+
+    insert_sorted_result_type insert_sorted (sorted_iterator siter_hint, T &&t)
+    {
+        const auto result = insert_ex (siter_hint, std::forward <T> (t));
+        return std::make_pair (boost::get <0> (result), boost::get <2> (result));
+    }
+
+    insert_sorted_result_type insert_sorted (list_iterator liter_pos, T &&t)
+    {
+        const auto result = insert_ex (liter_pos, std::forward <T> (t));
+        return std::make_pair (boost::get <0> (result), boost::get <2> (result));
+    }
+
+    insert_sorted_result_type insert_sorted (T &&t)
+    {
+        const auto result = insert_ex (std::forward <T> (t));
+        return std::make_pair (boost::get <0> (result), boost::get <2> (result));
+    }
+
+
+// insert_list:
+
+public:
+    typedef std::pair <list_iterator, bool> insert_list_result_type;
+
+    insert_list_result_type insert_list (sorted_iterator siter_hint, list_iterator liter_pos, T &&t)
+    {
+        const auto result = insert_ex (siter_hint, liter_pos, std::forward <T> (t));
+        return std::make_pair (boost::get <1> (result), boost::get <2> (result));
+    }
+
+    insert_list_result_type insert_list (sorted_iterator siter_hint, T &&t)
+    {
+        const auto result = insert_ex (siter_hint, std::forward <T> &&t);
+        return std::make_pair (boost::get <1> (result), boost::get <2> (result));
+    }
+
+    insert_list_result_type insert_list (list_iterator liter, T &&t)
+    {
+        const auto result = insert_ex (liter, std::forward <T> (t));
+        return std::make_pair (boost::get <1> (result), boost::get <2> (result));
+    }
+
+    insert_list_result_type insert_list (T &&t)
+    {
+        const auto result = insert_ex (std::forward <T> (t));
+        return std::make_pair (boost::get <1> (result), boost::get <2> (result));
+    }
+
+
+// erase_ex:
+
+public:
+    typedef std::pair <sorted_iterator, list_iterator> erase_ex_result_type;
+
+    erase_ex_result_type erase_ex (sorted_iterator siter)
+    {
+        const list_iterator liter = t2l_iterator (siter._titer);
+
+        const tree_iterator titer_result = _tree.erase (siter);
+        const list_iterator liter_result = _list.erase (liter);
+        return std::make_pair (sorted_iterator {titer_result}, liter_result);
+    }
+
+    erase_ex_result_type erase_ex (list_iterator liter)
+    {
+        const tree_iterator titer = l2t_iterator (liter);
+
+        const tree_iterator titer_result = _tree.erase (titer);
+        const list_iterator liter_result = _list.erase (liter);
+        return std::make_pair (sorted_iterator {titer_result}, liter_result);
+    }
+
+
+// erase_sorted:
+
+public:
+    sorted_iterator erase_sorted (sorted_iterator siter)
+    {
+        const auto result = erase_ex (siter);
+        return result.first;
+    }
+
+    list_iterator erase_sorted (list_iterator liter)
+    {
+        const auto result = erase_ex (liter);
+        return result.second;
+    }
+};
+
+
+//============================================================================
+
 
 #endif /* _LIB_ORDERED_SET_H_ */


### PR DESCRIPTION
Previously, for each element, we used to allocate (and later deallocate)
two separate nodes:

  - a node inside a list (two link-pointers plus payload of two pointers);
  - a node inside a tree (three link-pointers plus one bool plus actual payload).

Now, we only allocate a single node:

  - a node inside a set (three link-pointers plus payload).

The payload of the node inside the set
contains the two link-pointers for list operations
and then the actual payload (an element of type T).

Benefits:
  - fewer allocations/deallocations;
  - less memory consumed (the payload of two pointers in the list was wasteful);
  - better locality of data;
  - superiour error-safety guarantees
    (the intrusive container operations offer the strongest guarantee: nofail)
    (=> merging a fix such as PR #3294 is no longer needed);
  - improved speed.

Side note:
  We have preferred boost::container::set to std::set
  because the former by default tries to merge the colour flag (a bool flag)
  with one of the three links, therefore further reducing memory consumption.
  TODO: Consider how this works in a World of Garbage Collection.

The current changeset is a draft -- not yet complete for the purposes of p4c,
but offering the essential features of ordered_set:
iteration in sorted order (now with backwards iteration as well)
and iteration in user-controlled (sequence) order.

It represents a proof of concept and a request for comments. (-: