### PR TITLE
Migrate away from deprecated Bazel option

### DIFF
--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -163,7 +163,7 @@ p4_library = rule(
         "p4c_backend": attr.label(
             default = Label("@com_github_p4lang_p4c//:p4c_bmv2"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_p4include": attr.label(
             default = Label("@com_github_p4lang_p4c//:p4include"),
@@ -244,7 +244,7 @@ p4_graphs = rule(
         "p4c_backend": attr.label(
             default = Label("@com_github_p4lang_p4c//:p4c_graphs"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_p4include": attr.label(
             default = Label("@com_github_p4lang_p4c//:p4include"),


### PR DESCRIPTION
Migrate from cfg = "host" to cfg = "exec".
Host is being deprecated and replaced by exec, see details here: https://docs.bazel.build/versions/4.1.0/skylark/rules.html#configurations