### PR TITLE
Move timer from testgen to lib folder.

### DIFF
--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -52,7 +52,6 @@ set(
   lib/model.cpp
   lib/symbolic_env.cpp
   lib/taint.cpp
-  lib/timer.cpp
   lib/trace_events.cpp
   lib/util.cpp
   lib/zombie.cpp

--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -13,7 +13,6 @@
 
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/model.h"
-#include "backends/p4tools/common/lib/timer.h"
 #include "gsl/gsl-lite.hpp"
 #include "ir/ir.h"
 #include "ir/irutils.h"
@@ -25,6 +24,7 @@
 #include "lib/exceptions.h"
 #include "lib/indent.h"
 #include "lib/log.h"
+#include "lib/timer.h"
 
 namespace P4Tools {
 
@@ -283,8 +283,8 @@ boost::optional<bool> Z3Solver::checkSat(const std::vector<const Constraint*>& a
     }
     Z3_LOG("checking satisfiability for %d assertions",
            isIncremental ? z3solver.assertions().size() : z3Assertions.size());
-    ScopedTimer ctZ3("z3");
-    ScopedTimer ctCheckSat("checkSat");
+    Util::ScopedTimer ctZ3("z3");
+    Util::ScopedTimer ctCheckSat("checkSat");
     z3::check_result result = isIncremental ? z3solver.check() : z3solver.check(z3Assertions);
     switch (result) {
         case z3::sat:
@@ -332,8 +332,8 @@ const Model* Z3Solver::getModel() const {
     }
     // Then, get the model and match each declaration in the model to its StateVariable.
     try {
-        ScopedTimer ctZ3("z3");
-        ScopedTimer ctCheckSat("getModel");
+        Util::ScopedTimer ctZ3("z3");
+        Util::ScopedTimer ctCheckSat("getModel");
         auto z3Model = z3solver.get_model();
         Z3_LOG("z3 model:%s", toString(z3Model));
 

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
@@ -13,13 +13,13 @@
 #include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
-#include "backends/p4tools/common/lib/timer.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "frontends/p4/optimizeExpressions.h"
 #include "gsl/gsl-lite.hpp"
 #include "ir/ir.h"
 #include "ir/irutils.h"
 #include "lib/error.h"
+#include "lib/timer.h"
 #include "midend/coverage.h"
 
 #include "backends/p4tools/modules/testgen/core/program_info.h"
@@ -52,7 +52,7 @@ ExplorationStrategy::Branch::Branch(boost::optional<const Constraint*> c,
 }
 
 ExplorationStrategy::StepResult ExplorationStrategy::step(ExecutionState& state) {
-    ScopedTimer st("step");
+    Util::ScopedTimer st("step");
     StepResult successors = evaluator.step(state);
     // Assign branch ids to the branches. These integer branch ids are used by track-branches
     // and selected (input) branches features.

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -17,7 +17,6 @@
 #include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/taint.h"
-#include "backends/p4tools/common/lib/timer.h"
 #include "backends/p4tools/common/lib/trace_events.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "frontends/p4/optimizeExpressions.h"
@@ -25,6 +24,7 @@
 #include "lib/error.h"
 #include "lib/exceptions.h"
 #include "lib/null.h"
+#include "lib/timer.h"
 #include "midend/coverage.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
@@ -158,8 +158,9 @@ bool TestBackEnd::run(const FinalState& state) {
         P4::Coverage::logCoverage(allStatements, visitedStatements, executionState->getVisited());
 
         // Output the test.
-        withTimer("backend",
-                  [&] { testWriter->outputTest(testSpec, selectedBranches, testCount, coverage); });
+        Util::withTimer("backend", [&] {
+            testWriter->outputTest(testSpec, selectedBranches, testCount, coverage);
+        });
 
         printTraces("============ End Test %1% ============\n", testCount);
         testCount++;
@@ -267,7 +268,7 @@ bool TestBackEnd::printTestInfo(const ExecutionState* executionState, const Test
 
 void TestBackEnd::printPerformanceReport() {
     printFeature("performance", 4, "============ Timers ============");
-    for (const auto& c : getTimers()) {
+    for (const auto& c : Util::getTimers()) {
         if (c.timerName.empty()) {
             printFeature("performance", 4, "Total: %i ms", c.milliseconds);
         } else {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -34,6 +34,7 @@ set (LIBP4CTOOLKIT_SRCS
     path.cpp
     source_file.cpp
     stringify.cpp
+    timer.cpp
 )
 
 set (LIBP4CTOOLKIT_HDRS
@@ -77,6 +78,7 @@ set (LIBP4CTOOLKIT_HDRS
     stringify.h
     stringref.h
     symbitmatrix.h
+    timer.h
 )
 
 build_unified(LIBP4CTOOLKIT_SRCS ALL)

--- a/lib/timer.cpp
+++ b/lib/timer.cpp
@@ -66,6 +66,8 @@ struct RootCounter {
 }  // namespace
 
 #pragma GCC diagnostic push
+// Ignore a bogus subobject-linkage warning, which can occur in unity builds.
+// the #if pragma is a little awkward because some preprocessors do not like ||
 #if defined(__has_warning)
 #if __has_warning("-Wsubobject-linkage")
 #pragma GCC diagnostic ignored "-Wsubobject-linkage"

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -1,14 +1,13 @@
-#ifndef BACKENDS_P4TOOLS_COMMON_LIB_TIMER_H_
-#define BACKENDS_P4TOOLS_COMMON_LIB_TIMER_H_
+#ifndef _LIB_TIMER_H_
+#define _LIB_TIMER_H_
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>
 #include <vector>
 
-namespace P4Tools {
+namespace Util {
 
 /// Runs specified function and measures it's execution duration under specified timer name.
 /// Timers can be nested. Measured durations are added under given timer name. In case of nested
@@ -23,7 +22,7 @@ namespace P4Tools {
 /// });
 ///
 /// uses two separate counters denoted as "A.C" and "B.C".
-void withTimer(const char* timer_name, std::function<void()> fn);
+void withTimer(const char* timerName, const std::function<void()>& fn);
 
 struct TimerEntry {
     /// Counter name. If a timer "Y" was invoked inside timer "X", its timer name is "X.Y".
@@ -37,6 +36,9 @@ struct TimerEntry {
 /// Returns list of all timers for and their current values.
 std::vector<TimerEntry> getTimers();
 
+// Internal implementation.
+struct ScopedTimerCtx;
+
 /// Similar to withTimer function, measures execution time elapsed from instance creation to
 /// destruction.
 class ScopedTimer {
@@ -46,12 +48,9 @@ class ScopedTimer {
     ~ScopedTimer();
 
  private:
-    // Internal implementation.
-    struct Ctx;
-
-    std::unique_ptr<Ctx> ctx;
+    std::unique_ptr<ScopedTimerCtx> ctx;
 };
 
-}  // namespace P4Tools
+}  // namespace Util
 
-#endif /* BACKENDS_P4TOOLS_COMMON_LIB_TIMER_H_ */
+#endif /* _LIB_TIMER_H_ */


### PR DESCRIPTION
This moves the ScopedTimer class of P4Tools into the general lib folder. A scoped timer measures and logs the lifetime of the timer object from creation to destruction. This is a handy class as it only needs to be instantiated to record the time some functions take. 