### PR TITLE
Fix and improve ordered_map & ordered_set

### DIFF
--- a/lib/ordered_map.h
+++ b/lib/ordered_map.h
@@ -84,6 +84,8 @@ class ordered_map {
  public:
     ordered_map() {}
     ordered_map(const ordered_map &a) : data(a.data) { init_data_map(); }
+    template<typename InputIt>
+    ordered_map(InputIt first, InputIt last) : data(first, last) { init_data_map(); }
     ordered_map(ordered_map &&a) = default; /* move is ok? */
     ordered_map &operator=(const ordered_map &a) {
         /* std::list assignment broken by spec if elements are const... */

--- a/lib/ordered_map.h
+++ b/lib/ordered_map.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define LIB_ORDERED_MAP_H_
 
 #include <functional>
+#include <initializer_list>
 #include <list>
 #include <map>
 #include <utility>
@@ -96,7 +97,7 @@ class ordered_map {
             init_data_map(); }
         return *this; }
     ordered_map &operator=(ordered_map &&a) = default; /* move is ok? */
-    ordered_map(const std::initializer_list<value_type> &il) : data(il) { init_data_map(); }
+    ordered_map(std::initializer_list<value_type> il) : data(il) { init_data_map(); }
     // FIXME add allocator and comparator ctors...
 
     iterator                    begin() noexcept { return data.begin(); }

--- a/lib/ordered_map.h
+++ b/lib/ordered_map.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <list>
 #include <map>
 #include <utility>
+#include <cassert>
 
 // Map is ordered by order of element insertion.
 template <class K, class V, class COMP = std::less<K>,
@@ -37,6 +38,7 @@ class ordered_map {
 
  private:
     typedef std::list<value_type, ALLOC>                list_type;
+    typedef typename list_type::iterator                list_iterator;
     list_type                                           data;
 
  public:
@@ -59,9 +61,10 @@ class ordered_map {
     struct mapcmp : std::binary_function<const K*, const K*, bool> {
         COMP    comp;
         bool operator()(const K *a, const K *b) const { return comp(*a, *b); } };
-    using map_alloc = typename ALLOC::template rebind<std::pair<const K * const, iterator>>::other;
-    typedef std::map<const K *, iterator, mapcmp, map_alloc> map_type;
-    map_type                            data_map;
+    using map_alloc = typename ALLOC::template rebind<std::pair<const K * const, list_iterator>>
+                                    ::other;
+    using map_type = std::map<const K *, list_iterator, mapcmp, map_alloc>;
+    map_type data_map;
     void init_data_map() {
         data_map.clear();
         for (auto it = data.begin(); it != data.end(); it++)
@@ -174,6 +177,9 @@ class ordered_map {
             data_map.emplace(&it->first, it);
             return std::make_pair(it, true); }
         return std::make_pair(it, false); }
+
+    /* TODO: should not exist, does not make sense for map that preserves
+     * insertion order. This function does not preserve it. */
     std::pair<iterator, bool> insert(iterator pos, const value_type &v) {
         /* should be const_iterator pos, but glibc++ std::list is broken */
         auto it = find(v.first);
@@ -184,15 +190,22 @@ class ordered_map {
         return std::make_pair(it, false); }
     template<class InputIterator> void insert(InputIterator b, InputIterator e) {
         while (b != e) insert(*b++); }
+
+    /* TODO: should not exist, does not make sense for map that preserves
+     * insertion order. This function does not preserve it. */
     template<class InputIterator>
     void insert(iterator pos, InputIterator b, InputIterator e) {
         /* should be const_iterator pos, but glibc++ std::list is broken */
         while (b != e) insert(pos, *b++); }
 
-    /* should be erase(const_iterator), but glibc++ std::list::erase is broken */
-    iterator erase(iterator pos) {
-        data_map.erase(&pos->first);
-        return data.erase(pos); }
+    iterator erase(const_iterator pos) {
+        auto it = data_map.find(&pos->first);
+        assert(it != data_map.end());
+        // get the non-const std::list iterator -- libstdc++ is missing
+        // std::list::erase(const_iterator) overload
+        auto list_it = it->second;
+        data_map.erase(it);
+        return data.erase(list_it); }
     size_type erase(const K &k) {
         auto it = find(k);
         if (it != data.end()) {

--- a/lib/ordered_set.h
+++ b/lib/ordered_set.h
@@ -94,6 +94,8 @@ class ordered_set {
     ordered_set() {}
     ordered_set(const ordered_set &a) : data(a.data) { init_data_map(); }
     ordered_set(std::initializer_list<T> init) : data(init) { init_data_map(); }
+    template<typename InputIt>
+    ordered_set(InputIt first, InputIt last) : data(first, last) { init_data_map(); }
     ordered_set(ordered_set &&a) = default; /* move is ok? */
     ordered_set &operator=(const ordered_set &a) { data = a.data; init_data_map(); return *this; }
     ordered_set &operator=(ordered_set &&a) = default; /* move is ok? */

--- a/lib/ordered_set.h
+++ b/lib/ordered_set.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include <map>
 #include <set>
 #include <utility>
+#include <cassert>
 
 // Remembers items in insertion order
 template <class T, class COMP = std::less<T>, class ALLOC = std::allocator<T>>
@@ -38,6 +39,7 @@ class ordered_set {
 
  private:
     typedef std::list<T, ALLOC> list_type;
+    typedef typename list_type::iterator list_iterator;
     list_type                   data;
 
  public:
@@ -50,9 +52,10 @@ class ordered_set {
     struct mapcmp : std::binary_function<const T *, const T *, bool> {
         COMP    comp;
         bool operator()(const T *a, const T *b) const { return comp(*a, *b); } };
-    using map_alloc = typename ALLOC::template rebind<std::pair<const T * const, iterator>>::other;
-    typedef std::map<const T *, iterator, mapcmp, map_alloc>    map_type;
-    map_type                            data_map;
+    using map_alloc = typename ALLOC::template rebind<std::pair<const T * const, list_iterator>>
+                                    ::other;
+    using map_type = std::map<const T *, list_iterator, mapcmp, map_alloc>;
+    map_type data_map;
     void init_data_map() {
         data_map.clear();
         for (auto it = data.begin(); it != data.end(); it++)
@@ -139,16 +142,16 @@ class ordered_set {
     const_iterator  lower_bound(const T &a) const { return tr_iter(data_map.lower_bound(&a)); }
 
     std::pair<iterator, bool> insert(const T &v) {
-        auto it = find(v);
+        iterator it = find(v);
         if (it == data.end()) {
-            it = data.insert(data.end(), v);
+            list_iterator it = data.insert(data.end(), v);
             data_map.emplace(&*it, it);
             return std::make_pair(it, true); }
         return std::make_pair(it, false); }
     std::pair<iterator, bool> insert(T &&v) {
-        auto it = find(v);
+        iterator it = find(v);
         if (it == data.end()) {
-            it = data.insert(data.end(), std::move(v));
+            list_iterator it = data.insert(data.end(), std::move(v));
             data_map.emplace(&*it, it);
             return std::make_pair(it, true); }
         return std::make_pair(it, false); }
@@ -157,33 +160,33 @@ class ordered_set {
             insert(*it);
     }
     iterator insert(const_iterator pos, const T &v) {
-        auto it = find(v);
+        iterator it = find(v);
         if (it == data.end()) {
-            it = data.insert(pos, v);
+            list_iterator it = data.insert(pos, v);
             data_map.emplace(&*it, it);
             return it; }
         return it;
     }
     iterator insert(const_iterator pos, T &&v) {
-        auto it = find(v);
+        iterator it = find(v);
         if (it == data.end()) {
-            it = data.insert(pos, std::move(v));
+            list_iterator it = data.insert(pos, std::move(v));
             data_map.emplace(&*it, it);
             return it; }
         return it;
     }
 
     void push_back(const T &v) {
-        auto it = find(v);
+        iterator it = find(v);
         if (it == data.end()) {
-            it = data.insert(data.end(), v);
+            list_iterator it = data.insert(data.end(), v);
             data_map.emplace(&*it, it);
         } else {
             data.splice(data.end(), data, it); } }
     void push_back(T &&v) {
-        auto it = find(v);
+        iterator it = find(v);
         if (it == data.end()) {
-            it = data.insert(data.end(), std::move(v));
+            list_iterator it = data.insert(data.end(), std::move(v));
             data_map.emplace(&*it, it);
         } else {
             data.splice(data.end(), data, it); } }
@@ -208,10 +211,14 @@ class ordered_set {
         data_map.emplace(&*it, it);
         return std::make_pair(it, true); }
 
-    /* should be erase(const_iterator), but glibc++ std::list::erase is broken */
-    iterator erase(iterator pos) {
-        data_map.erase(&*pos);
-        return data.erase(pos); }
+    iterator erase(const_iterator pos) {
+        auto it = data_map.find(&*pos);
+        assert(it != data_map.end());
+        // get the non-const std::list iterator -- libstdc++ is missing
+        // std::list::erase(const_iterator) overload
+        auto list_it = it->second;
+        data_map.erase(it);
+        return data.erase(list_it); }
     size_type erase(const T &v) {
         auto it = find(v);
         if (it != data.end()) {

--- a/lib/ordered_set.h
+++ b/lib/ordered_set.h
@@ -43,7 +43,11 @@ class ordered_set {
     list_type                   data;
 
  public:
-    typedef typename list_type::iterator                iterator;
+    // This is a set, so we can't provide any iterator that would make it
+    // possible to modify the values in the set and therefore possibly make the
+    // set contain duplicate values. Therefore we base all our iterators on
+    // list's const_iterator.
+    typedef typename list_type::const_iterator          iterator;
     typedef typename list_type::const_iterator          const_iterator;
     typedef std::reverse_iterator<iterator>             reverse_iterator;
     typedef std::reverse_iterator<const_iterator>       const_reverse_iterator;

--- a/test/gtest/ordered_map.cpp
+++ b/test/gtest/ordered_map.cpp
@@ -115,5 +115,38 @@ TEST(ordered_map, map_not_equal) {
     EXPECT_TRUE(a != b);
 }
 
+TEST(ordered_map, insert_emplace_erase) {
+    ordered_map<unsigned, unsigned> om;
+    std::map<unsigned, unsigned> sm;
+
+    typename ordered_map<unsigned, unsigned>::const_iterator it = om.end();
+    for (auto v : {0, 1, 2, 3, 4, 5, 6, 7, 8}) {
+        sm.emplace(v, 2 * v);
+        std::pair<unsigned, unsigned> pair {v, 2 * v};
+        if (v % 2 == 0) {
+            if ((v / 2) % 2 == 0) {
+                it = om.insert(pair).first;
+            } else {
+                it = om.emplace(v, pair.second).first;
+            }
+        } else {
+            if ((v / 2) % 2 == 0) {
+                it = om.insert(std::move(pair)).first;
+            } else {
+                it = om.emplace(std::move(v), v * 2).first;
+            }
+        }
+    }
+
+    EXPECT_TRUE(std::equal(om.begin(), om.end(), sm.begin(), sm.end()));
+
+    it = std::next(om.begin(), 2);
+    om.erase(it);
+    sm.erase(std::next(sm.begin(), 2));
+
+    EXPECT_TRUE(om.size() == sm.size());
+    EXPECT_TRUE(std::equal(om.begin(), om.end(), sm.begin(), sm.end()));
+}
+
 
 }  // namespace Test

--- a/test/gtest/ordered_set.cpp
+++ b/test/gtest/ordered_set.cpp
@@ -82,6 +82,30 @@ TEST(ordered_set, set_not_equal) {
     EXPECT_TRUE(a != b);
 }
 
+TEST(ordered_set, insert_erase_iterators) {
+    ordered_set<unsigned> set;
+    std::vector<unsigned> vec;
+
+    typename ordered_set<unsigned>::const_iterator it = set.end();
+    for (auto v : {0, 1, 2, 3, 4}) {
+        vec.push_back(v);
+        if (v % 2 == 0) {
+            it = std::next(set.insert(it, v));
+        } else {
+            it = std::next(set.insert(it, std::move(v)));
+        }
+    }
+
+    EXPECT_TRUE(std::equal(set.begin(), set.end(), vec.begin(), vec.end()));
+
+    it = std::next(set.begin(), 2);
+    set.erase(it);
+    vec.erase(vec.begin() + 2);
+
+    EXPECT_TRUE(set.size() == vec.size());
+    EXPECT_TRUE(std::equal(set.begin(), set.end(), vec.begin(), vec.end()));
+}
+
 TEST(ordered_set, set_intersect) {
     ordered_set<unsigned> a = { 5, 8, 1, 10, 4 };
     ordered_set<unsigned> b = { 4, 2, 9, 5, 1 };


### PR DESCRIPTION
* Fix erase in ordered_{set,map}

  - The original implementation used non-const iterator which makes the interface
  different from the standard set/map.
  - ordered_map::{insert,emplace}(iterator hint, ...) overloads have the same
  problem, but I kept them. These functions don't really make sense for
  insertion-order-preserving containers so it would be best to remove them. But
  that is not possible as they are used. The {insert,emplace} for a
  iterator-range with hint is very broken as it inserts values in the reverse
  order to whay they are in the input range.

* Do not expose modifying iterator from ordered_set

  - It is very unsafe -- if the value was changed using the iterator there is a
    risk of introducing duplicates in the set.
  - Therefore both iterator and const_iterator are now the same -- this matches
    what std::set does in libstdc++.

* Allow construction of ordered_{map,set} from iterator range
* Fix initalizer_list constructor in ordered_map 
  Initializer list is a reference-like object, pass it by value (as std:: does).