### PR TITLE
Fixes related to type and function specialization

### DIFF
--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -103,6 +103,8 @@ StorageLocation* StorageFactory::create(const IR::Type* type, cstring name) cons
         result->setLastIndexField(create(IR::Type_Bits::get(32), name + "." + indexFieldName));
         return result;
     }
+    BUG_CHECK(!type->is<IR::Type_SpecializedCanonical>(),
+              "%1%: unspecialized type in def-use", type);
     return nullptr;
 }
 

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -103,8 +103,6 @@ StorageLocation* StorageFactory::create(const IR::Type* type, cstring name) cons
         result->setLastIndexField(create(IR::Type_Bits::get(32), name + "." + indexFieldName));
         return result;
     }
-    BUG_CHECK(!type->is<IR::Type_SpecializedCanonical>(),
-              "%1%: unspecialized type in def-use", type);
     return nullptr;
 }
 

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -181,17 +181,19 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new SetStrictStruct(&typeMap, false),
         new ValidateMatchAnnotations(&typeMap),
         new BindTypeVariables(&refMap, &typeMap),
-        new SpecializeGenericTypes(&refMap, &typeMap),
-        new DefaultArguments(&refMap, &typeMap),  // add default argument values to parameters
-        new ResolveReferences(&refMap),
-        new SetStrictStruct(&typeMap, true),  // Next pass uses strict struct checking
-        new TypeInference(&refMap, &typeMap, false),  // more casts may be needed
-        new SetStrictStruct(&typeMap, false),
+        new PassRepeated({
+            new SpecializeGenericTypes(&refMap, &typeMap),
+            new DefaultArguments(&refMap, &typeMap),  // add default argument values to parameters
+            new ResolveReferences(&refMap),
+            new SetStrictStruct(&typeMap, true),  // Next pass uses strict struct checking
+            new TypeInference(&refMap, &typeMap, false),  // more casts may be needed
+            new SetStrictStruct(&typeMap, false),
+            new SpecializeGenericFunctions(&refMap, &typeMap)
+        }),
         new CheckCoreMethods(&refMap, &typeMap),
         new StaticAssert(&refMap, &typeMap),
         new RemoveParserIfs(&refMap, &typeMap),
         new StructInitializers(&refMap, &typeMap),
