### PR TITLE
Add support for compound assignment operators

### DIFF
--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -269,6 +269,19 @@ using Parser = P4::P4Parser;
 "<="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(LE); }
 "++"    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(PP); }
 
+"+="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_PLUS); }
+"-="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_MINUS); }
+"*="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_MUL); }
+"/="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_DIV); }
+"%="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_MOD); }
+"&="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_BIT_AND); }
+"|="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_BIT_OR); }
+"^="    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_XOR); }
+"<<="   { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_SHL); }
+">>="   { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_SHR); }
+"|+|="  { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_PLUS_SAT); }
+"|-|="  { BEGIN(driver.saveState); driver.template_args = false; return makeToken(ASSIGN_MINUS_SAT); }
+
 "+"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(PLUS); }
 "|+|"   { BEGIN(driver.saveState); driver.template_args = false; return makeToken(PLUS_SAT); }
 "-"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(MINUS); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -206,6 +206,18 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %token<Token>      QUESTION "?"
 %token<Token>      DOT "."
 %token<Token>      ASSIGN "="
+%token<Token>      ASSIGN_PLUS "+="
+%token<Token>      ASSIGN_MINUS "-="
+%token<Token>      ASSIGN_MUL "*="
+%token<Token>      ASSIGN_DIV "/="
+%token<Token>      ASSIGN_MOD "%="
+%token<Token>      ASSIGN_BIT_AND "&="
+%token<Token>      ASSIGN_BIT_OR "|="
+%token<Token>      ASSIGN_XOR "^="
+%token<Token>      ASSIGN_SHL "<<="
+%token<Token>      ASSIGN_SHR ">>="
+%token<Token>      ASSIGN_PLUS_SAT "|+|="
+%token<Token>      ASSIGN_MINUS_SAT "|-|="
 %token<Token>      SEMICOLON ";"
 %token<Token>      AT "@"
 %token<Token>      PP "++"
@@ -1160,6 +1172,54 @@ assignmentOrMethodCallStatement
         { auto mc = new IR::MethodCallExpression(@1 + @7,
                                                  $1, $3, $6);
           $$ = new IR::MethodCallStatement(@1 + @7, mc); }
