### PR TITLE
Make ports an int32 type for the Protobuf BMv2 back end.

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
@@ -293,13 +293,13 @@ traces: "{{trace_item}}"
 
 input_packet {
   packet: "{{send.pkt}}"
-  port: "{{send.ig_port}}"
+  port: {{send.ig_port}}
 }
 
 ## if verify
 expected_output_packet {
   packet: "{{verify.exp_pkt}}"
-  port: "{{verify.eg_port}}"
+  port: {{verify.eg_port}}
   packet_mask: "{{verify.ignore_mask}}"
 }
 ## endif

--- a/backends/p4tools/modules/testgen/targets/bmv2/proto/p4testgen.proto
+++ b/backends/p4tools/modules/testgen/targets/bmv2/proto/p4testgen.proto
@@ -9,14 +9,14 @@ message InputPacketAtPort {
     // The raw bytes of the test packet.
     bytes packet = 1;
     // The raw bytes of the port associated with the packet.
-    bytes port = 2;
+    int32 port = 2;
 }
 
 message OutputPacketAtPort {
     // The raw bytes of the test packet.
     bytes packet = 1;
     // The raw bytes of the port associated with the packet.
-    bytes port = 2;
+    int32 port = 2;
     // The don't care mask of the packet.
     bytes packet_mask = 3;
 }


### PR DESCRIPTION
Make the protobuf format consistent with the output. It is strange that protoc has not complained. Likely because all output port values are single digits which do not require formatting.

@kheradmandG In general, ports are a 9-bit type but they are represented as int32. If they ever expand to larger bit-widths we can change the format. 