### PR TITLE
Fixing bug in parserUnroll

### DIFF
--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -695,8 +695,8 @@ class ParserSymbolicInterpreter {
         hasOutOfboundState = false;
     }
 
-    /// generate call OutOfBound
-    void addOutFoBound(ParserStateInfo* stateInfo, std::unordered_set<cstring>& newStates,
+    /// Creates a new state that immediately transitions to the "outOfBoundsState" state.
+    void addOutOfBound(ParserStateInfo* stateInfo, std::unordered_set<cstring>& newStates,
                        bool checkBefore = true) {
         hasOutOfboundState = true;
         IR::ID newName = getNewName(stateInfo);
@@ -743,7 +743,7 @@ class ParserSymbolicInterpreter {
             if (infLoop) {
                 // don't evaluate successors anymore
                 // generate call OutOfBound
-                addOutFoBound(stateInfo, newStates);
+                addOutOfBound(stateInfo, newStates);
                 continue;
             }
             IR::ID newName = getNewName(stateInfo);
@@ -753,7 +753,7 @@ class ParserSymbolicInterpreter {
                 if (nextStates.second && stateInfo->predecessor &&
                  newName.name !=stateInfo->predecessor->newState->name) {
                     // generate call OutOfBound
-                    addOutFoBound(stateInfo, newStates, false);
+                    addOutOfBound(stateInfo, newStates, false);
                 } else {
                     // save current state
                     if (notAdded) {

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -75,8 +75,9 @@ struct VisitedKey {
         if (name > e.name)
             return false;
         std::unordered_map<StackVariable, std::pair<size_t, size_t>, StackVariableHash > mp;
-        for (auto& i1 : indexes)
+        for (auto& i1 : indexes) {
             mp.emplace(i1.first, std::make_pair(i1.second, -1));
+        }
         for (auto& i2 : e.indexes) {
             auto ref = mp.find(i2.first);
             if (ref == mp.end())
@@ -153,7 +154,7 @@ class ParserStateRewriter : public Transform {
                         ExpressionEvaluator* afterExec, StatesVisitedMap& visitedStates) :
     parserStructure(parserStructure), state(state),
     valueMap(valueMap), refMap(refMap), typeMap(typeMap), afterExec(afterExec),
-    visitedStates(visitedStates)  {
+    visitedStates(visitedStates), wasOutOfBound(false)  {
         CHECK_NULL(parserStructure); CHECK_NULL(state);
         CHECK_NULL(refMap); CHECK_NULL(typeMap);
         CHECK_NULL(parserStructure); CHECK_NULL(state);
@@ -175,7 +176,11 @@ class ParserStateRewriter : public Transform {
         auto* res = value->to<SymbolicInteger>()->constant->clone();
         newExpression->right = res;
         BUG_CHECK(res->fitsInt64(), "To big integer for a header stack index %1%", res);
-        state->statesIndexes[expression->left] = (size_t)res->asInt64();
+        const auto* arrayType = basetype->to<IR::Type_Stack>();
+        if (res->asUnsigned() >= arrayType->getSize()) {
+            wasOutOfBound = true;
+            return expression;
+        }
         return newExpression;
     }
 
@@ -192,13 +197,17 @@ class ParserStateRewriter : public Transform {
             unsigned offset = 0;
             if (state->statesIndexes.count(expression->expr)) {
                 idx = state->statesIndexes.at(expression->expr);
-                if (idx + 1 < array->size && expression->member.name != IR::Type_Stack::last) {
+                if (expression->member.name != IR::Type_Stack::last) {
                     offset = 1;
                 }
             }
             if (expression->member.name == IR::Type_Stack::lastIndex) {
                 return new IR::Constant(IR::Type_Bits::get(32), idx);
             } else {
+                if (idx + offset >= array->size) {
+                    wasOutOfBound = true;
+                    return expression;
+                }
                 state->statesIndexes[expression->expr] = idx + offset;
                 return new IR::ArrayIndex(expression->expr->clone(),
                                           new IR::Constant(IR::Type_Bits::get(32), idx + offset));
@@ -218,6 +227,7 @@ class ParserStateRewriter : public Transform {
         return new IR::PathExpression(expression->type, new IR::Path(newName, false));
     }
     inline size_t getIndex() { return currentIndex; }
+    bool isOutOfBound() {return wasOutOfBound;}
 
  protected:
     const IR::Type* getTypeArray(const IR::Node* element) {
@@ -277,6 +287,7 @@ class ParserStateRewriter : public Transform {
     ExpressionEvaluator* afterExec;
     StatesVisitedMap& visitedStates;
     size_t currentIndex;
+    bool wasOutOfBound;
 };
 
 class ParserSymbolicInterpreter {
@@ -447,6 +458,9 @@ class ParserSymbolicInterpreter {
         ParserStateRewriter rewriter(structure, state, valueMap, refMap, typeMap, &ev,
                                      visitedStates);
         const IR::Node* node = sord->apply(rewriter);
+        if (rewriter.isOutOfBound()) {
+            return nullptr;
+        }
         newSord = node->to<IR::StatOrDecl>();
         LOG2("After " << sord << " state is\n" << valueMap);
         return newSord;
@@ -472,6 +486,9 @@ class ParserSymbolicInterpreter {
             ParserStateRewriter rewriter(structure, state, valueMap, refMap, typeMap, nullptr,
                                          visitedStates);
             const IR::Expression* node = select->apply(rewriter);
+            if (rewriter.isOutOfBound()) {
+                return EvaluationSelectResult(nullptr, nullptr);
+            }
             CHECK_NULL(node);
             newSelect = node->to<IR::Expression>();
             CHECK_NULL(newSelect);
@@ -489,6 +506,9 @@ class ParserSymbolicInterpreter {
             ParserStateRewriter rewriter(structure, state, valueMap, refMap, typeMap, &ev,
                                          visitedStates);
             const IR::Node* node = se->select->apply(rewriter);
+            if (rewriter.isOutOfBound()) {
+                return EvaluationSelectResult(nullptr, nullptr);
+            }
             const IR::ListExpression* newListSelect = node->to<IR::ListExpression>();
             auto etalonStateIndexes = state->statesIndexes;
             for (auto c : se->selectCases) {
@@ -501,6 +521,9 @@ class ParserSymbolicInterpreter {
                 ParserStateRewriter rewriter(structure, state, valueMap, refMap, typeMap,
                                              nullptr, visitedStates);
                 const IR::Node* node = c->apply(rewriter);
+                if (rewriter.isOutOfBound()) {
+                    return EvaluationSelectResult(nullptr, nullptr);
+                }
                 CHECK_NULL(node);
                 auto newC = node->to<IR::SelectCase>();
                 CHECK_NULL(newC);
@@ -601,10 +624,6 @@ class ParserSymbolicInterpreter {
 
                 // If no header validity has changed we can't really unroll
                 if (!headerValidityChange(crt->before, state->before)) {
-                    if (unroll)
-                        ::warning(ErrorType::ERR_INVALID,
-                                  "Parser cycle cannot be unrolled:\n%1%",
-                                  stateChain(state));
                     return true;
                 }
                 break;
@@ -616,7 +635,6 @@ class ParserSymbolicInterpreter {
     /// Gets new name for a state
     IR::ID getNewName(ParserStateInfo* state) {
         if (state->currentIndex == 0) {
-            structure->callsIndexes.emplace(state->state->name.name, 0);
             return state->state->name;
         }
         return IR::ID(state->state->name + std::to_string(state->currentIndex));
@@ -649,7 +667,9 @@ class ParserSymbolicInterpreter {
         state->after = valueMap;
         auto result = evaluateSelect(state, valueMap);
         if (unroll) {
-            BUG_CHECK(result.second, "Can't generate new selection %1%", state);
+            if (result.second == nullptr) {
+                return EvaluationStateResult(nullptr, true);
+            }
             if (state->name == newName) {
                 state->newState = new IR::ParserState(state->state->srcInfo, newName,
                                                       state->state->annotations, components,
@@ -674,6 +694,22 @@ class ParserSymbolicInterpreter {
         parser = structure->parser;
         hasOutOfboundState = false;
     }
+
+    /// generate call OutOfBound
+    void addOutFoBound(ParserStateInfo* stateInfo, std::unordered_set<cstring>& newStates,
+                       bool checkBefore = true) {
+        hasOutOfboundState = true;
+        IR::ID newName = getNewName(stateInfo);
+        if (checkBefore && newStates.count(newName)) {
+            return;
+        }
+        newStates.insert(newName);
+        stateInfo->newState = new IR::ParserState(newName,
+            IR::IndexedVector<IR::StatOrDecl>(),
+            new IR::PathExpression(new IR::Type_State(),
+            new IR::Path(outOfBoundsStateName, false)));
+    }
+
     /// running symbolic execution
     ParserInfo* run() {
         synthesizedParser = new ParserInfo();
@@ -682,6 +718,8 @@ class ParserSymbolicInterpreter {
             // error during initializer evaluation
             return synthesizedParser;
         auto startInfo = newStateInfo(nullptr, structure->start->name.name, initMap, 0);
+        structure->callsIndexes.emplace(structure->start->name.name, 0);
+        startInfo->scenarioStates.insert(structure->start->name.name);
         std::vector<ParserStateInfo*> toRun;  // worklist
         toRun.push_back(startInfo);
         std::set<VisitedKey> visited;
@@ -703,21 +741,19 @@ class ParserSymbolicInterpreter {
             stateInfo->scenarioStates.insert(stateInfo->name);  // add to loops detection
             bool infLoop = checkLoops(stateInfo);
             if (infLoop) {
-                wasError = true;
                 // don't evaluate successors anymore
+                // generate call OutOfBound
+                addOutFoBound(stateInfo, newStates);
                 continue;
             }
-            bool notAdded = newStates.count(getNewName(stateInfo)) == 0;
+            IR::ID newName = getNewName(stateInfo);
+            bool notAdded = newStates.count(newName) == 0;
             auto nextStates = evaluateState(stateInfo, newStates);
             if (nextStates.first == nullptr) {
                 if (nextStates.second && stateInfo->predecessor &&
-                 stateInfo->state->name !=stateInfo->predecessor->newState->name) {
+                 newName.name !=stateInfo->predecessor->newState->name) {
                     // generate call OutOfBound
-                    hasOutOfboundState = true;
-                    stateInfo->newState = new IR::ParserState(getNewName(stateInfo),
-                        IR::IndexedVector<IR::StatOrDecl>(),
-                        new IR::PathExpression(new IR::Type_State(),
-                            new IR::Path(outOfBoundsStateName, false)));
+                    addOutFoBound(stateInfo, newStates, false);
                 } else {
                     // save current state
                     if (notAdded) {

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -177,7 +177,7 @@ class ParserStateRewriter : public Transform {
         newExpression->right = res;
         if (!res->fitsInt64()) {
             // we need to leave expression as is.
-            ::warning(ErrorType::ERR_EXPRESSION, "Index can't be concretized : %1%", 
+            ::warning(ErrorType::ERR_EXPRESSION, "Index can't be concretized : %1%",
                       expression);
             return expression;
         }
@@ -511,7 +511,8 @@ class ParserSymbolicInterpreter {
             }
             catch (...) {
                 // Ignore throws from evaluator.
-                // If an index of a header stack is not substituted then we should leave a state as is.
+                // If an index of a header stack is not substituted then
+                // we should leave a state as is.
             }
             ParserStateRewriter rewriter(structure, state, valueMap, refMap, typeMap, &ev,
                                          visitedStates);

--- a/midend/parserUnroll.h
+++ b/midend/parserUnroll.h
@@ -263,7 +263,8 @@ class RewriteAllParsers : public Transform {
         for (auto& i : rewriter->current.result->states) {
             for (auto& j : *i.second)
                 if (j->newState) {
-                    if (rewriter->hasOutOfboundState && j->newState->name.name == "stateOutOfBound") {
+                    if (rewriter->hasOutOfboundState &&
+                        j->newState->name.name == "stateOutOfBound") {
                         continue;
                     }
                     newParser->states.push_back(j->newState);

--- a/midend/parserUnroll.h
+++ b/midend/parserUnroll.h
@@ -262,8 +262,12 @@ class RewriteAllParsers : public Transform {
         }
         for (auto& i : rewriter->current.result->states) {
             for (auto& j : *i.second)
-                if (j->newState)
+                if (j->newState) {
+                    if (rewriter->hasOutOfboundState && j->newState->name.name == "stateOutOfBound") {
+                        continue;
+                    }
                     newParser->states.push_back(j->newState);
+                }
         }
         // adding accept/reject
         newParser->states.push_back(new IR::ParserState(IR::ParserState::accept, nullptr));


### PR DESCRIPTION
These changes allow to unroll loops in the following examples: issue692-bmv2, issue2090, gauntlet_parser_test2, gautlet_parser_test4, spec-ex19.
To check, please, run the following command:
`./backends/p4test/p4test  -I "./p4include" --target bmv2 --std p4-16 --loopsUnroll --arch v1model "../testdata/p4_16_samples/example_name.p4"`