### PR TITLE
Fix: prevent copy elimination for statement which does not support constant values

### DIFF
--- a/backends/dpdk/dpdkAsmOpt.cpp
+++ b/backends/dpdk/dpdkAsmOpt.cpp
@@ -370,9 +370,6 @@ CopyPropagationAndElimination::copyPropAndDeadCodeElim(
         } else if (auto jne = stmt->to<IR::DpdkJmpNotEqualStatement>()) {
             instr.push_back(new IR::DpdkJmpNotEqualStatement(jne->label,
                         replaceIfCopy(jne->src1, false), replaceIfCopy(jne->src2)));
-       } else if (auto l = stmt->to<IR::DpdkLearnStatement>()) {
-            instr.push_back(new IR::DpdkLearnStatement(l->action,
-                        replaceIfCopy(l->timeout, false), replaceIfCopy(l->argument, false)));
        } else if (auto m = stmt->to<IR::DpdkMeterExecuteStatement>()) {
             instr.push_back(new IR::DpdkMeterExecuteStatement(m->meter,
                     replaceIfCopy(m->index), replaceIfCopy(m->length),
@@ -380,22 +377,6 @@ CopyPropagationAndElimination::copyPropAndDeadCodeElim(
        } else if (auto c = stmt->to<IR::DpdkCounterCountStatement>()) {
             instr.push_back(new IR::DpdkCounterCountStatement(c->counter,
                     replaceIfCopy(c->index), replaceIfCopy(c->incr)));
-       } else if (auto m = stmt->to<IR::DpdkMirrorStatement>()) {
-            instr.push_back(new IR::DpdkMirrorStatement(replaceIfCopy(m->slotId),
-                    replaceIfCopy(m->sessionId)));
-       } else if (auto e = stmt->to<IR::DpdkEmitStatement>()) {
-            instr.push_back(new IR::DpdkEmitStatement(replaceIfCopy(e->header)));
-       } else if (auto ext = stmt->to<IR::DpdkExtractStatement>()) {
-            instr.push_back(new IR::DpdkExtractStatement(replaceIfCopy(ext->header),
-                    replaceIfCopy(ext->length)));
-       } else if (auto lh = stmt->to<IR::DpdkLookaheadStatement>()) {
-            instr.push_back(new IR::DpdkLookaheadStatement(replaceIfCopy(lh->header)));
-       } else if (auto ji = stmt->to<IR::DpdkJmpIfInvalidStatement>()) {
-            instr.push_back(new IR::DpdkJmpIfInvalidStatement(ji->label,
-                    replaceIfCopy(ji->header)));
-       } else if (auto ji = stmt->to<IR::DpdkJmpIfValidStatement>()) {
-            instr.push_back(new IR::DpdkJmpIfValidStatement(ji->label,
-                    replaceIfCopy(ji->header)));
        } else if (auto neg = stmt->to<IR::DpdkNegStatement>()) {
             instr.push_back(new IR::DpdkNegStatement(replaceIfCopy(neg->dst, false),
                     replaceIfCopy(neg->src)));
@@ -455,24 +436,6 @@ CopyPropagationAndElimination::copyPropAndDeadCodeElim(
                     replaceIfCopy(neq->src1, false), replaceIfCopy(neq->src2)));
        } else if (auto recd = stmt->to<IR::DpdkRecircidStatement>()) {
             instr.push_back(new IR::DpdkRecircidStatement(replaceIfCopy(recd->pass, false)));
-       } else if (auto rarm = stmt->to<IR::DpdkRearmStatement>()) {
-            instr.push_back(new IR::DpdkRearmStatement(replaceIfCopy(rarm->timeout)));
-       } else if (auto csum = stmt->to<IR::DpdkChecksumAddStatement>()) {
-            instr.push_back(new IR::DpdkChecksumAddStatement(csum->csum, csum->intermediate_value,
-                    replaceIfCopy(csum->field)));
-       } else if (auto csum = stmt->to<IR::DpdkChecksumSubStatement>()) {
-            instr.push_back(new IR::DpdkChecksumSubStatement(csum->csum, csum->intermediate_value,
-                    replaceIfCopy(csum->field)));
-       } else if (auto hash = stmt->to<IR::DpdkGetHashStatement>()) {
-            instr.push_back(new IR::DpdkGetHashStatement(hash->hash, replaceIfCopy(hash->fields),
-                    replaceIfCopy(hash->dst, false)));
-       } else if (auto csum = stmt->to<IR::DpdkGetChecksumStatement>()) {
-            instr.push_back(new IR::DpdkGetChecksumStatement(
-                    replaceIfCopy(csum->dst, false), csum->checksum,
-                    csum->intermediate_value));
-       } else if (auto vrfy = stmt->to<IR::DpdkVerifyStatement>()) {
-            instr.push_back(new IR::DpdkVerifyStatement(replaceIfCopy(vrfy->condition),
-                    replaceIfCopy(vrfy->error)));
        } else if (auto mdecl = stmt->to<IR::DpdkMeterDeclStatement>()) {
             instr.push_back(new IR::DpdkMeterDeclStatement(mdecl->meter,
                     replaceIfCopy(mdecl->size)));
@@ -486,10 +449,6 @@ CopyPropagationAndElimination::copyPropAndDeadCodeElim(
        } else if (auto rrw = stmt->to<IR::DpdkRegisterWriteStatement>()) {
             instr.push_back(new IR::DpdkRegisterWriteStatement(rrw->reg, replaceIfCopy(rrw->index),
                     replaceIfCopy(rrw->src)));
-       } else if (auto vld = stmt->to<IR::DpdkValidateStatement>()) {
-            instr.push_back(new IR::DpdkValidateStatement(replaceIfCopy(vld->header)));
-       } else if (auto vld = stmt->to<IR::DpdkInvalidateStatement>()) {
-            instr.push_back(new IR::DpdkInvalidateStatement(replaceIfCopy(vld->header)));
        } else {
             instr.push_back(stmt);
         }

--- a/backends/dpdk/dpdkAsmOpt.cpp
+++ b/backends/dpdk/dpdkAsmOpt.cpp
@@ -266,7 +266,7 @@ bool ValidateTableKeys::preorder(const IR::DpdkAsmProgram *p) {
 
 const IR::Expression* CopyPropagationAndElimination::getIrreplaceableExpr(cstring str,
                                                                         bool allowConst) {
-    if (collectUseDef->dontEliminate[str])
+    if (collectUseDef->dontEliminate.count(str) != 0)
         return nullptr;
     if (!str.startsWith("m."))
         return nullptr;
@@ -278,7 +278,7 @@ const IR::Expression* CopyPropagationAndElimination::getIrreplaceableExpr(cstrin
         && (!allowConst ? expr->is<IR::Member>() : true)
         && str != exprStr
         && (!allowConst ? exprStr.startsWith("m.") : true)
-        && !collectUseDef->dontEliminate[exprStr]
+        && collectUseDef->dontEliminate.count(exprStr) == 0
         && newUsesInfo[exprStr] == 0
         && (expr->is<IR::Member>() ? collectUseDef->haveSingleUseDef(exprStr) : true)) {
         prev = expr;
@@ -323,7 +323,7 @@ const IR::DpdkAsmStatement* CopyPropagationAndElimination::elimCastOrMov(
     auto src = srcExpr->toString();
     auto dst = dstExpr->toString();
     bool dropCopy = false;
-    if (!collectUseDef->dontEliminate[dst]
+    if (collectUseDef->dontEliminate.count(dst) == 0
             && dst.startsWith("m.")
             && newUsesInfo[dst] == 0
             && collectUseDef->haveSingleUseDef(dst)) {

--- a/backends/dpdk/dpdkAsmOpt.cpp
+++ b/backends/dpdk/dpdkAsmOpt.cpp
@@ -266,7 +266,7 @@ bool ValidateTableKeys::preorder(const IR::DpdkAsmProgram *p) {
 
 const IR::Expression* CopyPropagationAndElimination::getIrreplaceableExpr(cstring str,
                                                                         bool allowConst) {
-    if (collectUseDef->dontEliminate.count(str))
+    if (collectUseDef->dontEliminate[str])
         return nullptr;
     if (!str.startsWith("m."))
         return nullptr;
@@ -278,7 +278,7 @@ const IR::Expression* CopyPropagationAndElimination::getIrreplaceableExpr(cstrin
         && (!allowConst ? expr->is<IR::Member>() : true)
         && str != exprStr
         && (!allowConst ? exprStr.startsWith("m.") : true)
-        && collectUseDef->dontEliminate.count(exprStr) == 0
+        && !collectUseDef->dontEliminate[exprStr]
         && newUsesInfo[exprStr] == 0
         && (expr->is<IR::Member>() ? collectUseDef->haveSingleUseDef(exprStr) : true)) {
         prev = expr;
@@ -323,7 +323,7 @@ const IR::DpdkAsmStatement* CopyPropagationAndElimination::elimCastOrMov(
     auto src = srcExpr->toString();
     auto dst = dstExpr->toString();
     bool dropCopy = false;
-    if (collectUseDef->dontEliminate.count(dst) == 0
+    if (!collectUseDef->dontEliminate[dst]
             && dst.startsWith("m.")
             && newUsesInfo[dst] == 0
             && collectUseDef->haveSingleUseDef(dst)) {

--- a/backends/dpdk/dpdkAsmOpt.cpp
+++ b/backends/dpdk/dpdkAsmOpt.cpp
@@ -407,52 +407,52 @@ CopyPropagationAndElimination::copyPropAndDeadCodeElim(
                     replaceIfCopy(lnot->src)));
        } else if (auto add = stmt->to<IR::DpdkAddStatement>()) {
             instr.push_back(new IR::DpdkAddStatement(replaceIfCopy(add->dst, false),
-                    replaceIfCopy(add->src1), replaceIfCopy(add->src2)));
+                    replaceIfCopy(add->src1, false), replaceIfCopy(add->src2)));
        } else if (auto shl = stmt->to<IR::DpdkShlStatement>()) {
             instr.push_back(new IR::DpdkShlStatement(replaceIfCopy(shl->dst, false),
-                    replaceIfCopy(shl->src1), replaceIfCopy(shl->src2)));
+                    replaceIfCopy(shl->src1, false), replaceIfCopy(shl->src2)));
        } else if (auto an = stmt->to<IR::DpdkAndStatement>()) {
             instr.push_back(new IR::DpdkAndStatement(replaceIfCopy(an->dst, false),
-                    replaceIfCopy(an->src1), replaceIfCopy(an->src2)));
+                    replaceIfCopy(an->src1, false), replaceIfCopy(an->src2)));
        } else if (auto shr = stmt->to<IR::DpdkShrStatement>()) {
             instr.push_back(new IR::DpdkShrStatement(replaceIfCopy(shr->dst, false),
-                    replaceIfCopy(shr->src1), replaceIfCopy(shr->src2)));
+                    replaceIfCopy(shr->src1, false), replaceIfCopy(shr->src2)));
        } else if (auto sub = stmt->to<IR::DpdkSubStatement>()) {
             instr.push_back(new IR::DpdkSubStatement(replaceIfCopy(sub->dst, false),
-                    replaceIfCopy(sub->src1), replaceIfCopy(sub->src2)));
+                    replaceIfCopy(sub->src1, false), replaceIfCopy(sub->src2)));
        } else if (auto or1 = stmt->to<IR::DpdkOrStatement>()) {
             instr.push_back(new IR::DpdkOrStatement(replaceIfCopy(or1->dst, false),
-                    replaceIfCopy(or1->src1), replaceIfCopy(or1->src2)));
+                    replaceIfCopy(or1->src1, false), replaceIfCopy(or1->src2)));
        } else if (auto eq = stmt->to<IR::DpdkEquStatement>()) {
             instr.push_back(new IR::DpdkEquStatement(replaceIfCopy(eq->dst, false),
-                    replaceIfCopy(eq->src1), replaceIfCopy(eq->src2)));
+                    replaceIfCopy(eq->src1, false), replaceIfCopy(eq->src2)));
        } else if (auto xor1 = stmt->to<IR::DpdkXorStatement>()) {
             instr.push_back(new IR::DpdkXorStatement(replaceIfCopy(xor1->dst, false),
-                    replaceIfCopy(xor1->src1), replaceIfCopy(xor1->src2)));
+                    replaceIfCopy(xor1->src1, false), replaceIfCopy(xor1->src2)));
        } else if (auto cmp = stmt->to<IR::DpdkCmpStatement>()) {
             instr.push_back(new IR::DpdkCmpStatement(replaceIfCopy(cmp->dst, false),
-                    replaceIfCopy(cmp->src1), replaceIfCopy(cmp->src2)));
+                    replaceIfCopy(cmp->src1, false), replaceIfCopy(cmp->src2)));
        } else if (auto and1 = stmt->to<IR::DpdkLAndStatement>()) {
             instr.push_back(new IR::DpdkLAndStatement(replaceIfCopy(and1->dst, false),
-                    replaceIfCopy(and1->src1), replaceIfCopy(and1->src2)));
+                    replaceIfCopy(and1->src1, false), replaceIfCopy(and1->src2)));
        } else if (auto lor = stmt->to<IR::DpdkLOrStatement>()) {
             instr.push_back(new IR::DpdkLOrStatement(replaceIfCopy(lor->dst, false),
-                    replaceIfCopy(lor->src1), replaceIfCopy(lor->src2)));
+                    replaceIfCopy(lor->src1, false), replaceIfCopy(lor->src2)));
        } else if (auto leq = stmt->to<IR::DpdkLeqStatement>()) {
             instr.push_back(new IR::DpdkLeqStatement(replaceIfCopy(leq->dst, false),
-                    replaceIfCopy(leq->src1), replaceIfCopy(leq->src2)));
+                    replaceIfCopy(leq->src1, false), replaceIfCopy(leq->src2)));
        } else if (auto lss = stmt->to<IR::DpdkLssStatement>()) {
             instr.push_back(new IR::DpdkLssStatement(replaceIfCopy(lss->dst, false),
-                    replaceIfCopy(lss->src1), replaceIfCopy(lss->src2)));
+                    replaceIfCopy(lss->src1, false), replaceIfCopy(lss->src2)));
        } else if (auto grt = stmt->to<IR::DpdkGrtStatement>()) {
             instr.push_back(new IR::DpdkGrtStatement(replaceIfCopy(grt->dst, false),
-                    replaceIfCopy(grt->src1), replaceIfCopy(grt->src2)));
+                    replaceIfCopy(grt->src1, false), replaceIfCopy(grt->src2)));
        } else if (auto geq = stmt->to<IR::DpdkGeqStatement>()) {
             instr.push_back(new IR::DpdkGeqStatement(replaceIfCopy(geq->dst, false),
-                    replaceIfCopy(geq->src1), replaceIfCopy(geq->src2)));
+                    replaceIfCopy(geq->src1, false), replaceIfCopy(geq->src2)));
        } else if (auto neq = stmt->to<IR::DpdkNeqStatement>()) {
             instr.push_back(new IR::DpdkNeqStatement(replaceIfCopy(neq->dst, false),
-                    replaceIfCopy(neq->src1), replaceIfCopy(neq->src2)));
+                    replaceIfCopy(neq->src1, false), replaceIfCopy(neq->src2)));
        } else if (auto recd = stmt->to<IR::DpdkRecircidStatement>()) {
             instr.push_back(new IR::DpdkRecircidStatement(replaceIfCopy(recd->pass, false)));
        } else if (auto rarm = stmt->to<IR::DpdkRearmStatement>()) {

--- a/backends/dpdk/dpdkAsmOpt.cpp
+++ b/backends/dpdk/dpdkAsmOpt.cpp
@@ -355,8 +355,14 @@ CopyPropagationAndElimination::copyPropAndDeadCodeElim(
         } else if (auto jc = stmt->to<IR::DpdkJmpLessStatement>()) {
             instr.push_back(new IR::DpdkJmpLessStatement(jc->label,
                         replaceIfCopy(jc->src1, false), replaceIfCopy(jc->src2)));
+        } else if (auto jc = stmt->to<IR::DpdkJmpLessOrEqualStatement>()) {
+            instr.push_back(new IR::DpdkJmpLessOrEqualStatement(jc->label,
+                        replaceIfCopy(jc->src1, false), replaceIfCopy(jc->src2)));
         } else if (auto jc = stmt->to<IR::DpdkJmpGreaterStatement>()) {
             instr.push_back(new IR::DpdkJmpGreaterStatement(jc->label,
+                        replaceIfCopy(jc->src1, false), replaceIfCopy(jc->src2)));
+        } else if (auto jc = stmt->to<IR::DpdkJmpGreaterEqualStatement>()) {
+            instr.push_back(new IR::DpdkJmpGreaterEqualStatement(jc->label,
                         replaceIfCopy(jc->src1, false), replaceIfCopy(jc->src2)));
         } else if (auto je = stmt->to<IR::DpdkJmpEqualStatement>()) {
             instr.push_back(new IR::DpdkJmpEqualStatement(je->label,
@@ -371,6 +377,119 @@ CopyPropagationAndElimination::copyPropAndDeadCodeElim(
             instr.push_back(new IR::DpdkMeterExecuteStatement(m->meter,
                     replaceIfCopy(m->index), replaceIfCopy(m->length),
                     replaceIfCopy(m->color_in), replaceIfCopy(m->color_out)));
+       } else if (auto c = stmt->to<IR::DpdkCounterCountStatement>()) {
+            instr.push_back(new IR::DpdkCounterCountStatement(c->counter,
+                    replaceIfCopy(c->index), replaceIfCopy(c->incr)));
+       } else if (auto m = stmt->to<IR::DpdkMirrorStatement>()) {
+            instr.push_back(new IR::DpdkMirrorStatement(replaceIfCopy(m->slotId),
+                    replaceIfCopy(m->sessionId)));
+       } else if (auto e = stmt->to<IR::DpdkEmitStatement>()) {
+            instr.push_back(new IR::DpdkEmitStatement(replaceIfCopy(e->header)));
+       } else if (auto ext = stmt->to<IR::DpdkExtractStatement>()) {
+            instr.push_back(new IR::DpdkExtractStatement(replaceIfCopy(ext->header),
+                    replaceIfCopy(ext->length)));
+       } else if (auto lh = stmt->to<IR::DpdkLookaheadStatement>()) {
+            instr.push_back(new IR::DpdkLookaheadStatement(replaceIfCopy(lh->header)));
+       } else if (auto ji = stmt->to<IR::DpdkJmpIfInvalidStatement>()) {
+            instr.push_back(new IR::DpdkJmpIfInvalidStatement(ji->label,
+                    replaceIfCopy(ji->header)));
+       } else if (auto ji = stmt->to<IR::DpdkJmpIfValidStatement>()) {
+            instr.push_back(new IR::DpdkJmpIfValidStatement(ji->label,
+                    replaceIfCopy(ji->header)));
+       } else if (auto neg = stmt->to<IR::DpdkNegStatement>()) {
+            instr.push_back(new IR::DpdkNegStatement(replaceIfCopy(neg->dst, false),
+                    replaceIfCopy(neg->src)));
+       } else if (auto cmpl = stmt->to<IR::DpdkCmplStatement>()) {
+            instr.push_back(new IR::DpdkCmplStatement(replaceIfCopy(cmpl->dst, false),
+                    replaceIfCopy(cmpl->src)));
+       } else if (auto lnot = stmt->to<IR::DpdkLNotStatement>()) {
+            instr.push_back(new IR::DpdkLNotStatement(replaceIfCopy(lnot->dst, false),
+                    replaceIfCopy(lnot->src)));
+       } else if (auto add = stmt->to<IR::DpdkAddStatement>()) {
+            instr.push_back(new IR::DpdkAddStatement(replaceIfCopy(add->dst, false),
+                    replaceIfCopy(add->src1), replaceIfCopy(add->src2)));
+       } else if (auto shl = stmt->to<IR::DpdkShlStatement>()) {
+            instr.push_back(new IR::DpdkShlStatement(replaceIfCopy(shl->dst, false),
+                    replaceIfCopy(shl->src1), replaceIfCopy(shl->src2)));
+       } else if (auto an = stmt->to<IR::DpdkAndStatement>()) {
+            instr.push_back(new IR::DpdkAndStatement(replaceIfCopy(an->dst, false),
+                    replaceIfCopy(an->src1), replaceIfCopy(an->src2)));
+       } else if (auto shr = stmt->to<IR::DpdkShrStatement>()) {
+            instr.push_back(new IR::DpdkShrStatement(replaceIfCopy(shr->dst, false),
+                    replaceIfCopy(shr->src1), replaceIfCopy(shr->src2)));
+       } else if (auto sub = stmt->to<IR::DpdkSubStatement>()) {
+            instr.push_back(new IR::DpdkSubStatement(replaceIfCopy(sub->dst, false),
+                    replaceIfCopy(sub->src1), replaceIfCopy(sub->src2)));
+       } else if (auto or1 = stmt->to<IR::DpdkOrStatement>()) {
+            instr.push_back(new IR::DpdkOrStatement(replaceIfCopy(or1->dst, false),
+                    replaceIfCopy(or1->src1), replaceIfCopy(or1->src2)));
+       } else if (auto eq = stmt->to<IR::DpdkEquStatement>()) {
+            instr.push_back(new IR::DpdkEquStatement(replaceIfCopy(eq->dst, false),
+                    replaceIfCopy(eq->src1), replaceIfCopy(eq->src2)));
+       } else if (auto xor1 = stmt->to<IR::DpdkXorStatement>()) {
+            instr.push_back(new IR::DpdkXorStatement(replaceIfCopy(xor1->dst, false),
+                    replaceIfCopy(xor1->src1), replaceIfCopy(xor1->src2)));
+       } else if (auto cmp = stmt->to<IR::DpdkCmpStatement>()) {
+            instr.push_back(new IR::DpdkCmpStatement(replaceIfCopy(cmp->dst, false),
+                    replaceIfCopy(cmp->src1), replaceIfCopy(cmp->src2)));
+       } else if (auto and1 = stmt->to<IR::DpdkLAndStatement>()) {
+            instr.push_back(new IR::DpdkLAndStatement(replaceIfCopy(and1->dst, false),
+                    replaceIfCopy(and1->src1), replaceIfCopy(and1->src2)));
+       } else if (auto lor = stmt->to<IR::DpdkLOrStatement>()) {
+            instr.push_back(new IR::DpdkLOrStatement(replaceIfCopy(lor->dst, false),
+                    replaceIfCopy(lor->src1), replaceIfCopy(lor->src2)));
+       } else if (auto leq = stmt->to<IR::DpdkLeqStatement>()) {
+            instr.push_back(new IR::DpdkLeqStatement(replaceIfCopy(leq->dst, false),
+                    replaceIfCopy(leq->src1), replaceIfCopy(leq->src2)));
+       } else if (auto lss = stmt->to<IR::DpdkLssStatement>()) {
+            instr.push_back(new IR::DpdkLssStatement(replaceIfCopy(lss->dst, false),
+                    replaceIfCopy(lss->src1), replaceIfCopy(lss->src2)));
+       } else if (auto grt = stmt->to<IR::DpdkGrtStatement>()) {
+            instr.push_back(new IR::DpdkGrtStatement(replaceIfCopy(grt->dst, false),
+                    replaceIfCopy(grt->src1), replaceIfCopy(grt->src2)));
+       } else if (auto geq = stmt->to<IR::DpdkGeqStatement>()) {
+            instr.push_back(new IR::DpdkGeqStatement(replaceIfCopy(geq->dst, false),
+                    replaceIfCopy(geq->src1), replaceIfCopy(geq->src2)));
+       } else if (auto neq = stmt->to<IR::DpdkNeqStatement>()) {
+            instr.push_back(new IR::DpdkNeqStatement(replaceIfCopy(neq->dst, false),
+                    replaceIfCopy(neq->src1), replaceIfCopy(neq->src2)));
+       } else if (auto recd = stmt->to<IR::DpdkRecircidStatement>()) {
+            instr.push_back(new IR::DpdkRecircidStatement(replaceIfCopy(recd->pass, false)));
+       } else if (auto rarm = stmt->to<IR::DpdkRearmStatement>()) {
+            instr.push_back(new IR::DpdkRearmStatement(replaceIfCopy(rarm->timeout)));
+       } else if (auto csum = stmt->to<IR::DpdkChecksumAddStatement>()) {
+            instr.push_back(new IR::DpdkChecksumAddStatement(csum->csum, csum->intermediate_value,
+                    replaceIfCopy(csum->field)));
+       } else if (auto csum = stmt->to<IR::DpdkChecksumSubStatement>()) {
+            instr.push_back(new IR::DpdkChecksumSubStatement(csum->csum, csum->intermediate_value,
+                    replaceIfCopy(csum->field)));
+       } else if (auto hash = stmt->to<IR::DpdkGetHashStatement>()) {
+            instr.push_back(new IR::DpdkGetHashStatement(hash->hash, replaceIfCopy(hash->fields),
+                    replaceIfCopy(hash->dst, false)));
+       } else if (auto csum = stmt->to<IR::DpdkGetChecksumStatement>()) {
+            instr.push_back(new IR::DpdkGetChecksumStatement(
+                    replaceIfCopy(csum->dst, false), csum->checksum,
+                    csum->intermediate_value));
+       } else if (auto vrfy = stmt->to<IR::DpdkVerifyStatement>()) {
+            instr.push_back(new IR::DpdkVerifyStatement(replaceIfCopy(vrfy->condition),
+                    replaceIfCopy(vrfy->error)));
+       } else if (auto mdecl = stmt->to<IR::DpdkMeterDeclStatement>()) {
+            instr.push_back(new IR::DpdkMeterDeclStatement(mdecl->meter,
+                    replaceIfCopy(mdecl->size)));
+       } else if (auto rdecl = stmt->to<IR::DpdkRegisterDeclStatement>()) {
+            instr.push_back(new IR::DpdkRegisterDeclStatement(rdecl->reg,
+                    replaceIfCopy(rdecl->size),
+                    replaceIfCopy(rdecl->init_val)));
+       } else if (auto rrd = stmt->to<IR::DpdkRegisterReadStatement>()) {
+            instr.push_back(new IR::DpdkRegisterReadStatement(replaceIfCopy(rrd->dst, false),
+                    rrd->reg, replaceIfCopy(rrd->index)));
+       } else if (auto rrw = stmt->to<IR::DpdkRegisterWriteStatement>()) {
+            instr.push_back(new IR::DpdkRegisterWriteStatement(rrw->reg, replaceIfCopy(rrw->index),
+                    replaceIfCopy(rrw->src)));
+       } else if (auto vld = stmt->to<IR::DpdkValidateStatement>()) {
+            instr.push_back(new IR::DpdkValidateStatement(replaceIfCopy(vld->header)));
+       } else if (auto vld = stmt->to<IR::DpdkInvalidateStatement>()) {
+            instr.push_back(new IR::DpdkInvalidateStatement(replaceIfCopy(vld->header)));
        } else {
             instr.push_back(stmt);
         }

--- a/backends/dpdk/dpdkAsmOpt.h
+++ b/backends/dpdk/dpdkAsmOpt.h
@@ -364,6 +364,14 @@ class CollectUseDefInfo : public Inspector {
         return false;
     }
 
+    bool preorder(const IR::DpdkMirrorStatement *m) override {
+        usesInfo[m->slotId->toString()]++;
+        usesInfo[m->sessionId->toString()]++;
+        dontEliminate[m->slotId->toString()] = true;
+        dontEliminate[m->sessionId->toString()] = true;
+        return false;
+    }
+
     bool preorder(const IR::DpdkEmitStatement* e) override {
         auto type = typeMap->getType(e->header)->to<IR::Type_Header>();
         if (type)
@@ -381,8 +389,10 @@ class CollectUseDefInfo : public Inspector {
                 cstring name = e->header->toString() + "." + f->name.toString();
                 defInfo[name]++;
             }
-        if (e->length)
+        if (e->length) {
             usesInfo[e->length->toString()]++;
+            dontEliminate[e->length->toString()] = true;
+        }
         return false;
     }
 
@@ -412,8 +422,10 @@ class CollectUseDefInfo : public Inspector {
     }
 
     bool preorder(const IR::DpdkRearmStatement* r) override {
-        if (r->timeout)
+        if (r->timeout) {
             usesInfo[r->timeout->toString()]++;
+            dontEliminate[r->timeout->toString()] = true;
+        }
         return false;
     }
 
@@ -429,6 +441,7 @@ class CollectUseDefInfo : public Inspector {
 
     bool preorder(const IR::DpdkGetHashStatement* c) override {
         usesInfo[c->dst->toString()]++;
+        dontEliminate[c->dst->toString()] = true;
         return false;
     }
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-token-too-big.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-token-too-big.p4.spec
@@ -100,6 +100,8 @@ struct local_metadata__dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpd4 {
 	bit<32> psa_ingress_input_metadata_ingress_port
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
+	bit<16> Ingress_tmp
+	bit<16> Ingress_tmp_0
 }
 metadata instanceof local_metadata__dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpd4
 
@@ -127,8 +129,10 @@ action vxlan_encap_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dp5 args instanc
 	mov h.vxlan.vni t.vxlan_vni
 	mov h.vxlan.reserved2 t.vxlan_reserved2
 	mov m.psa_ingress_output_metadata_egress_port t.port_out
-	ckadd h.cksum_state.state_0 h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.hdr_checksum
-	ckadd h.cksum_state.state_0 h.ipv4.total_len
+	mov m.Ingress_tmp h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.hdr_checksum
+	mov m.Ingress_tmp_0 h.ipv4.total_len
+	ckadd h.cksum_state.state_0 m.Ingress_tmp
+	ckadd h.cksum_state.state_0 m.Ingress_tmp_0
 	mov h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.hdr_checksum h.cksum_state.state_0
 	mov h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.total_len t.ipv4_total_len
 	add h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.total_len h.ipv4.total_len

--- a/testdata/p4_16_samples_outputs/psa-dpdk-token-too-big.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-token-too-big.p4.spec
@@ -100,8 +100,6 @@ struct local_metadata__dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpd4 {
 	bit<32> psa_ingress_input_metadata_ingress_port
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<16> Ingress_tmp
-	bit<16> Ingress_tmp_0
 }
 metadata instanceof local_metadata__dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpd4
 
@@ -129,8 +127,8 @@ action vxlan_encap_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dpdk_dp5 args instanc
 	mov h.vxlan.vni t.vxlan_vni
 	mov h.vxlan.reserved2 t.vxlan_reserved2
 	mov m.psa_ingress_output_metadata_egress_port t.port_out
-	ckadd h.cksum_state.state_0 m.Ingress_tmp
-	ckadd h.cksum_state.state_0 m.Ingress_tmp_0
+	ckadd h.cksum_state.state_0 h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.hdr_checksum
+	ckadd h.cksum_state.state_0 h.ipv4.total_len
 	mov h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.hdr_checksum h.cksum_state.state_0
 	mov h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.total_len t.ipv4_total_len
 	add h.outer_ipv4_dpdk_dpdk_dpdk_dpd3.total_len h.ipv4.total_len


### PR DESCRIPTION
dpdk does not expect operands of some of the statements as constant this pr prevent copy prop and elimination for those stmts.