### PR TITLE
Testgen: fix varbit handling

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
@@ -37,7 +37,7 @@ void ExprStepper::setFields(ExecutionState *nextState,
                             const std::vector<const IR::Member *> &flatFields,
                             int varBitFieldSize) {
     for (const auto *fieldRef : flatFields) {
-        const auto *fieldType = nextState->get(fieldRef)->type;
+        const auto *fieldType = fieldRef->type;
         // If the header had a varbit, the header needs to be updated.
         // We assign @param varbitFeldSize to the varbit field.
         if (const auto *varbit = fieldType->to<IR::Extracted_Varbits>()) {


### PR DESCRIPTION
Instead of enriching the program IR by a custom varbit type which remembers extracted size, assign bit<extracted_size> directly to varbit members.

The original approach with custom Extracted_Varbit type is problematic: the type inherits from bit<X> type where X is the maximum size of corresponding varbit type, however the width_bits method is also overridden to return the actually extracted varbit size. 