### PR TITLE
Fixed build with older bison on Ubuntu 18

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -21,7 +21,7 @@ limitations under the License.
 // Set up names.
 %defines
 %define api.namespace {P4}
-%define api.parser.class {P4Parser}
+%define parser_class_name {P4Parser}
 
 // Use the C++-native variant representation of tokens.
 %define api.token.constructor

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -21,7 +21,7 @@ limitations under the License.
 // Set up names.
 %defines
 %define api.namespace {V1}
-%define api.parser.class {V1Parser}
+%define parser_class_name {V1Parser}
 
 // Use the C++-native variant representation of tokens.
 %define api.token.constructor


### PR DESCRIPTION
Part of recent commit changed (deprecated) parser_class_name to api.parser.class but unfortnutely this broke build on Ubuntu 18, as bison version there does not support new form. So for now use parser_class_name..

Fixes https://github.com/p4lang/p4c/issues/3451