### PR TITLE
P4Tools: Implement default action override for BMv2 STF.

### DIFF
--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -452,7 +452,7 @@ class RunBMV2(object):
             actionArgs.set(k, v)
         command = "table_set_default " + tableName + " " + actionName
         if actionArgs.size():
-            command += " => " + str(actionArgs)
+            command += " " + str(actionArgs)
         return command
     def parse_table_add(self, cmd):
         tableName, cmd = nextWord(cmd)

--- a/backends/p4tools/testgen/core/small_step/table_stepper.h
+++ b/backends/p4tools/testgen/core/small_step/table_stepper.h
@@ -62,6 +62,9 @@ class TableStepper {
         /// Whether the table is constant and can not accept control plane entries.
         bool tableIsImmutable = false;
 
+        /// Indicates whether the default action can be overridden.
+        bool defaultIsImmutable = false;
+
         /// Ordered list of key fields with useful properties.
         std::vector<KeyProperties> resolvedKeys;
     } properties;
@@ -112,7 +115,7 @@ class TableStepper {
                                   size_t lpmIndex);
 
     /// @returns whether the table is immutable, meaning control plane entries can not be added.
-    bool checkTableIsImmutable();
+    void checkTableIsImmutable();
 
     /// Add the default action path to the expression stepper. If only hits if @param
     /// tableMissCondition is true.
