### PR TITLE
Added collapsedChain to IR::ParserState

### DIFF
--- a/frontends/p4/simplifyParsers.cpp
+++ b/frontends/p4/simplifyParsers.cpp
@@ -161,11 +161,13 @@ class CollapseChains : public Transform {
             if (chainStart.find(s) != chainStart.end()) {
                 // collapse chain
                 auto components = new IR::IndexedVector<IR::StatOrDecl>();
+                std::vector<const IR::ParserState*> collapsedChain;
                 auto crt = s;
                 LOG1("Chaining states into " << dbp(crt));
                 const IR::Expression *select = nullptr;
                 while (true) {
                     components->append(crt->components);
+                    collapsedChain.push_back(crt);
                     select = crt->selectExpression;
                     crt = ::get(chain, crt);
                     if (crt == nullptr)
@@ -173,7 +175,7 @@ class CollapseChains : public Transform {
                     LOG1("Adding " << dbp(crt) << " to chain");
                 }
                 s = new IR::ParserState(s->srcInfo, s->name, s->annotations,
-                                        *components, select);
+                                        *components, select, collapsedChain);
             }
             states->push_back(s);
         }

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -60,6 +60,7 @@ class ParserState : ISimpleNamespace, Declaration, IAnnotated {
     optional inline IndexedVector<StatOrDecl>   components;
     // selectExpression can be a SelectExpression, or a PathExpression representing a state
     NullOK Expression                   selectExpression;
+    optional std::vector<ParserState> collapsedChain;
 
     Annotations getAnnotations() const override { return annotations; }
     Util::Enumerator<IDeclaration>* getDeclarations() const override {


### PR DESCRIPTION
Knowing what original states made up a new merged state created by CollapseChains in SimplifyParsers allows more flexibility in the backend.