### PR TITLE
P4Testgen: Fix off-by-one bug in taint checking for slices

### DIFF
--- a/backends/p4tools/common/lib/taint.cpp
+++ b/backends/p4tools/common/lib/taint.cpp
@@ -43,10 +43,8 @@ static bitvec computeTaintedBits(const SymbolicMapType& varMap, const IR::Expres
         return (lTaint << concatExpr->right->type->width_bits()) | rTaint;
     }
     if (const auto* slice = expr->to<IR::Slice>()) {
-        auto slLeftInt = slice->e1->checkedTo<IR::Constant>()->asInt();
-        auto slRightInt = slice->e2->checkedTo<IR::Constant>()->asInt();
         auto subTaint = computeTaintedBits(varMap, slice->e0);
-        return subTaint.getslice(slRightInt, slLeftInt - slRightInt);
+        return subTaint.getslice(slice->getL(), slice->type->width_bits());
     }
     if (const auto* binaryExpr = expr->to<IR::Operation_Binary>()) {
         bitvec fullmask(0, expr->type->width_bits());

--- a/backends/p4tools/modules/testgen/test/lib/taint.cpp
+++ b/backends/p4tools/modules/testgen/test/lib/taint.cpp
@@ -287,6 +287,9 @@ TEST_F(TaintTest, Taint09) {
     const auto* taint64b = Utils::getTaintExpression(IR::getBitType(64));
     ASSERT_TRUE(Taint::hasTaint({}, taint64b));
 
+    ASSERT_TRUE(Taint::hasTaint({}, new IR::Slice(taint64b, 0, 0)));
+    ASSERT_TRUE(Taint::hasTaint({}, new IR::Slice(new IR::Slice(taint64b, 0, 0), 0, 0)));
+
     // 64w0 ++ taint<64>
     const auto* taint128bLowerQ = new IR::Cast(IR::getBitType(128), taint64b);
     ASSERT_TRUE(Taint::hasTaint({}, taint128bLowerQ));


### PR DESCRIPTION
Exposed by P4 programs which slice one bit from a tainted expression.