### PR TITLE
Update gitmodule to fix cloning with https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,7 +11,7 @@
 	ignore = dirty
 [submodule "backends/p4tools/submodules/gsl-lite"]
 	path = backends/p4tools/submodules/gsl-lite
-	url = git@github.com:gsl-lite/gsl-lite
+	url = https://github.com/gsl-lite/gsl-lite.git
 [submodule "backends/p4tools/submodules/inja"]
 	path = backends/p4tools/submodules/inja
-	url = git@github.com:pantor/inja.git
+	url = https://github.com/pantor/inja.git


### PR DESCRIPTION
Cloning using https fails

```
Cloning into 'p4c/backends/p4tools/submodules/gsl-lite'...
ssh: connect to host github.com port 22: Connection timed out
fatal: Could not read from remote repository.



Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:gsl-lite/gsl-lite' into submodule path 'p4c/backends/p4tools/submodules/gsl-lite' failed
Failed to clone 'backends/p4tools/submodules/gsl-lite'. Retry scheduled
```