### PR TITLE
Add Toeplitz hash algorithm to v1model

### DIFF
--- a/backends/bmv2/common/extern.cpp
+++ b/backends/bmv2/common/extern.cpp
@@ -259,6 +259,8 @@ ExternConverter::convertHashAlgorithm(cstring algorithm) {
         result = "csum16";
     else if (algorithm == P4V1::V1Model::instance.algorithm.xor16.name)
         result = "xor16";
+    else if (algorithm == P4V1::V1Model::instance.algorithm.toeplitz.name)
+        result = "toeplitz";
     else
         ::error(ErrorType::ERR_UNSUPPORTED, "Unsupported algorithm %1%", algorithm);
     return result;

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -251,7 +251,8 @@ Util::IJson* ExternConverter_hash::convertExternFunction(
         v1model.algorithm.crc32.name, v1model.algorithm.crc32_custom.name,
         v1model.algorithm.crc16.name, v1model.algorithm.crc16_custom.name,
         v1model.algorithm.random.name, v1model.algorithm.identity.name,
-        v1model.algorithm.csum16.name, v1model.algorithm.xor16.name
+        v1model.algorithm.csum16.name, v1model.algorithm.xor16.name,
+        v1model.algorithm.toeplitz.name
     };
 
     if (mc->arguments->size() != 5) {

--- a/frontends/p4/fromv1.0/programStructure.cpp
+++ b/frontends/p4/fromv1.0/programStructure.cpp
@@ -1121,6 +1121,8 @@ const IR::Expression* ProgramStructure::convertHashAlgorithm(
         result = v1model.algorithm.csum16.Id();
     } else if (algorithm == "xor16") {
         result = v1model.algorithm.xor16.Id();
+    } else if (algorithm == "toeplitz") {
+        result = v1model.algorithm.toeplitz.Id();
     } else {
         ::warning(ErrorType::WARN_UNSUPPORTED, "%1%: unexpected algorithm", algorithm);
         result = algorithm;

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -186,7 +186,8 @@ struct Algorithm_Model : public ::Model::Enum_Model {
     Algorithm_Model() : ::Model::Enum_Model("HashAlgorithm"),
                         crc32("crc32"), crc32_custom("crc32_custom"),
                         crc16("crc16"), crc16_custom("crc16_custom"),
-                        random("random"), identity("identity"), csum16("csum16"), xor16("xor16") {}
+                        random("random"), identity("identity"), csum16("csum16"), xor16("xor16"),
+                        toeplitz("toeplitz") {}
     ::Model::Elem crc32;
     ::Model::Elem crc32_custom;
     ::Model::Elem crc16;
@@ -195,6 +196,7 @@ struct Algorithm_Model : public ::Model::Enum_Model {
     ::Model::Elem identity;
     ::Model::Elem csum16;
     ::Model::Elem xor16;
+    ::Model::Elem toeplitz;
 };
 
 struct Hash_Model : public ::Model::Elem {

--- a/p4include/v1model.p4
+++ b/p4include/v1model.p4
@@ -399,7 +399,8 @@ enum HashAlgorithm {
     random,
     identity,
     csum16,
-    xor16
+    xor16,
+    toeplitz
 }
 
 @deprecated("Please use mark_to_drop(standard_metadata) instead.")


### PR DESCRIPTION
We'd like to make the Toeplitz hash algorithm available in v1model. The actual Toeplitz hash function has already been added to BMv2: https://github.com/p4lang/behavioral-model/pull/1134.