### PR TITLE
cmake: Fixed multi line comment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,8 +265,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clan
     unset(_LD_OPT_USED)
 endif()
 
-set(BUILD_USE_COLOR OFF CACHE BOOL "Use color in C++ compiler output (even if "
-    "the compiler does not detect terminal, e.g. when using ccache/distcc)")
+set(BUILD_USE_COLOR OFF CACHE BOOL "Use color in C++ compiler output (even if \
+    the compiler does not detect terminal, e.g. when using ccache/distcc)")
 if (BUILD_USE_COLOR)
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdiagnostics-color=always")


### PR DESCRIPTION
Currently, this variable is broken - if you print BUILD_USE_COLOR you will see:
-- BUILD_USE_COLOR= OFF;CACHE;BOOL;Use color in C++ compiler output (even if ;the compiler does not detect terminal, e.g. when using ccache

So even if BUILD_USE_COLOR is OFF, inside if(...) this variable as evaluated as true ("OFF;CACHE;BOOL;Use color in C++ compiler output (even if ;the compiler does not detect terminal, e.g. when using ccache" is not empty")

Solution: Use \ for line continuation.

