### PR TITLE
Add assert and assume mode for testgen.

### DIFF
--- a/backends/p4tools/modules/testgen/cmake/TestUtils.cmake
+++ b/backends/p4tools/modules/testgen/cmake/TestUtils.cmake
@@ -40,8 +40,8 @@ macro(p4tools_add_tests)
       "${TOOLS_TESTS_UNPARSED_ARGUMENTS}"
     )
   endforeach() # __tests
-  set(TEST_TAGS ${TEST_TAGS} ${tag} CACHE INTERNAL "test tags")
-  message(STATUS "Added ${__nTests} tests to '${tag}'.")
+  set(TEST_TAGS ${TEST_TAGS} ${TOOLS_TESTS_TAG} CACHE INTERNAL "test tags")
+  message(STATUS "Added ${__nTests} tests to '${TOOLS_TESTS_TAG}'.")
 endmacro(p4tools_add_tests)
 
 # Used to add a label to the test like xfail

--- a/backends/p4tools/modules/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/execution_state.cpp
@@ -67,6 +67,10 @@ ExecutionState::ExecutionState(const IR::P4Program *program)
     if (!TestgenOptions::get().pattern.empty()) {
         reachabilityEngineState = ReachabilityEngineState::getInitial();
     }
+    // If assertion mode is enabled, set the assertion property to false.
+    if (TestgenOptions::get().assertionModeEnabled) {
+        setProperty("assertionTriggered", false);
+    }
 }
 
 ExecutionState::ExecutionState(Continuation::Body body)

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -111,11 +111,13 @@ bool TestBackEnd::run(const FinalState &state) {
         CHECK_NULL(solver);
 
         // If assertion mode is active, ignore any test that does not trigger an assertion.
-        if (TestgenOptions::get().assertionModeEnabled &&
-            !executionState->getProperty<bool>("assertionTriggered")) {
-            return testCount > maxTests - 1;
+        if (TestgenOptions::get().assertionModeEnabled) {
+            if (!executionState->getProperty<bool>("assertionTriggered")) {
+                return testCount > maxTests - 1;
+            }
+            printFeature("test_info", 4,
+                         "AssertionMode: Found an input that triggers an assertion.");
         }
-        
         // Don't increase the test count if --with-output-packet is enabled and we don't
         // produce a test with an output packet.
         if (TestgenOptions::get().withOutputPacket) {

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -110,14 +110,6 @@ bool TestBackEnd::run(const FinalState &state) {
         auto *solver = state.getSolver()->to<Z3Solver>();
         CHECK_NULL(solver);
 
-        // If assertion mode is active, ignore any test that does not trigger an assertion.
-        if (TestgenOptions::get().assertionModeEnabled) {
-            if (!executionState->getProperty<bool>("assertionTriggered")) {
-                return testCount > maxTests - 1;
-            }
-            printFeature("test_info", 4,
-                         "AssertionMode: Found an input that triggers an assertion.");
-        }
         // Don't increase the test count if --with-output-packet is enabled and we don't
         // produce a test with an output packet.
         if (TestgenOptions::get().withOutputPacket) {
@@ -126,6 +118,15 @@ bool TestBackEnd::run(const FinalState &state) {
             if (outputPacketSize <= 0 || packetIsDropped) {
                 return needsToTerminate(testCount);
             }
+        }
+
+        // If assertion mode is active, ignore any test that does not trigger an assertion.
+        if (TestgenOptions::get().assertionModeEnabled) {
+            if (!executionState->getProperty<bool>("assertionTriggered")) {
+                return needsToTerminate(testCount);
+            }
+            printFeature("test_info", 4,
+                         "AssertionMode: Found an input that triggers an assertion.");
         }
 
         bool abort = false;

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -110,6 +110,12 @@ bool TestBackEnd::run(const FinalState &state) {
         auto *solver = state.getSolver()->to<Z3Solver>();
         CHECK_NULL(solver);
 
+        // If assertion mode is active, ignore any test that does not trigger an assertion.
+        if (TestgenOptions::get().assertionModeEnabled &&
+            !executionState->getProperty<bool>("assertionTriggered")) {
+            return testCount > maxTests - 1;
+        }
+        
         // Don't increase the test count if --with-output-packet is enabled and we don't
         // produce a test with an output packet.
         if (TestgenOptions::get().withOutputPacket) {

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -306,6 +306,23 @@ TestgenOptions::TestgenOptions()
             return true;
         },
         "List of the selected branches which should be chosen for selection.");
+
+    registerOption(
+        "--assumption-mode", nullptr,
+        [this](const char * /*arg*/) {
+            enforceAssumptions = true;
+            return true;
+        },
+        "Add conditions defined in assert/assume to the path conditions. Only tests which satisfy "
+        "these conditions can be generated.");
+    registerOption(
+        "--assertion-mode", nullptr,
+        [this](const char * /*arg*/) {
+            assertionModeEnabled = true;
+            return true;
+        },
+        "Produce only tests that violate the condition defined in assert calls. This will either "
+        "produce no tests or only tests that contain counter examples.");
 }
 
 }  // namespace P4Tools

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -308,13 +308,13 @@ TestgenOptions::TestgenOptions()
         "List of the selected branches which should be chosen for selection.");
 
     registerOption(
-        "--assumption-mode", nullptr,
+        "--disable-assumption-mode", nullptr,
         [this](const char * /*arg*/) {
-            enforceAssumptions = true;
+            enforceAssumptions = false;
             return true;
         },
-        "Add conditions defined in assert/assume to the path conditions. Only tests which satisfy "
-        "these conditions can be generated.");
+        "Do not apply the conditions defined within \"testgen_assume\" extern calls in P4 programs."
+        "They will have no effect on P4Testgen's path exploration.");
 
     registerOption(
         "--assertion-mode", nullptr,

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -315,6 +315,7 @@ TestgenOptions::TestgenOptions()
         },
         "Add conditions defined in assert/assume to the path conditions. Only tests which satisfy "
         "these conditions can be generated.");
