### PR TITLE
Fix bug caused by uninitialized variable in typechecker

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -134,7 +134,8 @@ TypeInference::TypeInference(ReferenceMap* refMap, TypeMap* typeMap, bool readOn
       typeMap(typeMap),
       initialNode(nullptr),
       readOnly(readOnly),
-      checkArrays(checkArrays) {
+      checkArrays(checkArrays),
+      currentActionList(nullptr) {
     CHECK_NULL(typeMap);
     CHECK_NULL(refMap);
     visitDagOnce = false;  // the done() method will take care of this

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -37,6 +37,7 @@ limitations under the License.
 #define _GLIBCXX_USE_NOEXCEPT _NOEXCEPT
 #endif
 
+#if HAVE_LIBGC
 static bool done_init, started_init;
 // emergency pool to allow a few extra allocations after a bad_alloc is thrown so we
 // can generate reasonable errors, a stack trace, etc
@@ -44,7 +45,6 @@ static char emergency_pool[16 * 1024];
 static char* emergency_ptr;
 
 // One can disable the GC, e.g., to run under Valgrind, by editing config.h
-#if HAVE_LIBGC
 void* operator new(std::size_t size) {
     /* DANGER -- on OSX, can't safely call the garbage collector allocation
      * routines from a static global constructor without manually initializing


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3719 
Also fixed a couple of warnings in gc.cpp
There is no simple test, but hopefully @smolkaj can confirm that the bug is fixed.