### PR TITLE
Tables cannot be compared

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1727,7 +1727,7 @@ const IR::Node* TypeInference::postorder(IR::BoolLiteral* expression) {
     return expression;
 }
 
-// Returns nullptr on error
+// Returns false on error
 bool TypeInference::compare(const IR::Node* errorPosition,
                             const IR::Type* ltype,
                             const IR::Type* rtype,
@@ -1735,6 +1735,10 @@ bool TypeInference::compare(const IR::Node* errorPosition,
     if (ltype->is<IR::Type_Action>() || rtype->is<IR::Type_Action>()) {
         // Actions return Type_Action instead of void.
         typeError("%1%: cannot be applied to action results", errorPosition);
+        return false;
+    }
+    if (ltype->is<IR::Type_Table>() || rtype->is<IR::Type_Table>()) {
+        typeError("%1%: tables cannot be compared", errorPosition);
         return false;
     }
 

--- a/testdata/p4_16_errors/issue3589.p4
+++ b/testdata/p4_16_errors/issue3589.p4
@@ -1,0 +1,24 @@
+action NoAction(){}
+control eq0()
+{
+  table t {
+    actions = {NoAction;}
+  }
+  apply {
+    bool b = t == t; // { dg-error "" }
+  }
+}
+control ne0()
+{
+  table t {
+    actions = {NoAction;}
+  }
+  apply {
+    bool b = t != t; // { dg-error "" }
+  }
+}
+
+control c();
+
+package top(c c1, c c2);
+top(eq0(), ne0()) main;

--- a/testdata/p4_16_errors_outputs/issue3589.p4
+++ b/testdata/p4_16_errors_outputs/issue3589.p4
@@ -1,0 +1,28 @@
+action NoAction() {
+}
+control eq0() {
+    table t {
+        actions = {
+            NoAction;
+        }
+    }
+    apply {
+        bool b = t == t;
+    }
+}
+
+control ne0() {
+    table t {
+        actions = {
+            NoAction;
+        }
+    }
+    apply {
+        bool b = t != t;
+    }
+}
+
+control c();
+package top(c c1, c c2);
+top(eq0(), ne0()) main;
+

--- a/testdata/p4_16_errors_outputs/issue3589.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3589.p4-stderr
@@ -1,0 +1,6 @@
+issue3589.p4(8): [--Werror=type-error] error: ==: tables cannot be compared
+    bool b = t == t; // { dg-error "" }
+             ^^^^^^
+issue3589.p4(17): [--Werror=type-error] error: !=: tables cannot be compared
+    bool b = t != t; // { dg-error "" }
+             ^^^^^^


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3589