### PR TITLE
Dpdk Backend: Fix shift overlimit error for valid bit slicing operation

### DIFF
--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -1,9 +1,4 @@
 p4c_add_xfail_reason("dpdk"
-  "shift amount limited to 64 bits on this target"
-  testdata/p4_16_samples/psa-example-register2-bmv2.p4
-)
-
-p4c_add_xfail_reason("dpdk"
   "Expected packet length argument for count method of indirect counter"
   testdata/p4_16_samples/psa-example-counters-bmv2.p4
   )

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.spec
@@ -45,18 +45,17 @@ struct metadata {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<80> Ingress_tmp
 	bit<80> Ingress_tmp_0
-	bit<32> Ingress_tmp_1
-	bit<32> Ingress_tmp_2
-	bit<80> Ingress_tmp_3
-	bit<80> Ingress_tmp_4
-	bit<80> Ingress_tmp_5
+	bit<80> Ingress_tmp_1
+	bit<80> Ingress_tmp_2
+	bit<32> Ingress_tmp_4
 	bit<80> Ingress_tmp_6
-	bit<48> Ingress_tmp_7
-	bit<48> Ingress_tmp_8
-	bit<48> Ingress_tmp_9
+	bit<80> Ingress_tmp_7
+	bit<80> Ingress_tmp_8
+	bit<80> Ingress_tmp_9
 	bit<80> Ingress_tmp_10
-	bit<80> Ingress_tmp_11
-	bit<80> Ingress_tmp_12
+	bit<48> Ingress_tmp_13
+	bit<80> Ingress_tmp_15
+	bit<80> Ingress_tmp_16
 	bit<80> Ingress_s
 }
 metadata instanceof metadata
@@ -77,35 +76,38 @@ apply {
 	validate h.ipv4
 	mov h.ipv4.totalLen 0xe
 	jmpnv LABEL_END h.ipv4
-	regrd m.Ingress_tmp_12 port_pkt_ip_bytes_in_0 m.psa_ingress_input_metadata_ingress_port
-	mov m.Ingress_s m.Ingress_tmp_12
+	regrd m.Ingress_tmp_16 port_pkt_ip_bytes_in_0 m.psa_ingress_input_metadata_ingress_port
+	mov m.Ingress_s m.Ingress_tmp_16
 	mov m.Ingress_tmp m.Ingress_s
 	and m.Ingress_tmp 0xffffffffffff
-	mov m.Ingress_tmp_0 m.Ingress_tmp_12
+	mov m.Ingress_tmp_0 m.Ingress_tmp_16
 	shr m.Ingress_tmp_0 0x30
 	mov m.Ingress_tmp_1 m.Ingress_tmp_0
+	and m.Ingress_tmp_1 0xffffffff
 	mov m.Ingress_tmp_2 m.Ingress_tmp_1
-	add m.Ingress_tmp_2 0x1
-	mov m.Ingress_tmp_3 m.Ingress_tmp_2
-	mov m.Ingress_tmp_4 m.Ingress_tmp_3
-	shl m.Ingress_tmp_4 0x30
-	mov m.Ingress_tmp_5 m.Ingress_tmp_4
-	and m.Ingress_tmp_5 0xffffffff000000000000
+	and m.Ingress_tmp_2 0xffffffff
+	mov m.Ingress_tmp_4 m.Ingress_tmp_2
+	add m.Ingress_tmp_4 0x1
+	mov m.Ingress_tmp_6 m.Ingress_tmp_4
+	shl m.Ingress_tmp_6 0x30
+	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	and m.Ingress_tmp_7 0xffffffff000000000000
 	mov m.Ingress_s m.Ingress_tmp
-	or m.Ingress_s m.Ingress_tmp_5
-	mov m.Ingress_tmp_6 m.Ingress_s
-	and m.Ingress_tmp_6 0xffffffff000000000000
-	mov m.Ingress_tmp_7 m.Ingress_s
-	mov m.Ingress_tmp_8 h.ipv4.totalLen
-	mov m.Ingress_tmp_9 m.Ingress_tmp_7
-	add m.Ingress_tmp_9 m.Ingress_tmp_8
+	or m.Ingress_s m.Ingress_tmp_7
+	mov m.Ingress_tmp_8 m.Ingress_s
+	and m.Ingress_tmp_8 0xffffffff000000000000
+	mov m.Ingress_tmp_9 m.Ingress_s
+	and m.Ingress_tmp_9 0xffffffffffff
 	mov m.Ingress_tmp_10 m.Ingress_tmp_9
-	mov m.Ingress_tmp_11 m.Ingress_tmp_10
-	and m.Ingress_tmp_11 0xffffffffffff
-	mov m.Ingress_s m.Ingress_tmp_6
-	or m.Ingress_s m.Ingress_tmp_11
-	mov m.Ingress_tmp_12 m.Ingress_s
-	regwr port_pkt_ip_bytes_in_0 m.psa_ingress_input_metadata_ingress_port m.Ingress_tmp_12
+	and m.Ingress_tmp_10 0xffffffffffff
+	mov m.Ingress_tmp_13 m.Ingress_tmp_10
+	add m.Ingress_tmp_13 h.ipv4.totalLen
+	mov m.Ingress_tmp_15 m.Ingress_tmp_13
+	and m.Ingress_tmp_15 0xffffffffffff
+	mov m.Ingress_s m.Ingress_tmp_8
+	or m.Ingress_s m.Ingress_tmp_15
+	mov m.Ingress_tmp_16 m.Ingress_s
+	regwr port_pkt_ip_bytes_in_0 m.psa_ingress_input_metadata_ingress_port m.Ingress_tmp_16
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4


### PR DESCRIPTION
Bit slice operations are lowered into shift and mask operations. While creating the shift operation, the type of shift amount is also set same as the left operand which is not correct. The shift operation handling assumes that the constant is of Type_InfInt and handles constant of only Type_infInt type.
To fix this , the type of constant shift amount is set to Type_InfInt.