### PR TITLE
Check if 'match_kind.exact' is defined when expanding switch statements

### DIFF
--- a/midend/eliminateSwitch.h
+++ b/midend/eliminateSwitch.h
@@ -79,11 +79,14 @@ class DoEliminateSwitch final : public Transform {
     const TypeMap* typeMap;
     std::vector<const IR::Declaration*> toInsert;
  public:
-    explicit DoEliminateSwitch(ReferenceMap* refMap, const TypeMap* typeMap):
+    bool exactNeeded = false;
+
+    DoEliminateSwitch(ReferenceMap* refMap, const TypeMap* typeMap):
             refMap(refMap), typeMap(typeMap)
     { setName("DoEliminateSwitch"); CHECK_NULL(refMap); CHECK_NULL(typeMap); }
     const IR::Node* postorder(IR::SwitchStatement* statement) override;
     const IR::Node* postorder(IR::P4Control* control) override;
+    const IR::Node* postorder(IR::P4Program* program) override;
 };
 
 class EliminateSwitch final : public PassManager {

--- a/testdata/p4_16_errors/issue3613.p4
+++ b/testdata/p4_16_errors/issue3613.p4
@@ -1,0 +1,11 @@
+control c(in bit<4> a)
+{
+  apply {
+    switch (a) {
+      4w0: {}
+    }
+  }
+}
+control ct(in bit<4> a);
+package pt(ct t);
+pt(c()) main;

--- a/testdata/p4_16_errors_outputs/issue3613-first.p4
+++ b/testdata/p4_16_errors_outputs/issue3613-first.p4
@@ -1,0 +1,12 @@
+control c(in bit<4> a) {
+    apply {
+        switch (a) {
+            4w0: {
+            }
+        }
+    }
+}
+
+control ct(in bit<4> a);
+package pt(ct t);
+pt(c()) main;

--- a/testdata/p4_16_errors_outputs/issue3613-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue3613-frontend.p4
@@ -1,0 +1,12 @@
+control c(in bit<4> a) {
+    apply {
+        switch (a) {
+            4w0: {
+            }
+        }
+    }
+}
+
+control ct(in bit<4> a);
+package pt(ct t);
+pt(c()) main;

--- a/testdata/p4_16_errors_outputs/issue3613.p4
+++ b/testdata/p4_16_errors_outputs/issue3613.p4
@@ -1,0 +1,12 @@
+control c(in bit<4> a) {
+    apply {
+        switch (a) {
+            4w0: {
+            }
+        }
+    }
+}
+
+control ct(in bit<4> a);
+package pt(ct t);
+pt(c()) main;

--- a/testdata/p4_16_errors_outputs/issue3613.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3613.p4-stderr
@@ -1,0 +1,1 @@
+[--Werror=not-found] error: Could not find declaration for 'match_kind.exact', which is needed to implement switch statements; did you include core.p4?


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3613