### PR TITLE
Remove backends from CMake include paths. 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,6 +32,6 @@ CheckOptions:
   - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
   - { key: readability-identifier-naming.StaticConstantCase,  value: UPPER_CASE }
   - { key: readability-identifier-naming.StaticVariableCase,  value: UPPER_CASE }
-...
 ExtraArgs:
-  - '--std=c++11'
+  - '--std=c++17'
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,6 @@ else()
 endif()
 
 include_directories (
-  ${P4C_SOURCE_DIR}/backends
   ${P4C_SOURCE_DIR}/extensions
   ${P4C_SOURCE_DIR}
   ${P4C_SOURCE_DIR}/test/frameworks/gtest/googletest/include

--- a/backends/p4tools/common/compiler/compiler_target.cpp
+++ b/backends/p4tools/common/compiler/compiler_target.cpp
@@ -9,6 +9,7 @@
 #include "backends/p4tools/common/compiler/context.h"
 #include "backends/p4tools/common/compiler/convert_hs_index.h"
 #include "backends/p4tools/common/compiler/midend.h"
+#include "backends/p4tools/common/core/target.h"
 #include "frontends/common/applyOptionsPragmas.h"
 #include "frontends/common/options.h"
 #include "frontends/common/parseInput.h"
@@ -16,7 +17,6 @@
 #include "frontends/p4/frontend.h"
 #include "lib/compile_context.h"
 #include "lib/error.h"
-#include "p4tools/common/core/target.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -11,6 +11,8 @@
 #include <string>
 #include <utility>
 
+#include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/timer.h"
 #include "gsl/gsl-lite.hpp"
 #include "ir/ir.h"
@@ -23,8 +25,6 @@
 #include "lib/exceptions.h"
 #include "lib/indent.h"
 #include "lib/log.h"
-#include "p4tools/common/lib/formulae.h"
-#include "p4tools/common/lib/model.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/common/lib/model.cpp
+++ b/backends/p4tools/common/lib/model.cpp
@@ -8,6 +8,7 @@
 #include <boost/container/vector.hpp>
 #include <boost/format.hpp>
 
+#include "backends/p4tools/common/lib/formulae.h"
 #include "frontends/p4/optimizeExpressions.h"
 #include "ir/id.h"
 #include "ir/indexed_vector.h"
@@ -20,7 +21,6 @@
 #include "lib/log.h"
 #include "lib/ordered_map.h"
 #include "lib/safe_vector.h"
-#include "p4tools/common/lib/formulae.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/common/lib/symbolic_env.cpp
+++ b/backends/p4tools/common/lib/symbolic_env.cpp
@@ -7,6 +7,8 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/container/vector.hpp>
 
+#include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/zombie.h"
 #include "frontends/p4/optimizeExpressions.h"
 #include "ir/indexed_vector.h"
@@ -14,8 +16,6 @@
 #include "ir/vector.h"
 #include "ir/visitor.h"
 #include "lib/exceptions.h"
-#include "p4tools/common/lib/formulae.h"
-#include "p4tools/common/lib/model.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/common/lib/taint.cpp
+++ b/backends/p4tools/common/lib/taint.cpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 
+#include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/indexed_vector.h"
@@ -16,7 +17,6 @@
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 #include "lib/null.h"
-#include "p4tools/common/lib/model.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/common/lib/trace_events.cpp
+++ b/backends/p4tools/common/lib/trace_events.cpp
@@ -6,14 +6,14 @@
 
 #include "backends/p4tools/common/lib/format_int.h"
 #include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/model.h"
+#include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/taint.h"
 #include "ir/id.h"
 #include "ir/vector.h"
 #include "lib/exceptions.h"
 #include "lib/log.h"
 #include "lib/safe_vector.h"
-#include "p4tools/common/lib/model.h"
-#include "p4tools/common/lib/symbolic_env.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/common/lib/util.cpp
+++ b/backends/p4tools/common/lib/util.cpp
@@ -20,12 +20,12 @@
 #include <boost/none.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 
+#include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/zombie.h"
 #include "ir/id.h"
 #include "ir/irutils.h"
 #include "ir/vector.h"
 #include "lib/safe_vector.h"
-#include "p4tools/common/lib/formulae.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/common/lib/zombie.cpp
+++ b/backends/p4tools/common/lib/zombie.cpp
@@ -4,8 +4,8 @@
 #include <string>
 #include <utility>
 
+#include "backends/p4tools/common/lib/formulae.h"
 #include "ir/id.h"
-#include "p4tools/common/lib/formulae.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
@@ -10,6 +10,8 @@
 #include <boost/format.hpp>
 #include <boost/none.hpp>
 
+#include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/timer.h"
 #include "backends/p4tools/common/lib/util.h"
@@ -19,8 +21,6 @@
 #include "ir/irutils.h"
 #include "lib/error.h"
 #include "midend/coverage.h"
-#include "p4tools/common/core/solver.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/small_step.h"

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/inc_max_coverage_stack.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/inc_max_coverage_stack.cpp
@@ -7,12 +7,12 @@
 
 #include <boost/none.hpp>
 
+#include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/formulae.h"
 #include "gsl/gsl-lite.hpp"
 #include "ir/ir.h"
 #include "lib/error.h"
 #include "midend/coverage.h"
-#include "p4tools/common/core/solver.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/incremental_stack.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/incremental_stack.cpp
@@ -4,11 +4,11 @@
 
 #include <boost/none.hpp>
 
+#include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/formulae.h"
 #include "gsl/gsl-lite.hpp"
 #include "ir/ir.h"
 #include "lib/error.h"
-#include "p4tools/common/core/solver.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/linear_enumeration.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/linear_enumeration.cpp
@@ -4,11 +4,11 @@
 
 #include <boost/none.hpp>
 
+#include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/formulae.h"
 #include "gsl/gsl-lite.hpp"
 #include "ir/ir.h"
 #include "lib/error.h"
-#include "p4tools/common/core/solver.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/random_access_stack.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/random_access_stack.cpp
@@ -3,9 +3,9 @@
 #include <ctime>
 #include <vector>
 
+#include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "lib/error.h"
-#include "p4tools/common/core/solver.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/incremental_stack.h"

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/rnd_access_max_coverage.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/rnd_access_max_coverage.cpp
@@ -7,13 +7,13 @@
 
 #include <boost/none.hpp>
 
+#include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "gsl/gsl-lite.hpp"
 #include "ir/ir.h"
 #include "lib/error.h"
 #include "midend/coverage.h"
-#include "p4tools/common/core/solver.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/inc_max_coverage_stack.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/selected_branches.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/selected_branches.cpp
@@ -6,10 +6,10 @@
 #include <utility>
 #include <vector>
 
+#include "backends/p4tools/common/core/solver.h"
 #include "gsl/gsl-lite.hpp"
 #include "lib/error.h"
 #include "lib/exceptions.h"
-#include "p4tools/common/core/solver.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/core/program_info.cpp
+++ b/backends/p4tools/modules/testgen/core/program_info.cpp
@@ -2,13 +2,13 @@
 
 #include <string>
 
+#include "backends/p4tools/common/compiler/reachability.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeMap.h"
 #include "ir/id.h"
 #include "lib/exceptions.h"
 #include "midend/coverage.h"
-#include "p4tools/common/compiler/reachability.h"
 
 #include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/lib/concolic.h"

--- a/backends/p4tools/modules/testgen/core/program_info.h
+++ b/backends/p4tools/modules/testgen/core/program_info.h
@@ -8,12 +8,12 @@
 #include <boost/optional/optional.hpp>
 
 #include "backends/p4tools/common/compiler/reachability.h"
+#include "backends/p4tools/common/lib/formulae.h"
 #include "ir/declaration.h"
 #include "ir/ir.h"
 #include "lib/castable.h"
 #include "lib/cstring.h"
 #include "midend/coverage.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/lib/concolic.h"

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
@@ -9,6 +9,7 @@
 #include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/compiler/convert_hs_index.h"
+#include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
@@ -21,7 +22,6 @@
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 #include "lib/log.h"
-#include "p4tools/common/core/solver.h"
 
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/small_step.h"

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -12,6 +12,8 @@
 #include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/compiler/convert_hs_index.h"
+#include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/trace_events.h"
 #include "backends/p4tools/common/lib/util.h"
@@ -26,8 +28,6 @@
 #include "lib/exceptions.h"
 #include "lib/null.h"
 #include "lib/safe_vector.h"
-#include "p4tools/common/core/solver.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen//lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/util.h"
@@ -15,7 +16,6 @@
 #include "lib/null.h"
 #include "lib/safe_vector.h"
 #include "midend/saturationElim.h"
-#include "p4tools/common/core/solver.h"
 
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h"

--- a/backends/p4tools/modules/testgen/core/small_step/small_step.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/small_step.cpp
@@ -11,6 +11,8 @@
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 
+#include "backends/p4tools/common/compiler/reachability.h"
+#include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/trace_events.h"
 #include "frontends/p4/optimizeExpressions.h"
@@ -21,8 +23,6 @@
 #include "lib/error.h"
 #include "lib/exceptions.h"
 #include "lib/null.h"
-#include "p4tools/common/compiler/reachability.h"
-#include "p4tools/common/core/solver.h"
 
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h"

--- a/backends/p4tools/modules/testgen/core/small_step/small_step.h
+++ b/backends/p4tools/modules/testgen/core/small_step/small_step.h
@@ -8,8 +8,8 @@
 
 #include "backends/p4tools/common/compiler/reachability.h"
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/formulae.h"
 #include "gsl/gsl-lite.hpp"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -10,6 +10,7 @@
 #include <boost/multiprecision/number.hpp>
 #include <boost/none.hpp>
 
+#include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/trace_events.h"
 #include "backends/p4tools/common/lib/util.h"
@@ -22,7 +23,6 @@
 #include "lib/log.h"
 #include "lib/null.h"
 #include "lib/safe_vector.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen/core/constants.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/lib/concolic.cpp
+++ b/backends/p4tools/modules/testgen/lib/concolic.cpp
@@ -6,10 +6,10 @@
 #include <boost/optional/optional.hpp>
 
 #include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/model.h"
 #include "ir/id.h"
 #include "lib/exceptions.h"
 #include "lib/null.h"
-#include "p4tools/common/lib/model.h"
 
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 

--- a/backends/p4tools/modules/testgen/lib/continuation.cpp
+++ b/backends/p4tools/modules/testgen/lib/continuation.cpp
@@ -5,10 +5,10 @@
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
 
+#include "backends/p4tools/common/lib/trace_events.h"
 #include "ir/id.h"
 #include "ir/visitor.h"
 #include "lib/exceptions.h"
-#include "p4tools/common/lib/trace_events.h"
 
 #include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 

--- a/backends/p4tools/modules/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/execution_state.cpp
@@ -13,18 +13,18 @@
 #include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/compiler/convert_hs_index.h"
+#include "backends/p4tools/common/compiler/reachability.h"
+#include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/model.h"
+#include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/taint.h"
+#include "backends/p4tools/common/lib/trace_events.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
 #include "ir/indexed_vector.h"
 #include "ir/irutils.h"
 #include "lib/log.h"
 #include "lib/null.h"
-#include "p4tools/common/compiler/reachability.h"
-#include "p4tools/common/lib/formulae.h"
-#include "p4tools/common/lib/model.h"
-#include "p4tools/common/lib/symbolic_env.h"
-#include "p4tools/common/lib/trace_events.h"
 
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/namespace_context.h"

--- a/backends/p4tools/modules/testgen/lib/final_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/final_state.cpp
@@ -2,10 +2,10 @@
 
 #include <vector>
 
+#include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
-#include "p4tools/common/core/solver.h"
-#include "p4tools/common/lib/model.h"
-#include "p4tools/common/lib/trace_events.h"
+#include "backends/p4tools/common/lib/trace_events.h"
 
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -11,11 +11,14 @@
 #include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/core/z3_solver.h"
 #include "backends/p4tools/common/lib/format_int.h"
 #include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/taint.h"
 #include "backends/p4tools/common/lib/timer.h"
+#include "backends/p4tools/common/lib/trace_events.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "frontends/p4/optimizeExpressions.h"
 #include "ir/irutils.h"
@@ -23,9 +26,6 @@
 #include "lib/exceptions.h"
 #include "lib/null.h"
 #include "midend/coverage.h"
-#include "p4tools/common/core/z3_solver.h"
-#include "p4tools/common/lib/model.h"
-#include "p4tools/common/lib/trace_events.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/lib/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_spec.cpp
@@ -8,10 +8,10 @@
 #include <boost/variant/apply_visitor.hpp>
 
 #include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/model.h"
+#include "backends/p4tools/common/lib/trace_events.h"
 #include "ir/irutils.h"
 #include "lib/exceptions.h"
-#include "p4tools/common/lib/model.h"
-#include "p4tools/common/lib/trace_events.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -4,8 +4,8 @@
 #include <iostream>
 #include <string>
 
+#include "backends/p4tools/common/options.h"
 #include "lib/exceptions.h"
-#include "p4tools/common/options.h"
 
 #include "backends/p4tools/modules/testgen/lib/logging.h"
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/bmv2.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/bmv2.cpp
@@ -2,13 +2,13 @@
 
 #include <string>
 
-#include "bmv2/common/annotations.h"
+#include "backends/bmv2/common/annotations.h"
+#include "backends/p4tools/common/compiler/compiler_target.h"
+#include "backends/p4tools/common/compiler/midend.h"
 #include "control-plane/addMissingIds.h"
 #include "control-plane/p4RuntimeArchStandard.h"
 #include "frontends/common/options.h"
 #include "lib/cstring.h"
-#include "p4tools/common/compiler/compiler_target.h"
-#include "p4tools/common/compiler/midend.h"
 
 #include "backends/p4tools/modules/testgen/options.h"
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/concolic.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/concolic.cpp
@@ -14,12 +14,12 @@
 #include <boost/multiprecision/traits/explicit_conversion.hpp>
 
 #include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/irutils.h"
 #include "ir/vector.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
-#include "p4tools/common/lib/model.h"
 
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
@@ -12,6 +12,7 @@
 #include <boost/optional/optional.hpp>
 
 #include "backends/p4tools/common/core/z3_solver.h"
+#include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
 #include "ir/indexed_vector.h"
@@ -24,7 +25,6 @@
 #include "lib/log.h"
 #include "lib/ordered_map.h"
 #include "lib/safe_vector.h"
-#include "p4tools/common/lib/formulae.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <string>
 
+#include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
 #include "ir/indexed_vector.h"
@@ -13,7 +14,6 @@
 #include "lib/exceptions.h"
 #include "lib/null.h"
 #include "lib/safe_vector.h"
-#include "p4tools/common/lib/formulae.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -7,6 +7,7 @@
 
 #include <boost/optional/optional.hpp>
 
+#include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
 #include "ir/indexed_vector.h"
@@ -15,7 +16,6 @@
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 #include "lib/null.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen//lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/core/arch_spec.h"

--- a/backends/p4tools/modules/testgen/targets/bmv2/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/target.cpp
@@ -6,11 +6,11 @@
 #include <string>
 #include <vector>
 
+#include "backends/p4tools/common/core/solver.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 #include "lib/ordered_map.h"
-#include "p4tools/common/core/solver.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
@@ -7,13 +7,13 @@
 
 #include <boost/none.hpp>
 
+#include "backends/p4tools/common/lib/model.h"
+#include "backends/p4tools/common/lib/trace_events.h"
 #include "gsl/gsl-lite.hpp"
 #include "ir/ir.h"
 #include "ir/irutils.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
-#include "p4tools/common/lib/model.h"
-#include "p4tools/common/lib/trace_events.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
@@ -1,7 +1,7 @@
 #include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
 
+#include "backends/p4tools/common/lib/model.h"
 #include "lib/exceptions.h"
-#include "p4tools/common/lib/model.h"
 
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 

--- a/backends/p4tools/modules/testgen/targets/ebpf/ebpf.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/ebpf.cpp
@@ -2,9 +2,9 @@
 
 #include <string>
 
+#include "backends/p4tools/common/compiler/compiler_target.h"
+#include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
-#include "p4tools/common/compiler/compiler_target.h"
-#include "p4tools/common/compiler/midend.h"
 
 namespace P4Tools {
 

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/optional/optional.hpp>
 
+#include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
 #include "ir/indexed_vector.h"
@@ -13,7 +14,6 @@
 #include "ir/irutils.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen//lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/core/arch_spec.h"

--- a/backends/p4tools/modules/testgen/targets/ebpf/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/target.cpp
@@ -5,11 +5,11 @@
 #include <string>
 #include <vector>
 
+#include "backends/p4tools/common/core/solver.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 #include "lib/ordered_map.h"
-#include "p4tools/common/core/solver.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/targets/ebpf/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test_backend.cpp
@@ -7,13 +7,13 @@
 
 #include <boost/none.hpp>
 
+#include "backends/p4tools/common/lib/model.h"
+#include "backends/p4tools/common/lib/trace_events.h"
 #include "gsl/gsl-lite.hpp"
 #include "ir/ir.h"
 #include "ir/irutils.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
-#include "p4tools/common/lib/model.h"
-#include "p4tools/common/lib/trace_events.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"

--- a/backends/p4tools/modules/testgen/test/small-step/p4_asserts_parser_test.cpp
+++ b/backends/p4tools/modules/testgen/test/small-step/p4_asserts_parser_test.cpp
@@ -9,6 +9,7 @@
 
 #include "backends/p4test/version.h"
 #include "backends/p4tools/common/compiler/midend.h"
+#include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "frontends/common/options.h"
 #include "frontends/common/parseInput.h"
@@ -23,7 +24,6 @@
 #include "ir/irutils.h"
 #include "lib/compile_context.h"
 #include "lib/null.h"
-#include "p4tools/common/lib/formulae.h"
 
 #include "backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.h"
 #include "backends/p4tools/modules/testgen/test/gtest_utils.h"

--- a/backends/p4tools/modules/testgen/test/small-step/util.h
+++ b/backends/p4tools/modules/testgen/test/small-step/util.h
@@ -11,6 +11,7 @@
 
 #include "backends/p4tools/common/core/z3_solver.h"
 #include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "gsl/gsl-lite.hpp"
 #include "gtest/gtest-message.h"
@@ -21,7 +22,6 @@
 #include "ir/ir.h"
 #include "ir/vector.h"
 #include "lib/enumerator.h"
-#include "p4tools/common/lib/model.h"
 
 #include "backends/p4tools/modules/testgen/core/small_step/small_step.h"
 #include "backends/p4tools/modules/testgen/core/target.h"

--- a/backends/ubpf/codeGen.h
+++ b/backends/ubpf/codeGen.h
@@ -1,7 +1,7 @@
 #ifndef BACKENDS_UBPF_CODEGEN_H_
 #define BACKENDS_UBPF_CODEGEN_H_
 
-#include "ebpf/codeGen.h"
+#include "backends/ebpf/codeGen.h"
 #include "lib/sourceCodeBuilder.h"
 #include "target.h"
 

--- a/backends/ubpf/ubpfControl.cpp
+++ b/backends/ubpf/ubpfControl.cpp
@@ -15,13 +15,13 @@ limitations under the License.
 */
 #include "ubpfControl.h"
 
+#include "backends/ubpf/ubpfType.h"
 #include "frontends/p4/enumInstance.h"
 #include "frontends/p4/methodInstance.h"
 #include "frontends/p4/parameterSubstitution.h"
 #include "frontends/p4/tableApply.h"
 #include "frontends/p4/typeMap.h"
 #include "lib/error.h"
-#include "ubpf/ubpfType.h"
 
 namespace UBPF {
 

--- a/backends/ubpf/ubpfDeparser.h
+++ b/backends/ubpf/ubpfDeparser.h
@@ -17,7 +17,7 @@ limitations under the License.
 #ifndef BACKENDS_UBPF_UBPFDEPARSER_H_
 #define BACKENDS_UBPF_UBPFDEPARSER_H_
 
-#include "ebpf/ebpfObject.h"
+#include "backends/ebpf/ebpfObject.h"
 #include "ir/ir.h"
 #include "ubpfHelpers.h"
 #include "ubpfProgram.h"


### PR DESCRIPTION
Fixes #3768. Make include paths more rigorous by removing ambiguity. Every backend include should contain the full path. 