### PR TITLE
Emit table config

### DIFF
--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -140,7 +140,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock* tlb) {
         new CopyPropagationAndElimination(typeMap),
         new CollectUsedMetadataField(used_fields),
         new RemoveUnusedMetadataFields(used_fields),
-        new ShortenTokenLength(refMap, typeMap, newNameMap),
+        new ShortenTokenLength(newNameMap),
         new EmitDpdkTableConfig(refMap, typeMap, newNameMap),
     };
 

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -133,14 +133,15 @@ void DpdkBackend::convert(const IR::ToplevelBlock* tlb) {
         };
         dpdk_program = dpdk_program->apply(post_code_gen)->to<IR::DpdkAsmProgram>();
     }
-
+    ordered_map<cstring, cstring> newNameMap;
     PassManager post_code_gen = {
         new EliminateUnusedAction(),
         new DpdkAsmOptimization,
         new CopyPropagationAndElimination(typeMap),
         new CollectUsedMetadataField(used_fields),
         new RemoveUnusedMetadataFields(used_fields),
-        new ShortenTokenLength(),
+        new ShortenTokenLength(refMap, typeMap, newNameMap),
+        new EmitDpdkTableConfig(refMap, typeMap, newNameMap),
     };
 
     dpdk_program = dpdk_program->apply(post_code_gen)->to<IR::DpdkAsmProgram>();

--- a/backends/dpdk/dpdk.def
+++ b/backends/dpdk/dpdk.def
@@ -43,7 +43,24 @@ class DpdkTable {
     Expression default_action;
     TableProperties properties;
     inline ParameterList default_action_paraList;
-
+    Key getKey() const {
+        auto kp = properties->getProperty(TableProperties::keyPropertyName);
+        if (kp == nullptr)
+            return nullptr;
+        if (!kp->value->is<IR::Key>()) {
+            ::error(ErrorType::ERR_INVALID, "%1%: must be a key", kp);
+            return nullptr; }
+        return kp->value->to<IR::Key>(); }
+    EntriesList getEntries() const {
+        auto ep = properties->getProperty(TableProperties::entriesPropertyName);
+        if (ep == nullptr)
+            return nullptr;
+        if (!ep->value->is<IR::EntriesList>()) {
+            ::error(ErrorType::ERR_INVALID, "%1%: must be a list of entries", ep);
+            return nullptr;
+        }
+        return ep->value->to<IR::EntriesList>();
+    }
     std::ostream& toSpec(std::ostream& out) const;
 #nodbprint
 #novalidate

--- a/backends/dpdk/dpdkAsmOpt.cpp
+++ b/backends/dpdk/dpdkAsmOpt.cpp
@@ -398,5 +398,318 @@ IR::IndexedVector<IR::DpdkAsmStatement> CopyPropagationAndElimination::copyPropA
     return instrr;
 }
 