-        new SpecializeGenericFunctions(&refMap, &typeMap),
         new TableKeyNames(&refMap, &typeMap),
         new PassRepeated({
             new ConstantFolding(&refMap, &typeMap),

--- a/frontends/p4/specializeGenericFunctions.h
+++ b/frontends/p4/specializeGenericFunctions.h
@@ -28,29 +28,55 @@ struct FunctionSpecialization {
     /// Name to use for specialized function.
     cstring name;
     /// Function that is being specialized
+    const IR::Function*                original;
+    /// Result of specialization
     const IR::Function*                specialized;
     /// Invocation which causes this specialization.
     const IR::MethodCallExpression*    invocation;
+    /// Point in IR tree where to insert the function
+    const IR::Node*                    insertBefore;
 
     FunctionSpecialization(cstring name,
                            const IR::MethodCallExpression* invocation,
-                           const IR::Function* function):
-            name(name), specialized(function), invocation(invocation)
-    { CHECK_NULL(invocation); }
+                           const IR::Function* function,
+                           const IR::Node* insert):
+            name(name), original(function), specialized(nullptr),
+            invocation(invocation), insertBefore(insert)
+    { CHECK_NULL(invocation); CHECK_NULL(invocation); CHECK_NULL(insertBefore); }
 };
 
 struct FunctionSpecializationMap {
     ReferenceMap* refMap;
     TypeMap* typeMap;
     ordered_map<const IR::MethodCallExpression*, FunctionSpecialization*> map;
+    // Keep track of the values in the above map which are already
+    // inserted in the program.
+    std::set<FunctionSpecialization*> inserted;
 
-    void add(const IR::MethodCallExpression* mce, const IR::Function* func) {
+    void add(const IR::MethodCallExpression* mce, const IR::Function* func, const
+             IR::Node* insert) {
         cstring name = refMap->newName(func->name);
-        FunctionSpecialization* fs = new FunctionSpecialization(name, mce, func);
+        FunctionSpecialization* fs = new FunctionSpecialization(name, mce, func, insert);
         map.emplace(mce, fs);
     }
     FunctionSpecialization* get(const IR::MethodCallExpression* mce) const {
         return ::get(map, mce);
+    }
+    IR::Vector<IR::Node>* getInsertions(const IR::Node* insertionPoint) {
+        IR::Vector<IR::Node>* result = nullptr;
+        for (auto s : map) {
+            if (inserted.find(s.second) != inserted.end())
+                continue;
+            if (s.second->insertBefore == insertionPoint) {
+                if (result == nullptr)
+                    result = new IR::Vector<IR::Node>();
+                LOG2("Will insert " << dbp(s.second->specialized) <<
+                     " before " << dbp(insertionPoint));
+                result->push_back(s.second->specialized);
+                inserted.emplace(s.second);
+            }
+        }
+        return result;
     }
 };
 
@@ -95,6 +121,13 @@ class SpecializeFunctions : public Transform {
     { CHECK_NULL(specMap); setName("SpecializeFunctions"); }
     const IR::Node* postorder(IR::Function* function) override;
     const IR::Node* postorder(IR::MethodCallExpression*) override;
+    const IR::Node* insert(const IR::Node* before);
+    const IR::Node* preorder(IR::P4Control* control) override
+    { return insert(control); }
+    const IR::Node* preorder(IR::P4Parser* parser) override
+    { return insert(parser); }
+    const IR::Node* preorder(IR::Function* function) override
+    { return insert(function); }
 };
 
 class SpecializeGenericFunctions : public PassManager {

--- a/frontends/p4/specializeGenericTypes.cpp
+++ b/frontends/p4/specializeGenericTypes.cpp
@@ -118,6 +118,8 @@ void FindTypeSpecializations::postorder(const IR::Type_Specialized* type) {
         insert = findContext<IR::Declaration_Variable>();
     if (!insert)
         insert = findContext<IR::Declaration_Instance>();
+    if (!insert)
+        insert = findContext<IR::P4Action>();
     CHECK_NULL(insert);
     specMap->add(type, st, insert);
 }

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -166,6 +166,10 @@ class ToP4 : public Inspector {
         builder.append(t->toString());
         return false;
     }
+    bool preorder(const IR::Type_SpecializedCanonical* t) override {
+        BUG("%1%: specialized canonical type in IR tree", t);
+        return false;
+    }
 
     // declarations
     bool preorder(const IR::Declaration_Constant* cst) override;

--- a/testdata/p4_16_errors/issue3291.p4
+++ b/testdata/p4_16_errors/issue3291.p4
@@ -1,0 +1,6 @@
+struct h<t>{
+  t f;
+}
+
+typedef h<bit> tt;
+typedef h<tt> t;

--- a/testdata/p4_16_errors_outputs/issue1296.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1296.p4-stderr
@@ -1,10 +1,10 @@
-issue1296.p4(7): [--Werror=type-error] error: test_extern: contains self test_extern as type argument
+issue1296.p4(7): [--Werror=type-error] error: test_extern: contains self 'test_extern' as type argument
 test_extern<test_extern<bit<32>>>() test;
 ^^^^^^^^^^^
 issue1296.p4(3)
 extern test_extern<T> {
        ^^^^^^^^^^^
-issue1296.p4(13): [--Werror=type-error] error: test_extern1: contains self test_extern1 as type argument
+issue1296.p4(13): [--Werror=type-error] error: test_extern1: contains self 'test_extern1' as type argument
 test_extern1<test_extern<test_extern1<bit<32>>>>() test1;
 ^^^^^^^^^^^^
 issue1296.p4(9)

--- a/testdata/p4_16_errors_outputs/issue1296.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1296.p4-stderr
@@ -1,6 +1,12 @@
-issue1296.p4(7): [--Werror=type-error] error: test_extern: recursive type specialization
+issue1296.p4(7): [--Werror=type-error] error: test_extern: contains self test_extern as type argument
 test_extern<test_extern<bit<32>>>() test;
-            ^^^^^^^^^^^
-issue1296.p4(13): [--Werror=type-error] error: test_extern1: recursive type specialization
+^^^^^^^^^^^
+issue1296.p4(3)
+extern test_extern<T> {
+       ^^^^^^^^^^^
+issue1296.p4(13): [--Werror=type-error] error: test_extern1: contains self test_extern1 as type argument
 test_extern1<test_extern<test_extern1<bit<32>>>>() test1;
-                         ^^^^^^^^^^^^
+^^^^^^^^^^^^
+issue1296.p4(9)
+extern test_extern1<T> {
+       ^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue3291.p4
+++ b/testdata/p4_16_errors_outputs/issue3291.p4
@@ -1,0 +1,6 @@
+struct h<t> {
+    t f;
+}
+
+typedef h<bit<1>> tt;
+typedef h<tt> t;

--- a/testdata/p4_16_errors_outputs/issue3291.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3291.p4-stderr
@@ -1,0 +1,6 @@
+issue3291.p4(6): [--Werror=type-error] error: h: contains self struct h as type argument
+typedef h<tt> t;
+        ^
+issue3291.p4(1)
+struct h<t>{
+       ^

--- a/testdata/p4_16_errors_outputs/issue3291.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3291.p4-stderr
@@ -1,4 +1,4 @@
-issue3291.p4(6): [--Werror=type-error] error: h: contains self struct h as type argument
+issue3291.p4(6): [--Werror=type-error] error: h: contains self 'struct h' as type argument
 typedef h<tt> t;
         ^
 issue3291.p4(1)

--- a/testdata/p4_16_errors_outputs/issue819-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue819-1.p4-stderr
@@ -4,9 +4,9 @@ control MyC1(WrapControls wc) {
 issue819-1.p4(19): [--Werror=type-error] error: Type parameters needed for wc
 control MyC2(WrapControls wc) {
                           ^^
-issue819-1.p4(27): [--Werror=type-error] error: WrapControls<MyC1, MyC2>: Cannot use control MyC1 as a type parameter
+issue819-1.p4(27): [--Werror=type-error] error: WrapControls: contains self 'WrapControls' as type argument
   WrapControls<MyC1,MyC2>(c1,c2) wc;
-  ^^^^^^^^^^^^^^^^^^^^^^^
-issue819-1.p4(14)
-control MyC1(WrapControls wc) {
-        ^^^^
+  ^^^^^^^^^^^^
+issue819-1.p4(7)
+extern WrapControls<T1,T2> {
+       ^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue819.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue819.p4-stderr
@@ -1,6 +1,6 @@
-issue819.p4(27): [--Werror=type-error] error: WrapControls<MyC1, MyC2>: Cannot use control MyC1 as a type parameter
+issue819.p4(27): [--Werror=type-error] error: WrapControls: contains self 'WrapControls' as type argument
   WrapControls<MyC1,MyC2>(c1,c2) wc;
-  ^^^^^^^^^^^^^^^^^^^^^^^
-issue819.p4(14)
-control MyC1(WrapControls<_,_> wc) {
-        ^^^^
+  ^^^^^^^^^^^^
+issue819.p4(7)
+extern WrapControls<T1,T2> {
+       ^^^^^^^^^^^^

--- a/testdata/p4_16_samples/issue3291-1.p4
+++ b/testdata/p4_16_samples/issue3291-1.p4
@@ -1,0 +1,24 @@
+struct h<t> {
+    t f;
+};
+bool g<t>(in t a) {
+    h<t> v;
+    v.f = a;
+    return v.f == a;
+}
+bool gg()
+{
+    h<bit> a = { 0 };
+    return g(a);
+}
+
+control c(out bool x) {
+    apply {
+        x = gg();
+    }
+}
+
+control C(out bool b);
+package top(C _c);
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue1830-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1830-first.p4
@@ -1,11 +1,11 @@
-void foo_0(in bool x) {
-}
-void foo_1(in bit<8> x) {
-}
 void foo<T>(in T x) {
+}
+void foo_0(in bool x) {
 }
 void bar() {
     foo_0(true);
+}
+void foo_1(in bit<8> x) {
 }
 void main() {
     foo_1(8w0);

--- a/testdata/p4_16_samples_outputs/issue2260-2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2260-2-first.p4
@@ -1,9 +1,9 @@
 control C();
 package S(C c);
-bit<8> f_0(bit<8> x) {
+T f<T>(T x) {
     return x;
 }
-T f<T>(T x) {
+bit<8> f_0(bit<8> x) {
     return x;
 }
 control MyC() {

--- a/testdata/p4_16_samples_outputs/issue3291-1-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3291-1-first.p4
@@ -1,0 +1,32 @@
+struct h<t> {
+    t f;
+}
+
+bool g<t>(in t a) {
+    h<t> v;
+    v.f = a;
+    return v.f == a;
+}
+struct h_0 {
+    bit<1> f;
+}
+
+bool g_0(in h_0 a) {
+    h<h_0> v;
+    v.f = a;
+    return v.f == a;
+}
+bool gg() {
+    h_0 a = (h_0){f = 1w0};
+    return g_0(a);
+}
+control c(out bool x) {
+    apply {
+        x = gg();
+    }
+}
+
+control C(out bool b);
+package top(C _c);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue3291-1-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3291-1-first.p4
@@ -11,8 +11,12 @@ struct h_0 {
     bit<1> f;
 }
 
+struct h_1 {
+    h_0 f;
+}
+
 bool g_0(in h_0 a) {
-    h<h_0> v;
+    h_1 v;
     v.f = a;
     return v.f == a;
 }

--- a/testdata/p4_16_samples_outputs/issue3291-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue3291-1-frontend.p4
@@ -6,6 +6,10 @@ struct h_0 {
     bit<1> f;
 }
 
+struct h_1 {
+    h_0 f;
+}
+
 control c(out bool x) {
     @name("c.hasReturned_0") bool hasReturned;
     @name("c.retval_0") bool retval;
@@ -14,12 +18,13 @@ control c(out bool x) {
     @name("c.a_0") h_0 a_2;
     @name("c.hasReturned") bool hasReturned_0;
     @name("c.retval") bool retval_0;
-    @name("c.v") h<h_0> v_0;
+    @name("c.v") h_1 v_0;
     apply {
         hasReturned = false;
         a = (h_0){f = 1w0};
         a_2 = a;
         hasReturned_0 = false;
+        v_0.f = a_2;
         hasReturned_0 = true;
         retval_0 = v_0.f == a_2;
         tmp = retval_0;

--- a/testdata/p4_16_samples_outputs/issue3291-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue3291-1-frontend.p4
@@ -1,0 +1,35 @@
+struct h<t> {
+    t f;
+}
+
+struct h_0 {
+    bit<1> f;
+}
+
+control c(out bool x) {
+    @name("c.hasReturned_0") bool hasReturned;
+    @name("c.retval_0") bool retval;
+    @name("c.tmp") bool tmp;
+    @name("c.a") h_0 a;
+    @name("c.a_0") h_0 a_2;
+    @name("c.hasReturned") bool hasReturned_0;
+    @name("c.retval") bool retval_0;
+    @name("c.v") h<h_0> v_0;
+    apply {
+        hasReturned = false;
+        a = (h_0){f = 1w0};
+        a_2 = a;
+        hasReturned_0 = false;
+        hasReturned_0 = true;
+        retval_0 = v_0.f == a_2;
+        tmp = retval_0;
+        hasReturned = true;
+        retval = tmp;
+        x = retval;
+    }
+}
+
+control C(out bool b);
+package top(C _c);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue3291-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue3291-1-midend.p4
@@ -1,0 +1,28 @@
+struct h<t> {
+    t f;
+}
+
+struct h_0 {
+    bit<1> f;
+}
+
+control c(out bool x) {
+    @name("c.v") h<h_0> v_0;
+    @hidden action issue32911l17() {
+        x = v_0.f.f == 1w0;
+    }
+    @hidden table tbl_issue32911l17 {
+        actions = {
+            issue32911l17();
+        }
+        const default_action = issue32911l17();
+    }
+    apply {
+        tbl_issue32911l17.apply();
+    }
+}
+
+control C(out bool b);
+package top(C _c);
+top(c()) main;
+

--- a/testdata/p4_16_samples_outputs/issue3291-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue3291-1-midend.p4
@@ -6,10 +6,13 @@ struct h_0 {
     bit<1> f;
 }
 
+struct h_1 {
+    h_0 f;
+}
+
 control c(out bool x) {
-    @name("c.v") h<h_0> v_0;
     @hidden action issue32911l17() {
-        x = v_0.f.f == 1w0;
+        x = true;
     }
     @hidden table tbl_issue32911l17 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue3291-1.p4
+++ b/testdata/p4_16_samples_outputs/issue3291-1.p4
@@ -1,0 +1,23 @@
+struct h<t> {
+    t f;
+}
+
+bool g<t>(in t a) {
+    h<t> v;
+    v.f = a;
+    return v.f == a;
+}
+bool gg() {
+    h<bit<1>> a = { 0 };
+    return g(a);
+}
+control c(out bool x) {
+    apply {
+        x = gg();
+    }
+}
+
+control C(out bool b);
+package top(C _c);
+top(c()) main;
+


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3291 
The fix is in the typechecking code.
But the tests revealed some bugs in the specialization code: now we insert the specialized function code in a different place in the source code, to make sure it's after all type declarations that it may depend on. So the function specialization code is more similar to the existing type specialization code.