### PR TITLE
Fixed usage of yyFlexLexer with multiple parsers

### DIFF
--- a/frontends/parsers/p4/p4lexer.hpp
+++ b/frontends/parsers/p4/p4lexer.hpp
@@ -4,31 +4,12 @@
 // FlexLexer.h requires you to provide an external #include guard so that it can
 // be included multiple times, each time providing a different definition for
 // yyFlexLexer, to define multiple lexer base classes.
-#ifndef yyFlexLexerOnce
+
 #define yyFlexLexer p4FlexLexer
 #include <FlexLexer.h>
-#endif
+#undef yyFlexLexer
 
-#include "frontends/parsers/p4/abstractP4Lexer.hpp"
-#include "frontends/parsers/p4/p4parser.hpp"
-#include "lib/source_file.h"
+#include "frontends/parsers/p4/p4lexer_internal.hpp"
 
-namespace P4 {
-
-class P4ParserDriver;
-
-class P4Lexer : public AbstractP4Lexer, public p4FlexLexer {
- public:
-    explicit P4Lexer(std::istream& input)
-        : p4FlexLexer(&input), needStartToken(true) { }
-
-    virtual Token yylex(P4::P4ParserDriver& driver) override;
-
- private:
-    bool needStartToken;
-    int yylex() override { return p4FlexLexer::yylex(); }
-};
-
-}  // namespace P4
 
 #endif  /* FRONTENDS_P4_LEXER_H_ */

