### PR TITLE
Dpdk Backend: Register extern support for bfrt.json

### DIFF
--- a/backends/dpdk/control-plane/bfruntime_arch_handler.h
+++ b/backends/dpdk/control-plane/bfruntime_arch_handler.h
@@ -282,6 +282,14 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
                     break;
                 }
             }
+        } else if (externBlock->type->name == "Register") {
+            for (auto& extType : *p4info->mutable_registers()) {
+                auto* pre = extType.mutable_preamble();
+                if (pre->name() == decl->controlPlaneName()) {
+                    pre->set_name(prefix(pipeName, pre->name()));
+                    break;
+                }
+            }
         }
     }
 

--- a/backends/dpdk/control-plane/bfruntime_ext.cpp
+++ b/backends/dpdk/control-plane/bfruntime_ext.cpp
@@ -232,7 +232,7 @@ const Util::JsonObject* BFRuntimeSchemaGenerator::genSchema() const {
     addActionProfs(tablesJson);
     addCounters(tablesJson);
     addMeters(tablesJson);
-    // TODO(antonin): handle "standard" (v1model / PSA) registers
+    addRegisters(tablesJson);
 
     auto* learnFiltersJson = new Util::JsonArray();
     json->emplace("learn_filters", learnFiltersJson);

--- a/control-plane/bfruntime.cpp
+++ b/control-plane/bfruntime.cpp
@@ -180,6 +180,15 @@ boost::optional<BFRuntimeGenerator::Meter> BFRuntimeGenerator::Meter::fromDirect
     return Meter{pre.name(), id, 0, unit, transformAnnotations(pre)};
 }
 
