### PR TITLE
Expand google.protobuf.Any when emit p4info in text format

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -146,7 +146,10 @@ static bool writeTextTo(const Message& message, std::ostream* destination) {
     // with a FileOutputStream object for performance reasons. However all we
     // have here is a std::ostream and performance is not a concern.
     std::string output;
-    if (!google::protobuf::TextFormat::PrintToString(message, &output)) {
+    google::protobuf::TextFormat::Printer textPrinter;
+    // set to expand google.protobuf.Any payloads
+    textPrinter.SetExpandAny(true);
+    if (textPrinter.PrintToString(message, &output) == false) {
         ::error(ErrorType::ERR_IO, "Failed to serialize protobuf message to text");
         return false;
     }


### PR DESCRIPTION
The target specific extern instance and table properties are using the google.protobuf.Any message ([p4info.proto](https://github.com/p4lang/p4runtime/blob/main/proto/p4/config/v1/p4info.proto#L160)). The google.protobuf.Any messages in runtime is required to be emitted in text format (human readable), not as serialized content. But the p4info text serializer outputs cryptic text (e.g. octal numbers) for google.protobuf.Any message.

This PR addresses this issue by using text format printer to serialize the messages to text. This printer instance allows us to set flag to expand the google.protobuf.Any message.

**p4info.txt output before this change:**
```
info {
    type_url: "type.googleapis.com/..."
    value: "\022\030\010\001\022\020object \010(\002\032\017\010\001\022\ttype\030\001...."
}
```
**p4info.txt output after this change**
```
info {
    [type.googleapis.com/...]
    fields {
        id: 1
        name: "object"
    }
    ...
}
```
