### PR TITLE
Make RemoveUnusedDeclarations constructor protected.

### DIFF
--- a/frontends/p4/unusedDeclarations.h
+++ b/frontends/p4/unusedDeclarations.h
@@ -64,7 +64,7 @@ class RemoveUnusedDeclarations : public Transform {
     const IR::Node* process(const IR::IDeclaration* decl);
     const IR::Node* warnIfUnused(const IR::Node* node);
 
-protected:
+ protected:
     // Prevent direct instantiations of this class.
     friend class RemoveAllUnusedDeclarations;
     explicit RemoveUnusedDeclarations(const ReferenceMap* refMap,

--- a/frontends/p4/unusedDeclarations.h
+++ b/frontends/p4/unusedDeclarations.h
@@ -64,9 +64,10 @@ class RemoveUnusedDeclarations : public Transform {
     const IR::Node* process(const IR::IDeclaration* decl);
     const IR::Node* warnIfUnused(const IR::Node* node);
 
+protected:
     // Prevent direct instantiations of this class.
     friend class RemoveAllUnusedDeclarations;
-    RemoveUnusedDeclarations(const ReferenceMap* refMap,
+    explicit RemoveUnusedDeclarations(const ReferenceMap* refMap,
                              std::set<const IR::Node*>* warned = nullptr) :
             refMap(refMap), warned(warned)
     { CHECK_NULL(refMap); setName("RemoveUnusedDeclarations"); }


### PR DESCRIPTION
Such that the constructor can still be inherited by other classes. This fixes the compilation of the Gauntlet module, which extends the RemoveUnusedDeclarations class. 