@@ -143,7 +146,7 @@ class TableStepper {
     /// handle constant entries, it is specialized for control plane entries.
     /// The function also tracks the list of field matches created to achieve a  hit. We later use
     /// this to insert table entries using the STF/PTF framework.
-    const IR::Expression* computeHit(ExecutionState* nextState, const IR::P4Table* table,
+    const IR::Expression* computeHit(ExecutionState* nextState,
                                      std::map<cstring, const FieldMatch>* matches);
 
     /// Collects properties that may be set per table. Target back end may have different semantics
@@ -185,6 +188,8 @@ class TableStepper {
     /// This function allows target back ends to implement their own interpretation of table
     /// execution. How a table is evaluated is target-specific.
     virtual void evalTargetTable(const std::vector<const IR::ActionListElement*>& tableActionList);
+
+    void setTableDefaultEntries(const std::vector<const IR::ActionListElement*>& tableActionList);
 
  public:
     /// Table implementations in P4 are rather flexible. Eval is a delegation function that chooses

--- a/backends/p4tools/testgen/lib/tf.h
+++ b/backends/p4tools/testgen/lib/tf.h
@@ -4,7 +4,9 @@
 #include <cstddef>
 
 #include <boost/optional/optional.hpp>
+#include <inja/inja.hpp>
 
+#include "backends/p4tools/common/lib/format_int.h"
 #include "lib/cstring.h"
 
 #include "backends/p4tools/testgen/lib/test_spec.h"
@@ -14,7 +16,7 @@ namespace P4Tools {
 namespace P4Testgen {
 
 /// THe default base class for the various test frameworks (TF). Every test framework has a test
-/// name and a seed associated with it.
+/// name and a seed associated with it. Also contains a variety of common utility functions.
 class TF {
  protected:
     /// The @testName to be used in test case generation.
@@ -25,6 +27,104 @@ class TF {
 
     /// Creates a generic test framework.
     explicit TF(cstring, boost::optional<unsigned int>);
+
+    /// Converts the traces of this test into a string representation and Inja object.
+    static inja::json getTrace(const TestSpec* testSpec) {
+        inja::json traceList = inja::json::array();
+        const auto* traces = testSpec->getTraces();
+        if ((traces != nullptr) && !traces->empty()) {
+            for (const auto& trace : *traces) {
+                std::stringstream ss;
+                ss << *trace;
+                traceList.push_back(ss.str());
+            }
+        }
+        return traceList;
+    }
+
+    /// Checks whether a table object has an action profile or selector associated with it.
+    /// If that is the case, we set a boolean flag for this particular inja object.
+    template <class ProfileType, class SelectorType>
+    static void checkForTableActionProfile(inja::json& tblJson, std::map<cstring, cstring>& apAsMap,
+                                           const TableConfig* tblConfig) {
+        const auto* apObject = tblConfig->getProperty("action_profile", false);
+        if (apObject != nullptr) {
+            const auto* actionProfile = apObject->checkedTo<ProfileType>();
+            tblJson["has_ap"] = true;
+            // Check if we have an Action Selector too.
+            // TODO: Change this to check in ActionSelector with table
+            // property "action_selectors".
+            const auto* asObject = tblConfig->getProperty("action_selector", false);
+            if (asObject != nullptr) {
+                const auto* actionSelector = asObject->checkedTo<SelectorType>();
+                apAsMap[actionProfile->getProfileDecl()->controlPlaneName()] =
+                    actionSelector->getSelectorDecl()->controlPlaneName();
+                tblJson["has_as"] = true;
+            }
+        }
+    }
+
+    /// Check whether the table object has an overridden default action.
+    /// In this case, we assume there are no keys and we just set the default action of the table.
+    static void checkForDefaultActionOverride(inja::json& tblJson, const TableConfig* tblConfig) {
+        const auto* defaultOverrideObj = tblConfig->getProperty("overriden_default_action", false);
+        if (defaultOverrideObj != nullptr) {
+            const auto* defaultAction = defaultOverrideObj->checkedTo<ActionCall>();
+            inja::json a;
+            a["action_name"] = defaultAction->getActionName();
+            auto const* actionArgs = defaultAction->getArgs();
+            inja::json b = inja::json::array();
+            for (const auto& actArg : *actionArgs) {
+                inja::json j;
+                j["param"] = actArg.getActionParamName().c_str();
+                j["value"] = formatHexExpr(actArg.getEvaluatedValue());
+                b.push_back(j);
+            }
+            a["act_args"] = b;
+            tblJson["default_override"] = a;
+        }
+    }
+
+    /// Collect all the action profile objects. These will have to be declared in the test.
+    template <class ProfileType>
+    static void collectActionProfileDeclarations(const TestSpec* testSpec,
+                                                 inja::json& controlPlaneJson,
+                                                 const std::map<cstring, cstring>& apAsMap) {
+        auto actionProfiles = testSpec->getTestObjectCategory("action_profiles");
+        if (!actionProfiles.empty()) {
+            controlPlaneJson["action_profiles"] = inja::json::array();
+        }
+        for (auto const& testObject : actionProfiles) {
+            const auto* const actionProfile = testObject.second->checkedTo<ProfileType>();
+            const auto* actions = actionProfile->getActions();
+            inja::json j;
+            j["profile"] = actionProfile->getProfileDecl()->controlPlaneName();
+            j["actions"] = inja::json::array();
+            for (size_t idx = 0; idx < actions->size(); ++idx) {
+                const auto& action = actions->at(idx);
+                auto actionName = action.first;
+                auto actionArgs = action.second;
+                inja::json a;
+                a["action_name"] = actionName;
+                a["action_idx"] = std::to_string(idx);
+                inja::json b = inja::json::array();
+                for (const auto& actArg : actionArgs) {
+                    inja::json c;
+                    c["param"] = actArg.getActionParamName().c_str();
+                    c["value"] = formatHexExpr(actArg.getEvaluatedValue()).c_str();
+                    b.push_back(c);
+                }
+                a["act_args"] = b;
+                j["actions"].push_back(a);
+            }
+            // Look up the selectors associated with the profile.
+            if (apAsMap.find(actionProfile->getProfileDecl()->controlPlaneName()) !=
+                apAsMap.end()) {
+                j["selector"] = apAsMap.at(actionProfile->getProfileDecl()->controlPlaneName());
+            }
+            controlPlaneJson["action_profiles"].push_back(j);
+        }
+    }
 
  public:
     /// The method used to output the test case to be implemented by

--- a/backends/p4tools/testgen/targets/bmv2/backend/protobuf/protobuf.h
+++ b/backends/p4tools/testgen/targets/bmv2/backend/protobuf/protobuf.h
@@ -11,7 +11,7 @@
 #include <boost/optional/optional.hpp>
 #include <inja/inja.hpp>
 
-/// Inja
+#include "control-plane/p4RuntimeArchStandard.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 
@@ -23,6 +23,10 @@ namespace P4Tools {
 namespace P4Testgen {
 
 namespace Bmv2 {
+
+using P4::ControlPlaneAPI::p4rt_id_t;
+using P4::ControlPlaneAPI::P4RuntimeSymbolType;
+using P4::ControlPlaneAPI::Standard::SymbolType;
 
 /// Extracts information from the @testSpec to emit a Protobuf test case.
 class Protobuf : public TF {
@@ -42,6 +46,7 @@ class Protobuf : public TF {
 
     Protobuf(cstring testName, boost::optional<unsigned int> seed);
 
+    /// Produce a Protobuf test.
     void outputTest(const TestSpec* spec, cstring selectedBranches, size_t testIdx,
                     float currentCoverage) override;
 
@@ -57,9 +62,6 @@ class Protobuf : public TF {
     /// preceding tests.
     void emitTestcase(const TestSpec* testSpec, cstring selectedBranches, size_t testId,
                       const std::string& testCase, float currentCoverage);
-
-    /// Converts the traces of this test into a string representation and Inja object.
-    static inja::json getTrace(const TestSpec* testSpec);
 
     /// Converts all the control plane objects into Inja format.
     static inja::json getControlPlane(const TestSpec* testSpec);
@@ -77,6 +79,16 @@ class Protobuf : public TF {
     /// Helper function for the control plane table inja objects.
     static inja::json getControlPlaneForTable(const std::map<cstring, const FieldMatch>& matches,
                                               const std::vector<ActionArg>& args);
+
+    /// @return the id allocated to the object through the @id annotation if any, or
+    /// boost::none.
+    static boost::optional<p4rt_id_t> getIdAnnotation(const IR::IAnnotated* node);
+
+    /// @return the value of any P4 '@id' annotation @declaration may have, and
+    /// ensure that the value is correct with respect to the P4Runtime
+    /// specification. The name 'externalId' is in analogy with externalName().
+    static boost::optional<p4rt_id_t> externalId(const P4RuntimeSymbolType& type,
+                                                 const IR::IDeclaration* declaration);
 };
 
 }  // namespace Bmv2

--- a/backends/p4tools/testgen/targets/bmv2/backend/ptf/ptf.h
+++ b/backends/p4tools/testgen/targets/bmv2/backend/ptf/ptf.h
@@ -44,6 +44,8 @@ class PTF : public TF {
     PTF& operator=(PTF&&) = delete;
 
     PTF(cstring testName, boost::optional<unsigned int> seed);
+
+    /// Produce a PTF test.
     void outputTest(const TestSpec* spec, cstring selectedBranches, size_t testIdx,
                     float currentCoverage) override;
 
@@ -59,9 +61,6 @@ class PTF : public TF {
     /// preceding tests.
     void emitTestcase(const TestSpec* testSpec, cstring selectedBranches, size_t testId,
                       const std::string& testCase, float currentCoverage);
-
-    /// Converts the traces of this test into a string representation and Inja object.
-    static inja::json getTrace(const TestSpec* testSpec);
 
     /// Converts all the control plane objects into Inja format.
     static inja::json getControlPlane(const TestSpec* testSpec);

--- a/backends/p4tools/testgen/targets/bmv2/backend/stf/stf.h
+++ b/backends/p4tools/testgen/targets/bmv2/backend/stf/stf.h
@@ -38,6 +38,8 @@ class STF : public TF {
     STF& operator=(STF&&) = delete;
 
     STF(cstring testName, boost::optional<unsigned int> seed);
+
+    /// Produce an STF test.
     void outputTest(const TestSpec* spec, cstring selectedBranches, size_t testIdx,
                     float currentCoverage) override;
 
@@ -49,9 +51,6 @@ class STF : public TF {
     /// preceding tests.
     void emitTestcase(const TestSpec* testSpec, cstring selectedBranches, size_t testId,
                       const std::string& testCase, float currentCoverage);
-
-    /// Converts the traces of this test into a string representation and Inja object.
-    static inja::json getTrace(const TestSpec* testSpec);
 
     /// Converts all the control plane objects into Inja format.
     static inja::json getControlPlane(const TestSpec* testSpec);

--- a/backends/p4tools/testgen/targets/bmv2/table_stepper.h
+++ b/backends/p4tools/testgen/targets/bmv2/table_stepper.h
@@ -44,7 +44,7 @@ class BMv2_V1ModelTableStepper : public TableStepper {
         bool addProfileToState = false;
 
         /// The type of the table implementation.
-        TableImplementation implementaton;
+        TableImplementation implementaton = TableImplementation::standard;
     } bmv2_V1ModelProperties;
 
     /// Check whether the table has an action profile implementation.

--- a/backends/p4tools/testgen/targets/bmv2/test/BMV2Xfail.cmake
+++ b/backends/p4tools/testgen/targets/bmv2/test/BMV2Xfail.cmake
@@ -160,7 +160,7 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2"
-  "Unknown extern method count from type jnf_counter"
+  "Unknown or unimplemented extern method: count"
   # user defined extern
   issue1193-bmv2.p4
 )

--- a/backends/p4tools/testgen/targets/bmv2/test/p4-programs/bmv2_table_default.p4
+++ b/backends/p4tools/testgen/targets/bmv2/test/p4-programs/bmv2_table_default.p4
@@ -1,0 +1,75 @@
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+    bit<8> b;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {}
+
+parser p(packet_in pkt, out Headers h, inout Meta meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(h.eth_hdr);
+        transition parse_h;
+    }
+    state parse_h {
+        pkt.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta meta) {
+    apply { }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+
+    action MyAction1() {
+        h.h.b = 1;
+    }
+
+    action MyAction2(bit<8> input_val) {
+        h.h.b = input_val;
+    }
+
+    table default_table {
+        actions = {
+            NoAction;
+            MyAction1;
+            MyAction2;
+        }
+        size = 1024;
+        default_action = NoAction();
+    }
+
+    apply {
+        default_table.apply();
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply { }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply { }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/backends/p4tools/testgen/targets/ebpf/backend/stf/stf.cpp
+++ b/backends/p4tools/testgen/targets/ebpf/backend/stf/stf.cpp
@@ -43,37 +43,27 @@ STF::STF(cstring testName, boost::optional<unsigned int> seed = boost::none) : T
     cstring testNameOnly(testFile.stem().c_str());
 }
 
-inja::json STF::getTrace(const TestSpec* testSpec) {
-    inja::json traceList = inja::json::array();
-    const auto* traces = testSpec->getTraces();
-    if ((traces != nullptr) && !traces->empty()) {
-        for (const auto& trace : *traces) {
-            std::stringstream ss;
-            ss << *trace;
-            traceList.push_back(ss.str());
-        }
-    }
-    return traceList;
-}
-
 inja::json STF::getControlPlane(const TestSpec* testSpec) {
     inja::json controlPlaneJson = inja::json::object();
+
+    // Map of actionProfiles and actionSelectors for easy reference.
+    std::map<cstring, cstring> apAsMap;
 
     auto tables = testSpec->getTestObjectCategory("tables");
     if (!tables.empty()) {
         controlPlaneJson["tables"] = inja::json::array();
     }
-    for (auto const& testObject : tables) {
+    for (const auto& testObject : tables) {
         inja::json tblJson;
         tblJson["table_name"] = testObject.first.c_str();
         const auto* const tblConfig = testObject.second->checkedTo<TableConfig>();
-        auto const* tblRules = tblConfig->getRules();
+        const auto* tblRules = tblConfig->getRules();
         tblJson["rules"] = inja::json::array();
         for (const auto& tblRule : *tblRules) {
             inja::json rule;
-            auto const* matches = tblRule.getMatches();
-            auto const* actionCall = tblRule.getActionCall();
-            auto const* actionArgs = actionCall->getArgs();
+            const auto* matches = tblRule.getMatches();
+            const auto* actionCall = tblRule.getActionCall();
+            const auto* actionArgs = actionCall->getArgs();
             rule["action_name"] = actionCall->getActionName().c_str();
             auto j = getControlPlaneForTable(*matches, *actionArgs);
             rule["rules"] = std::move(j);
@@ -95,9 +85,9 @@ inja::json STF::getControlPlaneForTable(const std::map<cstring, const FieldMatch
     rulesJson["act_args"] = inja::json::array();
     rulesJson["needs_priority"] = false;
 
-    for (auto const& match : matches) {
+    for (const auto& match : matches) {
         auto fieldName = match.first;
-        auto const& fieldMatch = match.second;
+        const auto& fieldMatch = match.second;
 
         // Replace header stack indices hdr[<index>] with hdr$<index>.
         // TODO: This is a limitation of the stf parser. We should fix this.

--- a/backends/p4tools/testgen/targets/ebpf/backend/stf/stf.h
+++ b/backends/p4tools/testgen/targets/ebpf/backend/stf/stf.h
@@ -38,6 +38,8 @@ class STF : public TF {
     STF& operator=(STF&&) = delete;
 
     STF(cstring testName, boost::optional<unsigned int> seed);
+
+    /// Produce an STF test.
     void outputTest(const TestSpec* spec, cstring selectedBranches, size_t testIdx,
                     float currentCoverage) override;
 
@@ -49,9 +51,6 @@ class STF : public TF {
     /// preceding tests.
     void emitTestcase(const TestSpec* testSpec, cstring selectedBranches, size_t testId,
                       const std::string& testCase, float currentCoverage);
-
-    /// Converts the traces of this test into a string representation and Inja object.
-    static inja::json getTrace(const TestSpec* testSpec);
 
     /// Converts all the control plane objects into Inja format.
     static inja::json getControlPlane(const TestSpec* testSpec);

--- a/backends/p4tools/testgen/targets/ebpf/table_stepper.cpp
+++ b/backends/p4tools/testgen/targets/ebpf/table_stepper.cpp
@@ -46,6 +46,13 @@ void EBPFTableStepper::checkTargetProperties(
 
 void EBPFTableStepper::evalTargetTable(
     const std::vector<const IR::ActionListElement*>& tableActionList) {
+    const auto* keys = table->getKey();
+    // If we have no keys, there is nothing to match.
+    if (keys == nullptr) {
+        addDefaultAction(boost::none);
+        return;
+    }
+
     // If the table is not constant, the default action can always be executed.
     // This is because we can simply not enter any table entry.
     boost::optional<const IR::Expression*> tableMissCondition = boost::none;

--- a/backends/p4tools/testgen/targets/ebpf/table_stepper.h
+++ b/backends/p4tools/testgen/targets/ebpf/table_stepper.h
@@ -30,7 +30,7 @@ class EBPFTableStepper : public TableStepper {
     /// eBPF-specific table properties.
     struct EBPFProperties {
         /// The type of the table implementation.
-        TableImplementation implementaton;
+        TableImplementation implementaton = TableImplementation::standard;
     } EBPFProperties;
 
  protected:


### PR DESCRIPTION
This PR implements default action overrides for P4Testgen's BMv2 extension. Only for the STF back end so far. 

If a table does not have a key, it can not match and pick an action. However, it might still be possible to override the default action and choose a different path. This PR implements the logic to override a table's default action.

Also fixes #3557. 