### PR TITLE
add ICastable interface to Backtrack::trigger

### DIFF
--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -422,7 +422,7 @@ class ControlFlowVisitor : public virtual Visitor {
 
 class Backtrack : public virtual Visitor {
  public:
-    struct trigger {
+    struct trigger : public ICastable {
         enum type_t { OK, OTHER }       type;
         explicit trigger(type_t t) : type(t) {}
         virtual ~trigger();


### PR DESCRIPTION
to() and is() methods were removed from Backtrack::trigger in commit: 7e5040f85c570160c027405893abd7fbc4b6a170
but some backends use and need these methods.