### PR TITLE
Silence -Warray-bounds for generated code for protobuf

### DIFF
--- a/backends/dpdk/CMakeLists.txt
+++ b/backends/dpdk/CMakeLists.txt
@@ -24,8 +24,9 @@ set (DPDK_P4RUNTIME_INFO_PROTO ${DPDK_P4RUNTIME_DIR}/p4info.proto)
 set (DPDK_P4RUNTIME_INFO_GEN_SRCS ${P4C_BINARY_DIR}/control-plane/p4/config/dpdk/p4info.pb.cc)
 set (DPDK_P4RUNTIME_INFO_GEN_HDRS ${P4C_BINARY_DIR}/control-plane/p4/config/dpdk/p4info.pb.h)
 # The generated code for protobuf has an excessive number of warnings
+# Silence -Warray-bounds as the root issue is out of our control: https://github.com/protocolbuffers/protobuf/issues/7140
 set_source_files_properties(${DPDK_P4RUNTIME_INFO_GEN_SRCS} PROPERTIES
-  COMPILE_FLAGS "-Wno-unused-parameter")
+  COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds")
 
 add_custom_target (dpdk_runtime_dir
   ${CMAKE_COMMAND} -E make_directory

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -101,7 +101,8 @@ set (CONTROLPLANE_HDRS
 add_cpplint_files (${CMAKE_CURRENT_SOURCE_DIR} "${CONTROLPLANE_HDRS};${CONTROLPLANE_SRCS}")
 
 include_directories (${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-set_source_files_properties (${CONTROLPLANE_SOURCES} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
+# Silence -Warray-bounds as the root issue is out of our control: https://github.com/protocolbuffers/protobuf/issues/7140
+set_source_files_properties (${CONTROLPLANE_SOURCES} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds")
 set_source_files_properties (${P4RUNTIME_GEN_SRCS} PROPERTIES GENERATED TRUE)
 build_unified(CONTROLPLANE_SOURCES)
 add_library (controlplane STATIC ${CONTROLPLANE_SOURCES} )


### PR DESCRIPTION
Reason: https://github.com/protocolbuffers/protobuf/issues/7140

As there is no easy way to workaround it (generated code), silence it, to avoid breakages eg. for builds with -Werror.