### PR TITLE
Dags needs to be revisited when renaming metadata

### DIFF
--- a/backends/bmv2/common/backend.h
+++ b/backends/bmv2/common/backend.h
@@ -140,6 +140,7 @@ class RenameUserMetadata : public Transform {
         : refMap(refMap), userMetaType(userMetaType), namePrefix(namePrefix) {
         setName("RenameUserMetadata");
         CHECK_NULL(refMap);
+        visitDagOnce = false;
     }
 
     const IR::Node* postorder(IR::Type_Struct* type) override {


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3620 
We actually don't have a test to reproduce the bug at this point, but this change cannot be wrong...