### PR TITLE
Enable permissive by default.

### DIFF
--- a/backends/p4tools/testgen/core/exploration_strategy/incremental_max_coverage_stack.cpp
+++ b/backends/p4tools/testgen/core/exploration_strategy/incremental_max_coverage_stack.cpp
@@ -58,8 +58,8 @@ void IncrementalMaxCoverageStack::run(const Callback& callback) {
                 }
             }
         } catch (TestgenUnimplemented& e) {
-            // If permissive is not enable, we just throw the exception.
-            if (!TestgenOptions::get().permissive) {
+            // If strict is enabled, bubble the exception up.
+            if (TestgenOptions::get().strict) {
                 throw;
             }
             // Otherwise we try to roll back as we typically do.

--- a/backends/p4tools/testgen/core/exploration_strategy/incremental_stack.cpp
+++ b/backends/p4tools/testgen/core/exploration_strategy/incremental_stack.cpp
@@ -54,8 +54,8 @@ void IncrementalStack::run(const Callback& callback) {
                 }
             }
         } catch (TestgenUnimplemented& e) {
-            // If permissive is not enable, we just throw the exception.
-            if (!TestgenOptions::get().permissive) {
+            // If strict is enabled, bubble the exception up.
+            if (TestgenOptions::get().strict) {
                 throw;
             }
             // Otherwise we try to roll back as we typically do.

--- a/backends/p4tools/testgen/core/exploration_strategy/linear_enumeration.cpp
+++ b/backends/p4tools/testgen/core/exploration_strategy/linear_enumeration.cpp
@@ -53,8 +53,8 @@ void LinearEnumeration::run(const Callback& callback) {
                 return;
             }
         } catch (TestgenUnimplemented& e) {
-            // If permissive is not enable, we just throw the exception.
-            if (!TestgenOptions::get().permissive) {
+            // If strict is enabled, bubble the exception up.
+            if (TestgenOptions::get().strict) {
                 throw;
             }
             // Otherwise we try to roll back as we typically do.

--- a/backends/p4tools/testgen/core/exploration_strategy/random_access_max_coverage.cpp
+++ b/backends/p4tools/testgen/core/exploration_strategy/random_access_max_coverage.cpp
@@ -66,8 +66,8 @@ void RandomAccessMaxCoverage::run(const Callback& callback) {
                 }
             }
         } catch (TestgenUnimplemented& e) {
-            // If permissive is not enable, we just throw the exception.
-            if (!TestgenOptions::get().permissive) {
+            // If strict is enabled, bubble the exception up.
+            if (TestgenOptions::get().strict) {
                 throw;
             }
             // Otherwise we try to roll back as we typically do.

--- a/backends/p4tools/testgen/core/exploration_strategy/random_access_stack.cpp
+++ b/backends/p4tools/testgen/core/exploration_strategy/random_access_stack.cpp
@@ -55,8 +55,8 @@ void RandomAccessStack::run(const Callback& callback) {
                 }
             }
         } catch (TestgenUnimplemented& e) {
-            // If permissive is not enable, we just throw the exception.
-            if (!TestgenOptions::get().permissive) {
+            // If strict is enabled, bubble the exception up.
+            if (TestgenOptions::get().strict) {
                 throw;
             }
             // Otherwise we try to roll back as we typically do.

--- a/backends/p4tools/testgen/options.cpp
+++ b/backends/p4tools/testgen/options.cpp
@@ -22,12 +22,12 @@ const char* TestgenOptions::getIncludePath() {
 TestgenOptions::TestgenOptions()
     : AbstractP4cToolOptions("Generate packet tests for a P4 program") {
     registerOption(
-        "--permissive", nullptr,
+        "--strict", nullptr,
         [this](const char*) {
-            permissive = true;
+            strict = true;
             return true;
         },
-        "Do not fail on unimplemented features. Instead, try the next branch.");
+        "Fail on unimplemented features instead of trying the next branch.");
     registerOption(
         "--input-packet-only", nullptr,
         [this](const char*) {

--- a/backends/p4tools/testgen/options.h
+++ b/backends/p4tools/testgen/options.h
@@ -48,8 +48,8 @@ class TestgenOptions : public AbstractP4cToolOptions {
     /// Directory for generated tests. Defaults to PWD.
     cstring outputDir = nullptr;
 
-    /// Do not fail on unimplemented features. Instead, try the next branch.
-    bool permissive = false;
+    /// Fail on unimplemented features instead of trying the next branch
+    bool strict = false;
 
     /// The test back end that P4Testgen will generate test for. Examples, STF, PTF or Protobuf.
     cstring testBackend;

--- a/backends/p4tools/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/testgen/targets/bmv2/test/P4Tests.cmake
@@ -14,9 +14,9 @@ if(NOT P4TOOLS_BMV2_PATH)
 endif()
 
 if(NOT NIGHTLY)
-  set(EXTRA_OPTS "--print-traces --seed 1000 --max-tests 10")
+  set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10")
 else()
-  set(EXTRA_OPTS "--print-traces --max-tests 10")
+  set(EXTRA_OPTS "--strict --print-traces --max-tests 10")
 endif()
 
 set(V1_SEARCH_PATTERNS "include.*v1model.p4" "main|common_v1_test")

--- a/backends/p4tools/testgen/targets/ebpf/test/P4Tests.cmake
+++ b/backends/p4tools/testgen/targets/ebpf/test/P4Tests.cmake
@@ -13,9 +13,9 @@ if(NOT P4TOOLS_EBPF_PATH)
 endif()
 
 if(NOT NIGHTLY)
-  set(EXTRA_OPTS "--print-traces --seed 1000 --max-tests 10")
+  set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10")
 else()
-  set(EXTRA_OPTS "--print-traces --max-tests 10")
+  set(EXTRA_OPTS "--strict --print-traces --max-tests 10")
 endif()
 
 set(


### PR DESCRIPTION
A usability improvement. P4Testgen will not automatically throw an error when it encounters unsafe states. Instead, it will move on to the next branch. 