### PR TITLE
Dpdk Backend: Fix action param processing for context json

### DIFF
--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -242,7 +242,7 @@ void DpdkContextGenerator::setActionAttributes(const IR::P4Table *tbl) {
 
         /* DPDK target takes a structure as parameter for Actions. So, all action
            parameters are collected into a structure by an earlier pass. */
-        auto params = ::get(structure->args_struct_map, act->externalName() + "_arg_t");
+        auto params = ::get(structure->args_struct_map, act->getPath()->name.name + "_arg_t");
         if (params)
             attr.params = params->clone();
         else


### PR DESCRIPTION
The internal name of action is used to create the struct to hold its parameters. While fetching this information for emitting in context json, external name was being used which caused params to be null.

Attached difference in output. with this fix.
[diff.txt](https://github.com/p4lang/p4c/files/9430241/diff.txt)
