### PR TITLE
initialize direction metadata at begining of pipeline

### DIFF
--- a/backends/dpdk/dpdkMetadata.cpp
+++ b/backends/dpdk/dpdkMetadata.cpp
@@ -43,8 +43,8 @@ const IR::Node* DirectionToRegRead::preorder(IR::DpdkAsmProgram* p) {
     p->externDeclarations.push_back(addRegDeclInstance(registerInstanceName));
     if (is_direction_used) {
         IR::IndexedVector<IR::DpdkAsmStatement> stmts;
-        stmts.push_back(new IR::DpdkListStatement(replaceDirectionWithRegRead(
-            p->statements[0]->to<IR::DpdkListStatement>()->statements)));
+        stmts.push_back(new IR::DpdkListStatement(
+            addRegReadStmtForDirection(p->statements[0]->to<IR::DpdkListStatement>()->statements)));
         p->statements = stmts;
     }
     return p;
@@ -75,11 +75,13 @@ const IR::Node* DirectionToRegRead::preorder(IR::Member* m) {
         return m;
 }
 
-IR::IndexedVector<IR::DpdkAsmStatement> DirectionToRegRead::replaceDirectionWithRegRead(
+IR::IndexedVector<IR::DpdkAsmStatement> DirectionToRegRead::addRegReadStmtForDirection(
     IR::IndexedVector<IR::DpdkAsmStatement> stmts) {
     IR::IndexedVector<IR::DpdkAsmStatement> newStmts;
     newStmts.insert(newStmts.begin(), *stmts.begin());
-    // insert direction read after rx statement
+    // insert direction read after rx statement, we initialize direction so early in
+    // pipeline because we sure that it's not going to change after this and this direction
+    // is available to all the blocks.
     auto dirMeta = new IR::Member(new IR::PathExpression(IR::ID("m")),
                                   IR::ID("pna_main_input_metadata_direction"));
     auto inputPort = new IR::Member(new IR::PathExpression(IR::ID("m")),

--- a/backends/dpdk/dpdkMetadata.cpp
+++ b/backends/dpdk/dpdkMetadata.cpp
@@ -83,7 +83,7 @@ const IR::Node* DirectionToRegRead::postorder(IR::DpdkAction* a) {
 // replace direction field uses with register read i.e.
 // istd.direction = direction.read(istd.input_port)
 void DirectionToRegRead::replaceDirection(const IR::Member* m) {
-    if (isInitialized[m->member.name]) return;
+    // if (isInitialized[m->member.name]) return;
     auto inputPort =
         new IR::Member(new IR::PathExpression(IR::ID("m")), IR::ID(dirToInput[m->member.name]));
 

--- a/backends/dpdk/dpdkMetadata.h
+++ b/backends/dpdk/dpdkMetadata.h
@@ -39,8 +39,7 @@ class IsDirectionMetadataUsed : public Inspector {
 
 // This pass adds decl instance of Register extern in dpdk pna program which will
 // be used by dpdk backend for initializing the mask for calculating packet direction
-// and all the use point of istd.direction will follow below calculation and assignment
-// istd.direction = direction.read(istd.input_port)
+// at beginning of pipeline
 class DirectionToRegRead : public Transform {
     ordered_map<cstring, cstring> dirToDirMapping;
     ordered_map<cstring, cstring> inputToInputPortMapping;
@@ -49,10 +48,9 @@ class DirectionToRegRead : public Transform {
 
  public:
     DirectionToRegRead() {
-        // direction to input metadata field name mapping
-        // but dpdk currently only uses pna_main_input_metadata_direction
+        // dpdk currently only uses pna_main_input_metadata_direction
         // and pna_main_input_metadata_input_port
-        // so even when we have uses anyother other direction or input port metadata we
+        // so even when we use any other direction or input port metadata we
         // replace it like below
         dirToDirMapping.insert(std::make_pair(cstring("pna_main_input_metadata_direction"),
                                               cstring("pna_main_input_metadata_direction")));
@@ -60,7 +58,6 @@ class DirectionToRegRead : public Transform {
                                               cstring("pna_main_input_metadata_direction")));
         dirToDirMapping.insert(std::make_pair(cstring("pna_main_parser_input_metadata_direction"),
                                               cstring("pna_main_input_metadata_direction")));
-
         inputToInputPortMapping.insert(
             std::make_pair(cstring("pna_main_input_metadata_input_port"),
                            cstring("pna_main_input_metadata_input_port")));

--- a/backends/dpdk/dpdkMetadata.h
+++ b/backends/dpdk/dpdkMetadata.h
@@ -74,7 +74,7 @@ class DirectionToRegRead : public Transform {
     void uniqueNames(IR::DpdkAsmProgram* p);
     IR::DpdkExternDeclaration* addRegDeclInstance(cstring instanceName);
     IR::DpdkListStatement* replaceDirection(IR::DpdkListStatement* l);
-    IR::IndexedVector<IR::DpdkAsmStatement> replaceDirectionWithRegRead(
+    IR::IndexedVector<IR::DpdkAsmStatement> addRegReadStmtForDirection(
         IR::IndexedVector<IR::DpdkAsmStatement> stmts);
 };
 

--- a/backends/dpdk/dpdkMetadata.h
+++ b/backends/dpdk/dpdkMetadata.h
@@ -17,44 +17,66 @@ limitations under the License.
 #ifndef BACKENDS_DPDK_DPDKMETADATA_H_
 #define BACKENDS_DPDK_DPDKMETADATA_H_
 
+#include "dpdkUtils.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "ir/ir.h"
 
 namespace DPDK {
+
+class IsDirectionMetadataUsed : public Inspector {
+    bool& is_direction_used;
+
+ public:
+    explicit IsDirectionMetadataUsed(bool& is_direction_used)
+        : is_direction_used(is_direction_used) {}
+    bool preorder(const IR::Member* m) override {
+        if (!is_direction_used && isDirection(m)) {
+            is_direction_used = true;
+        }
+        return false;
+    }
+};
 
 // This pass adds decl instance of Register extern in dpdk pna program which will
 // be used by dpdk backend for initializing the mask for calculating packet direction
 // and all the use point of istd.direction will follow below calculation and assignment
 // istd.direction = direction.read(istd.input_port)
 class DirectionToRegRead : public Transform {
-    ordered_map<cstring, cstring> dirToInput;
-    ordered_map<cstring, bool> isInitialized;
-    IR::IndexedVector<IR::DpdkAsmStatement> newStmts;
+    ordered_map<cstring, cstring> dirToDirMapping;
+    ordered_map<cstring, cstring> inputToInputPortMapping;
     ordered_set<cstring> usedNames;
     cstring registerInstanceName;
 
  public:
     DirectionToRegRead() {
         // direction to input metadata field name mapping
-        dirToInput.insert(std::make_pair(cstring("pna_main_input_metadata_direction"),
-                                         cstring("pna_main_input_metadata_input_port")));
-        dirToInput.insert(std::make_pair(cstring("pna_pre_input_metadata_direction"),
-                                         cstring("pna_pre_input_metadata_input_port")));
-        dirToInput.insert(std::make_pair(cstring("pna_main_parser_input_metadata_direction"),
-                                         cstring("pna_main_parser_input_metadata_input_port")));
-        isInitialized.insert(std::make_pair(cstring("pna_main_input_metadata_direction"), false));
-        isInitialized.insert(std::make_pair(cstring("pna_pre_input_metadata_direction"), false));
-        isInitialized.insert(
-            std::make_pair(cstring("pna_main_parser_input_metadata_direction"), false));
+        // but dpdk currently only uses pna_main_input_metadata_direction
+        // and pna_main_input_metadata_input_port
+        // so even when we have uses anyother other direction or input port metadata we
+        // replace it like below
+        dirToDirMapping.insert(std::make_pair(cstring("pna_main_input_metadata_direction"),
+                                              cstring("pna_main_input_metadata_direction")));
+        dirToDirMapping.insert(std::make_pair(cstring("pna_pre_input_metadata_direction"),
+                                              cstring("pna_main_input_metadata_direction")));
+        dirToDirMapping.insert(std::make_pair(cstring("pna_main_parser_input_metadata_direction"),
+                                              cstring("pna_main_input_metadata_direction")));
+
+        inputToInputPortMapping.insert(
+            std::make_pair(cstring("pna_main_input_metadata_input_port"),
+                           cstring("pna_main_input_metadata_input_port")));
+        inputToInputPortMapping.insert(
+            std::make_pair(cstring("pna_pre_input_metadata_direction"),
+                           cstring("pna_main_input_metadata_input_port")));
+        inputToInputPortMapping.insert(
+            std::make_pair(cstring("pna_main_parser_input_metadata_direction"),
+                           cstring("pna_main_input_metadata_input_port")));
     }
     const IR::Node* preorder(IR::DpdkAsmProgram* p) override;
-    const IR::Node* postorder(IR::DpdkAction* l) override;
+    const IR::Node* preorder(IR::Member* m) override;
 
     void uniqueNames(IR::DpdkAsmProgram* p);
     IR::DpdkExternDeclaration* addRegDeclInstance(cstring instanceName);
-    bool isDirection(const IR::Member* m);
     IR::DpdkListStatement* replaceDirection(IR::DpdkListStatement* l);
-    void replaceDirection(const IR::Member* m);
     IR::IndexedVector<IR::DpdkAsmStatement> replaceDirectionWithRegRead(
         IR::IndexedVector<IR::DpdkAsmStatement> stmts);
 };

--- a/backends/dpdk/dpdkUtils.cpp
+++ b/backends/dpdk/dpdkUtils.cpp
@@ -69,4 +69,10 @@ bool isEightBitAligned(const IR::Expression* e) {
     return true;
 }
 
+bool isDirection(const IR::Member* m) {
+    if (m == nullptr) return false;
+    return m->member.name == "pna_main_input_metadata_direction" ||
+           m->member.name == "pna_pre_input_metadata_direction" ||
+           m->member.name == "pna_main_parser_input_metadata_direction";
+}
 }  // namespace DPDK

--- a/backends/dpdk/dpdkUtils.h
+++ b/backends/dpdk/dpdkUtils.h
@@ -26,5 +26,6 @@ bool isStandardMetadata(cstring name);
 bool isMetadataStruct(const IR::Type_Struct* st);
 bool isMetadataField(const IR::Expression* e);
 bool isEightBitAligned(const IR::Expression* e);
+bool isDirection(const IR::Member* m);
 }  // namespace DPDK
 #endif /* BACKENDS_DPDK_DPDKUTILS_H_ */

--- a/testdata/p4_16_samples_outputs/pna-direction-main-parser-err.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-direction-main-parser-err.p4.spec
@@ -23,11 +23,7 @@ struct next_hop_0_arg_t {
 }
 
 struct main_metadata_t {
-	bit<32> pna_pre_input_metadata_input_port
 	bit<16> pna_pre_input_metadata_parser_error
-	bit<32> pna_pre_input_metadata_direction
-	bit<32> pna_main_parser_input_metadata_direction
-	bit<32> pna_main_parser_input_metadata_input_port
 	bit<32> pna_main_input_metadata_direction
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> local_metadata_tmpDir
@@ -68,12 +64,12 @@ table ipv4_da_lpm {
 
 apply {
 	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	extract h.ethernet
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	regrd m.pna_main_parser_input_metadata_direction direction m.pna_main_parser_input_metadata_input_port
-	jmpneq LABEL_FALSE 0x0 m.pna_main_parser_input_metadata_direction
+	jmpneq LABEL_FALSE 0x0 m.pna_main_input_metadata_direction
 	mov m.MainParserT_parser_tmp_0 0x1
 	jmp LABEL_END
 	LABEL_FALSE :	mov m.MainParserT_parser_tmp_0 0x0
@@ -84,13 +80,11 @@ apply {
 	jmp MAINPARSERIMPL_ACCEPT
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_NOMATCH :	mov m.pna_pre_input_metadata_parser_error 0x2
-	MAINPARSERIMPL_ACCEPT :	regrd m.pna_pre_input_metadata_direction direction m.pna_pre_input_metadata_input_port
-	jmpneq LABEL_FALSE_0 0x0 m.pna_pre_input_metadata_direction
+	MAINPARSERIMPL_ACCEPT :	jmpneq LABEL_FALSE_0 0x0 m.pna_main_input_metadata_direction
 	mov m.local_metadata_tmpDir h.ipv4.srcAddr
 	jmp LABEL_END_1
 	LABEL_FALSE_0 :	mov m.local_metadata_tmpDir h.ipv4.dstAddr
-	LABEL_END_1 :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
-	jmpneq LABEL_FALSE_1 0x0 m.pna_main_input_metadata_direction
+	LABEL_END_1 :	jmpneq LABEL_FALSE_1 0x0 m.pna_main_input_metadata_direction
 	mov m.MainControlT_tmpDir h.ipv4.srcAddr
 	jmp LABEL_END_2
 	LABEL_FALSE_1 :	mov m.MainControlT_tmpDir h.ipv4.dstAddr

--- a/testdata/p4_16_samples_outputs/pna-direction.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-direction.p4.spec
@@ -23,8 +23,6 @@ struct next_hop_arg_t {
 }
 
 struct main_metadata_t {
-	bit<32> pna_pre_input_metadata_input_port
-	bit<32> pna_pre_input_metadata_direction
 	bit<32> pna_main_input_metadata_direction
 	bit<32> pna_main_input_metadata_input_port
 	bit<32> local_metadata_tmpDir
@@ -64,22 +62,20 @@ table ipv4_da_lpm {
 
 apply {
 	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	extract h.ethernet
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	MAINPARSERIMPL_ACCEPT :	regrd m.pna_pre_input_metadata_direction direction m.pna_pre_input_metadata_input_port
-	jmpneq LABEL_TRUE m.pna_pre_input_metadata_direction 0x0
+	MAINPARSERIMPL_ACCEPT :	jmpneq LABEL_TRUE m.pna_main_input_metadata_direction 0x0
 	mov m.local_metadata_b 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.local_metadata_b 0x1
-	LABEL_END :	regrd m.pna_pre_input_metadata_direction direction m.pna_pre_input_metadata_input_port
-	jmpneq LABEL_FALSE_0 0x0 m.pna_pre_input_metadata_direction
+	LABEL_END :	jmpneq LABEL_FALSE_0 0x0 m.pna_main_input_metadata_direction
 	mov m.local_metadata_tmpDir h.ipv4.srcAddr
 	jmp LABEL_END_0
 	LABEL_FALSE_0 :	mov m.local_metadata_tmpDir h.ipv4.dstAddr
-	LABEL_END_0 :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
-	jmpneq LABEL_FALSE_1 0x0 m.pna_main_input_metadata_direction
+	LABEL_END_0 :	jmpneq LABEL_FALSE_1 0x0 m.pna_main_input_metadata_direction
 	mov m.MainControlT_tmpDir h.ipv4.srcAddr
 	jmp LABEL_END_1
 	LABEL_FALSE_1 :	mov m.MainControlT_tmpDir h.ipv4.dstAddr

--- a/testdata/p4_16_samples_outputs/pna-direction.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-direction.p4.spec
@@ -73,7 +73,8 @@ apply {
 	mov m.local_metadata_b 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.local_metadata_b 0x1
-	LABEL_END :	jmpneq LABEL_FALSE_0 0x0 m.pna_pre_input_metadata_direction
+	LABEL_END :	regrd m.pna_pre_input_metadata_direction direction m.pna_pre_input_metadata_input_port
+	jmpneq LABEL_FALSE_0 0x0 m.pna_pre_input_metadata_direction
 	mov m.local_metadata_tmpDir h.ipv4.srcAddr
 	jmp LABEL_END_0
 	LABEL_FALSE_0 :	mov m.local_metadata_tmpDir h.ipv4.dstAddr

--- a/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk.p4.spec
@@ -71,12 +71,12 @@ table ipv4_da_lpm {
 
 apply {
 	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	extract h.ethernet
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
-	MAINPARSERIMPL_ACCEPT :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
-	jmpneq LABEL_FALSE 0x0 m.pna_main_input_metadata_direction
+	MAINPARSERIMPL_ACCEPT :	jmpneq LABEL_FALSE 0x0 m.pna_main_input_metadata_direction
 	mov m.MainControlT_tmpDir h.ipv4.srcAddr
 	jmp LABEL_END
 	LABEL_FALSE :	mov m.MainControlT_tmpDir h.ipv4.dstAddr

--- a/testdata/p4_16_samples_outputs/pna-example-SelectByDirection.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-SelectByDirection.p4.spec
@@ -60,12 +60,12 @@ table ipv4_da_lpm {
 
 apply {
 	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	extract h.ethernet
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
-	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	jmpeq LABEL_TRUE_0 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_key h.ipv4.dstAddr
 	jmp LABEL_END_0

--- a/testdata/p4_16_samples_outputs/pna-example-SelectByDirection1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-SelectByDirection1.p4.spec
@@ -60,12 +60,12 @@ table ipv4_da_lpm {
 
 apply {
 	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	extract h.ethernet
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
-	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	jmpeq LABEL_TRUE_0 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_tmp h.ipv4.dstAddr
 	jmp LABEL_END_0

--- a/testdata/p4_16_samples_outputs/pna-example-SelectByDirection2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-SelectByDirection2.p4.spec
@@ -61,12 +61,12 @@ table ipv4_da_lpm {
 
 apply {
 	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	extract h.ethernet
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
-	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	jmpeq LABEL_TRUE_0 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_addr h.ipv4.dstAddr
 	jmp LABEL_END_0

--- a/testdata/p4_16_samples_outputs/pna-example-pass-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-pass-2.p4.spec
@@ -65,12 +65,12 @@ table ipv4_da_lpm {
 
 apply {
 	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	extract h.ethernet
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
-	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	jmpeq LABEL_TRUE_0 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_tmp h.ipv4.dstAddr
 	jmp LABEL_END_0

--- a/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.spec
@@ -138,6 +138,7 @@ learner ct_tcp_table {
 
 apply {
 	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	extract h.eth
 	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.eth.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
@@ -147,30 +148,25 @@ apply {
 	MAINPARSERIMPL_PARSE_TCP :	extract h.tcp
 	MAINPARSERIMPL_ACCEPT :	mov m.MainControlT_do_add_on_miss 0
 	mov m.MainControlT_update_expire_time 0
-	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	jmpneq LABEL_END m.pna_main_input_metadata_direction 0x1
 	jmpnv LABEL_END h.ipv4
 	jmpnv LABEL_END h.tcp
 	table set_ct_options
 	LABEL_END :	jmpnv LABEL_END_0 h.ipv4
 	jmpnv LABEL_END_0 h.tcp
-	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	jmpeq LABEL_TRUE_1 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_key h.ipv4.dstAddr
 	jmp LABEL_END_1
 	LABEL_TRUE_1 :	mov m.MainControlT_key h.ipv4.srcAddr
-	LABEL_END_1 :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
-	jmpeq LABEL_TRUE_2 m.pna_main_input_metadata_direction 0x0
+	LABEL_END_1 :	jmpeq LABEL_TRUE_2 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_key_0 h.ipv4.srcAddr
 	jmp LABEL_END_2
 	LABEL_TRUE_2 :	mov m.MainControlT_key_0 h.ipv4.dstAddr
-	LABEL_END_2 :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
-	jmpeq LABEL_TRUE_3 m.pna_main_input_metadata_direction 0x0
+	LABEL_END_2 :	jmpeq LABEL_TRUE_3 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_key_1 h.tcp.dstPort
 	jmp LABEL_END_3
 	LABEL_TRUE_3 :	mov m.MainControlT_key_1 h.tcp.srcPort
-	LABEL_END_3 :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
-	jmpeq LABEL_TRUE_4 m.pna_main_input_metadata_direction 0x0
+	LABEL_END_3 :	jmpeq LABEL_TRUE_4 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_key_2 h.tcp.srcPort
 	jmp LABEL_END_4
 	LABEL_TRUE_4 :	mov m.MainControlT_key_2 h.tcp.dstPort

--- a/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.spec
@@ -154,19 +154,23 @@ apply {
 	table set_ct_options
 	LABEL_END :	jmpnv LABEL_END_0 h.ipv4
 	jmpnv LABEL_END_0 h.tcp
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	jmpeq LABEL_TRUE_1 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_key h.ipv4.dstAddr
 	jmp LABEL_END_1
 	LABEL_TRUE_1 :	mov m.MainControlT_key h.ipv4.srcAddr
-	LABEL_END_1 :	jmpeq LABEL_TRUE_2 m.pna_main_input_metadata_direction 0x0
+	LABEL_END_1 :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
+	jmpeq LABEL_TRUE_2 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_key_0 h.ipv4.srcAddr
 	jmp LABEL_END_2
 	LABEL_TRUE_2 :	mov m.MainControlT_key_0 h.ipv4.dstAddr
-	LABEL_END_2 :	jmpeq LABEL_TRUE_3 m.pna_main_input_metadata_direction 0x0
+	LABEL_END_2 :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
+	jmpeq LABEL_TRUE_3 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_key_1 h.tcp.dstPort
 	jmp LABEL_END_3
 	LABEL_TRUE_3 :	mov m.MainControlT_key_1 h.tcp.srcPort
-	LABEL_END_3 :	jmpeq LABEL_TRUE_4 m.pna_main_input_metadata_direction 0x0
+	LABEL_END_3 :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
+	jmpeq LABEL_TRUE_4 m.pna_main_input_metadata_direction 0x0
 	mov m.MainControlT_key_2 h.tcp.srcPort
 	jmp LABEL_END_4
 	LABEL_TRUE_4 :	mov m.MainControlT_key_2 h.tcp.dstPort

--- a/testdata/p4_16_samples_outputs/pna-example-tunnel.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-tunnel.p4.spec
@@ -94,12 +94,12 @@ table tunnel_encap_set_tunnel_encap {
 
 apply {
 	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	extract h.outer_ethernet
 	jmpeq PACKET_PARSER_PARSE_IPV4_OTR h.outer_ethernet.ether_type 0x800
 	jmp PACKET_PARSER_ACCEPT
 	PACKET_PARSER_PARSE_IPV4_OTR :	extract h.outer_ipv4
-	PACKET_PARSER_ACCEPT :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
-	jmpneq LABEL_FALSE m.pna_main_input_metadata_direction 0x0
+	PACKET_PARSER_ACCEPT :	jmpneq LABEL_FALSE m.pna_main_input_metadata_direction 0x0
 	mov m.main_control_tunnel_decap_ipv4_tunnel_term_table_outer_ipv41 h.outer_ipv4.src_addr
 	mov m.main_control_tunnel_decap_ipv4_tunnel_term_table_outer_ipv42 h.outer_ipv4.dst_addr
 	mov m.main_control_tunnel_decap_ipv4_tunnel_term_table_local_meta3 m.local_metadata__tunnel_tun_type3

--- a/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk.p4.spec
@@ -71,12 +71,12 @@ table ipv4_da_lpm {
 
 apply {
 	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
 	extract h.ethernet
 	jmpeq MAINPARSERIMPL_PARSE_IPV4_DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD0 h.ethernet.etherType 0x800
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4_DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD0 :	extract h.ipv4
-	MAINPARSERIMPL_ACCEPT :	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
-	jmpneq LABEL_FALSE 0x0 m.pna_main_input_metadata_direction
+	MAINPARSERIMPL_ACCEPT :	jmpneq LABEL_FALSE 0x0 m.pna_main_input_metadata_direction
 	mov m.MainControlT_tmpDir h.ipv4.srcAddr
 	jmp LABEL_END
 	LABEL_FALSE :	mov m.MainControlT_tmpDir h.ipv4.dstAddr


### PR DESCRIPTION
Read direction only once in a pipeline and input port and direction is same throughout

