### PR TITLE
Raise minimum required CMake version to Ubuntu 18.04 version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 3.16.3 FATAL_ERROR)
+# This is the CMake version supplied by Ubuntu 18.04.
+cmake_minimum_required (VERSION 3.10.2 FATAL_ERROR)
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 3.0.2 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.16.3 FATAL_ERROR)
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
@@ -202,12 +202,7 @@ enable_testing ()
 # endif ()
 
 # set (CMAKE_CXX_EXTENSIONS OFF) # prefer using -std=c++17 rather than -std=gnu++17
-# CMAKE_CXX_STANDARD was introduced in CMake 3.1, so for older versions of CMake, we use -std=gnu++17
-if (CMAKE_VERSION VERSION_LESS "3.1")
-    set (CMAKE_CXX_FLAGS "-std=gnu++17 ${CMAKE_CXX_FLAGS}")
-elseif(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 17)
-    set (CMAKE_CXX_STANDARD 17)
-endif ()
+set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_cxx_compiler_option ("-Wall")

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ use them, but YMMV.
 
 - GNU autotools for the build process
 
-- CMake 3.0.2 or higher
+- CMake 3.16.3 or higher
 
 - Boehm-Weiser garbage-collector C++ library
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ use them, but YMMV.
 
 - GNU autotools for the build process
 
-- CMake 3.16.3 or higher
+- CMake 3.10.2 or higher
 
 - Boehm-Weiser garbage-collector C++ library
 

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -209,16 +209,9 @@ macro(add_parser pname)
   add_custom_target (mk${pname}dirs
     ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname})
 
-  # Versions of CMake before 3.7.2 require a filename argument to BISON_TARGET's
-  # VERBOSE option. Later versions "support" it, but they generate a file with
-  # the same name automatically anyway, and then issue a warning because the
-  # file gets overwritten, so we need this code to avoid warning spew during
-  # compilation.
-  if (CMAKE_VERSION VERSION_LESS "3.7.2")
-      BISON_TARGET (${pname}Parser parsers/${pname}/${pname}parser.ypp ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}parser.cpp VERBOSE ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}parser.output)
-  else ()
-      BISON_TARGET (${pname}Parser parsers/${pname}/${pname}parser.ypp ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}parser.cpp VERBOSE COMPILE_FLAGS "-Werror=conflicts-sr -Werror=conflicts-rr")
-  endif ()
+  # CMake generates a file with the same name automatically and then issues a warning because the
+  # file gets overwritten, so we need this code to avoid warning spew during compilation.
+  BISON_TARGET (${pname}Parser parsers/${pname}/${pname}parser.ypp ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}parser.cpp VERBOSE COMPILE_FLAGS "-Werror=conflicts-sr -Werror=conflicts-rr")
 
   # regardless of the output name, flex puts out yy.lex.c, so we use a custom command to generate
   # the file to stdout and redirect to the desired name


### PR DESCRIPTION
This PR is a proposal to raise the minimum required CMake version to 3.10.2, which is the default Ubuntu 18.04 version. Our CI only tests that version and support for older CMake versions can not be guaranteed. 

The number is tentative, it could also be 3.6, since the current CMake has code that requires at least 3.6. 