### PR TITLE
Use Type_Dontcare for _ expressions in table entries

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1914,8 +1914,6 @@ const IR::Node* TypeInference::postorder(IR::Key* key) {
     }
     LOG2("Setting key type to " << dbp(keyTuple));
     setType(key, keyTuple);
-    // installing also for the original because we cannot tell which one will survive in the ir
-    LOG2("Setting key type to " << dbp(getOriginal()));
     setType(getOriginal(), keyTuple);
     return key;
 }
@@ -1975,14 +1973,22 @@ const IR::Node* TypeInference::postorder(IR::Entry* entry) {
     auto entryKeyType = getType(entry->keys);
     if (entryKeyType == nullptr)
         return entry;
-    if (entryKeyType->is<IR::Type_Set>())
-        entryKeyType = entryKeyType->to<IR::Type_Set>()->elementType;
+    if (auto ts = entryKeyType->to<IR::Type_Set>())
+        entryKeyType = ts->elementType;
+    if (entry->singleton) {
+        if (auto tl = entryKeyType->to<IR::Type_BaseList>()) {
+            // An entry of _ does not have type Tuple<Type_Dontcare>, but rather Type_Dontcare
+            if (tl->getSize() == 1 && tl->components.at(0)->is<IR::Type_Dontcare>())
+                entryKeyType = tl->components.at(0);
+        }
+    }
 
     auto keyset = entry->getKeys();
     if (keyset == nullptr || !(keyset->is<IR::ListExpression>())) {
         typeError("%1%: key expression must be tuple", keyset);
         return entry;
-    } else if (keyset->components.size() < key->keyElements.size()) {
+    }
+    if (keyset->components.size() < key->keyElements.size()) {
         typeError("%1%: Size of entry keyset must match the table key set size", keyset);
         return entry;
     }
@@ -2009,7 +2015,7 @@ const IR::Node* TypeInference::postorder(IR::Entry* entry) {
 
     if (ks != keyset)
         entry = new IR::Entry(entry->srcInfo, entry->annotations,
-                              ks->to<IR::ListExpression>(), entry->action);
+                              ks->to<IR::ListExpression>(), entry->action, entry->singleton);
 
     auto actionRef = entry->getAction();
     auto ale = validateActionInitializer(actionRef, table);

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1296,12 +1296,12 @@ actionRef
 entry
     : keysetExpression ":" actionRef optAnnotations ";"
         { if (auto l = $1->to<IR::ListExpression>())
-            $$ = new IR::Entry(@1+@4, $4, l, $3);
+            $$ = new IR::Entry(@1+@4, $4, l, $3, false);
           else {  // if not a tuple, make it a list of 1
             IR::Vector<IR::Expression> le($1);
             $$ = new IR::Entry(@1+@4, $4,
                    new IR::ListExpression(@1, le),
-                   $3);
+                   $3, true);
           }
         }
     ;

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -257,6 +257,7 @@ class Entry : IAnnotated {
     ListExpression      keys;         /// must be a tuple expression
     Expression          action;       /// typically a MethodCallExpression.
                                       /// The action must be defined in action list
+    bool                singleton;    /// True if the entry is not a list.
 
     Annotations     getAnnotations() const override { return annotations; }
     ListExpression  getKeys() const { return keys; }

--- a/midend/eliminateSwitch.cpp
+++ b/midend/eliminateSwitch.cpp
@@ -98,7 +98,8 @@ const IR::Node* DoEliminateSwitch::postorder(IR::SwitchStatement* statement) {
 
             for (auto lab : pendingLabels) {
                 if (!lab->is<IR::DefaultExpression>()) {
-                    auto entry = new IR::Entry(scSrc, new IR::ListExpression({lab}), actionCall);
+                    auto entry = new IR::Entry(scSrc, new IR::ListExpression({lab}),
+                                               actionCall, false);
                     entries.push_back(entry);
                 }
             }

--- a/testdata/p4_16_samples/issue3442.p4
+++ b/testdata/p4_16_samples/issue3442.p4
@@ -1,0 +1,20 @@
+#include <core.p4>
+
+control c();
+package p(c c);
+
+control myc () {
+  action a() { }
+  action b() { }
+  table t {
+    key = {}
+    actions = { a; }
+    const entries = {
+      _ : a();
+    }
+  }
+  apply {
+    t.apply();
+  }
+}
+p(myc ()) main;

--- a/testdata/p4_16_samples_outputs/issue3442-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3442-first.p4
@@ -1,0 +1,28 @@
+#include <core.p4>
+
+control c();
+package p(c c);
+control myc() {
+    action a() {
+    }
+    action b() {
+    }
+    table t {
+        key = {
+        }
+        actions = {
+            a();
+            @defaultonly NoAction();
+        }
+        const entries = {
+                        default : a();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+p(myc()) main;
+

--- a/testdata/p4_16_samples_outputs/issue3442-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue3442-frontend.p4
@@ -1,0 +1,28 @@
+#include <core.p4>
+
+control c();
+package p(c c);
+control myc() {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("myc.a") action a() {
+    }
+    @name("myc.t") table t_0 {
+        key = {
+        }
+        actions = {
+            a();
+            @defaultonly NoAction_1();
+        }
+        const entries = {
+                        default : a();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+p(myc()) main;
+

--- a/testdata/p4_16_samples_outputs/issue3442-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue3442-midend.p4
@@ -1,0 +1,28 @@
+#include <core.p4>
+
+control c();
+package p(c c);
+control myc() {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("myc.a") action a() {
+    }
+    @name("myc.t") table t_0 {
+        key = {
+        }
+        actions = {
+            a();
+            @defaultonly NoAction_1();
+        }
+        const entries = {
+                        default : a();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+p(myc()) main;
+

--- a/testdata/p4_16_samples_outputs/issue3442.p4
+++ b/testdata/p4_16_samples_outputs/issue3442.p4
@@ -1,0 +1,26 @@
+#include <core.p4>
+
+control c();
+package p(c c);
+control myc() {
+    action a() {
+    }
+    action b() {
+    }
+    table t {
+        key = {
+        }
+        actions = {
+            a;
+        }
+        const entries = {
+                        default : a();
+        }
+    }
+    apply {
+        t.apply();
+    }
+}
+
+p(myc()) main;
+


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3442
For this to work we need to remember whether the original expression was _ or { _ }.
That's why the IR class had to be augmented.
(We may need to do the same for select expressions, which suffer from a similar confusion.)