### PR TITLE
Refactor ci-build.sh script.

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -33,13 +33,10 @@ jobs:
 
     - name: Build (Ubuntu 20.04)
       run: |
-        sudo cp -rf . /p4c/
-        (cd /p4c/ && sudo -E tools/ci-build.sh)
+       tools/ci-build.sh
 
     - name: Run cpplint.
       run: make cpplint -C build
-      working-directory: /p4c
 
     - name: Run clang-format.
       run: make clang-format -C build
-      working-directory: /p4c

--- a/.github/workflows/ci-p4tools.yml
+++ b/.github/workflows/ci-p4tools.yml
@@ -35,10 +35,9 @@ jobs:
 
     - name: Build (Ubuntu 20.04)
       run: |
-        sudo cp -rf . /p4c/
-        (cd /p4c/ && sudo -E tools/ci-build.sh)
-        sudo cp -rf /p4c/.ccache .
+        tools/ci-build.sh
 
     - name: Run tests (Ubuntu 20.04)
+      # Need to use sudo for the eBPF kernel tests.
       run: sudo -E ctest -R testgen- --output-on-failure --schedule-random
-      working-directory: /p4c/build
+      working-directory: ./build

--- a/.github/workflows/ci-ptf.yml
+++ b/.github/workflows/ci-ptf.yml
@@ -50,10 +50,8 @@ jobs:
 
       - name: Build (Ubuntu 20.04)
         run: |
-          sudo cp -rf . /p4c/
-          (cd /p4c/ && sudo -E tools/ci-build.sh)
-          sudo cp -rf /p4c/.ccache .
+          tools/ci-build.sh
 
       - name: Run PTF tests for eBPF backend (Ubuntu 20.04)
         run: sudo -E ./test.sh
-        working-directory: /p4c/backends/ebpf/tests
+        working-directory: ./backends/ebpf/tests

--- a/.github/workflows/ci-static-build-test.yml
+++ b/.github/workflows/ci-static-build-test.yml
@@ -35,6 +35,4 @@ jobs:
 
     - name: Build (Ubuntu 20.04)
       run: |
-        sudo cp -rf . /p4c/
-        (cd /p4c/ && sudo -E tools/ci-build.sh)
-        sudo cp -rf /p4c/.ccache .
+        sudo -E tools/ci-build.sh

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -35,16 +35,16 @@ jobs:
 
     - name: Build (Ubuntu 22.04, GCC)
       run: |
-        sudo cp -rf . /p4c/
-        (cd /p4c/ && sudo -E tools/ci-build.sh)
-        sudo cp -rf /p4c/.ccache .
+        tools/ci-build.sh
 
     - name: Run tests (Ubuntu 22.04)
+      # Need to use sudo for the eBPF kernel tests.
       run: sudo -E ctest --output-on-failure --schedule-random
-      working-directory: /p4c/build
+      working-directory: ./build
 
   # Build with gcc and test p4c on Ubuntu 20.04.
   test-ubuntu20:
+    name: test-ubuntu20 (Unified ${{ matrix.unified }})
     strategy:
       fail-fast: false
       matrix:
@@ -68,13 +68,12 @@ jobs:
 
     - name: Build (Ubuntu 20.04, GCC)
       run: |
-        sudo cp -rf . /p4c/
-        (cd /p4c/ && sudo -E tools/ci-build.sh)
-        sudo cp -rf /p4c/.ccache .
+        tools/ci-build.sh
 
     - name: Run tests (Ubuntu 20.04)
+      # Need to use sudo for the eBPF kernel tests.
       run: sudo -E ctest --output-on-failure --schedule-random
-      working-directory: /p4c/build
+      working-directory: ./build
       if: matrix.unified == 'ON'
 
   # Build with clang and test p4c on Ubuntu 20.04.
@@ -104,13 +103,12 @@ jobs:
 
     - name: Build (Ubuntu 20.04, Clang, Sanitizers)
       run: |
-        sudo cp -rf . /p4c/
-        (cd /p4c/ && sudo -E tools/ci-build.sh)
-        sudo cp -rf /p4c/.ccache .
+        tools/ci-build.sh
 
     - name: Run tests (Ubuntu 20.04)
+      # Need to use sudo for the eBPF kernel tests.
       run: sudo -E ctest --output-on-failure --schedule-random
-      working-directory: /p4c/build
+      working-directory: ./build
 
   # Build with gcc and test p4c on Ubuntu 18.04.
   test-ubuntu18:
@@ -178,7 +176,8 @@ jobs:
 
 
     - name: Run p4c tests (Fedora Linux)
-      run: ctest --output-on-failure --schedule-random
+      # Need to use sudo for the eBPF kernel tests.
+      run: sudo -E ctest --output-on-failure --schedule-random
       working-directory: ./build
 
   # Build and test p4c on MacOS 11

