### PR TITLE
Fix advance condition calculation.

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2Xfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2Xfail.cmake
@@ -90,7 +90,8 @@ p4tools_add_xfail_reason(
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2"
   "differs|Expected ([0-9]+) packets on port ([0-9]+) got ([0-9]+)"
-  issue3702-bmv2.p4
+  # Difficult to reproduce bug in the checksum calculation.
+  checksum-l4-bmv2.p4
 )
 
 p4tools_add_xfail_reason(


### PR DESCRIPTION
There was a condition missing for the calculation of advance conditions for non-constant extracts or advance statements. This PR adds this condition. 