### PR TITLE
Enable auto var initialization with pattern in Clang CI build

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Build (Ubuntu Linux, Clang)
       run: |
-        docker build -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=ON --build-arg COMPILE_WITH_CLANG=ON .
+        docker build -t p4c --build-arg IMAGE_TYPE=test --build-arg ENABLE_UNIFIED_COMPILATION=ON --build-arg COMPILE_WITH_CLANG=ON --build-arg BUILD_AUTO_VAR_INIT_PATTERN=ON .
         ./tools/export_ccache.sh
 
       # run with sudo (...) --privileged

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ OPTION (ENABLE_LTO "Enable Link Time Optimization (LTO)" OFF)
 OPTION (ENABLE_WERROR "Treat warnings as errors" OFF)
 OPTION (ENABLE_SANITIZERS "Enable sanitizers" OFF)
 OPTION (BUILD_STATIC_RELEASE "Build a statically linked release binary" OFF)
+OPTION (BUILD_AUTO_VAR_INIT_PATTERN "Initialize variables with pattern during build" OFF)
 
 set (P4C_DRIVER_NAME "p4c" CACHE STRING "Customize the name of the driver script")
 
@@ -217,6 +218,10 @@ add_cxx_compiler_option ("-Wno-deprecated-declarations")
 
 if (ENABLE_SANITIZERS)
   add_cxx_compiler_option  ("-fsanitize=undefined,address")
+endif ()
+
+if (BUILD_AUTO_VAR_INIT_PATTERN)
+  add_cxx_compiler_option  ("-ftrivial-auto-var-init=pattern")
 endif ()
 
 if (ENABLE_WERROR)

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ ARG COMPILE_WITH_CLANG=OFF
 ARG ENABLE_SANITIZERS=OFF
 # Only execute the steps necessary to successfully run CMake.
 ARG CMAKE_ONLY=OFF
+# Build with -ftrivial-auto-var-init=pattern to catch more bugs caused by
+# uninitialized variables.
+ARG BUILD_AUTO_VAR_INIT_PATTERN=OFF
 
 # Delegate the build to tools/ci-build.
 COPY . /p4c/

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -174,6 +174,8 @@ CMAKE_FLAGS+="-DCMAKE_BUILD_TYPE=RELEASE "
 CMAKE_FLAGS+="-DENABLE_WERROR=${ENABLE_WERROR} "
 # Enable sanitizers.
 CMAKE_FLAGS+="-DENABLE_SANITIZERS=${ENABLE_SANITIZERS} "
+# Enable auto var initialization with pattern.
+CMAKE_FLAGS+="-DBUILD_AUTO_VAR_INIT_PATTERN=${BUILD_AUTO_VAR_INIT_PATTERN} "
 
 # Run CMake in the build folder.
 if [ -e build ]; then /bin/rm -rf build; fi


### PR DESCRIPTION
Motivation: https://github.com/p4lang/p4c/pull/3720
GCC also have this feature so one with GCC 12 or newer can use it too. In our CI there is GCC 10 so I enabled it only for Clang.