### PR TITLE
Don't copy annotations for new parser states in ParserUnroll

### DIFF
--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -649,9 +649,14 @@ class ParserSymbolicInterpreter {
         auto result = evaluateSelect(state, valueMap);
         if (unroll) {
             BUG_CHECK(result.second, "Can't generate new selection %1%", state);
-            state->newState = new IR::ParserState(state->state->srcInfo, newName,
-                                                  state->state->annotations, components,
-                                                  result.second);
+            if (state->name == newName) {
+                state->newState = new IR::ParserState(state->state->srcInfo, newName,
+                                                      state->state->annotations, components,
+                                                      result.second);
+            } else {
+                state->newState =
+                    new IR::ParserState(state->state->srcInfo, newName, components, result.second);
+            }
         }
         return EvaluationStateResult(result.first, true);
     }

--- a/testdata/p4_16_samples/parser-unroll-test1.p4
+++ b/testdata/p4_16_samples/parser-unroll-test1.p4
@@ -73,7 +73,7 @@ parser MyParser(packet_in packet,
         }
     }
 
-    state parse_srcRouting {
+    @name (".parse_srcRouting") state parse_srcRouting {
         packet.extract(hdr.srcRoutes[index]);
         index = index + 1;
         transition select(hdr.srcRoutes[index - 1].bos) {

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1-first.p4
@@ -56,7 +56,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
             default: accept;
         }
     }
-    state parse_srcRouting {
+    @name(".parse_srcRouting") state parse_srcRouting {
         packet.extract<srcRoute_t>(hdr.srcRoutes[index]);
         index = index + 32s1;
         transition select(hdr.srcRoutes[index + -32s1].bos) {

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1-frontend.p4
@@ -50,7 +50,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
             default: accept;
         }
     }
-    state parse_srcRouting {
+    @name(".parse_srcRouting") state parse_srcRouting {
         tmp = index_0;
         packet.extract<srcRoute_t>(hdr.srcRoutes[tmp]);
         index_0 = index_0 + 32s1;

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1-midend.p4
@@ -49,7 +49,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
             default: accept;
         }
     }
-    state parse_srcRouting {
+    @name(".parse_srcRouting") state parse_srcRouting {
         packet.extract<srcRoute_t>(hdr.srcRoutes[index_0]);
         index_0 = index_0 + 32s1;
         transition select(hdr.srcRoutes[index_0 + -32s1].bos) {

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1.p4
@@ -56,7 +56,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
             default: accept;
         }
     }
-    state parse_srcRouting {
+    @name(".parse_srcRouting") state parse_srcRouting {
         packet.extract(hdr.srcRoutes[index]);
         index = index + 1;
         transition select(hdr.srcRoutes[index - 1].bos) {

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-first.p4
@@ -56,7 +56,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
             default: accept;
         }
     }
-    state parse_srcRouting {
+    @name(".parse_srcRouting") state parse_srcRouting {
         packet.extract<srcRoute_t>(hdr.srcRoutes[index]);
         index = index + 32s1;
         transition select(hdr.srcRoutes[index + -32s1].bos) {

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-frontend.p4
@@ -50,7 +50,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
             default: accept;
         }
     }
-    state parse_srcRouting {
+    @name(".parse_srcRouting") state parse_srcRouting {
         tmp = index_0;
         packet.extract<srcRoute_t>(hdr.srcRoutes[tmp]);
         index_0 = index_0 + 32s1;

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1-midend.p4
@@ -49,7 +49,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
         packet.extract<ipv4_t>(hdr.ipv4);
         transition accept;
     }
-    state parse_srcRouting {
+    @name(".parse_srcRouting") state parse_srcRouting {
         packet.extract<srcRoute_t>(hdr.srcRoutes[32s0]);
         index_0 = index_0 + 32s1;
         transition select(hdr.srcRoutes[32s0].bos) {

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-test1.p4
@@ -56,7 +56,7 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
             default: accept;
         }
     }
-    state parse_srcRouting {
+    @name(".parse_srcRouting") state parse_srcRouting {
         packet.extract(hdr.srcRoutes[index]);
         index = index + 1;
         transition select(hdr.srcRoutes[index - 1].bos) {


### PR DESCRIPTION
If initial parser state has annotation and new name of a parser state was created then new parser state can't contain the same annotation as was in initial parser state. 