+// Register
+boost::optional<BFRuntimeGenerator::Register> BFRuntimeGenerator::Register::from(
+    const p4configv1::Register& regInstance) {
+    const auto& pre = regInstance.preamble();
+    auto id = makeBFRuntimeId(pre.id(), p4configv1::P4Ids::REGISTER);
+    return Register{pre.name(),         "$REGISTER_INDEX",       id,
+                    regInstance.size(), regInstance.type_spec(), transformAnnotations(pre)};
+}
+
 // ActionProfile
 P4Id BFRuntimeGenerator::ActionProf::makeActProfId(P4Id implementationId) {
     return makeBFRuntimeId(implementationId, p4configv1::P4Ids::ACTION_PROFILE);
@@ -397,40 +406,29 @@ void BFRuntimeGenerator::transformTypeSpecToDataFields(Util::JsonArray* fieldsJs
 void BFRuntimeGenerator::addRegisterDataFields(Util::JsonArray* dataJson,
                                                const BFRuntimeGenerator::Register& register_,
                                                P4Id idOffset) const {
-    auto* fieldsJson = new Util::JsonArray();
-    transformTypeSpecToDataFields(fieldsJson, register_.typeSpec, "Register", register_.name,
-                                  nullptr, register_.dataFieldName + ".", "", idOffset);
-    for (auto* f : *fieldsJson) {
-        auto* fObj = f->to<Util::JsonObject>();
-        CHECK_NULL(fObj);
-        auto* fAnnotations = fObj->get("annotations")->to<Util::JsonArray>();
-        CHECK_NULL(fAnnotations);
-        // Add BF-RT "native" annotation to indicate to the BF-RT implementation
-        // - and potentially applications - that this data field is stateful
-        // data. The specific string for this annotation may be changed in the
-        // future if we start introducing more BF-RT annotations, in order to
-        // keep the syntax consistent.
-        {
-            auto* classAnnotation = new Util::JsonObject();
-            classAnnotation->emplace("name", "$bfrt_field_class");
-            classAnnotation->emplace("value", "register_data");
-            fAnnotations->append(classAnnotation);
-        }
-        addSingleton(dataJson, fObj, true /* mandatory */, false /* read-only */);
+    auto parser = TypeSpecParser::make(p4info, register_.typeSpec, "Register", register_.name,
+                                       nullptr, "", "", idOffset);
+
+    BUG_CHECK(parser.size() == 1, "Expected only one data field for Register extern %1%",
+              register_.name);
+    for (const auto& f : parser) {
+        auto* fJson =
+            makeCommonDataField(idOffset, "$REGISTER_INDEX", f.type, false /* repeated */);
+        addSingleton(dataJson, fJson, false /* mandatory */, false /* read-only */);
     }
 }
 
 void BFRuntimeGenerator::addRegisterCommon(Util::JsonArray* tablesJson,
                                            const BFRuntimeGenerator::Register& register_) const {
-    auto* tableJson = initTableJson(register_.name, register_.id, "Register", register_.size);
-
+    auto* tableJson = initTableJson(register_.name, register_.id, "Register", register_.size,
+                                    register_.annotations);
     auto* keyJson = new Util::JsonArray();
     addKeyField(keyJson, TD_DATA_REGISTER_INDEX, "$REGISTER_INDEX", true /* mandatory */, "Exact",
                 makeType("uint32"));
     tableJson->emplace("key", keyJson);
 
     auto* dataJson = new Util::JsonArray();
-    addRegisterDataFields(dataJson, register_);
+    addRegisterDataFields(dataJson, register_, TD_DATA_REGISTER_INDEX);
     tableJson->emplace("data", dataJson);
 
     auto* operationsJson = new Util::JsonArray();
@@ -827,6 +825,14 @@ void BFRuntimeGenerator::addMeters(Util::JsonArray* tablesJson) const {
     }
 }
 
+void BFRuntimeGenerator::addRegisters(Util::JsonArray* tablesJson) const {
+    for (const auto& reg : p4info.registers()) {
+        auto regInstance = Register::from(reg);
+        if (regInstance == boost::none) continue;
+        addRegisterCommon(tablesJson, *regInstance);
+    }
+}
+
 const Util::JsonObject* BFRuntimeGenerator::genSchema() const {
     auto* json = new Util::JsonObject();
 
@@ -839,7 +845,7 @@ const Util::JsonObject* BFRuntimeGenerator::genSchema() const {
     addActionProfs(tablesJson);
     addCounters(tablesJson);
     addMeters(tablesJson);
-    // TODO(antonin): handle "standard" (v1model / PSA) registers
+    addRegisters(tablesJson);
 
     auto* learnFiltersJson = new Util::JsonArray();
     json->emplace("learn_filters", learnFiltersJson);

--- a/control-plane/bfruntime.h
+++ b/control-plane/bfruntime.h
@@ -262,6 +262,7 @@ class TypeSpecParser {
     const_iterator cbegin() { return fields.cbegin(); }
     iterator end() { return fields.end(); }
     const_iterator cend() { return fields.cend(); }
+    size_t size() { return fields.size(); }
 
  private:
     explicit TypeSpecParser(Fields&& fields) : fields(std::move(fields)) {}
@@ -380,8 +381,7 @@ class BFRuntimeGenerator {
         p4configv1::P4DataTypeSpec typeSpec;
         Util::JsonArray* annotations;
 
-        // static boost::optional<Register>
-        // from(const p4configv1::ExternInstance& externInstance);
+        static boost::optional<Register> from(const p4configv1::Register& regInstance);
     };
 
     void addMatchTables(Util::JsonArray* tablesJson) const;
@@ -390,10 +390,11 @@ class BFRuntimeGenerator {
                                   Util::JsonObject* tableJson) const;
     void addCounters(Util::JsonArray* tablesJson) const;
     void addMeters(Util::JsonArray* tablesJson) const;
+    void addRegisters(Util::JsonArray* tablesJson) const;
 
     void addCounterCommon(Util::JsonArray* tablesJson, const Counter& counter) const;
     void addMeterCommon(Util::JsonArray* tablesJson, const Meter& meter) const;
-    void addRegisterCommon(Util::JsonArray* tablesJson, const Register& meter) const;
+    void addRegisterCommon(Util::JsonArray* tablesJson, const Register& reg) const;
     void addActionProfCommon(Util::JsonArray* tablesJson, const ActionProf& actionProf) const;
     void addLearnFilters(Util::JsonArray* learnFiltersJson) const;
     void addLearnFilterCommon(Util::JsonArray* learnFiltersJson, const Digest& digest) const;

--- a/testdata/p4_16_samples_outputs/psa-end-of-ingress-test-bmv2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-end-of-ingress-test-bmv2.p4.bfrt.json
@@ -1,5 +1,45 @@
 {
   "schema_version" : "1.0.0",
-  "tables" : [],
+  "tables" : [
+    {
+      "name" : "ep.cEgress.egress_pkt_seen",
+      "id" : 369999048,
+      "table_type" : "Register",
+      "size" : 256,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 16
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    }
+  ],
   "learn_filters" : []
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.bfrt.json
@@ -266,6 +266,45 @@
       ],
       "supported_operations" : [],
       "attributes" : ["MeterByteCountAdjust"]
+    },
+    {
+      "name" : "ip.ingress.reg",
+      "id" : 382856063,
+      "table_type" : "Register",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 32
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.bfrt.json
@@ -295,6 +295,45 @@
       ],
       "supported_operations" : [],
       "attributes" : ["MeterByteCountAdjust"]
+    },
+    {
+      "name" : "ip.ingress.reg",
+      "id" : 382856063,
+      "table_type" : "Register",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 32
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.bfrt.json
@@ -266,6 +266,45 @@
       ],
       "supported_operations" : [],
       "attributes" : ["MeterByteCountAdjust"]
+    },
+    {
+      "name" : "ip.ingress.reg",
+      "id" : 382856063,
+      "table_type" : "Register",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 32
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.bfrt.json
@@ -266,6 +266,45 @@
       ],
       "supported_operations" : [],
       "attributes" : ["MeterByteCountAdjust"]
+    },
+    {
+      "name" : "ip.ingress.reg",
+      "id" : 382856063,
+      "table_type" : "Register",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 32
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.bfrt.json
@@ -266,6 +266,45 @@
       ],
       "supported_operations" : [],
       "attributes" : ["MeterByteCountAdjust"]
+    },
+    {
+      "name" : "ip.ingress.reg",
+      "id" : 382856063,
+      "table_type" : "Register",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 32
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.bfrt.json
@@ -266,6 +266,45 @@
       ],
       "supported_operations" : [],
       "attributes" : ["MeterByteCountAdjust"]
+    },
+    {
+      "name" : "ip.ingress.reg",
+      "id" : 382856063,
+      "table_type" : "Register",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 32
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.bfrt.json
@@ -290,6 +290,45 @@
       ],
       "supported_operations" : [],
       "attributes" : ["MeterByteCountAdjust"]
