### PR TITLE
Fix non-contiguous table keys for learner and exact match tables

### DIFF
--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -1628,6 +1628,7 @@ const IR::Node* CopyMatchKeysToSingleStruct::preorder(IR::Key* keys) {
     /* If copyNeeded is false at this point, it means the keys are from same struct.
      * Check remaining conditions to see if the copy is needed or not */
     metaCopyNeeded = false;
+    if (copyNeeded) contiguous = false;
 
     if (!contiguous &&
         ((keyInfoInstance->isLearner) ||
@@ -1673,10 +1674,14 @@ const IR::Node* CopyMatchKeysToSingleStruct::postorder(IR::KeyElement* element) 
         keyName = keyName.replace('.', '_');
         keyName =
             keyName.replace("h_", control->name.toString() + "_" + table->name.toString() + "_");
-    } else if (keyName.startsWith("m.") && metaCopyNeeded) {
-        keyName = keyName.replace('.', '_');
-        keyName =
-            keyName.replace("m_", control->name.toString() + "_" + table->name.toString() + "_");
+    } else if (metaCopyNeeded) {
+        if (keyName.startsWith("m.")) {
+            keyName = keyName.replace('.', '_');
+            keyName = keyName.replace(
+                "m_", control->name.toString() + "_" + table->name.toString() + "_");
+        } else {
+            keyName = control->name.toString() + "_" + table->name.toString() + "_" + keyName;
+        }
     }
 
     if (isHeader || metaCopyNeeded) {

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4.spec
@@ -32,7 +32,7 @@ struct main_metadata_t {
 	bit<8> local_metadata_timeout
 	bit<32> pna_main_output_metadata_output_port
 	bit<32> MainControlImpl_ipv4_da_ipv4_dstAddr
-	bit<8> key_1
+	bit<8> MainControlImpl_ipv4_da_key
 	bit<32> MainControlT_tmp
 	bit<32> MainControlT_tmp_0
 	bit<32> learnArg
@@ -71,7 +71,7 @@ action add_on_miss_action2 args none {
 learner ipv4_da {
 	key {
 		m.MainControlImpl_ipv4_da_ipv4_dstAddr
-		m.key_1
+		m.MainControlImpl_ipv4_da_key
 	}
 	actions {
 		next_hop @tableonly
@@ -123,7 +123,7 @@ apply {
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
 	mov m.MainControlImpl_ipv4_da_ipv4_dstAddr h.ipv4.dstAddr
-	mov m.key_1 0x48
+	mov m.MainControlImpl_ipv4_da_key 0x48
 	table ipv4_da
 	table ipv4_da2
 	LABEL_END :	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.spec
@@ -34,7 +34,11 @@ struct metadata_t {
 	bit<32> pna_main_input_metadata_direction
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlImpl_ct_tcp_table_key
+	bit<32> MainControlImpl_ct_tcp_table_key_0
 	bit<8> MainControlImpl_ct_tcp_table_ipv4_protocol
+	bit<16> MainControlImpl_ct_tcp_table_key_1
+	bit<16> MainControlImpl_ct_tcp_table_key_2
 	bit<8> MainControlT_do_add_on_miss
 	bit<8> MainControlT_update_aging_info
 	bit<8> MainControlT_update_expire_time
@@ -107,11 +111,11 @@ table set_ct_options {
 
 learner ct_tcp_table {
 	key {
-		m.MainControlT_key
-		m.MainControlT_key_0
+		m.MainControlImpl_ct_tcp_table_key
+		m.MainControlImpl_ct_tcp_table_key_0
 		m.MainControlImpl_ct_tcp_table_ipv4_protocol
-		m.MainControlT_key_1
-		m.MainControlT_key_2
+		m.MainControlImpl_ct_tcp_table_key_1
+		m.MainControlImpl_ct_tcp_table_key_2
 	}
 	actions {
 		ct_tcp_table_hit @tableonly
@@ -166,7 +170,11 @@ apply {
 	mov m.MainControlT_key_2 h.tcp.srcPort
 	jmp LABEL_END_4
 	LABEL_TRUE_4 :	mov m.MainControlT_key_2 h.tcp.dstPort
-	LABEL_END_4 :	mov m.MainControlImpl_ct_tcp_table_ipv4_protocol h.ipv4.protocol
+	LABEL_END_4 :	mov m.MainControlImpl_ct_tcp_table_key m.MainControlT_key
+	mov m.MainControlImpl_ct_tcp_table_key_0 m.MainControlT_key_0
+	mov m.MainControlImpl_ct_tcp_table_ipv4_protocol h.ipv4.protocol
+	mov m.MainControlImpl_ct_tcp_table_key_1 m.MainControlT_key_1
+	mov m.MainControlImpl_ct_tcp_table_key_2 m.MainControlT_key_2
 	table ct_tcp_table
 	LABEL_END_0 :	emit h.eth
 	tx m.pna_main_output_metadata_output_port

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.spec
@@ -58,7 +58,7 @@ struct metadata {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
 	bit<16> ingress_tbl_local_metadata_data
-	bit<8> key_1
+	bit<8> ingress_tbl_key
 	bit<16> tmpMask
 	bit<8> tmpMask_0
 }
@@ -80,7 +80,7 @@ action execute_1 args none {
 table tbl {
 	key {
 		m.ingress_tbl_local_metadata_data exact
-		m.key_1 exact
+		m.ingress_tbl_key exact
 	}
 	actions {
 		NoAction
@@ -107,7 +107,7 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
 	INGRESSPARSERIMPL_ACCEPT :	mov m.ingress_tbl_local_metadata_data m.local_metadata_data
-	mov m.key_1 0x48
+	mov m.ingress_tbl_key 0x48
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4.spec
@@ -58,7 +58,7 @@ struct metadata {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
 	bit<16> ingress_tbl_tcp_dstPort
-	bit<8> key_1
+	bit<8> ingress_tbl_key
 	bit<16> tmpMask
 	bit<8> tmpMask_0
 }
@@ -80,7 +80,7 @@ action execute_1 args none {
 table tbl {
 	key {
 		m.ingress_tbl_tcp_dstPort exact
-		m.key_1 exact
+		m.ingress_tbl_key exact
 	}
 	actions {
 		NoAction
@@ -107,7 +107,7 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
 	INGRESSPARSERIMPL_ACCEPT :	mov m.ingress_tbl_tcp_dstPort h.tcp.dstPort
-	mov m.key_1 0x48
+	mov m.ingress_tbl_key 0x48
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4.spec
@@ -58,7 +58,7 @@ struct metadata {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
 	bit<16> ingress_tbl_local_metadata_data
-	bit<8> key_1
+	bit<8> ingress_tbl_key
 	bit<16> ingress_tbl_tcp_dstPort
 	bit<16> tmpMask
 	bit<8> tmpMask_0
@@ -81,7 +81,7 @@ action execute_1 args none {
 table tbl {
 	key {
 		m.ingress_tbl_local_metadata_data exact
-		m.key_1 exact
+		m.ingress_tbl_key exact
 		m.ingress_tbl_tcp_dstPort exact
 	}
 	actions {
@@ -109,7 +109,7 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_TCP :	extract h.tcp
 	INGRESSPARSERIMPL_ACCEPT :	mov m.ingress_tbl_local_metadata_data m.local_metadata_data
-	mov m.key_1 0x48
+	mov m.ingress_tbl_key 0x48
 	mov m.ingress_tbl_tcp_dstPort h.tcp.dstPort
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.spec
@@ -57,6 +57,7 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
+	bit<8> ingress_tbl_key
 	bit<48> ingress_tbl_ethernet_dstAddr
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<8> Ingress_tmp
@@ -82,7 +83,7 @@ action execute_1 args none {
 
 table tbl {
 	key {
-		m.Ingress_key exact
+		m.ingress_tbl_key exact
 		m.ingress_tbl_ethernet_dstAddr exact
 		m.ingress_tbl_ethernet_srcAddr exact
 	}
@@ -122,7 +123,8 @@ apply {
 	mov m.Ingress_key 0x0
 	jmp LABEL_END_1
 	LABEL_TRUE :	mov m.Ingress_key 0x1
-	LABEL_END_1 :	mov m.ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	LABEL_END_1 :	mov m.ingress_tbl_key m.Ingress_key
+	mov m.ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
 	mov m.ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.spec
@@ -57,6 +57,7 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
+	bit<8> ingress_tbl_key
 	bit<48> ingress_tbl_ethernet_dstAddr
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<8> Ingress_tmp
@@ -84,7 +85,7 @@ action execute_1 args none {
 
 table tbl {
 	key {
-		m.Ingress_key exact
+		m.ingress_tbl_key exact
 		m.ingress_tbl_ethernet_dstAddr exact
 		m.ingress_tbl_ethernet_srcAddr exact
 	}
@@ -133,7 +134,8 @@ apply {
 	mov m.Ingress_key 0x0
 	jmp LABEL_END_3
 	LABEL_TRUE_0 :	mov m.Ingress_key 0x1
-	LABEL_END_3 :	mov m.ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	LABEL_END_3 :	mov m.ingress_tbl_key m.Ingress_key
+	mov m.ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
 	mov m.ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.spec
@@ -57,6 +57,7 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
+	bit<8> ingress_tbl_key
 	bit<48> ingress_tbl_ethernet_dstAddr
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<8> Ingress_tmp
@@ -81,7 +82,7 @@ action execute_1 args none {
 
 table tbl {
 	key {
-		m.Ingress_key exact
+		m.ingress_tbl_key exact
 		m.ingress_tbl_ethernet_dstAddr exact
 		m.ingress_tbl_ethernet_srcAddr exact
 	}
@@ -116,7 +117,8 @@ apply {
 	mov m.Ingress_key 0x0
 	jmp LABEL_END_0
 	LABEL_TRUE :	mov m.Ingress_key 0x1
-	LABEL_END_0 :	mov m.ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	LABEL_END_0 :	mov m.ingress_tbl_key m.Ingress_key
+	mov m.ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
 	mov m.ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.spec
@@ -57,6 +57,7 @@ struct metadata {
 	bit<8> psa_ingress_output_metadata_drop
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<16> local_metadata_data
+	bit<8> ingress_tbl_key
 	bit<48> ingress_tbl_ethernet_dstAddr
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<8> Ingress_tmp
@@ -83,7 +84,7 @@ action execute_1 args none {
 
 table tbl {
 	key {
-		m.Ingress_key exact
+		m.ingress_tbl_key exact
 		m.ingress_tbl_ethernet_dstAddr exact
 		m.ingress_tbl_ethernet_srcAddr exact
 	}
@@ -127,7 +128,8 @@ apply {
 	mov m.Ingress_key 0x0
 	jmp LABEL_END_2
 	LABEL_TRUE_0 :	mov m.Ingress_key 0x1
-	LABEL_END_2 :	mov m.ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
+	LABEL_END_2 :	mov m.ingress_tbl_key m.Ingress_key
+	mov m.ingress_tbl_ethernet_dstAddr h.ethernet.dstAddr
 	mov m.ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	table tbl
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.spec
@@ -53,8 +53,8 @@ struct metadata_t {
 	bit<32> psa_ingress_output_metadata_egress_port
 	bit<32> local_metadata_port_out
 	bit<48> ingress_tbl_ethernet_srcAddr
-	bit<32> key_2
-	bit<32> key_3
+	bit<32> ingress_tbl_key
+	bit<32> ingress_tbl_key_0
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
 	bit<32> IngressParser_parser_tmp_1
@@ -137,8 +137,8 @@ action execute_1 args instanceof execute_1_arg_t {
 table tbl {
 	key {
 		m.ingress_tbl_ethernet_srcAddr exact
-		m.key_2 exact
-		m.key_3 exact
+		m.ingress_tbl_key exact
+		m.ingress_tbl_key_0 exact
 	}
 	actions {
 		NoAction
@@ -172,8 +172,8 @@ apply {
 	mov m.Ingress_tmp_21 m.Ingress_tmp_20
 	and m.Ingress_tmp_21 0xF
 	mov m.ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
-	mov m.key_2 m.Ingress_tmp_19
-	mov m.key_3 m.Ingress_tmp_21
+	mov m.ingress_tbl_key m.Ingress_tmp_19
+	mov m.ingress_tbl_key_0 m.Ingress_tmp_21
 	table tbl
 	regadd counter0_0_packets 0x3FF 1
 	regadd counter0_0_bytes 0x3FF 0x14

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.spec
@@ -54,7 +54,7 @@ struct metadata_t {
 	bit<32> local_metadata_port_out
 	bit<48> ingress_tbl_ethernet_srcAddr
 	bit<16> ingress_tbl_ipv4_hdrChecksum
-	bit<32> key_1
+	bit<32> ingress_tbl_key
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
 	bit<32> IngressParser_parser_tmp_1
@@ -136,7 +136,7 @@ table tbl {
 	key {
 		m.ingress_tbl_ethernet_srcAddr exact
 		m.ingress_tbl_ipv4_hdrChecksum exact
-		m.key_1 exact
+		m.ingress_tbl_key exact
 	}
 	actions {
 		NoAction
@@ -167,7 +167,7 @@ apply {
 	and m.Ingress_tmp_19 0xF
 	mov m.ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	mov m.ingress_tbl_ipv4_hdrChecksum h.ipv4.hdrChecksum
-	mov m.key_1 m.Ingress_tmp_19
+	mov m.ingress_tbl_key m.Ingress_tmp_19
 	table tbl
 	regadd counter0_0_packets 0x3FF 1
 	regadd counter0_0_bytes 0x3FF 0x14


### PR DESCRIPTION
Fix non-contiguous table keys when keys come from different header and metadata struct but existing metadata keys are already contiguous.