### PR TITLE
Dpdk backend: Support for large keysize >64 bytes with additional restrictions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,11 +344,11 @@ foreach (ext ${p4c_extensions})
   endif()
 endforeach(ext)
 
-# With the current implementation of ir-generator, all targets shares the
+# With the current implementation of ir-generator, all targets share the
 # same ir-generated.h and ir-generated.cpp file, which means all targets
 # share the same set of IR classes (frontend and backend). The DPDK backend
 # introduces additional IR classes and cpp sources which need to be added to
-# EXTENSION_FRONTEND_SOURCES. We need to pupulate EXTENSION_FRONTEND_SOURCES
+# EXTENSION_FRONTEND_SOURCES. We need to populate EXTENSION_FRONTEND_SOURCES
 # before it is added to libfrontend.a in frontends/CMakeList.txt
 if (ENABLE_DPDK)
     add_subdirectory (backends/dpdk)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,12 +201,12 @@ enable_testing ()
 #   set (CPACK_PACKAGE_VERSION_PATCH ${CPACK_PACKAGE_VERSION_PATCH}-${__P4C_VERSION_RC})
 # endif ()
 
-# set (CMAKE_CXX_EXTENSIONS OFF) # prefer using -std=c++11 rather than -std=gnu++11
-# CMAKE_CXX_STANDARD was introduced in CMake 3.1, so for older versions of CMake, we use -std=gnu++11
+# set (CMAKE_CXX_EXTENSIONS OFF) # prefer using -std=c++17 rather than -std=gnu++17
+# CMAKE_CXX_STANDARD was introduced in CMake 3.1, so for older versions of CMake, we use -std=gnu++17
 if (CMAKE_VERSION VERSION_LESS "3.1")
-    set (CMAKE_CXX_FLAGS "-std=gnu++11 ${CMAKE_CXX_FLAGS}")
-elseif(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 11)
-    set (CMAKE_CXX_STANDARD 11)
+    set (CMAKE_CXX_FLAGS "-std=gnu++17 ${CMAKE_CXX_FLAGS}")
+elseif(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 17)
+    set (CMAKE_CXX_STANDARD 17)
 endif ()
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Ubuntu 20.04 is the officially supported platform for p4c. There's also
 unofficial support for macOS 10.12. Other platforms are untested; you can try to
 use them, but YMMV.
 
-- A C++11 compiler. GCC 4.9 or later or Clang 3.3 or later is required.
+- A C++17 compiler. GCC 9.1 or later or Clang 6.0 or later is required.
 
 - `git` for version control
 
