### PR TITLE
Implicit casts between InfInt and Bit are allowed

### DIFF
--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -330,9 +330,11 @@ bool TypeMap::equivalent(const IR::Type* left, const IR::Type* right, bool stric
 bool TypeMap::implicitlyConvertibleTo(const IR::Type* from, const IR::Type* to) const {
     if (equivalent(from, to))
         return true;
-    if (from->is<IR::Type_InfInt>() && to->is<IR::Type_InfInt>())
-        // this case is not caught by the equivalence check
-        return true;
+    if (from->is<IR::Type_InfInt>()) {
+        if (to->is<IR::Type_InfInt>() || to->is<IR::Type_Bits>())
+            // this case is not caught by the equivalence check
+            return true;
+    }
     if (auto rt = to->to<IR::Type_BaseList>()) {
         if (auto sl = from->to<IR::Type_StructLike>()) {
             // We allow implicit casts from list types to structs

--- a/testdata/p4_16_samples/issue3238.p4
+++ b/testdata/p4_16_samples/issue3238.p4
@@ -1,0 +1,17 @@
+bit func(bit t1)
+{
+  tuple<int> t = {t1};
+  return t[0];
+}
+
+bit func1(bit t1)
+{
+  tuple<int> t = {t1};
+  return t[0];
+}
+
+bit func2(bit t1)
+{
+  tuple<int> t = {1};
+  return t[0];
+}

--- a/testdata/p4_16_samples_outputs/issue3238-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3238-first.p4
@@ -1,0 +1,12 @@
+bit<1> func(bit<1> t1) {
+    tuple<int> t = { t1 };
+    return (bit<1>)t[0];
+}
+bit<1> func1(bit<1> t1) {
+    tuple<int> t = { t1 };
+    return (bit<1>)t[0];
+}
+bit<1> func2(bit<1> t1) {
+    tuple<int> t = { 1 };
+    return (bit<1>)t[0];
+}

--- a/testdata/p4_16_samples_outputs/issue3238.p4
+++ b/testdata/p4_16_samples_outputs/issue3238.p4
@@ -1,0 +1,12 @@
+bit<1> func(bit<1> t1) {
+    tuple<int> t = { t1 };
+    return t[0];
+}
+bit<1> func1(bit<1> t1) {
+    tuple<int> t = { t1 };
+    return t[0];
+}
+bit<1> func2(bit<1> t1) {
+    tuple<int> t = { 1 };
+    return t[0];
+}

--- a/testdata/p4_16_samples_outputs/issue3238.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3238.p4-stderr
@@ -1,0 +1,1 @@
+[--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3238