--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -1,7 +1,7 @@
 %{
 #include "frontends/common/constantParsing.h"
 #include "frontends/parsers/parserDriver.h"
-#include "frontends/parsers/p4/p4lexer.hpp"
+#include "frontends/parsers/p4/p4lexer_internal.hpp"
 #include "frontends/parsers/p4/p4parser.hpp"
 
 using Parser = P4::P4Parser;

--- a/frontends/parsers/p4/p4lexer_internal.hpp
+++ b/frontends/parsers/p4/p4lexer_internal.hpp
@@ -1,0 +1,26 @@
+#ifndef FRONTENDS_P4_LEXER_INTERNAL_H_
+#define FRONTENDS_P4_LEXER_INTERNAL_H_
+
+#include "frontends/parsers/p4/abstractP4Lexer.hpp"
+#include "frontends/parsers/p4/p4parser.hpp"
+#include "lib/source_file.h"
+
+namespace P4 {
+
+class P4ParserDriver;
+
+class P4Lexer : public AbstractP4Lexer, public p4FlexLexer {
+ public:
+    explicit P4Lexer(std::istream& input)
+        : p4FlexLexer(&input), needStartToken(true) { }
+
+    virtual Token yylex(P4::P4ParserDriver& driver) override;
+
+ private:
+    bool needStartToken;
+    int yylex() override { return p4FlexLexer::yylex(); }
+};
+
+}  // namespace P4
+
+#endif  /* FRONTENDS_P4_LEXER_INTERNAL_H_ */

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -21,7 +21,7 @@ limitations under the License.
 // Set up names.
 %defines
 %define api.namespace {P4}
-%define parser_class_name {P4Parser}
+%define api.parser.class {P4Parser}
 
 // Use the C++-native variant representation of tokens.
 %define api.token.constructor

--- a/frontends/parsers/v1/v1lexer.hpp
+++ b/frontends/parsers/v1/v1lexer.hpp
@@ -4,43 +4,11 @@
 // FlexLexer.h requires you to provide an external #include guard so that it can
 // be included multiple times, each time providing a different definition for
 // yyFlexLexer, to define multiple lexer base classes.
-#ifndef yyFlexLexerOnce
+
 #define yyFlexLexer v1FlexLexer
 #include <FlexLexer.h>
-#endif
+#undef yyFlexLexer
 
-#include "frontends/common/constantParsing.h"
-#include "frontends/parsers/v1/v1parser.hpp"
-#include "lib/source_file.h"
-
-namespace V1 {
-
-class V1ParserDriver;
-
-class V1Lexer : public yyFlexLexer {
-    typedef V1::V1Parser::symbol_type Token;
-
- public:
-    explicit V1Lexer(std::istream& input) : yyFlexLexer(&input) { }
-
-    /**
-     * Invoked by the parser to advance to the next token in the input stream.
-     *
-     * Note that we could store @driver as a member on the class, but it's
-     * actually useful to explicitly pass it in. In C++, you cannot overload a
-     * method on return type only. Since yyFlexLexer already declares a version
-     * of yylex() that takes no arguments and returns an int, and we need to
-     * return a Token, we need to add an additional argument to permit the
-     * overload.
-     *
-     * @return the token that was just read.
-     */
-    virtual Token yylex(V1::V1ParserDriver& driver);
-
- private:
-    int yylex() override { return yyFlexLexer::yylex(); }
-};
-
-}  // namespace V1
+#include "frontends/parsers/v1/v1lexer_internal.hpp"
 
 #endif  /* FRONTENDS_V1LEXER_H_ */

--- a/frontends/parsers/v1/v1lexer.ll
+++ b/frontends/parsers/v1/v1lexer.ll
@@ -1,7 +1,7 @@
 %{
 #include "frontends/common/constantParsing.h"
 #include "frontends/parsers/parserDriver.h"
-#include "frontends/parsers/v1/v1lexer.hpp"
+#include "frontends/parsers/v1/v1lexer_internal.hpp"
 #include "frontends/parsers/v1/v1parser.hpp"
 #include "lib/stringref.h"
 

--- a/frontends/parsers/v1/v1lexer_internal.hpp
+++ b/frontends/parsers/v1/v1lexer_internal.hpp
@@ -1,0 +1,38 @@
+#ifndef FRONTENDS_V1LEXER_INTERNAL_H_
+#define FRONTENDS_V1LEXER_INTERNAL_H_
+
+#include "frontends/common/constantParsing.h"
+#include "frontends/parsers/v1/v1parser.hpp"
+#include "lib/source_file.h"
+
+namespace V1 {
+
+class V1ParserDriver;
+
+class V1Lexer : public v1FlexLexer {
+    typedef V1::V1Parser::symbol_type Token;
+
+ public:
+    explicit V1Lexer(std::istream& input) : v1FlexLexer(&input) { }
+
+    /**
+     * Invoked by the parser to advance to the next token in the input stream.
+     *
+     * Note that we could store @driver as a member on the class, but it's
+     * actually useful to explicitly pass it in. In C++, you cannot overload a
+     * method on return type only. Since yyFlexLexer already declares a version
+     * of yylex() that takes no arguments and returns an int, and we need to
+     * return a Token, we need to add an additional argument to permit the
+     * overload.
+     *
+     * @return the token that was just read.
+     */
+    virtual Token yylex(V1::V1ParserDriver& driver);
+
+ private:
+    int yylex() override { return v1FlexLexer::yylex(); }
+};
+
+}  // namespace V1
+
+#endif  /* FRONTENDS_V1LEXER_INTERNAL_H_ */

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -21,7 +21,7 @@ limitations under the License.
 // Set up names.
 %defines
 %define api.namespace {V1}
-%define parser_class_name {V1Parser}
+%define api.parser.class {V1Parser}
 
 // Use the C++-native variant representation of tokens.
 %define api.token.constructor


### PR DESCRIPTION
First, UBSan found issue here:

> [2022-04-27T21:17:41.988Z] /bfn/bf-p4c-compilers/p4c/frontends/parsers/v1/v1lexer.hpp:20:7: runtime error: member call on address 0x7ffeb47d6800 which does not point to an object of type 'p4FlexLexer' [2022-04-27T21:17:41.988Z] 0x7ffeb47d6800: note: object is of type 'V1::V1Lexer' [2022-04-27T21:17:41.988Z] fe 7f 00 00 78 44 cd 13 46 56 00 00 00 10 b9 26 46 56 00 00 01 00 00 00 01 00 00 00 00 00 00 00 [2022-04-27T21:17:41.988Z] ^~~~~~~~~~~~~~~~~~~~~~~ [2022-04-27T21:17:41.988Z] vptr for 'V1::V1Lexer'

I analyzed it and we should drop "yyFlexLexerOnce" hacks and use recommended ways to do it. Fixes bugs and follows bison guidelines.

Nicely explained here:
https://stackoverflow.com/questions/35606354/multiple-parsers-in-flex-bison-include-fails

While here, I also replaced parser_class_name with api.parser.class, as bison warns that parser_class_name  is deprecated.
