### PR TITLE
create dpdk specific pna.p4 and extend it 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,7 +444,8 @@ add_custom_target(update_includes ALL
 if (ENABLE_DPDK)
 add_custom_target(dpdk_includes ALL
   COMMAND ${CMAKE_COMMAND} -E make_directory ${P4C_BINARY_DIR}/p4include/dpdk
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${P4C_SOURCE_DIR}/p4include/dpdk/psa.p4 ${P4C_BINARY_DIR}/p4include/dpdk)
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${P4C_SOURCE_DIR}/p4include/dpdk/psa.p4 ${P4C_BINARY_DIR}/p4include/dpdk
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${P4C_SOURCE_DIR}/p4include/dpdk/pna.p4 ${P4C_BINARY_DIR}/p4include/dpdk)
 endif ()
 
 # Installation

--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -79,12 +79,12 @@ p4c_add_xfail_reason("dpdk"
   "Expected default action .* to have .* method call for .* extern instance"
    testdata/p4_16_samples/pna-dpdk-direct-counter-err-1.p4
    testdata/p4_16_samples/pna-dpdk-direct-meter-err-4.p4
+   testdata/p4_16_samples/pna-dpdk-direct-meter-err-3.p4
   )
 
 p4c_add_xfail_reason("dpdk"
   ".* method for different .* instances (.*) called within same action"
   testdata/p4_16_samples/pna-dpdk-direct-counter-err-4.p4
-  testdata/p4_16_samples/pna-dpdk-direct-meter-err-3.p4
   )
 
 p4c_add_xfail_reason("dpdk"

--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -1,8 +1,13 @@
 p4c_add_xfail_reason("dpdk"
   "use dpdk specific `dpdk_execute` method"
   testdata/p4_16_samples/psa-example-dpdk-meter-execute-err.p4
+  testdata/p4_16_samples/psa-meter3.p4
+  testdata/p4_16_samples/psa-meter7-bmv2.p4
   )
-
+p4c_add_xfail_reason("dpdk"
+  "Meter function execute not implemented, use dpdk_execute"
+  testdata/p4_16_samples/psa-meter1.p4
+  )
 p4c_add_xfail_reason("dpdk"
   "Expected packet length argument for count method of indirect counter"
   testdata/p4_16_samples/psa-example-counters-bmv2.p4

--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -66,7 +66,29 @@ p4c_add_xfail_reason("dpdk"
   )
 
 p4c_add_xfail_reason("dpdk"
-  "Expected atleast 2 arguments"
-  testdata/p4_16_samples/psa-meter3.p4
-  testdata/p4_16_samples/psa-meter7-bmv2.p4
+  "can only be invoked from within action of ownertable"
+  testdata/p4_16_samples/psa-example-dpdk-directmeter-err.p4
+  testdata/p4_16_samples/pna-dpdk-direct-counter-err-3.p4
+  )
+p4c_add_xfail_reason("dpdk"
+  "execute method not supported"
+  testdata/p4_16_samples/psa-meter6.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  "Expected default action .* to have .* method call for .* extern instance"
+   testdata/p4_16_samples/pna-dpdk-direct-counter-err-1.p4
+   testdata/p4_16_samples/pna-dpdk-direct-meter-err-4.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  ".* method for different .* instances (.*) called within same action"
+  testdata/p4_16_samples/pna-dpdk-direct-counter-err-4.p4
+  testdata/p4_16_samples/pna-dpdk-direct-meter-err-3.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+   "Learner table .* must have all exact match keys"
+   testdata/p4_16_samples/pna-add-on-miss-err1.p4
+   testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-2.p4
   )

--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -1,4 +1,24 @@
 p4c_add_xfail_reason("dpdk"
+  "use dpdk specific `dpdk_execute` method"
+  testdata/p4_16_samples/psa-example-dpdk-meter-execute-err.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  "Expected packet length argument for count method of indirect counter"
+  testdata/p4_16_samples/psa-example-counters-bmv2.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  "error: Name .* is used for multiple direct counter objects in the P4Info message"
+  testdata/p4_16_samples/psa-counter6.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
+  "Expected psa_implementation property value for table.* to resolve to an extern instance"
+  testdata/p4_16_samples/psa-action-profile2.p4
+  )
+
+p4c_add_xfail_reason("dpdk"
   "not implemented"
   testdata/p4_16_samples/psa-example-dpdk-byte-alignment_4.p4
   )

--- a/backends/dpdk/DpdkXfail.cmake
+++ b/backends/dpdk/DpdkXfail.cmake
@@ -4,23 +4,10 @@ p4c_add_xfail_reason("dpdk"
   testdata/p4_16_samples/psa-meter3.p4
   testdata/p4_16_samples/psa-meter7-bmv2.p4
   )
+
 p4c_add_xfail_reason("dpdk"
   "Meter function execute not implemented, use dpdk_execute"
   testdata/p4_16_samples/psa-meter1.p4
-  )
-p4c_add_xfail_reason("dpdk"
-  "Expected packet length argument for count method of indirect counter"
-  testdata/p4_16_samples/psa-example-counters-bmv2.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
-  "error: Name .* is used for multiple direct counter objects in the P4Info message"
-  testdata/p4_16_samples/psa-counter6.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
-  "Expected psa_implementation property value for table.* to resolve to an extern instance"
-  testdata/p4_16_samples/psa-action-profile2.p4
   )
 
 p4c_add_xfail_reason("dpdk"
@@ -63,32 +50,4 @@ p4c_add_xfail_reason("dpdk"
 p4c_add_xfail_reason("dpdk"
   "Direct counters and direct meters are unsupported for wildcard match"
   testdata/p4_16_samples/psa-example-counters-bmv2.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
-  "can only be invoked from within action of ownertable"
-  testdata/p4_16_samples/psa-example-dpdk-directmeter-err.p4
-  testdata/p4_16_samples/pna-dpdk-direct-counter-err-3.p4
-  )
-p4c_add_xfail_reason("dpdk"
-  "execute method not supported"
-  testdata/p4_16_samples/psa-meter6.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
-  "Expected default action .* to have .* method call for .* extern instance"
-   testdata/p4_16_samples/pna-dpdk-direct-counter-err-1.p4
-   testdata/p4_16_samples/pna-dpdk-direct-meter-err-4.p4
-   testdata/p4_16_samples/pna-dpdk-direct-meter-err-3.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
-  ".* method for different .* instances (.*) called within same action"
-  testdata/p4_16_samples/pna-dpdk-direct-counter-err-4.p4
-  )
-
-p4c_add_xfail_reason("dpdk"
-   "Learner table .* must have all exact match keys"
-   testdata/p4_16_samples/pna-add-on-miss-err1.p4
-   testdata/p4_16_samples/pna-dpdk-table-key-consolidation-learner-2.p4
   )

--- a/backends/dpdk/README.md
+++ b/backends/dpdk/README.md
@@ -74,7 +74,7 @@ In P4 the second argument of the extract method is the number of bits.
 Compiler generates instructions which compute the size in bytes from the value in bits.
 If the value in bits is not a multiple of 8, the value is rounded down to the lower
 multiple of 8 bits.
-- Currently dpdk target does not support standard count and execute as defined in PSA and PNA, it requires packet length in methods count and execute which are part of Counter and Meter externs. Adding param ``` in bit<32> pkt_len``` to execute (part of Meter extern) leads to overload resolution failure due to ambiguous candidates, as p4c do overload resolution based on number of parameter and does not consider types. To workaround this we introduced new method in Meter extern `dpdk_execute` which has extra param.
+- Currently dpdk target does not support standard count and execute methods for Counter and Meter externs as defined in PSA and PNA specifications. It requires packet length as parameter in count and execute methods.
 ```Meter
 PNA_MeterColor_t dpdk_execute(in S index, in PNA_MeterColor_t color, in bit<32> pkt_len);
 ```

--- a/backends/dpdk/README.md
+++ b/backends/dpdk/README.md
@@ -74,6 +74,13 @@ In P4 the second argument of the extract method is the number of bits.
 Compiler generates instructions which compute the size in bytes from the value in bits.
 If the value in bits is not a multiple of 8, the value is rounded down to the lower
 multiple of 8 bits.
+- Currently dpdk target does not support standard count and execute as defined in PSA and PNA, it requires packet length in methods count and execute which are part of Counter and Meter externs. Adding param ``` in bit<32> pkt_len``` to execute (part of Meter extern) leads to overload resolution failure due to ambiguous candidates, as p4c do overload resolution based on number of parameter and does not consider types. To workaround this we introduced new method in Meter extern `dpdk_execute` which has extra param.
+```Meter
+PNA_MeterColor_t dpdk_execute(in S index, in PNA_MeterColor_t color, in bit<32> pkt_len);
+```
+```Counter
+void count(in S index, in bit<32> pkt_len);
+```
 
 ## Contacts
 

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -2526,7 +2526,7 @@ bool CollectDirectCounterMeter::preorder(const IR::P4Table* tbl) {
                         return false;
                     }
                 }
-                if (!ifMethodFound(defaultActionDecl, "execute", meterExternName)) {
+                if (!ifMethodFound(defaultActionDecl, "dpdk_execute", meterExternName)) {
                     if (meterInstance) {
                         ::error(ErrorType::ERR_EXPECTED, "Expected default action %1% to have "
                                 "'execute' method call for DirectMeter extern instance %2%",

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -2465,13 +2465,13 @@ bool CollectDirectCounterMeter::ifMethodFound(const IR::P4Action *a,
     return methodCallFound;
 }
 
-/* ifMethodFound() is called from here to make sure that an action only contains count/execute
+/* ifMethodFound() is called from here to make sure that an action only contains count/dpdk_execute
  * method calls for only one Direct counter/meter instance. The error for the same is emitted
  * in the ifMethodFound function itself and return value is not required to be checked here.
  */
 bool CollectDirectCounterMeter::preorder(const IR::P4Action* a) {
     ifMethodFound(a, "count");
-    ifMethodFound(a, "execute");
+    ifMethodFound(a, "dpdk_execute");
     return false;
 }
 
@@ -2529,7 +2529,7 @@ bool CollectDirectCounterMeter::preorder(const IR::P4Table* tbl) {
                 if (!ifMethodFound(defaultActionDecl, "dpdk_execute", meterExternName)) {
                     if (meterInstance) {
                         ::error(ErrorType::ERR_EXPECTED, "Expected default action %1% to have "
-                                "'execute' method call for DirectMeter extern instance %2%",
+                                "'dpdk_execute' method call for DirectMeter extern instance %2%",
                                  defaultActionDecl->name, *meterInstance->name);
                         return false;
                     }

--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -2557,7 +2557,7 @@ void ValidateDirectCounterMeter::validateMethodInvocation(P4::ExternMethod *a) {
     }
 
     if ((externName == "DirectCounter" && methodName != "count") ||
-        (externName == "DirectMeter" && methodName != "execute")) {
+        (externName == "DirectMeter" && methodName != "dpdk_execute")) {
         ::error(ErrorType::ERR_UNEXPECTED, "%1% method not supported for %2% extern",
                                            methodName, externName);
         return;

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -348,8 +348,14 @@ bool ConvertStatementToDpdk::preorder(const IR::AssignmentStatement *a) {
                         left, e->object->getName(), intermediate);
                 }
             } else if (e->originalExternType->getName().name == "Meter") {
-                if (e->method->getName().name == "execute"
-                    || e->method->getName().name == "dpdk_execute") {
+                if (e->method->getName().name == "execute") {
+                    ::error(ErrorType::ERR_UNEXPECTED,
+                            "use dpdk specific `dpdk_execute` method, `%1%`"
+                            " not supported by dpdk",
+                            e->method->getName());
+                    return false;
+                }
+                if (e->method->getName().name == "dpdk_execute") {
                     auto argSize = e->expr->arguments->size();
 
                     // DPDK target needs index and packet length as mandatory parameters
@@ -1055,9 +1061,9 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                 }
             }
         } else if (a->originalExternType->getName().name == "Meter") {
-            if (a->method->getName().name != "execute"
-                && a->method->getName().name != "dpdk_execute") {
-                BUG("Meter function %1% not implemented.", a->method->getName());
+            if (a->method->getName().name != "dpdk_execute") {
+                BUG("Meter function %1% not implemented, use dpdk_execute",
+                    a->method->getName());
             }
         } else if (a->originalExternType->getName().name == "DirectMeter") {
             if (a->method->getName().name != "execute") {

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -378,7 +378,7 @@ bool ConvertStatementToDpdk::preorder(const IR::AssignmentStatement *a) {
                          e->object->getName(), index, length, color_in, left);
                 }
             } else if (e->originalExternType->getName().name == "DirectMeter") {
-                if (e->method->getName().name == "execute") {
+                if (e->method->getName().name == "dpdk_execute") {
                     auto argSize = e->expr->arguments->size();
 
                     // DPDK target needs packet length as mandatory parameters
@@ -1066,7 +1066,7 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                     a->method->getName());
             }
         } else if (a->originalExternType->getName().name == "DirectMeter") {
-            if (a->method->getName().name != "execute") {
+            if (a->method->getName().name != "dpdk_execute") {
                 BUG("Direct Meter function %1% not implemented.", a->method->getName().name);
             }
         } else if (a->originalExternType->getName().name == "DirectCounter") {

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -348,7 +348,8 @@ bool ConvertStatementToDpdk::preorder(const IR::AssignmentStatement *a) {
                         left, e->object->getName(), intermediate);
                 }
             } else if (e->originalExternType->getName().name == "Meter") {
-                if (e->method->getName().name == "execute") {
+                if (e->method->getName().name == "execute"
+                    || e->method->getName().name == "dpdk_execute") {
                     auto argSize = e->expr->arguments->size();
 
                     // DPDK target needs index and packet length as mandatory parameters
@@ -1054,8 +1055,9 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
                 }
             }
         } else if (a->originalExternType->getName().name == "Meter") {
-            if (a->method->getName().name != "execute") {
-                BUG("Meter function not implemented.");
+            if (a->method->getName().name != "execute"
+                && a->method->getName().name != "dpdk_execute") {
+                BUG("Meter function %1% not implemented.", a->method->getName());
             }
         } else if (a->originalExternType->getName().name == "DirectMeter") {
             if (a->method->getName().name != "execute") {

--- a/backends/dpdk/midend.cpp
+++ b/backends/dpdk/midend.cpp
@@ -136,6 +136,7 @@ DpdkMidEnd::DpdkMidEnd(CompilerOptions &options,
                     {"Register", "write"},
                     {"Counter", "count"},
                     {"Meter", "execute"},
+                    {"Meter", "dpdk_execute"},
                     {"Digest", "pack"},
                 };
                 for (auto f : doNotCopyPropList) {

--- a/p4include/dpdk/pna.p4
+++ b/p4include/dpdk/pna.p4
@@ -407,7 +407,7 @@ extern Meter<S> {
   // RFC 2698). The color of the packet before the method call was
   // made is specified by the color parameter.
   PNA_MeterColor_t execute(in S index, in PNA_MeterColor_t color);
-  PNA_MeterColor_t execute(in S index, in PNA_MeterColor_t color, in bit<32> pkt_len);
+  PNA_MeterColor_t dpdk_execute(in S index, in PNA_MeterColor_t color, in bit<32> pkt_len);
 
   // Use this method call to perform a color blind meter update (see
   // RFC 2698).  It may be implemented via a call to execute(index,
@@ -423,7 +423,7 @@ extern DirectMeter {
   // See the corresponding methods for extern Meter.
   PNA_MeterColor_t execute(in PNA_MeterColor_t color);
   PNA_MeterColor_t execute();
-  PNA_MeterColor_t execute(in PNA_MeterColor_t color, in bit<32> pkt_len);
+  PNA_MeterColor_t dpdk_execute(in PNA_MeterColor_t color, in bit<32> pkt_len);
   PNA_MeterColor_t dpdk_execute(in bit<32> pkt_len);
 }
 // END:DirectMeter_extern

--- a/p4include/dpdk/pna.p4
+++ b/p4include/dpdk/pna.p4
@@ -373,6 +373,7 @@ enum PNA_CounterType_t {
 @noWarn("unused")
 extern Counter<W, S> {
   Counter(bit<32> n_counters, PNA_CounterType_t type);
+  void count(in S index);
   void count(in S index, in bit<32> pkt_len);
 }
 // END:Counter_extern
@@ -381,6 +382,7 @@ extern Counter<W, S> {
 @noWarn("unused")
 extern DirectCounter<W> {
   DirectCounter(PNA_CounterType_t type);
+  void count();
   void count(in bit<32> pkt_len);
 }
 // END:DirectCounter_extern
@@ -404,12 +406,14 @@ extern Meter<S> {
   // Use this method call to perform a color aware meter update (see
   // RFC 2698). The color of the packet before the method call was
   // made is specified by the color parameter.
+  PNA_MeterColor_t execute(in S index, in PNA_MeterColor_t color);
   PNA_MeterColor_t execute(in S index, in PNA_MeterColor_t color, in bit<32> pkt_len);
 
   // Use this method call to perform a color blind meter update (see
   // RFC 2698).  It may be implemented via a call to execute(index,
   // MeterColor_t.GREEN), which has the same behavior.
-  PNA_MeterColor_t execute(in S index, in bit<32> pkt_len);
+  PNA_MeterColor_t execute(in S index);
+  PNA_MeterColor_t dpdk_execute(in S index, in bit<32> pkt_len);
 }
 // END:Meter_extern
 
@@ -417,8 +421,10 @@ extern Meter<S> {
 extern DirectMeter {
   DirectMeter(PNA_MeterType_t type);
   // See the corresponding methods for extern Meter.
+  PNA_MeterColor_t execute(in PNA_MeterColor_t color);
+  PNA_MeterColor_t execute();
   PNA_MeterColor_t execute(in PNA_MeterColor_t color, in bit<32> pkt_len);
-  PNA_MeterColor_t execute(in bit<32> pkt_len);
+  PNA_MeterColor_t dpdk_execute(in bit<32> pkt_len);
 }
 // END:DirectMeter_extern
 

--- a/p4include/dpdk/pna.p4
+++ b/p4include/dpdk/pna.p4
@@ -407,6 +407,11 @@ extern Meter<S> {
   // RFC 2698). The color of the packet before the method call was
   // made is specified by the color parameter.
   PNA_MeterColor_t execute(in S index, in PNA_MeterColor_t color);
+  // Adding param `in bit<32> pkt_len` to execute (part of Meter extern)
+  // leads to overload resolution failure due to ambiguous candidates,
+  // as p4c do overload resolution based on number of parameter and does
+  // not consider types. To workaround this we introduced new method in
+  // Meter extern `dpdk_execute` which has extra param.
   PNA_MeterColor_t dpdk_execute(in S index, in PNA_MeterColor_t color, in bit<32> pkt_len);
 
   // Use this method call to perform a color blind meter update (see

--- a/p4include/dpdk/pna.p4
+++ b/p4include/dpdk/pna.p4
@@ -1,0 +1,704 @@
+/* Copyright 2020-present Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**************************************************************
+ * PNA specification is work-in-progress, this file is subject
+ * to change without any notification. Use at your own risk.
+ **************************************************************/
+
+#ifndef __PNA_P4__
+#define __PNA_P4__
+
+#include <core.p4>
+
+/**
+ *   P4-16 declaration of the Portable NIC Architecture
+ */
+
+/* The bit widths shown below are placeholders that might not be
+ * implemented by any PNA device.
+ *
+ * Each PNA implementation is free to use its own custom width in bits
+ * for those types that are bit<W> for some W. */
+
+/* These are defined using `typedef`, not `type`, so they are truly
+ * just different names for the type bit<W> for the particular width W
+ * shown.  Unlike the `type` definitions below, values declared with
+ * the `typedef` type names can be freely mingled in expressions, just
+ * as any value declared with type bit<W> can.  Values declared with
+ * one of the `type` names below _cannot_ be so freely mingled, unless
+ * you first cast them to the corresponding `typedef` type.  While
+ * that may be inconvenient when you need to do arithmetic on such
+ * values, it is the price to pay for having all occurrences of values
+ * of the `type` types marked as such in the automatically generated
+ * control plane API.
+ *
+ * Note that the width of typedef <name>Uint_t will always be the same
+ * as the width of type <name>_t. */
+typedef bit<32> PortIdUint_t;
+typedef bit<32> InterfaceIdUint_t;
+typedef bit<32> MulticastGroupUint_t;
+typedef bit<16> MirrorSessionIdUint_t;
+typedef bit<8>  MirrorSlotIdUint_t;
+typedef bit<8>  ClassOfServiceUint_t;
+typedef bit<16> PacketLengthUint_t;
+typedef bit<16> MulticastInstanceUint_t;
+typedef bit<64> TimestampUint_t;
+typedef bit<32> FlowIdUint_t;
+typedef bit<8>  ExpireTimeProfileIdUint_t;
+typedef bit<3>  PassNumberUint_t;
+
+typedef bit<32> SecurityAssocIdUint_t;
+
+@p4runtime_translation("p4.org/pna/v1/PortId_t", 32)
+type PortIdUint_t         PortId_t;
+@p4runtime_translation("p4.org/pna/v1/InterfaceId_t", 32)
+type InterfaceIdUint_t    InterfaceId_t;
+@p4runtime_translation("p4.org/pna/v1/MulticastGroup_t", 32)
+type MulticastGroupUint_t MulticastGroup_t;
+@p4runtime_translation("p4.org/pna/v1/MirrorSessionId_t", 16)
+type MirrorSessionIdUint_t MirrorSessionId_t;
+@p4runtime_translation("p4.org/pna/v1/MirrorSlotId_t", 8)
+type MirrorSlotIdUint_t MirrorSlotId_t;
+@p4runtime_translation("p4.org/pna/v1/ClassOfService_t", 8)
+type ClassOfServiceUint_t ClassOfService_t;
+@p4runtime_translation("p4.org/pna/v1/PacketLength_t", 16)
+type PacketLengthUint_t   PacketLength_t;
+@p4runtime_translation("p4.org/pna/v1/MulticastInstance_t", 16)
+type MulticastInstanceUint_t MulticastInstance_t;
+@p4runtime_translation("p4.org/pna/v1/Timestamp_t", 64)
+type TimestampUint_t      Timestamp_t;
+@p4runtime_translation("p4.org/pna/v1/FlowId_t", 32)
+type FlowIdUint_t      FlowId_t;
+@p4runtime_translation("p4.org/pna/v1/ExpireTimeProfileId_t", 8)
+type ExpireTimeProfileIdUint_t      ExpireTimeProfileId_t;
+@p4runtime_translation("p4.org/pna/v1/PassNumber_t", 8)
+type PassNumberUint_t      PassNumber_t;
+
+@p4runtime_translation("p4.org/pna/v1/SecurityAssocId_t", 64)
+type SecurityAssocIdUint_t      SecurityAssocId_t;
+
+typedef error   ParserError_t;
+
+const InterfaceId_t PNA_PORT_CPU = (InterfaceId_t) 0xfffffffd;
+
+const MirrorSessionId_t PNA_MIRROR_SESSION_TO_CPU = (MirrorSessionId_t) 0;
+
+// BEGIN:Type_defns2
+
+/* Note: All of the types with `InHeader` in their name are intended
+ * only to carry values of the corresponding types in packet headers
+ * between a PNA device and the P4Runtime Server software that manages
+ * it.
+ *
+ * The widths are intended to be at least as large as any PNA device
+ * will ever have for that type.  Thus these types may also be useful
+ * to define packet headers that are sent directly between a PNA
+ * device and other devices, without going through P4Runtime Server
+ * software (e.g. this could be useful for sending packets to a
+ * controller or data collection system using higher packet rates than
+ * the P4Runtime Server can handle).  If used for this purpose, there
+ * is no requirement that the PNA data plane _automatically_ perform
+ * the numerical translation of these types that would occur if the
+ * header went through the P4Runtime Server.  Any such desired
+ * translation is up to the author of the P4 program to perform with
+ * explicit code.
+ *
+ * All widths must be a multiple of 8, so that any subset of these
+ * fields may be used in a single P4 header definition, even on P4
+ * implementations that restrict headers to contain fields with a
+ * total length that is a multiple of 8 bits. */
+
+/* See the comments near the definition of PortIdUint_t for why these
+ * typedef definitions exist. */
+typedef bit<32> PortIdInHeaderUint_t;
+typedef bit<32> InterfaceIdInHeaderUint_t;
+typedef bit<32> MulticastGroupInHeaderUint_t;
+typedef bit<16> MirrorSessionIdInHeaderUint_t;
+typedef bit<8>  MirrorSlotIdInHeaderUint_t;
+typedef bit<8>  ClassOfServiceInHeaderUint_t;
+typedef bit<16> PacketLengthInHeaderUint_t;
+typedef bit<16> MulticastInstanceInHeaderUint_t;
+typedef bit<64> TimestampInHeaderUint_t;
+typedef bit<32> FlowIdInHeaderUint_t;
+typedef bit<8>  ExpireTimeProfileIdInHeaderUint_t;
+typedef bit<8>  PassNumberInHeaderUint_t;
+
+typedef bit<32> SecurityAssocIdInHeaderUint_t;
+
+@p4runtime_translation("p4.org/pna/v1/PortIdInHeader_t", 32)
+type  PortIdInHeaderUint_t         PortIdInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/InterfaceIdInHeader_t", 32)
+type  InterfaceIdInHeaderUint_t     InterfaceIdInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/MulticastGroupInHeader_t", 32)
+type  MulticastGroupInHeaderUint_t MulticastGroupInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/MirrorSessionIdInHeader_t", 16)
+type  MirrorSessionIdInHeaderUint_t MirrorSessionIdInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/MirrorSlotIdInHeader_t", 8)
+type  MirrorSlotIdInHeaderUint_t MirrorSlotIdInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/ClassOfServiceInHeader_t", 8)
+type  ClassOfServiceInHeaderUint_t ClassOfServiceInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/PacketLengthInHeader_t", 16)
+type  PacketLengthInHeaderUint_t   PacketLengthInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/MulticastInstanceInHeader_t", 16)
+type  MulticastInstanceInHeaderUint_t MulticastInstanceInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/TimestampInHeader_t", 64)
+type  TimestampInHeaderUint_t      TimestampInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/FlowIdInHeader_t", 32)
+type  FlowIdInHeaderUint_t      FlowIdInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/ExpireTimeProfileIdInHeader_t", 8)
+type  ExpireTimeProfileIdInHeaderUint_t      ExpireTimeProfileIdInHeader_t;
+@p4runtime_translation("p4.org/pna/v1/PassNumberInHeader_t", 8)
+type  PassNumberInHeaderUint_t      PassNumberInHeader_t;
+
+@p4runtime_translation("p4.org/pna/v1/SecurityAssocIdInHeader_t", 64)
+type  SecurityAssocIdInHeaderUint_t      SecurityAssocIdInHeader_t;
+// END:Type_defns2
+
+/* The _int_to_header functions were written to convert a value of
+ * type <name>_t (a value INTernal to the data path) to a value of
+ * type <name>InHeader_t inside a header that will be sent to the CPU
+ * port.
+ *
+ * The _header_to_int functions were written to convert values in the
+ * opposite direction, typically for assigning a value in a header
+ * received from the CPU port, to a value you wish to use in the rest
+ * of your code.
+ *
+ * The reason that three casts are needed is that each of the original
+ * and target types is declared via P4_16 'type', so without a cast
+ * they can only be assigned to values of that identical type.  The
+ * first cast changes it from the original 'type' to a 'bit<W1>' value
+ * of the same bit width W1.  The second cast changes its bit width,
+ * either prepending 0s if it becomes wider, or discarding the most
+ * significant bits if it becomes narrower.  The third cast changes it
+ * from a 'bit<W2>' value to the final 'type', with the same width
+ * W2. */
+
+PortId_t pna_PortId_header_to_int (in PortIdInHeader_t x) {
+    return (PortId_t) (PortIdUint_t) (PortIdInHeaderUint_t) x;
+}
+InterfaceId_t pna_InterfaceId_header_to_int (in InterfaceIdInHeader_t x) {
+    return (InterfaceId_t) (InterfaceIdUint_t) (InterfaceIdInHeaderUint_t) x;
+}
+MulticastGroup_t pna_MulticastGroup_header_to_int (in MulticastGroupInHeader_t x) {
+    return (MulticastGroup_t) (MulticastGroupUint_t) (MulticastGroupInHeaderUint_t) x;
+}
+MirrorSessionId_t pna_MirrorSessionId_header_to_int (in MirrorSessionIdInHeader_t x) {
+    return (MirrorSessionId_t) (MirrorSessionIdUint_t) (MirrorSessionIdInHeaderUint_t) x;
+}
+ClassOfService_t pna_ClassOfService_header_to_int (in ClassOfServiceInHeader_t x) {
+    return (ClassOfService_t) (ClassOfServiceUint_t) (ClassOfServiceInHeaderUint_t) x;
+}
+PacketLength_t pna_PacketLength_header_to_int (in PacketLengthInHeader_t x) {
+    return (PacketLength_t) (PacketLengthUint_t) (PacketLengthInHeaderUint_t) x;
+}
+MulticastInstance_t pna_MulticastInstance_header_to_int (in MulticastInstanceInHeader_t x) {
+    return (MulticastInstance_t) (MulticastInstanceUint_t) (MulticastInstanceInHeaderUint_t) x;
+}
+Timestamp_t pna_Timestamp_header_to_int (in TimestampInHeader_t x) {
+    return (Timestamp_t) (TimestampUint_t) (TimestampInHeaderUint_t) x;
+}
+FlowId_t pna_FlowId_header_to_int (in FlowIdInHeader_t x) {
+    return (FlowId_t) (FlowIdUint_t) (FlowIdInHeaderUint_t) x;
+}
+ExpireTimeProfileId_t pna_ExpireTimeProfileId_header_to_int (in ExpireTimeProfileIdInHeader_t x) {
+    return (ExpireTimeProfileId_t) (ExpireTimeProfileIdUint_t) (ExpireTimeProfileIdInHeaderUint_t) x;
+}
+PassNumber_t pna_PassNumber_header_to_int (in PassNumberInHeader_t x) {
+    return (PassNumber_t) (PassNumberUint_t) (PassNumberInHeaderUint_t) x;
+}
+
+PortIdInHeader_t pna_PortId_int_to_header (in PortId_t x) {
+    return (PortIdInHeader_t) (PortIdInHeaderUint_t) (PortIdUint_t) x;
+}
+InterfaceIdInHeader_t pna_InterfaceId_int_to_header (in InterfaceId_t x) {
+    return (InterfaceIdInHeader_t) (InterfaceIdInHeaderUint_t) (InterfaceIdUint_t) x;
+}
+MulticastGroupInHeader_t pna_MulticastGroup_int_to_header (in MulticastGroup_t x) {
+    return (MulticastGroupInHeader_t) (MulticastGroupInHeaderUint_t) (MulticastGroupUint_t) x;
+}
+MirrorSessionIdInHeader_t pna_MirrorSessionId_int_to_header (in MirrorSessionId_t x) {
+    return (MirrorSessionIdInHeader_t) (MirrorSessionIdInHeaderUint_t) (MirrorSessionIdUint_t) x;
+}
+ClassOfServiceInHeader_t pna_ClassOfService_int_to_header (in ClassOfService_t x) {
+    return (ClassOfServiceInHeader_t) (ClassOfServiceInHeaderUint_t) (ClassOfServiceUint_t) x;
+}
+PacketLengthInHeader_t pna_PacketLength_int_to_header (in PacketLength_t x) {
+    return (PacketLengthInHeader_t) (PacketLengthInHeaderUint_t) (PacketLengthUint_t) x;
+}
+MulticastInstanceInHeader_t pna_MulticastInstance_int_to_header (in MulticastInstance_t x) {
+    return (MulticastInstanceInHeader_t) (MulticastInstanceInHeaderUint_t) (MulticastInstanceUint_t) x;
+}
+TimestampInHeader_t pna_Timestamp_int_to_header (in Timestamp_t x) {
+    return (TimestampInHeader_t) (TimestampInHeaderUint_t) (TimestampUint_t) x;
+}
+FlowIdInHeader_t pna_FlowId_int_to_header (in FlowId_t x) {
+    return (FlowIdInHeader_t) (FlowIdInHeaderUint_t) (FlowIdUint_t) x;
+}
+ExpireTimeProfileIdInHeader_t pna_ExpireTimeProfileId_int_to_header (in ExpireTimeProfileId_t x) {
+    return (ExpireTimeProfileIdInHeader_t) (ExpireTimeProfileIdInHeaderUint_t) (ExpireTimeProfileIdUint_t) x;
+}
+PassNumberInHeader_t pna_PassNumber_int_to_header (in PassNumber_t x) {
+    return (PassNumberInHeader_t) (PassNumberInHeaderUint_t) (PassNumberUint_t) x;
+}
+
+/// Supported range of values for the pna_idle_timeout table properties
+enum PNA_IdleTimeout_t {
+    NO_TIMEOUT,
+    NOTIFY_CONTROL
+};
+
+// BEGIN:Match_kinds
+match_kind {
+    range,   /// Used to represent min..max intervals
+    selector /// Used for dynamic action selection via the ActionSelector extern
+}
+// END:Match_kinds
+
+// BEGIN:Hash_algorithms
+enum PNA_HashAlgorithm_t {
+  // TBD what this type's values will be for PNA
+  TARGET_DEFAULT      /// target implementation defined
+}
+// END:Hash_algorithms
+
+// BEGIN:Hash_extern
+extern Hash<O> {
+  /// Constructor
+  Hash(PNA_HashAlgorithm_t algo);
+
+  /// Compute the hash for data.
+  /// @param data The data over which to calculate the hash.
+  /// @return The hash value.
+  O get_hash<D>(in D data);
+
+  /// Compute the hash for data, with modulo by max, then add base.
+  /// @param base Minimum return value.
+  /// @param data The data over which to calculate the hash.
+  /// @param max The hash value is divided by max to get modulo.
+  ///        An implementation may limit the largest value supported,
+  ///        e.g. to a value like 32, or 256, and may also only
+  ///        support powers of 2 for this value.  P4 developers should
+  ///        limit their choice to such values if they wish to
+  ///        maximize portability.
+  /// @return (base + (h % max)) where h is the hash value.
+  O get_hash<T, D>(in T base, in D data, in T max);
+}
+// END:Hash_extern
+
+// BEGIN:Checksum_extern
+extern Checksum<W> {
+  /// Constructor
+  Checksum(PNA_HashAlgorithm_t hash);
+
+  /// Reset internal state and prepare unit for computation.
+  /// Every instance of a Checksum object is automatically initialized as
+  /// if clear() had been called on it. This initialization happens every
+  /// time the object is instantiated, that is, whenever the parser or control
+  /// containing the Checksum object are applied.
+  /// All state maintained by the Checksum object is independent per packet.
+  void clear();
+
+  /// Add data to checksum
+  void update<T>(in T data);
+
+  /// Get checksum for data added (and not removed) since last clear
+  W    get();
+}
+// END:Checksum_extern
+
+// BEGIN:InternetChecksum_extern
+// Checksum based on `ONES_COMPLEMENT16` algorithm used in IPv4, TCP, and UDP.
+// Supports incremental updating via `subtract` method.
+// See IETF RFC 1624.
+extern InternetChecksum {
+  /// Constructor
+  InternetChecksum();
+
+  /// Reset internal state and prepare unit for computation.  Every
+  /// instance of an InternetChecksum object is automatically
+  /// initialized as if clear() had been called on it, once for each
+  /// time the parser or control it is instantiated within is
+  /// executed.  All state maintained by it is independent per packet.
+  void clear();
+
+  /// Add data to checksum.  data must be a multiple of 16 bits long.
+  void add<T>(in T data);
+
+  /// Subtract data from existing checksum.  data must be a multiple of
+  /// 16 bits long.
+  void subtract<T>(in T data);
+
+  /// Get checksum for data added (and not removed) since last clear
+  bit<16> get();
+
+  /// Get current state of checksum computation.  The return value is
+  /// only intended to be used for a future call to the set_state
+  /// method.
+  bit<16> get_state();
+
+  /// Restore the state of the InternetChecksum instance to one
+  /// returned from an earlier call to the get_state method.  This
+  /// state could have been returned from the same instance of the
+  /// InternetChecksum extern, or a different one.
+  void set_state(in bit<16> checksum_state);
+}
+// END:InternetChecksum_extern
+
+// BEGIN:CounterType_defn
+enum PNA_CounterType_t {
+    PACKETS,
+    BYTES,
+    PACKETS_AND_BYTES
+}
+// END:CounterType_defn
+
+// BEGIN:Counter_extern
+/// Indirect counter with n_counters independent counter values, where
+/// every counter value has a data plane size specified by type W.
+
+@noWarn("unused")
+extern Counter<W, S> {
+  Counter(bit<32> n_counters, PNA_CounterType_t type);
+  void count(in S index, in bit<32> pkt_len);
+}
+// END:Counter_extern
+
+// BEGIN:DirectCounter_extern
+@noWarn("unused")
+extern DirectCounter<W> {
+  DirectCounter(PNA_CounterType_t type);
+  void count(in bit<32> pkt_len);
+}
+// END:DirectCounter_extern
+
+// BEGIN:MeterType_defn
+enum PNA_MeterType_t {
+    PACKETS,
+    BYTES
+}
+// END:MeterType_defn
+
+// BEGIN:MeterColor_defn
+enum PNA_MeterColor_t { RED, GREEN, YELLOW }
+// END:MeterColor_defn
+
+// BEGIN:Meter_extern
+// Indexed meter with n_meters independent meter states.
+
+extern Meter<S> {
+  Meter(bit<32> n_meters, PNA_MeterType_t type);
+  // Use this method call to perform a color aware meter update (see
+  // RFC 2698). The color of the packet before the method call was
+  // made is specified by the color parameter.
+  PNA_MeterColor_t execute(in S index, in PNA_MeterColor_t color, in bit<32> pkt_len);
+
+  // Use this method call to perform a color blind meter update (see
+  // RFC 2698).  It may be implemented via a call to execute(index,
+  // MeterColor_t.GREEN), which has the same behavior.
+  PNA_MeterColor_t execute(in S index, in bit<32> pkt_len);
+}
+// END:Meter_extern
+
+// BEGIN:DirectMeter_extern
+extern DirectMeter {
+  DirectMeter(PNA_MeterType_t type);
+  // See the corresponding methods for extern Meter.
+  PNA_MeterColor_t execute(in PNA_MeterColor_t color, in bit<32> pkt_len);
+  PNA_MeterColor_t execute(in bit<32> pkt_len);
+}
+// END:DirectMeter_extern
+
+// BEGIN:Register_extern
+extern Register<T, S> {
+  /// Instantiate an array of <size> registers. The initial value is
+  /// undefined.
+  Register(bit<32> size);
+  /// Initialize an array of <size> registers and set their value to
+  /// initial_value.
+  Register(bit<32> size, T initial_value);
+
+  T    read  (in S index);
+  void write (in S index, in T value);
+}
+// END:Register_extern
+
+// BEGIN:Random_extern
+extern Random<T> {
+
+  /// Return a random value in the range [min, max], inclusive.
+  /// Implementations are allowed to support only ranges where (max -
+  /// min + 1) is a power of 2.  P4 developers should limit their
+  /// arguments to such values if they wish to maximize portability.
+
+  Random(T min, T max);
+  T read();
+}
+// END:Random_extern
+
+// BEGIN:ActionProfile_extern
+extern ActionProfile {
+  /// Construct an action profile of 'size' entries
+  ActionProfile(bit<32> size);
+}
+// END:ActionProfile_extern
+
+// BEGIN:ActionSelector_extern
+extern ActionSelector {
+  /// Construct an action selector of 'size' entries
+  /// @param algo hash algorithm to select a member in a group
+  /// @param size number of entries in the action selector
+  /// @param outputWidth size of the key
+  ActionSelector(PNA_HashAlgorithm_t algo, bit<32> size, bit<32> outputWidth);
+}
+// END:ActionSelector_extern
+
+// BEGIN:Digest_extern
+extern Digest<T> {
+  Digest();                       /// define a digest stream to the control plane
+  void pack(in T data);           /// emit data into the stream
+}
+// END:Digest_extern
+
+enum PNA_Direction_t {
+    NET_TO_HOST,
+    HOST_TO_NET
+}
+
+// BEGIN:Metadata_types
+enum PNA_PacketPath_t {
+    // TBD if this type remains, whether it should be an enum or
+    // several separate fields representing the same cases in a
+    // different form.
+    FROM_NET_PORT,
+    FROM_NET_LOOPEDBACK,
+    FROM_NET_RECIRCULATED,
+    FROM_HOST,
+    FROM_HOST_LOOPEDBACK,
+    FROM_HOST_RECIRCULATED
+}
+
+struct pna_pre_input_metadata_t {
+    PortId_t                 input_port;
+    ParserError_t            parser_error;
+    PNA_Direction_t          direction;
+    PassNumber_t             pass;
+    bool                     loopedback;
+}
+
+struct pna_pre_output_metadata_t {
+    bool                     decrypt;  // TBD: or use said==0 to mean no decrypt?
+
+    // The following things are stored internally within the decrypt
+    // block, in a table indexed by said:
+
+    // + The decryption algorithm, e.g. AES256, etc.
+    // + The decryption key
+    // + Any read-modify-write state in the data plane used to
+    //   implement anti-replay attack detection.
+
+    SecurityAssocId_t        said;
+    bit<16>                  decrypt_start_offset;  // in bytes?
+
+    // TBD whether it is important to explicitly pass information to a
+    // decryption extern in a way visible to a P4 program about where
+    // headers were parsed and found.  An alternative is to assume
+    // that the architecture saves the pre parser results somewhere,
+    // in a way not visible to the P4 program.
+}
+
+struct pna_main_parser_input_metadata_t {
+    // common fields initialized for all packets that are input to main
+    // parser, regardless of direction.
+    PNA_Direction_t          direction;
+    PassNumber_t             pass;
+    bool                     loopedback;
+    // If this packet has direction NET_TO_HOST, input_port contains
+    // the id of the network port on which the packet arrived.
+    // If this packet has direction HOST_TO_NET, input_port contains
+    // the id of the vport from which the packet came
+    PortId_t                 input_port;   // network port id
+}
+
+struct pna_main_input_metadata_t {
+    // common fields initialized for all packets that are input to main
+    // parser, regardless of direction.
+    PNA_Direction_t          direction;
+    PassNumber_t             pass;
+    bool                     loopedback;
+    Timestamp_t              timestamp;
+    ParserError_t            parser_error;
+    ClassOfService_t         class_of_service;
+    // See comments for field input_port in struct
+    // pna_main_parser_input_metadata_t
+    PortId_t                 input_port;
+}
+
+// BEGIN:Metadata_main_output
+struct pna_main_output_metadata_t {
+  // common fields used by the architecture to decide what to do with
+  // the packet next, after the main parser, control, and deparser
+  // have finished executing one pass, regardless of the direction.
+  ClassOfService_t         class_of_service; // 0
+}
+// END:Metadata_main_output
+// END:Metadata_types
+
+
+// The following extern functions are "forwarding" functions -- they
+// all set the destination of the packet.  Calling one of them
+// overwrites and replaces the effect of any earlier call to any of
+// the functions in this set.  Only the last one executed will
+// actually take effect for the packet.
+
+// + drop_packet
+// + send_to_port
+
+
+// drop_packet() - Cause the packet to be dropped when it finishes
+// completing the main control.
+//
+// Invoking drop_packet() is supported only within the main control.
+
+extern void drop_packet();
+
+extern void send_to_port(PortId_t dest_port);
+
+extern void mirror_packet(MirrorSlotId_t mirror_slot_id,
+                          MirrorSessionId_t mirror_session_id);
+
+extern void recirculate();
+
+// TBD: Does it make sense to have a data plane add of a hit action
+// that has in, out, or inout parameters?
+//
+// TBD: Should we require the return value?  Can most targets
+// implement it?  If not, consider having two separate variants of
+// add_entry, one with no return value (i.e. type void).  Such a
+// variant of add_entry seems difficult to use correctly, if it is
+// possible for entries to fail to be added.
+
+// TBD: For add_entry calls to a table with property 'idle_timeout' or
+// 'idle_timeout_with_auto_delete' equal to true, there should
+// probably be an optional parameter at the end that specifies the new
+// entry's initial expire_time_profile_id.
+
+extern bool add_entry<T>(string action_name,
+                         in T action_params,
+                         in ExpireTimeProfileId_t expire_time_profile_id);
+
+extern FlowId_t allocate_flow_id();
+
+
+// set_entry_expire_time() may only be called from within an action of
+// a table with property 'idle_timeout' or
+// 'idle_timeout_with_auto_delete' equal to true.
+
+// Calling it causes the expiration time of the entry to be the one
+// that the control plane has configured for the specified
+// expire_time_profile_id.
+
+extern void set_entry_expire_time(
+    in ExpireTimeProfileId_t expire_time_profile_id);
+
+
+// restart_expire_timer() may only be called from within an action of
+// a table with property 'idle_timeout' or
+// 'idle_timeout_with_auto_delete' equal to true.
+
+// Calling it causes the dynamic expiration timer of the entry to be
+// reset, so that the entry will remain active from the now until that
+// time in the future.
+
+// TBD: Do any targets support a table with one of the idle_timeout
+// properties such that matching an entry _does not_ cause this side
+// effect to occur?  If not, we could simply document it the way that
+// I believe it currently behaves in all existing architectures, which
+// is that every hit action implicitly causes the entry's expiration
+// timer to be reset to its configured time interval in the future.
+
+extern void restart_expire_timer();
+
+
+// SelectByDirection is a simple pure function that behaves exactly as
+// the P4_16 function definition given in comments below.  It is an
+// extern function to ensure that the front/mid end of the p4c
+// compiler leaves occurrences of it as is, visible to target-specific
+// compiler back end code, so targets have all information needed to
+// optimize it as they wish.
+
+// One example of its use is in table key expressions, for tables
+// where one wishes to swap IP source/destination addresses for
+// packets processed in the different directions.
+
+/*
+T SelectByDirection<T>(
+    in PNA_Direction_t direction,
+    in T n2h_value,
+    in T h2n_value)
+{
+    if (direction == PNA_Direction_t.NET_TO_HOST) {
+        return n2h_value;
+    } else {
+        return h2n_value;
+    }
+}
+*/
+
+@pure
+extern T SelectByDirection<T>(
+    in PNA_Direction_t direction,
+    in T n2h_value,
+    in T h2n_value);
+
+
+
+
+// BEGIN:Programmable_blocks
+control PreControlT<PH, PM>(
+    in    PH pre_hdr,
+    inout PM pre_user_meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd);
+
+parser MainParserT<MH, MM>(
+    packet_in pkt,
+    //in    PM pre_user_meta,
+    out   MH main_hdr,
+    inout MM main_user_meta,
+    in    pna_main_parser_input_metadata_t istd);
+
+control MainControlT<MH, MM>(
+    //in    PM pre_user_meta,
+    inout MH main_hdr,
+    inout MM main_user_meta,
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd);
+
+control MainDeparserT<MH, MM>(
+    packet_out pkt,
+    in    MH main_hdr,
+    in    MM main_user_meta,
+    in    pna_main_output_metadata_t ostd);
+
+package PNA_NIC<PH, PM, MH, MM>(
+    MainParserT<MH, MM> main_parser,
+    PreControlT<PH, PM> pre_control,
+    MainControlT<MH, MM> main_control,
+    MainDeparserT<MH, MM> main_deparser);
+// END:Programmable_blocks
+
+#endif   // __PNA_P4__

--- a/p4include/dpdk/psa.p4
+++ b/p4include/dpdk/psa.p4
@@ -598,7 +598,10 @@ enum PSA_CounterType_t {
 @noWarn("unused")
 extern Counter<W, S> {
   Counter(bit<32> n_counters, PSA_CounterType_t type);
+  // dpdk does not support this overload currently if used with
+  // BYTES counter type
   void count(in S index);
+  // Dpdk support this overload and requires packet length
   void count(in S index, in bit<32> pkt_len);
 
   /*
@@ -629,9 +632,11 @@ extern Counter<W, S> {
 @noWarn("unused")
 extern DirectCounter<W> {
   DirectCounter(PSA_CounterType_t type);
-  void count();
+  // dpdk does not support this overload currently if used with
+  // BYTES counter type
+  void count(); 
+  // Dpdk support this overload and requires packet length
   void count(in bit<32> pkt_len);
-
   /*
   @ControlPlaneAPI
   {
@@ -663,21 +668,24 @@ enum PSA_MeterColor_t { RED, GREEN, YELLOW }
 extern Meter<S> {
   Meter(bit<32> n_meters, PSA_MeterType_t type);
 
+  // dpdk does not support below two execute overload, using it
+  // result in compilation failure and suggest using `dpdk_execute`
+
   // Use this method call to perform a color aware meter update (see
   // RFC 2698). The color of the packet before the method call was
   // made is specified by the color parameter.
   PSA_MeterColor_t execute(in S index, in PSA_MeterColor_t color);
+  // Use this method call to perform a color blind meter update (see
+  // RFC 2698).  It may be implemented via a call to execute(index,
+  // MeterColor_t.GREEN), which has the same behavior.
+  PSA_MeterColor_t execute(in S index);
+  
   // Adding param `in bit<32> pkt_len` to execute (part of Meter extern)
   // leads to overload resolution failure due to ambiguous candidates,
   // as p4c do overload resolution based on number of parameter and does
   // not consider types. To workaround this we introduced new method in
   // Meter extern `dpdk_execute` which has extra param.  
-  PSA_MeterColor_t dpdk_execute(in S index, in PSA_MeterColor_t color, in bit<32> pkt_len);
-
-  // Use this method call to perform a color blind meter update (see
-  // RFC 2698).  It may be implemented via a call to execute(index,
-  // MeterColor_t.GREEN), which has the same behavior.
-  PSA_MeterColor_t execute(in S index);
+  PSA_MeterColor_t dpdk_execute(in S index, in PSA_MeterColor_t color, in bit<32> pkt_len);  
   PSA_MeterColor_t dpdk_execute(in S index, in bit<32> pkt_len);
 
   /*
@@ -695,9 +703,12 @@ extern Meter<S> {
 extern DirectMeter {
   DirectMeter(PSA_MeterType_t type);
   // See the corresponding methods for extern Meter.
+  // dpdk does not support below two execute overload, using it
+  // result in compilation failure and suggest using `dpdk_execute`
   PSA_MeterColor_t execute(in PSA_MeterColor_t color);
-  PSA_MeterColor_t dpdk_execute(in PSA_MeterColor_t color, in bit<32> pkt_len);
   PSA_MeterColor_t execute();
+
+  PSA_MeterColor_t dpdk_execute(in PSA_MeterColor_t color, in bit<32> pkt_len);
   PSA_MeterColor_t dpdk_execute(in bit<32> pkt_len);
 
   /*

--- a/p4include/dpdk/psa.p4
+++ b/p4include/dpdk/psa.p4
@@ -598,7 +598,29 @@ enum PSA_CounterType_t {
 @noWarn("unused")
 extern Counter<W, S> {
   Counter(bit<32> n_counters, PSA_CounterType_t type);
-  void count(in S index, @optional in bit<32> increment);
+  void count(in S index, in bit<32> increment);
+
+  /*
+  /// The control plane API uses 64-bit wide counter values.  It is
+  /// not intended to represent the size of counters as they are
+  /// stored in the data plane.  It is expected that control plane
+  /// software will periodically read the data plane counter values,
+  /// and accumulate them into larger counters that are large enough
+  /// to avoid reaching their maximum values for a suitably long
+  /// operational time.  A 64-bit byte counter increased at maximum
+  /// line rate for a 100 gigabit port would take over 46 years to
+  /// wrap.
+
+  @ControlPlaneAPI
+  {
+    bit<64> read      (in S index);
+    bit<64> sync_read (in S index);
+    void set          (in S index, in bit<64> seed);
+    void reset        (in S index);
+    void start        (in S index);
+    void stop         (in S index);
+  }
+  */
 }
 // END:Counter_extern
 
@@ -606,7 +628,19 @@ extern Counter<W, S> {
 @noWarn("unused")
 extern DirectCounter<W> {
   DirectCounter(PSA_CounterType_t type);
-  void count(@optional in bit<32> increment);
+  void count(in bit<32> increment);
+
+  /*
+  @ControlPlaneAPI
+  {
+    W    read<W>      (in TableEntry key);
+    W    sync_read<W> (in TableEntry key);
+    void set          (in TableEntry key, in W seed);
+    void reset        (in TableEntry key);
+    void start        (in TableEntry key);
+    void stop         (in TableEntry key);
+  }
+  */
 }
 // END:DirectCounter_extern
 
@@ -630,12 +664,21 @@ extern Meter<S> {
   // Use this method call to perform a color aware meter update (see
   // RFC 2698). The color of the packet before the method call was
   // made is specified by the color parameter.
-  PSA_MeterColor_t execute(in S index, in PSA_MeterColor_t color, @optional in bit<32> pkt_len);
+  PSA_MeterColor_t execute(in S index, in PSA_MeterColor_t color, in bit<32> pkt_len);
 
   // Use this method call to perform a color blind meter update (see
   // RFC 2698).  It may be implemented via a call to execute(index,
   // MeterColor_t.GREEN), which has the same behavior.
-  PSA_MeterColor_t execute(in S index, @optional in bit<32> pkt_len);
+  PSA_MeterColor_t execute(in S index, in bit<32> pkt_len);
+
+  /*
+  @ControlPlaneAPI
+  {
+    reset(in MeterColor_t color);
+    setParams(in S index, in MeterConfig config);
+    getParams(in S index, out MeterConfig config);
+  }
+  */
 }
 // END:Meter_extern
 
@@ -643,8 +686,17 @@ extern Meter<S> {
 extern DirectMeter {
   DirectMeter(PSA_MeterType_t type);
   // See the corresponding methods for extern Meter.
-  PSA_MeterColor_t execute(in PSA_MeterColor_t color, @optional in bit<32> pkt_len);
-  PSA_MeterColor_t execute(@optional in bit<32> pkt_len);
+  PSA_MeterColor_t execute(in PSA_MeterColor_t color);
+  PSA_MeterColor_t execute(in bit<32> pkt_len);
+
+  /*
+  @ControlPlaneAPI
+  {
+    reset(in TableEntry entry, in MeterColor_t color);
+    void setConfig(in TableEntry entry, in MeterConfig config);
+    void getConfig(in TableEntry entry, out MeterConfig config);
+  }
+  */
 }
 // END:DirectMeter_extern
 

--- a/p4include/dpdk/psa.p4
+++ b/p4include/dpdk/psa.p4
@@ -667,7 +667,7 @@ extern Meter<S> {
   // RFC 2698). The color of the packet before the method call was
   // made is specified by the color parameter.
   PSA_MeterColor_t execute(in S index, in PSA_MeterColor_t color);
-  PSA_MeterColor_t execute(in S index, in PSA_MeterColor_t color, in bit<32> pkt_len);
+  PSA_MeterColor_t dpdk_execute(in S index, in PSA_MeterColor_t color, in bit<32> pkt_len);
 
   // Use this method call to perform a color blind meter update (see
   // RFC 2698).  It may be implemented via a call to execute(index,
@@ -691,7 +691,7 @@ extern DirectMeter {
   DirectMeter(PSA_MeterType_t type);
   // See the corresponding methods for extern Meter.
   PSA_MeterColor_t execute(in PSA_MeterColor_t color);
-  PSA_MeterColor_t execute(in PSA_MeterColor_t color, in bit<32> pkt_len);
+  PSA_MeterColor_t dpdk_execute(in PSA_MeterColor_t color, in bit<32> pkt_len);
   PSA_MeterColor_t execute();
   PSA_MeterColor_t dpdk_execute(in bit<32> pkt_len);
 

--- a/p4include/dpdk/psa.p4
+++ b/p4include/dpdk/psa.p4
@@ -603,28 +603,6 @@ extern Counter<W, S> {
   void count(in S index);
   // Dpdk support this overload and requires packet length
   void count(in S index, in bit<32> pkt_len);
-
-  /*
-  /// The control plane API uses 64-bit wide counter values.  It is
-  /// not intended to represent the size of counters as they are
-  /// stored in the data plane.  It is expected that control plane
-  /// software will periodically read the data plane counter values,
-  /// and accumulate them into larger counters that are large enough
-  /// to avoid reaching their maximum values for a suitably long
-  /// operational time.  A 64-bit byte counter increased at maximum
-  /// line rate for a 100 gigabit port would take over 46 years to
-  /// wrap.
-
-  @ControlPlaneAPI
-  {
-    bit<64> read      (in S index);
-    bit<64> sync_read (in S index);
-    void set          (in S index, in bit<64> seed);
-    void reset        (in S index);
-    void start        (in S index);
-    void stop         (in S index);
-  }
-  */
 }
 // END:Counter_extern
 
@@ -637,17 +615,6 @@ extern DirectCounter<W> {
   void count(); 
   // Dpdk support this overload and requires packet length
   void count(in bit<32> pkt_len);
-  /*
-  @ControlPlaneAPI
-  {
-    W    read<W>      (in TableEntry key);
-    W    sync_read<W> (in TableEntry key);
-    void set          (in TableEntry key, in W seed);
-    void reset        (in TableEntry key);
-    void start        (in TableEntry key);
-    void stop         (in TableEntry key);
-  }
-  */
 }
 // END:DirectCounter_extern
 
@@ -687,15 +654,6 @@ extern Meter<S> {
   // Meter extern `dpdk_execute` which has extra param.  
   PSA_MeterColor_t dpdk_execute(in S index, in PSA_MeterColor_t color, in bit<32> pkt_len);  
   PSA_MeterColor_t dpdk_execute(in S index, in bit<32> pkt_len);
-
-  /*
-  @ControlPlaneAPI
-  {
-    reset(in MeterColor_t color);
-    setParams(in S index, in MeterConfig config);
-    getParams(in S index, out MeterConfig config);
-  }
-  */
 }
 // END:Meter_extern
 
@@ -710,15 +668,6 @@ extern DirectMeter {
 
   PSA_MeterColor_t dpdk_execute(in PSA_MeterColor_t color, in bit<32> pkt_len);
   PSA_MeterColor_t dpdk_execute(in bit<32> pkt_len);
-
-  /*
-  @ControlPlaneAPI
-  {
-    reset(in TableEntry entry, in MeterColor_t color);
-    void setConfig(in TableEntry entry, in MeterConfig config);
-    void getConfig(in TableEntry entry, out MeterConfig config);
-  }
-  */
 }
 // END:DirectMeter_extern
 

--- a/p4include/dpdk/psa.p4
+++ b/p4include/dpdk/psa.p4
@@ -667,6 +667,11 @@ extern Meter<S> {
   // RFC 2698). The color of the packet before the method call was
   // made is specified by the color parameter.
   PSA_MeterColor_t execute(in S index, in PSA_MeterColor_t color);
+  // Adding param `in bit<32> pkt_len` to execute (part of Meter extern)
+  // leads to overload resolution failure due to ambiguous candidates,
+  // as p4c do overload resolution based on number of parameter and does
+  // not consider types. To workaround this we introduced new method in
+  // Meter extern `dpdk_execute` which has extra param.  
   PSA_MeterColor_t dpdk_execute(in S index, in PSA_MeterColor_t color, in bit<32> pkt_len);
 
   // Use this method call to perform a color blind meter update (see

--- a/p4include/dpdk/psa.p4
+++ b/p4include/dpdk/psa.p4
@@ -598,7 +598,8 @@ enum PSA_CounterType_t {
 @noWarn("unused")
 extern Counter<W, S> {
   Counter(bit<32> n_counters, PSA_CounterType_t type);
-  void count(in S index, in bit<32> increment);
+  void count(in S index);
+  void count(in S index, in bit<32> pkt_len);
 
   /*
   /// The control plane API uses 64-bit wide counter values.  It is
@@ -628,7 +629,8 @@ extern Counter<W, S> {
 @noWarn("unused")
 extern DirectCounter<W> {
   DirectCounter(PSA_CounterType_t type);
-  void count(in bit<32> increment);
+  void count();
+  void count(in bit<32> pkt_len);
 
   /*
   @ControlPlaneAPI
@@ -664,12 +666,14 @@ extern Meter<S> {
   // Use this method call to perform a color aware meter update (see
   // RFC 2698). The color of the packet before the method call was
   // made is specified by the color parameter.
+  PSA_MeterColor_t execute(in S index, in PSA_MeterColor_t color);
   PSA_MeterColor_t execute(in S index, in PSA_MeterColor_t color, in bit<32> pkt_len);
 
   // Use this method call to perform a color blind meter update (see
   // RFC 2698).  It may be implemented via a call to execute(index,
   // MeterColor_t.GREEN), which has the same behavior.
-  PSA_MeterColor_t execute(in S index, in bit<32> pkt_len);
+  PSA_MeterColor_t execute(in S index);
+  PSA_MeterColor_t dpdk_execute(in S index, in bit<32> pkt_len);
 
   /*
   @ControlPlaneAPI
@@ -687,7 +691,9 @@ extern DirectMeter {
   DirectMeter(PSA_MeterType_t type);
   // See the corresponding methods for extern Meter.
   PSA_MeterColor_t execute(in PSA_MeterColor_t color);
-  PSA_MeterColor_t execute(in bit<32> pkt_len);
+  PSA_MeterColor_t execute(in PSA_MeterColor_t color, in bit<32> pkt_len);
+  PSA_MeterColor_t execute();
+  PSA_MeterColor_t dpdk_execute(in bit<32> pkt_len);
 
   /*
   @ControlPlaneAPI

--- a/testdata/p4_16_pna_errors/pna-dpdk-direct-counter-err-3.p4
+++ b/testdata/p4_16_pna_errors/pna-dpdk-direct-counter-err-3.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48>  EthernetAddress;
 const bit<8> ETHERNET_HEADER_LEN = 14;

--- a/testdata/p4_16_pna_errors/pna-dpdk-direct-meter-err-2.p4
+++ b/testdata/p4_16_pna_errors/pna-dpdk-direct-meter-err-2.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48>  EthernetAddress;
 const bit<8> ETHERNET_HEADER_LEN = 14;
@@ -80,7 +80,7 @@ control MainControlImpl(
     PNA_MeterColor_t color_in = PNA_MeterColor_t.RED;
     DirectMeter(PNA_MeterType_t.PACKETS) meter0;
     action send() {
-       out1 = meter0.execute(color_in, 32w1024);
+       out1 = meter0.dpdk_execute(color_in, 32w1024);
        user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0); 
     }
 
@@ -99,7 +99,7 @@ control MainControlImpl(
     }
 
     apply {
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (color_out == PNA_MeterColor_t.GREEN ? 32w1 : 32w0); 
         ipv4_host.apply();
     }

--- a/testdata/p4_16_pna_errors/pna-dpdk-direct-meter-err-3.p4
+++ b/testdata/p4_16_pna_errors/pna-dpdk-direct-meter-err-3.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include "pna.p4"
+#include "dpdk/pna.p4"
 
 
 typedef bit<48>  EthernetAddress;
@@ -88,19 +88,19 @@ control MainControlImpl(
     DirectMeter(PNA_MeterType_t.BYTES) meter0;
     DirectMeter(PNA_MeterType_t.BYTES) meter1;
     action next_hop(PortId_t oport) {
-        out1 = meter0.execute(color_in, 32w1024);
+        out1 = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
-        color_out = meter1.execute(color_in, 32w1024);
+        color_out = meter1.dpdk_execute(color_in, 32w1024);
         user_meta.port_out1 = (color_out == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);        
         send_to_port(oport);
     }
     action default_route_drop() {
-        out1 = meter0.execute(color_in, 32w1024);
+        out1 = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         drop_packet();
     }
     action default_route_drop1() {
-        out1 = meter1.execute(color_in, 32w1024);
+        out1 = meter1.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         drop_packet();
     }

--- a/testdata/p4_16_pna_errors/pna-example-tcp-connection-tracking-err-1.p4
+++ b/testdata/p4_16_pna_errors/pna-example-tcp-connection-tracking-err-1.p4
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../pna.p4"
+#include "pna.p4"
 
 
 // Very simple PNA program intended to demonstrate one use of an

--- a/testdata/p4_16_pna_errors/pna-example-tcp-connection-tracking-err.p4
+++ b/testdata/p4_16_pna_errors/pna-example-tcp-connection-tracking-err.p4
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../pna.p4"
+#include "pna.p4"
 
 
 // Very simple PNA program intended to demonstrate one use of an

--- a/testdata/p4_16_pna_errors/psa-example-dpdk-directmeter-1.p4
+++ b/testdata/p4_16_pna_errors/psa-example-dpdk-directmeter-1.p4
@@ -60,7 +60,7 @@ control MyIC(
 
     DirectMeter(PSA_MeterType_t.BYTES) meter0;
     action execute_meter () {
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         b.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_psa_errors/psa-counter6.p4
+++ b/testdata/p4_16_psa_errors/psa-counter6.p4
@@ -50,7 +50,7 @@ control MyIC(
 
     DirectCounter<bit<12>>(PSA_CounterType_t.PACKETS) counter0;
     action execute() {
-        counter0.count(64);
+        counter0.count();
     }
     table tbl {
         key = {

--- a/testdata/p4_16_psa_errors/psa-counter6.p4
+++ b/testdata/p4_16_psa_errors/psa-counter6.p4
@@ -50,7 +50,7 @@ control MyIC(
 
     DirectCounter<bit<12>>(PSA_CounterType_t.PACKETS) counter0;
     action execute() {
-        counter0.count();
+        counter0.count(64);
     }
     table tbl {
         key = {

--- a/testdata/p4_16_psa_errors/psa-example-dpdk-directmeter-err.p4
+++ b/testdata/p4_16_psa_errors/psa-example-dpdk-directmeter-err.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <bmv2/psa.p4>
+#include <dpdk/psa.p4>
 
 struct EMPTY { };
 
@@ -50,7 +50,7 @@ control MyIC(
 
     DirectMeter(PSA_MeterType_t.BYTES) meter0;
     action execute_meter () {
-        meter0.execute();
+        meter0.dpdk_execute(32w0);
     }
     table tbl {
         key = {

--- a/testdata/p4_16_samples/pna-dpdk-bvec_union.p4
+++ b/testdata/p4_16_samples/pna-dpdk-bvec_union.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 struct alt_t {
   bit<1> valid;

--- a/testdata/p4_16_samples/pna-dpdk-direct-meter-learner.p4
+++ b/testdata/p4_16_samples/pna-dpdk-direct-meter-learner.p4
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "pna.p4"
+#include "dpdk/pna.p4"
 
 
 typedef bit<48>  EthernetAddress;
@@ -103,7 +103,7 @@ control MainControlImpl(
 
     action add_on_miss_action() {
         bit<32> tmp = 0;
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (color_out == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
     }

--- a/testdata/p4_16_samples/pna-dpdk-invalid-hdr-warnings5.p4
+++ b/testdata/p4_16_samples/pna-dpdk-invalid-hdr-warnings5.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Header1 {
     bit<32> data;

--- a/testdata/p4_16_samples/pna-dpdk-invalid-hdr-warnings6.p4
+++ b/testdata/p4_16_samples/pna-dpdk-invalid-hdr-warnings6.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Header1 {
     bit<32> data;

--- a/testdata/p4_16_samples/pna-dpdk-parser-state-err.p4
+++ b/testdata/p4_16_samples/pna-dpdk-parser-state-err.p4
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "pna.p4"
+#include "dpdk/pna.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/testdata/p4_16_samples/pna-dpdk-table-key-use-annon.p4
+++ b/testdata/p4_16_samples/pna-dpdk-table-key-use-annon.p4
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "pna.p4"
+#include "dpdk/pna.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/testdata/p4_16_samples/pna-dpdk-union-bmv2.p4
+++ b/testdata/p4_16_samples/pna-dpdk-union-bmv2.p4
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Hdr1 {
     bit<8> a;

--- a/testdata/p4_16_samples/pna-dpdk-wrong-warning.p4
+++ b/testdata/p4_16_samples/pna-dpdk-wrong-warning.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48>  EthernetAddress;
 

--- a/testdata/p4_16_samples/pna-elim-hdr-copy-dpdk.p4
+++ b/testdata/p4_16_samples/pna-elim-hdr-copy-dpdk.p4
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "pna.p4"
+#include "dpdk/pna.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/testdata/p4_16_samples/pna-example-dpdk-varbit-1.p4
+++ b/testdata/p4_16_samples/pna-example-dpdk-varbit-1.p4
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48>  EthernetAddress;
 

--- a/testdata/p4_16_samples/pna-example-dpdk-varbit.p4
+++ b/testdata/p4_16_samples/pna-example-dpdk-varbit.p4
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48>  EthernetAddress;
 

--- a/testdata/p4_16_samples/pna-example-tcp-connection-tracking.p4
+++ b/testdata/p4_16_samples/pna-example-tcp-connection-tracking.p4
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../pna.p4"
+#include "pna.p4"
 
 
 // Very simple PNA program intended to demonstrate one use of an

--- a/testdata/p4_16_samples/pna-too-big-label-name-dpdk.p4
+++ b/testdata/p4_16_samples/pna-too-big-label-name-dpdk.p4
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include <core.p4>
-#include "pna.p4"
+#include "dpdk/pna.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_1.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_1.p4
@@ -70,7 +70,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_1.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_1.p4
@@ -97,7 +97,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_1.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_1.p4
@@ -70,7 +70,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.execute(index, color_in, (bit<32>) hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_2.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_2.p4
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.execute(index, color_in, (bit<32>) hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_2.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_2.p4
@@ -96,7 +96,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_2.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_2.p4
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_3.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_3.p4
@@ -98,7 +98,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_3.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_3.p4
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.execute(index, color_in, (bit <32>) hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_3.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_3.p4
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_5.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_5.p4
@@ -70,7 +70,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_5.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_5.p4
@@ -97,7 +97,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_5.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_5.p4
@@ -70,7 +70,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.execute(index, color_in, (bit<32>) hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_6.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_6.p4
@@ -77,7 +77,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.execute(index, color_in, (bit<32>) hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_6.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_6.p4
@@ -107,7 +107,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_6.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_6.p4
@@ -77,7 +77,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_7.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_7.p4
@@ -83,7 +83,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.execute(index, color_in, (bit<32>) hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_7.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_7.p4
@@ -83,7 +83,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_7.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_7.p4
@@ -115,7 +115,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_8.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_8.p4
@@ -83,7 +83,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.execute(index, color_in, (bit<32>) hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_8.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_8.p4
@@ -83,7 +83,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_8.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_8.p4
@@ -115,7 +115,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_9.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_9.p4
@@ -98,7 +98,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_9.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_9.p4
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.execute(index, color_in, (bit<32>) hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_9.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-byte-alignment_9.p4
@@ -69,7 +69,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6)

--- a/testdata/p4_16_samples/psa-example-dpdk-counter.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-counter.p4
@@ -34,7 +34,7 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
     apply {
         counter0.count(1023, 20);
-        counter1.count(512);
+        counter1.count(512, 32);
         counter2.count(1023, 64);
     }
 }

--- a/testdata/p4_16_samples/psa-example-dpdk-directmeter.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-directmeter.p4
@@ -58,7 +58,7 @@ control MyIC(
 
     DirectMeter(PSA_MeterType_t.PACKETS) meter0;
     action execute_meter () {
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         b.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples/psa-example-dpdk-externs.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-externs.p4
@@ -59,7 +59,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-        color_out = meter0.execute(index, color_in, (bit <32>) hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, (bit <32>) hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
     }

--- a/testdata/p4_16_samples/psa-example-dpdk-externs.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-externs.p4
@@ -76,7 +76,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
         } else {

--- a/testdata/p4_16_samples/psa-example-dpdk-meter-execute-err.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-meter-execute-err.p4
@@ -1,0 +1,139 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+		verify(hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in/*, hdr.ipv4.totalLen*/);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6)
+           hdr.ipv4.ihl = 5;
+        if (hdr.ipv4.version == 6)
+           hdr.ipv4.ihl = 6;
+    }
+    
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512, 32);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;                                           // Works fine
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples/psa-example-dpdk-meter.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-meter.p4
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, /*color_in,*/ (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples/psa-example-dpdk-meter1.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-meter1.p4
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples/psa-example-dpdk-meter1.p4
+++ b/testdata/p4_16_samples/psa-example-dpdk-meter1.p4
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-        color_out = meter0.execute(index, color_in, (bit<32>) hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-bvec_union-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-bvec_union-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 struct alt_t {
     bit<1> valid;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-bvec_union-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-bvec_union-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 struct alt_t {
     bit<1> valid;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-bvec_union-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-bvec_union-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 struct alt_t {
     bit<1> valid;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-bvec_union.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-bvec_union.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 struct alt_t {
     bit<1> valid;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter-err-3-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter-err-3-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 const bit<8> ETHERNET_HEADER_LEN = 8w14;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter-err-3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter-err-3-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter-err-3-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter-err-3-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter-err-3.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter-err-3.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 const bit<8> ETHERNET_HEADER_LEN = 14;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-2-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-2-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 const bit<8> ETHERNET_HEADER_LEN = 8w14;
@@ -62,7 +62,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     PNA_MeterColor_t color_in = PNA_MeterColor_t.RED;
     DirectMeter(PNA_MeterType_t.PACKETS) meter0;
     action send() {
-        out1 = meter0.execute(color_in, 32w1024);
+        out1 = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table ipv4_host {
@@ -77,7 +77,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         pna_direct_meter = meter0;
     }
     apply {
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (color_out == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         ipv4_host.apply();
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-2-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {
@@ -60,7 +60,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     @name("MainControlImpl.tmp") bit<32> tmp;
     @name("MainControlImpl.meter0") DirectMeter(PNA_MeterType_t.PACKETS) meter0_0;
     @name("MainControlImpl.send") action send() {
-        out1_0 = meter0_0.execute(color_in_0, 32w1024);
+        out1_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         if (out1_0 == PNA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {
@@ -81,7 +81,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     }
     apply {
         color_in_0 = PNA_MeterColor_t.RED;
-        meter0_0.execute(color_in_0, 32w1024);
+        meter0_0.dpdk_execute(color_in_0, 32w1024);
         ipv4_host_0.apply();
     }
 }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-2-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;
@@ -58,7 +58,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     @name("MainControlImpl.color_in") PNA_MeterColor_t color_in_0;
     @name("MainControlImpl.meter0") DirectMeter(PNA_MeterType_t.PACKETS) meter0_0;
     @name("MainControlImpl.send") action send() {
-        out1_0 = meter0_0.execute(color_in_0, 32w1024);
+        out1_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         user_meta.port_out = (out1_0 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     @name("MainControlImpl.ipv4_host") table ipv4_host_0 {
@@ -74,7 +74,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     }
     @hidden action pnadpdkdirectmetererr2l80() {
         color_in_0 = PNA_MeterColor_t.RED;
-        meter0_0.execute(PNA_MeterColor_t.RED, 32w1024);
+        meter0_0.dpdk_execute(PNA_MeterColor_t.RED, 32w1024);
     }
     @hidden table tbl_pnadpdkdirectmetererr2l80 {
         actions = {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-2.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-2.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 const bit<8> ETHERNET_HEADER_LEN = 14;
@@ -62,7 +62,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     PNA_MeterColor_t color_in = PNA_MeterColor_t.RED;
     DirectMeter(PNA_MeterType_t.PACKETS) meter0;
     action send() {
-        out1 = meter0.execute(color_in, 32w1024);
+        out1 = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table ipv4_host {
@@ -77,7 +77,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         pna_direct_meter = meter0;
     }
     apply {
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (color_out == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         ipv4_host.apply();
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-3-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-3-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {
@@ -66,19 +66,19 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     DirectMeter(PNA_MeterType_t.BYTES) meter0;
     DirectMeter(PNA_MeterType_t.BYTES) meter1;
     action next_hop(PortId_t oport) {
-        out1 = meter0.execute(color_in, 32w1024);
+        out1 = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
-        color_out = meter1.execute(color_in, 32w1024);
+        color_out = meter1.dpdk_execute(color_in, 32w1024);
         user_meta.port_out1 = (color_out == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         send_to_port(oport);
     }
     action default_route_drop() {
-        out1 = meter0.execute(color_in, 32w1024);
+        out1 = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         drop_packet();
     }
     action default_route_drop1() {
-        out1 = meter1.execute(color_in, 32w1024);
+        out1 = meter1.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         drop_packet();
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-3-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {
@@ -65,14 +65,14 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     @name("MainControlImpl.meter0") DirectMeter(PNA_MeterType_t.BYTES) meter0_0;
     @name("MainControlImpl.meter1") DirectMeter(PNA_MeterType_t.BYTES) meter1_0;
     @name("MainControlImpl.next_hop") action next_hop(@name("oport") PortId_t oport) {
-        out1_0 = meter0_0.execute(color_in_0, 32w1024);
+        out1_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         if (out1_0 == PNA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {
             tmp = 32w0;
         }
         user_meta.port_out = tmp;
-        color_out_0 = meter1_0.execute(color_in_0, 32w1024);
+        color_out_0 = meter1_0.dpdk_execute(color_in_0, 32w1024);
         if (color_out_0 == PNA_MeterColor_t.GREEN) {
             tmp_0 = 32w1;
         } else {
@@ -82,8 +82,8 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         send_to_port(oport);
     }
     @name("MainControlImpl.next_hop") action next_hop_1(@name("oport") PortId_t oport_1) {
-        out1_0 = meter0_0.execute(color_in_0, 32w1024);
-        color_out_0 = meter1_0.execute(color_in_0, 32w1024);
+        out1_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
+        color_out_0 = meter1_0.dpdk_execute(color_in_0, 32w1024);
         if (color_out_0 == PNA_MeterColor_t.GREEN) {
             tmp_0 = 32w1;
         } else {
@@ -93,7 +93,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         send_to_port(oport_1);
     }
     @name("MainControlImpl.default_route_drop") action default_route_drop() {
-        out1_0 = meter0_0.execute(color_in_0, 32w1024);
+        out1_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         if (out1_0 == PNA_MeterColor_t.GREEN) {
             tmp_1 = 32w1;
         } else {
@@ -103,7 +103,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         drop_packet();
     }
     @name("MainControlImpl.default_route_drop1") action default_route_drop1() {
-        meter1_0.execute(color_in_0, 32w1024);
+        meter1_0.dpdk_execute(color_in_0, 32w1024);
         drop_packet();
     }
     @name("MainControlImpl.ipv4_da1") table ipv4_da1_0 {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-3-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-3-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;
@@ -61,25 +61,25 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     @name("MainControlImpl.meter0") DirectMeter(PNA_MeterType_t.BYTES) meter0_0;
     @name("MainControlImpl.meter1") DirectMeter(PNA_MeterType_t.BYTES) meter1_0;
     @name("MainControlImpl.next_hop") action next_hop(@name("oport") bit<32> oport) {
-        out1_0 = meter0_0.execute(color_in_0, 32w1024);
+        out1_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         user_meta.port_out = (out1_0 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
-        color_out_0 = meter1_0.execute(color_in_0, 32w1024);
+        color_out_0 = meter1_0.dpdk_execute(color_in_0, 32w1024);
         user_meta.port_out1 = (color_out_0 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         send_to_port(oport);
     }
     @name("MainControlImpl.next_hop") action next_hop_1(@name("oport") bit<32> oport_1) {
-        out1_0 = meter0_0.execute(color_in_0, 32w1024);
-        color_out_0 = meter1_0.execute(color_in_0, 32w1024);
+        out1_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
+        color_out_0 = meter1_0.dpdk_execute(color_in_0, 32w1024);
         user_meta.port_out1 = (color_out_0 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         send_to_port(oport_1);
     }
     @name("MainControlImpl.default_route_drop") action default_route_drop() {
-        out1_0 = meter0_0.execute(color_in_0, 32w1024);
+        out1_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         user_meta.port_out = (out1_0 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         drop_packet();
     }
     @name("MainControlImpl.default_route_drop1") action default_route_drop1() {
-        meter1_0.execute(color_in_0, 32w1024);
+        meter1_0.dpdk_execute(color_in_0, 32w1024);
         drop_packet();
     }
     @name("MainControlImpl.ipv4_da1") table ipv4_da1_0 {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-3.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-err-3.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {
@@ -66,19 +66,19 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     DirectMeter(PNA_MeterType_t.BYTES) meter0;
     DirectMeter(PNA_MeterType_t.BYTES) meter1;
     action next_hop(PortId_t oport) {
-        out1 = meter0.execute(color_in, 32w1024);
+        out1 = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
-        color_out = meter1.execute(color_in, 32w1024);
+        color_out = meter1.dpdk_execute(color_in, 32w1024);
         user_meta.port_out1 = (color_out == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         send_to_port(oport);
     }
     action default_route_drop() {
-        out1 = meter0.execute(color_in, 32w1024);
+        out1 = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         drop_packet();
     }
     action default_route_drop1() {
-        out1 = meter1.execute(color_in, 32w1024);
+        out1 = meter1.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (out1 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         drop_packet();
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {
@@ -65,7 +65,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     }
     action add_on_miss_action() {
         bit<32> tmp = 32w0;
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (color_out == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         add_entry<bit<32>>(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {
@@ -66,7 +66,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     }
     @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
         tmp = 32w0;
-        color_out_0 = meter0_0.execute(color_in_0, 32w1024);
+        color_out_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         if (color_out_0 == PNA_MeterColor_t.GREEN) {
             tmp_0 = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;
@@ -67,7 +67,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
         send_to_port(vport);
     }
     @name("MainControlImpl.add_on_miss_action") action add_on_miss_action() {
-        color_out_0 = meter0_0.execute(color_in_0, 32w1024);
+        color_out_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         user_meta.port_out = (color_out_0 == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         add_entry<bit<32>>(action_name = "next_hop", action_params = 32w0, expire_time_profile_id = user_meta.timeout);
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {
@@ -65,7 +65,7 @@ control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in
     }
     action add_on_miss_action() {
         bit<32> tmp = 0;
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         user_meta.port_out = (color_out == PNA_MeterColor_t.GREEN ? 32w1 : 32w0);
         add_entry(action_name = "next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
     }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner.p4.spec
@@ -33,6 +33,7 @@ struct main_metadata_t {
 	bit<8> local_metadata_timeout
 	bit<32> local_metadata_port_out
 	bit<32> pna_main_output_metadata_output_port
+	bit<32> table_entry_index
 	bit<32> MainControlT_tmp
 	bit<32> MainControlT_tmp_0
 	bit<32> MainControlT_color_out
@@ -55,6 +56,8 @@ action next_hop args instanceof next_hop_arg_t {
 }
 
 action add_on_miss_action args none {
+	entryid m.table_entry_index 
+	meter meter0_0 m.table_entry_index 0x400 m.MainControlT_color_in m.MainControlT_color_out
 	jmpneq LABEL_FALSE_0 m.MainControlT_color_out 0x1
 	mov m.MainControlT_tmp_1 0x1
 	jmp LABEL_END_0

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner.p4.spec
@@ -33,7 +33,6 @@ struct main_metadata_t {
 	bit<8> local_metadata_timeout
 	bit<32> local_metadata_port_out
 	bit<32> pna_main_output_metadata_output_port
-	bit<32> table_entry_index
 	bit<32> MainControlT_tmp
 	bit<32> MainControlT_tmp_0
 	bit<32> MainControlT_color_out
@@ -56,8 +55,6 @@ action next_hop args instanceof next_hop_arg_t {
 }
 
 action add_on_miss_action args none {
-	entryid m.table_entry_index 
-	meter meter0_0 m.table_entry_index 0x400 m.MainControlT_color_in m.MainControlT_color_out
 	jmpneq LABEL_FALSE_0 m.MainControlT_color_out 0x1
 	mov m.MainControlT_tmp_1 0x1
 	jmp LABEL_END_0

--- a/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings5-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings5-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Header1 {
     bit<32> data;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings5-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Header1 {
     bit<32> data;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings5-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings5-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Header1 {
     bit<32> data;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings5.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings5.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Header1 {
     bit<32> data;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings6-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings6-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Header1 {
     bit<32> data;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings6-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Header1 {
     bit<32> data;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings6-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings6-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Header1 {
     bit<32> data;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings6.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings6.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Header1 {
     bit<32> data;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-union-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-union-bmv2-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Hdr1 {
     bit<8> a;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-union-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-union-bmv2-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Hdr1 {
     bit<8> a;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-union-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-union-bmv2-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Hdr1 {
     bit<8> a;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-union-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-union-bmv2.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header Hdr1 {
     bit<8> a;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-wrong-warning-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-wrong-warning-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-wrong-warning-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-wrong-warning-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-wrong-warning-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-wrong-warning-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-wrong-warning.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-wrong-warning.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;

--- a/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk.p4
+++ b/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-example-addhit.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-addhit.p4.spec
@@ -1,0 +1,194 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<16> dataOffset_res_ecn_flags
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct do_range_checks_1_arg_t {
+	bit<16> min1
+	bit<16> max1
+}
+
+struct do_range_checks_2_arg_t {
+	bit<16> min1
+	bit<16> max1
+}
+
+struct next_hop2_arg_t {
+	bit<32> vport
+	bit<32> newAddr
+}
+
+struct next_hop_arg_t {
+	bit<32> vport
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<32> local_metadata_rng_result1
+	bit<32> local_metadata_val1
+	bit<32> local_metadata_val2
+	bit<8> local_metadata_timeout
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_0
+	bit<32> MainControlT_tmp_1
+	bit<32> MainControlT_tmp_2
+	bit<32> MainControlT_tmp_3
+	bit<32> MainControlT_tmp_4
+	bit<32> learnArg
+	bit<32> learnArg_0
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+regarray direction size 0x100 initval 0
+
+action do_range_checks_1 args instanceof do_range_checks_1_arg_t {
+	jmpgt LABEL_FALSE_1 t.min1 h.tcp.srcPort
+	jmpgt LABEL_FALSE_1 h.tcp.srcPort t.max1
+	mov m.MainControlT_tmp_3 0x1
+	jmp LABEL_END_1
+	LABEL_FALSE_1 :	mov m.MainControlT_tmp_3 0x0
+	LABEL_END_1 :	mov m.local_metadata_rng_result1 m.MainControlT_tmp_3
+	return
+}
+
+action next_hop args instanceof next_hop_arg_t {
+	mov m.learnArg 0x0
+	learn next_hop m.learnArg m.local_metadata_timeout
+	mov m.pna_main_output_metadata_output_port t.vport
+	return
+}
+
+action add_on_miss_action args none {
+	mov m.learnArg_0 0x0
+	learn next_hop m.learnArg_0 m.local_metadata_timeout
+	return
+}
+
+action do_range_checks_2 args instanceof do_range_checks_2_arg_t {
+	jmpgt LABEL_FALSE_2 t.min1 h.tcp.srcPort
+	jmpgt LABEL_FALSE_2 h.tcp.srcPort t.max1
+	jmpgt LABEL_FALSE_3 0x32 h.tcp.srcPort
+	jmpgt LABEL_FALSE_3 h.tcp.srcPort 0x64
+	mov m.MainControlT_tmp_2 m.local_metadata_val1
+	jmp LABEL_END_3
+	LABEL_FALSE_3 :	mov m.MainControlT_tmp_2 m.local_metadata_val2
+	LABEL_END_3 :	mov m.MainControlT_tmp_1 m.MainControlT_tmp_2
+	jmp LABEL_END_2
+	LABEL_FALSE_2 :	mov m.MainControlT_tmp_1 m.local_metadata_val1
+	LABEL_END_2 :	mov m.local_metadata_rng_result1 m.MainControlT_tmp_1
+	return
+}
+
+action next_hop2 args instanceof next_hop2_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov h.ipv4.srcAddr t.newAddr
+	return
+}
+
+action add_on_miss_action2 args none {
+	mov m.MainControlT_tmp 0x0
+	mov m.MainControlT_tmp_0 0x4d2
+	learn next_hop m.MainControlT_tmp m.local_metadata_timeout
+	return
+}
+
+learner ipv4_da {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop @tableonly
+		add_on_miss_action @defaultonly
+	}
+	default_action add_on_miss_action args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+learner ipv4_da2 {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop2 @tableonly
+		add_on_miss_action2 @defaultonly
+		do_range_checks_2
+		do_range_checks_1
+	}
+	default_action add_on_miss_action2 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpgt LABEL_FALSE 0x64 h.tcp.srcPort
+	jmpgt LABEL_FALSE h.tcp.srcPort 0xc8
+	mov m.MainControlT_tmp_4 0x1
+	jmp LABEL_END
+	LABEL_FALSE :	mov m.MainControlT_tmp_4 0x0
+	LABEL_END :	mov m.local_metadata_rng_result1 m.MainControlT_tmp_4
+	jmpnv LABEL_END_0 h.ipv4
+	table ipv4_da
+	table ipv4_da2
+	LABEL_END_0 :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-1-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-1-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-1-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-1-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-1.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-1.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-example-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-miss.p4.spec
@@ -1,0 +1,191 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct tcp_t {
+	bit<16> srcPort
+	bit<16> dstPort
+	bit<32> seqNo
+	bit<32> ackNo
+	bit<16> dataOffset_res_ecn_flags
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgentPtr
+}
+
+struct do_range_checks_1_arg_t {
+	bit<16> min1
+	bit<16> max1
+}
+
+struct do_range_checks_2_arg_t {
+	bit<16> min1
+	bit<16> max1
+}
+
+struct next_hop2_arg_t {
+	bit<32> vport
+	bit<32> newAddr
+}
+
+struct next_hop_arg_t {
+	bit<32> vport
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<32> local_metadata_rng_result1
+	bit<32> local_metadata_val1
+	bit<32> local_metadata_val2
+	bit<8> local_metadata_timeout
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_0
+	bit<32> MainControlT_tmp_1
+	bit<32> MainControlT_tmp_2
+	bit<32> MainControlT_tmp_3
+	bit<32> MainControlT_tmp_4
+	bit<32> learnArg
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header tcp instanceof tcp_t
+
+regarray direction size 0x100 initval 0
+
+action do_range_checks_1 args instanceof do_range_checks_1_arg_t {
+	jmpgt LABEL_FALSE_1 t.min1 h.tcp.srcPort
+	jmpgt LABEL_FALSE_1 h.tcp.srcPort t.max1
+	mov m.MainControlT_tmp_3 0x1
+	jmp LABEL_END_1
+	LABEL_FALSE_1 :	mov m.MainControlT_tmp_3 0x0
+	LABEL_END_1 :	mov m.local_metadata_rng_result1 m.MainControlT_tmp_3
+	return
+}
+
+action next_hop args instanceof next_hop_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	return
+}
+
+action add_on_miss_action args none {
+	mov m.learnArg 0x0
+	learn add_on_miss_action m.learnArg m.local_metadata_timeout
+	return
+}
+
+action do_range_checks_2 args instanceof do_range_checks_2_arg_t {
+	jmpgt LABEL_FALSE_2 t.min1 h.tcp.srcPort
+	jmpgt LABEL_FALSE_2 h.tcp.srcPort t.max1
+	jmpgt LABEL_FALSE_3 0x32 h.tcp.srcPort
+	jmpgt LABEL_FALSE_3 h.tcp.srcPort 0x64
+	mov m.MainControlT_tmp_2 m.local_metadata_val1
+	jmp LABEL_END_3
+	LABEL_FALSE_3 :	mov m.MainControlT_tmp_2 m.local_metadata_val2
+	LABEL_END_3 :	mov m.MainControlT_tmp_1 m.MainControlT_tmp_2
+	jmp LABEL_END_2
+	LABEL_FALSE_2 :	mov m.MainControlT_tmp_1 m.local_metadata_val1
+	LABEL_END_2 :	mov m.local_metadata_rng_result1 m.MainControlT_tmp_1
+	return
+}
+
+action next_hop2 args instanceof next_hop2_arg_t {
+	mov m.pna_main_output_metadata_output_port t.vport
+	mov h.ipv4.srcAddr t.newAddr
+	return
+}
+
+action add_on_miss_action2 args none {
+	mov m.MainControlT_tmp 0x0
+	mov m.MainControlT_tmp_0 0x4d2
+	learn next_hop m.MainControlT_tmp m.local_metadata_timeout
+	return
+}
+
+learner ipv4_da {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop @tableonly
+		add_on_miss_action @defaultonly
+	}
+	default_action add_on_miss_action args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+learner ipv4_da2 {
+	key {
+		h.ipv4.dstAddr
+	}
+	actions {
+		next_hop2 @tableonly
+		add_on_miss_action2 @defaultonly
+		do_range_checks_2
+		do_range_checks_1
+	}
+	default_action add_on_miss_action2 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	jmpgt LABEL_FALSE 0x64 h.tcp.srcPort
+	jmpgt LABEL_FALSE h.tcp.srcPort 0xc8
+	mov m.MainControlT_tmp_4 0x1
+	jmp LABEL_END
+	LABEL_FALSE :	mov m.MainControlT_tmp_4 0x0
+	LABEL_END :	mov m.local_metadata_rng_result1 m.MainControlT_tmp_4
+	jmpnv LABEL_END_0 h.ipv4
+	table ipv4_da
+	table ipv4_da2
+	LABEL_END_0 :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 header ethernet_t {
     bit<48> dstAddr;

--- a/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk.p4
+++ b/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <pna.p4>
+#include <dpdk/pna.p4>
 
 typedef bit<48> EthernetAddress;
 header ethernet_t {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-first.p4
@@ -96,7 +96,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl.apply();
             counter0.count(12w1023, 32w20);
-            counter1.count(12w512);
+            counter1.count(12w512, 32w32);
             counter2.count(12w1023, 32w64);
             user_meta.port_out = reg.read(12w1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-first.p4
@@ -67,7 +67,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-first.p4
@@ -67,11 +67,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-frontend.p4
@@ -71,11 +71,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-frontend.p4
@@ -71,7 +71,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-frontend.p4
@@ -107,7 +107,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
             counter0_0.count(12w1023, 32w20);
-            counter1_0.count(12w512);
+            counter1_0.count(12w512, 32w32);
             counter2_0.count(12w1023, 32w64);
             user_meta.port_out = reg_0.read(12w1);
             test();

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-midend.p4
@@ -68,11 +68,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4.ihl = 4w5;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-midend.p4
@@ -89,7 +89,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @hidden action psaexampledpdkbytealignment_1l99() {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
         user_meta.port_out = reg_0.read(12w1);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1-midend.p4
@@ -68,7 +68,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4.ihl = 4w5;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4
@@ -95,7 +95,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4
@@ -67,11 +67,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4
@@ -67,7 +67,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-first.p4
@@ -95,7 +95,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl.apply();
             counter0.count(12w1023, 32w20);
-            counter1.count(12w512);
+            counter1.count(12w512, 32w32);
             counter2.count(12w1023, 32w64);
             user_meta.port_out = reg.read(12w1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-first.p4
@@ -66,11 +66,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-first.p4
@@ -66,7 +66,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-frontend.p4
@@ -106,7 +106,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
             counter0_0.count(12w1023, 32w20);
-            counter1_0.count(12w512);
+            counter1_0.count(12w512, 32w32);
             counter2_0.count(12w1023, 32w64);
             user_meta.port_out = reg_0.read(12w1);
             test();

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-frontend.p4
@@ -70,7 +70,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-frontend.p4
@@ -70,11 +70,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-midend.p4
@@ -88,7 +88,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @hidden action psaexampledpdkbytealignment_2l98() {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
         user_meta.port_out = reg_0.read(12w1);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-midend.p4
@@ -67,11 +67,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4.ihl = 4w5;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2-midend.p4
@@ -67,7 +67,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4.ihl = 4w5;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4
@@ -66,7 +66,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4
@@ -66,11 +66,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4
@@ -94,7 +94,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-first.p4
@@ -97,7 +97,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl.apply();
             counter0.count(12w1023, 32w20);
-            counter1.count(12w512);
+            counter1.count(12w512, 32w32);
             counter2.count(12w1023, 32w64);
             user_meta.port_out = reg.read(12w1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-first.p4
@@ -66,11 +66,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-first.p4
@@ -66,7 +66,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-frontend.p4
@@ -70,7 +70,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-frontend.p4
@@ -108,7 +108,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
             counter0_0.count(12w1023, 32w20);
-            counter1_0.count(12w512);
+            counter1_0.count(12w512, 32w32);
             counter2_0.count(12w1023, 32w64);
             user_meta.port_out = reg_0.read(12w1);
             test();

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-frontend.p4
@@ -70,11 +70,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-midend.p4
@@ -67,11 +67,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4.ihl = 4w5;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-midend.p4
@@ -90,7 +90,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @hidden action psaexampledpdkbytealignment_3l100() {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
         user_meta.port_out = reg_0.read(12w1);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3-midend.p4
@@ -67,7 +67,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4.ihl = 4w5;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4
@@ -66,7 +66,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4
@@ -66,11 +66,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4
@@ -96,7 +96,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-first.p4
@@ -96,7 +96,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl.apply();
             counter0.count(12w1023, 32w20);
-            counter1.count(12w512);
+            counter1.count(12w512, 32w32);
             counter2.count(12w1023, 32w64);
             user_meta.port_out = reg.read(12w1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-first.p4
@@ -67,7 +67,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-first.p4
@@ -67,11 +67,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-frontend.p4
@@ -71,11 +71,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-frontend.p4
@@ -71,7 +71,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-frontend.p4
@@ -107,7 +107,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
             counter0_0.count(12w1023, 32w20);
-            counter1_0.count(12w512);
+            counter1_0.count(12w512, 32w32);
             counter2_0.count(12w1023, 32w64);
             user_meta.port_out = reg_0.read(12w1);
             test();

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-midend.p4
@@ -68,11 +68,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4.ihl = 4w5;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-midend.p4
@@ -68,7 +68,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4.ihl = 4w5;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5-midend.p4
@@ -89,7 +89,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @hidden action psaexampledpdkbytealignment_5l99() {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
         user_meta.port_out = reg_0.read(12w1);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4
@@ -95,7 +95,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4
@@ -67,11 +67,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4
@@ -67,7 +67,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-first.p4
@@ -105,7 +105,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl.apply();
             counter0.count(12w1023, 32w20);
-            counter1.count(12w512);
+            counter1.count(12w512, 32w32);
             counter2.count(12w1023, 32w64);
             user_meta.port_out = reg.read(12w1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-first.p4
@@ -74,11 +74,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 4w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-first.p4
@@ -74,7 +74,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 4w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-frontend.p4
@@ -116,7 +116,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
             counter0_0.count(12w1023, 32w20);
-            counter1_0.count(12w512);
+            counter1_0.count(12w512, 32w32);
             counter2_0.count(12w1023, 32w64);
             user_meta.port_out = reg_0.read(12w1);
             test();

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-frontend.p4
@@ -78,7 +78,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-frontend.p4
@@ -78,11 +78,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-midend.p4
@@ -76,11 +76,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4._ihl1 = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4._totalLen3);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4._totalLen3);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4._totalLen3);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4._ihl1 = (hdr.ipv4._version0 == 4w6 ? 4w6 : 4w5);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-midend.p4
@@ -76,7 +76,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4._ihl1 = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4._totalLen3);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4._totalLen3);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4._ihl1 = (hdr.ipv4._version0 == 4w6 ? 4w6 : 4w5);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6-midend.p4
@@ -100,7 +100,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @hidden action psaexampledpdkbytealignment_6l109() {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
         user_meta.port_out = reg_0.read(12w1);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4
@@ -104,7 +104,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4
@@ -74,7 +74,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4
@@ -74,11 +74,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-first.p4
@@ -80,11 +80,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 4w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-first.p4
@@ -80,7 +80,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 4w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-first.p4
@@ -113,7 +113,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl.apply();
             counter0.count(12w1023, 32w20);
-            counter1.count(12w512);
+            counter1.count(12w512, 32w32);
             counter2.count(12w1023, 32w64);
             user_meta.port_out = reg.read(12w1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-frontend.p4
@@ -124,7 +124,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
             counter0_0.count(12w1023, 32w20);
-            counter1_0.count(12w512);
+            counter1_0.count(12w512, 32w32);
             counter2_0.count(12w1023, 32w64);
             user_meta.port_out = reg_0.read(12w1);
             test();

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-frontend.p4
@@ -84,11 +84,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-frontend.p4
@@ -84,7 +84,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-midend.p4
@@ -83,7 +83,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4._ihl1 = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4._totalLen3);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4._totalLen3);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4._ihl1 = (hdr.ipv4._version0 == 4w6 ? 4w6 : 4w5);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-midend.p4
@@ -83,11 +83,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4._ihl1 = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4._totalLen3);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4._totalLen3);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4._totalLen3);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4._ihl1 = (hdr.ipv4._version0 == 4w6 ? 4w6 : 4w5);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7-midend.p4
@@ -111,7 +111,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @hidden action psaexampledpdkbytealignment_7l117() {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
         user_meta.port_out = reg_0.read(12w1);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4
@@ -80,11 +80,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4
@@ -80,7 +80,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4
@@ -112,7 +112,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-first.p4
@@ -80,11 +80,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 4w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-first.p4
@@ -80,7 +80,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 4w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-first.p4
@@ -113,7 +113,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl.apply();
             counter0.count(12w1023, 32w20);
-            counter1.count(12w512);
+            counter1.count(12w512, 32w32);
             counter2.count(12w1023, 32w64);
             user_meta.port_out = reg.read(12w1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-frontend.p4
@@ -124,7 +124,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
             counter0_0.count(12w1023, 32w20);
-            counter1_0.count(12w512);
+            counter1_0.count(12w512, 32w32);
             counter2_0.count(12w1023, 32w64);
             user_meta.port_out = reg_0.read(12w1);
             test();

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-frontend.p4
@@ -84,11 +84,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-frontend.p4
@@ -84,7 +84,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-midend.p4
@@ -83,7 +83,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4._ihl1 = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4._totalLen3);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4._totalLen3);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4._ihl1 = (hdr.ipv4._version0 == 4w6 ? 4w6 : 4w5);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-midend.p4
@@ -83,11 +83,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4._ihl1 = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4._totalLen3);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4._totalLen3);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4._totalLen3);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4._ihl1 = (hdr.ipv4._version0 == 4w6 ? 4w6 : 4w5);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8-midend.p4
@@ -111,7 +111,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @hidden action psaexampledpdkbytealignment_8l117() {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
         user_meta.port_out = reg_0.read(12w1);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4
@@ -80,11 +80,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4
@@ -80,7 +80,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.version == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4
@@ -112,7 +112,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-first.p4
@@ -97,7 +97,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl.apply();
             counter0.count(12w1023, 32w20);
-            counter1.count(12w512);
+            counter1.count(12w512, 32w32);
             counter2.count(12w1023, 32w64);
             user_meta.port_out = reg.read(12w1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-first.p4
@@ -66,11 +66,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-first.p4
@@ -66,7 +66,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-frontend.p4
@@ -70,7 +70,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-frontend.p4
@@ -108,7 +108,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
             counter0_0.count(12w1023, 32w20);
-            counter1_0.count(12w512);
+            counter1_0.count(12w512, 32w32);
             counter2_0.count(12w1023, 32w64);
             user_meta.port_out = reg_0.read(12w1);
             test();

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-frontend.p4
@@ -70,11 +70,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-midend.p4
@@ -90,7 +90,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @hidden action psaexampledpdkbytealignment_9l100() {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
         user_meta.port_out = reg_0.read(12w1);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-midend.p4
@@ -67,11 +67,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4.ihl = 4w5;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9-midend.p4
@@ -67,7 +67,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
         hdr.ipv4.ihl = 4w5;
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
         hdr.ipv4.ihl = 4w5;

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4
@@ -66,7 +66,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4
@@ -66,11 +66,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
         hdr.ipv4.ihl = 5;
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
         if (hdr.ipv4.hdrChecksum[5:0] == 6) {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4
@@ -96,7 +96,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
             test(hdr.ipv4.version);

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-first.p4
@@ -34,7 +34,7 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2;
     apply {
         counter0.count(12w1023, 32w20);
-        counter1.count(12w512);
+        counter1.count(12w512, 32w32);
         counter2.count(12w1023, 32w64);
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-frontend.p4
@@ -34,7 +34,7 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     @name("MyIC.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
     apply {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter-midend.p4
@@ -33,7 +33,7 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     @name("MyIC.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
     @hidden action psaexampledpdkcounter36() {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
     }
     @hidden table tbl_psaexampledpdkcounter36 {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4
@@ -34,7 +34,7 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
     apply {
         counter0.count(1023, 20);
-        counter1.count(512);
+        counter1.count(512, 32);
         counter2.count(1023, 64);
     }
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-1-first.p4
@@ -40,7 +40,7 @@ control MyIC(inout headers_t hdr, inout metadata_t b, in psa_ingress_input_metad
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     DirectMeter(PSA_MeterType_t.BYTES) meter0;
     action execute_meter() {
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         b.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-1-frontend.p4
@@ -43,7 +43,7 @@ control MyIC(inout headers_t hdr, inout metadata_t b, in psa_ingress_input_metad
     @name("MyIC.as") ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as_0;
     @name("MyIC.meter0") DirectMeter(PSA_MeterType_t.BYTES) meter0_0;
     @name("MyIC.execute_meter") action execute_meter() {
-        color_out_0 = meter0_0.execute(color_in_0, 32w1024);
+        color_out_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-1-midend.p4
@@ -41,7 +41,7 @@ control MyIC(inout headers_t hdr, inout metadata_t b, in psa_ingress_input_metad
     @name("MyIC.as") ActionSelector(PSA_HashAlgorithm_t.CRC32, 32w1024, 32w16) as_0;
     @name("MyIC.meter0") DirectMeter(PSA_MeterType_t.BYTES) meter0_0;
     @name("MyIC.execute_meter") action execute_meter() {
-        color_out_0 = meter0_0.execute(color_in_0, 32w1024);
+        color_out_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         b.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     @name("MyIC.tbl") table tbl_0 {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-1.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-1.p4
@@ -40,7 +40,7 @@ control MyIC(inout headers_t hdr, inout metadata_t b, in psa_ingress_input_metad
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     DirectMeter(PSA_MeterType_t.BYTES) meter0;
     action execute_meter() {
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         b.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-err-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-err-first.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <bmv2/psa.p4>
+#include <dpdk/psa.p4>
 
 struct EMPTY {
 }
@@ -31,7 +31,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     DirectMeter(PSA_MeterType_t.BYTES) meter0;
     action execute_meter() {
-        meter0.execute();
+        meter0.dpdk_execute(32w0);
     }
     table tbl {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-err-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-err-frontend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <bmv2/psa.p4>
+#include <dpdk/psa.p4>
 
 struct EMPTY {
 }
@@ -35,7 +35,7 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     }
     @name("MyIC.meter0") DirectMeter(PSA_MeterType_t.BYTES) meter0_0;
     @name("MyIC.execute_meter") action execute_meter() {
-        meter0_0.execute();
+        meter0_0.dpdk_execute(32w0);
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-err-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-err-midend.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <bmv2/psa.p4>
+#include <dpdk/psa.p4>
 
 struct EMPTY {
 }
@@ -34,7 +34,7 @@ control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t
     }
     @name("MyIC.meter0") DirectMeter(PSA_MeterType_t.BYTES) meter0_0;
     @name("MyIC.execute_meter") action execute_meter() {
-        meter0_0.execute();
+        meter0_0.dpdk_execute(32w0);
     }
     @name("MyIC.tbl") table tbl_0 {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-err.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-err.p4
@@ -1,5 +1,5 @@
 #include <core.p4>
-#include <bmv2/psa.p4>
+#include <dpdk/psa.p4>
 
 struct EMPTY {
 }
@@ -31,7 +31,7 @@ parser MyEP(packet_in buffer, out EMPTY a, inout EMPTY b, in psa_egress_parser_i
 control MyIC(inout headers_t hdr, inout EMPTY b, in psa_ingress_input_metadata_t c, inout psa_ingress_output_metadata_t d) {
     DirectMeter(PSA_MeterType_t.BYTES) meter0;
     action execute_meter() {
-        meter0.execute();
+        meter0.dpdk_execute(32w0);
     }
     table tbl {
         key = {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-first.p4
@@ -38,7 +38,7 @@ control MyIC(inout headers_t hdr, inout metadata_t b, in psa_ingress_input_metad
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     DirectMeter(PSA_MeterType_t.PACKETS) meter0;
     action execute_meter() {
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         b.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-frontend.p4
@@ -41,7 +41,7 @@ control MyIC(inout headers_t hdr, inout metadata_t b, in psa_ingress_input_metad
     }
     @name("MyIC.meter0") DirectMeter(PSA_MeterType_t.PACKETS) meter0_0;
     @name("MyIC.execute_meter") action execute_meter() {
-        color_out_0 = meter0_0.execute(color_in_0, 32w1024);
+        color_out_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter-midend.p4
@@ -39,7 +39,7 @@ control MyIC(inout headers_t hdr, inout metadata_t b, in psa_ingress_input_metad
     }
     @name("MyIC.meter0") DirectMeter(PSA_MeterType_t.PACKETS) meter0_0;
     @name("MyIC.execute_meter") action execute_meter() {
-        color_out_0 = meter0_0.execute(color_in_0, 32w1024);
+        color_out_0 = meter0_0.dpdk_execute(color_in_0, 32w1024);
         b.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     @name("MyIC.tbl") table tbl_0 {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter.p4
@@ -38,7 +38,7 @@ control MyIC(inout headers_t hdr, inout metadata_t b, in psa_ingress_input_metad
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     DirectMeter(PSA_MeterType_t.PACKETS) meter0;
     action execute_meter() {
-        color_out = meter0.execute(color_in, 32w1024);
+        color_out = meter0.dpdk_execute(color_in, 32w1024);
         b.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter.p4.spec
@@ -33,7 +33,6 @@ struct metadata_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_port_out
-	bit<32> table_entry_index
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
 	bit<32> Ingress_tmp
@@ -47,8 +46,6 @@ action NoAction args none {
 }
 
 action execute_meter args none {
-	entryid m.table_entry_index 
-	meter meter0_0 m.table_entry_index 0x400 m.Ingress_color_in m.Ingress_color_out
 	jmpneq LABEL_FALSE m.Ingress_color_out 0x0
 	mov m.Ingress_tmp 0x1
 	jmp LABEL_END

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter.p4.spec
@@ -33,6 +33,7 @@ struct metadata_t {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_port_out
+	bit<32> table_entry_index
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
 	bit<32> Ingress_tmp
@@ -46,6 +47,8 @@ action NoAction args none {
 }
 
 action execute_meter args none {
+	entryid m.table_entry_index 
+	meter meter0_0 m.table_entry_index 0x400 m.Ingress_color_in m.Ingress_color_out
 	jmpneq LABEL_FALSE m.Ingress_color_out 0x0
 	mov m.Ingress_tmp 0x1
 	jmp LABEL_END

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-first.p4
@@ -59,7 +59,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-first.p4
@@ -77,7 +77,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl.apply();
             counter0.count(12w1023, 32w20);
-            counter1.count(12w512);
+            counter1.count(12w512, 32w32);
             counter2.count(12w1023, 32w64);
             user_meta.port_out = reg.read(12w1);
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-first.p4
@@ -59,11 +59,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-frontend.p4
@@ -62,11 +62,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-frontend.p4
@@ -86,7 +86,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
             counter0_0.count(12w1023, 32w20);
-            counter1_0.count(12w512);
+            counter1_0.count(12w512, 32w32);
             counter2_0.count(12w1023, 32w64);
             user_meta.port_out = reg_0.read(12w1);
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-frontend.p4
@@ -62,7 +62,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-midend.p4
@@ -60,7 +60,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-midend.p4
@@ -60,11 +60,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs-midend.p4
@@ -76,7 +76,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @hidden action psaexampledpdkexterns78() {
         counter0_0.count(12w1023, 32w20);
-        counter1_0.count(12w512);
+        counter1_0.count(12w512, 32w32);
         counter2_0.count(12w1023, 32w64);
         user_meta.port_out = reg_0.read(12w1);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4
@@ -59,7 +59,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4
@@ -59,11 +59,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
         reg.write(index, user_meta.port_out);
     }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4
@@ -76,7 +76,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         if (user_meta.port_out == 1) {
             tbl.apply();
             counter0.count(1023, 20);
-            counter1.count(512);
+            counter1.count(512, 32);
             counter2.count(1023, 64);
             user_meta.port_out = reg.read(1);
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-first.p4
@@ -1,0 +1,138 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(32w1024) reg;
+    Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 4w5;
+        color_out = meter0.execute(index, color_in);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {
+            hdr.ipv4.ihl = 4w5;
+        }
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction();
+            execute();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (user_meta.port_out == 32w1) {
+            tbl.apply();
+            counter0.count(12w1023, 32w20);
+            counter1.count(12w512, 32w32);
+            counter2.count(12w1023, 32w64);
+            user_meta.port_out = reg.read(12w1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-first.p4
@@ -84,7 +84,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     table tbl {
         key = {
-            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr");
         }
         actions = {
             NoAction();
@@ -131,8 +131,5 @@ control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_met
 }
 
 IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
-
 EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
-
 PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
-

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-frontend.p4
@@ -61,7 +61,6 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     @name("ingress.color_out") PSA_MeterColor_t color_out_0;
     @name("ingress.color_in") PSA_MeterColor_t color_in_0;
     @name("ingress.tmp") bit<32> tmp;
-    @name("ingress.hasReturned") bool hasReturned;
     @name("ingress.version") bit<4> version_0;
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
@@ -95,7 +94,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @name("ingress.tbl") table tbl_0 {
         key = {
-            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr");
         }
         actions = {
             NoAction_1();
@@ -104,7 +103,6 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         default_action = NoAction_1();
     }
     apply {
-        hasReturned = false;
         color_in_0 = PSA_MeterColor_t.RED;
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
@@ -114,7 +112,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
             user_meta.port_out = reg_0.read(12w1);
             test();
         } else {
-            hasReturned = true;
+            ;
         }
     }
 }
@@ -144,8 +142,5 @@ control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_met
 }
 
 IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
-
 EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
-
 PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
-

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-frontend.p4
@@ -1,0 +1,151 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @name("ingress.tmp") bit<32> tmp;
+    @name("ingress.hasReturned") bool hasReturned;
+    @name("ingress.version") bit<4> version_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0);
+        if (color_out_0 == PSA_MeterColor_t.GREEN) {
+            tmp = 32w1;
+        } else {
+            tmp = 32w0;
+        }
+        user_meta.port_out = tmp;
+        reg_0.write(index_1, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6w6) {
+            hdr.ipv4.ihl = 4w5;
+        }
+        if (hdr.ipv4.version == 4w6) {
+            hdr.ipv4.ihl = 4w6;
+        }
+    }
+    @name("ingress.test") action test() {
+        version_0 = hdr.ipv4.version;
+        if (version_0 == 4w4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 4w5;
+        }
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        hasReturned = false;
+        color_in_0 = PSA_MeterColor_t.RED;
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            counter0_0.count(12w1023, 32w20);
+            counter1_0.count(12w512, 32w32);
+            counter2_0.count(12w1023, 32w64);
+            user_meta.port_out = reg_0.read(12w1);
+            test();
+        } else {
+            hasReturned = true;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-midend.p4
@@ -79,7 +79,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @name("ingress.tbl") table tbl_0 {
         key = {
-            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr");
         }
         actions = {
             NoAction_1();
@@ -120,6 +120,8 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
             tbl_0.apply();
             tbl_psaexampledpdkmeterexecuteerr99.apply();
             tbl_test.apply();
+        } else {
+            ;
         }
     }
 }
@@ -158,8 +160,5 @@ control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_met
 }
 
 IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
-
 EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
-
 PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
-

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err-midend.p4
@@ -1,0 +1,165 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract<ipv4_t>(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 4w5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.color_out") PSA_MeterColor_t color_out_0;
+    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.counter0") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0_0;
+    @name("ingress.counter1") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.PACKETS) counter1_0;
+    @name("ingress.counter2") Counter<bit<10>, bit<12>>(32w1024, PSA_CounterType_t.BYTES) counter2_0;
+    @name("ingress.reg") Register<bit<32>, bit<12>>(32w1024) reg_0;
+    @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
+    @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+        hdr.ipv4.ihl = 4w5;
+        color_out_0 = meter0_0.execute(index_1, color_in_0);
+        user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg_0.write(index_1, (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0));
+        hdr.ipv4.ihl = 4w5;
+        hdr.ipv4.ihl = (hdr.ipv4.version == 4w6 ? 4w6 : 4w5);
+    }
+    @name("ingress.test") action test() {
+        hdr.ipv4.hdrChecksum[3:0] = (hdr.ipv4.version == 4w4 ? hdr.ipv4.version + 4w5 : hdr.ipv4.hdrChecksum[3:0]);
+    }
+    @name("ingress.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr") ;
+        }
+        actions = {
+            NoAction_1();
+            execute_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action psaexampledpdkmeterexecuteerr99() {
+        counter0_0.count(12w1023, 32w20);
+        counter1_0.count(12w512, 32w32);
+        counter2_0.count(12w1023, 32w64);
+        user_meta.port_out = reg_0.read(12w1);
+    }
+    @hidden action psaexampledpdkmeterexecuteerr70() {
+        color_in_0 = PSA_MeterColor_t.RED;
+    }
+    @hidden table tbl_psaexampledpdkmeterexecuteerr70 {
+        actions = {
+            psaexampledpdkmeterexecuteerr70();
+        }
+        const default_action = psaexampledpdkmeterexecuteerr70();
+    }
+    @hidden table tbl_psaexampledpdkmeterexecuteerr99 {
+        actions = {
+            psaexampledpdkmeterexecuteerr99();
+        }
+        const default_action = psaexampledpdkmeterexecuteerr99();
+    }
+    @hidden table tbl_test {
+        actions = {
+            test();
+        }
+        const default_action = test();
+    }
+    apply {
+        tbl_psaexampledpdkmeterexecuteerr70.apply();
+        if (user_meta.port_out == 32w1) {
+            tbl_0.apply();
+            tbl_psaexampledpdkmeterexecuteerr99.apply();
+            tbl_test.apply();
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psaexampledpdkmeterexecuteerr123() {
+        hdr.ipv4.hdrChecksum = 16w4;
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_psaexampledpdkmeterexecuteerr123 {
+        actions = {
+            psaexampledpdkmeterexecuteerr123();
+        }
+        const default_action = psaexampledpdkmeterexecuteerr123();
+    }
+    apply {
+        tbl_psaexampledpdkmeterexecuteerr123.apply();
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline<headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch<headers, metadata_t, headers, metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t, empty_metadata_t>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err.p4
@@ -130,8 +130,5 @@ control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_met
 }
 
 IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
-
 EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
-
 PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
-

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err.p4
@@ -1,0 +1,137 @@
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<32> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct metadata_t {
+    bit<32> port_in;
+    bit<32> port_out;
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_metadata_t resubmit_meta, in empty_metadata_t recirculate_meta) {
+    state start {
+        buffer.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(hdr.ipv4);
+        verify(hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(hdr.ipv4.version) {
+            default: accept;
+        }
+    }
+}
+
+control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS_AND_BYTES) counter0;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.PACKETS) counter1;
+    Counter<bit<10>, bit<12>>(1024, PSA_CounterType_t.BYTES) counter2;
+    Register<bit<32>, bit<12>>(1024) reg;
+    Meter<bit<12>>(1024, PSA_MeterType_t.BYTES) meter0;
+    PSA_MeterColor_t color_out;
+    PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
+    action execute(bit<12> index) {
+        hdr.ipv4.ihl = 5;
+        color_out = meter0.execute(index, color_in);
+        user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
+        reg.write(index, user_meta.port_out);
+        if (hdr.ipv4.hdrChecksum[5:0] == 6) {
+            hdr.ipv4.ihl = 5;
+        }
+        if (hdr.ipv4.version == 6) {
+            hdr.ipv4.ihl = 6;
+        }
+    }
+    action test(bit<4> version) {
+        if (version == 4) {
+            hdr.ipv4.hdrChecksum[3:0] = hdr.ipv4.version + 5;
+        }
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            execute;
+        }
+    }
+    apply {
+        if (user_meta.port_out == 1) {
+            tbl.apply();
+            counter0.count(1023, 20);
+            counter1.count(512, 32);
+            counter2.count(1023, 64);
+            user_meta.port_out = reg.read(1);
+            test(hdr.ipv4.version);
+        } else {
+            return;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer, out headers hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_metadata_t normal_meta, in empty_metadata_t clone_i2e_meta, in empty_metadata_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control IngressDeparserImpl(packet_out packet, out empty_metadata_t clone_i2e_meta, out empty_metadata_t resubmit_meta, out empty_metadata_t normal_meta, inout headers hdr, in metadata_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        hdr.ipv4.hdrChecksum = 4;
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control EgressDeparserImpl(packet_out packet, out empty_metadata_t clone_e2e_meta, out empty_metadata_t recirculate_meta, inout headers hdr, in metadata_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err.p4.p4info.txt
@@ -1,0 +1,111 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44506256
+    name: "ingress.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.ethernet.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 29480552
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 29480552
+    name: "ingress.execute"
+    alias: "execute"
+  }
+  params {
+    id: 1
+    name: "index"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 30967736
+    name: "ingress.test"
+    alias: "test"
+  }
+}
+counters {
+  preamble {
+    id: 314114784
+    name: "ingress.counter0"
+    alias: "counter0"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 318473483
+    name: "ingress.counter1"
+    alias: "counter1"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 313911423
+    name: "ingress.counter2"
+    alias: "counter2"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+meters {
+  preamble {
+    id: 344514043
+    name: "ingress.meter0"
+    alias: "meter0"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+registers {
+  preamble {
+    id: 382856063
+    name: "ingress.reg"
+    alias: "reg"
+  }
+  type_spec {
+    bitstring {
+      bit {
+        bitwidth: 32
+      }
+    }
+  }
+  size: 1024
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-first.p4
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-frontend.p4
@@ -52,13 +52,12 @@ parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t use
 
 control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
     @name("ingress.color_out") PSA_MeterColor_t color_out_0;
-    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
     @name("ingress.tmp") bit<32> tmp;
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+        color_out_0 = meter0_0.dpdk_execute(index_1, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {
@@ -78,6 +77,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     apply {
         color_in_0 = PSA_MeterColor_t.RED;
+        hasReturned = false;
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-frontend.p4
@@ -76,8 +76,6 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         default_action = NoAction_1();
     }
     apply {
-        color_in_0 = PSA_MeterColor_t.RED;
-        hasReturned = false;
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-midend.p4
@@ -51,12 +51,11 @@ parser IngressParserImpl(packet_in buffer, out headers hdr, inout metadata_t use
 
 control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
     @name("ingress.color_out") PSA_MeterColor_t color_out_0;
-    @name("ingress.color_in") PSA_MeterColor_t color_in_0;
     @noWarn("unused") @name(".NoAction") action NoAction_1() {
     }
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.BYTES) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+        color_out_0 = meter0_0.dpdk_execute(index_1, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     @name("ingress.tbl") table tbl_0 {
@@ -69,17 +68,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
         }
         default_action = NoAction_1();
     }
-    @hidden action psaexampledpdkmeter56() {
-        color_in_0 = PSA_MeterColor_t.RED;
-    }
-    @hidden table tbl_psaexampledpdkmeter56 {
-        actions = {
-            psaexampledpdkmeter56();
-        }
-        const default_action = psaexampledpdkmeter56();
-    }
     apply {
-        tbl_psaexampledpdkmeter56.apply();
         if (user_meta.port_out == 32w1) {
             tbl_0.apply();
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+        color_out = meter0.dpdk_execute(index, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
@@ -49,7 +49,6 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_port_out
 	bit<32> Ingress_color_out
-	bit<32> Ingress_color_in
 	bit<32> Ingress_tmp_0
 }
 metadata instanceof metadata_t
@@ -64,7 +63,7 @@ action NoAction args none {
 }
 
 action execute_1 args instanceof execute_1_arg_t {
-	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in m.Ingress_color_out
+	meter meter0_0 t.index h.ipv4.totalLen 0x1 m.Ingress_color_out
 	jmpneq LABEL_FALSE_0 m.Ingress_color_out 0x0
 	mov m.Ingress_tmp_0 0x1
 	jmp LABEL_END_0
@@ -93,8 +92,7 @@ apply {
 	jmpeq INGRESSPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
-	jmpneq LABEL_END m.local_metadata_port_out 0x1
+	INGRESSPARSERIMPL_ACCEPT :	jmpneq LABEL_END m.local_metadata_port_out 0x1
 	table tbl
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-first.p4
@@ -55,11 +55,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-first.p4
@@ -55,7 +55,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-frontend.p4
@@ -58,11 +58,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-frontend.p4
@@ -58,7 +58,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         if (color_out_0 == PSA_MeterColor_t.GREEN) {
             tmp = 32w1;
         } else {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-midend.p4
@@ -56,7 +56,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
+<<<<<<< HEAD
         color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     @name("ingress.tbl") table tbl_0 {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1-midend.p4
@@ -56,11 +56,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     }
     @name("ingress.meter0") Meter<bit<12>>(32w1024, PSA_MeterType_t.PACKETS) meter0_0;
     @name("ingress.execute") action execute_1(@name("index") bit<12> index_1) {
-<<<<<<< HEAD
-        color_out_0 = meter0_0.execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out_0 = meter0_0.dpdk_execute(index_1, color_in_0, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out_0 == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     @name("ingress.tbl") table tbl_0 {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4
@@ -55,11 +55,7 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
-<<<<<<< HEAD
-        color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
-=======
-        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
->>>>>>> rename execute to dpdk_execute
+        color_out = meter0.dpdk_execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4
@@ -55,7 +55,11 @@ control ingress(inout headers hdr, inout metadata_t user_meta, in psa_ingress_in
     PSA_MeterColor_t color_out;
     PSA_MeterColor_t color_in = PSA_MeterColor_t.RED;
     action execute(bit<12> index) {
+<<<<<<< HEAD
         color_out = meter0.execute(index, color_in, (bit<32>)hdr.ipv4.totalLen);
+=======
+        color_out = meter0.dpdk_execute(index, color_in, hdr.ipv4.totalLen);
+>>>>>>> rename execute to dpdk_execute
         user_meta.port_out = (color_out == PSA_MeterColor_t.GREEN ? 32w1 : 32w0);
     }
     table tbl {


### PR DESCRIPTION
dpdk target requires packet length in `count` and `execute` methods part of `Counter` and `Meter` externs.