### PR TITLE
Clone empty blocks before def-use analysis

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -174,8 +174,6 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/issue1205-bmv2.p4
   # These psa tests are not ready to run on bmv2 yet
   testdata/p4_16_samples/psa-example-digest-bmv2.p4
-  # This test triggers a bug in the behavioral model.
-  testdata/p4_16_samples/gauntlet_action_mux-bmv2.p4
   # This reads stack.next
   testdata/p4_16_samples/issue692-bmv2.p4
   # These test use computations in the verify/update checksum controls - unsupported

--- a/backends/ebpf/targets/xdp_target.py
+++ b/backends/ebpf/targets/xdp_target.py
@@ -1,1 +1,0 @@
-/home/mbudiu/git/p4c/extensions/p4c-xdp/xdp_target.py

--- a/backends/ebpf/targets/xdp_target.py
+++ b/backends/ebpf/targets/xdp_target.py
@@ -1,0 +1,1 @@
+/home/mbudiu/git/p4c/extensions/p4c-xdp/xdp_target.py

--- a/backends/p4tools/testgen/targets/bmv2/test/BMV2Xfail.cmake
+++ b/backends/p4tools/testgen/targets/bmv2/test/BMV2Xfail.cmake
@@ -62,12 +62,6 @@ p4tools_add_xfail_reason(
   extract_for_header_union.p4
 )
 
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2"
-  "Duplicate objects of type '.*' with name '.*'"
-  gauntlet_action_mux-bmv2.p4
-)
-
 ####################################################################################################
 # 2. P4Testgen Issues
 # These are failures in P4Testgen that need to be fixed.

