### PR TITLE
Introduce cmake option to enable -Werror; use it for CI/docker builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ OPTION (ENABLE_GC "Use libgc" ON)
 OPTION (ENABLE_MULTITHREAD "Use multithreading" OFF)
 OPTION (ENABLE_GMP "Use GMP library" ON)
 OPTION (ENABLE_LTO "Enable Link Time Optimization (LTO)" OFF)
+OPTION (ENABLE_WERROR "Treat warnings as errors" OFF)
 OPTION (BUILD_STATIC_RELEASE "Build a statically linked release binary" OFF)
 
 set (P4C_DRIVER_NAME "p4c" CACHE STRING "Customize the name of the driver script")
@@ -218,6 +219,10 @@ add_cxx_compiler_option ("-Wno-deprecated")
 add_cxx_compiler_option ("-Wno-deprecated-declarations")
 # Enable/disable runtime exceptions on nullpointer dereferencing
 # add_cxx_compiler_option ("-fsanitize=null")
+
+if (ENABLE_WERROR)
+  add_cxx_compiler_option  ("-Werror")
+endif ()
 
 # If we're on GCC or Clang, use the prefer LLD or Gold linker if available.
 set(BUILD_LINK_WITH_GOLD ON CACHE BOOL "Use Gold linker for build if available")

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ ARG INSTALL_PTF_EBPF_DEPENDENCIES=OFF
 ARG KERNEL_VERSIONS
 # Whether to build the P4Tools back end and platform.
 ARG ENABLE_TEST_TOOLS=OFF
+# Whether to treat warnings as errors.
+ARG ENABLE_WERROR=ON
 
 # Delegate the build to tools/ci-build.
 COPY . /p4c/

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ p4c has package support for several Ubuntu and Debian distributions.
 
 ### Ubuntu
 
-A p4c pacakge is available in the following repositories for Ubuntu 20.04 and newer.
+A p4c package is available in the following repositories for Ubuntu 20.04 and newer.
 
 ```bash
 . /etc/os-release
@@ -199,6 +199,7 @@ sudo dpkg -i /path/to/package.deb
      - `-DBUILD_LINK_WITH_GOLD=ON|OFF`. Use Gold linker for build if available.
      - `-DBUILD_LINK_WITH_LLD=ON|OFF`. Use LLD linker for build if available (overrides BUILD_LINK_WITH_GOLD).
      - `-DENABLE_LTO=ON|OFF`. Use Link Time Optimization (LTO).  Default is OFF.
+     - `-DENABLE_WERROR=ON|OFF`. Treat warnings as errors.  Default is OFF.
 
     If adding new targets to this build system, please see
     [instructions](#defining-new-cmake-targets).

--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -46,7 +46,7 @@ void DpdkContextGenerator::CollectTablesAndSetAttributes() {
         auto control = kv.second->to<IR::P4Control>();
         for (auto d : control->controlLocals) {
             if (auto tbl = d->to<IR::P4Table>()) {
-                struct TableAttributes tblAttr;
+                struct TableAttributes tblAttr = {};
                 tblAttr.direction = direction;
                 tblAttr.controlName = control->name.originalName;
                 tblAttr.externalName = tbl->controlPlaneName();

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -168,8 +168,9 @@ CMAKE_FLAGS+="-DENABLE_GMP=${ENABLE_GMP} "
 # Toggle the installation of the tools back end.
 CMAKE_FLAGS+="-DENABLE_TEST_TOOLS=${ENABLE_TEST_TOOLS} "
 # RELEASE should be default, but we want to make sure.
-CMAKE_FLAGS+="-DCMAKE_BUILD_TYPE=RELEASE"
-
+CMAKE_FLAGS+="-DCMAKE_BUILD_TYPE=RELEASE "
+# Treat warnings as errors.
+CMAKE_FLAGS+="-DENABLE_WERROR=${ENABLE_WERROR} "
 build ${CMAKE_FLAGS}
 
 make install


### PR DESCRIPTION
CI should now guarantee that patches are warning-free.
Also really helps downstream users of p4c who build their own version of p4c compiler with -Werror.