### PR TITLE
Do not reset header valid bits when inlining a subparser

### DIFF
--- a/frontends/p4/inlining.cpp
+++ b/frontends/p4/inlining.cpp
@@ -650,10 +650,6 @@ const IR::Node* GeneralInliner::preorder(IR::MethodCallStatement* statement) {
             if (!initializer->expression->equiv(*arg->expression)) {
                 auto stat = new IR::AssignmentStatement(initializer->expression, arg->expression);
                 body.push_back(stat); }
-        } else if (param->direction == IR::Direction::Out) {
-            auto paramType = typeMap->getType(param, true);
-            // This is important, since this variable may be used many times.
-            DoResetHeaders::generateResets(typeMap, paramType, initializer->expression, &body);
         } else if (param->direction == IR::Direction::None) {
             // already set; the value must be the same, or else we cannot compile
             auto initializer = mi->substitution.lookup(param);
@@ -810,11 +806,6 @@ const IR::Node* GeneralInliner::preorder(IR::ParserState* state) {
                     auto stat = new IR::AssignmentStatement(arg->expression,
                                                             initializer->expression);
                     current.push_back(stat); }
-            } else if (param->direction == IR::Direction::Out) {
-                auto arg = substs->paramSubst.lookupByName(param->name);
-                auto paramType = typeMap->getType(param, true);
-                // This is important, since this variable may be used many times.
-                DoResetHeaders::generateResets(typeMap, paramType, arg->expression, &current);
             } else if (param->direction == IR::Direction::None) {
                 // already set; the value must be the same, or else we cannot compile
                 auto prev = substs->paramSubst.lookup(param);

--- a/testdata/p4_16_samples_outputs/annotation-inline-propagate-frontend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-inline-propagate-frontend.p4
@@ -15,7 +15,6 @@ struct headers {
 
 @my_anno_2 @name("MyParser.outer_parser") @my_anno_1 parser MyParser(packet_in buffer, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {
-        hdr.hdr.setInvalid();
         transition InnerParser_start;
     }
     state InnerParser_start {
@@ -70,4 +69,3 @@ control MyDeparser(packet_out packet, in headers hdr) {
 }
 
 V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/annotation-inline-propagate-midend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-inline-propagate-midend.p4
@@ -15,7 +15,6 @@ struct headers {
 
 @my_anno_2 @name("MyParser.outer_parser") @my_anno_1 parser MyParser(packet_in buffer, out headers hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
     state start {
-        hdr.hdr.setInvalid();
         buffer.extract<hdr_t>(hdr.hdr);
         transition accept;
     }
@@ -75,4 +74,3 @@ control MyDeparser(packet_out packet, in headers hdr) {
 }
 
 V1Switch<headers, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-frontend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-frontend.p4
@@ -670,8 +670,6 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     @name("FabricIngress.port_counters_control.egress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_egress_port_counter;
     @name("FabricIngress.port_counters_control.ingress_port_counter") counter(32w511, CounterType.packets_and_bytes) port_counters_control_ingress_port_counter;
     apply {
-        hdr.gtpu_ipv4.setInvalid();
-        hdr.gtpu_udp.setInvalid();
         spgw_normalizer_hasReturned = false;
         if (hdr.gtpu.isValid()) {
             ;
@@ -874,4 +872,3 @@ control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_
 }
 
 V1Switch<parsed_headers_t, fabric_metadata_t>(FabricParser(), FabricVerifyChecksum(), FabricIngress(), FabricEgress(), FabricComputeChecksum(), FabricDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
@@ -657,10 +657,8 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     @hidden action spgw30() {
         spgw_normalizer_hasReturned = true;
     }
-    @hidden action fabric78() {
+    @hidden action act() {
         hasExited = false;
-        hdr.gtpu_ipv4.setInvalid();
-        hdr.gtpu_udp.setInvalid();
         spgw_normalizer_hasReturned = false;
     }
     @hidden action spgw35() {
@@ -702,7 +700,7 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         fabric_metadata._spgw_direction17 = 2w0;
         spgw_ingress_hasReturned = true;
     }
-    @hidden action act() {
+    @hidden action act_0() {
         spgw_ingress_hasReturned = false;
     }
     @hidden action spgw175() {
@@ -714,11 +712,11 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     @hidden action port_counter34() {
         port_counters_control_ingress_port_counter.count((bit<32>)standard_metadata.ingress_port);
     }
-    @hidden table tbl_fabric78 {
+    @hidden table tbl_act {
         actions = {
-            fabric78();
+            act();
         }
-        const default_action = fabric78();
+        const default_action = act();
     }
     @hidden table tbl_spgw30 {
         actions = {
@@ -762,11 +760,11 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         }
         const default_action = filtering115();
     }
-    @hidden table tbl_act {
+    @hidden table tbl_act_0 {
         actions = {
-            act();
+            act_0();
         }
-        const default_action = act();
+        const default_action = act_0();
     }
     @hidden table tbl_spgw149 {
         actions = {
@@ -817,7 +815,7 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
         const default_action = port_counter34();
     }
     apply {
-        tbl_fabric78.apply();
+        tbl_act.apply();
         if (hdr.gtpu.isValid()) {
             ;
         } else {
@@ -849,7 +847,7 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
             }
             filtering_ingress_port_vlan.apply();
             filtering_fwd_classifier.apply();
-            tbl_act.apply();
+            tbl_act_0.apply();
             if (hdr.gtpu.isValid()) {
                 if (spgw_ingress_s1u_filter_table.apply().hit) {
                     ;
@@ -973,7 +971,7 @@ control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_
     @hidden action packetio41() {
         hasExited_0 = true;
     }
-    @hidden action act_0() {
+    @hidden action act_1() {
         hasExited_0 = false;
     }
     @hidden action packetio47() {
@@ -999,11 +997,11 @@ control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_
     @hidden action next330() {
         hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
     }
-    @hidden table tbl_act_0 {
+    @hidden table tbl_act_1 {
         actions = {
-            act_0();
+            act_1();
         }
-        const default_action = act_0();
+        const default_action = act_1();
     }
     @hidden table tbl_packetio41 {
         actions = {
@@ -1078,7 +1076,7 @@ control FabricEgress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric_
         const default_action = spgw_egress_gtpu_encap_0();
     }
     apply {
-        tbl_act_0.apply();
+        tbl_act_1.apply();
         if (fabric_metadata._is_controller_packet_out12) {
             tbl_packetio41.apply();
         }

--- a/testdata/p4_16_samples_outputs/gauntlet_bounded_loop-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_bounded_loop-frontend.p4
@@ -16,8 +16,6 @@ struct headers {
 parser p(packet_in packet, out headers hdr) {
     @name("p.sub_parser.tracker") bit<8> sub_parser_tracker;
     state start {
-        hdr.nop.setInvalid();
-        hdr.p.setInvalid();
         transition sub_parser_start;
     }
     state sub_parser_start {
@@ -54,4 +52,3 @@ parser p(packet_in packet, out headers hdr) {
 parser Parser(packet_in b, out headers hdr);
 package top(Parser p);
 top(p()) main;
-

--- a/testdata/p4_16_samples_outputs/gauntlet_bounded_loop-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_bounded_loop-midend.p4
@@ -16,8 +16,6 @@ struct headers {
 parser p(packet_in packet, out headers hdr) {
     @name("p.sub_parser.tracker") bit<8> sub_parser_tracker;
     state start {
-        hdr.nop.setInvalid();
-        hdr.p.setInvalid();
         sub_parser_tracker = 8w0;
         transition sub_parser_next;
     }
@@ -56,4 +54,3 @@ parser p(packet_in packet, out headers hdr) {
 parser Parser(packet_in b, out headers hdr);
 package top(Parser p);
 top(p()) main;
-

--- a/testdata/p4_16_samples_outputs/gauntlet_infinite_loop-frontend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_infinite_loop-frontend.p4
@@ -17,9 +17,6 @@ parser p(packet_in packet, out headers hdr) {
     @name("p.tmp") headers tmp;
     @name("p.tmp_0") padding tmp_0;
     state start {
-        tmp.nop.setInvalid();
-        tmp.p.setInvalid();
-        tmp_0.setInvalid();
         transition sub_parser_start;
     }
     state sub_parser_start {
@@ -45,4 +42,3 @@ parser p(packet_in packet, out headers hdr) {
 parser Parser(packet_in b, out headers hdr);
 package top(Parser p);
 top(p()) main;
-

--- a/testdata/p4_16_samples_outputs/gauntlet_infinite_loop-midend.p4
+++ b/testdata/p4_16_samples_outputs/gauntlet_infinite_loop-midend.p4
@@ -18,9 +18,6 @@ parser p(packet_in packet, out headers hdr) {
     padding tmp_p;
     @name("p.tmp_0") padding tmp_0;
     state start {
-        tmp_nop.setInvalid();
-        tmp_p.setInvalid();
-        tmp_0.setInvalid();
         transition sub_parser_next;
     }
     state sub_parser_next {
@@ -44,4 +41,3 @@ parser p(packet_in packet, out headers hdr) {
 parser Parser(packet_in b, out headers hdr);
 package top(Parser p);
 top(p()) main;
-

--- a/testdata/p4_16_samples_outputs/inline-parser-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-parser-frontend.p4
@@ -7,7 +7,6 @@ header Header {
 parser p1(packet_in p, out Header[2] h) {
     @name("p1.h_0") Header h_0;
     state start {
-        h_0.setInvalid();
         transition p0_start;
     }
     state p0_start {
@@ -16,7 +15,6 @@ parser p1(packet_in p, out Header[2] h) {
     }
     state start_0 {
         h[0] = h_0;
-        h_0.setInvalid();
         transition p0_start_0;
     }
     state p0_start_0 {
@@ -32,4 +30,3 @@ parser p1(packet_in p, out Header[2] h) {
 parser proto(packet_in p, out Header[2] h);
 package top(proto _p);
 top(p1()) main;
-

--- a/testdata/p4_16_samples_outputs/inline-parser-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-parser-midend.p4
@@ -7,10 +7,8 @@ header Header {
 parser p1(packet_in p, out Header[2] h) {
     @name("p1.h_0") Header h_0;
     state start {
-        h_0.setInvalid();
         p.extract<Header>(h_0);
         h[0] = h_0;
-        h_0.setInvalid();
         p.extract<Header>(h_0);
         h[1] = h_0;
         transition accept;
@@ -20,4 +18,3 @@ parser p1(packet_in p, out Header[2] h) {
 parser proto(packet_in p, out Header[2] h);
 package top(proto _p);
 top(p1()) main;
-

--- a/testdata/p4_16_samples_outputs/issue1470-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1470-bmv2-frontend.p4
@@ -33,8 +33,6 @@ struct headers_t {
 
 parser OuterParser(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t meta) {
     state start {
-        hdr.eth.setInvalid();
-        hdr.ipv4.setInvalid();
         transition InnerParser_start;
     }
     state InnerParser_start {
@@ -81,4 +79,3 @@ control SimpleDeparser(packet_out pkt, in headers_t hdr) {
 }
 
 V1Switch<headers_t, meta_t>(OuterParser(), NoVerify(), NoIngress(), NoEgress(), NoCheck(), SimpleDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/issue1470-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1470-bmv2-midend.p4
@@ -33,8 +33,6 @@ struct headers_t {
 
 parser OuterParser(packet_in pkt, out headers_t hdr, inout meta_t m, inout standard_metadata_t meta) {
     state start {
-        hdr.eth.setInvalid();
-        hdr.ipv4.setInvalid();
         pkt.extract<eth_h>(hdr.eth);
         transition select(hdr.eth.type) {
             16w0x800: InnerParser_parse_ipv4;
@@ -78,4 +76,3 @@ control SimpleDeparser(packet_out pkt, in headers_t hdr) {
 }
 
 V1Switch<headers_t, meta_t>(OuterParser(), NoVerify(), NoIngress(), NoEgress(), NoCheck(), SimpleDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2-frontend.p4
@@ -97,7 +97,6 @@ parser PROTParser(packet_in packet, out headers hdr, inout metadata meta, inout 
         meta.addrLen = meta.addrLen + paddingLen_0;
         meta.currPos = (bit<8>)(9w3 + (meta.addrLen >> 6));
         currentISelected_0 = hdr.prot_common.curri == meta.currPos;
-        inf_0.setInvalid();
         meta_0 = meta;
         currentISelected_2 = currentISelected_0;
         currI_0 = hdr.prot_common.curri;
@@ -137,7 +136,6 @@ parser PROTParser(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     state parse_prot_inf_1 {
         currentISelected_1 = meta.currPos == hdr.prot_common.curri;
-        inf_0.setInvalid();
         meta_0 = meta;
         currentISelected_2 = currentISelected_1;
         currI_0 = hdr.prot_common.curri;
@@ -188,4 +186,3 @@ control PROTDeparser(packet_out packet, in headers hdr) {
 }
 
 V1Switch<headers, metadata>(PROTParser(), PROTVerifyChecksum(), PROTIngress(), PROTEgress(), PROTComputeChecksum(), PROTDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2-midend.p4
@@ -89,7 +89,6 @@ parser PROTParser(packet_in packet, out headers hdr, inout metadata meta, inout 
         packet.extract<prot_host_addr_padding_t>(hdr.prot_host_addr_padding, (bit<32>)(9w64 - (meta._addrLen2 & 9w63) & 9w63));
         meta._addrLen2 = meta._addrLen2 + (9w64 - (meta._addrLen2 & 9w63) & 9w63);
         meta._currPos3 = (bit<8>)(9w3 + (meta._addrLen2 >> 6));
-        inf_0.setInvalid();
         meta_0_currenti.upDirection = meta._currenti_upDirection4;
         packet.extract<prot_i_t>(inf_0);
         meta_0_currenti.upDirection = meta._currenti_upDirection4 + (bit<1>)(hdr.prot_common.curri == (bit<8>)(9w3 + (meta._addrLen2 >> 6))) * inf_0.upDirection;
@@ -118,7 +117,6 @@ parser PROTParser(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state parse_prot_inf_1 {
-        inf_0.setInvalid();
         meta_0_currenti.upDirection = meta._currenti_upDirection4;
         packet.extract<prot_i_t>(inf_0);
         meta_0_currenti.upDirection = meta._currenti_upDirection4 + (bit<1>)(hdr.prot_common.curri == meta._currPos3) * inf_0.upDirection;
@@ -190,4 +188,3 @@ control PROTDeparser(packet_out packet, in headers hdr) {
 }
 
 V1Switch<headers, metadata>(PROTParser(), PROTVerifyChecksum(), PROTIngress(), PROTEgress(), PROTComputeChecksum(), PROTDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2-frontend.p4
@@ -35,8 +35,6 @@ parser ProtParser(packet_in packet, out headers hdr, inout metadata meta, inout 
     state start {
         packet.extract<addr_type_t>(hdr.addr_type);
         addrType_0 = hdr.addr_type.dstType;
-        addr_0.ipv4.setInvalid();
-        addr_0.ipv6.setInvalid();
         transition ProtAddrParser_start;
     }
     state ProtAddrParser_start {
@@ -56,8 +54,6 @@ parser ProtParser(packet_in packet, out headers hdr, inout metadata meta, inout 
     state start_0 {
         hdr.addr_dst = addr_0;
         addrType_0 = hdr.addr_type.srcType;
-        addr_0.ipv4.setInvalid();
-        addr_0.ipv6.setInvalid();
         transition ProtAddrParser_start_0;
     }
     state ProtAddrParser_start_0 {
@@ -107,4 +103,3 @@ control ProtDeparser(packet_out packet, in headers hdr) {
 }
 
 V1Switch<headers, metadata>(ProtParser(), ProtVerifyChecksum(), ProtIngress(), ProtEgress(), ProtComputeChecksum(), ProtDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2-midend.p4
@@ -33,8 +33,6 @@ parser ProtParser(packet_in packet, out headers hdr, inout metadata meta, inout 
     @name("ProtParser.addr_0") addr_t addr_0;
     state start {
         packet.extract<addr_type_t>(hdr.addr_type);
-        addr_0.ipv4.setInvalid();
-        addr_0.ipv6.setInvalid();
         transition select(hdr.addr_type.dstType) {
             8w0x1: ProtAddrParser_ipv4;
             8w0x2: ProtAddrParser_ipv6;
@@ -52,8 +50,6 @@ parser ProtParser(packet_in packet, out headers hdr, inout metadata meta, inout 
     state start_0 {
         hdr.addr_dst.ipv4 = addr_0.ipv4;
         hdr.addr_dst.ipv6 = addr_0.ipv6;
-        addr_0.ipv4.setInvalid();
-        addr_0.ipv6.setInvalid();
         transition select(hdr.addr_type.srcType) {
             8w0x1: ProtAddrParser_ipv4_0;
             8w0x2: ProtAddrParser_ipv6_0;
@@ -110,4 +106,3 @@ control ProtDeparser(packet_out packet, in headers hdr) {
 }
 
 V1Switch<headers, metadata>(ProtParser(), ProtVerifyChecksum(), ProtIngress(), ProtEgress(), ProtComputeChecksum(), ProtDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/issue281-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue281-frontend.p4
@@ -45,13 +45,9 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
         transition start_0;
     }
     state start_0 {
-        hdr.ether.setInvalid();
-        hdr.vlan.setInvalid();
-        hdr.ipv4.setInvalid();
         transition L2_start;
     }
     state L2_start {
-        hdr.ether.setInvalid();
         transition L2_EthernetParser_start;
     }
     state L2_EthernetParser_start {
@@ -76,7 +72,6 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
         }
     }
     state L3_ipv4 {
-        hdr.ipv4.setInvalid();
         transition L3_Ipv4Parser_start;
     }
     state L3_Ipv4Parser_start {
@@ -87,7 +82,6 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
         transition start_3;
     }
     state L3_vlan {
-        hdr.vlan.setInvalid();
         transition L3_VlanParser_start;
     }
     state L3_VlanParser_start {
@@ -129,4 +123,3 @@ control MyDeparser(packet_out b, in h hdr) {
 }
 
 V1Switch<h, m>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/issue281-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue281-midend.p4
@@ -42,10 +42,6 @@ struct m {
 parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t std) {
     @name("MyParser.l3.etherType") bit<16> l3_etherType;
     state start {
-        hdr.ether.setInvalid();
-        hdr.vlan.setInvalid();
-        hdr.ipv4.setInvalid();
-        hdr.ether.setInvalid();
         b.extract<ethernet_t>(hdr.ether);
         l3_etherType = hdr.ether.etherType;
         transition L3_start_0;
@@ -58,12 +54,10 @@ parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t 
         }
     }
     state L3_ipv4 {
-        hdr.ipv4.setInvalid();
         b.extract<ipv4_t>(hdr.ipv4);
         transition start_3;
     }
     state L3_vlan {
-        hdr.vlan.setInvalid();
         b.extract<vlan_t>(hdr.vlan);
         l3_etherType = hdr.vlan.etherType;
         transition L3_start_0;
@@ -99,4 +93,3 @@ control MyDeparser(packet_out b, in h hdr) {
 }
 
 V1Switch<h, m>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;
-

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-frontend.p4
@@ -124,57 +124,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     state parse_tcp {
         packet.extract<tcp_t>(hdr.tcp);
-        hdr.tcp_options_vec[0].end.setInvalid();
-        hdr.tcp_options_vec[0].nop.setInvalid();
-        hdr.tcp_options_vec[0].ss.setInvalid();
-        hdr.tcp_options_vec[0].s.setInvalid();
-        hdr.tcp_options_vec[0].sack.setInvalid();
-        hdr.tcp_options_vec[1].end.setInvalid();
-        hdr.tcp_options_vec[1].nop.setInvalid();
-        hdr.tcp_options_vec[1].ss.setInvalid();
-        hdr.tcp_options_vec[1].s.setInvalid();
-        hdr.tcp_options_vec[1].sack.setInvalid();
-        hdr.tcp_options_vec[2].end.setInvalid();
-        hdr.tcp_options_vec[2].nop.setInvalid();
-        hdr.tcp_options_vec[2].ss.setInvalid();
-        hdr.tcp_options_vec[2].s.setInvalid();
-        hdr.tcp_options_vec[2].sack.setInvalid();
-        hdr.tcp_options_vec[3].end.setInvalid();
-        hdr.tcp_options_vec[3].nop.setInvalid();
-        hdr.tcp_options_vec[3].ss.setInvalid();
-        hdr.tcp_options_vec[3].s.setInvalid();
-        hdr.tcp_options_vec[3].sack.setInvalid();
-        hdr.tcp_options_vec[4].end.setInvalid();
-        hdr.tcp_options_vec[4].nop.setInvalid();
-        hdr.tcp_options_vec[4].ss.setInvalid();
-        hdr.tcp_options_vec[4].s.setInvalid();
-        hdr.tcp_options_vec[4].sack.setInvalid();
-        hdr.tcp_options_vec[5].end.setInvalid();
-        hdr.tcp_options_vec[5].nop.setInvalid();
-        hdr.tcp_options_vec[5].ss.setInvalid();
-        hdr.tcp_options_vec[5].s.setInvalid();
-        hdr.tcp_options_vec[5].sack.setInvalid();
-        hdr.tcp_options_vec[6].end.setInvalid();
-        hdr.tcp_options_vec[6].nop.setInvalid();
-        hdr.tcp_options_vec[6].ss.setInvalid();
-        hdr.tcp_options_vec[6].s.setInvalid();
-        hdr.tcp_options_vec[6].sack.setInvalid();
-        hdr.tcp_options_vec[7].end.setInvalid();
-        hdr.tcp_options_vec[7].nop.setInvalid();
-        hdr.tcp_options_vec[7].ss.setInvalid();
-        hdr.tcp_options_vec[7].s.setInvalid();
-        hdr.tcp_options_vec[7].sack.setInvalid();
-        hdr.tcp_options_vec[8].end.setInvalid();
-        hdr.tcp_options_vec[8].nop.setInvalid();
-        hdr.tcp_options_vec[8].ss.setInvalid();
-        hdr.tcp_options_vec[8].s.setInvalid();
-        hdr.tcp_options_vec[8].sack.setInvalid();
-        hdr.tcp_options_vec[9].end.setInvalid();
-        hdr.tcp_options_vec[9].nop.setInvalid();
-        hdr.tcp_options_vec[9].ss.setInvalid();
-        hdr.tcp_options_vec[9].s.setInvalid();
-        hdr.tcp_options_vec[9].sack.setInvalid();
-        hdr.tcp_options_padding.setInvalid();
         transition Tcp_option_parser_start;
     }
     state Tcp_option_parser_start {
@@ -330,4 +279,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2-midend.p4
@@ -123,57 +123,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     }
     state parse_tcp {
         packet.extract<tcp_t>(hdr.tcp);
-        hdr.tcp_options_vec[0].end.setInvalid();
-        hdr.tcp_options_vec[0].nop.setInvalid();
-        hdr.tcp_options_vec[0].ss.setInvalid();
-        hdr.tcp_options_vec[0].s.setInvalid();
-        hdr.tcp_options_vec[0].sack.setInvalid();
-        hdr.tcp_options_vec[1].end.setInvalid();
-        hdr.tcp_options_vec[1].nop.setInvalid();
-        hdr.tcp_options_vec[1].ss.setInvalid();
-        hdr.tcp_options_vec[1].s.setInvalid();
-        hdr.tcp_options_vec[1].sack.setInvalid();
-        hdr.tcp_options_vec[2].end.setInvalid();
-        hdr.tcp_options_vec[2].nop.setInvalid();
-        hdr.tcp_options_vec[2].ss.setInvalid();
-        hdr.tcp_options_vec[2].s.setInvalid();
-        hdr.tcp_options_vec[2].sack.setInvalid();
-        hdr.tcp_options_vec[3].end.setInvalid();
-        hdr.tcp_options_vec[3].nop.setInvalid();
-        hdr.tcp_options_vec[3].ss.setInvalid();
-        hdr.tcp_options_vec[3].s.setInvalid();
-        hdr.tcp_options_vec[3].sack.setInvalid();
-        hdr.tcp_options_vec[4].end.setInvalid();
-        hdr.tcp_options_vec[4].nop.setInvalid();
-        hdr.tcp_options_vec[4].ss.setInvalid();
-        hdr.tcp_options_vec[4].s.setInvalid();
-        hdr.tcp_options_vec[4].sack.setInvalid();
-        hdr.tcp_options_vec[5].end.setInvalid();
-        hdr.tcp_options_vec[5].nop.setInvalid();
-        hdr.tcp_options_vec[5].ss.setInvalid();
-        hdr.tcp_options_vec[5].s.setInvalid();
-        hdr.tcp_options_vec[5].sack.setInvalid();
-        hdr.tcp_options_vec[6].end.setInvalid();
-        hdr.tcp_options_vec[6].nop.setInvalid();
-        hdr.tcp_options_vec[6].ss.setInvalid();
-        hdr.tcp_options_vec[6].s.setInvalid();
-        hdr.tcp_options_vec[6].sack.setInvalid();
-        hdr.tcp_options_vec[7].end.setInvalid();
-        hdr.tcp_options_vec[7].nop.setInvalid();
-        hdr.tcp_options_vec[7].ss.setInvalid();
-        hdr.tcp_options_vec[7].s.setInvalid();
-        hdr.tcp_options_vec[7].sack.setInvalid();
-        hdr.tcp_options_vec[8].end.setInvalid();
-        hdr.tcp_options_vec[8].nop.setInvalid();
-        hdr.tcp_options_vec[8].ss.setInvalid();
-        hdr.tcp_options_vec[8].s.setInvalid();
-        hdr.tcp_options_vec[8].sack.setInvalid();
-        hdr.tcp_options_vec[9].end.setInvalid();
-        hdr.tcp_options_vec[9].nop.setInvalid();
-        hdr.tcp_options_vec[9].ss.setInvalid();
-        hdr.tcp_options_vec[9].s.setInvalid();
-        hdr.tcp_options_vec[9].sack.setInvalid();
-        hdr.tcp_options_padding.setInvalid();
         verify(hdr.tcp.dataOffset >= 4w5, error.TcpDataOffsetTooSmall);
         Tcp_option_parser_tcp_hdr_bytes_left = (bit<7>)(hdr.tcp.dataOffset + 4w11) << 2;
         transition Tcp_option_parser_next_option;
@@ -468,4 +417,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/issue823-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue823-frontend.p4
@@ -13,7 +13,6 @@ struct headers_t {
 
 parser MyP1(packet_in pkt, out headers_t hdr) {
     state start {
-        hdr.data.setInvalid();
         transition MyP2_start;
     }
     state MyP2_start {
@@ -27,4 +26,3 @@ control MyC1() {
 }
 
 S<headers_t>(MyP1(), MyC1()) main;
-

--- a/testdata/p4_16_samples_outputs/issue823-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue823-midend.p4
@@ -13,7 +13,6 @@ struct headers_t {
 
 parser MyP1(packet_in pkt, out headers_t hdr) {
     state start {
-        hdr.data.setInvalid();
         transition reject;
     }
 }
@@ -24,4 +23,3 @@ control MyC1() {
 }
 
 S<headers_t>(MyP1(), MyC1()) main;
-

--- a/testdata/p4_16_samples_outputs/issue982-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue982-frontend.p4
@@ -269,8 +269,6 @@ parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata
         }
     }
     state parse_ethernet {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         transition CommonParser_start;
     }
     state CommonParser_start {
@@ -339,8 +337,6 @@ control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         transition CommonParser_start_0;
     }
     state CommonParser_start_0 {
@@ -406,4 +402,3 @@ control EgressDeparserImpl(packet_out packet, inout headers hdr, in metadata met
 }
 
 PSA_Switch<headers, metadata, headers, metadata>(IngressParserImpl(), ingress(), IngressDeparserImpl(), EgressParserImpl(), egress(), EgressDeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/issue982-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue982-midend.p4
@@ -270,8 +270,6 @@ parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata
         }
     }
     state parse_ethernet {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition select(parsed_hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4;
@@ -338,8 +336,6 @@ control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition select(parsed_hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4_0;
@@ -439,4 +435,3 @@ control EgressDeparserImpl(packet_out packet, inout headers hdr, in metadata met
 }
 
 PSA_Switch<headers, metadata, headers, metadata>(IngressParserImpl(), ingress(), IngressDeparserImpl(), EgressParserImpl(), egress(), EgressDeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test1-frontend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state Subparser_start {
@@ -66,10 +62,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition p2;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state p2 {
@@ -112,4 +104,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test1-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test1-midend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state Subparser_start {
@@ -67,10 +63,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition accept;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
 }
@@ -139,4 +131,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test11-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test11-frontend.p4
@@ -38,10 +38,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state Subparser_start {
@@ -67,10 +63,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition p2;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start_0;
     }
     state Subparser_start_0 {
@@ -135,4 +127,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test11-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test11-midend.p4
@@ -38,10 +38,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         subp1_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -64,10 +60,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition p2;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         subp2_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -159,4 +151,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test12-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test12-frontend.p4
@@ -40,10 +40,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state Subparser_start {
@@ -69,17 +65,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition p4;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state p2 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start_0;
     }
     state Subparser_start_0 {
@@ -105,10 +93,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition p4;
     }
     state p3 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start_0;
     }
     state p4 {
@@ -151,4 +135,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test12-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test12-midend.p4
@@ -40,10 +40,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state Subparser_start {
@@ -69,17 +65,9 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition p4;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state p2 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start_0;
     }
     state Subparser_start_0 {
@@ -105,10 +93,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition p4;
     }
     state p3 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start_0;
     }
     state p4 {
@@ -181,4 +165,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test13-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test13-frontend.p4
@@ -40,10 +40,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     state p0 {
         phdr_0.h1.setInvalid();
         packet.extract<data_t>(phdr_0.h1);
-        hdr_0.h1.setInvalid();
-        hdr_0.h2.setInvalid();
-        hdr_0.h3.setInvalid();
-        hdr_0.h4.setInvalid();
         inout_hdr_0 = phdr_0;
         transition Subparser_start;
     }
@@ -74,10 +70,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     state p1 {
         phdr_1.h1.setInvalid();
         packet.extract<data_t>(phdr_1.h1);
-        hdr_0.h1.setInvalid();
-        hdr_0.h2.setInvalid();
-        hdr_0.h3.setInvalid();
-        hdr_0.h4.setInvalid();
         inout_hdr_0 = phdr_1;
         transition Subparser_start_0;
     }
@@ -145,4 +137,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test13-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test13-midend.p4
@@ -43,10 +43,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     state p0 {
         phdr_0_h1.setInvalid();
         packet.extract<data_t>(phdr_0_h1);
-        hdr_0_h1.setInvalid();
-        hdr_0_h2.setInvalid();
-        hdr_0_h3.setInvalid();
-        hdr_0_h4.setInvalid();
         inout_hdr_0_h1 = phdr_0_h1;
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr_0_h1);
@@ -77,10 +73,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
     state p1 {
         phdr_1_h1.setInvalid();
         packet.extract<data_t>(phdr_1_h1);
-        hdr_0_h1.setInvalid();
-        hdr_0_h2.setInvalid();
-        hdr_0_h3.setInvalid();
-        hdr_0_h4.setInvalid();
         inout_hdr_0_h1 = phdr_1_h1;
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr_0_h1);
@@ -178,4 +170,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test2-frontend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state Subparser_start {
@@ -67,10 +63,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition accept;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start_0;
     }
     state Subparser_start_0 {
@@ -131,4 +123,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test2-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test2-midend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -64,10 +60,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition accept;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -155,4 +147,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test3-frontend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state Subparser_start {
@@ -69,10 +65,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start_0;
     }
     state Subparser_start_0 {
@@ -140,4 +132,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test3-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test3-midend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -66,10 +62,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -164,4 +156,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test4-frontend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state Subparser_start {
@@ -69,10 +65,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start_0;
     }
     state Subparser_start_0 {
@@ -140,4 +132,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test4-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test4-midend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -66,10 +62,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -164,4 +156,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test5-frontend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state Subparser_start {
@@ -67,10 +63,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition accept;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start_0;
     }
     state Subparser_start_0 {
@@ -132,4 +124,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test5-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test5-midend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -64,10 +60,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition accept;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -156,4 +148,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test6-frontend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start;
     }
     state Subparser_start {
@@ -67,10 +63,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition accept;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         transition Subparser_start_0;
     }
     state Subparser_start_0 {
@@ -141,4 +133,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test6-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test6-midend.p4
@@ -37,10 +37,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         }
     }
     state p0 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -64,10 +60,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition accept;
     }
     state p1 {
-        hdr.h1.setInvalid();
-        hdr.h2.setInvalid();
-        hdr.h3.setInvalid();
-        hdr.h4.setInvalid();
         p_shdr_h1.setInvalid();
         packet.extract<data_t>(hdr.h1);
         transition select(hdr.h1.f) {
@@ -192,4 +184,3 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
 }
 
 V1Switch<headers, metadata>(ParserImpl(), verifyChecksum(), ingress(), egress(), computeChecksum(), DeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/pna-subparser-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-subparser-frontend.p4
@@ -30,8 +30,6 @@ struct headers_t {
 
 parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t meta, in pna_main_parser_input_metadata_t istd) {
     state start {
-        hdr.ethernet.setInvalid();
-        hdr.ipv4.setInvalid();
         transition CommonParser_start;
     }
     state CommonParser_start {
@@ -66,4 +64,3 @@ control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t me
 }
 
 PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/pna-subparser-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-subparser-midend.p4
@@ -30,8 +30,6 @@ struct headers_t {
 
 parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t meta, in pna_main_parser_input_metadata_t istd) {
     state start {
-        hdr.ethernet.setInvalid();
-        hdr.ipv4.setInvalid();
         pkt.extract<ethernet_t>(hdr.ethernet);
         transition select(hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4;
@@ -63,4 +61,3 @@ control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t me
 }
 
 PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
-

--- a/testdata/p4_16_samples_outputs/pna-subparser.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-subparser.p4.spec
@@ -31,13 +31,9 @@ regarray direction size 0x100 initval 0
 
 apply {
 	rx m.pna_main_input_metadata_input_port
-	invalidate h.ethernet
-	invalidate h.ipv4
 	extract h.ethernet
 	jmpeq MAINPARSERIMPL_COMMONPARSER_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_START_0
 	MAINPARSERIMPL_COMMONPARSER_PARSE_IPV4 :	extract h.ipv4
 	MAINPARSERIMPL_START_0 :	tx m.pna_main_output_metadata_output_port
 }
-
-

--- a/testdata/p4_16_samples_outputs/psa-example-counters-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-counters-bmv2-frontend.p4
@@ -42,8 +42,6 @@ struct headers {
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         transition CommonParser_start;
     }
     state CommonParser_start {
@@ -64,8 +62,6 @@ parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadat
 
 parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         transition CommonParser_start_0;
     }
     state CommonParser_start_0 {
@@ -150,4 +146,3 @@ IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_met
 EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
-

--- a/testdata/p4_16_samples_outputs/psa-example-counters-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-counters-bmv2-midend.p4
@@ -41,8 +41,6 @@ struct headers {
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition select(parsed_hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4;
@@ -60,8 +58,6 @@ parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadat
 
 parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition select(parsed_hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4_0;
@@ -171,4 +167,3 @@ IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_met
 EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
-

--- a/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-frontend.p4
@@ -54,8 +54,6 @@ struct metadata {
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         transition CommonParser_start;
     }
     state CommonParser_start {
@@ -76,8 +74,6 @@ parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadat
 
 parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         transition CommonParser_start_0;
     }
     state CommonParser_start_0 {
@@ -194,4 +190,3 @@ IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_met
 EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
-

--- a/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-digest-bmv2-midend.p4
@@ -45,8 +45,6 @@ struct metadata {
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition select(parsed_hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4;
@@ -64,8 +62,6 @@ parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadat
 
 parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
-        parsed_hdr.ipv4.setInvalid();
         buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition select(parsed_hdr.ethernet.etherType) {
             16w0x800: CommonParser_parse_ipv4_0;
@@ -205,4 +201,3 @@ IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_met
 EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
-

--- a/testdata/p4_16_samples_outputs/psa-fwd-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-fwd-bmv2-frontend.p4
@@ -24,7 +24,6 @@ struct headers {
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
         transition CommonParser_start;
     }
     state CommonParser_start {
@@ -38,7 +37,6 @@ parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadat
 
 parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
         transition CommonParser_start_0;
     }
     state CommonParser_start_0 {
@@ -77,4 +75,3 @@ IngressPipeline<headers, metadata, empty_t, empty_t, empty_t, empty_t>(IngressPa
 EgressPipeline<headers, metadata, empty_t, empty_t, empty_t, empty_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers, metadata, headers, metadata, empty_t, empty_t, empty_t, empty_t, empty_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
-

--- a/testdata/p4_16_samples_outputs/psa-fwd-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-fwd-bmv2-midend.p4
@@ -23,7 +23,6 @@ struct headers {
 
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
         buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition accept;
     }
@@ -31,7 +30,6 @@ parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadat
 
 parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
     state start {
-        parsed_hdr.ethernet.setInvalid();
         buffer.extract<ethernet_t>(parsed_hdr.ethernet);
         transition accept;
     }
@@ -82,4 +80,3 @@ IngressPipeline<headers, metadata, empty_t, empty_t, empty_t, empty_t>(IngressPa
 EgressPipeline<headers, metadata, empty_t, empty_t, empty_t, empty_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
 
 PSA_Switch<headers, metadata, headers, metadata, empty_t, empty_t, empty_t, empty_t, empty_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
-

--- a/testdata/p4_16_samples_outputs/psa-fwd-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-fwd-bmv2.p4.spec
@@ -37,12 +37,9 @@ header ethernet instanceof ethernet_t
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x0
-	invalidate h.ethernet
 	extract h.ethernet
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop
 }
-
-


### PR DESCRIPTION
This operation seems to be unnecessary and mainly just increases the number of fields that have to be dealt with in a backend. This PR removes the calls to the pass that inserts the `setInvalid()` calls, and modifies the expected test outputs accordingly.