### PR TITLE
Build DCG if pattern flag was enabled

### DIFF
--- a/backends/p4tools/testgen/core/program_info.cpp
+++ b/backends/p4tools/testgen/core/program_info.cpp
@@ -15,7 +15,7 @@ ProgramInfo::ProgramInfo(const IR::P4Program* program)
       concolicMethodImpls({}),
       program(program) {
     concolicMethodImpls.add(*Concolic::getCoreConcolicMethodImpls());
-    if (TestgenOptions::get().dcg) {
+    if (TestgenOptions::get().dcg || TestgenOptions::get().pattern.length()) {
         // Create DCG.
         P4::ReferenceMap refMap;
         P4::TypeMap typeMap;


### PR DESCRIPTION
These changes allow to build DCG for p4tools if pattern flag was enabled. Otherwise, reachability engine featured will not work.