--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -35,10 +35,8 @@ jobs:
 
     - name: Build (Ubuntu 20.04)
       run: |
-        sudo cp -rf . /p4c/
-        (cd /p4c/ && sudo -E tools/ci-build.sh)
-        sudo cp -rf /p4c/.ccache .
+        tools/ci-build.sh
 
     - name: Validate
-      run: sudo -E ctest  -R toz3-validate-p4c --output-on-failure --schedule-random
-      working-directory: /p4c/build
+      run: ctest -R toz3-validate-p4c --output-on-failure --schedule-random
+      working-directory: ./build

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ LABEL maintainer="P4 Developers <p4-dev@lists.p4.org>"
 # building locally or you know there are more cores available, you may want to
 # override this.
 ARG MAKEFLAGS=-j2
-
+# Useful environment variable for scripts.
+ARG IN_DOCKER=TRUE
 # Select the type of image we're building. Use `build` for a normal build, which
 # is optimized for image size. Use `test` if this image will be used for
 # testing; in this case, the source code and build-only dependencies will not be

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -5,6 +5,9 @@
 set -e  # Exit on error.
 set -x  # Make command execution verbose
 
+THIS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+P4C_DIR=$(readlink -f ${THIS_DIR}/..)
+
 # Default to using 2 make jobs, which is a good default for CI. If you're
 # building locally or you know there are more cores available, you may want to
 # override this.
@@ -72,6 +75,13 @@ P4C_EBPF_DEPS="libpcap-dev \
                iptables \
                net-tools"
 
+# In Docker builds, sudo is not available. So make it a noop.
+if [ "$IN_DOCKER" == "TRUE" ]; then
+  echo "Executing within docker container."
+  function sudo() { command "$@"; }
+fi
+
+# TODO: Remove this check once 18.04 is deprecated.
 if [[ "${DISTRIB_RELEASE}" == "18.04" ]] ; then
   P4C_RUNTIME_DEPS_BOOST="libboost-graph1.65.1 libboost-iostreams1.65.1"
 else
@@ -92,36 +102,36 @@ P4C_PIP_PACKAGES="ipaddr \
                   scapy==2.4.5 \
                   clang-format>=15.0.4"
 
+
+# TODO: Remove this check once 18.04 is deprecated.
 if [[ "${DISTRIB_RELEASE}" == "18.04" ]] || [[ "$(which simple_switch 2> /dev/null)" != "" ]] ; then
   P4C_DEPS+=" libprotobuf-dev protobuf-compiler"
 else
-  apt-get update && apt-get install -y curl gnupg
-  echo "deb https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/ /" | tee /etc/apt/sources.list.d/home:p4lang.list
-  curl -L "https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/Release.key" | apt-key add -
+  sudo apt-get update && sudo apt-get install -y curl gnupg
+  echo "deb https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/ /" | sudo tee /etc/apt/sources.list.d/home:p4lang.list
+  curl -L "https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/Release.key" | sudo apt-key add -
   P4C_DEPS+=" p4lang-bmv2"
 fi
 
-apt-get update
-apt-get install -y --no-install-recommends \
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
   ${P4C_DEPS} \
   ${P4C_EBPF_DEPS} \
   ${P4C_RUNTIME_DEPS}
 
-ccache --set-config cache_dir=/p4c/.ccache
+if [[ "${DISTRIB_RELEASE}" == "18.04" ]] ; then
+  ccache --set-config cache_dir=.ccache
+fi
 ccache --set-config max_size=1G
 
-# we want to use Python as the default so change the symlinks
-ln -sf /usr/bin/python3 /usr/bin/python
-ln -sf /usr/bin/pip3 /usr/bin/pip
-
-pip3 install --upgrade pip
-pip3 install wheel
-pip3 install $P4C_PIP_PACKAGES
+sudo pip3 install --upgrade pip
+sudo pip3 install wheel
+sudo pip3 install $P4C_PIP_PACKAGES
 
 # Build libbpf for eBPF tests.
-cd /p4c
+pushd ${P4C_DIR}
 backends/ebpf/build_libbpf
