### PR TITLE
Change warrning messages in ParserUnroll

### DIFF
--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -638,7 +638,7 @@ class ParserSymbolicInterpreter {
                     if (equStackVariableMap(crt->statesIndexes, state->statesIndexes)) {
                         ::warning(ErrorType::ERR_INVALID,
                                   "Parser cycle can't be unrolled, because ParserUnroll can't \
-                                   detect the number of loops iterations:\n%1%",
+                                   detect the number of loop iterations:\n%1%",
                                   stateChain(state));
                         wasError = true;
                     }

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -635,16 +635,11 @@ class ParserSymbolicInterpreter {
                             }
                         }
                     }
-
-                    if (conservative)
-                        ::warning(ErrorType::WARN_PARSER_TRANSITION,
-                                    "Potential parser cycle without extracting any bytes:\n%1%",
-                                    stateChain(state));
-                    else
-                        ::warning(ErrorType::ERR_INVALID,
-                                  "Parser cycle without extracting any bytes:\n%1%",
-                                  stateChain(state));
                     if (equStackVariableMap(crt->statesIndexes, state->statesIndexes)) {
+                        ::warning(ErrorType::ERR_INVALID,
+                                  "Parser cycle can't be unrolled, because ParserUnroll can't \
+                                   detect the number of loops iterations:\n%1%",
+                                  stateChain(state));
                         wasError = true;
                     }
                     return true;

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -625,20 +625,18 @@ class ParserSymbolicInterpreter {
                 auto packets = state->before->filter(filter);
                 auto prevPackets = crt->before->filter(filter);
                 if (packets->equals(prevPackets)) {
-                    bool conservative = false;
                     for (auto p : state->before->map) {
                         if (p.second->is<SymbolicPacketIn>()) {
                             auto pkt = p.second->to<SymbolicPacketIn>();
                             if (pkt->isConservative()) {
-                                conservative = true;
                                 break;
                             }
                         }
                     }
                     if (equStackVariableMap(crt->statesIndexes, state->statesIndexes)) {
                         ::warning(ErrorType::ERR_INVALID,
-                                  "Parser cycle can't be unrolled, because ParserUnroll can't \
-                                   detect the number of loop iterations:\n%1%",
+                                  "Parser cycle can't be unrolled, because ParserUnroll can't "
+                                  "detect the number of loop iterations:\n%1%",
                                   stateChain(state));
                         wasError = true;
                     }
@@ -648,6 +646,10 @@ class ParserSymbolicInterpreter {
                 // If no header validity has changed we can't really unroll
                 if (!headerValidityChange(crt->before, state->before)) {
                     if (equStackVariableMap(crt->statesIndexes, state->statesIndexes)) {
+                        ::warning(ErrorType::ERR_INVALID,
+                                  "Parser cycle can't be unrolled, because ParserUnroll can't "
+                                  "detect the number of loop iterations:\n%1%",
+                                  stateChain(state));
                         wasError = true;
                     }
                     return true;

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue3537-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue3537-1.p4-stderr
@@ -1,2 +1,2 @@
-[--Wwarn=invalid] warning: Parser cycle without extracting any bytes:
+[--Wwarn=invalid] warning: Parser cycle can't be unrolled, because ParserUnroll can't detect the number of loop iterations:
 Parser ParserI state chain: start, s1, s2, s2

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue3537.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue3537.p4-stderr
@@ -4,3 +4,5 @@ parser-unroll-issue3537.p4(62): [--Wwarn=ignore-prop] warning: Result of packet.
 parser-unroll-issue3537.p4(42): [--Wwarn=ignore-prop] warning: Result of packet.extract is not defined: Exception: OverwritingHeader
         packet.extract<h3_t>(hdr.h3);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[--Wwarn=invalid] warning: Parser cycle can't be unrolled, because ParserUnroll can't detect the number of loop iterations:
+Parser ParserI state chain: start, parse_ipv6, parse_udp, parse_ipv4, parse_udp, parse_ipv4, parse_udp


### PR DESCRIPTION
These changes were done according to #3544. ParserUnroll hasn't any deep analysis for the real reason of non-unrolled loops. I think that such analysis will need the same efforts for implementation as ParserUnroll. So, I think that the warning messages should be changed:  ParserUnroll can't detect the number of loop iterations without an explanation of the real reason.