### PR TITLE
Fix include headers for lib/stringify.h

### DIFF
--- a/lib/stringify.cpp
+++ b/lib/stringify.cpp
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <stdarg.h>
 #include <sstream>
 #include <deque>
 #include "stringify.h"

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -20,6 +20,7 @@ limitations under the License.
 #define _LIB_STRINGIFY_H_
 
 #include <stdint.h>
+#include <cstdarg>
 #include "gmputil.h"
 #include "cstring.h"
 #include "stringref.h"


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>

This is the fix from #3295; github doesn't let me merge that one.
