### PR TITLE
P4Tools: Unify packet sizing options.

### DIFF
--- a/backends/ebpf/targets/ebpfenv.py
+++ b/backends/ebpf/targets/ebpfenv.py
@@ -101,6 +101,7 @@ class Bridge(object):
             avoid ICMPv6 spam. """
         # We do not care about failures here
         self.ns_exec("ip link set dev %s up" % br_name)
+        self.ns_exec("ip link set dev %s mtu 9000" % br_name)
         # Prevent the broadcasting of ipv6 link discovery messages
         self.ns_exec("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
         self.ns_exec("sysctl -w net.ipv6.conf.default.disable_ipv6=1")
@@ -118,6 +119,7 @@ class Bridge(object):
     def _configure_bridge_port(self, port_name):
         """ Set a bridge port active. """
         cmd = "ip link set dev %s up" % port_name
+        cmd += " && ip link set dev %s mtu 9000" % port_name
         return self.ns_exec(cmd)
 
     def attach_interfaces(self, num_ifaces):

--- a/backends/p4tools/common/options.cpp
+++ b/backends/p4tools/common/options.cpp
@@ -1,8 +1,8 @@
 #include "backends/p4tools/common/options.h"
 
-#include <string.h>
-
+#include <algorithm>
 #include <cstdlib>
+#include <cstring>
 #include <functional>
 #include <string>
 #include <tuple>
@@ -124,32 +124,14 @@ AbstractP4cToolOptions::AbstractP4cToolOptions(cstring message) : Options(messag
         "Prints version information and exits");
 
     registerOption(
-        "--min-packet-size", "bytes",
-        [this](const char* arg) {
-            int minLen_bytes = std::atoi(arg);
-            if (minLen_bytes <= 0) {
-                ::error("Invalid minimum packet length: %1%", arg);
-                return false;
-            }
-            minPacketSize_bytes = minLen_bytes;
+        "--packet-size-range", "packetSizeRange",
+        [](const char* /*arg*/) {
+            // packetSize = std::atoi(arg);
             return true;
         },
-        "Sets the minimum allowed packet size, in bytes. Any packet shorter than this is "
-        "considered to be invalid, and will be dropped if the program would otherwise send the "
-        "packet on the network.");
-
-    registerOption(
-        "--mtu", "bytes",
-        [this](const char* arg) {
-            int maxLen_bytes = std::atoi(arg);
-            if (maxLen_bytes <= 0) {
-                ::error("Invalid network MTU: %1%", arg);
-                return false;
-            }
-            networkMtu_bytes = maxLen_bytes;
-            return true;
-        },
-        "Sets the network's MTU, in bytes");
+        "Specify the possible range of the input packet size in bits. The format is [min]:[max]. "
+        "The default values are \"0:72000\". This also is the widest possible range (0 to jumbo "
+        "frame size).");
 
     registerOption(
         "--seed", "seed",

--- a/backends/p4tools/common/options.h
+++ b/backends/p4tools/common/options.h
@@ -20,11 +20,12 @@ namespace P4Tools {
 /// instance.
 class AbstractP4cToolOptions : protected Util::Options {
  public:
-    /// The network's MTU, in bytes.
-    int networkMtu_bytes = 1500;
+    /// The maximum permitted packet size, in bits.
+    // The default is the jumbo frame packet size, 9000 bytes.
+    int maxPktSize = 72000;
 
-    /// The minimum packet length allowed by the network, in bytes.
-    int minPacketSize_bytes = 64;
+    /// The minimum permitted packet size, in bits.
+    int minPktSize = 0;
 
     /// A seed for the PRNG.
     boost::optional<uint32_t> seed = boost::none;
@@ -48,6 +49,7 @@ class AbstractP4cToolOptions : protected Util::Options {
 
     // No copy constructor and no self-assignments.
     AbstractP4cToolOptions(const AbstractP4cToolOptions&) = delete;
+
     AbstractP4cToolOptions& operator=(const AbstractP4cToolOptions&) = delete;
 };
 

--- a/backends/p4tools/testgen/README.md
+++ b/backends/p4tools/testgen/README.md
@@ -44,7 +44,7 @@ These are the current usage flags:
 --dump folder              Folder where P4 programs are dumped.
 -v                         Increase verbosity level (can be repeated)
 --input-packet-only        Only produce the input packet for each test
--- packet-size-range       Specify the possible range of the input packet size in bits. The format is [min]:[max]. The default values are "0:72000". This also is the widest possible range (0 to jumbo frame size).
+-- packet-size-range       Specify the possible range of the input packet size in bits. The format is [min]:[max]. The default values are "0:72000". The maximum is set to jumbo frame size (9000 bytes).
 --max-tests maxTests       Sets the maximum number of tests to be generated
 --out-dir outputDir        Directory for generated tests
 --test-backend             Select a test back end. Available test back ends are defined by the respective target.

--- a/backends/p4tools/testgen/README.md
+++ b/backends/p4tools/testgen/README.md
@@ -28,8 +28,6 @@ These are the current usage flags:
 ./p4check: Generate packet tests for a P4 program
 --help                     Shows this help message and exits
 --version                  Prints version information and exits
---min-packet-size bytes    Sets the minimum allowed packet size, in bytes. Any packet shorter than this is considered to be invalid, and will be dropped if the program would otherwise send the packet on the network.
---mtu bytes                Sets the network's MTU, in bytes
 --seed seed                Provides a randomization seed
 -I path                    Adds the given path to the preprocessor include path
 -D arg=value               Defines a preprocessor symbol
@@ -46,6 +44,7 @@ These are the current usage flags:
 --dump folder              Folder where P4 programs are dumped.
 -v                         Increase verbosity level (can be repeated)
 --input-packet-only        Only produce the input packet for each test
+-- packet-size-range       Specify the possible range of the input packet size in bits. The format is [min]:[max]. The default values are "0:72000". This also is the widest possible range (0 to jumbo frame size).
 --max-tests maxTests       Sets the maximum number of tests to be generated
 --out-dir outputDir        Directory for generated tests
 --test-backend             Select a test back end. Available test back ends are defined by the respective target.

--- a/backends/p4tools/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/testgen/core/small_step/cmd_stepper.cpp
@@ -358,12 +358,6 @@ bool CmdStepper::preorder(const IR::P4Program* /*program*/) {
     // If this option is active, mandate that all packets conform to a fixed size.
     auto pktSize = TestgenOptions::get().minPktSize;
     if (pktSize != 0) {
-        auto maxPktLength = ExecutionState::getMaxPacketLength();
-        if (pktSize < 0 || pktSize > maxPktLength) {
-            ::error("Invalid input packet size. The valid range is from 1 to %1% bits.",
-                    maxPktLength);
-            return false;
-        }
         const auto* fixedSizeEqu =
             new IR::Equ(ExecutionState::getInputPacketSizeVar(),
                         IR::getConstant(ExecutionState::getPacketSizeVarType(), pktSize));

--- a/backends/p4tools/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/testgen/core/small_step/cmd_stepper.cpp
@@ -356,9 +356,9 @@ bool CmdStepper::preorder(const IR::P4Program* /*program*/) {
     initializeTargetEnvironment(nextState);
 
     // If this option is active, mandate that all packets conform to a fixed size.
-    auto pktSize = TestgenOptions::get().packetSize;
+    auto pktSize = TestgenOptions::get().minPktSize;
     if (pktSize != 0) {
-        auto maxPktLength = ExecutionState::getMaxPacketLength_bits();
+        auto maxPktLength = ExecutionState::getMaxPacketLength();
         if (pktSize < 0 || pktSize > maxPktLength) {
             ::error("Invalid input packet size. The valid range is from 1 to %1% bits.",
                     maxPktLength);
@@ -513,9 +513,9 @@ const Constraint* CmdStepper::startParser(const IR::P4Parser* parser, ExecutionS
 
     // Constrain the input packet size to its maximum.
     const auto* boolType = IR::Type::Boolean::get();
-    const Constraint* result = new IR::Leq(
-        boolType, ExecutionState::getInputPacketSizeVar(),
-        IR::getConstant(parserCursorVarType, ExecutionState::getMaxPacketLength_bits()));
+    const Constraint* result =
+        new IR::Leq(boolType, ExecutionState::getInputPacketSizeVar(),
+                    IR::getConstant(parserCursorVarType, ExecutionState::getMaxPacketLength()));
 
     // Constrain the input packet size to be a multiple of 8 bits. Do this by constraining the
     // lowest three bits of the packet size to 0.

--- a/backends/p4tools/testgen/core/small_step/extern_stepper.cpp
+++ b/backends/p4tools/testgen/core/small_step/extern_stepper.cpp
@@ -553,7 +553,7 @@ void ExprStepper::evalExternMethodCall(const IR::MethodCallExpression* call,
                  // size.
                  auto* sizeRestriction = new IR::Leq(
                      advanceExpr,
-                     IR::getConstant(advanceExpr->type, ExecutionState::getMaxPacketLength_bits()));
+                     IR::getConstant(advanceExpr->type, ExecutionState::getMaxPacketLength()));
                  // The advance expression should ideally have a size that is a multiple of 8 bits.
                  auto* bytesRestriction =
                      new IR::Equ(new IR::Mod(advanceExpr, IR::getConstant(advanceExpr->type, 8)),
@@ -723,7 +723,7 @@ void ExprStepper::evalExternMethodCall(const IR::MethodCallExpression* call,
                  }
                  // The size of the advance expression should be smaller than the maximum packet
                  // size.
-                 auto maxVarbit = std::min(ExecutionState::getMaxPacketLength_bits(), varbit->size);
+                 auto maxVarbit = std::min(ExecutionState::getMaxPacketLength(), varbit->size);
                  auto* sizeRestriction = new IR::Leq(
                      varbitExtractExpr, IR::getConstant(varbitExtractExpr->type, maxVarbit));
                  // The advance expression should ideally fit into a multiple of 8 bits.

--- a/backends/p4tools/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/testgen/lib/execution_state.cpp
@@ -333,9 +333,7 @@ const StateVariable& ExecutionState::getInputPacketSizeVar() {
     return Utils::getZombieConst(getPacketSizeVarType(), 0, "*packetLen_bits");
 }
 
-int ExecutionState::getMaxPacketLength_bits() {
-    return 8 * (TestgenOptions::get().networkMtu_bytes);
-}
+int ExecutionState::getMaxPacketLength() { return TestgenOptions::get().maxPktSize; }
 
 const IR::Expression* ExecutionState::getInputPacket() const { return env.get(&inputPacketLabel); }
 

--- a/backends/p4tools/testgen/lib/execution_state.h
+++ b/backends/p4tools/testgen/lib/execution_state.h
@@ -359,7 +359,7 @@ class ExecutionState {
 
     /// @returns the maximum length, in bits, of the packet in the current packet buffer. This is
     /// the network's MTU.
-    static int getMaxPacketLength_bits();
+    static int getMaxPacketLength();
 
     /// @returns the current version of the packet that is intended as input.
     const IR::Expression* getInputPacket() const;

--- a/backends/p4tools/testgen/options.cpp
+++ b/backends/p4tools/testgen/options.cpp
@@ -29,6 +29,7 @@ TestgenOptions::TestgenOptions()
             return true;
         },
         "Fail on unimplemented features instead of trying the next branch.");
+
     registerOption(
         "--input-packet-only", nullptr,
         [this](const char*) {
@@ -71,15 +72,6 @@ TestgenOptions::TestgenOptions()
         },
         "Select the test back end. P4Testgen will produce tests that correspond to the input "
         "format of this test back end.");
-
-    registerOption(
-        "--packet-size", "packetSize",
-        [this](const char* arg) {
-            packetSize = std::atoi(arg);
-            return true;
-        },
-        "If enabled, sets all input packets to a fixed size in bits (from 1 to 12000 bits). 0 "
-        "implies no packet sizing.");
 
     registerOption(
         "--input-branches", "selectedBranches",

--- a/backends/p4tools/testgen/options.h
+++ b/backends/p4tools/testgen/options.h
@@ -17,9 +17,6 @@ class TestgenOptions : public AbstractP4cToolOptions {
     /// Maximum number of tests to be generated. Defaults to 1.
     int maxTests = 1;
 
-    /// Fixed packet size in bits. Defaults to 0, which implies no sizing.
-    int packetSize = 0;
-
     /// Selects the exploration strategy for test generation
     std::string explorationStrategy;
 

--- a/backends/p4tools/testgen/targets/ebpf/target.cpp
+++ b/backends/p4tools/testgen/targets/ebpf/target.cpp
@@ -60,6 +60,15 @@ const EBPFProgramInfo* EBPFTestgenTarget::initProgram_impl(
         programmableBlocks.emplace(canonicalName, declType);
     }
 
+    // TODO: We bound the max packet size. However, eBPF should be able to support jumbo sized
+    // packets. There might be a bug in the framework
+    auto& testgenOptions = TestgenOptions::get();
+    if (testgenOptions.maxPktSize > 12000) {
+        ::warning("Max packet size %1% larger than 12000 bits. Bounding size to 12000 bits.",
+                  testgenOptions.maxPktSize);
+        testgenOptions.maxPktSize = 12000;
+    }
+
     return new EBPFProgramInfo(program, programmableBlocks);
 }
 


### PR DESCRIPTION
Consolidate several packet sizing options into one. Packet sizes are now defined as range (`[min]:[max]`). The maximum packet size is now jumbo frame size (9000 byte). Extensions which do not support this size will have to override or implement their own checks (see the eBPF back end). 

Fixes #3559. 