+
+    | lvalue "+=" expression ";"
+        { auto exp = new IR::Add(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue "-=" expression ";"
+        { auto exp = new IR::Sub(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue "*=" expression ";"
+        { auto exp = new IR::Mul(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue "/=" expression ";"
+        { auto exp = new IR::Div(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue "%=" expression ";"
+        { auto exp = new IR::Mod(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue "&=" expression ";"
+        { auto exp = new IR::BAnd(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue "|=" expression ";"
+        { auto exp = new IR::BOr(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue "^=" expression ";"
+        { auto exp = new IR::BXor(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue "<<=" expression ";"
+        { auto exp = new IR::Shl(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue ">>=" expression ";"
+        { auto exp = new IR::Shr(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue "|+|=" expression ";"
+        { auto exp = new IR::AddSat(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
+
+    | lvalue "|-|=" expression ";"
+        { auto exp = new IR::SubSat(@1 + @3, $1, $3);
+          $$ = new IR::AssignmentStatement(@2, $1, exp); }
 
     | lvalue "=" expression ";"
         { $$ = new IR::AssignmentStatement(@2, $1, $3); }

--- a/testdata/p4_16_errors/compound-assignment.p4
+++ b/testdata/p4_16_errors/compound-assignment.p4
@@ -1,0 +1,163 @@
+/*
+Copyright 2022-present University of Oxford
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+
+const bit<24>  P4CALC_ADD      = 0x2b;      // '+'
+const bit<24>  P4CALC_SUB      = 0x2d;      // '-'
+const bit<24>  P4CALC_MUL      = 0x2a;      // '*'
+const bit<24>  P4CALC_DIV      = 0x2f;      // '/'
+const bit<24>  P4CALC_MOD      = 0x25;      // '%'
+const bit<24>  P4CALC_BAND     = 0x26;      // '&'
+const bit<24>  P4CALC_BOR      = 0x7c;      // '|'
+const bit<24>  P4CALC_BXOR     = 0x5e;      // '^'
+const bit<24>  P4CALC_SHL      = 0x3c3c;    // '<<'
+const bit<24>  P4CALC_SHR      = 0x3e3e;    // '>>'
+const bit<24>  P4CALC_SATADD   = 0x7c2b7c;  // '|+|'
+const bit<24>  P4CALC_SATSUB   = 0x7c2d7c;  // '|-|'
+
+header p4calc_t {
+    bit<24>  op;
+    bit<32> operand_a;
+    bit<32> operand_b;
+    bit<32> res;
+}
+
+struct headers {
+    p4calc_t     p4calc;
+}
+
+control caller(inout headers hdr) {
+    action operation_add() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result += hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_sub() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result -= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_mul() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result *= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_div() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result /= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_mod() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result %= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_band() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result &= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_bor() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result |= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_bxor() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result ^= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_shl() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result <<= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_shr() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result >>= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_addsat() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result |+|= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    action operation_subsat() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result |-|= hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+
+    table calculate {
+        key = {
+            hdr.p4calc.op        : exact;
+        }
+        actions = {
+            operation_add;
+            operation_sub;
+            operation_mul;
+            operation_div;
+            operation_mod;
+            operation_band;
+            operation_bor;
+            operation_bxor;
+            operation_shl;
+            operation_shr;
+            operation_addsat;
+            operation_subsat;
+            NoAction;
+        }
+        const default_action = NoAction();
+        const entries = {
+            P4CALC_ADD    : operation_add();
+            P4CALC_SUB    : operation_sub();
+            P4CALC_MUL    : operation_mul();
+            P4CALC_DIV    : operation_div();
+            P4CALC_MOD    : operation_mod();
+            P4CALC_BAND   : operation_band();
+            P4CALC_BOR    : operation_bor();
+            P4CALC_BXOR   : operation_bxor();
+            P4CALC_SHL    : operation_shl();
+            P4CALC_SHR    : operation_shr();
+            P4CALC_SATADD : operation_addsat();
+            P4CALC_SATSUB : operation_subsat();
+        }
+    }
+
+    apply {
+        if (hdr.p4calc.isValid()) {
+            calculate.apply();
+        }
+    }
+}
+
+control Ingress<H>(inout H hdr);
+
+package s<H>(Ingress<H> ig);
+
+s(caller()) main;

--- a/testdata/p4_16_errors_outputs/compound-assignment-first.p4
+++ b/testdata/p4_16_errors_outputs/compound-assignment-first.p4
@@ -1,0 +1,131 @@
+#include <core.p4>
+
+const bit<24> P4CALC_ADD = 24w0x2b;
+const bit<24> P4CALC_SUB = 24w0x2d;
+const bit<24> P4CALC_MUL = 24w0x2a;
+const bit<24> P4CALC_DIV = 24w0x2f;
+const bit<24> P4CALC_MOD = 24w0x25;
+const bit<24> P4CALC_BAND = 24w0x26;
+const bit<24> P4CALC_BOR = 24w0x7c;
+const bit<24> P4CALC_BXOR = 24w0x5e;
+const bit<24> P4CALC_SHL = 24w0x3c3c;
+const bit<24> P4CALC_SHR = 24w0x3e3e;
+const bit<24> P4CALC_SATADD = 24w0x7c2b7c;
+const bit<24> P4CALC_SATSUB = 24w0x7c2d7c;
+header p4calc_t {
+    bit<24> op;
+    bit<32> operand_a;
+    bit<32> operand_b;
+    bit<32> res;
+}
+
+struct headers {
+    p4calc_t p4calc;
+}
+
+control caller(inout headers hdr) {
+    action operation_add() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result + hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_sub() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result - hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_mul() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result * hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_div() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result / hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_mod() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result % hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_band() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result & hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_bor() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result | hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_bxor() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result ^ hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_shl() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result << hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_shr() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result >> hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_addsat() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result |+| hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_subsat() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result |-| hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    table calculate {
+        key = {
+            hdr.p4calc.op: exact @name("hdr.p4calc.op");
+        }
+        actions = {
+            operation_add();
+            operation_sub();
+            operation_mul();
+            operation_div();
+            operation_mod();
+            operation_band();
+            operation_bor();
+            operation_bxor();
+            operation_shl();
+            operation_shr();
+            operation_addsat();
+            operation_subsat();
+            NoAction();
+        }
+        const default_action = NoAction();
+        const entries = {
+                        24w0x2b : operation_add();
+                        24w0x2d : operation_sub();
+                        24w0x2a : operation_mul();
+                        24w0x2f : operation_div();
+                        24w0x25 : operation_mod();
+                        24w0x26 : operation_band();
+                        24w0x7c : operation_bor();
+                        24w0x5e : operation_bxor();
+                        24w0x3c3c : operation_shl();
+                        24w0x3e3e : operation_shr();
+                        24w0x7c2b7c : operation_addsat();
+                        24w0x7c2d7c : operation_subsat();
+        }
+    }
+    apply {
+        if (hdr.p4calc.isValid()) {
+            calculate.apply();
+        }
+    }
+}
+
+control Ingress<H>(inout H hdr);
+package s<H>(Ingress<H> ig);
+s<headers>(caller()) main;

--- a/testdata/p4_16_errors_outputs/compound-assignment-frontend.p4
+++ b/testdata/p4_16_errors_outputs/compound-assignment-frontend.p4
@@ -1,0 +1,133 @@
+#include <core.p4>
+
+header p4calc_t {
+    bit<24> op;
+    bit<32> operand_a;
+    bit<32> operand_b;
+    bit<32> res;
+}
+
+struct headers {
+    p4calc_t p4calc;
+}
+
+control caller(inout headers hdr) {
+    @name("caller.result") bit<32> result_0;
+    @name("caller.result") bit<32> result_1;
+    @name("caller.result") bit<32> result_2;
+    @name("caller.result") bit<32> result_3;
+    @name("caller.result") bit<32> result_4;
+    @name("caller.result") bit<32> result_5;
+    @name("caller.result") bit<32> result_6;
+    @name("caller.result") bit<32> result_7;
+    @name("caller.result") bit<32> result_8;
+    @name("caller.result") bit<32> result_9;
+    @name("caller.result") bit<32> result_10;
+    @name("caller.result") bit<32> result_11;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("caller.operation_add") action operation_add() {
+        result_0 = hdr.p4calc.operand_a;
+        result_0 = result_0 + hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_0;
+    }
+    @name("caller.operation_sub") action operation_sub() {
+        result_1 = hdr.p4calc.operand_a;
+        result_1 = result_1 - hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_1;
+    }
+    @name("caller.operation_mul") action operation_mul() {
+        result_2 = hdr.p4calc.operand_a;
+        result_2 = result_2 * hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_2;
+    }
+    @name("caller.operation_div") action operation_div() {
+        result_3 = hdr.p4calc.operand_a;
+        result_3 = result_3 / hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_3;
+    }
+    @name("caller.operation_mod") action operation_mod() {
+        result_4 = hdr.p4calc.operand_a;
+        result_4 = result_4 % hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_4;
+    }
+    @name("caller.operation_band") action operation_band() {
+        result_5 = hdr.p4calc.operand_a;
+        result_5 = result_5 & hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_5;
+    }
+    @name("caller.operation_bor") action operation_bor() {
+        result_6 = hdr.p4calc.operand_a;
+        result_6 = result_6 | hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_6;
+    }
+    @name("caller.operation_bxor") action operation_bxor() {
+        result_7 = hdr.p4calc.operand_a;
+        result_7 = result_7 ^ hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_7;
+    }
+    @name("caller.operation_shl") action operation_shl() {
+        result_8 = hdr.p4calc.operand_a;
+        result_8 = result_8 << hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_8;
+    }
+    @name("caller.operation_shr") action operation_shr() {
+        result_9 = hdr.p4calc.operand_a;
+        result_9 = result_9 >> hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_9;
+    }
+    @name("caller.operation_addsat") action operation_addsat() {
+        result_10 = hdr.p4calc.operand_a;
+        result_10 = result_10 |+| hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_10;
+    }
+    @name("caller.operation_subsat") action operation_subsat() {
+        result_11 = hdr.p4calc.operand_a;
+        result_11 = result_11 |-| hdr.p4calc.operand_b;
+        hdr.p4calc.res = result_11;
+    }
+    @name("caller.calculate") table calculate_0 {
+        key = {
+            hdr.p4calc.op: exact @name("hdr.p4calc.op");
+        }
+        actions = {
+            operation_add();
+            operation_sub();
+            operation_mul();
+            operation_div();
+            operation_mod();
+            operation_band();
+            operation_bor();
+            operation_bxor();
+            operation_shl();
+            operation_shr();
+            operation_addsat();
+            operation_subsat();
+            NoAction_1();
+        }
+        const default_action = NoAction_1();
+        const entries = {
+                        24w0x2b : operation_add();
+                        24w0x2d : operation_sub();
+                        24w0x2a : operation_mul();
+                        24w0x2f : operation_div();
+                        24w0x25 : operation_mod();
+                        24w0x26 : operation_band();
+                        24w0x7c : operation_bor();
+                        24w0x5e : operation_bxor();
+                        24w0x3c3c : operation_shl();
+                        24w0x3e3e : operation_shr();
+                        24w0x7c2b7c : operation_addsat();
+                        24w0x7c2d7c : operation_subsat();
+        }
+    }
+    apply {
+        if (hdr.p4calc.isValid()) {
+            calculate_0.apply();
+        }
+    }
+}
+
+control Ingress<H>(inout H hdr);
+package s<H>(Ingress<H> ig);
+s<headers>(caller()) main;

--- a/testdata/p4_16_errors_outputs/compound-assignment.p4
+++ b/testdata/p4_16_errors_outputs/compound-assignment.p4
@@ -1,0 +1,131 @@
+#include <core.p4>
+
+const bit<24> P4CALC_ADD = 0x2b;
+const bit<24> P4CALC_SUB = 0x2d;
+const bit<24> P4CALC_MUL = 0x2a;
+const bit<24> P4CALC_DIV = 0x2f;
+const bit<24> P4CALC_MOD = 0x25;
+const bit<24> P4CALC_BAND = 0x26;
+const bit<24> P4CALC_BOR = 0x7c;
+const bit<24> P4CALC_BXOR = 0x5e;
+const bit<24> P4CALC_SHL = 0x3c3c;
+const bit<24> P4CALC_SHR = 0x3e3e;
+const bit<24> P4CALC_SATADD = 0x7c2b7c;
+const bit<24> P4CALC_SATSUB = 0x7c2d7c;
+header p4calc_t {
+    bit<24> op;
+    bit<32> operand_a;
+    bit<32> operand_b;
+    bit<32> res;
+}
+
+struct headers {
+    p4calc_t p4calc;
+}
+
+control caller(inout headers hdr) {
+    action operation_add() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result + hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_sub() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result - hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_mul() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result * hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_div() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result / hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_mod() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result % hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_band() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result & hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_bor() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result | hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_bxor() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result ^ hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_shl() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result << hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_shr() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result >> hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_addsat() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result |+| hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    action operation_subsat() {
+        bit<32> result = hdr.p4calc.operand_a;
+        result = result |-| hdr.p4calc.operand_b;
+        hdr.p4calc.res = result;
+    }
+    table calculate {
+        key = {
+            hdr.p4calc.op: exact;
+        }
+        actions = {
+            operation_add;
+            operation_sub;
+            operation_mul;
+            operation_div;
+            operation_mod;
+            operation_band;
+            operation_bor;
+            operation_bxor;
+            operation_shl;
+            operation_shr;
+            operation_addsat;
+            operation_subsat;
+            NoAction;
+        }
+        const default_action = NoAction();
+        const entries = {
+                        P4CALC_ADD : operation_add();
+                        P4CALC_SUB : operation_sub();
+                        P4CALC_MUL : operation_mul();
+                        P4CALC_DIV : operation_div();
+                        P4CALC_MOD : operation_mod();
+                        P4CALC_BAND : operation_band();
+                        P4CALC_BOR : operation_bor();
+                        P4CALC_BXOR : operation_bxor();
+                        P4CALC_SHL : operation_shl();
+                        P4CALC_SHR : operation_shr();
+                        P4CALC_SATADD : operation_addsat();
+                        P4CALC_SATSUB : operation_subsat();
+        }
+    }
+    apply {
+        if (hdr.p4calc.isValid()) {
+            calculate.apply();
+        }
+    }
+}
+
+control Ingress<H>(inout H hdr);
+package s<H>(Ingress<H> ig);
+s(caller()) main;

--- a/testdata/p4_16_errors_outputs/compound-assignment.p4-stderr
+++ b/testdata/p4_16_errors_outputs/compound-assignment.p4-stderr
@@ -1,0 +1,6 @@
+compound-assignment.p4(65): [--Werror=invalid] error: /: could not evaluate expression at compilation time
+        hdr.p4calc.res = result;
+                         ^^^^^^
+compound-assignment.p4(71): [--Werror=invalid] error: %: could not evaluate expression at compilation time
+        hdr.p4calc.res = result;
+                         ^^^^^^


### PR DESCRIPTION
This pull request adds support for compound assignment expressions of the form `E1 op= E2` as discussed in https://github.com/p4lang/p4-spec/pull/1144 and https://github.com/p4lang/p4-spec/issues/1139.

Fixes https://github.com/p4lang/p4c/issues/3258