+cstring EmitDpdkTableConfig::getKeyMatchType(const IR::KeyElement* ke, P4::ReferenceMap* refMap) {
+    auto path = ke->matchType->path;
+    auto mt = refMap->getDeclaration(path, true)->to<IR::Declaration_ID>();
+    BUG_CHECK(mt != nullptr, "%1%: could not find declaration", ke->matchType);
+    return mt->name.name;
+}
+
+int EmitDpdkTableConfig::getTypeWidth(const IR::Type* type,
+                                      P4::TypeMap* typeMap) {
+    return typeMap->widthBits(type, type->getNode(), false);
+}
+
+void EmitDpdkTableConfig::print(cstring str, cstring sep) {
+    dpdkTableConfigFile<<str<<sep;
+}
+
+void EmitDpdkTableConfig::print(big_int str, cstring sep) {
+    try {
+        dpdkTableConfigFile<<"0x"<<std::hex<<str<<sep;
+    } catch(const std::runtime_error& re) {
+        dpdkTableConfigFile<<std::dec<<str<<sep;
+    }
+}
+
+big_int EmitDpdkTableConfig::convertSimpleKeyExpressionToBigInt(
+            const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap) {
+    if (k->is<IR::Constant>()) {
+        return k->to<IR::Constant>()->value;
+    } else if (k->is<IR::BoolLiteral>()) {
+        return static_cast<big_int>(k->to<IR::BoolLiteral>()->value
+                                    ? 1 : 0);
+    } else if (k->is<IR::Member>()) {  // handle SerEnum members
+        auto mem = k->to<IR::Member>();
+        auto se = mem->type->to<IR::Type_SerEnum>();
+        auto ei = P4::EnumInstance::resolve(mem, typeMap);
+        if (!ei) return -1;
+        if (auto sei = ei->to<P4::SerEnumInstance>()) {
+            auto type = sei->value->to<IR::Constant>();
+            auto w = se->type->width_bits();
+            BUG_CHECK(w == keyWidth, "SerEnum bitwidth mismatch");
+            return type->value;
+        }
+        ::error(ErrorType::ERR_INVALID, "%1% invalid Member key expression", k);
+        return -1;
+    } else if (k->is<IR::Cast>()) {
+        return convertSimpleKeyExpressionToBigInt(k->to<IR::Cast>()->expr, keyWidth, typeMap);
+    } else {
+        ::error(ErrorType::ERR_INVALID, "%1% invalid key expression", k);
+        return -1;
+    }
+}
+
+const IR::Key *EmitDpdkTableConfig::getKey(const IR::DpdkTable* dt) {
+        auto kp = dt->properties->getProperty(IR::TableProperties::keyPropertyName);
+        if (kp == nullptr)
+            return nullptr;
+        if (!kp->value->is<IR::Key>()) {
+            ::error(ErrorType::ERR_INVALID, "%1%: must be a key", kp);
+            return nullptr;
+        }
+        return kp->value->to<IR::Key>();
+}
+
+const IR::EntriesList* EmitDpdkTableConfig::getEntries(const IR::DpdkTable* dt) {
+    auto ep = dt->properties->getProperty(IR::TableProperties::entriesPropertyName);
+    if (ep == nullptr)
+        return nullptr;
+    if (!ep->value->is<IR::EntriesList>()) {
+        ::error(ErrorType::ERR_INVALID, "%1%: must be a list of entries", ep);
+        return nullptr;
+    }
+    return ep->value->to<IR::EntriesList>();
+}
+
+void EmitDpdkTableConfig::addAction(const IR::Expression* actionRef,
+                P4::ReferenceMap* refMap,
+                P4::TypeMap* typeMap) {
+    auto actionCall = actionRef->to<IR::MethodCallExpression>();
+    auto method = actionCall->method->to<IR::PathExpression>()->path;
+    const IR::Path* origMethod = nullptr;
+    if (ShortenTokenLength::origNameMap.count(method->name) > 0) {
+        origMethod = new IR::Path(ShortenTokenLength::origNameMap[method->name]);
+    } else {
+        origMethod = method;
+    }
+    auto decl = refMap->getDeclaration(origMethod, true);
+    auto actionDecl = decl->to<IR::P4Action>();
+    cstring actionName;
+    if (newNameMap.count(actionDecl->name.name) > 0)
+        actionName = newNameMap[actionDecl->name.name];
+    else
+        actionName = actionDecl->name.name;
+    print(actionName, " ");
+    if (actionDecl->parameters->parameters.size() == 1) {
+        std::vector<cstring> paramNames;
+        std::vector<big_int> argVals;
+        auto parameter = actionDecl->parameters->parameters.at(0);
+        auto type = typeMap->getType(parameter);
+        if (auto actArg = type->to<IR::Type_Struct>()) {
+            for (auto f : actArg->fields)
+                paramNames.push_back(f->name);
+        }
+        for (auto args : *actionCall->arguments) {
+            for (auto arg : args->expression->to<IR::ListExpression>()->components) {
+                auto ei = P4::EnumInstance::resolve(arg, typeMap);
+                if (arg->is<IR::Constant>()) {
+                    auto constant = arg->to<IR::Constant>();
+                    auto argValue = constant->value;
+                    argVals.push_back(argValue);
+                } else if (arg->is<IR::BoolLiteral>()) {
+                    auto constant = arg->to<IR::BoolLiteral>();
+                    auto argValue = static_cast<big_int>(constant->value ? 1 : 0);
+                    argVals.push_back(argValue);
+                } else if (ei != nullptr && ei->is<P4::SerEnumInstance>()) {
+                    auto sei = ei->to<P4::SerEnumInstance>();
+                    auto argValue = sei->value->to<IR::Constant>();
+                    argVals.push_back(argValue->value);
+                } else {
+                    ::error(ErrorType::ERR_UNSUPPORTED,
+                            "%1% unsupported argument expression", arg);
+                    continue;
+                }
+            }
+        }
+
+        for (size_t i = 0; i < argVals.size(); i++) {
+            print(paramNames[i], " ");
+            print(argVals[i], " ");
+        }
+    }
+}
+
+void EmitDpdkTableConfig::addExact(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap) {
+    if (k->is<IR::DefaultExpression>()) {
+        print("0x0/0x0", " ");
+    } else {
+        auto value = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
+        print(value, " ");
+    }
+}
+
+void EmitDpdkTableConfig::addLpm(const IR::Expression* k,
+            int keyWidth, P4::TypeMap *typeMap) {
+    big_int valueStr;
+    big_int mask;
+    if (k->is<IR::DefaultExpression>()) {
+        valueStr = 0x0;
+        mask = 0x0;
+    } else if (k->is<IR::Mask>()) {
+        auto km = k->to<IR::Mask>();
+        auto value = convertSimpleKeyExpressionToBigInt(km->left, keyWidth, typeMap);
+        auto trailing_zeros = [keyWidth](const big_int& n) -> int {
+            return (n == 0) ? keyWidth : boost::multiprecision::lsb(n); };
+        auto count_ones = [](const big_int& n) -> int {
+            return bitcount(n); };
+        mask = km->right->to<IR::Constant>()->value;
+        auto len = trailing_zeros(mask);
+        if (len + count_ones(mask) != keyWidth) {  // any remaining 0s in the prefix?
+            ::error(ErrorType::ERR_INVALID, "%1% invalid mask for LPM key", k);
+            return;
+        }
+        if ((value & mask) != value) {
+            ::warning(ErrorType::WARN_MISMATCH,
+                        "P4Runtime requires that LPM matches have masked-off bits set to 0, "
+                        "updating value %1% to conform to the P4Runtime specification", km->left);
+            value &= mask;
+        }
+        valueStr = value;
+    } else {
+        valueStr = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
+    }
+    print(valueStr,"/");
+    print(mask," ");
+}
+
+void EmitDpdkTableConfig::addTernary(const IR::Expression* k, int keyWidth,
+                P4::TypeMap* typeMap) {
+    big_int valueStr;
+    big_int maskStr;
+    if (k->is<IR::DefaultExpression>()) {
+        valueStr = 0x0;
+        maskStr = 0x0;
+    } else if (k->is<IR::Mask>()) {
+        auto km = k->to<IR::Mask>();
+        auto value = convertSimpleKeyExpressionToBigInt(km->left, keyWidth, typeMap);
+        auto mask = convertSimpleKeyExpressionToBigInt(km->right, keyWidth, typeMap);
+        if ((value & mask) != value) {
+            ::warning(ErrorType::WARN_MISMATCH,
+                        "P4Runtime requires that Ternary matches have masked-off bits set to 0, "
+                        "updating value %1% to conform to the P4Runtime specification", km->left);
+            value &= mask;
+        }
+        valueStr = value;
+        maskStr = mask;
+    } else {
+        valueStr = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
+        maskStr = Util::mask(keyWidth);
+    }
+    print(valueStr, "/");
+    print(maskStr, " ");
+}
+
+void EmitDpdkTableConfig::addRange(const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap) {
+    big_int startStr;
+    big_int endStr;
+    if (k->is<IR::DefaultExpression>()) {
+        startStr = 0x0;
+        endStr = 0x0;
+    } else if (k->is<IR::Range>()) {
+        auto kr = k->to<IR::Range>();
+        auto start = convertSimpleKeyExpressionToBigInt(kr->left, keyWidth, typeMap);
+        auto end = convertSimpleKeyExpressionToBigInt(kr->right, keyWidth, typeMap);
+        // Error on invalid range values
+        big_int maxValue = (big_int(1) << keyWidth) - 1;
+        // NOTE: If end value is > max allowed for keyWidth, value gets
+        // wrapped around. A warning is issued in this case by the frontend
+        // earlier.
+        // For e.g. 16 bit key has a max value of 65535, Range of (1..65536)
+        // will be converted to (1..0) and will fail below check.
+        if (start > end)
+            ::error(ErrorType::ERR_INVALID, "%s Invalid range for table entry", kr->srcInfo);
+        startStr = start;
+        endStr = end;
+    } else {
+        startStr = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
+        endStr = startStr;
+    }
+    print(startStr,"/");
+    print(endStr," ");
+}
+
+void EmitDpdkTableConfig::addOptional(const IR::Expression* k, int keyWidth,
+                    P4::TypeMap* typeMap) {
+    if (k->is<IR::DefaultExpression>()) {
+        print("0x0/0x0"," ");
+    } else {
+        auto value = convertSimpleKeyExpressionToBigInt(k, keyWidth, typeMap);
+        print(value," ");
+    }
+}
+
+void EmitDpdkTableConfig::addMatchKey(const IR::DpdkTable* table,
+                     const IR::ListExpression* keyset,
+                     P4::TypeMap* typeMap) {
+    int keyIndex = 0;
+    for (auto k : keyset->components) {
+            auto tableKey = getKey(table)->keyElements.at(keyIndex++);
+            auto keyWidth = getTypeWidth(tableKey->expression->type, typeMap);
+            auto matchType = getKeyMatchType(tableKey, refMap);
+            if (matchType == P4::P4CoreLibrary::instance.exactMatch.name) {
+              addExact(k, keyWidth, typeMap);
+            } else if (matchType == P4::P4CoreLibrary::instance.lpmMatch.name) {
+              addLpm(k, keyWidth, typeMap);
+            } else if (matchType == P4::P4CoreLibrary::instance.ternaryMatch.name) {
+              addTernary(k, keyWidth, typeMap);
+            } else if (matchType == "range") {
+              addRange(k, keyWidth, typeMap);
+            } else if (matchType == "optional") {
+              addOptional(k, keyWidth, typeMap);
+            } else {
+                if (!k->is<IR::DefaultExpression>())
+                    ::error(ErrorType::ERR_UNSUPPORTED,
+                         "%1%: match type not supported by P4Runtime serializer", matchType);
+                continue;
+            }
+    }
+}
+
+/// Checks if the @table entries need to be assigned a priority, i.e. does
+/// the match key for the table includes a ternary, range, or optional match?
+bool EmitDpdkTableConfig::tableNeedsPriority(const IR::DpdkTable* table, P4::ReferenceMap* refMap) {
+    for (auto e : getKey(table)->keyElements) {
+        auto matchType = getKeyMatchType(e, refMap);
+        // TODO(antonin): remove dependency on v1model.
+        if (matchType == "ternary" ||
+            matchType == "range" ||
+            matchType == "optional") {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool EmitDpdkTableConfig::isAllKeysDefaultExpression(const IR::ListExpression* keyset) {
+    bool allKeyDefaultExp = true;
+    for (auto k : keyset->components) {
+            allKeyDefaultExp = allKeyDefaultExp && k->is<IR::DefaultExpression>();
+    }
+    return allKeyDefaultExp;
+}
+
+void EmitDpdkTableConfig::postorder(const IR::DpdkTable* table) {
+    auto entriesList = getEntries(table);
+    if (entriesList == nullptr) return;
+    dpdkTableConfigFile.open(table->name+".txt");
+    auto needsPriority = tableNeedsPriority(table, refMap);
+    int entryPriority = entriesList->entries.size();
+    for (auto e : entriesList->entries) {
+        if (!isAllKeysDefaultExpression(e->getKeys())) {
+            print("match"," ");
+            addMatchKey(table, e->getKeys(), typeMap);
+            if (needsPriority) {
+                print("priority", " ");
+                print(entryPriority--," ");
+            }
+            print("action"," ");
+            addAction(e->getAction(), refMap, typeMap);
+            print("", "\n");
+        }
+    }
+    dpdkTableConfigFile.close();
+}
 size_t ShortenTokenLength::count = 0;
 }  // namespace DPDK

--- a/backends/dpdk/dpdkAsmOpt.h
+++ b/backends/dpdk/dpdkAsmOpt.h
@@ -167,8 +167,6 @@ class RemoveUnusedMetadataFields : public Transform {
 
 // This pass shorten the Identifier length
 class ShortenTokenLength : public Transform {
-    P4::ReferenceMap* refMap;
-    P4::TypeMap* typeMap;
     ordered_map<cstring, cstring>& newNameMap;
     static size_t count;
     // Currently Dpdk allows Identifier of 63 char long or less
@@ -195,9 +193,8 @@ class ShortenTokenLength : public Transform {
     }
 
  public:
-    ShortenTokenLength(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
-        ordered_map<cstring, cstring>& newNameMap) :
-        refMap(refMap), typeMap(typeMap) , newNameMap(newNameMap){}
+    explicit ShortenTokenLength(ordered_map<cstring, cstring>& newNameMap) :
+        newNameMap(newNameMap){}
     static ordered_map<cstring, cstring> origNameMap;
 
     const IR::Node* preorder(IR::Member* m) override {

--- a/backends/dpdk/dpdkAsmOpt.h
+++ b/backends/dpdk/dpdkAsmOpt.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define BACKENDS_DPDK_DPDKASMOPT_H_
 
 #include <fstream>
+
 #include "dpdkUtils.h"
 #include "frontends/common/constantFolding.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
@@ -193,8 +194,8 @@ class ShortenTokenLength : public Transform {
     }
 
  public:
-    explicit ShortenTokenLength(ordered_map<cstring, cstring>& newNameMap) :
-        newNameMap(newNameMap){}
+    explicit ShortenTokenLength(ordered_map<cstring, cstring>& newNameMap)
+        : newNameMap(newNameMap) {}
     static ordered_map<cstring, cstring> origNameMap;
 
     const IR::Node* preorder(IR::Member* m) override {
@@ -604,38 +605,29 @@ class EmitDpdkTableConfig : public Inspector {
     ordered_map<cstring, cstring>& newNameMap;
     std::ofstream dpdkTableConfigFile;
 
-    void addExact(const IR::Expression* k,
-                int keyWidth, P4::TypeMap* typeMap);
-    void addLpm(const IR::Expression* k,
-                int keyWidth, P4::TypeMap* typeMap);
-    void addTernary(const IR::Expression* k,
-                int keyWidth, P4::TypeMap* typeMap);
-    void addRange(const IR::Expression* k,
-                int keyWidth, P4::TypeMap* typeMap);
-    void addOptional(const IR::Expression* k,
-                int keyWidth, P4::TypeMap* typeMap);
-    void addMatchKey(const IR::DpdkTable* table,
-                     const IR::ListExpression* keyset,
+    void addExact(const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap);
+    void addLpm(const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap);
+    void addTernary(const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap);
+    void addRange(const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap);
+    void addOptional(const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap);
+    void addMatchKey(const IR::DpdkTable* table, const IR::ListExpression* keyset,
                      P4::TypeMap* typeMap);
-    void addAction(const IR::Expression* actionRef,
-                   P4::ReferenceMap* refMap,
-                   P4::TypeMap* typeMap);
+    void addAction(const IR::Expression* actionRef, P4::ReferenceMap* refMap, P4::TypeMap* typeMap);
     int getTypeWidth(const IR::Type* type, P4::TypeMap* typeMap);
     cstring getKeyMatchType(const IR::KeyElement* ke, P4::ReferenceMap* refMap);
     const IR::EntriesList* getEntries(const IR::DpdkTable* dt);
-    const IR::Key *getKey(const IR::DpdkTable* dt);
-    big_int convertSimpleKeyExpressionToBigInt(
-        const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap);
+    const IR::Key* getKey(const IR::DpdkTable* dt);
+    big_int convertSimpleKeyExpressionToBigInt(const IR::Expression* k, int keyWidth,
+                                               P4::TypeMap* typeMap);
     bool tableNeedsPriority(const IR::DpdkTable* table, P4::ReferenceMap* refMap);
     bool isAllKeysDefaultExpression(const IR::ListExpression* keyset);
-    void print(cstring str, cstring sep="");
-    void print(big_int, cstring sep="");
+    void print(cstring str, cstring sep = "");
+    void print(big_int, cstring sep = "");
 
  public:
-    EmitDpdkTableConfig(P4::ReferenceMap* refMap,
-                        P4::TypeMap *typeMap,
-                        ordered_map<cstring, cstring>& newNameMap) : refMap(refMap),
-                        typeMap(typeMap), newNameMap(newNameMap) {}
+    EmitDpdkTableConfig(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
+                        ordered_map<cstring, cstring>& newNameMap)
+        : refMap(refMap), typeMap(typeMap), newNameMap(newNameMap) {}
     void postorder(const IR::DpdkTable* table) override;
 };
 

--- a/backends/dpdk/dpdkAsmOpt.h
+++ b/backends/dpdk/dpdkAsmOpt.h
@@ -17,6 +17,7 @@ limitations under the License.
 #ifndef BACKENDS_DPDK_DPDKASMOPT_H_
 #define BACKENDS_DPDK_DPDKASMOPT_H_
 
+#include <fstream>
 #include "dpdkUtils.h"
 #include "frontends/common/constantFolding.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
@@ -166,7 +167,9 @@ class RemoveUnusedMetadataFields : public Transform {
 
 // This pass shorten the Identifier length
 class ShortenTokenLength : public Transform {
-    ordered_map<cstring, cstring> newNameMap;
+    P4::ReferenceMap* refMap;
+    P4::TypeMap* typeMap;
+    ordered_map<cstring, cstring>& newNameMap;
     static size_t count;
     // Currently Dpdk allows Identifier of 63 char long or less
     // including dots(.) for member exp.
@@ -192,6 +195,9 @@ class ShortenTokenLength : public Transform {
     }
 
  public:
+    ShortenTokenLength(P4::ReferenceMap* refMap, P4::TypeMap* typeMap,
+        ordered_map<cstring, cstring>& newNameMap) :
+        refMap(refMap), typeMap(typeMap) , newNameMap(newNameMap){}
     static ordered_map<cstring, cstring> origNameMap;
 
     const IR::Node* preorder(IR::Member* m) override {
@@ -590,6 +596,50 @@ class CopyPropagationAndElimination : public Transform {
     const IR::Node* postorder(IR::DpdkListStatement* l) override {
         return new IR::DpdkListStatement(copyPropAndDeadCodeElim(l->statements));
     }
+};
+
+// This Pass emits Table config consumed by dpdk target in a text file if
+// const entries are present in p4 program.
+// Most of the code taken from control-plane/p4RuntimeSerializer.h/.cpp
+class EmitDpdkTableConfig : public Inspector {
+    P4::ReferenceMap* refMap;
+    P4::TypeMap* typeMap;
+    ordered_map<cstring, cstring>& newNameMap;
+    std::ofstream dpdkTableConfigFile;
+
+    void addExact(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap);
+    void addLpm(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap);
+    void addTernary(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap);
+    void addRange(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap);
+    void addOptional(const IR::Expression* k,
+                int keyWidth, P4::TypeMap* typeMap);
+    void addMatchKey(const IR::DpdkTable* table,
+                     const IR::ListExpression* keyset,
+                     P4::TypeMap* typeMap);
+    void addAction(const IR::Expression* actionRef,
+                   P4::ReferenceMap* refMap,
+                   P4::TypeMap* typeMap);
+    int getTypeWidth(const IR::Type* type, P4::TypeMap* typeMap);
+    cstring getKeyMatchType(const IR::KeyElement* ke, P4::ReferenceMap* refMap);
+    const IR::EntriesList* getEntries(const IR::DpdkTable* dt);
+    const IR::Key *getKey(const IR::DpdkTable* dt);
+    big_int convertSimpleKeyExpressionToBigInt(
+        const IR::Expression* k, int keyWidth, P4::TypeMap* typeMap);
+    bool tableNeedsPriority(const IR::DpdkTable* table, P4::ReferenceMap* refMap);
+    bool isAllKeysDefaultExpression(const IR::ListExpression* keyset);
+    void print(cstring str, cstring sep="");
+    void print(big_int, cstring sep="");
+
+ public:
+    EmitDpdkTableConfig(P4::ReferenceMap* refMap,
+                        P4::TypeMap *typeMap,
+                        ordered_map<cstring, cstring>& newNameMap) : refMap(refMap),
+                        typeMap(typeMap), newNameMap(newNameMap) {}
+    void postorder(const IR::DpdkTable* table) override;
 };
 
 // Instructions can only appear in actions and apply block of .spec file.

--- a/testdata/p4_16_samples/psa-dpdk-table-entries-exact-ternary.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-entries-exact-ternary.p4
@@ -1,0 +1,127 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+header EMPTY_H {};
+struct EMPTY_RESUB {};
+struct EMPTY_CLONE {};
+struct EMPTY_BRIDGE {};
+struct EMPTY_RECIRC {};
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8> r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+struct Meta_t {}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, in psa_ingress_parser_input_metadata_t x,
+    in EMPTY_RESUB resub_meta,
+    in EMPTY_RECIRC recirc_meta) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+parser egressParserImpl(
+    packet_in buffer,
+    out EMPTY_H a,
+    inout Meta_t b,
+    in psa_egress_parser_input_metadata_t c,
+    in EMPTY_BRIDGE d,
+    in EMPTY_CLONE e,
+    in EMPTY_CLONE f) {
+    state start {
+        transition accept;
+    }
+}
+
+
+control ingress(inout Header_t h, inout Meta_t m, in psa_ingress_input_metadata_t istd,
+                            inout psa_ingress_output_metadata_t ostd) {
+
+    action a() { ostd.egress_port = (PortId_t)(PortIdUint_t)0; }
+    action a_with_control_params(bit<9> x) { ostd.egress_port = (PortId_t)(PortIdUint_t)x; }
+
+    table t_exact_ternary {
+
+  	key = {
+            h.h.e : exact;
+            h.h.t : ternary;
+        }
+
+	actions = {
+            a;
+            a_with_control_params;
+        }
+
+	default_action = a;
+
+        const entries = {
+            (0x01, 0x1111 &&& 0xF   ) : a_with_control_params(1);
+            (0x02, 0x1181           ) : a_with_control_params(2);
+            (0x03, 0x1111 &&& 0xF000) : a_with_control_params(3);
+            // test default entries
+            (0x04, _                ) : a_with_control_params(4);
+        }
+    }
+
+    apply {
+        t_exact_ternary.apply();
+    }
+}
+
+control egressControlImpl(
+    inout EMPTY_H h,
+    inout Meta_t meta,
+    in psa_egress_input_metadata_t x,
+                            inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control deparser(packet_out b, out EMPTY_CLONE clone_i2e_meta,
+                            out EMPTY_RESUB resubmit_meta,
+                            out EMPTY_BRIDGE normal_meta,
+                            inout Header_t h,
+                            in Meta_t local_metadata,
+                            in psa_ingress_output_metadata_t istd) { apply { b.emit(h.h); } }
+
+control egressDeparserImpl(
+    packet_out buffer,
+    out EMPTY_CLONE a,
+    out EMPTY_RECIRC b,
+    inout EMPTY_H c,
+    in Meta_t d,
+    in psa_egress_output_metadata_t e,
+    in psa_egress_deparser_input_metadata_t f) {
+    apply { }
+}
+
+
+IngressPipeline(p(), ingress(), deparser()) ip; 
+EgressPipeline(egressParserImpl(), egressControlImpl(), egressDeparserImpl()) ep; 
+
+PSA_Switch(
+    ip, 
+    PacketReplicationEngine(),
+    ep, 
+    BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-dpdk-table-entries-exact-ternary.p4
+++ b/testdata/p4_16_samples/psa-dpdk-table-entries-exact-ternary.p4
@@ -76,7 +76,7 @@ control ingress(inout Header_t h, inout Meta_t m, in psa_ingress_input_metadata_
 	default_action = a;
 
         const entries = {
-            (0x01, 0x1111 &&& 0xF   ) : a_with_control_params(1);
+            ((bit<8>)32w0x01, 0x1111 &&& 0xF   ) : a_with_control_params(1);
             (0x02, 0x1181           ) : a_with_control_params(2);
             (0x03, 0x1111 &&& 0xF000) : a_with_control_params(3);
             // test default entries

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary-first.p4
@@ -1,0 +1,94 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+header EMPTY_H {
+}
+
+struct EMPTY_RESUB {
+}
+
+struct EMPTY_CLONE {
+}
+
+struct EMPTY_BRIDGE {
+}
+
+struct EMPTY_RECIRC {
+}
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, in psa_ingress_parser_input_metadata_t x, in EMPTY_RESUB resub_meta, in EMPTY_RECIRC recirc_meta) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+parser egressParserImpl(packet_in buffer, out EMPTY_H a, inout Meta_t b, in psa_egress_parser_input_metadata_t c, in EMPTY_BRIDGE d, in EMPTY_CLONE e, in EMPTY_CLONE f) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action a() {
+        ostd.egress_port = (PortId_t)32w0;
+    }
+    action a_with_control_params(bit<9> x) {
+        ostd.egress_port = (PortId_t)(PortIdUint_t)x;
+    }
+    table t_exact_ternary {
+        key = {
+            h.h.e: exact @name("h.h.e");
+            h.h.t: ternary @name("h.h.t");
+        }
+        actions = {
+            a();
+            a_with_control_params();
+        }
+        default_action = a();
+        const entries = {
+                        (8w0x1, 16w0x1111 &&& 16w0xf) : a_with_control_params(9w1);
+                        (8w0x2, 16w0x1181) : a_with_control_params(9w2);
+                        (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params(9w3);
+                        (8w0x4, default) : a_with_control_params(9w4);
+        }
+    }
+    apply {
+        t_exact_ternary.apply();
+    }
+}
+
+control egressControlImpl(inout EMPTY_H h, inout Meta_t meta, in psa_egress_input_metadata_t x, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, out EMPTY_CLONE clone_i2e_meta, out EMPTY_RESUB resubmit_meta, out EMPTY_BRIDGE normal_meta, inout Header_t h, in Meta_t local_metadata, in psa_ingress_output_metadata_t istd) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control egressDeparserImpl(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMPTY_H c, in Meta_t d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<Header_t, Meta_t, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(p(), ingress(), deparser()) ip;
+EgressPipeline<EMPTY_H, Meta_t, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(egressParserImpl(), egressControlImpl(), egressDeparserImpl()) ep;
+PSA_Switch<Header_t, Meta_t, EMPTY_H, Meta_t, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary-frontend.p4
@@ -1,0 +1,94 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+header EMPTY_H {
+}
+
+struct EMPTY_RESUB {
+}
+
+struct EMPTY_CLONE {
+}
+
+struct EMPTY_BRIDGE {
+}
+
+struct EMPTY_RECIRC {
+}
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, in psa_ingress_parser_input_metadata_t x, in EMPTY_RESUB resub_meta, in EMPTY_RECIRC recirc_meta) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+parser egressParserImpl(packet_in buffer, out EMPTY_H a, inout Meta_t b, in psa_egress_parser_input_metadata_t c, in EMPTY_BRIDGE d, in EMPTY_CLONE e, in EMPTY_CLONE f) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.a") action a_1() {
+        ostd.egress_port = (PortId_t)32w0;
+    }
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x_1) {
+        ostd.egress_port = (PortId_t)(PortIdUint_t)x_1;
+    }
+    @name("ingress.t_exact_ternary") table t_exact_ternary_0 {
+        key = {
+            h.h.e: exact @name("h.h.e");
+            h.h.t: ternary @name("h.h.t");
+        }
+        actions = {
+            a_1();
+            a_with_control_params();
+        }
+        default_action = a_1();
+        const entries = {
+                        (8w0x1, 16w0x1111 &&& 16w0xf) : a_with_control_params(9w1);
+                        (8w0x2, 16w0x1181) : a_with_control_params(9w2);
+                        (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params(9w3);
+                        (8w0x4, default) : a_with_control_params(9w4);
+        }
+    }
+    apply {
+        t_exact_ternary_0.apply();
+    }
+}
+
+control egressControlImpl(inout EMPTY_H h, inout Meta_t meta, in psa_egress_input_metadata_t x, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, out EMPTY_CLONE clone_i2e_meta, out EMPTY_RESUB resubmit_meta, out EMPTY_BRIDGE normal_meta, inout Header_t h, in Meta_t local_metadata, in psa_ingress_output_metadata_t istd) {
+    apply {
+        b.emit<hdr>(h.h);
+    }
+}
+
+control egressDeparserImpl(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMPTY_H c, in Meta_t d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<Header_t, Meta_t, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(p(), ingress(), deparser()) ip;
+EgressPipeline<EMPTY_H, Meta_t, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(egressParserImpl(), egressControlImpl(), egressDeparserImpl()) ep;
+PSA_Switch<Header_t, Meta_t, EMPTY_H, Meta_t, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary-midend.p4
@@ -1,0 +1,103 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+header EMPTY_H {
+}
+
+struct EMPTY_RESUB {
+}
+
+struct EMPTY_CLONE {
+}
+
+struct EMPTY_BRIDGE {
+}
+
+struct EMPTY_RECIRC {
+}
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, in psa_ingress_parser_input_metadata_t x, in EMPTY_RESUB resub_meta, in EMPTY_RECIRC recirc_meta) {
+    state start {
+        b.extract<hdr>(h.h);
+        transition accept;
+    }
+}
+
+parser egressParserImpl(packet_in buffer, out EMPTY_H a, inout Meta_t b, in psa_egress_parser_input_metadata_t c, in EMPTY_BRIDGE d, in EMPTY_CLONE e, in EMPTY_CLONE f) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @name("ingress.a") action a_1() {
+        ostd.egress_port = 32w0;
+    }
+    @name("ingress.a_with_control_params") action a_with_control_params(@name("x") bit<9> x_1) {
+        ostd.egress_port = (bit<32>)x_1;
+    }
+    @name("ingress.t_exact_ternary") table t_exact_ternary_0 {
+        key = {
+            h.h.e: exact @name("h.h.e");
+            h.h.t: ternary @name("h.h.t");
+        }
+        actions = {
+            a_1();
+            a_with_control_params();
+        }
+        default_action = a_1();
+        const entries = {
+                        (8w0x1, 16w0x1111 &&& 16w0xf) : a_with_control_params(9w1);
+                        (8w0x2, 16w0x1181) : a_with_control_params(9w2);
+                        (8w0x3, 16w0x1111 &&& 16w0xf000) : a_with_control_params(9w3);
+                        (8w0x4, default) : a_with_control_params(9w4);
+        }
+    }
+    apply {
+        t_exact_ternary_0.apply();
+    }
+}
+
+control egressControlImpl(inout EMPTY_H h, inout Meta_t meta, in psa_egress_input_metadata_t x, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, out EMPTY_CLONE clone_i2e_meta, out EMPTY_RESUB resubmit_meta, out EMPTY_BRIDGE normal_meta, inout Header_t h, in Meta_t local_metadata, in psa_ingress_output_metadata_t istd) {
+    @hidden action psadpdktableentriesexactternary106() {
+        b.emit<hdr>(h.h);
+    }
+    @hidden table tbl_psadpdktableentriesexactternary106 {
+        actions = {
+            psadpdktableentriesexactternary106();
+        }
+        const default_action = psadpdktableentriesexactternary106();
+    }
+    apply {
+        tbl_psadpdktableentriesexactternary106.apply();
+    }
+}
+
+control egressDeparserImpl(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMPTY_H c, in Meta_t d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline<Header_t, Meta_t, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(p(), ingress(), deparser()) ip;
+EgressPipeline<EMPTY_H, Meta_t, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RECIRC>(egressParserImpl(), egressControlImpl(), egressDeparserImpl()) ep;
+PSA_Switch<Header_t, Meta_t, EMPTY_H, Meta_t, EMPTY_BRIDGE, EMPTY_CLONE, EMPTY_CLONE, EMPTY_RESUB, EMPTY_RECIRC>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4
@@ -62,7 +62,7 @@ control ingress(inout Header_t h, inout Meta_t m, in psa_ingress_input_metadata_
         }
         default_action = a;
         const entries = {
-                        (0x1, 0x1111 &&& 0xf) : a_with_control_params(1);
+                        ((bit<8>)32w0x1, 0x1111 &&& 0xf) : a_with_control_params(1);
                         (0x2, 0x1181) : a_with_control_params(2);
                         (0x3, 0x1111 &&& 0xf000) : a_with_control_params(3);
                         (0x4, default) : a_with_control_params(4);

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4
@@ -1,0 +1,94 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+header EMPTY_H {
+}
+
+struct EMPTY_RESUB {
+}
+
+struct EMPTY_CLONE {
+}
+
+struct EMPTY_BRIDGE {
+}
+
+struct EMPTY_RECIRC {
+}
+
+header hdr {
+    bit<8>  e;
+    bit<16> t;
+    bit<8>  l;
+    bit<8>  r;
+    bit<8>  v;
+}
+
+struct Header_t {
+    hdr h;
+}
+
+struct Meta_t {
+}
+
+parser p(packet_in b, out Header_t h, inout Meta_t m, in psa_ingress_parser_input_metadata_t x, in EMPTY_RESUB resub_meta, in EMPTY_RECIRC recirc_meta) {
+    state start {
+        b.extract(h.h);
+        transition accept;
+    }
+}
+
+parser egressParserImpl(packet_in buffer, out EMPTY_H a, inout Meta_t b, in psa_egress_parser_input_metadata_t c, in EMPTY_BRIDGE d, in EMPTY_CLONE e, in EMPTY_CLONE f) {
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout Header_t h, inout Meta_t m, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    action a() {
+        ostd.egress_port = (PortId_t)(PortIdUint_t)0;
+    }
+    action a_with_control_params(bit<9> x) {
+        ostd.egress_port = (PortId_t)(PortIdUint_t)x;
+    }
+    table t_exact_ternary {
+        key = {
+            h.h.e: exact;
+            h.h.t: ternary;
+        }
+        actions = {
+            a;
+            a_with_control_params;
+        }
+        default_action = a;
+        const entries = {
+                        (0x1, 0x1111 &&& 0xf) : a_with_control_params(1);
+                        (0x2, 0x1181) : a_with_control_params(2);
+                        (0x3, 0x1111 &&& 0xf000) : a_with_control_params(3);
+                        (0x4, default) : a_with_control_params(4);
+        }
+    }
+    apply {
+        t_exact_ternary.apply();
+    }
+}
+
+control egressControlImpl(inout EMPTY_H h, inout Meta_t meta, in psa_egress_input_metadata_t x, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control deparser(packet_out b, out EMPTY_CLONE clone_i2e_meta, out EMPTY_RESUB resubmit_meta, out EMPTY_BRIDGE normal_meta, inout Header_t h, in Meta_t local_metadata, in psa_ingress_output_metadata_t istd) {
+    apply {
+        b.emit(h.h);
+    }
+}
+
+control egressDeparserImpl(packet_out buffer, out EMPTY_CLONE a, out EMPTY_RECIRC b, inout EMPTY_H c, in Meta_t d, in psa_egress_output_metadata_t e, in psa_egress_deparser_input_metadata_t f) {
+    apply {
+    }
+}
+
+IngressPipeline(p(), ingress(), deparser()) ip;
+EgressPipeline(egressParserImpl(), egressControlImpl(), egressDeparserImpl()) ep;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4-error
@@ -1,6 +1,6 @@
 psa-dpdk-table-entries-exact-ternary.p4(79): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 16w0x1111 to conform to the P4Runtime specification
-            (0x01, 0x1111 &&& 0xF ) : a_with_control_params(1);
-                   ^^^^^^
+            ((bit<8>)32w0x01, 0x1111 &&& 0xF ) : a_with_control_params(1);
+                              ^^^^^^
 psa-dpdk-table-entries-exact-ternary.p4(81): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 16w0x1111 to conform to the P4Runtime specification
             (0x03, 0x1111 &&& 0xF000) : a_with_control_params(3);
                    ^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4-error
@@ -1,0 +1,6 @@
+psa-dpdk-table-entries-exact-ternary.p4(79): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 16w0x1111 to conform to the P4Runtime specification
+            (0x01, 0x1111 &&& 0xF ) : a_with_control_params(1);
+                   ^^^^^^
+psa-dpdk-table-entries-exact-ternary.p4(81): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 16w0x1111 to conform to the P4Runtime specification
+            (0x03, 0x1111 &&& 0xF000) : a_with_control_params(3);
+                   ^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4-stderr
@@ -1,6 +1,6 @@
 psa-dpdk-table-entries-exact-ternary.p4(79): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 16w0x1111 to conform to the P4Runtime specification
-            (0x01, 0x1111 &&& 0xF ) : a_with_control_params(1);
-                   ^^^^^^
+            ((bit<8>)32w0x01, 0x1111 &&& 0xF ) : a_with_control_params(1);
+                              ^^^^^^
 psa-dpdk-table-entries-exact-ternary.p4(81): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 16w0x1111 to conform to the P4Runtime specification
             (0x03, 0x1111 &&& 0xF000) : a_with_control_params(3);
                    ^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4-stderr
@@ -1,0 +1,6 @@
+psa-dpdk-table-entries-exact-ternary.p4(79): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 16w0x1111 to conform to the P4Runtime specification
+            (0x01, 0x1111 &&& 0xF ) : a_with_control_params(1);
+                   ^^^^^^
+psa-dpdk-table-entries-exact-ternary.p4(81): [--Wwarn=mismatch] warning: P4Runtime requires that Ternary matches have masked-off bits set to 0, updating value 16w0x1111 to conform to the P4Runtime specification
+            (0x03, 0x1111 &&& 0xF000) : a_with_control_params(3);
+                   ^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.bfrt.json
@@ -1,0 +1,84 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "ip.ingress.t_exact_ternary",
+      "id" : 44168292,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "h.h.e",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 8
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "h.h.t",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Ternary",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 65537,
+          "name" : "$MATCH_PRIORITY",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21186165,
+          "name" : "ingress.a",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 17165658,
+          "name" : "ingress.a_with_control_params",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "x",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 9
+              }
+            }
+          ]
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope", "ConstTable"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.entries.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.entries.txt
@@ -1,0 +1,117 @@
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 44168292
+      match {
+        field_id: 1
+        exact {
+          value: "\001"
+        }
+      }
+      match {
+        field_id: 2
+        ternary {
+          value: "\000\001"
+          mask: "\000\017"
+        }
+      }
+      action {
+        action {
+          action_id: 17165658
+          params {
+            param_id: 1
+            value: "\000\001"
+          }
+        }
+      }
+      priority: 4
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 44168292
+      match {
+        field_id: 1
+        exact {
+          value: "\002"
+        }
+      }
+      match {
+        field_id: 2
+        ternary {
+          value: "\021\201"
+          mask: "\377\377"
+        }
+      }
+      action {
+        action {
+          action_id: 17165658
+          params {
+            param_id: 1
+            value: "\000\002"
+          }
+        }
+      }
+      priority: 3
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 44168292
+      match {
+        field_id: 1
+        exact {
+          value: "\003"
+        }
+      }
+      match {
+        field_id: 2
+        ternary {
+          value: "\020\000"
+          mask: "\360\000"
+        }
+      }
+      action {
+        action {
+          action_id: 17165658
+          params {
+            param_id: 1
+            value: "\000\003"
+          }
+        }
+      }
+      priority: 2
+    }
+  }
+}
+updates {
+  type: INSERT
+  entity {
+    table_entry {
+      table_id: 44168292
+      match {
+        field_id: 1
+        exact {
+          value: "\004"
+        }
+      }
+      action {
+        action {
+          action_id: 17165658
+          params {
+            param_id: 1
+            value: "\000\004"
+          }
+        }
+      }
+      priority: 1
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.p4info.txt
@@ -1,0 +1,51 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44168292
+    name: "ingress.t_exact_ternary"
+    alias: "t_exact_ternary"
+  }
+  match_fields {
+    id: 1
+    name: "h.h.e"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "h.h.t"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 21186165
+  }
+  action_refs {
+    id: 17165658
+  }
+  size: 1024
+  is_const_table: true
+}
+actions {
+  preamble {
+    id: 21186165
+    name: "ingress.a"
+    alias: "a"
+  }
+}
+actions {
+  preamble {
+    id: 17165658
+    name: "ingress.a_with_control_params"
+    alias: "a_with_control_params"
+  }
+  params {
+    id: 1
+    name: "x"
+    bitwidth: 9
+  }
+}
+type_info {
+}

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.spec
@@ -1,0 +1,78 @@
+
+struct hdr {
+	bit<8> e
+	bit<16> t
+	bit<8> l
+	bit<8> r
+	bit<8> v
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+struct a_with_control_params_arg_t {
+	bit<32> x
+}
+
+header h instanceof hdr
+
+struct Meta_t {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_egress_port
+}
+metadata instanceof Meta_t
+
+action a_1 args none {
+	mov m.psa_ingress_output_metadata_egress_port 0x0
+	return
+}
+
+action a_with_control_params args instanceof a_with_control_params_arg_t {
+	mov m.psa_ingress_output_metadata_egress_port t.x
+	return
+}
+
+table t_exact_ternary {
+	key {
+		h.h.e exact
+		h.h.t wildcard
+	}
+	actions {
+		a_1
+		a_with_control_params
+	}
+	default_action a_1 args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x1
+	extract h.h
+	table t_exact_ternary
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.h
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+


### PR DESCRIPTION
Here is table config for added test.
```
match 0x1 0x1/0xF priority 0x4 action a_with_control_params x 0x1 
match 0x2 0x1181/0xFFFF priority 0x3 action a_with_control_params x 0x2 
match 0x3 0x1000/0xF000 priority 0x2 action a_with_control_params x 0x3 
match 0x4 0x0/0x0 priority 0x1 action a_with_control_params x 0x4 
```

references: https://elixir.bootlin.com/dpdk/latest/source/examples/pipeline/examples/fib_nexthop_table.txt