### PR TITLE
Log/IndentCtl sanity/cleanup

### DIFF
--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -442,8 +442,7 @@ void ComputeWriteSet::enterScope(const IR::ParameterList* parameters,
     }
     allDefinitions->setDefinitionsAt(entryPoint, defs, false);
     currentDefinitions = defs;
-    LOG3("CWS Entered scope " << entryPoint << " definitions are " <<
-         IndentCtl::endl << defs);
+    LOG3("CWS Entered scope " << entryPoint << " definitions are " << Log::endl << defs);
 }
 
 void ComputeWriteSet::exitScope(const IR::ParameterList* parameters,
@@ -496,7 +495,7 @@ bool ComputeWriteSet::setDefinitions(Definitions* defs, const IR::Node* node, bo
     if (findContext<IR::ParserState>())
         overwrite = true;
     allDefinitions->setDefinitionsAt(point, currentDefinitions, overwrite);
-    LOG3("CWS Definitions at " << point << " are " << IndentCtl::endl << defs);
+    LOG3("CWS Definitions at " << point << " are " << Log::endl << defs);
     return false;  // always returns false
 }
 
@@ -703,8 +702,9 @@ bool ComputeWriteSet::preorder(const IR::MethodCallExpression* expression) {
         // symbolically call all the methods that might be called via this extern method
         callees = em->mayCall(); }
     if (!callees.empty()) {
+        Log::TempIndent indent;
         LOG3("Analyzing callees of " << expression << DBPrint::Brief << callees <<
-             DBPrint::Reset << IndentCtl::indent);
+             DBPrint::Reset << indent);
         ProgramPoint pt(callingContext, expression);
         ComputeWriteSet cw(this, pt, currentDefinitions);
         cw.setCalledBy(this);
@@ -713,7 +713,7 @@ bool ComputeWriteSet::preorder(const IR::MethodCallExpression* expression) {
         currentDefinitions = cw.currentDefinitions;
         exitDefinitions = exitDefinitions->joinDefinitions(cw.exitDefinitions);
         LOG3("Definitions after call of " << DBPrint::Brief << expression << ":" <<
-             IndentCtl::endl << currentDefinitions << DBPrint::Reset << IndentCtl::unindent);
+             Log::endl << currentDefinitions << DBPrint::Reset);
     }
 
     auto result = LocationSet::empty;
@@ -1007,12 +1007,12 @@ bool ComputeWriteSet::preorder(const IR::MethodCallStatement* statement) {
 }  // namespace P4
 
 // functions for calling from gdb
-void dump(const P4::StorageLocation *s) { std::cout << *s << IndentCtl::endl; }
-void dump(const P4::StorageMap *s) { std::cout << *s << IndentCtl::endl; }
-void dump(const P4::LocationSet *s) { std::cout << *s << IndentCtl::endl; }
-void dump(const P4::ProgramPoint *p) { std::cout << *p << IndentCtl::endl; }
-void dump(const P4::ProgramPoint &p) { std::cout << p << IndentCtl::endl; }
-void dump(const P4::ProgramPoints *p) { std::cout << *p << IndentCtl::endl; }
-void dump(const P4::ProgramPoints &p) { std::cout << p << IndentCtl::endl; }
-void dump(const P4::Definitions *d) { std::cout << *d << IndentCtl::endl; }
-void dump(const P4::AllDefinitions *d) { std::cout << *d << IndentCtl::endl; }
+void dump(const P4::StorageLocation *s) { std::cout << *s << Log::endl; }
+void dump(const P4::StorageMap *s) { std::cout << *s << Log::endl; }
+void dump(const P4::LocationSet *s) { std::cout << *s << Log::endl; }
+void dump(const P4::ProgramPoint *p) { std::cout << *p << Log::endl; }
+void dump(const P4::ProgramPoint &p) { std::cout << p << Log::endl; }
+void dump(const P4::ProgramPoints *p) { std::cout << *p << Log::endl; }
+void dump(const P4::ProgramPoints &p) { std::cout << p << Log::endl; }
+void dump(const P4::Definitions *d) { std::cout << *d << Log::endl; }
+void dump(const P4::AllDefinitions *d) { std::cout << *d << Log::endl; }

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -256,7 +256,7 @@ class StorageMap : public IHasDbPrint {
     }
     void dbprint(std::ostream& out) const override {
         for (auto &it : storage)
-            out << it.first << ": " << it.second << IndentCtl::endl;
+            out << it.first << ": " << it.second << Log::endl;
     }
 };
 
