### PR TITLE
Forbid use of .lastIndex outside of parsers

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -3117,8 +3117,9 @@ const IR::Node* TypeInference::postorder(IR::Member* expression) {
         if (member == IR::Type_Stack::next ||
             member == IR::Type_Stack::last) {
             if (parser == nullptr) {
-                typeError("%1%: 'last' and 'next' for stacks can only be used in a parser",
-                          expression);
+                typeError(
+                    "%1%: 'last', and 'next' for stacks can only be used in a parser",
+                    expression);
                 return expression;
             }
             auto stack = type->to<IR::Type_Stack>();
@@ -3134,6 +3135,12 @@ const IR::Node* TypeInference::postorder(IR::Member* expression) {
             setType(expression, IR::Type_Bits::get(32));
             return expression;
         } else if (member == IR::Type_Stack::lastIndex) {
+            if (parser == nullptr) {
+                typeError(
+                    "%1%: 'lastIndex' for stacks can only be used in a parser",
+                    expression);
+                return expression;
+            }
             setType(getOriginal(), IR::Type_Bits::get(32, false));
             setType(expression, IR::Type_Bits::get(32, false));
             return expression;

--- a/testdata/p4_14_errors_outputs/issue1853.p4-stderr
+++ b/testdata/p4_14_errors_outputs/issue1853.p4-stderr
@@ -1,3 +1,3 @@
-issue1853.p4(26): [--Werror=type-error] error: hdr.value.last: 'last' and 'next' for stacks can only be used in a parser
+issue1853.p4(26): [--Werror=type-error] error: hdr.value.last: 'last', and 'next' for stacks can only be used in a parser
     modify_field(value[last].bos, 0);
                  ^^^^^^^^^^^

--- a/testdata/p4_16_errors/issue3522.p4
+++ b/testdata/p4_16_errors/issue3522.p4
@@ -1,0 +1,11 @@
+header h {
+    bit field;
+};
+
+struct s {
+    h[2] field;
+};
+
+action a(in s v) {
+    bit<32> t = v.field.lastIndex;
+}

--- a/testdata/p4_16_errors_outputs/issue3522.p4
+++ b/testdata/p4_16_errors_outputs/issue3522.p4
@@ -1,0 +1,11 @@
+header h {
+    bit<1> field;
+}
+
+struct s {
+    h[2] field;
+}
+
+action a(in s v) {
+    bit<32> t = v.field.lastIndex;
+}

--- a/testdata/p4_16_errors_outputs/issue3522.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3522.p4-stderr
@@ -1,0 +1,3 @@
+issue3522.p4(10): [--Werror=type-error] error: v.field.lastIndex: 'lastIndex' for stacks can only be used in a parser
+    bit<32> t = v.field.lastIndex;
+                ^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/next.p4-stderr
+++ b/testdata/p4_16_errors_outputs/next.p4-stderr
@@ -1,3 +1,3 @@
-next.p4(24): [--Werror=type-error] error: stack.last: 'last' and 'next' for stacks can only be used in a parser
+next.p4(24): [--Werror=type-error] error: stack.last: 'last', and 'next' for stacks can only be used in a parser
         stack.last = { 10 };
         ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/stack2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack2.p4-stderr
@@ -18,7 +18,7 @@ stack2.p4(22)
 stack2.p4(21)
           h[5] stack1;
           ^^^^
-stack2.p4(25): [--Werror=type-error] error: Expression stack1.lastIndex cannot be the target of an assignment
+stack2.p4(25): [--Werror=type-error] error: stack1.lastIndex: 'lastIndex' for stacks can only be used in a parser
         stack1.lastIndex = 3; // not an l-value
         ^^^^^^^^^^^^^^^^
 stack2.p4(26): [--Werror=type-error] error: Expression stack2.size cannot be the target of an assignment


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>