### PR TITLE
Arithmetic and bitwise operations are typechecked the same way

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -2307,28 +2307,33 @@ const IR::Node* TypeInference::binaryArith(const IR::Operation_Binary* expressio
         }
     }
     if ((bl == nullptr && br != nullptr) || castLeft) {
+        // must insert cast on the left
+        auto leftResultType = br;
+        if (castLeft && !br) leftResultType = bl;
         auto e = expression->clone();
-        e->left = new IR::Cast(e->left->srcInfo, br, e->left);
-        setType(e->left, rtype);
+        e->left = new IR::Cast(e->left->srcInfo, leftResultType, e->left);
+        setType(e->left, leftResultType);
         if (isCompileTimeConstant(expression->left)) {
             e->left = constantFold(e->left);
             setCompileTimeConstant(e->left);
-            setType(e->left, rtype);
+            setType(e->left, leftResultType);
         }
         expression = e;
-        resultType = rtype;
+        resultType = leftResultType;
     }
     if ((bl != nullptr && br == nullptr) || castRight) {
         auto e = expression->clone();
-        e->right = new IR::Cast(e->right->srcInfo, bl, e->right);
-        setType(e->right, ltype);
+        auto rightResultType = bl;
+        if (castRight && !bl) rightResultType = br;
+        e->right = new IR::Cast(e->right->srcInfo, rightResultType, e->right);
+        setType(e->right, rightResultType);
         if (isCompileTimeConstant(expression->right)) {
             e->right = constantFold(e->right);
             setCompileTimeConstant(e->right);
-            setType(e->right, ltype);
+            setType(e->right, rightResultType);
         }
         expression = e;
-        resultType = ltype;
+        resultType = rightResultType;
     }
 
     setType(getOriginal(), resultType);

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -165,7 +165,6 @@ class TypeInference : public Transform {
     const IR::Node* binaryArith(const IR::Operation_Binary* op);
     const IR::Node* unsBinaryArith(const IR::Operation_Binary* op);
     const IR::Node* shift(const IR::Operation_Binary* op);
-    const IR::Node* bitwise(const IR::Operation_Binary* op);
     const IR::Node* typeSet(const IR::Operation_Binary* op);
 
     const IR::Type* cloneWithFreshTypeVariables(const IR::IMayBeGenericType* type);
@@ -288,9 +287,9 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::Mod* expression) override { return unsBinaryArith(expression); }
     const IR::Node* postorder(IR::Shl* expression) override { return shift(expression); }
     const IR::Node* postorder(IR::Shr* expression) override { return shift(expression); }
-    const IR::Node* postorder(IR::BXor* expression) override { return bitwise(expression); }
-    const IR::Node* postorder(IR::BAnd* expression) override { return bitwise(expression); }
-    const IR::Node* postorder(IR::BOr* expression) override { return bitwise(expression); }
+    const IR::Node* postorder(IR::BXor* expression) override { return binaryArith(expression); }
+    const IR::Node* postorder(IR::BAnd* expression) override { return binaryArith(expression); }
+    const IR::Node* postorder(IR::BOr* expression) override { return binaryArith(expression); }
     const IR::Node* postorder(IR::Mask* expression) override { return typeSet(expression); }
     const IR::Node* postorder(IR::Range* expression) override { return typeSet(expression); }
     const IR::Node* postorder(IR::LNot* expression) override;

--- a/testdata/p4_16_errors_outputs/binary_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/binary_e.p4-stderr
@@ -4,7 +4,7 @@ binary_e.p4(32): [--Werror=type-error] error: Indexing a[2] applied to non-array
 binary_e.p4(33): [--Werror=type-error] error: Array index d must be an integer, but it has type bool
         c = stack[d]; // indexing with bool
                   ^
