### PR TITLE
Add missing semicolon at end of Bison rule in p4parser.ypp

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1409,6 +1409,7 @@ prefixedNonTypeName
 dot_name:
     "." { driver.structure->relativePathFromLastSymbol(); } name {
           driver.structure->clearPath(); $$ = $3; }
+    ;
 
 lvalue
     : prefixedNonTypeName                { $$ = new IR::PathExpression($1); }


### PR DESCRIPTION
This omission does not seem to have caused any functional problems.  I only noticed it while doing diffs between an updated version of the P4 language spec repo's grammar.mdk file and this one.