### PR TITLE
Do not allow type arguments that are generic if they are not specialized

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -3613,8 +3613,8 @@ static void convertStructToTuple(const IR::Type_StructLike* structType, IR::Type
         } else if (auto ft = field->type->to<IR::Type_Boolean>()) {
             tuple->components.push_back(ft);
         } else {
-            typeError("Type not supported %1% for struct field %2% in 'select'",
-                      field->type, field);
+            typeError("Type not supported %1% for struct field %2% in 'select'", field->type,
+                      field);
         }
     }
 }

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1301,6 +1301,12 @@ const IR::Node* TypeInference::postorder(IR::Type_Specialized* type) {
             typeError("%1%: contains self '%2%' as type argument", type->baseType, self);
             return type;
         }
+        if (auto tg = argtype->to<IR::IMayBeGenericType>()) {
+            if (tg->getTypeParameters()->size() != 0) {
+                typeError("%1%: generic type needs type arguments", arg);
+                return type;
+            }
+        }
     }
     (void)setTypeType(type);
     return type;
@@ -3604,8 +3610,11 @@ static void convertStructToTuple(const IR::Type_StructLike* structType, IR::Type
             convertStructToTuple(ft, tuple);
         } else if (auto ft = field->type->to<IR::Type_InfInt>()) {
             tuple->components.push_back(ft);
+        } else if (auto ft = field->type->to<IR::Type_Boolean>()) {
+            tuple->components.push_back(ft);
         } else {
-            BUG("Unexpected type %1% for struct field %2%", field->type, field);
+            typeError("Type not supported %1% for struct field %2% in 'select'",
+                      field->type, field);
         }
     }
 }

--- a/testdata/p4_16_errors/issue3305.p4
+++ b/testdata/p4_16_errors/issue3305.p4
@@ -1,0 +1,25 @@
+struct s<t>
+{
+ t field;
+}
+
+struct s1<t>
+{
+  t field;
+}
+
+void f()
+{
+    s<s1> v;
+}
+
+control c() {
+    apply {
+        f();
+    }
+}
+
+control C();
+package top(C _c);
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/issue3305.p4
+++ b/testdata/p4_16_errors_outputs/issue3305.p4
@@ -1,0 +1,20 @@
+struct s<t> {
+    t field;
+}
+
+struct s1<t> {
+    t field;
+}
+
+void f() {
+    s<s1> v;
+}
+control c() {
+    apply {
+        f();
+    }
+}
+
+control C();
+package top(C _c);
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/issue3305.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3305.p4-stderr
@@ -1,0 +1,3 @@
+issue3305.p4(13): [--Werror=type-error] error: s1: generic type needs type arguments
+    s<s1> v;
+      ^^


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3305