### PR TITLE
eBPF/PSA: Implement caching for ActionSelector, LPM and ternary tables

### DIFF
--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -355,6 +355,11 @@ void ControlBodyTranslator::processApply(const P4::ApplyMethod* method) {
     builder->endOfStatement(true);
     builder->blockEnd(true);
 
+    if (table->cacheEnabled()) {
+        table->emitCacheUpdate(builder, keyname, valueName);
+        builder->blockEnd(true);
+    }
+
     builder->emitIndent();
     builder->appendFormat("if (%s != NULL) ", valueName.c_str());
     builder->blockStart();

--- a/backends/ebpf/ebpfOptions.cpp
+++ b/backends/ebpf/ebpfOptions.cpp
@@ -84,4 +84,11 @@ EbpfOptions::EbpfOptions() {
         },
         "[psa only] Select the mode used to pass metadata from XDP to TC "
         "(possible values: meta, head, cpumap).");
+    registerOption(
+        "--table-caching", nullptr,
+        [this](const char*) {
+            enableTableCache = true;
+            return true;
+        },
+        "[psa only] Enable caching entries for tables with lpm or ternary key");
 }

--- a/backends/ebpf/ebpfOptions.h
+++ b/backends/ebpf/ebpfOptions.h
@@ -37,6 +37,8 @@ class EbpfOptions : public CompilerOptions {
     enum XDP2TC xdp2tcMode = XDP2TC_NONE;
     // maximum number of unique ternary masks
     unsigned int maxTernaryMasks = 128;
+    // Enable table cache for LPM and ternary tables
+    bool enableTableCache = false;
 
     EbpfOptions();
 

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -739,6 +739,8 @@ void EBPFTable::emitInitializer(CodeBuilder* builder) {
 }
 
 void EBPFTable::emitLookup(CodeBuilder* builder, cstring key, cstring value) {
+    if (cacheEnabled()) emitCacheLookup(builder, key, value);
+
     if (!isTernaryTable()) {
         builder->target->emitTableLookup(builder, dataMapName, key, value);
         builder->endOfStatement(true);

--- a/backends/ebpf/ebpfTable.h
+++ b/backends/ebpf/ebpfTable.h
@@ -129,6 +129,18 @@ class EBPFTable : public EBPFTableBase {
     // Whether to drop packet if no match entry found.
     // Some table implementations may want to continue processing.
     virtual bool dropOnNoMatchingEntryFound() const { return true; }
+
+    virtual bool cacheEnabled() { return false; }
+    virtual void emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) {
+        (void)builder;
+        (void)key;
+        (void)value;
+    }
+    virtual void emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) {
+        (void)builder;
+        (void)key;
+        (void)value;
+    }
 };
 
 class EBPFCounterTable : public EBPFTableBase {

--- a/backends/ebpf/psa/ebpfPsaTable.h
+++ b/backends/ebpf/psa/ebpfPsaTable.h
@@ -43,6 +43,13 @@ class EBPFTablePSA : public EBPFTable {
     void initDirectMeters();
     void initImplementation();
 
+    bool tableCacheEnabled = false;
+    cstring cacheValueTypeName;
+    cstring cacheTableName;
+    cstring cacheKeyTypeName;
+    void tryEnableTableCache();
+    void createCacheTypeNames(bool isCacheKeyType, bool isCacheValueType);
+
     void emitTableValue(CodeBuilder* builder, const IR::MethodCallExpression* actionMce,
                         cstring valueName);
     void emitDefaultActionInitializer(CodeBuilder* builder);
@@ -80,6 +87,12 @@ class EBPFTablePSA : public EBPFTable {
                            cstring actionRunVariable) override;
     bool dropOnNoMatchingEntryFound() const override;
     static cstring addPrefixFunc(bool trace);
+
+    virtual void emitCacheTypes(CodeBuilder* builder);
+    void emitCacheInstance(CodeBuilder* builder);
+    void emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) override;
+    void emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) override;
+    bool cacheEnabled() override { return tableCacheEnabled; }
 
     EBPFCounterPSA* getDirectCounter(cstring name) const {
         auto result = std::find_if(counters.begin(), counters.end(),

--- a/backends/ebpf/psa/externs/ebpfPsaTableImplementation.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaTableImplementation.cpp
@@ -730,7 +730,8 @@ void EBPFActionSelectorPSA::emitCacheLookup(CodeBuilder* builder, cstring key, c
 
         builder->emitIndent();
         if (memcpy) {
-            builder->appendFormat("memcpy(&%s.%s, &", cacheKeyVar.c_str(), fieldName.c_str());
+            builder->appendFormat("__builtin_memcpy(&%s.%s, &", cacheKeyVar.c_str(),
+                                  fieldName.c_str());
             codeGen->visit(s->expression);
             builder->appendFormat(", %d)", scalar->bytesRequired());
         } else {

--- a/backends/ebpf/psa/externs/ebpfPsaTableImplementation.h
+++ b/backends/ebpf/psa/externs/ebpfPsaTableImplementation.h
@@ -75,6 +75,11 @@ class EBPFActionSelectorPSA : public EBPFTableImplementationPSA {
 
     void registerTable(const EBPFTablePSA* instance) override;
 
+    void emitCacheTypes(CodeBuilder* builder) override;
+    void emitCacheVariables(CodeBuilder* builder);
+    void emitCacheLookup(CodeBuilder* builder, cstring key, cstring value) override;
+    void emitCacheUpdate(CodeBuilder* builder, cstring key, cstring value) override;
+
  protected:
     typedef std::vector<const IR::KeyElement*> SelectorsListType;
 
@@ -88,6 +93,8 @@ class EBPFActionSelectorPSA : public EBPFTableImplementationPSA {
     cstring outputHashMask;
     cstring isGroupEntryName;
     cstring groupStateVarName;
+    cstring cacheKeyVar;
+    cstring cacheDoUpdateVar;
 
     EBPFHashAlgorithmPSA::ArgumentsList unpackSelectors();
     SelectorsListType getSelectorsFromTable(const EBPFTablePSA* instance);

--- a/backends/ebpf/tests/p4testdata/table-cache-lpm.p4
+++ b/backends/ebpf/tests/p4testdata/table-cache-lpm.p4
@@ -1,0 +1,127 @@
+/*
+Copyright 2022-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+struct metadata {
+}
+
+struct headers {
+    ethernet_t       ethernet;
+}
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_t resubmit_meta,
+                         in empty_t recirculate_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition accept;
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_t normal_meta,
+                        in empty_t clone_i2e_meta,
+                        in empty_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action a1(EthernetAddress dst) {
+        hdr.ethernet.dstAddr = dst;
+    }
+
+    table tbl_lpm {
+        key = {
+            hdr.ethernet.dstAddr : lpm;
+        }
+        actions = { NoAction; a1; }
+        default_action = NoAction;
+    }
+
+    apply {
+        if (tbl_lpm.apply().hit) {
+            hdr.ethernet.etherType = 0x8601;
+        }
+
+        send_to_port(ostd, (PortId_t) 5);
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply {}
+}
+
+control CommonDeparserImpl(packet_out packet,
+                           inout headers hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_t clone_i2e_meta,
+                            out empty_t resubmit_meta,
+                            out empty_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_t clone_e2e_meta,
+                           out empty_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/p4testdata/table-cache-ternary.p4
+++ b/backends/ebpf/tests/p4testdata/table-cache-ternary.p4
@@ -1,0 +1,127 @@
+/*
+Copyright 2022-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+struct metadata {
+}
+
+struct headers {
+    ethernet_t       ethernet;
+}
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_t resubmit_meta,
+                         in empty_t recirculate_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition accept;
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_t normal_meta,
+                        in empty_t clone_i2e_meta,
+                        in empty_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action a1(EthernetAddress dst) {
+        hdr.ethernet.dstAddr = dst;
+    }
+
+    table tbl_ternary {
+        key = {
+            hdr.ethernet.dstAddr : ternary;
+        }
+        actions = { NoAction; a1; }
+        default_action = NoAction;
+    }
+
+    apply {
+        if (tbl_ternary.apply().hit) {
+            hdr.ethernet.etherType = 0x8601;
+        }
+
+        send_to_port(ostd, (PortId_t) 5);
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply {}
+}
+
+control CommonDeparserImpl(packet_out packet,
+                           inout headers hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_t clone_i2e_meta,
+                            out empty_t resubmit_meta,
+                            out empty_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_t clone_e2e_meta,
+                           out empty_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/ptf/bng.py
+++ b/backends/ebpf/tests/ptf/bng.py
@@ -68,6 +68,7 @@ line_id = 99
 pppoe_session_id = 0xbeac
 core_router_mac = HOST1_MAC
 
+
 def pkt_route(pkt, mac_dst):
     new_pkt = pkt.copy()
     new_pkt[Ether].src = pkt[Ether].dst

--- a/backends/ebpf/tests/ptf/table_implementation.py
+++ b/backends/ebpf/tests/ptf/table_implementation.py
@@ -201,7 +201,16 @@ class SimpleActionSelectorPSATest(ActionSelectorTest):
         testutils.send_packet(self, PORT0, pkt)
         testutils.verify_packet_any_port(self, pkt, output_ports)
 
-        # TODO: test cache
+        if "--table-caching" in self.p4c_additional_args:
+            # modify cache directly and verify its usage
+            self.table_update(table="MyIC_as_cache", key=[1, "22:33:44:55:66:78"], action=1, data=[DP_PORTS[1]])
+            testutils.send_packet(self, PORT0, pkt)
+            testutils.verify_packet(self, pkt, PORT1)
+
+
+class CacheActionSelectorPSATest(SimpleActionSelectorPSATest):
+    """Test ActionSelector in the same way as in the base class but also test cache after it"""
+    p4c_additional_args = "--table-caching"
 
 
 class ActionSelectorTwoTablesSameInstancePSATest(ActionSelectorTest):

--- a/backends/ebpf/tests/ptf/upf.py
+++ b/backends/ebpf/tests/ptf/upf.py
@@ -22,7 +22,7 @@ from scapy.layers.l2 import Ether
 
 GTPU_UDP_PORT=2152
 
-#PTF
+# PTF
 N3_PTF_PORT=0
 N6_PTF_PORT=1
 N9_PTF_PORT=2
@@ -32,7 +32,7 @@ ACCESS = 0
 CORE= 1
 SGi_LAN = 2
 
-#MAC addresses
+# MAC addresses
 UPF_N3_MAC = "00:00:00:00:00:01"
 UPF_N6_MAC = "00:00:00:00:00:02"
 UPF_N9_MAC = "00:00:00:00:00:03"
@@ -61,15 +61,18 @@ SERVER1_IP="192.168.2.21"
 SERVER2_IP="5.5.5.5"
 SERVER2_UDP_PORT=6970
 
+
 def pkt_gtpu_encap(pkt,teid,ip_dst,ip_src):
     return Ether(src=pkt[Ether].src, dst=pkt[Ether].dst) / \
            IP(src=ip_src,dst=ip_dst)/UDP(dport=GTPU_UDP_PORT)/GTP_U_Header(teid=teid)/pkt[Ether].payload
+
 
 def pkt_route(pkt, mac_src, mac_dst):
     new_pkt = pkt.copy()
     new_pkt[Ether].src = mac_src
     new_pkt[Ether].dst = mac_dst
     return new_pkt
+
 
 class UPFTest(P4EbpfTest):
     p4_file_path = "../psa/examples/upf.p4"
@@ -79,10 +82,10 @@ class UPFTest(P4EbpfTest):
         self.table_add(table="ingress_upf_ingress_session_lookup_by_ue_ip", key=[ue_ip], action=1,data=[seid])
 
     def runTest(self):
-        #link number
-        N3_PORT=DP_PORTS[0]
-        N6_PORT=DP_PORTS[1]
-        N9_PORT=DP_PORTS[2]
+        # link number
+        N3_PORT = DP_PORTS[0]
+        N6_PORT = DP_PORTS[1]
+        N9_PORT = DP_PORTS[2]
         self.table_add(table="ingress_upf_ingress_source_interface_lookup_by_port", key=[N3_PORT], action=1, data=[ACCESS])
         self.table_add(table="ingress_upf_ingress_source_interface_lookup_by_port", key=[N9_PORT], action=1, data=[CORE])
         self.table_add(table="ingress_upf_ingress_source_interface_lookup_by_port", key=[N6_PORT], action=1, data=[SGi_LAN])


### PR DESCRIPTION
This PR introduces optimization for the PSA/eBPF backend called `table caching` which adds cache table with only `exact` match keys for time consuming look-ups. We identified three situations where this optimization can improve performance:

- Table with `ternary` (and/or `lpm`, `exact`) key - skip slow TSS algorithm if the key was earlier matched.
- Table with `lpm` (and/or `exact`) key - skip slow `LPM_TRIE` map (especially when there is many entries) if the key was earlier matched.
- `ActionSelector` member selection from group - skip slow checksum calculation for `selector` key if it was earlier calculated.

This optimization may not improve performance in every case, so it must be explicitly enabled by compiler option `--table-caching`.

Limitations/to do:

- `DirectCounter` and `DirectMeter` are not supported by this optimization (tables with these externs will not have enabled cache).
- Cache size is a half of table size, but it would be more configurable or smart during compilation.
- Updates to tables with cache or `ActionSelector` require cache invalidation (`nikss` library will remove all cached entries).