### PR TITLE
Switch to macOS 11

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -96,7 +96,7 @@ jobs:
       working-directory: ./build
       if: matrix.unified == 'ON'
 
-  # Build and test p4c on MacOS 10.15
+  # Build and test p4c on MacOS 11
   build-mac-os:
     strategy:
       fail-fast: false
@@ -106,7 +106,7 @@ jobs:
         exclude:
           - unified: OFF
             enable_gmp: OFF
-    runs-on: macos-10.15
+    runs-on: macos-11
     env:
       CTEST_PARALLEL_LEVEL: 4
     steps:

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ sudo dpkg -i /path/to/package.deb
     ```
 
 2.  Install [dependencies](#dependencies). You can find specific instructions
-    for Ubuntu 20.04 [here](#ubuntu-dependencies) and for macOS 10.12
+    for Ubuntu 20.04 [here](#ubuntu-dependencies) and for macOS 11
     [here](#macos-dependencies).  You can also look at the
     [CI installation script](tools/ci-build.sh).
 
@@ -221,7 +221,7 @@ If you plan to contribute to p4c, you'll find more useful information
 # Dependencies
 
 Ubuntu 20.04 is the officially supported platform for p4c. There's also
-unofficial support for macOS 10.12. Other platforms are untested; you can try to
+unofficial support for macOS 11. Other platforms are untested; you can try to
 use them, but YMMV.
 
 - A C++17 compiler. GCC 9.1 or later or Clang 6.0 or later is required.


### PR DESCRIPTION
Github actions with macos 10.15 are broken due to ongoing brownout period as macos 10.15 support is deprecated.
Please see:
https://github.com/actions/runner-images/issues/5583

So either we drop "official" support for macOS 10.15 or p4c will still support 10.15 "unofficially, without CI" as CI has to switch to macOS 11 anyway.

