### PR TITLE
Remove useless grammar rule

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1145,8 +1145,6 @@ typedefDeclaration
                         $$ = new IR::Type_Typedef(@4, *$4, new IR::Annotations(*$1), $3); }
     | optAnnotations TYPE typeRef name   { driver.structure->declareType(*$4);
           $$ = new IR::Type_Newtype(@4, *$4, new IR::Annotations(*$1), $3); }
-    | optAnnotations TYPE derivedTypeDeclaration name   { driver.structure->declareType(*$4);
-                        $$ = new IR::Type_Newtype(@4, *$4, new IR::Annotations(*$1), $3); }
     ;
 
 /*************************** STATEMENTS *************************/

--- a/testdata/p4_16_errors/typedef-and-type-definitions.p4
+++ b/testdata/p4_16_errors/typedef-and-type-definitions.p4
@@ -118,13 +118,13 @@ type    bool       boolT_t;
 type    enum1_t    enum1T_t;  // error
 type    serializable_enum1_t serializable_enum1T_t;  // error
 type    h1_t       H1T_t;  // error
-type    header h2b_t { bit<16> f2; bit<8> f3; } H2bT_t;  // error
-type    h1_t[3]    h1StackT_t;  // error
+//type    header h2b_t { bit<16> f2; bit<8> f3; } H2bT_t;  // error
+//type    h1_t[3]    h1StackT_t;  // error
 type    hu1_t      hu1T_t;  // error
 type    s1_t       s1T_t;  // error
-type    struct PointB_t { int<32> x; int<32> y; } PointBD_t;  // error
-type    tuple<bit<8>, bit<17> > Tuple1T_t;  // error
-type    tuple<bit<8>, varbit<17> > Tuple2T_t;  // error
+//type    struct PointB_t { int<32> x; int<32> y; } PointBD_t;  // error
+//type    tuple<bit<8>, bit<17> > Tuple1T_t;  // error
+//type    tuple<bit<8>, varbit<17> > Tuple2T_t;  // error
 
 
 // typedef on top of another typedef or type are allowed

--- a/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4
+++ b/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4
@@ -60,21 +60,8 @@ type bool boolT_t;
 type enum1_t enum1T_t;
 type serializable_enum1_t serializable_enum1T_t;
 type h1_t H1T_t;
-type header h2b_t {
-    bit<16> f2;
-    bit<8>  f3;
-}
-H2bT_t;
-type h1_t[3] h1StackT_t;
 type hu1_t hu1T_t;
 type s1_t s1T_t;
-type struct PointB_t {
-    int<32> x;
-    int<32> y;
-}
-PointBD_t;
-type tuple<bit<8>, bit<17>> Tuple1T_t;
-type tuple<bit<8>, varbit<17>> Tuple2T_t;
 typedef bD_t bDD_t;
 typedef bT_t bTD_t;
 type bD_t bDT_t;

--- a/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typedef-and-type-definitions.p4-stderr
@@ -16,27 +16,12 @@ type serializable_enum1_t serializable_enum1T_t; // error
 typedef-and-type-definitions.p4(120): [--Werror=type-error] error: H1T_t: `type' can only be applied to base types
 type h1_t H1T_t; // error
           ^^^^^
-typedef-and-type-definitions.p4(121): [--Werror=type-error] error: H2bT_t: `type' can only be applied to base types
-type header h2b_t { bit<16> f2; bit<8> f3; } H2bT_t; // error
-                                             ^^^^^^
-typedef-and-type-definitions.p4(122): [--Werror=type-error] error: h1StackT_t: `type' can only be applied to base types
-type h1_t[3] h1StackT_t; // error
-             ^^^^^^^^^^
 typedef-and-type-definitions.p4(123): [--Werror=type-error] error: hu1T_t: `type' can only be applied to base types
 type hu1_t hu1T_t; // error
            ^^^^^^
 typedef-and-type-definitions.p4(124): [--Werror=type-error] error: s1T_t: `type' can only be applied to base types
 type s1_t s1T_t; // error
           ^^^^^
-typedef-and-type-definitions.p4(125): [--Werror=type-error] error: PointBD_t: `type' can only be applied to base types
-type struct PointB_t { int<32> x; int<32> y; } PointBD_t; // error
-                                               ^^^^^^^^^
-typedef-and-type-definitions.p4(126): [--Werror=type-error] error: Tuple1T_t: `type' can only be applied to base types
-type tuple<bit<8>, bit<17> > Tuple1T_t; // error
-                             ^^^^^^^^^
-typedef-and-type-definitions.p4(127): [--Werror=type-error] error: Tuple2T_t: `type' can only be applied to base types
-type tuple<bit<8>, varbit<17> > Tuple2T_t; // error
-                                ^^^^^^^^^
 typedef-and-type-definitions.p4(146): [--Werror=type-error] error: vDT_t: `type' can only be applied to base types
 type vD_t vDT_t; // error
           ^^^^^


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>

Turns out that `type` declarations are restricted to base types, so the grammar rule that allows derived types is useless.
This could technically be a backwards-incompatible change. To be discussed by the LDWG together with https://github.com/p4lang/p4-spec/issues/1044