### PR TITLE
Option to produce tests exclusively with output packets

### DIFF
--- a/backends/p4tools/modules/testgen/README.md
+++ b/backends/p4tools/modules/testgen/README.md
@@ -53,6 +53,7 @@ These are the current usage flags:
 --pop-level                This is the fraction of unexploredBranches we select on randomAccessStack. Defaults to 3.
 --linear-enumeration       Max bound for LinearEnumeration strategy. Defaults to 2. **Experimental feature**.
 --saddle-point             To be used with randomAccessMaxCoverage. Specifies when to randomly explore the map after a saddle point in the coverage of the test generation.
+--with-output-packet       Produced tests must have an output packet.
 ```
 
 Once P4Testgen has generated tests, the tests can be executed by either the P4Runtime or STF test back ends.

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
@@ -28,6 +28,9 @@
 #include "backends/p4tools/modules/testgen/lib/final_state.h"
 #include "backends/p4tools/modules/testgen/lib/logging.h"
 
+
+#include "backends/p4tools/modules/testgen/options.h"
+
 namespace P4Tools {
 
 namespace P4Testgen {
@@ -90,10 +93,21 @@ bool ExplorationStrategy::handleTerminalState(const Callback& callback,
         ::warning("Path constraints unsatisfiable");
         return false;
     }
+
     // Get the model from the solver, complete it with respect to the
     // final symbolic environment and trace, use it to evaluate the
     // final execution state, and finally delegate to the callback.
     const FinalState finalState(&solver, terminalState);
+    if (TestgenOptions::get().withOutputPacket) {
+        // const auto* outputPacketExpr = terminalState->getPacketBuffer();
+        // const auto* completedModel = finalState.getCompletedModel();
+        // const auto* outputPacket = completedModel->evaluate(outputPacketExpr);
+        // auto outputPacketSize = outputPacket->type->width_bits();
+        auto outputPacketSize = terminalState.getPacketBufferSize();
+        if (outputPacketSize >= 0) {
+            return false;
+        }
+    }
     return callback(finalState);
 }
 

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
@@ -28,9 +28,6 @@
 #include "backends/p4tools/modules/testgen/lib/final_state.h"
 #include "backends/p4tools/modules/testgen/lib/logging.h"
 
-
-#include "backends/p4tools/modules/testgen/options.h"
-
 namespace P4Tools {
 
 namespace P4Testgen {
@@ -98,16 +95,6 @@ bool ExplorationStrategy::handleTerminalState(const Callback& callback,
     // final symbolic environment and trace, use it to evaluate the
     // final execution state, and finally delegate to the callback.
     const FinalState finalState(&solver, terminalState);
-    if (TestgenOptions::get().withOutputPacket) {
-        // const auto* outputPacketExpr = terminalState->getPacketBuffer();
-        // const auto* completedModel = finalState.getCompletedModel();
-        // const auto* outputPacket = completedModel->evaluate(outputPacketExpr);
-        // auto outputPacketSize = outputPacket->type->width_bits();
-        auto outputPacketSize = terminalState.getPacketBufferSize();
-        if (outputPacketSize >= 0) {
-            return false;
-        }
-    }
     return callback(finalState);
 }
 

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -144,7 +144,7 @@ bool TestBackEnd::run(const FinalState& state) {
         // selectBranches, trackBranches and others continue to work.
         if (TestgenOptions::get().withOutputPacket && testCount > 0) {
             auto outputPacketSize = testInfo.outputPacket->type->width_bits();
-            if (outputPacketSize <= 0) {
+            if (outputPacketSize <= 0 || testInfo.packetIsDropped) {
                 return testCount > maxTests - 1;
             }
         }

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -139,6 +139,13 @@ bool TestBackEnd::run(const FinalState& state) {
             return testCount > maxTests - 1;
         }
 
+        if (TestgenOptions::get().withOutputPacket && testCount > 0) {
+            auto outputPacketSize = testInfo.outputPacket->type->width_bits();
+            if (outputPacketSize <= 0) {
+                return testCount > maxTests - 1;
+            }
+        }
+
         const auto* testSpec = createTestSpec(executionState, completedModel, testInfo);
 
         float coverage = static_cast<float>(visitedStatements.size()) / allStatements.size();

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -139,6 +139,9 @@ bool TestBackEnd::run(const FinalState& state) {
             return testCount > maxTests - 1;
         }
 
+        // Don't increase the test count if --with-output-packet is enabled and we don't
+        // produce a test with an output packet. Excludes the first test, so
+        // selectBranches, trackBranches and others continue to work.
         if (TestgenOptions::get().withOutputPacket && testCount > 0) {
             auto outputPacketSize = testInfo.outputPacket->type->width_bits();
             if (outputPacketSize <= 0) {

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -109,11 +109,10 @@ bool TestBackEnd::run(const FinalState& state) {
 
         auto* solver = state.getSolver()->to<Z3Solver>();
         CHECK_NULL(solver);
-        
+
         // Don't increase the test count if --with-output-packet is enabled and we don't
-        // produce a test with an output packet. Excludes the first test, so
-        // selectBranches, trackBranches and others continue to work.
-        if (TestgenOptions::get().withOutputPacket && testCount > 0) {
+        // produce a test with an output packet.
+        if (TestgenOptions::get().withOutputPacket) {
             auto outputPacketSize = executionState->getPacketBufferSize();
             bool packetIsDropped = executionState->getProperty<bool>("drop");
             if (outputPacketSize <= 0 || packetIsDropped) {

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -117,6 +117,13 @@ bool TestBackEnd::run(const FinalState& state) {
             testCount++;
             P4::Coverage::coverageReportFinal(allStatements, visitedStatements);
             printPerformanceReport();
+            if (TestgenOptions::get().withOutputPacket && testCount > 0) {
+                auto outputPacketSize = executionState->getPacketBufferSize();
+                bool packetIsDropped = executionState->getProperty<bool>("drop");
+                if (outputPacketSize <= 0 || packetIsDropped) {
+                    return testCount > maxTests - 1;
+                }
+            }
             return testCount > maxTests - 1;
         }
         completedModel = concolicModel;

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -108,8 +108,8 @@ TestgenOptions::TestgenOptions()
         "--with-output-packet", nullptr,
         [this](const char*) {
             withOutputPacket = true;
-            if (trackBranches) {
-                std::cerr << "--track-branches cannot guarantee --with-output-packet."
+            if (!selectedBranches.empty()) {
+                std::cerr << "--input-branches cannot guarantee --with-output-packet."
                              " Aborting."
                           << std::endl;
                 exit(1);

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -108,6 +108,12 @@ TestgenOptions::TestgenOptions()
         "--with-output-packet", nullptr,
         [this](const char*) {
             withOutputPacket = true;
+            if (trackBranches) {
+                std::cerr << "--track-branches cannot guarantee --with-output-packet."
+                             " Aborting."
+                          << std::endl;
+                exit(1);
+            }
             return true;
         },
         "Produced tests must have an output packet.");

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -105,6 +105,14 @@ TestgenOptions::TestgenOptions()
         "deterministic replay.");
 
     registerOption(
+        "--with-output-packet", nullptr,
+        [this](const char*) {
+            withOutputPacket = true;
+            return true;
+        },
+        "Produced tests must have an output packet.");
+
+    registerOption(
         "--exploration-strategy", "explorationStrategy",
         [this](const char* arg) {
             explorationStrategy = arg;

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -65,6 +65,9 @@ class TestgenOptions : public AbstractP4cToolOptions {
     /// for statement reachability analysis.
     bool dcg = false;
 
+    /// Enforces the test generation of tests with mandatory output packet.
+    bool withOutputPacket = false;
+
     const char* getIncludePath() override;
 
  private:


### PR DESCRIPTION
Enforces the test generation of tests with an output packet.