### PR TITLE
Fix cpplint CMake check.

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  cpplint:
+  p4c-lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   # Build with gcc and test p4c on Ubuntu 20.04.
-  build-linux-sanitizers:
+  test-linux-sanitizers:
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +45,7 @@ jobs:
       if: matrix.unified == 'ON'
 
   # Build with clang and test p4c on Ubuntu 20.04.
-  build-linux-clang:
+  test-linux-clang:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -74,7 +74,7 @@ jobs:
         sudo docker run --privileged -w /p4c/build -e $CTEST_PARALLEL_LEVEL p4c ctest --output-on-failure --schedule-random
   
   # Build and test p4c on Fedora.
-  build-fedora-linux:
+  test-fedora-linux:
     strategy:
       fail-fast: false
     # This job runs in Fedora container that runs in Ubuntu VM.
@@ -112,7 +112,7 @@ jobs:
       working-directory: ./build
 
   # Build and test p4c on MacOS 11
-  build-mac-os:
+  test-mac-os:
     strategy:
       fail-fast: false
     runs-on: macos-11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,7 +453,7 @@ install (DIRECTORY ${P4C_SOURCE_DIR}/p4include
   DESTINATION ${P4C_ARTIFACTS_OUTPUT_DIRECTORY})
 
 # cpplint
-if (${CPPLINT_FILES})
+if(DEFINED CPPLINT_FILES)
   list ( SORT CPPLINT_FILES )
   set (CPPLINT_CMD ${P4C_SOURCE_DIR}/tools/cpplint.py)
   set (CPPLINT_ARGS --root=${P4C_SOURCE_DIR} --extensions=h,hpp,cpp,ypp,l)


### PR DESCRIPTION
The `CPPLINT_FILES` variable is not an empty string, it is not defined actually. 

Fixes #3682. 