### PR TITLE
Allow serenum members initializers refer to other serenum members

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -222,6 +222,7 @@ class TypeInference : public Transform {
     const IR::Node* preorder(IR::Declaration_Instance* decl) override;
     // check invariants for entire list before checking the entries
     const IR::Node* preorder(IR::EntriesList* el) override;
+    const IR::Node* preorder(IR::Type_SerEnum* type) override;
 
     const IR::Node* postorder(IR::Declaration_MatchKind* decl) override;
     const IR::Node* postorder(IR::Declaration_Variable* decl) override;
@@ -239,7 +240,6 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::Type_Base* type) override;
     const IR::Node* postorder(IR::Type_Var* type) override;
     const IR::Node* postorder(IR::Type_Enum* type) override;
-    const IR::Node* postorder(IR::Type_SerEnum* type) override;
     const IR::Node* postorder(IR::Type_Extern* type) override;
     const IR::Node* postorder(IR::StructField* field) override;
     const IR::Node* postorder(IR::Type_Header* type) override;

--- a/testdata/p4_16_errors_outputs/serenum-type.p4-stderr
+++ b/testdata/p4_16_errors_outputs/serenum-type.p4-stderr
@@ -1,6 +1,14 @@
 serenum-type.p4(8): [--Werror=type-error] error: EthT: Illegal type for enum; only bit<> and int<> are allowed
 enum EthT EthTypes {
      ^^^^
-serenum-type.p4(57): [--Werror=type-error] error: prs: cannot evaluate to a compile-time constant
-top(prs(), c()) main;
-    ^^^^^
+serenum-type.p4(49): [--Werror=type-error] error: cast
+            h.eth.type = (EthTypes)(bit<16>)0;
+                         ^^^^^^^^^^^^^^^^^^^^
+  ---- Actual error:
+serenum-type.p4(8): Cannot unify type 'bit<16>' with type 'EthTypes'
+  enum EthT EthTypes {
+            ^^^^^^^^
+  ---- Originating from:
+serenum-type.p4(8): Cannot cast from 'bit<16>' to 'EthTypes'
+  enum EthT EthTypes {
+            ^^^^^^^^

--- a/testdata/p4_16_errors_outputs/serenum-typedef.p4-stderr
+++ b/testdata/p4_16_errors_outputs/serenum-typedef.p4-stderr
@@ -1,6 +1,14 @@
 serenum-typedef.p4(8): [--Werror=type-error] error: EthT: Illegal type for enum; only bit<> and int<> are allowed
 enum EthT EthTypes {
      ^^^^
-serenum-typedef.p4(57): [--Werror=type-error] error: prs: cannot evaluate to a compile-time constant
-top(prs(), c()) main;
-    ^^^^^
+serenum-typedef.p4(49): [--Werror=type-error] error: cast
+            h.eth.type = (EthTypes)(bit<16>)0;
+                         ^^^^^^^^^^^^^^^^^^^^
+  ---- Actual error:
+serenum-typedef.p4(8): Cannot unify type 'bit<16>' with type 'EthTypes'
+  enum EthT EthTypes {
+            ^^^^^^^^
+  ---- Originating from:
+serenum-typedef.p4(8): Cannot cast from 'bit<16>' to 'EthTypes'
+  enum EthT EthTypes {
+            ^^^^^^^^

--- a/testdata/p4_16_samples/issue3616.p4
+++ b/testdata/p4_16_samples/issue3616.p4
@@ -1,0 +1,6 @@
+enum bit<4> e {
+    a = 0,
+    b = 0,
+    c = (bit<4>)a,
+    d = a
+}

--- a/testdata/p4_16_samples_outputs/issue3616-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3616-first.p4
@@ -1,0 +1,7 @@
+enum bit<4> e {
+    a = 4w0,
+    b = 4w0,
+    c = (bit<4>)a,
+    d = a
+}
+

--- a/testdata/p4_16_samples_outputs/issue3616.p4
+++ b/testdata/p4_16_samples_outputs/issue3616.p4
@@ -1,0 +1,7 @@
+enum bit<4> e {
+    a = 0,
+    b = 0,
+    c = (bit<4>)a,
+    d = a
+}
+

--- a/testdata/p4_16_samples_outputs/issue3616.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3616.p4-stderr
@@ -1,0 +1,1 @@
+[--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>