-binary_e.p4(35): [--Werror=type-error] error: &: Cannot operate on values with different types bit<2> and bit<4>
+binary_e.p4(35): [--Werror=type-error] error: &: Cannot operate on values with different widths 2 and 4
         f = e & f; // different width
             ^^^^^
 binary_e.p4(38): [--Werror=type-error] error: <: not defined on bool and bool

--- a/testdata/p4_16_samples/enumCast.p4
+++ b/testdata/p4_16_samples/enumCast.p4
@@ -41,7 +41,7 @@ parser p(packet_in packet, out O o) {
         bb = bb && (b == 0);
 
         a = (E1) b; // OK
-        a = (E1)(E1.e1 + 1); // Final explicit casting makes the assinment legal
+        a = (E1)(E1.e1 + 1); // Final explicit casting makes the assignment legal
         a = (E1)(E2.e1 + E2.e2); //  Final explicit casting makes the assignment legal
 
         packet.extract(o.b);

--- a/testdata/p4_16_samples/issue3635.p4
+++ b/testdata/p4_16_samples/issue3635.p4
@@ -1,0 +1,16 @@
+enum bit<4> e
+{
+  a = 1,
+  b = 2,
+  c = 3
+}
+void f()
+{
+  bit<8> good1;
+  good1 = e.a ++ e.b;
+}
+
+const bit<8> good = ((bit<4>)e.a) ++ ((bit<4>)e.b);
+const bit<4> bad = e.a + e.b;
+const bit<8> bad1 = e.a ++ e.b;
+const bit<4> bad2 = e.a & e.b;

--- a/testdata/p4_16_samples_outputs/enumCast-first.p4
+++ b/testdata/p4_16_samples_outputs/enumCast-first.p4
@@ -42,8 +42,8 @@ parser p(packet_in packet, out O o) {
         bb = bb && a == 8w0;
         bb = bb && b == 8w0;
         a = (E1)b;
-        a = (E1)(E1.e1 + 8w1);
-        a = (E1)(E2.e1 + E2.e2);
+        a = (E1)8w1;
+        a = (E1)8w21;
         packet.extract<B>(o.b);
         transition select(o.b.x) {
             X.Zero &&& 32w0x1: accept;

--- a/testdata/p4_16_samples_outputs/issue3056-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3056-first.p4
@@ -10,9 +10,9 @@ control compute() {
         bit<8> x2 = -e;
         bit<4> x3 = e[3:0];
         bool x4 = 8w0 == e;
-        bit<8> x5 = e;
+        bit<8> x5 = (bit<8>)e;
         bit<8> x6 = e << 3;
-        bit<16> x7 = e ++ 8w0;
+        bit<16> x7 = (bit<8>)e ++ 8w0;
         bit<4> x8 = 4w0;
     }
 }

--- a/testdata/p4_16_samples_outputs/issue3635-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3635-first.p4
@@ -1,0 +1,14 @@
+enum bit<4> e {
+    a = 4w1,
+    b = 4w2,
+    c = 4w3
+}
+
+void f() {
+    bit<8> good1;
+    good1 = 8w18;
+}
+const bit<8> good = 8w18;
+const bit<4> bad = 4w3;
+const bit<8> bad1 = 8w18;
+const bit<4> bad2 = 4w0;

--- a/testdata/p4_16_samples_outputs/issue3635.p4
+++ b/testdata/p4_16_samples_outputs/issue3635.p4
@@ -1,0 +1,14 @@
+enum bit<4> e {
+    a = 1,
+    b = 2,
+    c = 3
+}
+
+void f() {
+    bit<8> good1;
+    good1 = e.a ++ e.b;
+}
+const bit<8> good = (bit<4>)e.a ++ (bit<4>)e.b;
+const bit<4> bad = e.a + e.b;
+const bit<8> bad1 = e.a ++ e.b;
+const bit<4> bad2 = e.a & e.b;

--- a/testdata/p4_16_samples_outputs/issue3635.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3635.p4-stderr
@@ -1,0 +1,1 @@
+[--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3635 
Arithmetic of Serializable enums always needs to insert casts