### PR TITLE
missing return

### DIFF
--- a/lib/log.cpp
+++ b/lib/log.cpp
@@ -150,6 +150,7 @@ std::ostream& operator<<(std::ostream& out, const OutputLogPrefix& pfx) {
 std::ostream &clearPrefix(std::ostream &out) {
     if (OutputLogPrefix::ostream_xalloc >= 0)
         out.iword(OutputLogPrefix::ostream_xalloc) = 0;
+    return out;
 }
 
 static bool match(const char *pattern, const char *name) {


### PR DESCRIPTION
Of course, immediately after merging my change I found a ciritcal bug that somehow the CI failed to notice...

This *should* be a compile error (and is if you use a new enough version of gcc), but apparently is not with the old version that CI uses.