### PR TITLE
Fix IndexedVector methods and constructor

### DIFF
--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -80,9 +80,7 @@ class IndexedVector : public Vector<T> {
     explicit IndexedVector(const safe_vector<const T*>& a) {
         insert(Vector<T>::end(), a.begin(), a.end());
     }
-    explicit IndexedVector(const Vector<T>& a) {
-        insert(Vector<T>::end(), a.begin(), a.end());
-    }
+    explicit IndexedVector(const Vector<T>& a) { insert(Vector<T>::end(), a.begin(), a.end()); }
     explicit IndexedVector(JSONLoader& json);
 
     void clear() {

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -137,7 +137,7 @@ class IndexedVector : public Vector<T> {
     template <class... Args>
     void emplace_back(Args&&... args) {
         auto el = new T(std::forward<Args>(args)...);
-        insert(el);
+        push_back(el);
     }
     bool removeByName(cstring name) {
         for (auto it = begin(); it != end(); ++it) {

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -78,10 +78,10 @@ class IndexedVector : public Vector<T> {
     IndexedVector& operator=(IndexedVector&&) = default;
     explicit IndexedVector(const T* a) { push_back(std::move(a)); }
     explicit IndexedVector(const safe_vector<const T*>& a) {
-        insert(typename Vector<T>::end(), a.begin(), a.end());
+        insert(Vector<T>::end(), a.begin(), a.end());
     }
     explicit IndexedVector(const Vector<T>& a) {
-        insert(typename Vector<T>::end(), a.begin(), a.end());
+        insert(Vector<T>::end(), a.begin(), a.end());
     }
     explicit IndexedVector(JSONLoader& json);
 
@@ -162,10 +162,10 @@ class IndexedVector : public Vector<T> {
         insertInMap(a);
     }
     void pop_back() {
-        if (typename Vector<T>::empty()) BUG("pop_back from empty IndexedVector");
-        auto last = typename Vector<T>::back();
+        if (Vector<T>::empty()) BUG("pop_back from empty IndexedVector");
+        auto last = Vector<T>::back();
         removeFromMap(last);
-        typename Vector<T>::pop_back();
+        Vector<T>::pop_back();
     }
     template <class U>
     void push_back(U& a) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/expr_uses_test.cpp
   gtest/format_test.cpp
   gtest/helpers.cpp
+  gtest/indexed_vector.cpp
   gtest/json_test.cpp
   gtest/midend_test.cpp
   gtest/opeq_test.cpp

--- a/test/gtest/indexed_vector.cpp
+++ b/test/gtest/indexed_vector.cpp
@@ -1,0 +1,96 @@
+#include "gtest/gtest.h"
+#include "ir/indexed_vector.h"
+#include "ir/ir.h"
+
+namespace Test {
+
+using namespace IR;
+
+using TestVector = IndexedVector<StructField>;
+
+const Type* testType() { return Type_Bits::get(8); }
+StructField* testItem(cstring val) { return new StructField(ID(val), testType()); }
+
+TEST(IndexedVector, basics) {
+    TestVector vec;
+    EXPECT_TRUE(vec.empty());
+    EXPECT_EQ(vec.size(), 0u);
+
+    vec.emplace_back(ID("foo"), testType());
+    EXPECT_FALSE(vec.empty());
+    EXPECT_EQ(vec.size(), 1u);
+    EXPECT_EQ(vec[0]->name.name, "foo");
+
+    vec.push_back(testItem("bar"));
+    EXPECT_FALSE(vec.empty());
+    EXPECT_EQ(vec.size(), 2u);
+    EXPECT_EQ(vec[1]->name.name, "bar");
+
+    cstring check = "foo";
+    for (auto *dec : vec) {
+        EXPECT_EQ(dec->name.name, check);
+        check = "bar";
+    }
+
+    vec.pop_back();
+    EXPECT_FALSE(vec.empty());
+    EXPECT_EQ(vec.size(), 1u);
+    EXPECT_EQ(vec[0]->name.name, "foo");
+
+    vec.removeByName("foo");
+    EXPECT_TRUE(vec.empty());
+    EXPECT_EQ(vec.size(), 0u);
+}
+
+TEST(IndexedVector, copy_ctor) {
+    TestVector vec;
+    TestVector vec2(vec);
+    EXPECT_TRUE(vec.empty());
+    EXPECT_TRUE(vec2.empty());
+    vec2.emplace_back(ID("foo"), testType());
+    EXPECT_TRUE(vec.empty());
+    EXPECT_FALSE(vec2.empty());
+
+    TestVector vec3(vec2);
+    EXPECT_FALSE(vec2.empty());
+    EXPECT_FALSE(vec3.empty());
+    EXPECT_EQ(vec3.back()->name.name, "foo");
+}
+
+TEST(IndexedVector, move_ctor) {
+    TestVector vec;
+    TestVector vec2(std::move(vec));
+    EXPECT_TRUE(vec.empty());
+    EXPECT_TRUE(vec2.empty());
+    vec2.push_back(testItem("foo"));
+    EXPECT_TRUE(vec.empty());
+    EXPECT_FALSE(vec2.empty());
+
+    TestVector vec3(std::move(vec2));
+    EXPECT_TRUE(vec2.empty());
+    EXPECT_FALSE(vec3.empty());
+    EXPECT_EQ(vec3.back()->name.name, "foo");
+}
+
+TEST(IndexedVector, ilist_ctor) {
+    TestVector vec{testItem("foo"), testItem("bar")};
+    EXPECT_EQ(vec.size(), 2u);
+    EXPECT_EQ(vec[0]->name.name, "foo");
+    EXPECT_EQ(vec[1]->name.name, "bar");
+}
+
+TEST(IndexedVector, save_vector_ctor) {
+    TestVector vec(safe_vector<const StructField *>{testItem("foo"), testItem("bar")});
+    EXPECT_EQ(vec.size(), 2u);
+    EXPECT_EQ(vec[0]->name.name, "foo");
+    EXPECT_EQ(vec[1]->name.name, "bar");
+}
+
+TEST(IndexedVector, Vector_ctor) {
+    TestVector vec(Vector<StructField>{testItem("foo"), testItem("bar")});
+    EXPECT_EQ(vec.size(), 2u);
+    EXPECT_EQ(vec[0]->name.name, "foo");
+    EXPECT_EQ(vec[1]->name.name, "bar");
+}
+
+}  // namespace Test


### PR DESCRIPTION
This fixes `IndexedVector::pop_back` and a constructor from `safe_vector`. These do not compile if instantiated, therefore it is not possible to call `pop_back` on `IndexedVector`. This is required for a bugfix in the Intel Tofino P4 compiler.