### PR TITLE
Emit dpdk table config from p4 const entries

### DIFF
--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -132,7 +132,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         };
         dpdk_program = dpdk_program->apply(post_code_gen)->to<IR::DpdkAsmProgram>();
     }
-
+    ordered_map<cstring, cstring> newNameMap;
     PassManager post_code_gen = {
         new EliminateUnusedAction(),
         new DpdkAsmOptimization,
@@ -140,8 +140,8 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new CollectUsedMetadataField(used_fields),
         new RemoveUnusedMetadataFields(used_fields),
         new ValidateTableKeys(),
-        new ShortenTokenLength(refMap, typeMap),
-        new EmitDpdkTableConfig(refMap, typeMap),
+        new ShortenTokenLength(refMap, typeMap, newNameMap),
+        new EmitDpdkTableConfig(refMap, typeMap, newNameMap),
     };
 
     dpdk_program = dpdk_program->apply(post_code_gen)->to<IR::DpdkAsmProgram>();

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -140,7 +140,8 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new CollectUsedMetadataField(used_fields),
         new RemoveUnusedMetadataFields(used_fields),
         new ValidateTableKeys(),
-        new ShortenTokenLength(),
+        new ShortenTokenLength(refMap, typeMap),
+        new EmitDpdkTableConfig(refMap, typeMap),
     };
 
     dpdk_program = dpdk_program->apply(post_code_gen)->to<IR::DpdkAsmProgram>();