@@ -382,14 +382,14 @@ class Definitions : public IHasDbPrint {
     bool operator==(const Definitions& other) const;
     void dbprint(std::ostream& out) const override {
         if (unreachable) {
-            out << "  Unreachable" << IndentCtl::endl;
+            out << "  Unreachable" << Log::endl;
         }
         if (definitions.empty())
             out << "  Empty definitions";
         bool first = true;
         for (auto d : definitions) {
             if (!first)
-                out << IndentCtl::endl;
+                out << Log::endl;
             out << "  " << *d.first << "=>" << *d.second;
             first = false;
         }
@@ -435,7 +435,7 @@ class AllDefinitions : public IHasDbPrint {
     }
     void dbprint(std::ostream& out) const override {
         for (auto e : atPoint)
-            out << e.first << " => " << e.second << IndentCtl::endl;
+            out << e.first << " => " << e.second << Log::endl;
     }
 };
 
@@ -498,7 +498,7 @@ class ComputeWriteSet : public Inspector, public IHasDbPrint {
         if (writes.empty())
             out << "No writes";
         for (auto &it : writes)
-            out << it.first << " writes " << it.second << IndentCtl::endl;
+            out << it.first << " writes " << it.second << Log::endl;
     }
 
  public:

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -416,7 +416,6 @@ class FindUninitialized : public Inspector {
     }
     bool setCurrent(const IR::Statement* statement) {
         currentPoint = ProgramPoint(context, statement);
-        LOG3(IndentCtl::unindent);
         return false;
     }
     profile_t init_apply(const IR::Node *root) override {
@@ -459,7 +458,7 @@ class FindUninitialized : public Inspector {
     Definitions* getCurrentDefinitions() const {
         auto defs = definitions->getDefinitions(currentPoint, true);
         LOG3("FU Current point is (after) " << currentPoint <<
-                " definitions are " << IndentCtl::endl << defs);
+                " definitions are " << Log::endl << defs);
         return defs;
     }
 
@@ -479,7 +478,7 @@ class FindUninitialized : public Inspector {
                             const IR::ParameterList* parameters,
                             Definitions* defs) {
         LOG2("Checking output parameters of " << block <<
-             "; definitions are " << IndentCtl::endl << defs);
+             "; definitions are " << Log::endl << defs);
         for (auto p : parameters->parameters) {
             if (p->direction == IR::Direction::Out || p->direction == IR::Direction::InOut) {
                 auto storage = definitions->storageMap->getStorage(p);
@@ -824,7 +823,8 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::AssignmentStatement* statement) override {
-        LOG3("FU Visiting " << dbp(statement) << " " << statement << IndentCtl::indent);
+        Log::TempIndent indent;
+        LOG3("FU Visiting " << dbp(statement) << " " << statement << indent);
         if (!unreachable) {
             lhs = true;
             visit(statement->left);
@@ -844,7 +844,8 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::ReturnStatement* statement) override {
-        LOG3("FU Visiting " << statement);
+        Log::TempIndent indent;
+        LOG3("FU Visiting " << statement << indent);
         if (!unreachable && statement->expression != nullptr)
             visit(statement->expression);
         else
@@ -854,14 +855,16 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::ExitStatement* statement) override {
-        LOG3("FU Visiting " << statement);
+        Log::TempIndent indent;
+        LOG3("FU Visiting " << statement << indent);
         unreachable = true;
         LOG3("Unreachable");
         return setCurrent(statement);
     }
 
     bool preorder(const IR::MethodCallStatement* statement) override {
-        LOG3("FU Visiting " << statement);
+        Log::TempIndent indent;
+        LOG3("FU Visiting " << statement << indent);
         if (!unreachable)
             visit(statement->methodCall);
         else
@@ -871,7 +874,8 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::BlockStatement* statement) override {
-        LOG3("FU Visiting " << statement);
+        Log::TempIndent indent;
+        LOG3("FU Visiting " << statement << indent);
         if (!unreachable) {
             visit(statement->components, "components");
         } else {
@@ -881,7 +885,8 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::IfStatement* statement) override {
-        LOG3("FU Visiting " << statement);
+        Log::TempIndent indent;
+        LOG3("FU Visiting " << statement << indent);
         if (!unreachable) {
             auto saveHeaderDefsBeforeCondition = headerDefs->clone();
             visit(statement->condition);
@@ -907,7 +912,8 @@ class FindUninitialized : public Inspector {
     }
 
     bool preorder(const IR::SwitchStatement* statement) override {
-        LOG3("FU Visiting " << statement);
+        Log::TempIndent indent;
+        LOG3("FU Visiting " << statement << indent);
         if (!unreachable) {
             bool finalUnreachable = true;
             bool hasDefault = false;
@@ -1100,8 +1106,7 @@ class FindUninitialized : public Inspector {
         }
         auto decl = refMap->getDeclaration(expression->path, true);
         LOG4("Declaration for path '" << expression->path << "' is "
-            << IndentCtl::indent << IndentCtl::endl << decl
-            << IndentCtl::unindent);
+            << Log::indent << Log::endl << decl << Log::unindent);
 
         auto storage = definitions->storageMap->getStorage(decl);
         const LocationSet* result;
@@ -1110,8 +1115,8 @@ class FindUninitialized : public Inspector {
         else
             result = LocationSet::empty;
 
-        LOG4("LocationSet for declaration " << IndentCtl::indent << IndentCtl::endl << decl
-            << IndentCtl::unindent << IndentCtl::endl << "is <<" << result << ">>");
+        LOG4("LocationSet for declaration " << Log::indent << Log::endl << decl
+            << Log::unindent << Log::endl << "is <<" << result << ">>");
         reads(expression, result);
         registerUses(expression);
         return false;
@@ -1211,7 +1216,7 @@ class FindUninitialized : public Inspector {
         }
 
         // The effect of copy-in: in arguments are read
-        LOG3("Summarizing call effect on in arguments; definitions are " << IndentCtl::endl <<
+        LOG3("Summarizing call effect on in arguments; definitions are " << Log::endl <<
              getCurrentDefinitions());
 
         bool isControlOrParserApply = false;
@@ -1277,7 +1282,8 @@ class FindUninitialized : public Inspector {
         // side effects.
 
         if (!callee.empty()) {
-            LOG3("Analyzing " << callee << IndentCtl::indent);
+            Log::TempIndent indent;
+            LOG3("Analyzing " << callee << indent);
             ProgramPoint pt(context, expression);
             FindUninitialized fu(this, pt);
             fu.setCalledBy(this);
@@ -1457,7 +1463,8 @@ class RemoveUnused : public Transform {
     { CHECK_NULL(hasUses);  CHECK_NULL(refMap);  CHECK_NULL(typeMap); setName("RemoveUnused"); }
     const IR::Node* postorder(IR::AssignmentStatement* statement) override {
         if (!hasUses->hasUses(getOriginal())) {
-            LOG3("Removing statement " << getOriginal() << " " << statement << IndentCtl::indent);
+            Log::TempIndent indent;
+            LOG3("Removing statement " << getOriginal() << " " << statement << indent);
             SideEffects se(refMap, typeMap);
             se.setCalledBy(this);
             (void)statement->right->apply(se);
@@ -1483,7 +1490,7 @@ class RemoveUnused : public Transform {
                 return mcs;
             }
             // removing
-            LOG3("Removing statement " << getOriginal() << IndentCtl::indent);
+            LOG3("Removing statement " << getOriginal());
             return new IR::EmptyStatement(mcs->srcInfo);
         }
         return mcs;
@@ -1508,7 +1515,7 @@ class ProcessDefUse : public PassManager {
 const IR::Node* DoSimplifyDefUse::process(const IR::Node* node) {
     ProcessDefUse process(refMap, typeMap);
     process.setCalledBy(this);
-    LOG5("ProcessDefUse of:" << IndentCtl::endl << node);
+    LOG5("ProcessDefUse of:" << Log::endl << node);
     return node->apply(process);
 }
 

--- a/lib/indent.h
+++ b/lib/indent.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <iostream>
 #include <iomanip>
+#include <vector>
 
 class indent_t {
     int         indent;
@@ -48,6 +49,20 @@ inline std::ostream &endl(std::ostream &out) {
     return out << std::endl << indent_t::getindent(out); }
 inline std::ostream &indent(std::ostream &out) { ++indent_t::getindent(out); return out; }
 inline std::ostream &unindent(std::ostream &out) { --indent_t::getindent(out); return out; }
+
+class TempIndent {
+    // an indent that can be added to any stream and unrolls when the object is destroyed
+    std::vector<std::ostream *> streams;        // streams that have been indented
+    TempIndent(const TempIndent &) = delete;    // not copyable
+
+ public:
+    TempIndent() = default;
+    friend std::ostream &operator<<(std::ostream &out, TempIndent &ti) {
+        ti.streams.push_back(&out);
+        return out << indent; }
+    ~TempIndent() { for (auto *out : streams) *out << unindent; }
+};
+
 }  // end namespace IndentCtl
 
 #endif /* _LIB_INDENT_H_ */

--- a/lib/log.cpp
+++ b/lib/log.cpp
@@ -147,6 +147,11 @@ std::ostream& operator<<(std::ostream& out, const OutputLogPrefix& pfx) {
     return out;
 }
 
+std::ostream &clearPrefix(std::ostream &out) {
+    if (OutputLogPrefix::ostream_xalloc >= 0)
+        out.iword(OutputLogPrefix::ostream_xalloc) = 0;
+}
+
 static bool match(const char *pattern, const char *name) {
     const char *pend = pattern + strcspn(pattern, ",:");
     const char *pbackup = 0;

--- a/lib/log.h
+++ b/lib/log.h
@@ -49,6 +49,7 @@ class OutputLogPrefix {
     static int ostream_xalloc;
     static void setup_ostream_xalloc(std::ostream &);
     friend std::ostream& operator<<(std::ostream&, const OutputLogPrefix&);
+    friend std::ostream& clearPrefix(std::ostream &out);
 #ifdef MULTITHREAD
     struct lock_t;
     mutable lock_t *lock = nullptr;
@@ -60,12 +61,16 @@ class OutputLogPrefix {
 };
 
 void addInvalidateCallback(void (*)(void));
+std::ostream& clearPrefix(std::ostream &out);
 }  // namespace Detail
 
 inline std::ostream &endl(std::ostream &out) {
     out << std::endl;
     Detail::OutputLogPrefix::indent(out);
     return out; }
+using IndentCtl::indent;
+using IndentCtl::unindent;
+using IndentCtl::TempIndent;
 
 inline bool fileLogLevelIsAtLeast(const char* file, int level) {
     // If there's no file with a log level of at least @level, we don't need to do
@@ -95,7 +100,7 @@ void increaseVerbosity();
 #define LOGN(N, X) (LOGGING(N)                                                  \
                       ? ::Log::Detail::fileLogOutput(__FILE__)                  \
                           << ::Log::Detail::OutputLogPrefix(__FILE__, N)        \
-                          << X << std::endl                                     \
+                          << X << ::Log::Detail::clearPrefix << std::endl       \
                       : std::clog)
 #define LOG1(X) LOGN(1, X)
 #define LOG2(X) LOGN(2, X)

--- a/midend/nestedStructs.h
+++ b/midend/nestedStructs.h
@@ -42,7 +42,7 @@ class ComplexValues final {
         Component* getComponent(cstring) override
         { return nullptr; }
         void dbprint(std::ostream& out) const override
-        { out << newName << IndentCtl::endl; }
+        { out << newName << Log::endl; }
     };
 
     struct FieldsMap : public Component {
@@ -63,10 +63,10 @@ class ComplexValues final {
         Component* getComponent(cstring name) override
         { return ::get(members, name); }
         void dbprint(std::ostream& out) const override {
-            out << IndentCtl::indent;
+            out << Log::indent;
             for (auto m : members)
                 out << m.first << "=>" << m.second;
-            out << IndentCtl::unindent;
+            out << Log::unindent;
         }
     };
 


### PR DESCRIPTION
- new TempIndent for temporary indents (in logs or elsewhere) that go
  away when the dtor runs
- Code should generally use Log:: methods which should work even with
  non-logging ostreams (log extra functionality becomes noop in that case)