### PR TITLE
Remove undefined behaviour in pass manager initialization

### DIFF
--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -191,7 +191,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new StructInitializers(&refMap, &typeMap),
         new SpecializeGenericFunctions(&refMap, &typeMap),
         new TableKeyNames(&refMap, &typeMap),
-        PassRepeated({
+        new PassRepeated({
             new ConstantFolding(&refMap, &typeMap),
             new StrengthReduction(&refMap, &typeMap),
             new Reassociation(),


### PR DESCRIPTION
`1062: +pass_manager.h:43:5: runtime error: load of value 160, which is not a valid value for type 'bool'
1062: +    #0 0x558499773b3d in PassRepeated::clone() const (/home/dbolvans/speed/p4c/build/backends/p4test/p4test+0x89f8b3d)
1062: +    #1 0x55849977433e in covariant return thunk to PassRepeated::clone() const (/home/dbolvans/speed/p4c/build/backends/p4test/p4test+0x89f933e)
1062: +    #2 0x55849d53ed42 in P4::FrontEnd::run(CompilerOptions const&, IR::P4Program const*, bool, std::ostream*) (/home/dbolvans/speed/p4c/build/backends/p4test/p4test+0xc7c3d42)
1062: +    #3 0x5584998c49b9 in main (/home/dbolvans/speed/p4c/build/backends/p4test/p4test+0x8b499b9)
1062: +    #4 0x7efca3c380b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
1062: +    #5 0x55849969a4cd in _start (/home/dbolvans/speed/p4c/build/backends/p4test/p4test+0x891f4cd)`