-cd /p4c
+popd
 
 # ! ------  BEGIN PTF_EBPF -----------------------------------------------
 function install_ptf_ebpf_test_deps() (
@@ -134,26 +144,27 @@ function install_ptf_ebpf_test_deps() (
                            python3-six \
                            libgmp-dev \
                            libjansson-dev"
-  apt-get install -y --no-install-recommends ${P4C_PTF_PACKAGES}
+  sudo apt-get install -y --no-install-recommends ${P4C_PTF_PACKAGES}
 
-  if apt-cache show ${LINUX_TOOLS}; then
-    apt-get install -y --no-install-recommends ${LINUX_TOOLS}
+  if sudo apt-cache show ${LINUX_TOOLS}; then
+    sudo apt-get install -y --no-install-recommends ${LINUX_TOOLS}
   fi
 
   git clone --depth 1 --recursive --branch v0.3.0 https://github.com/NIKSS-vSwitch/nikss /tmp/nikss
-  cd /tmp/nikss
+  pushd /tmp/nikss
   ./build_libbpf.sh
   mkdir build
   cd build
   cmake -DCMAKE_BUILD_TYPE=Release ..
   make "-j$(nproc)"
-  make install
+  sudo make install
 
   # install bpftool
   git clone --recurse-submodules https://github.com/libbpf/bpftool.git /tmp/bpftool
   cd /tmp/bpftool/src
   make "-j$(nproc)"
-  make install
+  sudo make install
+  popd
 )
 # ! ------  END PTF_EBPF -----------------------------------------------
 
@@ -164,12 +175,12 @@ fi
 # ! ------  BEGIN VALIDATION -----------------------------------------------
 function build_gauntlet() {
   # For add-apt-repository.
-  apt-get install -y software-properties-common
+  sudo apt-get install -y software-properties-common
   # Symlink the toz3 extension for the p4 compiler.
-  mkdir -p /p4c/extensions
-  git clone -b stable https://github.com/p4gauntlet/toz3 /p4c/extensions/toz3
+  mkdir -p ${P4C_DIR}/extensions
+  git clone -b stable https://github.com/p4gauntlet/toz3 extensions/toz3
   # The interpreter requires boost filesystem for file management.
-  apt-get install -y libboost-filesystem-dev
+  sudo apt-get install -y libboost-filesystem-dev
   # Disable failures on crashes
   CMAKE_FLAGS+="-DVALIDATION_IGNORE_CRASHES=ON "
 }
@@ -184,18 +195,18 @@ fi
 # ! ------  BEGIN P4TESTGEN -----------------------------------------------
 function build_tools_deps() {
   # This is needed for P4Testgen.
-  apt-get install -y libboost-filesystem-dev libboost-system-dev wget zip
+  sudo apt-get install -y libboost-filesystem-dev libboost-system-dev wget zip
 
   # Install a recent version of Z3
   Z3_VERSION="z3-4.8.14"
   Z3_DIST="${Z3_VERSION}-x64-glibc-2.31"
 
-  cd /tmp
+  pushd /tmp
   wget https://github.com/Z3Prover/z3/releases/download/${Z3_VERSION}/${Z3_DIST}.zip
   unzip ${Z3_DIST}.zip
-  cp -r ${Z3_DIST}/bin/libz3.* /usr/local/lib/
-  cp -r ${Z3_DIST}/include/* /usr/local/include/
-  cd /p4c
+  sudo cp -r ${Z3_DIST}/bin/libz3.* /usr/local/lib/
+  sudo cp -r ${Z3_DIST}/include/* /usr/local/include/
+  popd
   rm -rf /tmp/${Z3_DIST}
 }
 # ! ------  END P4TESTGEN -----------------------------------------------
@@ -237,23 +248,24 @@ fi
 
 # Run CMake in the build folder.
 if [ -e build ]; then /bin/rm -rf build; fi
-mkdir -p build
-cd build
+mkdir -p ${P4C_DIR}/build
+cd ${P4C_DIR}/build
 cmake ${CMAKE_FLAGS} ..
 
 # If CMAKE_ONLY is active, only run CMake. Do not build.
 if [ "$CMAKE_ONLY" == "OFF" ]; then
   make
-  make install
+  sudo make install
   # Print ccache statistics after building
   ccache -p -s
 fi
 
 
 if [[ "${IMAGE_TYPE}" == "build" ]] ; then
-  apt-get purge -y ${P4C_DEPS} git
-  apt-get autoremove --purge -y
-  rm -rf /p4c /var/cache/apt/* /var/lib/apt/lists/*
+  cd ~
+  sudo apt-get purge -y ${P4C_DEPS} git
+  sudo apt-get autoremove --purge -y
+  rm -rf ${P4C_DIR} /var/cache/apt/* /var/lib/apt/lists/*
   echo 'Build image ready'
 
 elif [[ "${IMAGE_TYPE}" == "test" ]] ; then

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -5,7 +5,7 @@
 set -e  # Exit on error.
 set -x  # Make command execution verbose
 
-THIS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+THIS_DIR=$( cd -- "$( dirname -- "${0}" )" &> /dev/null && pwd )
 P4C_DIR=$(readlink -f ${THIS_DIR}/..)
 
 # Default to using 2 make jobs, which is a good default for CI. If you're


### PR DESCRIPTION
Refactor the `ci-build` script.
- Remove unnecessary `.ccache` copy calls from Github action scripts.
- Only use sudo calls in `ci-build` script where necessary. Gets the script one step closer to be run as a normal dependency install script.
- Add a check for building with Docker in `ci-build` script.