+    },
+    {
+      "name" : "ip.ingress.reg",
+      "id" : 382856063,
+      "table_type" : "Register",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 32
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.bfrt.json
@@ -266,6 +266,45 @@
       ],
       "supported_operations" : [],
       "attributes" : ["MeterByteCountAdjust"]
+    },
+    {
+      "name" : "ip.ingress.reg",
+      "id" : 382856063,
+      "table_type" : "Register",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 32
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.bfrt.json
@@ -1,5 +1,45 @@
 {
   "schema_version" : "1.0.0",
-  "tables" : [],
+  "tables" : [
+    {
+      "name" : "ip.ingress.port_pkt_ip_bytes_in",
+      "id" : 383813656,
+      "table_type" : "Register",
+      "size" : 512,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 80
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    }
+  ],
   "learn_filters" : []
 }

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.bfrt.json
@@ -1,5 +1,45 @@
 {
   "schema_version" : "1.0.0",
-  "tables" : [],
+  "tables" : [
+    {
+      "name" : "ip.cIngress.regfile",
+      "id" : 376043845,
+      "table_type" : "Register",
+      "size" : 128,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 48
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    }
+  ],
   "learn_filters" : []
 }

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4.bfrt.json
@@ -1,5 +1,45 @@
 {
   "schema_version" : "1.0.0",
-  "tables" : [],
+  "tables" : [
+    {
+      "name" : "ip.MyIC.reg",
+      "id" : 369588800,
+      "table_type" : "Register",
+      "size" : 6,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 16
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    }
+  ],
   "learn_filters" : []
 }

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.bfrt.json
@@ -1,5 +1,45 @@
 {
   "schema_version" : "1.0.0",
-  "tables" : [],
+  "tables" : [
+    {
+      "name" : "ip.cIngress.regfile",
+      "id" : 376043845,
+      "table_type" : "Register",
+      "size" : 128,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 48
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
+    }
+  ],
   "learn_filters" : []
 }

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.bfrt.json
@@ -55,6 +55,45 @@
       "data" : [],
       "supported_operations" : [],
       "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.MyIC.reg",
+      "id" : 369588800,
+      "table_type" : "Register",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 16
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.bfrt.json
@@ -55,6 +55,45 @@
       "data" : [],
       "supported_operations" : [],
       "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.MyIC.reg",
+      "id" : 369588800,
+      "table_type" : "Register",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 16
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.bfrt.json
@@ -55,6 +55,45 @@
       "data" : [],
       "supported_operations" : [],
       "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "ip.MyIC.reg",
+      "id" : 369588800,
+      "table_type" : "Register",
+      "size" : 512,
+      "annotations" : [],
+      "depends_on" : [],
+      "key" : [
+        {
+          "id" : 65557,
+          "name" : "$REGISTER_INDEX",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : true,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "uint32"
+          }
+        }
+      ],
+      "data" : [
+        {
+          "mandatory" : false,
+          "read_only" : false,
+          "singleton" : {
+            "id" : 65557,
+            "name" : "$REGISTER_INDEX",
+            "repeated" : false,
+            "annotations" : [],
+            "type" : {
+              "type" : "bytes",
+              "width" : 16
+            }
+          }
+        }
+      ],
+      "supported_operations" : ["Sync"],
+      "attributes" : []
     }
   ],
   "learn_filters" : []


### PR DESCRIPTION
This PR adds support for register extern in bfrt.json.
A new table is emitted for the register instance. This is as expected by the p4-dpdk-target.

    {
      "name" : "ip.MyIC.reg",
      "id" : 369588800,
      "table_type" : "Register",
      "size" : 1024,
      "annotations" : [],
      "depends_on" : [],
      "key" : [
        {
          "id" : 65557,
          "name" : "$REGISTER_INDEX",
          "repeated" : false,
          "annotations" : [],
          "mandatory" : true,
          "match_type" : "Exact",
          "type" : {
            "type" : "uint32"
          }
        }
      ],
      "data" : [
        {
          "mandatory" : false,
          "read_only" : false,
          "singleton" : {
            "id" : 65557,
            "name" : "$REGISTER_INDEX",
            "repeated" : false,
            "annotations" : [],
            "type" : {
              "type" : "bytes",
              "width" : 16
            }
          }
        }
      ],
      "supported_operations" : ["Sync"],
      "attributes" : []
    }