--- a/frontends/common/programMap.h
+++ b/frontends/common/programMap.h
@@ -26,6 +26,7 @@ namespace P4 {
 // If the program has not changed, the map is up-to-date.
 class ProgramMap : public IHasDbPrint {
  protected:
+    const IR::P4Program* fake = new IR::P4Program();
     const IR::P4Program* program = nullptr;
     cstring mapKind;
     explicit ProgramMap(cstring kind) : mapKind(kind) {}
@@ -55,6 +56,11 @@ class ProgramMap : public IHasDbPrint {
             return;
         program = node->to<IR::P4Program>();
         LOG2(mapKind << " updated to " << dbp(node));
+    }
+    void clear() {
+        // This ensures that a clear map is never up-to-date,
+        // since the 'fake' node cannot appear in a program.
+        program = fake;
     }
 };
 

--- a/frontends/common/resolveReferences/referenceMap.cpp
+++ b/frontends/common/resolveReferences/referenceMap.cpp
@@ -28,12 +28,14 @@ MinimalNameGenerator::MinimalNameGenerator() {
 ReferenceMap::ReferenceMap() : ProgramMap("ReferenceMap"), isv1(false) { clear(); }
 
 void ReferenceMap::clear() {
+    LOG2("Clearing reference map");
     pathToDeclaration.clear();
     usedNames.clear();
     used.clear();
     thisToDeclaration.clear();
     for (auto &reserved : P4::reservedWords)
         usedNames.insert({reserved, 0});
+    ProgramMap::clear();
 }
 
 void ReferenceMap::setDeclaration(const IR::Path* path, const IR::IDeclaration* decl) {

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -244,7 +244,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new UniqueNames(&refMap),  // needed again after inlining
         new MoveDeclarations(),  // needed again after inlining
         new SimplifyDefUse(&refMap, &typeMap),
-        new RemoveUnusedDeclarations(&refMap),
+        new RemoveAllUnusedDeclarations(&refMap),
         new SimplifyControlFlow(&refMap, &typeMap),
         new HierarchicalNames(),
         new FrontEndLast(),

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -96,6 +96,7 @@ void TypeMap::clear() {
     LOG3("Clearing typeMap");
     typeMap.clear(); leftValues.clear(); constants.clear(); allTypeVariables.clear();
     program = nullptr;
+    ProgramMap::clear();
 }
 
 void TypeMap::checkPrecondition(const IR::Node* element, const IR::Type* type) const {

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -52,8 +52,9 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::Type_SerEnum* type) {
 }
 
 const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Control* cont) {
-    if (!refMap->isUsed(getOriginal<IR::IDeclaration>())) {
-        LOG3("Removing " << cont);
+    auto orig = getOriginal<IR::P4Control>();
+    if (!refMap->isUsed(orig)) {
+        LOG3("Removing " << cont << dbp(orig));
         prune();
         return nullptr;
     }
@@ -64,17 +65,18 @@ const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Control* cont) {
     return cont;
 }
 
-const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Parser* cont) {
-    if (!refMap->isUsed(getOriginal<IR::IDeclaration>())) {
-        LOG3("Removing " << cont);
+const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Parser* parser) {
+    auto orig = getOriginal<IR::P4Parser>();
+    if (!refMap->isUsed(orig)) {
+        LOG3("Removing " << parser << dbp(orig));
         prune();
         return nullptr;
     }
 
-    visit(cont->parserLocals, "parserLocals");
-    visit(cont->states, "states");
+    visit(parser->parserLocals, "parserLocals");
+    visit(parser->states, "states");
     prune();
-    return cont;
+    return parser;
 }
 
 const IR::Node* RemoveUnusedDeclarations::preorder(IR::P4Table* table) {

--- a/frontends/p4/unusedDeclarations.h
+++ b/frontends/p4/unusedDeclarations.h
@@ -64,12 +64,14 @@ class RemoveUnusedDeclarations : public Transform {
     const IR::Node* process(const IR::IDeclaration* decl);
     const IR::Node* warnIfUnused(const IR::Node* node);
 
- public:
-    explicit RemoveUnusedDeclarations(const ReferenceMap* refMap,
-                                      std::set<const IR::Node*>* warned = nullptr) :
+    // Prevent direct instantiations of this class.
+    friend class RemoveAllUnusedDeclarations;
+    RemoveUnusedDeclarations(const ReferenceMap* refMap,
+                             std::set<const IR::Node*>* warned = nullptr) :
             refMap(refMap), warned(warned)
     { CHECK_NULL(refMap); setName("RemoveUnusedDeclarations"); }
 
+ public:
     using Transform::postorder;
     using Transform::preorder;
     using Transform::init_apply;
@@ -124,6 +126,7 @@ class RemoveAllUnusedDeclarations : public PassManager {
         if (warn)
             warned = new std::set<const IR::Node*>();
 
+        refMap->clear();
         passes.emplace_back(
             new PassRepeated {
                 new ResolveReferences(refMap),

--- a/testdata/p4_16_samples/issue3650.p4
+++ b/testdata/p4_16_samples/issue3650.p4
@@ -1,0 +1,59 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header payload_t {
+    bit<8> x;
+}
+struct header_t {
+    payload_t payload;
+}
+struct metadata {}
+
+parser MyParser(packet_in packet,
+                out header_t hdr,
+                inout metadata meta,
+                inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract(hdr.payload);
+        transition accept;
+    }
+}
+
+control C1(in bit<8> val) {
+    apply {
+        switch(val) {
+            1 : {
+            }
+        }
+    }
+}
+
+control MyIngress(inout header_t hdr,
+                  inout metadata meta,
+                  inout standard_metadata_t standard_metadata) {
+    apply {
+        switch(hdr.payload.x) {
+            1 : {
+                C1.apply(hdr.payload.x);
+            }
+            0 : {
+                C1.apply(hdr.payload.x);
+            }
+        }
+    }
+}
+
+control MyVerifyChecksum(inout header_t hdr, inout metadata meta) { apply { } }
+control MyEgress(inout header_t hdr, inout metadata meta,
+                 inout standard_metadata_t standard_metadata) { apply {  } }
+control MyDeparser(packet_out packet, in header_t hdr) { apply { } }
+control MyComputeChecksum(inout header_t hdr, inout metadata meta) { apply { } }
+
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;

--- a/testdata/p4_16_samples_outputs/issue3650-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3650-first.p4
@@ -1,0 +1,67 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header payload_t {
+    bit<8> x;
+}
+
+struct header_t {
+    payload_t payload;
+}
+
+struct metadata {
+}
+
+parser MyParser(packet_in packet, out header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<payload_t>(hdr.payload);
+        transition accept;
+    }
+}
+
+control C1(in bit<8> val) {
+    apply {
+        switch (val) {
+            8w1: {
+            }
+        }
+    }
+}
+
+control MyIngress(inout header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    @name("C1") C1() C1_inst;
+    @name("C1") C1() C1_inst_0;
+    apply {
+        switch (hdr.payload.x) {
+            8w1: {
+                C1_inst.apply(hdr.payload.x);
+            }
+            8w0: {
+                C1_inst_0.apply(hdr.payload.x);
+            }
+        }
+    }
+}
+
+control MyVerifyChecksum(inout header_t hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyEgress(inout header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in header_t hdr) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout header_t hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<header_t, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue3650-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue3650-frontend.p4
@@ -1,0 +1,62 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header payload_t {
+    bit<8> x;
+}
+
+struct header_t {
+    payload_t payload;
+}
+
+struct metadata {
+}
+
+parser MyParser(packet_in packet, out header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<payload_t>(hdr.payload);
+        transition accept;
+    }
+}
+
+control MyIngress(inout header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+        switch (hdr.payload.x) {
+            8w1: {
+                switch (hdr.payload.x) {
+                    8w1: {
+                    }
+                }
+            }
+            8w0: {
+                switch (hdr.payload.x) {
+                    8w1: {
+                    }
+                }
+            }
+        }
+    }
+}
+
+control MyVerifyChecksum(inout header_t hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyEgress(inout header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in header_t hdr) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout header_t hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<header_t, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue3650-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue3650-midend.p4
@@ -1,0 +1,162 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header payload_t {
+    bit<8> x;
+}
+
+struct header_t {
+    payload_t payload;
+}
+
+struct metadata {
+}
+
+parser MyParser(packet_in packet, out header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<payload_t>(hdr.payload);
+        transition accept;
+    }
+}
+
+control MyIngress(inout header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    bit<8> switch_0_key;
+    @hidden action switch_0_case() {
+    }
+    @hidden action switch_0_case_0() {
+    }
+    @hidden table switch_0_table {
+        key = {
+            switch_0_key: exact;
+        }
+        actions = {
+            switch_0_case();
+            switch_0_case_0();
+        }
+        const default_action = switch_0_case_0();
+        const entries = {
+                        8w1 : switch_0_case();
+        }
+    }
+    bit<8> switch_1_key;
+    @hidden action switch_1_case() {
+    }
+    @hidden action switch_1_case_0() {
+    }
+    @hidden table switch_1_table {
+        key = {
+            switch_1_key: exact;
+        }
+        actions = {
+            switch_1_case();
+            switch_1_case_0();
+        }
+        const default_action = switch_1_case_0();
+        const entries = {
+                        8w1 : switch_1_case();
+        }
+    }
+    bit<8> switch_2_key;
+    @hidden action switch_2_case() {
+    }
+    @hidden action switch_2_case_0() {
+    }
+    @hidden action switch_2_case_1() {
+    }
+    @hidden table switch_2_table {
+        key = {
+            switch_2_key: exact;
+        }
+        actions = {
+            switch_2_case();
+            switch_2_case_0();
+            switch_2_case_1();
+        }
+        const default_action = switch_2_case_1();
+        const entries = {
+                        8w1 : switch_2_case();
+                        8w0 : switch_2_case_0();
+        }
+    }
+    @hidden action issue3650l24() {
+        switch_0_key = hdr.payload.x;
+    }
+    @hidden action issue3650l24_0() {
+        switch_1_key = hdr.payload.x;
+    }
+    @hidden action issue3650l35() {
+        switch_2_key = hdr.payload.x;
+    }
+    @hidden table tbl_issue3650l35 {
+        actions = {
+            issue3650l35();
+        }
+        const default_action = issue3650l35();
+    }
+    @hidden table tbl_issue3650l24 {
+        actions = {
+            issue3650l24();
+        }
+        const default_action = issue3650l24();
+    }
+    @hidden table tbl_issue3650l24_0 {
+        actions = {
+            issue3650l24_0();
+        }
+        const default_action = issue3650l24_0();
+    }
+    apply {
+        {
+            tbl_issue3650l35.apply();
+            switch (switch_2_table.apply().action_run) {
+                switch_2_case: {
+                    {
+                        tbl_issue3650l24.apply();
+                        switch (switch_0_table.apply().action_run) {
+                            switch_0_case: {
+                            }
+                            switch_0_case_0: {
+                            }
+                        }
+                    }
+                }
+                switch_2_case_0: {
+                    {
+                        tbl_issue3650l24_0.apply();
+                        switch (switch_1_table.apply().action_run) {
+                            switch_1_case: {
+                            }
+                            switch_1_case_0: {
+                            }
+                        }
+                    }
+                }
+                switch_2_case_1: {
+                }
+            }
+        }
+    }
+}
+
+control MyVerifyChecksum(inout header_t hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyEgress(inout header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in header_t hdr) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout header_t hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch<header_t, metadata>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue3650.p4
+++ b/testdata/p4_16_samples_outputs/issue3650.p4
@@ -1,0 +1,65 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header payload_t {
+    bit<8> x;
+}
+
+struct header_t {
+    payload_t payload;
+}
+
+struct metadata {
+}
+
+parser MyParser(packet_in packet, out header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract(hdr.payload);
+        transition accept;
+    }
+}
+
+control C1(in bit<8> val) {
+    apply {
+        switch (val) {
+            1: {
+            }
+        }
+    }
+}
+
+control MyIngress(inout header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+        switch (hdr.payload.x) {
+            1: {
+                C1.apply(hdr.payload.x);
+            }
+            0: {
+                C1.apply(hdr.payload.x);
+            }
+        }
+    }
+}
+
+control MyVerifyChecksum(inout header_t hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control MyEgress(inout header_t hdr, inout metadata meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in header_t hdr) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout header_t hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/issue3650.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/issue3650.p4.p4info.txt
@@ -1,0 +1,3 @@
+pkg_info {
+  arch: "v1model"
+}


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3650 
This was harder to fix than I expected. The visitor infra is too smart for its own good: it wouldn't duplicate empty blocks since it realizes they are identical. So you have to add annotations to empty blocks to make then different, then remove them again.

This also uncovered a bug in the frontend where RemoveUnusedDeclarations was called instead of RemoveAllUnusedDeclarations. That won't happen again, since I made the constructor private.