+
     registerOption(
         "--assertion-mode", nullptr,
         [this](const char * /*arg*/) {

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -74,6 +74,14 @@ class TestgenOptions : public AbstractP4cToolOptions {
 
     /// Enforces the test generation of tests with mandatory output packet.
     bool withOutputPacket = false;
+    
+    /// Add conditions defined in assert/assume to the path conditions.
+    /// Only tests which satisfy these conditions can be generated.
+    bool enforceAssumptions = false;
+
+    /// Produce only tests that violate the condition defined in assert calls.
+    /// This will either produce no tests or only tests that contain counter examples.
+    bool assertionModeEnabled = false;
 
     const char *getIncludePath() override;
 

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -74,7 +74,7 @@ class TestgenOptions : public AbstractP4cToolOptions {
 
     /// Enforces the test generation of tests with mandatory output packet.
     bool withOutputPacket = false;
-    
+
     /// Add conditions defined in assert/assume to the path conditions.
     /// Only tests which satisfy these conditions can be generated.
     bool enforceAssumptions = false;

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -76,8 +76,8 @@ class TestgenOptions : public AbstractP4cToolOptions {
     bool withOutputPacket = false;
 
     /// Add conditions defined in assert/assume to the path conditions.
-    /// Only tests which satisfy these conditions can be generated.
-    bool enforceAssumptions = false;
+    /// Only tests which satisfy these conditions can be generated. This is active by default.
+    bool enforceAssumptions = true;
 
     /// Produce only tests that violate the condition defined in assert calls.
     /// This will either produce no tests or only tests that contain counter examples.

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/AssumeAssertTests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/AssumeAssertTests.cmake
@@ -1,13 +1,13 @@
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_1.p4"
   TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_1.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE DISABLE_ASSUME_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )
 
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_2.p4"
   TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_2.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE  CHECK_EMPTY TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE DISABLE_ASSUME_MODE CHECK_EMPTY TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )
 
 p4tools_add_test_with_args(
@@ -19,17 +19,17 @@ p4tools_add_test_with_args(
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_1.p4"
   TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_1_neg.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE DISABLE_ASSUME_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )
 
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_2.p4"
   TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_2.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE USE_ASSUME_MODE CHECK_EMPTY TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE CHECK_EMPTY TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )
 
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_3.p4"
   TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_3.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE USE_ASSUME_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/AssumeAssertTests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/AssumeAssertTests.cmake
@@ -1,0 +1,35 @@
+p4tools_add_test_with_args(
+  P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_1.p4"
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_1.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+)
+
+p4tools_add_test_with_args(
+  P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_2.p4"
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_2.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE  CHECK_EMPTY TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+)
+
+p4tools_add_test_with_args(
+  P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_1.p4"
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_1.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE USE_ASSUME_MODE CHECK_EMPTY TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+)
+
+p4tools_add_test_with_args(
+  P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_1.p4"
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_1_neg.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+)
+
+p4tools_add_test_with_args(
+  P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_2.p4"
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_2.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE USE_ASSUME_MODE CHECK_EMPTY TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+)
+
+p4tools_add_test_with_args(
+  P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_3.p4"
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_3.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE USE_ASSUME_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
+)

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
@@ -36,6 +36,7 @@ set(
 p4c_find_tests("${TESTGEN_BMV2_P416_TESTS}" BMV2_P4_16_V1_TESTS INCLUDE "${V1_SEARCH_PATTERNS}" EXCLUDE "")
 p4tools_find_tests("${BMV2_P4_16_V1_TESTS}" bmv2v1tests EXCLUDE "")
 
+
 # Add bmv2 tests from p4c and from testgen/test/p4-programs/bmv2
 set(P4C_V1_TEST_SUITES_P416 ${v1tests} ${bmv2v1tests})
 
@@ -44,6 +45,11 @@ p4tools_add_tests(
   TAG "testgen-p4c-bmv2" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
   TARGET "bmv2" ARCH "v1model" ENABLE_RUNNER TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF ${EXTRA_OPTS} "
 )
+
+#############################################################################
+# ASSERT_ASSUME TESTS
+#############################################################################
+include(${CMAKE_CURRENT_LIST_DIR}/AssumeAssertTests.cmake)
 
 #############################################################################
 # TEST PROPERTIES

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
@@ -80,7 +80,7 @@ endfunction(check_empty_folder)
 # Sets the timeout on tests at 300s. For the slow CI machines.
 function(p4tools_add_test_with_args)
   # Parse arguments.
-  set(options ENABLE_RUNNER VALIDATE_PROTOBUF P416_PTF USE_ASSERT_MODE USE_ASSUME_MODE CHECK_EMPTY)
+  set(options ENABLE_RUNNER VALIDATE_PROTOBUF P416_PTF USE_ASSERT_MODE DISABLE_ASSUME_MODE CHECK_EMPTY)
   set(oneValueArgs TAG DRIVER ALIAS P4TEST TARGET ARCH)
   set(multiValueArgs TEST_ARGS CMAKE_ARGS)
   cmake_parse_arguments(
@@ -111,8 +111,8 @@ function(p4tools_add_test_with_args)
   if(${TOOLS_BMV2_TESTS_USE_ASSERT_MODE})
     set(test_args "${test_args} --assertion-mode")
   endif()
-  if(${TOOLS_BMV2_TESTS_USE_ASSUME_MODE})
-    set(test_args "${test_args} --assumption-mode")
+  if(${TOOLS_BMV2_TESTS_DISABLE_ASSUME_MODE})
+    set(test_args "${test_args} --disable-assumption-mode")
   endif()
 
   file(
@@ -120,7 +120,7 @@ function(p4tools_add_test_with_args)
     "--std p4-16 ${test_args} --out-dir ${__testfolder} \"$@\" ${P4C_SOURCE_DIR}/${p4test}\n"
   )
 
-  if(${TOOLS_BMV2_TESTS_USE_ASSERT_MODE} OR ${TOOLS_BMV2_TESTS_USE_ASSUME_MODE})
+  if(${TOOLS_BMV2_TESTS_USE_ASSERT_MODE} OR ${TOOLS_BMV2_TESTS_DISABLE_ASSUME_MODE})
     # Check whether the folder is empty.
     if(${TOOLS_BMV2_TESTS_CHECK_EMPTY})
       file(APPEND ${__testfile} "[ \"$(ls -A ${__testfolder})\" ] && exit 1 || exit 0")

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_1.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_1.p4
@@ -1,0 +1,63 @@
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+    bit<8> b;
+    bit<16> c;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {}
+
+// Custom extern definitions.
+extern void testgen_assert(in bool check);
+extern void testgen_assume(in bool check);
+
+
+parser p(packet_in pkt, out Headers h, inout Meta meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(h.eth_hdr);
+        transition parse_h;
+    }
+    state parse_h {
+        pkt.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta meta) {
+  apply { }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply {
+        // All tests should be generated.
+        testgen_assert(false);
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply { }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply { }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_2.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_2.p4
@@ -1,0 +1,63 @@
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+    bit<8> b;
+    bit<16> c;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {}
+
+// Custom extern definitions.
+extern void testgen_assert(in bool check);
+extern void testgen_assume(in bool check);
+
+
+parser p(packet_in pkt, out Headers h, inout Meta meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(h.eth_hdr);
+        transition parse_h;
+    }
+    state parse_h {
+        pkt.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta meta) {
+  apply { }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply {
+        // No tests should be generated.
+        testgen_assert(true);
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply { }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply { }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_1.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_1.p4
@@ -1,0 +1,64 @@
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+    bit<8> b;
+    bit<16> c;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {}
+
+// Custom extern definitions.
+extern void testgen_assert(in bool check);
+extern void testgen_assume(in bool check);
+
+
+parser p(packet_in pkt, out Headers h, inout Meta meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(h.eth_hdr);
+        transition parse_h;
+    }
+    state parse_h {
+        pkt.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta meta) {
+  apply { }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply {
+        testgen_assume(h.eth_hdr.eth_type != 0);
+        // No tests should be generated because the precondition forbids such entries.
+        testgen_assert(h.eth_hdr.eth_type != 0);
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply { }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply { }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_2.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_2.p4
@@ -1,0 +1,64 @@
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+    bit<8> b;
+    bit<16> c;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {}
+
+// Custom extern definitions.
+extern void testgen_assert(in bool check);
+extern void testgen_assume(in bool check);
+
+
+parser p(packet_in pkt, out Headers h, inout Meta meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(h.eth_hdr);
+        transition parse_h;
+    }
+    state parse_h {
+        pkt.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta meta) {
+  apply { }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply {
+        testgen_assume(h.eth_hdr.eth_type >= 0xFFFE);
+        // There is only one possible eth_type counterexample, which is 0xFFFF.
+        testgen_assert(h.eth_hdr.eth_type != 0);
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply { }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply { }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_3.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_3.p4
@@ -1,0 +1,70 @@
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+    bit<8> b;
+    bit<16> c;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {}
+
+// Custom extern definitions.
+extern void testgen_assert(in bool check);
+extern void testgen_assume(in bool check);
+
+
+parser p(packet_in pkt, out Headers h, inout Meta meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(h.eth_hdr);
+        transition parse_h;
+    }
+    state parse_h {
+        pkt.extract(h.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta meta) {
+  apply { }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply {
+        // The packet should be exactly 144 bits, which is h.eth_hdr + h.h
+        testgen_assume(s.packet_length == 18);
+        // We can not fail this assertion because we assume the packet is just long enough.
+        testgen_assert(h.eth_hdr.isValid());
+        // Assume that all packets ether types values are >= 0xFFFF.
+        testgen_assume(h.eth_hdr.eth_type == 0xFFFF);
+        // There is only one possible eth_type counterexample, which is 0xFFFF.
+        // Also only one packet, since we constrain the packet length.
+        testgen_assert(h.eth_hdr.eth_type != 0xFFFF);
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply { }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply { }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -133,7 +133,8 @@ int Testgen::mainImpl(const IR::P4Program *program) {
         throw;
     }
 
-    if (testBackend->getTestCount() == 0) {
+    // Do not print this warning if assertion mode is enabled.
+    if (testBackend->getTestCount() == 0 && !testgenOptions.assertionModeEnabled) {
         ::warning(
             "Unable to generate tests with given inputs. Double-check provided options and "
             "parameters.\n");


### PR DESCRIPTION
This PR adds assert and assume mode to P4Testgen. These modes can be enabled via the `--assumption-mode` and `--assertion-mode` flags.

- If only `--assumption-mode` is active, P4Testgen will only generate tests that satisfy all assert and assume conditions.
- If also `--assertion-mode` is active, P4Testgen will try to only produce tests that violate assertions also including assumptions in assume calls.
- If only `--assertion-mode` is active, P4Testgen will not add assumptions to the path and only generate tests that violate asserts.


