### PR TITLE
Use https with opensuse repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ A p4c package is available in the following repositories for Ubuntu 20.04 and ne
 
 ```bash
 . /etc/os-release
-echo "deb http://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/home:p4lang.list
-curl -L "http://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
+echo "deb https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/home:p4lang.list
+curl -L "https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
 sudo apt-get update
 sudo apt install p4lang-p4c
 ```
@@ -122,7 +122,7 @@ sudo apt install p4lang-p4c
 For Debian 11 (Bullseye) it can be installed as follows:
 
 ```bash
-echo 'deb http://download.opensuse.org/repositories/home:/p4lang/Debian_11/ /' | sudo tee /etc/apt/sources.list.d/home:p4lang.list
+echo 'deb https://download.opensuse.org/repositories/home:/p4lang/Debian_11/ /' | sudo tee /etc/apt/sources.list.d/home:p4lang.list
 curl -fsSL https://download.opensuse.org/repositories/home:p4lang/Debian_11/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_p4lang.gpg > /dev/null
 sudo apt update
 sudo apt install p4lang-p4c

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -96,8 +96,8 @@ if [[ "${DISTRIB_RELEASE}" == "18.04" ]] || [[ "$(which simple_switch 2> /dev/nu
   P4C_DEPS+=" libprotobuf-dev protobuf-compiler"
 else
   apt-get update && apt-get install -y curl gnupg
-  echo "deb http://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/ /" | tee /etc/apt/sources.list.d/home:p4lang.list
-  curl -L "http://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/Release.key" | apt-key add -
+  echo "deb https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/ /" | tee /etc/apt/sources.list.d/home:p4lang.list
+  curl -L "https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/Release.key" | apt-key add -
   P4C_DEPS+=" p4lang-bmv2"
 fi
 


### PR DESCRIPTION
This pull request updates the links to download.opensuse.org to use https instead of http. 