### PR TITLE
made "errorCount", "warningCount", and "maxErrorCount" [all "unsigned int"] be "protected" rather than "private" in "class ErrorReporter" in "error_reporter.h"

### DIFF
--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -36,6 +36,10 @@ enum class DiagnosticAction {
 // Some compatibility for printf-style arguments is also supported.
 class ErrorReporter {
  protected:
+    unsigned int errorCount;
+    unsigned int warningCount;
+    unsigned int maxErrorCount;  /// the maximum number of errors that we print before fail
+
     std::ostream* outputstream;
 
     /// Track errors or warnings that have already been issued for a particular source location
@@ -242,10 +246,6 @@ class ErrorReporter {
     }
 
  private:
-    unsigned errorCount;
-    unsigned warningCount;
-    unsigned maxErrorCount;  /// the maximum number of errors that we print before fail
-
     /// The default diagnostic action for calls to `::warning()`.
     DiagnosticAction defaultWarningDiagnosticAction;
 


### PR DESCRIPTION
This small change-set will enable the developers of in-house P4 compilers [e.g. Intel] to elegantly [i.e. without nasty kludges] make local changes to the errors/warnings/both behavior in subclasses of "`class ErrorReporter`".