### PR TITLE
Handle spaces in preprocessor options

### DIFF
--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -71,7 +71,7 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
     registerOption(
         "-D", "arg=value",
         [this](const char* arg) {
-            preprocessor_options += std::string(" -D") + arg;
+            preprocessor_options += std::string(" -D=\"") + arg + std::string("\"");
             return true;
         },
         "Define macro (passed to preprocessor)");

--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -117,8 +117,8 @@ class BackendDriver:
 
         # append to the list of defines
         for d in opts.preprocessor_defines:
-            self.add_command_option('preprocessor', "-D"+d)
-            self.add_command_option('compiler', "-D"+d)
+            self.add_command_option('preprocessor', "-D'{}'".format(d))
+            self.add_command_option('compiler', "-D'{}'".format(d))
 
         # Preserve comments: -C
         # Unix and std C keywords should be allowed in P4 (-undef and -nostdinc)


### PR DESCRIPTION
This pull request encloses the value specified with the `-D` option into quotes to allow the use of white-spaces.

Fixes: #3772