@@ -370,7 +370,7 @@ We recommend using `clang++` with no optimizations for speeding up
 compilation and simplifying debugging.
 
 We recommend installing a new version of [gdb](http://ftp.gnu.org/gnu/gdb).,
-because older gdb versions do not always handle C++11 correctly.
+because older gdb versions do not always handle C++11 or newer correctly.
 
 We recommend exuberant ctags for navigating source code in Emacs and vi.  `sudo
 apt-get install exuberant-ctags.` The Makefile targets `make ctags` and `make

--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -95,12 +95,6 @@ p4c_add_xfail_reason("dpdk"
   )
 
 p4c_add_xfail_reason("dpdk"
-  "All table keys together with holes in the underlying structure should fit in 64 bytes"
-   testdata/p4_16_samples/psa-dpdk-table-key-error.p4
-   testdata/p4_16_samples/psa-dpdk-table-key-error-1.p4
-   )
-
-p4c_add_xfail_reason("dpdk"
   "must only be called from within an action"
   testdata/p4_16_samples/pna-add-on-miss-err.p4
   testdata/p4_16_samples/pna-example-tcp-connection-tracking-err-1.p4

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -139,7 +139,6 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new CopyPropagationAndElimination(typeMap),
         new CollectUsedMetadataField(used_fields),
         new RemoveUnusedMetadataFields(used_fields),
-        new ValidateTableKeys(),
         new ShortenTokenLength(),
     };
 

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -809,9 +809,25 @@ class CollectTableInfo : public Inspector {
 // This pass must be called right before CollectLocalVariables pass as the temporary
 // variables created for holding copy of the table keys are inserted to Metadata by
 // CollectLocalVariables pass.
+struct keyElementInfo {
+    int offsetInMetadata;
+    int size;
+};
+
+struct keyInfo {
+    int numElements;
+    int numExistingMetaFields;
+    bool isLearner;
+    bool isExact;
+    int size;
+    std::vector<struct keyElementInfo *> elements;
+};
+
 class CopyMatchKeysToSingleStruct : public P4::KeySideEffect {
     IR::IndexedVector<IR::Declaration> decls;
     DpdkProgramStructure *structure;
+    bool metaCopyNeeded;
+
  public:
     CopyMatchKeysToSingleStruct(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
              std::set<const IR::P4Table*>* invokedInKey, DpdkProgramStructure *structure)
@@ -822,6 +838,9 @@ class CopyMatchKeysToSingleStruct : public P4::KeySideEffect {
     const IR::Node* postorder(IR::KeyElement* element) override;
     const IR::Node* doStatement(const IR::Statement* statement,
                                 const IR::Expression* expression) override;
+    struct keyInfo *getKeyInfo(IR::Key* keys);
+    int getFieldSizeBits(const IR::Type *field_type);
+    bool isLearnerTable(const IR::P4Table *t);
 };
 
 /**

--- a/backends/dpdk/dpdkAsmOpt.h
+++ b/backends/dpdk/dpdkAsmOpt.h
@@ -164,15 +164,6 @@ class RemoveUnusedMetadataFields : public Transform {
     bool isByteSizeField(const IR::Type *field_type);
 };
 
-// This pass validates that the table keys from Metadata struct fit within 64 bytes including any
-// holes between the key fields in metadata.
-class ValidateTableKeys : public Inspector {
- public:
-    ValidateTableKeys() {}
-    bool preorder(const IR::DpdkAsmProgram *p) override;
-    int getFieldSizeBits(const IR::Type *field_type);
-};
-
 // This pass shorten the Identifier length
 class ShortenTokenLength : public Transform {
     ordered_map<cstring, cstring> newNameMap;

--- a/backends/dpdk/dpdkProgram.cpp
+++ b/backends/dpdk/dpdkProgram.cpp
@@ -518,7 +518,6 @@ bool ConvertToDpdkControl::preorder(const IR::P4Action *a) {
 
 /* This function checks if a table satisfies the DPDK limitations mentioned below:
      - Only one LPM match field allowed per table.
-     - Maximum allowed key size of header/metadata field is 64 bits.
      - If there is a key field with lpm match kind, the other match fields, if any,
        must all be exact match.
 */

--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -26,6 +26,7 @@ using Parser = P4::P4Parser;
 #pragma GCC diagnostic ignored "-Wtautological-undefined-compare"
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wnull-conversion"
+#pragma clang diagnostic ignored "-Wregister"
 #endif
 
 %}

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1403,8 +1403,7 @@ expression
     | TRUE                               { $$ = new IR::BoolLiteral(@1, true); }
     | FALSE                              { $$ = new IR::BoolLiteral(@1, false); }
     | THIS                               { $$ = new IR::This(@1); }
-    | nonTypeName                        { $$ = new IR::PathExpression(*$1); }
-    | dotPrefix nonTypeName              { $$ = new IR::PathExpression(new IR::Path(*$2, true)); driver.structure->clearPath(); }
+    | prefixedNonTypeName                { $$ = new IR::PathExpression($1); }
     | expression "[" expression "]"      { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | expression "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
     | "{" expressionList "}"             { $$ = new IR::ListExpression(@1 + @3, *$2); }
@@ -1460,8 +1459,7 @@ nonBraceExpression
     | TRUE                               { $$ = new IR::BoolLiteral(@1, true); }
     | FALSE                              { $$ = new IR::BoolLiteral(@1, false); }
     | THIS                               { $$ = new IR::This(@1); }
-    | nonTypeName                        { $$ = new IR::PathExpression(*$1); }
-    | dotPrefix nonTypeName              { $$ = new IR::PathExpression(new IR::Path(*$2, true)); driver.structure->clearPath(); }
+    | prefixedNonTypeName                { $$ = new IR::PathExpression($1); }
     | nonBraceExpression "[" expression "]"      { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | nonBraceExpression "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
     | "(" expression ")"                 { $$ = $2; }

--- a/frontends/parsers/v1/v1lexer.ll
+++ b/frontends/parsers/v1/v1lexer.ll
@@ -22,6 +22,7 @@ using Parser = V1::V1Parser;
 #pragma GCC diagnostic ignored "-Wtautological-undefined-compare"
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wnull-conversion"
+#pragma clang diagnostic ignored "-Wregister"
 #endif
 
 %}

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -68,9 +68,15 @@ void operator delete(void *p) _GLIBCXX_USE_NOEXCEPT {
     gc::operator delete(p);
 }
 
+void operator delete(void *p, std::size_t) _GLIBCXX_USE_NOEXCEPT {
+    if (p >= emergency_pool && p < emergency_pool + sizeof(emergency_pool))
+        return;
+    gc::operator delete(p);
+}
+
 void *operator new[](std::size_t size) { return ::operator new(size); }
 void operator delete[](void *p) _GLIBCXX_USE_NOEXCEPT { ::operator delete(p); }
-
+void operator delete[](void *p, std::size_t) _GLIBCXX_USE_NOEXCEPT { ::operator delete(p); }
 
 namespace {
 

--- a/lib/hash.cpp
+++ b/lib/hash.cpp
@@ -59,10 +59,10 @@ std::uint32_t murmur32(const void* data, std::uint32_t size) {
     switch (size) {
     case 3:
         result ^= static_cast<unsigned char>(raw[2]) << 16;
-        // fallthrough
+        [[fallthrough]];
     case 2:
         result ^= static_cast<unsigned char>(raw[1]) << 8;
-        // fallthrough
+        [[fallthrough]];
     case 1:
         result ^= static_cast<unsigned char>(raw[0]);
         result *= m;

--- a/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-1.p4
+++ b/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-1.p4
@@ -1,0 +1,183 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+// BEGIN:Counter_Example_Part1
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+
+const bit<32> NUM_PORTS = 4;
+// END:Counter_Example_Part1
+
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    // empty for this skeleton
+    ExpireTimeProfileId_t timeout;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+// BEGIN:Counter_Example_Part2
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+            8w0x48 : exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name="next_hop2", action_params = {32w0, 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+// END:Counter_Example_Part2
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-2.p4
+++ b/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-2.p4
@@ -1,0 +1,184 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+// BEGIN:Counter_Example_Part1
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+
+const bit<32> NUM_PORTS = 4;
+// END:Counter_Example_Part1
+
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    // empty for this skeleton
+    ExpireTimeProfileId_t timeout;
+    bit<32> meta;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+// BEGIN:Counter_Example_Part2
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+            user_meta.meta : lpm;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name="next_hop2", action_params = {32w0, 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+// END:Counter_Example_Part2
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-3.p4
+++ b/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-3.p4
@@ -1,0 +1,183 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+// BEGIN:Counter_Example_Part1
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+
+const bit<32> NUM_PORTS = 4;
+// END:Counter_Example_Part1
+
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    // empty for this skeleton
+    ExpireTimeProfileId_t timeout;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+// BEGIN:Counter_Example_Part2
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+            hdr.ipv4.srcAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name="next_hop2", action_params = {32w0, 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+// END:Counter_Example_Part2
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-4.p4
+++ b/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-4.p4
@@ -1,0 +1,186 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+// BEGIN:Counter_Example_Part1
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+
+const bit<32> NUM_PORTS = 4;
+// END:Counter_Example_Part1
+
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    // empty for this skeleton
+    ExpireTimeProfileId_t timeout;
+    bit<32> meta;
+    bit<32> meta1;
+    bit<16> meta2;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+// BEGIN:Counter_Example_Part2
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            user_meta.meta2: exact;
+            user_meta.meta: exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name="next_hop2", action_params = {32w0, 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+// END:Counter_Example_Part2
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-5.p4
+++ b/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-5.p4
@@ -1,0 +1,187 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+// BEGIN:Counter_Example_Part1
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+
+const bit<32> NUM_PORTS = 4;
+// END:Counter_Example_Part1
+
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    // empty for this skeleton
+    ExpireTimeProfileId_t timeout;
+    bit<32> meta;
+    bit<32> meta1;
+    bit<16> meta2;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+// BEGIN:Counter_Example_Part2
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.srcAddr: exact;
+            hdr.ipv4.dstAddr: exact;
+            hdr.ipv4.totalLen: exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name="next_hop2", action_params = {32w0, 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+// END:Counter_Example_Part2
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-6.p4
+++ b/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-6.p4
@@ -1,0 +1,186 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+// BEGIN:Counter_Example_Part1
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+
+const bit<32> NUM_PORTS = 4;
+// END:Counter_Example_Part1
+
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    // empty for this skeleton
+    ExpireTimeProfileId_t timeout;
+    bit<32> meta;
+    bit<32> meta1;
+    bit<16> meta2;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+// BEGIN:Counter_Example_Part2
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.srcAddr: exact;
+            user_meta.meta: exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name="next_hop2", action_params = {32w0, 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+// END:Counter_Example_Part2
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-7.p4
+++ b/testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-7.p4
@@ -1,0 +1,188 @@
+/*
+Copyright 2020 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+// BEGIN:Counter_Example_Part1
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+
+const bit<32> NUM_PORTS = 4;
+// END:Counter_Example_Part1
+
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    // empty for this skeleton
+    ExpireTimeProfileId_t timeout;
+    bit<32> meta;
+    bit<32> meta1;
+    bit<16> meta2;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+// BEGIN:Counter_Example_Part2
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.srcAddr: exact;
+            hdr.ipv4.dstAddr: exact;
+            user_meta.meta: exact;
+            hdr.ethernet.isValid():exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name="next_hop2", action_params = {32w0, 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+// END:Counter_Example_Part2
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-5.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-5.p4
@@ -1,0 +1,168 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.tcp.dstPort : exact;
+            8w0x48 : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+// END:Parse_Error_Example
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+// BEGIN:Compute_New_IPv4_Checksum_Example
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+// END:Compute_New_IPv4_Checksum_Example
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-6.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-6.p4
@@ -1,0 +1,171 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+     bit<32> data1;
+     bit<8> data2;
+     bit<16> data3;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            user_meta.data : exact;
+            user_meta.data3 : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+// END:Parse_Error_Example
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+// BEGIN:Compute_New_IPv4_Checksum_Example
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+// END:Compute_New_IPv4_Checksum_Example
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-7.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-7.p4
@@ -1,0 +1,172 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+     bit<32> data1;
+     bit<8> data2;
+     bit<16> data3;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            user_meta.data : exact;
+            8w0x48 : exact;
+            hdr.tcp.dstPort: exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+// END:Parse_Error_Example
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+// BEGIN:Compute_New_IPv4_Checksum_Example
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+// END:Compute_New_IPv4_Checksum_Example
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-8.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-8.p4
@@ -1,0 +1,168 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr : exact;
+            hdr.ethernet.dstAddr : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+// END:Parse_Error_Example
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+// BEGIN:Compute_New_IPv4_Checksum_Example
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+// END:Compute_New_IPv4_Checksum_Example
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-9.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-key-consolidation-mixed-keys-9.p4
@@ -1,0 +1,182 @@
+#include <core.p4>
+#include <psa.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+
+struct metadata {
+     bit<16> data;
+     bit<16> data1;
+     bit<16> data2;
+     bit<16> data3;
+     bit<16> data4;
+     bit<16> data5;
+     bit<16> data6;
+     bit<16> data7;
+     bit<16> data8;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta)
+{
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800 &&& 0x0F00 : parse_ipv4;
+            16w0x0d00 : parse_tcp;
+            default : accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.tcp.dstPort : exact;
+            8w0x48 : exact;
+            user_meta.data : exact;
+            user_meta.data2 : exact;
+            user_meta.data4 : exact;
+            user_meta.data5 : exact;
+            user_meta.data6 : exact;
+            user_meta.data3 : exact;
+        }
+        actions = { NoAction; execute; }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+// END:Parse_Error_Example
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+// BEGIN:Compute_New_IPv4_Checksum_Example
+control EgressDeparserImpl(packet_out packet,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+// END:Compute_New_IPv4_Checksum_Example
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1-first.p4
@@ -1,0 +1,115 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 32w4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+            8w0x48          : exact @name("0x48") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1-frontend.p4
@@ -1,0 +1,112 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<32> tmp_0;
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        tmp_0 = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp_0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+            8w0x48          : exact @name("0x48") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1-midend.p4
@@ -1,0 +1,135 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+struct tuple_0 {
+    bit<32> f0;
+    bit<32> f1;
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    bit<8> key_0;
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        add_entry<bit<32>>(action_name = "next_hop", action_params = 32w0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+            key_0           : exact @name("0x48") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple_0>(action_name = "next_hop2", action_params = (tuple_0){f0 = 32w0,f1 = 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    @hidden action pnadpdktablekeyconsolidationlearner1l125() {
+        key_0 = 8w0x48;
+    }
+    @hidden table tbl_pnadpdktablekeyconsolidationlearner1l125 {
+        actions = {
+            pnadpdktablekeyconsolidationlearner1l125();
+        }
+        const default_action = pnadpdktablekeyconsolidationlearner1l125();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            tbl_pnadpdktablekeyconsolidationlearner1l125.apply();
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdktablekeyconsolidationlearner1l168() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnadpdktablekeyconsolidationlearner1l168 {
+        actions = {
+            pnadpdktablekeyconsolidationlearner1l168();
+        }
+        const default_action = pnadpdktablekeyconsolidationlearner1l168();
+    }
+    apply {
+        tbl_pnadpdktablekeyconsolidationlearner1l168.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4
@@ -1,0 +1,115 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+            8w0x48          : exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4-error
@@ -1,0 +1,7 @@
+pna-dpdk-table-key-consolidation-learner-1.p4(125): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            8w0x48 : exact;
+            ^^^^^^
+pna-dpdk-table-key-consolidation-learner-1.p4(125): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
+            8w0x48 : exact;
+            ^^^^^^
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table ipv4_da. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4-stderr
@@ -1,0 +1,6 @@
+pna-dpdk-table-key-consolidation-learner-1.p4(125): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            8w0x48 : exact;
+            ^^^^^^
+pna-dpdk-table-key-consolidation-learner-1.p4(125): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
+            8w0x48 : exact;
+            ^^^^^^

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4.bfrt.json
@@ -1,0 +1,156 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da",
+      "id" : 38237845,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "0x48",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 8
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 25584005,
+          "name" : "MainControlImpl.next_hop",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 18241179,
+          "name" : "MainControlImpl.add_on_miss_action",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da2",
+      "id" : 36615223,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 26610824,
+          "name" : "MainControlImpl.next_hop2",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            },
+            {
+              "id" : 2,
+              "name" : "newAddr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 25338952,
+          "name" : "MainControlImpl.add_on_miss_action2",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4.spec
@@ -1,0 +1,134 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct next_hop2_arg_t {
+	bit<32> vport
+	bit<32> newAddr
+}
+
+struct next_hop_arg_t {
+	bit<32> vport
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<8> local_metadata_timeout
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlImpl_ipv4_da_ipv4_dstAddr
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_0
+	bit<8> MainControlT_key
+	bit<32> learnArg
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray direction size 0x100 initval 0
+
+action next_hop args instanceof next_hop_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	return
+}
+
+action add_on_miss_action args none {
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg m.local_metadata_timeout
+	return
+}
+
+action next_hop2 args instanceof next_hop2_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov h.ipv4.srcAddr t.newAddr
+	return
+}
+
+action add_on_miss_action2 args none {
+	mov m.MainControlT_tmp 0x0
+	mov m.MainControlT_tmp_0 0x4d2
+	learn next_hop2 m.MainControlT_tmp m.local_metadata_timeout
+	return
+}
+
+learner ipv4_da {
+	key {
+		m.MainControlImpl_ipv4_da_ipv4_dstAddr
+		m.MainControlT_key
+	}
+	actions {
+		next_hop @tableonly
+		add_on_miss_action @defaultonly
+	}
+	default_action add_on_miss_action args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+learner ipv4_da2 {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop2 @tableonly
+		add_on_miss_action2 @defaultonly
+	}
+	default_action add_on_miss_action2 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
+	mov m.MainControlT_key 0x48
+	mov m.MainControlImpl_ipv4_da_ipv4_dstAddr h.ipv4.dstAddr
+	table ipv4_da
+	table ipv4_da2
+	LABEL_END :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2-first.p4
@@ -1,0 +1,116 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 32w4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+            user_meta.meta  : lpm @name("user_meta.meta") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2-frontend.p4
@@ -1,0 +1,113 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<32> tmp_0;
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        tmp_0 = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp_0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+            user_meta.meta  : lpm @name("user_meta.meta") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <pna.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {
@@ -27,8 +26,8 @@ struct empty_metadata_t {
 }
 
 struct main_metadata_t {
-    ExpireTimeProfileId_t timeout;
-    bit<32>               meta;
+    bit<8>  timeout;
+    bit<32> meta;
 }
 
 struct headers_t {
@@ -61,7 +60,7 @@ struct tuple_0 {
 }
 
 control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
-    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") bit<32> vport) {
         send_to_port(vport);
     }
     @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
@@ -79,7 +78,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         add_on_miss = true;
         const default_action = add_on_miss_action();
     }
-    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") bit<32> vport_2, @name("newAddr") bit<32> newAddr) {
         send_to_port(vport_2);
         hdr.ipv4.srcAddr = newAddr;
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2-midend.p4
@@ -1,0 +1,125 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+struct tuple_0 {
+    bit<32> f0;
+    bit<32> f1;
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        add_entry<bit<32>>(action_name = "next_hop", action_params = 32w0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+            user_meta.meta  : lpm @name("user_meta.meta") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple_0>(action_name = "next_hop2", action_params = (tuple_0){f0 = 32w0,f1 = 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdktablekeyconsolidationlearner2l169() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnadpdktablekeyconsolidationlearner2l169 {
+        actions = {
+            pnadpdktablekeyconsolidationlearner2l169();
+        }
+        const default_action = pnadpdktablekeyconsolidationlearner2l169();
+    }
+    apply {
+        tbl_pnadpdktablekeyconsolidationlearner2l169.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2.p4
@@ -1,0 +1,116 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+            user_meta.meta  : lpm;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table ipv4_da. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2.p4.bfrt.json
@@ -1,0 +1,156 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da",
+      "id" : 38237845,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "user_meta.meta",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "LPM",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 25584005,
+          "name" : "MainControlImpl.next_hop",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 18241179,
+          "name" : "MainControlImpl.add_on_miss_action",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da2",
+      "id" : 36615223,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 26610824,
+          "name" : "MainControlImpl.next_hop2",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            },
+            {
+              "id" : 2,
+              "name" : "newAddr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 25338952,
+          "name" : "MainControlImpl.add_on_miss_action2",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-2.p4.spec
@@ -1,0 +1,133 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct next_hop2_arg_t {
+	bit<32> vport
+	bit<32> newAddr
+}
+
+struct next_hop_arg_t {
+	bit<32> vport
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<8> local_metadata_timeout
+	bit<32> local_metadata_meta
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlImpl_ipv4_da_ipv4_dstAddr
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_0
+	bit<32> learnArg
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray direction size 0x100 initval 0
+
+action next_hop args instanceof next_hop_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	return
+}
+
+action add_on_miss_action args none {
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg m.local_metadata_timeout
+	return
+}
+
+action next_hop2 args instanceof next_hop2_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov h.ipv4.srcAddr t.newAddr
+	return
+}
+
+action add_on_miss_action2 args none {
+	mov m.MainControlT_tmp 0x0
+	mov m.MainControlT_tmp_0 0x4d2
+	learn next_hop2 m.MainControlT_tmp m.local_metadata_timeout
+	return
+}
+
+learner ipv4_da {
+	key {
+		m.MainControlImpl_ipv4_da_ipv4_dstAddr
+		m.local_metadata_meta
+	}
+	actions {
+		next_hop @tableonly
+		add_on_miss_action @defaultonly
+	}
+	default_action add_on_miss_action args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+learner ipv4_da2 {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop2 @tableonly
+		add_on_miss_action2 @defaultonly
+	}
+	default_action add_on_miss_action2 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
+	mov m.MainControlImpl_ipv4_da_ipv4_dstAddr h.ipv4.dstAddr
+	table ipv4_da
+	table ipv4_da2
+	LABEL_END :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3-first.p4
@@ -1,0 +1,115 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 32w4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.srcAddr: exact @name("hdr.ipv4.srcAddr") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3-frontend.p4
@@ -1,0 +1,112 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<32> tmp_0;
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        tmp_0 = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp_0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.srcAddr: exact @name("hdr.ipv4.srcAddr") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <pna.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {
@@ -27,7 +26,7 @@ struct empty_metadata_t {
 }
 
 struct main_metadata_t {
-    ExpireTimeProfileId_t timeout;
+    bit<8> timeout;
 }
 
 struct headers_t {
@@ -60,7 +59,7 @@ struct tuple_0 {
 }
 
 control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
-    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") bit<32> vport) {
         send_to_port(vport);
     }
     @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
@@ -78,7 +77,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         add_on_miss = true;
         const default_action = add_on_miss_action();
     }
-    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") bit<32> vport_2, @name("newAddr") bit<32> newAddr) {
         send_to_port(vport_2);
         hdr.ipv4.srcAddr = newAddr;
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3-midend.p4
@@ -1,0 +1,124 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+struct tuple_0 {
+    bit<32> f0;
+    bit<32> f1;
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        add_entry<bit<32>>(action_name = "next_hop", action_params = 32w0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.srcAddr: exact @name("hdr.ipv4.srcAddr") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple_0>(action_name = "next_hop2", action_params = (tuple_0){f0 = 32w0,f1 = 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdktablekeyconsolidationlearner3l168() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnadpdktablekeyconsolidationlearner3l168 {
+        actions = {
+            pnadpdktablekeyconsolidationlearner3l168();
+        }
+        const default_action = pnadpdktablekeyconsolidationlearner3l168();
+    }
+    apply {
+        tbl_pnadpdktablekeyconsolidationlearner3l168.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3.p4
@@ -1,0 +1,115 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+            hdr.ipv4.srcAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3.p4.bfrt.json
@@ -1,0 +1,156 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da",
+      "id" : 38237845,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ipv4.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 25584005,
+          "name" : "MainControlImpl.next_hop",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 18241179,
+          "name" : "MainControlImpl.add_on_miss_action",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da2",
+      "id" : 36615223,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 26610824,
+          "name" : "MainControlImpl.next_hop2",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            },
+            {
+              "id" : 2,
+              "name" : "newAddr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 25338952,
+          "name" : "MainControlImpl.add_on_miss_action2",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3.p4.spec
@@ -1,0 +1,130 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct next_hop2_arg_t {
+	bit<32> vport
+	bit<32> newAddr
+}
+
+struct next_hop_arg_t {
+	bit<32> vport
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<8> local_metadata_timeout
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_0
+	bit<32> learnArg
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray direction size 0x100 initval 0
+
+action next_hop args instanceof next_hop_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	return
+}
+
+action add_on_miss_action args none {
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg m.local_metadata_timeout
+	return
+}
+
+action next_hop2 args instanceof next_hop2_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov h.ipv4.srcAddr t.newAddr
+	return
+}
+
+action add_on_miss_action2 args none {
+	mov m.MainControlT_tmp 0x0
+	mov m.MainControlT_tmp_0 0x4d2
+	learn next_hop2 m.MainControlT_tmp m.local_metadata_timeout
+	return
+}
+
+learner ipv4_da {
+	key {
+		h.ipv4.dstAddr
+		h.ipv4.srcAddr
+	}
+	actions {
+		next_hop @tableonly
+		add_on_miss_action @defaultonly
+	}
+	default_action add_on_miss_action args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+learner ipv4_da2 {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop2 @tableonly
+		add_on_miss_action2 @defaultonly
+	}
+	default_action add_on_miss_action2 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
+	table ipv4_da
+	table ipv4_da2
+	LABEL_END :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4-first.p4
@@ -1,0 +1,118 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 32w4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            user_meta.meta2: exact @name("user_meta.meta2") ;
+            user_meta.meta : exact @name("user_meta.meta") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4-frontend.p4
@@ -1,0 +1,115 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<32> tmp_0;
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        tmp_0 = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp_0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            user_meta.meta2: exact @name("user_meta.meta2") ;
+            user_meta.meta : exact @name("user_meta.meta") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4-midend.p4
@@ -1,0 +1,127 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+struct tuple_0 {
+    bit<32> f0;
+    bit<32> f1;
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        add_entry<bit<32>>(action_name = "next_hop", action_params = 32w0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            user_meta.meta2: exact @name("user_meta.meta2") ;
+            user_meta.meta : exact @name("user_meta.meta") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple_0>(action_name = "next_hop2", action_params = (tuple_0){f0 = 32w0,f1 = 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdktablekeyconsolidationlearner4l171() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnadpdktablekeyconsolidationlearner4l171 {
+        actions = {
+            pnadpdktablekeyconsolidationlearner4l171();
+        }
+        const default_action = pnadpdktablekeyconsolidationlearner4l171();
+    }
+    apply {
+        tbl_pnadpdktablekeyconsolidationlearner4l171.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <pna.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {
@@ -27,10 +26,10 @@ struct empty_metadata_t {
 }
 
 struct main_metadata_t {
-    ExpireTimeProfileId_t timeout;
-    bit<32>               meta;
-    bit<32>               meta1;
-    bit<16>               meta2;
+    bit<8>  timeout;
+    bit<32> meta;
+    bit<32> meta1;
+    bit<16> meta2;
 }
 
 struct headers_t {
@@ -63,7 +62,7 @@ struct tuple_0 {
 }
 
 control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
-    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") bit<32> vport) {
         send_to_port(vport);
     }
     @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
@@ -81,7 +80,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         add_on_miss = true;
         const default_action = add_on_miss_action();
     }
-    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") bit<32> vport_2, @name("newAddr") bit<32> newAddr) {
         send_to_port(vport_2);
         hdr.ipv4.srcAddr = newAddr;
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4.p4
@@ -1,0 +1,118 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            user_meta.meta2: exact;
+            user_meta.meta : exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table ipv4_da. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4.p4.bfrt.json
@@ -1,0 +1,156 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da",
+      "id" : 38237845,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "user_meta.meta2",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "user_meta.meta",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 25584005,
+          "name" : "MainControlImpl.next_hop",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 18241179,
+          "name" : "MainControlImpl.add_on_miss_action",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da2",
+      "id" : 36615223,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 26610824,
+          "name" : "MainControlImpl.next_hop2",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            },
+            {
+              "id" : 2,
+              "name" : "newAddr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 25338952,
+          "name" : "MainControlImpl.add_on_miss_action2",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4.p4.spec
@@ -1,0 +1,136 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct next_hop2_arg_t {
+	bit<32> vport
+	bit<32> newAddr
+}
+
+struct next_hop_arg_t {
+	bit<32> vport
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<8> local_metadata_timeout
+	bit<32> local_metadata_meta
+	bit<16> local_metadata_meta2
+	bit<32> pna_main_output_metadata_output_port
+	bit<16> MainControlImpl_ipv4_da_local_metadata_meta2
+	bit<32> MainControlImpl_ipv4_da_local_metadata_meta
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_0
+	bit<32> learnArg
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray direction size 0x100 initval 0
+
+action next_hop args instanceof next_hop_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	return
+}
+
+action add_on_miss_action args none {
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg m.local_metadata_timeout
+	return
+}
+
+action next_hop2 args instanceof next_hop2_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov h.ipv4.srcAddr t.newAddr
+	return
+}
+
+action add_on_miss_action2 args none {
+	mov m.MainControlT_tmp 0x0
+	mov m.MainControlT_tmp_0 0x4d2
+	learn next_hop2 m.MainControlT_tmp m.local_metadata_timeout
+	return
+}
+
+learner ipv4_da {
+	key {
+		m.MainControlImpl_ipv4_da_local_metadata_meta2
+		m.MainControlImpl_ipv4_da_local_metadata_meta
+	}
+	actions {
+		next_hop @tableonly
+		add_on_miss_action @defaultonly
+	}
+	default_action add_on_miss_action args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+learner ipv4_da2 {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop2 @tableonly
+		add_on_miss_action2 @defaultonly
+	}
+	default_action add_on_miss_action2 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
+	mov m.MainControlImpl_ipv4_da_local_metadata_meta2 m.local_metadata_meta2
+	mov m.MainControlImpl_ipv4_da_local_metadata_meta m.local_metadata_meta
+	table ipv4_da
+	table ipv4_da2
+	LABEL_END :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5-first.p4
@@ -1,0 +1,119 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 32w4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.totalLen: exact @name("hdr.ipv4.totalLen") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5-frontend.p4
@@ -1,0 +1,116 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<32> tmp_0;
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        tmp_0 = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp_0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.totalLen: exact @name("hdr.ipv4.totalLen") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <pna.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {
@@ -27,10 +26,10 @@ struct empty_metadata_t {
 }
 
 struct main_metadata_t {
-    ExpireTimeProfileId_t timeout;
-    bit<32>               meta;
-    bit<32>               meta1;
-    bit<16>               meta2;
+    bit<8>  timeout;
+    bit<32> meta;
+    bit<32> meta1;
+    bit<16> meta2;
 }
 
 struct headers_t {
@@ -63,7 +62,7 @@ struct tuple_0 {
 }
 
 control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
-    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") bit<32> vport) {
         send_to_port(vport);
     }
     @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
@@ -82,7 +81,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         add_on_miss = true;
         const default_action = add_on_miss_action();
     }
-    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") bit<32> vport_2, @name("newAddr") bit<32> newAddr) {
         send_to_port(vport_2);
         hdr.ipv4.srcAddr = newAddr;
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5-midend.p4
@@ -1,0 +1,128 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+struct tuple_0 {
+    bit<32> f0;
+    bit<32> f1;
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        add_entry<bit<32>>(action_name = "next_hop", action_params = 32w0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.srcAddr : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr : exact @name("hdr.ipv4.dstAddr") ;
+            hdr.ipv4.totalLen: exact @name("hdr.ipv4.totalLen") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple_0>(action_name = "next_hop2", action_params = (tuple_0){f0 = 32w0,f1 = 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdktablekeyconsolidationlearner5l172() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnadpdktablekeyconsolidationlearner5l172 {
+        actions = {
+            pnadpdktablekeyconsolidationlearner5l172();
+        }
+        const default_action = pnadpdktablekeyconsolidationlearner5l172();
+    }
+    apply {
+        tbl_pnadpdktablekeyconsolidationlearner5l172.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5.p4
@@ -1,0 +1,119 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.srcAddr : exact;
+            hdr.ipv4.dstAddr : exact;
+            hdr.ipv4.totalLen: exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table ipv4_da. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5.p4.bfrt.json
@@ -1,0 +1,168 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da",
+      "id" : 38237845,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.ipv4.totalLen",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 25584005,
+          "name" : "MainControlImpl.next_hop",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 18241179,
+          "name" : "MainControlImpl.add_on_miss_action",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da2",
+      "id" : 36615223,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 26610824,
+          "name" : "MainControlImpl.next_hop2",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            },
+            {
+              "id" : 2,
+              "name" : "newAddr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 25338952,
+          "name" : "MainControlImpl.add_on_miss_action2",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5.p4.spec
@@ -1,0 +1,137 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct next_hop2_arg_t {
+	bit<32> vport
+	bit<32> newAddr
+}
+
+struct next_hop_arg_t {
+	bit<32> vport
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<8> local_metadata_timeout
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlImpl_ipv4_da_ipv4_srcAddr
+	bit<32> MainControlImpl_ipv4_da_ipv4_dstAddr
+	bit<16> MainControlImpl_ipv4_da_ipv4_totalLen
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_0
+	bit<32> learnArg
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray direction size 0x100 initval 0
+
+action next_hop args instanceof next_hop_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	return
+}
+
+action add_on_miss_action args none {
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg m.local_metadata_timeout
+	return
+}
+
+action next_hop2 args instanceof next_hop2_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov h.ipv4.srcAddr t.newAddr
+	return
+}
+
+action add_on_miss_action2 args none {
+	mov m.MainControlT_tmp 0x0
+	mov m.MainControlT_tmp_0 0x4d2
+	learn next_hop2 m.MainControlT_tmp m.local_metadata_timeout
+	return
+}
+
+learner ipv4_da {
+	key {
+		m.MainControlImpl_ipv4_da_ipv4_srcAddr
+		m.MainControlImpl_ipv4_da_ipv4_dstAddr
+		m.MainControlImpl_ipv4_da_ipv4_totalLen
+	}
+	actions {
+		next_hop @tableonly
+		add_on_miss_action @defaultonly
+	}
+	default_action add_on_miss_action args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+learner ipv4_da2 {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop2 @tableonly
+		add_on_miss_action2 @defaultonly
+	}
+	default_action add_on_miss_action2 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
+	mov m.MainControlImpl_ipv4_da_ipv4_srcAddr h.ipv4.srcAddr
+	mov m.MainControlImpl_ipv4_da_ipv4_dstAddr h.ipv4.dstAddr
+	mov m.MainControlImpl_ipv4_da_ipv4_totalLen h.ipv4.totalLen
+	table ipv4_da
+	table ipv4_da2
+	LABEL_END :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6-first.p4
@@ -1,0 +1,118 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 32w4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.srcAddr: exact @name("hdr.ipv4.srcAddr") ;
+            user_meta.meta  : exact @name("user_meta.meta") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6-frontend.p4
@@ -1,0 +1,115 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<32> tmp_0;
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        tmp_0 = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp_0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.srcAddr: exact @name("hdr.ipv4.srcAddr") ;
+            user_meta.meta  : exact @name("user_meta.meta") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6-midend.p4
@@ -1,0 +1,127 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+struct tuple_0 {
+    bit<32> f0;
+    bit<32> f1;
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        add_entry<bit<32>>(action_name = "next_hop", action_params = 32w0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.srcAddr: exact @name("hdr.ipv4.srcAddr") ;
+            user_meta.meta  : exact @name("user_meta.meta") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple_0>(action_name = "next_hop2", action_params = (tuple_0){f0 = 32w0,f1 = 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdktablekeyconsolidationlearner6l171() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnadpdktablekeyconsolidationlearner6l171 {
+        actions = {
+            pnadpdktablekeyconsolidationlearner6l171();
+        }
+        const default_action = pnadpdktablekeyconsolidationlearner6l171();
+    }
+    apply {
+        tbl_pnadpdktablekeyconsolidationlearner6l171.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <pna.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {
@@ -27,10 +26,10 @@ struct empty_metadata_t {
 }
 
 struct main_metadata_t {
-    ExpireTimeProfileId_t timeout;
-    bit<32>               meta;
-    bit<32>               meta1;
-    bit<16>               meta2;
+    bit<8>  timeout;
+    bit<32> meta;
+    bit<32> meta1;
+    bit<16> meta2;
 }
 
 struct headers_t {
@@ -63,7 +62,7 @@ struct tuple_0 {
 }
 
 control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
-    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") bit<32> vport) {
         send_to_port(vport);
     }
     @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
@@ -81,7 +80,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         add_on_miss = true;
         const default_action = add_on_miss_action();
     }
-    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") bit<32> vport_2, @name("newAddr") bit<32> newAddr) {
         send_to_port(vport_2);
         hdr.ipv4.srcAddr = newAddr;
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6.p4
@@ -1,0 +1,118 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.srcAddr: exact;
+            user_meta.meta  : exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table ipv4_da. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6.p4.bfrt.json
@@ -1,0 +1,156 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da",
+      "id" : 38237845,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "user_meta.meta",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 25584005,
+          "name" : "MainControlImpl.next_hop",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 18241179,
+          "name" : "MainControlImpl.add_on_miss_action",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da2",
+      "id" : 36615223,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 26610824,
+          "name" : "MainControlImpl.next_hop2",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            },
+            {
+              "id" : 2,
+              "name" : "newAddr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 25338952,
+          "name" : "MainControlImpl.add_on_miss_action2",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6.p4.spec
@@ -1,0 +1,133 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct next_hop2_arg_t {
+	bit<32> vport
+	bit<32> newAddr
+}
+
+struct next_hop_arg_t {
+	bit<32> vport
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<8> local_metadata_timeout
+	bit<32> local_metadata_meta
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlImpl_ipv4_da_ipv4_srcAddr
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_0
+	bit<32> learnArg
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray direction size 0x100 initval 0
+
+action next_hop args instanceof next_hop_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	return
+}
+
+action add_on_miss_action args none {
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg m.local_metadata_timeout
+	return
+}
+
+action next_hop2 args instanceof next_hop2_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov h.ipv4.srcAddr t.newAddr
+	return
+}
+
+action add_on_miss_action2 args none {
+	mov m.MainControlT_tmp 0x0
+	mov m.MainControlT_tmp_0 0x4d2
+	learn next_hop2 m.MainControlT_tmp m.local_metadata_timeout
+	return
+}
+
+learner ipv4_da {
+	key {
+		m.MainControlImpl_ipv4_da_ipv4_srcAddr
+		m.local_metadata_meta
+	}
+	actions {
+		next_hop @tableonly
+		add_on_miss_action @defaultonly
+	}
+	default_action add_on_miss_action args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+learner ipv4_da2 {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop2 @tableonly
+		add_on_miss_action2 @defaultonly
+	}
+	default_action add_on_miss_action2 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
+	mov m.MainControlImpl_ipv4_da_ipv4_srcAddr h.ipv4.srcAddr
+	table ipv4_da
+	table ipv4_da2
+	LABEL_END :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7-first.p4
@@ -1,0 +1,120 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 32w4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.srcAddr      : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr      : exact @name("hdr.ipv4.dstAddr") ;
+            user_meta.meta        : exact @name("user_meta.meta") ;
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7-frontend.p4
@@ -1,0 +1,117 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<32> tmp_0;
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        tmp_0 = 32w0;
+        add_entry<bit<32>>(action_name = "next_hop", action_params = tmp_0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.srcAddr      : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr      : exact @name("hdr.ipv4.dstAddr") ;
+            user_meta.meta        : exact @name("user_meta.meta") ;
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple<bit<32>, bit<32>>>(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <pna.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {
@@ -27,10 +26,10 @@ struct empty_metadata_t {
 }
 
 struct main_metadata_t {
-    ExpireTimeProfileId_t timeout;
-    bit<32>               meta;
-    bit<32>               meta1;
-    bit<16>               meta2;
+    bit<8>  timeout;
+    bit<32> meta;
+    bit<32> meta1;
+    bit<16> meta2;
 }
 
 struct headers_t {
@@ -63,7 +62,7 @@ struct tuple_0 {
 }
 
 control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
-    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") bit<32> vport) {
         send_to_port(vport);
     }
     @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
@@ -83,7 +82,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         add_on_miss = true;
         const default_action = add_on_miss_action();
     }
-    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") bit<32> vport_2, @name("newAddr") bit<32> newAddr) {
         send_to_port(vport_2);
         hdr.ipv4.srcAddr = newAddr;
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7-midend.p4
@@ -1,0 +1,129 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+struct tuple_0 {
+    bit<32> f0;
+    bit<32> f1;
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.next_hop") action next_hop(@name("vport") PortId_t vport) {
+        send_to_port(vport);
+    }
+    @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
+        add_entry<bit<32>>(action_name = "next_hop", action_params = 32w0, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da") table ipv4_da_0 {
+        key = {
+            hdr.ipv4.srcAddr      : exact @name("hdr.ipv4.srcAddr") ;
+            hdr.ipv4.dstAddr      : exact @name("hdr.ipv4.dstAddr") ;
+            user_meta.meta        : exact @name("user_meta.meta") ;
+            hdr.ethernet.isValid(): exact @name("hdr.ethernet.$valid$") ;
+        }
+        actions = {
+            @tableonly next_hop();
+            @defaultonly add_on_miss_action();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action();
+    }
+    @name("MainControlImpl.next_hop2") action next_hop2(@name("vport") PortId_t vport_2, @name("newAddr") bit<32> newAddr) {
+        send_to_port(vport_2);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    @name("MainControlImpl.add_on_miss_action2") action add_on_miss_action2() {
+        add_entry<tuple_0>(action_name = "next_hop2", action_params = (tuple_0){f0 = 32w0,f1 = 32w1234}, expire_time_profile_id = user_meta.timeout);
+    }
+    @name("MainControlImpl.ipv4_da2") table ipv4_da2_0 {
+        key = {
+            hdr.ipv4.dstAddr: exact @name("hdr.ipv4.dstAddr") ;
+        }
+        actions = {
+            @tableonly next_hop2();
+            @defaultonly add_on_miss_action2();
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2();
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_0.apply();
+            ipv4_da2_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdktablekeyconsolidationlearner7l173() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnadpdktablekeyconsolidationlearner7l173 {
+        actions = {
+            pnadpdktablekeyconsolidationlearner7l173();
+        }
+        const default_action = pnadpdktablekeyconsolidationlearner7l173();
+    }
+    apply {
+        tbl_pnadpdktablekeyconsolidationlearner7l173.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7.p4
@@ -1,0 +1,120 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+const bit<32> NUM_PORTS = 4;
+struct main_metadata_t {
+    ExpireTimeProfileId_t timeout;
+    bit<32>               meta;
+    bit<32>               meta1;
+    bit<16>               meta2;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action next_hop(PortId_t vport) {
+        send_to_port(vport);
+    }
+    action add_on_miss_action() {
+        bit<32> tmp = 0;
+        add_entry(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da {
+        key = {
+            hdr.ipv4.srcAddr      : exact;
+            hdr.ipv4.dstAddr      : exact;
+            user_meta.meta        : exact;
+            hdr.ethernet.isValid(): exact;
+        }
+        actions = {
+            @tableonly next_hop;
+            @defaultonly add_on_miss_action;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action;
+    }
+    action next_hop2(PortId_t vport, bit<32> newAddr) {
+        send_to_port(vport);
+        hdr.ipv4.srcAddr = newAddr;
+    }
+    action add_on_miss_action2() {
+        add_entry(action_name = "next_hop2", action_params = { 32w0, 32w1234 }, expire_time_profile_id = user_meta.timeout);
+    }
+    table ipv4_da2 {
+        key = {
+            hdr.ipv4.dstAddr: exact;
+        }
+        actions = {
+            @tableonly next_hop2;
+            @defaultonly add_on_miss_action2;
+        }
+        add_on_miss = true;
+        const default_action = add_on_miss_action2;
+    }
+    apply {
+        if (hdr.ipv4.isValid()) {
+            ipv4_da.apply();
+            ipv4_da2.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table ipv4_da. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7.p4.bfrt.json
@@ -1,0 +1,180 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da",
+      "id" : 38237845,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "user_meta.meta",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 4,
+          "name" : "hdr.ethernet.$valid",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 1
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 25584005,
+          "name" : "MainControlImpl.next_hop",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 18241179,
+          "name" : "MainControlImpl.add_on_miss_action",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.MainControlImpl.ipv4_da2",
+      "id" : 36615223,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 26610824,
+          "name" : "MainControlImpl.next_hop2",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "vport",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            },
+            {
+              "id" : 2,
+              "name" : "newAddr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 25338952,
+          "name" : "MainControlImpl.add_on_miss_action2",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7.p4.spec
@@ -1,0 +1,141 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct next_hop2_arg_t {
+	bit<32> vport
+	bit<32> newAddr
+}
+
+struct next_hop_arg_t {
+	bit<32> vport
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<8> local_metadata_timeout
+	bit<32> local_metadata_meta
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlImpl_ipv4_da_ipv4_srcAddr
+	bit<32> MainControlImpl_ipv4_da_ipv4_dstAddr
+	bit<8> MainControlImpl_ipv4_da_ethernet_isValid
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_0
+	bit<32> learnArg
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray direction size 0x100 initval 0
+
+action next_hop args instanceof next_hop_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	return
+}
+
+action add_on_miss_action args none {
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg m.local_metadata_timeout
+	return
+}
+
+action next_hop2 args instanceof next_hop2_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov h.ipv4.srcAddr t.newAddr
+	return
+}
+
+action add_on_miss_action2 args none {
+	mov m.MainControlT_tmp 0x0
+	mov m.MainControlT_tmp_0 0x4d2
+	learn next_hop2 m.MainControlT_tmp m.local_metadata_timeout
+	return
+}
+
+learner ipv4_da {
+	key {
+		m.MainControlImpl_ipv4_da_ipv4_srcAddr
+		m.MainControlImpl_ipv4_da_ipv4_dstAddr
+		m.local_metadata_meta
+		m.MainControlImpl_ipv4_da_ethernet_isValid
+	}
+	actions {
+		next_hop @tableonly
+		add_on_miss_action @defaultonly
+	}
+	default_action add_on_miss_action args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+learner ipv4_da2 {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop2 @tableonly
+		add_on_miss_action2 @defaultonly
+	}
+	default_action add_on_miss_action2 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
+	mov m.MainControlImpl_ipv4_da_ipv4_srcAddr h.ipv4.srcAddr
+	mov m.MainControlImpl_ipv4_da_ipv4_dstAddr h.ipv4.dstAddr
+	mov m.MainControlImpl_ipv4_da_ethernet_isValid 1
+	jmpv LABEL_END_0 h.ethernet
+	mov m.MainControlImpl_ipv4_da_ethernet_isValid 0
+	LABEL_END_0 :	table ipv4_da
+	table ipv4_da2
+	LABEL_END :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-1.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-1.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table flowTable. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-1.p4.spec
@@ -29,6 +29,9 @@ header ipv4 instanceof ipv4_t
 struct main_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlImpl_flowTable_ipv4_srcAddr
+	bit<32> MainControlImpl_flowTable_ipv4_dstAddr
+	bit<8> MainControlImpl_flowTable_ipv4_protocol
 	bit<8> mirrorSlot
 	bit<16> mirrorSession
 	bit<8> mirrorSlot_0
@@ -60,9 +63,9 @@ action drop_with_mirror args none {
 
 table flowTable {
 	key {
-		h.ipv4.srcAddr exact
-		h.ipv4.dstAddr exact
-		h.ipv4.protocol exact
+		m.MainControlImpl_flowTable_ipv4_srcAddr exact
+		m.MainControlImpl_flowTable_ipv4_dstAddr exact
+		m.MainControlImpl_flowTable_ipv4_protocol exact
 	}
 	actions {
 		send_with_mirror
@@ -80,7 +83,10 @@ apply {
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	MAINPARSERIMPL_ACCEPT :	table flowTable
+	MAINPARSERIMPL_ACCEPT :	mov m.MainControlImpl_flowTable_ipv4_srcAddr h.ipv4.srcAddr
+	mov m.MainControlImpl_flowTable_ipv4_dstAddr h.ipv4.dstAddr
+	mov m.MainControlImpl_flowTable_ipv4_protocol h.ipv4.protocol
+	table flowTable
 	emit h.ethernet
 	emit h.ipv4
 	tx m.pna_main_output_metadata_output_port

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table flowTable. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4.spec
@@ -28,6 +28,9 @@ header ipv4 instanceof ipv4_t
 struct main_metadata_t {
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlImpl_flowTable_ipv4_srcAddr
+	bit<32> MainControlImpl_flowTable_ipv4_dstAddr
+	bit<8> MainControlImpl_flowTable_ipv4_protocol
 	bit<8> mirrorSlot
 	bit<16> mirrorSession
 	bit<8> mirrorSlot_0
@@ -59,9 +62,9 @@ action drop_with_mirror args none {
 
 table flowTable {
 	key {
-		h.ipv4.srcAddr exact
-		h.ipv4.dstAddr exact
-		h.ipv4.protocol exact
+		m.MainControlImpl_flowTable_ipv4_srcAddr exact
+		m.MainControlImpl_flowTable_ipv4_dstAddr exact
+		m.MainControlImpl_flowTable_ipv4_protocol exact
 	}
 	actions {
 		send_with_mirror
@@ -79,7 +82,10 @@ apply {
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	MAINPARSERIMPL_ACCEPT :	table flowTable
+	MAINPARSERIMPL_ACCEPT :	mov m.MainControlImpl_flowTable_ipv4_srcAddr h.ipv4.srcAddr
+	mov m.MainControlImpl_flowTable_ipv4_dstAddr h.ipv4.dstAddr
+	mov m.MainControlImpl_flowTable_ipv4_protocol h.ipv4.protocol
+	table flowTable
 	emit h.ethernet
 	emit h.ipv4
 	tx m.pna_main_output_metadata_output_port

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4-error
@@ -4,3 +4,4 @@ psa-dpdk-table-key-consolidation-mixed-keys-3.p4(97): [--Wwarn=ignore-prop] warn
 psa-dpdk-table-key-consolidation-mixed-keys-3.p4(97): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
             8w0x48 : exact;
             ^^^^^^
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
@@ -57,7 +57,8 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
-	bit<8> Ingress_key
+	bit<16> ingress_tbl_local_metadata_data
+	bit<8> key_1
 	bit<16> tmpMask
 	bit<8> tmpMask_0
 }
@@ -78,8 +79,8 @@ action execute_1 args none {
 
 table tbl {
 	key {
-		m.local_metadata_data exact
-		m.Ingress_key exact
+		m.ingress_tbl_local_metadata_data exact
+		m.key_1 exact
 	}
 	actions {
 		NoAction
@@ -105,7 +106,8 @@ apply {
 	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
-	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_key 0x48
+	INGRESSPARSERIMPL_ACCEPT :	mov m.ingress_tbl_local_metadata_data m.local_metadata_data
+	mov m.key_1 0x48
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4-error
@@ -4,3 +4,4 @@ psa-dpdk-table-key-consolidation-mixed-keys-4.p4(119): [--Wwarn=ignore-prop] war
 psa-dpdk-table-key-consolidation-mixed-keys-4.p4(119): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
             8w0x48 : exact;
             ^^^^^^
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5-first.p4
@@ -1,0 +1,128 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 16w1;
+    }
+    table tbl {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+            8w0x48         : exact @name("0x48") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5-frontend.p4
@@ -1,0 +1,130 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+            8w0x48         : exact @name("0x48") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5-midend.p4
@@ -1,0 +1,159 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 &&& 8w252: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    bit<8> key_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+            key_0          : exact @name("0x48") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psadpdktablekeyconsolidationmixedkeys5l97() {
+        key_0 = 8w0x48;
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys5l97 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys5l97();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys5l97();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys5l97.apply();
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys5l137() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys5l137 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys5l137();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys5l137();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys5l137.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys5l153() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys5l153 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys5l153();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys5l153();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys5l153.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <bmv2/psa.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4
@@ -1,0 +1,127 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800 &&& 0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.tcp.dstPort: exact;
+            8w0x48         : exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4-error
@@ -1,0 +1,7 @@
+psa-dpdk-table-key-consolidation-mixed-keys-5.p4(97): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            8w0x48 : exact;
+            ^^^^^^
+psa-dpdk-table-key-consolidation-mixed-keys-5.p4(97): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
+            8w0x48 : exact;
+            ^^^^^^
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4-stderr
@@ -1,0 +1,6 @@
+psa-dpdk-table-key-consolidation-mixed-keys-5.p4(97): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            8w0x48 : exact;
+            ^^^^^^
+psa-dpdk-table-key-consolidation-mixed-keys-5.p4(97): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
+            8w0x48 : exact;
+            ^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4.bfrt.json
@@ -1,0 +1,60 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.tcp.dstPort",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "0x48",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 8
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4.p4info.txt
@@ -1,0 +1,46 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.tcp.dstPort"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "0x48"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4.spec
@@ -1,0 +1,120 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<16> dataOffset_res_ecn_ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct metadata {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<16> local_metadata_data
+	bit<16> ingress_tbl_tcp_dstPort
+	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.ingress_tbl_tcp_dstPort exact
+		m.Ingress_key exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_key 0x48
+	mov m.ingress_tbl_tcp_dstPort h.tcp.dstPort
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6-first.p4
@@ -1,0 +1,131 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<32> data1;
+    bit<8>  data2;
+    bit<16> data3;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 16w1;
+    }
+    table tbl {
+        key = {
+            user_meta.data : exact @name("user_meta.data") ;
+            user_meta.data3: exact @name("user_meta.data3") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6-frontend.p4
@@ -1,0 +1,133 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<32> data1;
+    bit<8>  data2;
+    bit<16> data3;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            user_meta.data : exact @name("user_meta.data") ;
+            user_meta.data3: exact @name("user_meta.data3") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6-midend.p4
@@ -1,0 +1,151 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<32> data1;
+    bit<8>  data2;
+    bit<16> data3;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 &&& 8w252: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            user_meta.data : exact @name("user_meta.data") ;
+            user_meta.data3: exact @name("user_meta.data3") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys6l140() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys6l140 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys6l140();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys6l140();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys6l140.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys6l156() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys6l156 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys6l156();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys6l156();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys6l156.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <bmv2/psa.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4
@@ -1,0 +1,130 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<32> data1;
+    bit<8>  data2;
+    bit<16> data3;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800 &&& 0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            user_meta.data : exact;
+            user_meta.data3: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4.bfrt.json
@@ -1,0 +1,60 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "user_meta.data",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "user_meta.data3",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4.p4info.txt
@@ -1,0 +1,46 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "user_meta.data"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "user_meta.data3"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4.spec
@@ -1,0 +1,121 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<16> dataOffset_res_ecn_ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct metadata {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<16> local_metadata_data
+	bit<16> local_metadata_data3
+	bit<16> ingress_tbl_local_metadata_data
+	bit<16> ingress_tbl_local_metadata_data3
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.ingress_tbl_local_metadata_data exact
+		m.ingress_tbl_local_metadata_data3 exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.ingress_tbl_local_metadata_data m.local_metadata_data
+	mov m.ingress_tbl_local_metadata_data3 m.local_metadata_data3
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7-first.p4
@@ -1,0 +1,132 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<32> data1;
+    bit<8>  data2;
+    bit<16> data3;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 16w1;
+    }
+    table tbl {
+        key = {
+            user_meta.data : exact @name("user_meta.data") ;
+            8w0x48         : exact @name("0x48") ;
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7-frontend.p4
@@ -1,0 +1,134 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<32> data1;
+    bit<8>  data2;
+    bit<16> data3;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            user_meta.data : exact @name("user_meta.data") ;
+            8w0x48         : exact @name("0x48") ;
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7-midend.p4
@@ -1,0 +1,163 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<32> data1;
+    bit<8>  data2;
+    bit<16> data3;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 &&& 8w252: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    bit<8> key_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            user_meta.data : exact @name("user_meta.data") ;
+            key_0          : exact @name("0x48") ;
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psadpdktablekeyconsolidationmixedkeys7l100() {
+        key_0 = 8w0x48;
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys7l100 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys7l100();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys7l100();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys7l100.apply();
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys7l141() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys7l141 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys7l141();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys7l141();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys7l141.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys7l157() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys7l157 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys7l157();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys7l157();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys7l157.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <bmv2/psa.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4
@@ -1,0 +1,131 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<32> data1;
+    bit<8>  data2;
+    bit<16> data3;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800 &&& 0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            user_meta.data : exact;
+            8w0x48         : exact;
+            hdr.tcp.dstPort: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4-error
@@ -1,0 +1,7 @@
+psa-dpdk-table-key-consolidation-mixed-keys-7.p4(100): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            8w0x48 : exact;
+            ^^^^^^
+psa-dpdk-table-key-consolidation-mixed-keys-7.p4(100): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
+            8w0x48 : exact;
+            ^^^^^^
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4-stderr
@@ -1,0 +1,6 @@
+psa-dpdk-table-key-consolidation-mixed-keys-7.p4(100): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            8w0x48 : exact;
+            ^^^^^^
+psa-dpdk-table-key-consolidation-mixed-keys-7.p4(100): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
+            8w0x48 : exact;
+            ^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4.bfrt.json
@@ -1,0 +1,72 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "user_meta.data",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "0x48",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 8
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.tcp.dstPort",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4.p4info.txt
@@ -1,0 +1,52 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "user_meta.data"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "0x48"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  match_fields {
+    id: 3
+    name: "hdr.tcp.dstPort"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4.spec
@@ -1,0 +1,121 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<16> dataOffset_res_ecn_ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct metadata {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<16> local_metadata_data
+	bit<16> ingress_tbl_tcp_dstPort
+	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.local_metadata_data exact
+		m.Ingress_key exact
+		m.ingress_tbl_tcp_dstPort exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_key 0x48
+	mov m.ingress_tbl_tcp_dstPort h.tcp.dstPort
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8-first.p4
@@ -1,0 +1,128 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 16w1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            hdr.ethernet.dstAddr: exact @name("hdr.ethernet.dstAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8-frontend.p4
@@ -1,0 +1,130 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            hdr.ethernet.dstAddr: exact @name("hdr.ethernet.dstAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8-midend.p4
@@ -1,0 +1,148 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 &&& 8w252: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            hdr.ethernet.dstAddr: exact @name("hdr.ethernet.dstAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys8l137() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys8l137 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys8l137();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys8l137();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys8l137.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys8l153() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys8l153 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys8l153();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys8l153();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys8l153.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <bmv2/psa.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8.p4
@@ -1,0 +1,127 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800 &&& 0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+            hdr.ethernet.dstAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8.p4.bfrt.json
@@ -1,0 +1,60 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ethernet.dstAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8.p4.p4info.txt
@@ -1,0 +1,46 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "hdr.ethernet.dstAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8.p4.spec
@@ -1,0 +1,116 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<16> dataOffset_res_ecn_ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct metadata {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<16> local_metadata_data
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		h.ethernet.srcAddr exact
+		h.ethernet.dstAddr exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9-first.p4
@@ -1,0 +1,142 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<16> data1;
+    bit<16> data2;
+    bit<16> data3;
+    bit<16> data4;
+    bit<16> data5;
+    bit<16> data6;
+    bit<16> data7;
+    bit<16> data8;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 16w1;
+    }
+    table tbl {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+            8w0x48         : exact @name("0x48") ;
+            user_meta.data : exact @name("user_meta.data") ;
+            user_meta.data2: exact @name("user_meta.data2") ;
+            user_meta.data4: exact @name("user_meta.data4") ;
+            user_meta.data5: exact @name("user_meta.data5") ;
+            user_meta.data6: exact @name("user_meta.data6") ;
+            user_meta.data3: exact @name("user_meta.data3") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9-frontend.p4
@@ -1,0 +1,144 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<16> data1;
+    bit<16> data2;
+    bit<16> data3;
+    bit<16> data4;
+    bit<16> data5;
+    bit<16> data6;
+    bit<16> data7;
+    bit<16> data8;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+            8w0x48         : exact @name("0x48") ;
+            user_meta.data : exact @name("user_meta.data") ;
+            user_meta.data2: exact @name("user_meta.data2") ;
+            user_meta.data4: exact @name("user_meta.data4") ;
+            user_meta.data5: exact @name("user_meta.data5") ;
+            user_meta.data6: exact @name("user_meta.data6") ;
+            user_meta.data3: exact @name("user_meta.data3") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9-midend.p4
@@ -1,0 +1,173 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<16> data1;
+    bit<16> data2;
+    bit<16> data3;
+    bit<16> data4;
+    bit<16> data5;
+    bit<16> data6;
+    bit<16> data7;
+    bit<16> data8;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800 &&& 16w0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 &&& 8w252: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract<tcp_t>(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    bit<8> key_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.execute") action execute_1() {
+        user_meta.data = 16w1;
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.tcp.dstPort: exact @name("hdr.tcp.dstPort") ;
+            key_0          : exact @name("0x48") ;
+            user_meta.data : exact @name("user_meta.data") ;
+            user_meta.data2: exact @name("user_meta.data2") ;
+            user_meta.data4: exact @name("user_meta.data4") ;
+            user_meta.data5: exact @name("user_meta.data5") ;
+            user_meta.data6: exact @name("user_meta.data6") ;
+            user_meta.data3: exact @name("user_meta.data3") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psadpdktablekeyconsolidationmixedkeys9l105() {
+        key_0 = 8w0x48;
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys9l105 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys9l105();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys9l105();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys9l105.apply();
+        tbl_0.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys9l151() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys9l151 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys9l151();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys9l151();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys9l151.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    @hidden action psadpdktablekeyconsolidationmixedkeys9l167() {
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<tcp_t>(hdr.tcp);
+    }
+    @hidden table tbl_psadpdktablekeyconsolidationmixedkeys9l167 {
+        actions = {
+            psadpdktablekeyconsolidationmixedkeys9l167();
+        }
+        const default_action = psadpdktablekeyconsolidationmixedkeys9l167();
+    }
+    apply {
+        tbl_psadpdktablekeyconsolidationmixedkeys9l167.apply();
+    }
+}
+
+IngressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata, headers, metadata, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9-midend.p4
@@ -1,11 +1,10 @@
 #include <core.p4>
 #include <bmv2/psa.p4>
 
-typedef bit<48> EthernetAddress;
 header ethernet_t {
-    EthernetAddress dstAddr;
-    EthernetAddress srcAddr;
-    bit<16>         etherType;
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
 }
 
 header ipv4_t {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4
@@ -1,0 +1,141 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+    bit<80> newfield;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata {
+    bit<16> data;
+    bit<16> data1;
+    bit<16> data2;
+    bit<16> data3;
+    bit<16> data4;
+    bit<16> data5;
+    bit<16> data6;
+    bit<16> data7;
+    bit<16> data8;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+    tcp_t      tcp;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800 &&& 0xf00: parse_ipv4;
+            16w0xd00: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w4 .. 8w7: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action execute() {
+        user_meta.data = 1;
+    }
+    table tbl {
+        key = {
+            hdr.tcp.dstPort: exact;
+            8w0x48         : exact;
+            user_meta.data : exact;
+            user_meta.data2: exact;
+            user_meta.data4: exact;
+            user_meta.data5: exact;
+            user_meta.data6: exact;
+            user_meta.data3: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4-error
@@ -1,0 +1,7 @@
+psa-dpdk-table-key-consolidation-mixed-keys-9.p4(105): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            8w0x48 : exact;
+            ^^^^^^
+psa-dpdk-table-key-consolidation-mixed-keys-9.p4(105): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
+            8w0x48 : exact;
+            ^^^^^^
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4-stderr
@@ -1,0 +1,6 @@
+psa-dpdk-table-key-consolidation-mixed-keys-9.p4(105): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            8w0x48 : exact;
+            ^^^^^^
+psa-dpdk-table-key-consolidation-mixed-keys-9.p4(105): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
+            8w0x48 : exact;
+            ^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4.bfrt.json
@@ -1,0 +1,132 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.tcp.dstPort",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "0x48",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 8
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "user_meta.data",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 4,
+          "name" : "user_meta.data2",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 5,
+          "name" : "user_meta.data4",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 6,
+          "name" : "user_meta.data5",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 7,
+          "name" : "user_meta.data6",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 8,
+          "name" : "user_meta.data3",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4.p4info.txt
@@ -1,0 +1,82 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.tcp.dstPort"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "0x48"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  match_fields {
+    id: 3
+    name: "user_meta.data"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 4
+    name: "user_meta.data2"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 5
+    name: "user_meta.data4"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 6
+    name: "user_meta.data5"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 7
+    name: "user_meta.data6"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 8
+    name: "user_meta.data3"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4.spec
@@ -1,0 +1,131 @@
+
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+	bit<80> newfield
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<16> dataOffset_res_ecn_ctrl
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct metadata {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<16> local_metadata_data
+	bit<16> local_metadata_data2
+	bit<16> local_metadata_data3
+	bit<16> local_metadata_data4
+	bit<16> local_metadata_data5
+	bit<16> local_metadata_data6
+	bit<16> ingress_tbl_tcp_dstPort
+	bit<8> Ingress_key
+	bit<16> tmpMask
+	bit<8> tmpMask_0
+}
+metadata instanceof metadata
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+action NoAction args none {
+	return
+}
+
+action execute_1 args none {
+	mov m.local_metadata_data 0x1
+	return
+}
+
+table tbl {
+	key {
+		m.ingress_tbl_tcp_dstPort exact
+		m.Ingress_key exact
+		m.local_metadata_data exact
+		m.local_metadata_data2 exact
+		m.local_metadata_data4 exact
+		m.local_metadata_data5 exact
+		m.local_metadata_data6 exact
+		m.local_metadata_data3 exact
+	}
+	actions {
+		NoAction
+		execute_1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x0
+	extract h.ethernet
+	mov m.tmpMask h.ethernet.etherType
+	and m.tmpMask 0xf00
+	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 m.tmpMask 0x800
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ethernet.etherType 0xd00
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	mov m.tmpMask_0 h.ipv4.protocol
+	and m.tmpMask_0 0xfc
+	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
+	jmp INGRESSPARSERIMPL_ACCEPT
+	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
+	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_key 0x48
+	mov m.ingress_tbl_tcp_dstPort h.tcp.dstPort
+	table tbl
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error-1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error-1.p4.bfrt.json
@@ -1,0 +1,144 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.tbl",
+      "id" : 44506256,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "user_meta.data1",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 64
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "user_meta.data2",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 64
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "user_meta.data3",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 64
+          }
+        },
+        {
+          "id" : 4,
+          "name" : "user_meta.data4",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 64
+          }
+        },
+        {
+          "id" : 5,
+          "name" : "user_meta.data5",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 64
+          }
+        },
+        {
+          "id" : 6,
+          "name" : "user_meta.data6",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 64
+          }
+        },
+        {
+          "id" : 7,
+          "name" : "user_meta.data7",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 64
+          }
+        },
+        {
+          "id" : 8,
+          "name" : "user_meta.data8",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 64
+          }
+        },
+        {
+          "id" : 9,
+          "name" : "user_meta.data9",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 64
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 29480552,
+          "name" : "ingress.execute",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error-1.p4.spec
@@ -56,24 +56,21 @@ struct metadata {
 	bit<32> psa_ingress_input_metadata_ingress_port
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
-	bit<48> local_metadata_data1
-	bit<48> local_metadata_data2
-	bit<48> local_metadata_data3
-	bit<48> local_metadata_data4
-	bit<48> local_metadata_data5
-	bit<48> local_metadata_data6
-	bit<48> local_metadata_data7
-	bit<48> local_metadata_data8
-	bit<48> local_metadata_data9
-	bit<48> local_metadata_data10
-	bit<48> local_metadata_data11
-	bit<48> local_metadata_data12
-	bit<48> local_metadata_data13
-	bit<48> local_metadata_data14
-	bit<48> local_metadata_data15
-	bit<8> ingress_tbl_ethernet_isValid
-	bit<8> ingress_tbl_tcp_isValid
-	bit<8> ingress_tbl_ipv4_isValid
+	bit<64> local_metadata_data1
+	bit<64> local_metadata_data2
+	bit<64> local_metadata_data3
+	bit<64> local_metadata_data4
+	bit<64> local_metadata_data5
+	bit<64> local_metadata_data6
+	bit<64> local_metadata_data7
+	bit<64> local_metadata_data8
+	bit<64> local_metadata_data9
+	bit<64> local_metadata_data10
+	bit<64> local_metadata_data11
+	bit<64> local_metadata_data12
+	bit<64> local_metadata_data13
+	bit<64> local_metadata_data14
+	bit<64> local_metadata_data15
 	bit<16> tmpMask
 	bit<8> tmpMask_0
 }
@@ -109,9 +106,14 @@ action execute_1 args none {
 table tbl {
 	key {
 		m.local_metadata_data1 exact
-		m.ingress_tbl_ethernet_isValid exact
-		m.ingress_tbl_tcp_isValid exact
-		m.ingress_tbl_ipv4_isValid exact
+		m.local_metadata_data2 exact
+		m.local_metadata_data3 exact
+		m.local_metadata_data4 exact
+		m.local_metadata_data5 exact
+		m.local_metadata_data6 exact
+		m.local_metadata_data7 exact
+		m.local_metadata_data8 exact
+		m.local_metadata_data9 exact
 	}
 	actions {
 		NoAction
@@ -137,16 +139,7 @@ apply {
 	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
-	INGRESSPARSERIMPL_ACCEPT :	mov m.ingress_tbl_ethernet_isValid 1
-	jmpv LABEL_END h.ethernet
-	mov m.ingress_tbl_ethernet_isValid 0
-	LABEL_END :	mov m.ingress_tbl_tcp_isValid 1
-	jmpv LABEL_END_0 h.tcp
-	mov m.ingress_tbl_tcp_isValid 0
-	LABEL_END_0 :	mov m.ingress_tbl_ipv4_isValid 1
-	jmpv LABEL_END_1 h.ipv4
-	mov m.ingress_tbl_ipv4_isValid 0
-	LABEL_END_1 :	table tbl
+	INGRESSPARSERIMPL_ACCEPT :	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet
 	emit h.ipv4

--- a/tools/ir-generator/ir-generator-lex.l
+++ b/tools/ir-generator/ir-generator-lex.l
@@ -10,6 +10,7 @@
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wnull-conversion"
+#pragma clang diagnostic ignored "-Wregister"
 #endif
 
 


### PR DESCRIPTION
Earlier, dpdk target had a limitation of keysize to be within 64 bytes including any holes in the key fields in the underlying structure.
```
Ex:
struct meta {
bit <8> meta1; // table key
bit <32> meta2; // hole
bit <64> meta3; // table key
}

table {
keys = {
meta3: exact;
meta1 : exact
}
}

```
This limitation is now removed but newer restrictions are imposed and based on the conditions a copy of tables keys should be made to make them come from the same underlying structure and make them contiguous in the underlying structure.

The following conditions are  checked to make decision about making a copy of the header/metadata field used as table key.
- As before, all the table key fields must be part of the same structure (either header or meta-data).
- As before, a mix of header and meta-data fields in the table key requires copying the header fields to meta-data.
- “Regular” tables (exact match, wildcard match): In the target implementation,  if all fields are contiguous and exact match, the exact match table type is used, otherwise the wildcard match table type is used. Even if all the fields are exact match, if they are not contiguous, the wildcard match table type will be used. So in the case of a mix of header and meta-data fields in the table key, which requires a copying the header fields to meta-data, it is important is there is a hole in between fields: if there is a hole, the exact match table type cannot be used, which result in performance penalty.
- P4C needs to do the best to make all fields contiguou. Sometimes, when there is a large gap between (A) existing meta-data fields and the (B) new meta-data fields (generated by the compiler to mirror the header fields), we should also create  metadata copies for the (A) fields, so that the (A) fields and the (B) fields now become contiguous in meta-data , so the exact match table type could be used. This should be done for the typical case of relatively small key sizes with a relatively small number of fields, where performance delta might be important (if the key is very large, performance will be typically not great anyway); Heuristic adopted: copy only if the number of (A) fields is less than 5.

- Learner tables (add_on_miss tables) are a special type of exact match tables: The key fields must be contiguous in their structure. If not contiguous, need to create meta-data copies for all key fields (in order to make the key fields contiguous).

This PR removes the validation for keysize limit and adds the new restrictions and makes copy of fields used as key based on the conditions described above.