### PR TITLE
readme: Update supported Ubuntu versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ p4c has package support for several Ubuntu and Debian distributions.
 
 ### Ubuntu
 
-For Ubuntu 20.04 and Ubuntu 21.04 it can be installed as follows:
+A p4c pacakge is available in the following repositories for Ubuntu 20.04 and newer.
 
 ```bash
 . /etc/os-release


### PR DESCRIPTION
With the last release of p4c, we have also enabled Ubuntu 22.04 support. This pull request updates the readme file accordingly.

https://build.opensuse.org/package/show/home:p4lang/p4lang-p4c