### PR TITLE
Bug of loopsUnroll for loops with one parser state

### DIFF
--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -615,8 +615,10 @@ class ParserSymbolicInterpreter {
 
     /// Gets new name for a state
     IR::ID getNewName(ParserStateInfo* state) {
-        if (state->currentIndex == 0)
+        if (state->currentIndex == 0) {
+            structure->callsIndexes.emplace(state->state->name.name, 0);
             return state->state->name;
+        }
         return IR::ID(state->state->name + std::to_string(state->currentIndex));
     }
 


### PR DESCRIPTION
loopsUnroll has a bug for unrolling loops with one parser state where such loop is restricted by header stack size only. These changes fix this bug. To see the problem, please, run:
`./backends/p4test/p4test  -I "p4include" --target  bmv2 --std p4-16 --loopsUnroll --arch v1model ../testdata/p4_16_samples/stack_complex-bmv2.p4`