### PR TITLE
Remove "frontends" from the include directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,6 @@ else()
 endif()
 
 include_directories (
-  ${P4C_SOURCE_DIR}/frontends
   ${P4C_SOURCE_DIR}/backends
   ${P4C_SOURCE_DIR}/extensions
   ${P4C_SOURCE_DIR}

--- a/backends/ubpf/ubpfControl.cpp
+++ b/backends/ubpf/ubpfControl.cpp
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <p4/enumInstance.h>
 #include "ubpfType.h"
 #include "ubpfControl.h"
 #include "lib/error.h"
-#include "frontends/p4/tableApply.h"
-#include "frontends/p4/typeMap.h"
+#include <frontends/p4/enumInstance.h>
 #include "frontends/p4/methodInstance.h"
 #include "frontends/p4/parameterSubstitution.h"
+#include "frontends/p4/tableApply.h"
+#include "frontends/p4/typeMap.h"
 
 namespace UBPF {
 

--- a/backends/ubpf/ubpfControl.cpp
+++ b/backends/ubpf/ubpfControl.cpp
@@ -13,11 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-#include "ubpfType.h"
 #include "ubpfControl.h"
+
+#include "ubpf/ubpfType.h"
 #include "lib/error.h"
-#include <frontends/p4/enumInstance.h>
+#include "frontends/p4/enumInstance.h"
 #include "frontends/p4/methodInstance.h"
 #include "frontends/p4/parameterSubstitution.h"
 #include "frontends/p4/tableApply.h"

--- a/backends/ubpf/ubpfTable.cpp
+++ b/backends/ubpf/ubpfTable.cpp
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <p4/enumInstance.h>
 #include "ubpfTable.h"
 #include "ubpfType.h"
 #include "ubpfParser.h"
 #include "ir/ir.h"
 #include "frontends/p4/coreLibrary.h"
+#include "frontends/p4/enumInstance.h"
 #include "frontends/p4/methodInstance.h"
 #include "ubpfControl.h"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,7 +92,7 @@ set (GTESTP4C_SOURCES ${GTEST_SOURCES} ${GTEST_BASE_SOURCES})
 # can also link in additional libraries, if needed, by adding them to
 # `GTEST_LDADD`.
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/test)
-configure_file(gtest/env.h.in ${CMAKE_CURRENT_BINARY_DIR}/test/env.h)
+configure_file(gtest/env.h.in ${CMAKE_CURRENT_BINARY_DIR}/gtest/env.h)
 add_executable (gtestp4c ${GTESTP4C_SOURCES})
 target_link_libraries (gtestp4c ${GTEST_LDADD} ${P4C_LIBRARIES} gtest ${P4C_LIB_DEPS})
 

--- a/test/gtest/arch_test.cpp
+++ b/test/gtest/arch_test.cpp
@@ -22,10 +22,10 @@ limitations under the License.
 #include "frontends/common/parseInput.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
+#include "frontends/p4/createBuiltins.h"
+#include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/p4/typeMap.h"
 
-#include "p4/createBuiltins.h"
-#include "p4/typeChecking/typeChecker.h"
 
 using namespace P4;
 

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -1,23 +1,19 @@
-#include <stdlib.h>
-
+#include <cstdlib>
 #include <fstream>
 
-#include "env.h"
 
+#include "test/gtest/env.h"
+#include "test/gtest/helpers.h"
 #include "gtest/gtest.h"
 #include "ir/ir.h"
-#include "helpers.h"
 #include "lib/log.h"
-
-#include "frontends/common/parseInput.h"
 
 #include "backends/p4test/version.h"
 
-#include "p4/createBuiltins.h"
-#include "p4/typeChecking/typeChecker.h"
-
 #include "frontends/common/constantFolding.h"
+#include "frontends/common/parseInput.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
+#include "frontends/p4/createBuiltins.h"
 #include "frontends/p4/evaluator/evaluator.h"
 #include "frontends/p4/fromv1.0/v1model.h"
 #include "frontends/p4/moveDeclarations.h"


### PR DESCRIPTION
Forces back ends and extensions to use consistent include paths