--- a/backends/dpdk/dpdkAsmOpt.cpp
+++ b/backends/dpdk/dpdkAsmOpt.cpp
@@ -540,9 +540,19 @@ void EmitDpdkTableConfig::addAction(const IR::Expression* actionRef,
                 P4::TypeMap* typeMap) {
     auto actionCall = actionRef->to<IR::MethodCallExpression>();
     auto method = actionCall->method->to<IR::PathExpression>()->path;
-    auto decl = refMap->getDeclaration(method, true);
+    const IR::Path* origMethod = nullptr;
+    if (ShortenTokenLength::origNameMap.count(method->name) > 0) {
+        origMethod = new IR::Path(ShortenTokenLength::origNameMap[method->name]);
+    } else {
+        origMethod = method;
+    }
+    auto decl = refMap->getDeclaration(origMethod, true);
     auto actionDecl = decl->to<IR::P4Action>();
-    auto actionName = actionDecl->name.name;
+    cstring actionName;
+    if (newNameMap.count(actionDecl->name.name) > 0)
+        actionName = newNameMap[actionDecl->name.name];
+    else
+        actionName = actionDecl->name.name;
     print(actionName, " ");
     if (actionDecl->parameters->parameters.size() == 1) {
         std::vector<cstring> paramNames;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-const_ent.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-const_ent.p4
@@ -1,0 +1,196 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+     bit<48> key1;
+     bit<48> key2;
+     bit<48> key3;
+     bit<48> key4;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute(bit<48> x) {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.isValid(): exact;
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : exact;
+            user_meta.key1 : ternary;
+            user_meta.key2 : range;
+            user_meta.key4: optional;
+
+        }
+
+        actions = { NoAction; execute; }
+        const entries = {
+            (true,48w1,48w2,48w2&&&48w3, 48w2 .. 48w4, 48w10) : execute(48w1);
+            (true,48w1,48w2,48w2&&&48w3, 48w2 .. 48w5, 48w10)  : execute(48w1);
+            (true,48w3,48w3,48w2&&&48w3, 48w2 .. 48w6, 48w10) : execute(48w1);
+            }
+    }
+    table tbl1 {
+        key = {
+            hdr.ethernet.isValid(): exact;
+            hdr.ethernet.dstAddr : exact;
+            hdr.ethernet.srcAddr : exact;
+            user_meta.key3: lpm;
+        }
+
+        actions = { NoAction; execute; }
+        const entries = {
+            (true,48w1,48w2, 48w10) : execute(48w1);
+            (true,48w1,48w2, 48w11)  : execute(48w1);
+            (true,48w3,48w3, 48w12) : execute(48w1);
+            }
+    }
+    apply {
+            tbl.apply();
+            tbl1.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-large-struct-fields.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-large-struct-fields.p4.spec
@@ -74,9 +74,9 @@ table stub_0 {
 	}
 	actions {
 		macswp
-		NoAction_1
+		NoAction
 	}
-	default_action NoAction_1 args none 
+	default_action NoAction args none 
 	size 0xf4240
 }
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-first.p4
@@ -1,0 +1,160 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<48> key1;
+    bit<48> key2;
+    bit<48> key3;
+    bit<48> key4;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute(bit<48> x) {
+        user_meta.data = 16w1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.key1        : ternary @name("user_meta.key1") ;
+            user_meta.key2        : range @name("user_meta.key2") ;
+            user_meta.key4        : optional @name("user_meta.key4") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w4, 48w10) : execute(48w1);
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w5, 48w10) : execute(48w1);
+                        (true, 48w3, 48w3, 48w2 &&& 48w3, 48w2 .. 48w6, 48w10) : execute(48w1);
+        }
+        default_action = NoAction();
+    }
+    table tbl1 {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.key3        : lpm @name("user_meta.key3") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w10) : execute(48w1);
+                        (true, 48w1, 48w2, 48w11) : execute(48w1);
+                        (true, 48w3, 48w3, 48w12) : execute(48w1);
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+        tbl1.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-frontend.p4
@@ -1,0 +1,167 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<48> key1;
+    bit<48> key2;
+    bit<48> key3;
+    bit<48> key4;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_2() {
+    }
+    @name("ingress.execute") action execute_1(@name("x") bit<48> x) {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.execute") action execute_2(@name("x") bit<48> x_1) {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.key1        : ternary @name("user_meta.key1") ;
+            user_meta.key2        : range @name("user_meta.key2") ;
+            user_meta.key4        : optional @name("user_meta.key4") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w4, 48w10) : execute_1(48w1);
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w5, 48w10) : execute_1(48w1);
+                        (true, 48w3, 48w3, 48w2 &&& 48w3, 48w2 .. 48w6, 48w10) : execute_1(48w1);
+        }
+        default_action = NoAction_1();
+    }
+    @name("ingress.tbl1") table tbl1_0 {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.key3        : lpm @name("user_meta.key3") ;
+        }
+        actions = {
+            NoAction_2();
+            execute_2();
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w10) : execute_2(48w1);
+                        (true, 48w1, 48w2, 48w11) : execute_2(48w1);
+                        (true, 48w3, 48w3, 48w12) : execute_2(48w1);
+        }
+        default_action = NoAction_2();
+    }
+    apply {
+        tbl_0.apply();
+        tbl1_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent-midend.p4
@@ -1,0 +1,184 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<48> key1;
+    bit<48> key2;
+    bit<48> key3;
+    bit<48> key4;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 &&& 8w252: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_2() {
+    }
+    @name("ingress.execute") action execute_1(@name("x") bit<48> x) {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.execute") action execute_2(@name("x") bit<48> x_1) {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.key1        : ternary @name("user_meta.key1") ;
+            user_meta.key2        : range @name("user_meta.key2") ;
+            user_meta.key4        : optional @name("user_meta.key4") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w4, 48w10) : execute_1(48w1);
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w5, 48w10) : execute_1(48w1);
+                        (true, 48w3, 48w3, 48w2 &&& 48w3, 48w2 .. 48w6, 48w10) : execute_1(48w1);
+        }
+        default_action = NoAction_1();
+    }
+    @name("ingress.tbl1") table tbl1_0 {
+        key = {
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+            hdr.ethernet.dstAddr  : exact @name("hdr.ethernet.dstAddr") ;
+            hdr.ethernet.srcAddr  : exact @name("hdr.ethernet.srcAddr") ;
+            user_meta.key3        : lpm @name("user_meta.key3") ;
+        }
+        actions = {
+            NoAction_2();
+            execute_2();
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w10) : execute_2(48w1);
+                        (true, 48w1, 48w2, 48w11) : execute_2(48w1);
+                        (true, 48w3, 48w3, 48w12) : execute_2(48w1);
+        }
+        default_action = NoAction_2();
+    }
+    apply {
+        tbl_0.apply();
+        tbl1_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psadpdktablekeyconst_ent167() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconst_ent167 {
+        actions = {
+            psadpdktablekeyconst_ent167();
+        }
+        const default_action = psadpdktablekeyconst_ent167();
+    }
+    apply {
+        tbl_psadpdktablekeyconst_ent167.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action psadpdktablekeyconst_ent182() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconst_ent182 {
+        actions = {
+            psadpdktablekeyconst_ent182();
+        }
+        const default_action = psadpdktablekeyconst_ent182();
+    }
+    apply {
+        tbl_psadpdktablekeyconst_ent182.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4
@@ -1,0 +1,158 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<48> key1;
+    bit<48> key2;
+    bit<48> key3;
+    bit<48> key4;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800 &&& 0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute(bit<48> x) {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.isValid(): exact;
+            hdr.ethernet.dstAddr  : exact;
+            hdr.ethernet.srcAddr  : exact;
+            user_meta.key1        : ternary;
+            user_meta.key2        : range;
+            user_meta.key4        : optional;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w4, 48w10) : execute(48w1);
+                        (true, 48w1, 48w2, 48w2 &&& 48w3, 48w2 .. 48w5, 48w10) : execute(48w1);
+                        (true, 48w3, 48w3, 48w2 &&& 48w3, 48w2 .. 48w6, 48w10) : execute(48w1);
+        }
+    }
+    table tbl1 {
+        key = {
+            hdr.ethernet.isValid(): exact;
+            hdr.ethernet.dstAddr  : exact;
+            hdr.ethernet.srcAddr  : exact;
+            user_meta.key3        : lpm;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+        const entries = {
+                        (true, 48w1, 48w2, 48w10) : execute(48w1);
+                        (true, 48w1, 48w2, 48w11) : execute(48w1);
+                        (true, 48w3, 48w3, 48w12) : execute(48w1);
+        }
+    }
+    apply {
+        tbl.apply();
+        tbl1.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-error
@@ -1,0 +1,5 @@
+psa-dpdk-table-key-const_ent.p4(95): [--Wwarn=unused] warning: 'x' is unused
+    action execute(bit<48> x) {
+                           ^
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl1. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4-stderr
@@ -1,0 +1,3 @@
+psa-dpdk-table-key-const_ent.p4(95): [--Wwarn=unused] warning: 'x' is unused
+    action execute(bit<48> x) {
+                           ^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.bfrt.json
@@ -1,0 +1,223 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.$valid",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 1
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ethernet.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 4,
+          "name" : "user_meta.key1",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Ternary",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 5,
+          "name" : "user_meta.key2",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Range",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 6,
+          "name" : "user_meta.key4",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Optional",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 65537,
+          "name" : "$MATCH_PRIORITY",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "x",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 48
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope", "ConstTable"]
+    },
+    {
+      "name" : "ip.ingress.tbl1",
+      "id" : 33873526,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.$valid",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 1
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ethernet.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 4,
+          "name" : "user_meta.key3",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "LPM",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "x",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 48
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope", "ConstTable"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.entries.txt
@@ -1,0 +1,294 @@
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 44506256
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\001"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\002"
+        }
+      }
+      match {
+        field_id: 4
+        ternary {
+          value: "\000\000\000\000\000\002"
+          mask: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 5
+        range {
+          low: "\000\000\000\000\000\002"
+          high: "\000\000\000\000\000\004"
+        }
+      }
+      match {
+        field_id: 6
+        optional {
+          value: "\000\000\000\000\000\n"
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+      priority: 3
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 44506256
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\001"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\002"
+        }
+      }
+      match {
+        field_id: 4
+        ternary {
+          value: "\000\000\000\000\000\002"
+          mask: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 5
+        range {
+          low: "\000\000\000\000\000\002"
+          high: "\000\000\000\000\000\005"
+        }
+      }
+      match {
+        field_id: 6
+        optional {
+          value: "\000\000\000\000\000\n"
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+      priority: 2
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 44506256
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 4
+        ternary {
+          value: "\000\000\000\000\000\002"
+          mask: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 5
+        range {
+          low: "\000\000\000\000\000\002"
+          high: "\000\000\000\000\000\006"
+        }
+      }
+      match {
+        field_id: 6
+        optional {
+          value: "\000\000\000\000\000\n"
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+      priority: 1
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33873526
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\001"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\002"
+        }
+      }
+      match {
+        field_id: 4
+        lpm {
+          value: "\000\000\000\000\000\n"
+          prefix_len: 48
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33873526
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\001"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\002"
+        }
+      }
+      match {
+        field_id: 4
+        lpm {
+          value: "\000\000\000\000\000\013"
+          prefix_len: 48
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 33873526
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        exact {
+          value: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 3
+        exact {
+          value: "\000\000\000\000\000\003"
+        }
+      }
+      match {
+        field_id: 4
+        lpm {
+          value: "\000\000\000\000\000\014"
+          prefix_len: 48
+        }
+      }
+      action {
+        action {
+          action_id: 29480552
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\001"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.p4info.txt
@@ -1,0 +1,115 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.$valid$"
+    bitwidth: 1
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "hdr.ethernet.dstAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 3
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 4
+    name: "user_meta.key1"
+    bitwidth: 48
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 5
+    name: "user_meta.key2"
+    bitwidth: 48
+    match_type: RANGE
+  }
+  match_fields {
+    id: 6
+    name: "user_meta.key4"
+    bitwidth: 48
+    match_type: OPTIONAL
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+  is_const_table: true
+}
+tables {
+  preamble {
+    id: 33873526
+    name: "ingress.tbl1"
+    alias: "tbl1"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.$valid$"
+    bitwidth: 1
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "hdr.ethernet.dstAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 3
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 4
+    name: "user_meta.key3"
+    bitwidth: 48
+    match_type: LPM
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+  is_const_table: true
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+  params {
+    id: 1
+    name: "x"
+    bitwidth: 48
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-const_ent.p4.spec
@@ -1,0 +1,170 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<16> dataOffset_res_ecn_ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct execute_1_arg_t {
+	bit<48> x
+}
+
+struct execute_2_arg_t {
+	bit<48> x
+}
+
+struct metadata {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<16> local_metadata_data
+	bit<48> local_metadata_key1
+	bit<48> local_metadata_key2
+	bit<48> local_metadata_key3
+	bit<48> local_metadata_key4
+	bit<8> ingress_tbl_ethernet_isValid
+	bit<48> ingress_tbl_ethernet_dstAddr
+	bit<48> ingress_tbl_ethernet_srcAddr
+	bit<8> ingress_tbl1_ethernet_isValid
+	bit<48> ingress_tbl1_ethernet_dstAddr
+	bit<48> ingress_tbl1_ethernet_srcAddr
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args instanceof execute_1_arg_t {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+action execute_2 args instanceof execute_2_arg_t {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.ingress_tbl_ethernet_isValid exact
+		m.ingress_tbl_ethernet_dstAddr exact
+		m.ingress_tbl_ethernet_srcAddr exact
+		m.local_metadata_key1 wildcard
+		m.local_metadata_key2 wildcard
+		m.local_metadata_key4 wildcard
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+table tbl1 {
+	key {
+		m.ingress_tbl1_ethernet_isValid exact
+		m.ingress_tbl1_ethernet_dstAddr exact
+		m.ingress_tbl1_ethernet_srcAddr exact
+		m.local_metadata_key3 lpm
+	}
+	actions {
+		NoAction
+		execute_2
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.ingress_tbl_ethernet_isValid 1
+	jmpv LABEL_END h.ethernet
+	mov m.ingress_tbl_ethernet_isValid 0
+	LABEL_END :	mov m.ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	mov m.ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl
+	mov m.ingress_tbl1_ethernet_isValid 1
+	jmpv LABEL_END_0 h.ethernet
+	mov m.ingress_tbl1_ethernet_isValid 0
+	LABEL_END_0 :	mov m.ingress_tbl1_ethernet_dstAddr h.ethernet.dstAddr
+	mov m.ingress_tbl1_ethernet_srcAddr h.ethernet.srcAddr
+	table tbl1
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+


### PR DESCRIPTION
This PR emits new table config in txt format from const entries present in p4 program to be consumed by dpdk target.

i.e.

match 0x2/0x2 action MainControlImpl.tcp_syn_packet
match 0x1/0x1 action MainControlImpl.tcp_fin_or_rst_packet
match 0x4/0x4 action MainControlImpl.tcp_fin_or_rst_packet

for p4 const entries:
const bit<8> TCP_RST_MASK = 0x04;
const bit<8> TCP_SYN_MASK = 0x02;
const bit<8> TCP_FIN_MASK = 0x01;

const entries = {
TCP_SYN_MASK &&& TCP_SYN_MASK: tcp_syn_packet;
TCP_FIN_MASK &&& TCP_FIN_MASK: tcp_fin_or_rst_packet;
TCP_RST_MASK &&& TCP_RST_MASK: tcp_fin_or_rst_packet;
}