### PR TITLE
Set C++ standard only if it is not set at parent scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ enable_testing ()
 # CMAKE_CXX_STANDARD was introduced in CMake 3.1, so for older versions of CMake, we use -std=gnu++11
 if (CMAKE_VERSION VERSION_LESS "3.1")
     set (CMAKE_CXX_FLAGS "-std=gnu++11 ${CMAKE_CXX_FLAGS}")
-else ()
+elseif(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 11)
     set (CMAKE_CXX_STANDARD 11)
 endif ()
 set (CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
This change allows cleaner inclusion of p4c into projects that set `CMAKE_CXX_STANDARD` to value greater then 11, it does not change anything if p4c is built standalone.

Essentially, in Intel we have top-level target that includes p4c and p4c then includes our extensions. We build our extensions with C++17, but we would like to build p4c with C++17  too to avoid having some code compiled with older standard. In particular, problem can be in the code that is built as part of `p4c`, but is coming from extensions (such as additional IR defs). With this change, we would be able to use C++17 cleanly.

Of course, anyone setting `CMAKE_CXX_STANDARD` > 11 takes the risk it will break something in p4c. This risk is very small for C++17 (bigger for C++20 if anyone would be brave enough to try it).