### PR TITLE
Add stop metrics for P4Testgen. Sanitize some P4Testgen options.

### DIFF
--- a/backends/p4tools/common/lib/util.h
+++ b/backends/p4tools/common/lib/util.h
@@ -144,6 +144,24 @@ class Utils {
         std::advance(start, random);
         return start;
     }
+
+    /// Convert a container type (array, set, vector, etc.) into a well-formed [val1, val2, ...]
+    /// representation. This function is used for debugging output.
+    template <typename ContainerType>
+    static std::string containerToString(const ContainerType& container) {
+        std::stringstream stringStream;
+
+        stringStream << '[';
+        auto val = container.cbegin();
+        if (val != container.cend()) {
+            stringStream << *val++;
+            while (val != container.cend()) {
+                stringStream << ", " << *val++;
+            }
+        }
+        stringStream << ']';
+        return stringStream.str();
+    }
 };
 
 }  // namespace P4Tools

--- a/backends/p4tools/common/options.cpp
+++ b/backends/p4tools/common/options.cpp
@@ -123,47 +123,6 @@ AbstractP4cToolOptions::AbstractP4cToolOptions(cstring message) : Options(messag
         },
         "Prints version information and exits");
 
-    registerOption(
-        "--packet-size-range", "packetSizeRange",
-        [this](const char* arg) {
-            auto rangeStr = std::string(arg);
-            size_t packetLenStr = rangeStr.find_first_of(':');
-            try {
-                auto minPacketLenStr = rangeStr.substr(0, packetLenStr);
-                minPktSize = std::stoi(minPacketLenStr);
-                if (minPktSize < 0) {
-                    ::error(
-                        "Invalid minimum packet size %1%. Minimum packet size must be at least 0.",
-                        minPktSize);
-                }
-                auto maxPacketLenStr = rangeStr.substr(packetLenStr + 1);
-                maxPktSize = std::stoi(maxPacketLenStr);
-                if (maxPktSize < minPktSize) {
-                    ::error(
-                        "Invalid packet size range %1%:%2%.  The maximum packet size must be at "
-                        "least the size of the minimum packet size.",
-                        minPktSize, maxPktSize);
-                }
-            } catch (std::invalid_argument&) {
-                ::error(
-                    "Invalid packet size range %1%. Expected format is [min]:[max], where [min] "
-                    "and [max] are integers.",
-                    arg);
-                return false;
-            }
-            return true;
-        },
-        "Specify the possible range of the input packet size in bits. The format is [min]:[max]. "
-        "The default values are \"0:72000\". The maximum is set to jumbo frame size (9000 bytes).");
-
-    registerOption(
-        "--seed", "seed",
-        [this](const char* arg) {
-            seed = std::stoul(arg);
-            return true;
-        },
-        "Provides a randomization seed");
-
     // Inherit some compiler options, setting them up to be forwarded to the compiler.
     std::vector<InheritedCompilerOptionSpec> inheritedCompilerOptions = {
         {"-I", "path", "Adds the given path to the preprocessor include path", {}},
@@ -206,6 +165,14 @@ AbstractP4cToolOptions::AbstractP4cToolOptions(cstring message) : Options(messag
         {"--dump", "folder", "Folder where P4 programs are dumped.", {}},
         {"-v", nullptr, "Increase verbosity level (can be repeated)", {}},
     };
+
+    registerOption(
+        "--seed", "seed",
+        [this](const char* arg) {
+            seed = std::stoul(arg);
+            return true;
+        },
+        "Provides a randomization seed");
 
     for (const auto& optionSpec : inheritedCompilerOptions) {
         registerOption(

--- a/backends/p4tools/modules/testgen/README.md
+++ b/backends/p4tools/modules/testgen/README.md
@@ -1,6 +1,6 @@
 # P4Testgen - Generating Tests for P4 Targets
 
-The P4Testgen tool uses symbolic execution to automatically generate input-output tests for a given P4 program. P4Testgen attempts to generate a set of tests of all reachable paths within the program. Each test consists of an input packet, the control-plane commands to populate match-action tables, and a predicate on the output packet. Each generated test also has a human-readable trace that indicates the path through the program being exercised by that test.
+P4Testgen uses symbolic execution to automatically generate input-output tests for a given P4 program. P4Testgen attempts to generate a set of tests of all reachable paths within the program. Each test consists of an input packet, the control-plane commands to populate match-action tables, and a predicate on the output packet. Each generated test also has a human-readable trace that indicates the path through the program being exercised by that test.
 
 ## Directory Structure
 
@@ -20,40 +20,52 @@ testgen
 ## Usage
 The main binary can be found in `build/p4testgen`.
 
-To generate tests for a particular target and P4 architecture, run `p4testgen –target [TARGET] –arch [ARCH] –max-tests 10 –out-dir [OUT] prog.p4`
-`p4testgen` specifies that the p4testgen tool should be used. In the future, other tools may be supported, for example random program generation or translation validators.
+To generate 10 tests for a particular target and P4 architecture, run `p4testgen –target [TARGET] –arch [ARCH] –max-tests 10 –out-dir [OUT] prog.p4`
+`p4testgen` specifies that P4Testgen should be used. In the future, other tools may be supported, for example random program generation or translation validators.
 These are the current usage flags:
 
 ```
-./p4testgen: Generate packet tests for a P4 program
---help                     Shows this help message and exits
---version                  Prints version information and exits
---seed seed                Provides a randomization seed
--I path                    Adds the given path to the preprocessor include path
--D arg=value               Defines a preprocessor symbol
--U arg                     Undefines a preprocessor symbol
--E                         Preprocess only. Prints preprocessed program on stdout.
---nocpp                    Skips the preprocessor; assumes the input file is already preprocessed.
---std {p4-14|p4-16}        Specifies source language version.
--T loglevel                Adjusts logging level per file.
---target target            Specifies the device targeted by the program.
---arch arch                Specifies the architecture targeted by the program.
---top4 pass1[,pass2]       Dump the P4 representation after
-                           passes whose name contains one of `passX' substrings.
-                           When '-v' is used this will include the compiler IR.
---dump folder              Folder where P4 programs are dumped.
--v                         Increase verbosity level (can be repeated)
---input-packet-only        Only produce the input packet for each test
--- packet-size-range       Specify the possible range of the input packet size in bits. The format is [min]:[max]. The default values are "0:72000". The maximum is set to jumbo frame size (9000 bytes).
---max-tests maxTests       Sets the maximum number of tests to be generated
---out-dir outputDir        Directory for generated tests
---test-backend             Select a test back end. Available test back ends are defined by the respective target.
---packet-size packetSize   If enabled, sets all input packets to a fixed size in bits (from 1 to 12000 bits). 0 implies no packet sizing.
---exploration-strategy     Selects a specific exploration strategy for test generation. Options are: randomAccessStack, linearEnumeration, maxCoverage. Defaults to incrementalStack.
---pop-level                This is the fraction of unexploredBranches we select on randomAccessStack. Defaults to 3.
---linear-enumeration       Max bound for LinearEnumeration strategy. Defaults to 2. **Experimental feature**.
---saddle-point             To be used with randomAccessMaxCoverage. Specifies when to randomly explore the map after a saddle point in the coverage of the test generation.
---with-output-packet       Produced tests must have an output packet.
+./p4testgen: Generate packet tests for a P4 program.
+--help                                       Shows this help message and exits
+--version                                    Prints version information and exits
+--seed seed                                  Provides a randomization seed
+-I path                                      Adds the given path to the preprocessor include path
+--Wwarn diagnostic                           Report a warning for a compiler diagnostic, or treat all warnings as warnings (the default) if no diagnostic is specified.
+-D arg=value                                 Defines a preprocessor symbol
+-U arg                                       Undefines a preprocessor symbol
+-E                                           Preprocess only. Prints preprocessed program on stdout.
+--nocpp                                      Skips the preprocessor; assumes the input file is already preprocessed.
+--std {p4-14|p4-16}                          Specifies source language version.
+-T loglevel                                  Adjusts logging level per file.
+--target target                              Specifies the device targeted by the program.
+--arch arch                                  Specifies the architecture targeted by the program.
+--top4 pass1[,pass2]                         Dump the P4 representation after
+                                             passes whose name contains one of `passX' substrings.
+                                             When '-v' is used this will include the compiler IR.
+--dump folder                                Folder where P4 programs are dumped.
+-v                                           Increase verbosity level (can be repeated)
+--strict                                     Fail on unimplemented features instead of trying the next branch.
+--input-packet-only                          Only produce the input packet for each test.
+--max-tests maxTests                         Sets the maximum number of tests to be generated [default: 1]. Setting the value to 0 will generate tests until no more paths can be found.
+--stop-metric stopMetric                     Stops generating tests when a particular metric is satisifed. Currently supported options are:
+                                             "MAX_STATEMENT_COVERAGE".
+--packet-size-range packetSizeRange          Specify the possible range of the input packet size in bits. The format is [min]:[max]. The default values are "0:72000". The maximum is set to jumbo frame size (9000 bytes).
+--out-dir outputDir                          The output directory for the generated tests. The directory will be created, if it does not exist.
+--test-backend testBackend                   Select the test back end. P4Testgen will produce tests that correspond to the input format of this test back end.
+--input-branches selectedBranches            List of the selected branches which should be chosen for selection.
+--track-branches                             Track the branches that are chosen in the symbolic executor. This can be used for deterministic replay.
+--with-output-packet                         Produced tests must have an output packet.
+--exploration-strategy explorationStrategy   Selects a specific exploration strategy for test generation. Options are: INCREMENTAL_STACK, RANDOM_ACCESS_STACK, LINEAR_ENUMERATION, MAX_COVERAGE, and RANDOM_ACCESS_MAX_COVERAGE. Defaults to INCREMENTAL_STACK.
+--pop-level popLevel                         Sets the fraction for multiPop exploration; default is 3 when meaningful strategy is activated.
+--linear-enumeration linearEnumeration       Max bound for vector size in LINEAR_ENUMERATION; defaults to 2.
+--saddle-point saddlePoint                   Threshold to invoke multiPop on RANDOM_ACCESS_MAX_COVERAGE.
+--print-traces                               Print the associated traces and test information for each generated test.
+--print-steps                                Print the representation of each program node while the stepper steps through the program.
+--print-coverage                             Print detailed statement coverage statistics the interpreter collects while stepping through the program.
+--print-performance-report                   Print timing report summary at the end of the program.
+--dcg DCG                                    Build a DCG for input graph. This control flow graph directed cyclic graph can be used
+                                                     for statement reachability analysis.
+--pattern pattern                            List of the selected branches which should be chosen for selection.
 ```
 
 Once P4Testgen has generated tests, the tests can be executed by either the P4Runtime or STF test back ends.

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/linear_enumeration.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/linear_enumeration.cpp
@@ -55,8 +55,8 @@ void LinearEnumeration::run(const Callback& callback) {
 }
 
 LinearEnumeration::LinearEnumeration(AbstractSolver& solver, const ProgramInfo& programInfo,
-                                     boost::optional<uint32_t> seed, int linearEnumeration)
-    : ExplorationStrategy(solver, programInfo, seed), maxBound(linearEnumeration) {
+                                     boost::optional<uint32_t> seed, uint64_t maxBound)
+    : ExplorationStrategy(solver, programInfo, seed), maxBound(maxBound) {
     // The constructor populates the initial vector of branches holding a terminal state.
     // It fill the vector with a recursive call to mapBranch and stops at maxBound.
     StepResult initialSuccessors = step(*executionState);

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/linear_enumeration.h
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/linear_enumeration.h
@@ -28,7 +28,7 @@ class LinearEnumeration : public ExplorationStrategy {
 
     /// Constructor for this strategy, considering inheritance.
     LinearEnumeration(AbstractSolver& solver, const ProgramInfo& programInfo,
-                      boost::optional<uint32_t> seed, int linearEnumeration);
+                      boost::optional<uint32_t> seed, uint64_t maxBound);
 
  protected:
     /// The max size for the exploredBranches vector.

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/rnd_access_max_coverage.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/rnd_access_max_coverage.cpp
@@ -90,7 +90,7 @@ void RandomAccessMaxCoverage::run(const Callback& callback) {
                 bufferUnexploredBranches.erase(coverageKey);
                 next = chooseBranch(successors, guaranteeViability);
             } else {
-                // If we are stuck in a sadlle point for too long,
+                // If we are stuck in a saddle point for too long,
                 // trust in the lookahead and take the higher ranks.
                 if (coverageSaddleTrack.second >= (2 * saddlePoint)) {
                     // Empty unexploredBranches.
@@ -144,6 +144,7 @@ void RandomAccessMaxCoverage::run(const Callback& callback) {
 uint64_t RandomAccessMaxCoverage::getRandomUnexploredMapEntry() {
     // Collect all the keys and select a random one.
     std::vector<uint64_t> unexploredCoverageKeys;
+    unexploredCoverageKeys.reserve(bufferUnexploredBranches.size());
     for (auto const& unexplored : bufferUnexploredBranches) {
         unexploredCoverageKeys.push_back(unexplored.first);
     }
@@ -157,6 +158,7 @@ uint64_t RandomAccessMaxCoverage::getRandomUnexploredMapEntry() {
 void RandomAccessMaxCoverage::updateBufferRankings() {
     // Collect all the keys
     std::vector<uint64_t> unexploredCoverageKeys;
+    unexploredCoverageKeys.reserve(bufferUnexploredBranches.size());
     for (auto const& unexplored : bufferUnexploredBranches) {
         unexploredCoverageKeys.push_back(unexplored.first);
     }
@@ -169,12 +171,11 @@ void RandomAccessMaxCoverage::updateBufferRankings() {
 
 void RandomAccessMaxCoverage::sortBranchesByCoverage(std::vector<Branch>& branches) {
     // Transfers branches to rankedBranches and sorts them by coverage
-    for (uint64_t i = 0; i < branches.size(); i++) {
-        auto localBranch = branches.at(i);
+    for (const auto& localBranch : branches) {
         ExecutionState* branchState = localBranch.nextState;
         // Calculate coverage for each branch:
         uint64_t coverage = 0;
-        if (branchState) {
+        if (branchState != nullptr) {
             uint64_t lookAheadCoverage = 0;
             for (const auto& stmt : branchState->getVisited()) {
                 // We need to take into account the set of visitedStatements.
@@ -246,7 +247,7 @@ ExecutionState* RandomAccessMaxCoverage::chooseBranch(std::vector<Branch>& branc
             }
         }
         // Push the new set of branches if the remaining vector is not empty.
-        if (branches.size() > 0) {
+        if (!branches.empty()) {
             unexploredBranches.push_back(branches);
         }
 

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -282,7 +282,7 @@ void TestBackEnd::printPerformanceReport() {
     }
 }
 
-uint64_t TestBackEnd::getTestCount() const { return testCount; }
+int64_t TestBackEnd::getTestCount() const { return testCount; }
 
 }  // namespace P4Testgen
 

--- a/backends/p4tools/modules/testgen/lib/test_backend.h
+++ b/backends/p4tools/modules/testgen/lib/test_backend.h
@@ -23,6 +23,10 @@ namespace P4Tools {
 namespace P4Testgen {
 
 class TestBackEnd {
+ private:
+    /// The current test count. If it exceeds @var maxTests, the symbolic executor will stop.
+    uint64_t testCount = 0;
+
  protected:
     /// ProgramInfo is used to access some target specific information for test generation.
     const ProgramInfo& programInfo;
@@ -35,10 +39,7 @@ class TestBackEnd {
     ExplorationStrategy& symbex;
 
     /// Test maximum number of tests that are to be produced.
-    int maxTests;
-
-    /// The current test count. If it exceeds @var maxTests, the symbolic executor will stop.
-    int testCount = 0;
+    uint64_t maxTests;
 
     explicit TestBackEnd(const ProgramInfo& programInfo, ExplorationStrategy& symbex)
         : programInfo(programInfo), symbex(symbex), maxTests(TestgenOptions::get().maxTests) {
@@ -47,6 +48,8 @@ class TestBackEnd {
             maxTests = 1;
         }
     }
+
+    [[nodiscard]] bool needsToTerminate(uint64_t testCount) const { return testCount == maxTests; }
 
  public:
     TestBackEnd(const TestBackEnd&) = default;
@@ -92,7 +95,7 @@ class TestBackEnd {
     /// @returns false if the test generation is to be aborted (for example when the port is
     /// tainted.)
     virtual bool printTestInfo(const ExecutionState* executionState, const TestInfo& testInfo,
-                               int testCount, const IR::Expression* outputPortExpr);
+                               const IR::Expression* outputPortExpr);
 
     /// @returns a new modules with all concolic variables in the program resolved.
     const Model* computeConcolicVariables(const ExecutionState* executionState,
@@ -114,7 +117,7 @@ class TestBackEnd {
     static void printPerformanceReport();
 
     /// Accessors.
-    int getTestCount();
+    [[nodiscard]] uint64_t getTestCount() const;
 };
 
 }  // namespace P4Testgen

--- a/backends/p4tools/modules/testgen/lib/test_backend.h
+++ b/backends/p4tools/modules/testgen/lib/test_backend.h
@@ -25,7 +25,7 @@ namespace P4Testgen {
 class TestBackEnd {
  private:
     /// The current test count. If it exceeds @var maxTests, the symbolic executor will stop.
-    uint64_t testCount = 0;
+    int64_t testCount = 0;
 
  protected:
     /// ProgramInfo is used to access some target specific information for test generation.
@@ -39,7 +39,7 @@ class TestBackEnd {
     ExplorationStrategy& symbex;
 
     /// Test maximum number of tests that are to be produced.
-    uint64_t maxTests;
+    int64_t maxTests;
 
     explicit TestBackEnd(const ProgramInfo& programInfo, ExplorationStrategy& symbex)
         : programInfo(programInfo), symbex(symbex), maxTests(TestgenOptions::get().maxTests) {
@@ -49,7 +49,7 @@ class TestBackEnd {
         }
     }
 
-    [[nodiscard]] bool needsToTerminate(uint64_t testCount) const { return testCount == maxTests; }
+    [[nodiscard]] bool needsToTerminate(int64_t testCount) const { return testCount == maxTests; }
 
  public:
     TestBackEnd(const TestBackEnd&) = default;
@@ -117,7 +117,7 @@ class TestBackEnd {
     static void printPerformanceReport();
 
     /// Accessors.
-    [[nodiscard]] uint64_t getTestCount() const;
+    [[nodiscard]] int64_t getTestCount() const;
 };
 
 }  // namespace P4Testgen

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -218,13 +218,13 @@ TestgenOptions::TestgenOptions()
                 // Unfortunately, we can not use std::stoul because negative inputs are okay
                 // according to the C++ standard.
                 linearEnumerationTmp = std::stoll(arg);
-                if (linearEnumerationTmp < 0) {
-                    throw std::invalid_argument("Negative input.");
+                if (linearEnumerationTmp <= 1) {
+                    throw std::invalid_argument("Invalid input.");
                 }
             } catch (std::invalid_argument&) {
                 ::error(
-                    "Invalid input value %1% for --linear-enumeration. Expected positive "
-                    "integer.",
+                    "Invalid input value %1% for --linear-enumeration. Expected an integer greater "
+                    "than 1.",
                     arg);
                 return false;
             }
@@ -241,12 +241,14 @@ TestgenOptions::TestgenOptions()
                 // Unfortunately, we can not use std::stoul because negative inputs are okay
                 // according to the C++ standard.
                 saddlePointTmp = std::stoll(arg);
-                if (saddlePointTmp < 0) {
-                    throw std::invalid_argument("Negative input.");
+                if (saddlePointTmp <= 1) {
+                    throw std::invalid_argument("Invalid input.");
                 }
             } catch (std::invalid_argument&) {
-                ::error("Invalid input value %1% for --saddle-point. Expected positive integer.",
-                        arg);
+                ::error(
+                    "Invalid input value %1% for --saddle-point. Expected an integer greater than "
+                    "1.",
+                    arg);
                 return false;
             }
             saddlePoint = saddlePointTmp;

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -20,8 +20,13 @@ const char* TestgenOptions::getIncludePath() {
     P4C_UNIMPLEMENTED("getIncludePath not implemented for P4Testgen.");
 }
 
+const std::set<cstring> TestgenOptions::SUPPORTED_STOP_METRICS = {"MAX_STATEMENT_COVERAGE"};
+const std::set<cstring> TestgenOptions::SUPPORTED_EXPLORATION_STRATEGIES = {
+    "INCREMENTAL_STACK", "RANDOM_ACCESS_STACK", "LINEAR_ENUMERATION", "MAX_COVERAGE",
+    "RANDOM_ACCESS_MAX_COVERAGE"};
+
 TestgenOptions::TestgenOptions()
-    : AbstractP4cToolOptions("Generate packet tests for a P4 program") {
+    : AbstractP4cToolOptions("Generate packet tests for a P4 program.") {
     registerOption(
         "--strict", nullptr,
         [this](const char*) {
@@ -33,19 +38,65 @@ TestgenOptions::TestgenOptions()
     registerOption(
         "--max-tests", "maxTests",
         [this](const char* arg) {
-            maxTests = std::atoi(arg);
+            try {
+                maxTests = std::stoull(arg);
+            } catch (std::invalid_argument&) {
+                ::error("Invalid input value %1% for --max-tests. Expected integer.", arg);
+                return false;
+            }
             return true;
         },
-        "Sets the maximum number of tests to be generated");
+        "Sets the maximum number of tests to be generated [default: 1]. Setting the value to <=0 "
+        "will generate tests until no more paths can be found.");
 
     registerOption(
-        "--pop-level", "popLevel",
+        "--stop-metric", "stopMetric",
         [this](const char* arg) {
-            popLevel = std::atoi(arg);
+            stopMetric = cstring(arg).toUpper();
+            if (SUPPORTED_STOP_METRICS.count(stopMetric) == 0) {
+                ::error(
+                    "Stop metric %1% not supported. Supported stop metrics are "
+                    "%2%.",
+                    stopMetric, Utils::containerToString(SUPPORTED_STOP_METRICS));
+                return false;
+            }
             return true;
         },
-        "Sets the fraction for multiPop exploration; default is 3 when meaningful strategy is "
-        "activated.");
+        "Stops generating tests when a particular metric is satisifed. Currently supported options "
+        "are:\n\"MAX_STATEMENT_COVERAGE\".");
+
+    registerOption(
+        "--packet-size-range", "packetSizeRange",
+        [this](const char* arg) {
+            auto rangeStr = std::string(arg);
+            size_t packetLenStr = rangeStr.find_first_of(':');
+            try {
+                auto minPacketLenStr = rangeStr.substr(0, packetLenStr);
+                minPktSize = std::stoi(minPacketLenStr);
+                if (minPktSize < 0) {
+                    ::error(
+                        "Invalid minimum packet size %1%. Minimum packet size must be at least 0.",
+                        minPktSize);
+                }
+                auto maxPacketLenStr = rangeStr.substr(packetLenStr + 1);
+                maxPktSize = std::stoi(maxPacketLenStr);
+                if (maxPktSize < minPktSize) {
+                    ::error(
+                        "Invalid packet size range %1%:%2%.  The maximum packet size must be at "
+                        "least the size of the minimum packet size.",
+                        minPktSize, maxPktSize);
+                }
+            } catch (std::invalid_argument&) {
+                ::error(
+                    "Invalid packet size range %1%. Expected format is [min]:[max], where [min] "
+                    "and [max] are integers.",
+                    arg);
+                return false;
+            }
+            return true;
+        },
+        "Specify the possible range of the input packet size in bits. The format is [min]:[max]. "
+        "The default values are \"0:72000\". The maximum is set to jumbo frame size (9000 bytes).");
 
     registerOption(
         "--out-dir", "outputDir",
@@ -53,7 +104,8 @@ TestgenOptions::TestgenOptions()
             outputDir = arg;
             return true;
         },
-        "Directory for generated tests\n");
+        "The output directory for the generated tests. The directory will be created, if it does "
+        "not exist.");
 
     registerOption(
         "--test-backend", "testBackend",
@@ -113,27 +165,88 @@ TestgenOptions::TestgenOptions()
     registerOption(
         "--exploration-strategy", "explorationStrategy",
         [this](const char* arg) {
-            explorationStrategy = arg;
+            explorationStrategy = cstring(arg).toUpper();
+            if (SUPPORTED_EXPLORATION_STRATEGIES.count(explorationStrategy) == 0) {
+                ::error(
+                    "Exploration strategy %1% not supported. Supported exploration strategies are "
+                    "%2%.",
+                    explorationStrategy,
+                    Utils::containerToString(SUPPORTED_EXPLORATION_STRATEGIES));
+                return false;
+            }
             return true;
         },
         "Selects a specific exploration strategy for test generation. Options are: "
-        "randomAccessStack, linearEnumeration, maxCoverage. Defaults to incrementalStack.");
+        "INCREMENTAL_STACK, RANDOM_ACCESS_STACK, LINEAR_ENUMERATION, MAX_COVERAGE, and "
+        "RANDOM_ACCESS_MAX_COVERAGE. Defaults to "
+        "INCREMENTAL_STACK.");
+
+    registerOption(
+        "--pop-level", "popLevel",
+        [this](const char* arg) {
+            int64_t popLevelTmp = 0;
+            try {
+                // Unfortunately, we can not use std::stoul because negative inputs are okay
+                // according to the C++ standard.
+                popLevelTmp = std::stoll(arg);
+                if (popLevelTmp < 0) {
+                    throw std::invalid_argument("Negative input.");
+                }
+            } catch (std::invalid_argument&) {
+                ::error("Invalid input value %1% for --pop-level. Expected non-negative integer.",
+                        arg);
+                return false;
+            }
+            popLevel = popLevelTmp;
+            return true;
+        },
+        "Sets the fraction for multiPop exploration; default is 3 when meaningful strategy is "
+        "activated.");
 
     registerOption(
         "--linear-enumeration", "linearEnumeration",
         [this](const char* arg) {
-            linearEnumeration = std::atoi(arg);
+            int64_t linearEnumerationTmp = 0;
+            try {
+                // Unfortunately, we can not use std::stoul because negative inputs are okay
+                // according to the C++ standard.
+                linearEnumerationTmp = std::stoll(arg);
+                if (linearEnumerationTmp < 0) {
+                    throw std::invalid_argument("Negative input.");
+                }
+            } catch (std::invalid_argument&) {
+                ::error(
+                    "Invalid input value %1% for --linear-enumeration. Expected non-negative "
+                    "integer.",
+                    arg);
+                return false;
+            }
+            linearEnumeration = linearEnumerationTmp;
             return true;
         },
-        "Max bound for vector size in linearEnumeration; defaults to 2.");
+        "Max bound for vector size in LINEAR_ENUMERATION; defaults to 2.");
 
     registerOption(
         "--saddle-point", "saddlePoint",
         [this](const char* arg) {
-            saddlePoint = std::atoi(arg);
+            int64_t saddlePointTmp = 0;
+            try {
+                // Unfortunately, we can not use std::stoul because negative inputs are okay
+                // according to the C++ standard.
+                saddlePointTmp = std::stoll(arg);
+                if (saddlePointTmp < 0) {
+                    throw std::invalid_argument("Negative input.");
+                }
+            } catch (std::invalid_argument&) {
+                ::error(
+                    "Invalid input value %1% for --saddle-point. Expected non-negative integer.",
+                    arg);
+                return false;
+            }
+            saddlePoint = saddlePointTmp;
             return true;
         },
-        "Threshold to invoke multiPop on randomAccessMaxCoverage.");
+        "Threshold to invoke multiPop on RANDOM_ACCESS_MAX_COVERAGE.");
 
     registerOption(
         "--print-traces", nullptr,

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -39,14 +39,19 @@ TestgenOptions::TestgenOptions()
         "--max-tests", "maxTests",
         [this](const char* arg) {
             try {
-                maxTests = std::stoull(arg);
+                // Unfortunately, we can not use std::stoul because negative inputs are okay
+                // according to the C++ standard.
+                maxTests = std::stoll(arg);
+                if (maxTests < 0) {
+                    throw std::invalid_argument("Invalid input.");
+                }
             } catch (std::invalid_argument&) {
-                ::error("Invalid input value %1% for --max-tests. Expected integer.", arg);
+                ::error("Invalid input value %1% for --max-tests. Expected positive integer.", arg);
                 return false;
             }
             return true;
         },
-        "Sets the maximum number of tests to be generated [default: 1]. Setting the value to <=0 "
+        "Sets the maximum number of tests to be generated [default: 1]. Setting the value to 0 "
         "will generate tests until no more paths can be found.");
 
     registerOption(
@@ -189,12 +194,14 @@ TestgenOptions::TestgenOptions()
                 // Unfortunately, we can not use std::stoul because negative inputs are okay
                 // according to the C++ standard.
                 popLevelTmp = std::stoll(arg);
-                if (popLevelTmp < 0) {
-                    throw std::invalid_argument("Negative input.");
+                if (popLevelTmp <= 0) {
+                    throw std::invalid_argument("Invalid input.");
                 }
             } catch (std::invalid_argument&) {
-                ::error("Invalid input value %1% for --pop-level. Expected non-negative integer.",
-                        arg);
+                ::error(
+                    "Invalid input value %1% for --pop-level. Expected positive, non-zero "
+                    "integer.",
+                    arg);
                 return false;
             }
             popLevel = popLevelTmp;
@@ -216,7 +223,7 @@ TestgenOptions::TestgenOptions()
                 }
             } catch (std::invalid_argument&) {
                 ::error(
-                    "Invalid input value %1% for --linear-enumeration. Expected non-negative "
+                    "Invalid input value %1% for --linear-enumeration. Expected positive "
                     "integer.",
                     arg);
                 return false;
@@ -238,9 +245,8 @@ TestgenOptions::TestgenOptions()
                     throw std::invalid_argument("Negative input.");
                 }
             } catch (std::invalid_argument&) {
-                ::error(
-                    "Invalid input value %1% for --saddle-point. Expected non-negative integer.",
-                    arg);
+                ::error("Invalid input value %1% for --saddle-point. Expected positive integer.",
+                        arg);
                 return false;
             }
             saddlePoint = saddlePointTmp;

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -12,10 +12,20 @@ namespace P4Tools {
 class TestgenOptions : public AbstractP4cToolOptions {
  public:
     /// Maximum number of tests to be generated. Defaults to 1.
-    int maxTests = 1;
+    uint64_t maxTests = 1;
+
+    /// List of the supported exploration strategies.
+    static const std::set<cstring> SUPPORTED_EXPLORATION_STRATEGIES;
 
     /// Selects the exploration strategy for test generation
-    std::string explorationStrategy;
+    cstring explorationStrategy;
+
+    /// List of the supported stop metrics.
+    static const std::set<cstring> SUPPORTED_STOP_METRICS;
+
+    // Stops generating tests when a particular metric is satisifed. Currently supported options are
+    // listed in @var SUPPORTED_STOP_METRICS.
+    cstring stopMetric;
 
     /// Level of multiPop step. A good value is 10, namely, 10 per cent of
     /// the size of the unexploredBranches. The smaller the number,
@@ -23,18 +33,18 @@ class TestgenOptions : public AbstractP4cToolOptions {
     /// then this variable calculates 100/10 or 100/2 for the pop level.
     /// Defaults to 3, which maximizes exploration of exploration. Minimum
     /// level is 2, for max randomness.
-    int popLevel = 3;
+    uint64_t popLevel = 3;
 
     /// Max bound of the buffer vector collecting all terminal branches.
     /// Defaults to 2, which means only two terminal paths are populated
     /// by default.
-    int linearEnumeration = 2;
+    uint64_t linearEnumeration = 2;
 
     /// To be used with randomAccessMaxCoverage. It specifies after how many
     /// tests (saddle point) we should randomly explore the program and pick
     /// a random branch ranked by how many unique non-visited statements it
     /// has.
-    int saddlePoint = 5;
+    uint64_t saddlePoint = 5;
 
     /// @returns the singleton instance of this class.
     static TestgenOptions& get();

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -12,7 +12,7 @@ namespace P4Tools {
 class TestgenOptions : public AbstractP4cToolOptions {
  public:
     /// Maximum number of tests to be generated. Defaults to 1.
-    uint64_t maxTests = 1;
+    int64_t maxTests = 1;
 
     /// List of the supported exploration strategies.
     static const std::set<cstring> SUPPORTED_EXPLORATION_STRATEGIES;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
@@ -9,6 +9,7 @@
 
 #include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/trace_events.h"
+#include "backends/p4tools/common/lib/util.h"
 #include "gsl/gsl-lite.hpp"
 #include "ir/ir.h"
 #include "ir/irutils.h"
@@ -33,7 +34,7 @@ namespace Bmv2 {
 
 const big_int Bmv2TestBackend::ZERO_PKT_VAL = 0x2000000;
 const big_int Bmv2TestBackend::ZERO_PKT_MAX = 0xffffffff;
-const std::vector<std::string> Bmv2TestBackend::SUPPORTED_BACKENDS = {"PTF-P4", "STF", "PROTOBUF"};
+const std::set<std::string> Bmv2TestBackend::SUPPORTED_BACKENDS = {"PTF-P4", "STF", "PROTOBUF"};
 
 Bmv2TestBackend::Bmv2TestBackend(const ProgramInfo& programInfo, ExplorationStrategy& symbex,
                                  const boost::filesystem::path& testPath,
@@ -54,19 +55,9 @@ Bmv2TestBackend::Bmv2TestBackend(const ProgramInfo& programInfo, ExplorationStra
     } else if (testBackendString == "PROTOBUF") {
         testWriter = new Protobuf(testPath.c_str(), seed);
     } else {
-        std::stringstream supportedBackendString;
-        bool isFirst = true;
-        for (const auto& backend : SUPPORTED_BACKENDS) {
-            if (!isFirst) {
-                supportedBackendString << ", ";
-            } else {
-                isFirst = false;
-            }
-            supportedBackendString << backend;
-        }
         P4C_UNIMPLEMENTED(
             "Test back end %1% not implemented for this target. Supported back ends are %2%.",
-            testBackendString, supportedBackendString.str());
+            testBackendString, Utils::containerToString(SUPPORTED_BACKENDS));
     }
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.h
@@ -36,7 +36,7 @@ class Bmv2TestBackend : public TestBackEnd {
     static const big_int ZERO_PKT_VAL;
     static const big_int ZERO_PKT_MAX;
     /// List of the supported back ends.
-    static const std::vector<std::string> SUPPORTED_BACKENDS;
+    static const std::set<std::string> SUPPORTED_BACKENDS;
 
  public:
     explicit Bmv2TestBackend(const ProgramInfo& programInfo, ExplorationStrategy& symbex,

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -63,8 +63,9 @@ int Testgen::mainImpl(const IR::P4Program* program) {
     enableInformationLogging();
 
     auto const inputFile = P4CContext::get().options().file;
-    cstring testDirStr = TestgenOptions::get().outputDir;
-    auto seed = TestgenOptions::get().seed;
+    const auto& testgenOptions = TestgenOptions::get();
+    cstring testDirStr = testgenOptions.outputDir;
+    auto seed = testgenOptions.seed;
 
     // Get the basename of the input file and remove the extension
     // This assumes that inputFile is not null.
@@ -85,21 +86,21 @@ int Testgen::mainImpl(const IR::P4Program* program) {
 
     Z3Solver solver;
 
-    auto symExec = [&solver, &programInfo, seed]() -> ExplorationStrategy* {
-        std::string explorationStrategy = TestgenOptions::get().explorationStrategy;
-        if (explorationStrategy.compare("randomAccessStack") == 0) {
+    auto* symExec = [&solver, &programInfo, seed, &testgenOptions]() -> ExplorationStrategy* {
+        auto explorationStrategy = testgenOptions.explorationStrategy;
+        if (explorationStrategy == "RANDOM_ACCESS_STACK") {
             // If the user mistakenly specifies an invalid popLevel, we set it to 3.
-            int popLevel = TestgenOptions::get().popLevel;
+            int popLevel = testgenOptions.popLevel;
             if (popLevel <= 1) {
                 ::warning("--pop-level must be greater than 1; using default value of 3.\n");
                 popLevel = 3;
             }
             return new RandomAccessStack(solver, *programInfo, seed, popLevel);
         }
-        if (explorationStrategy.compare("linearEnumeration") == 0) {
+        if (explorationStrategy == "LINEAR_ENUMERATION") {
             // If the user mistakenly specifies an invalid bound, we set it to 2
             // to generate at least 2 tests.
-            int linearBound = TestgenOptions::get().linearEnumeration;
+            int linearBound = testgenOptions.linearEnumeration;
             if (linearBound <= 1) {
                 ::warning(
                     "--linear-enumeration must be greater than 1; using default value of 2.\n");
@@ -107,20 +108,20 @@ int Testgen::mainImpl(const IR::P4Program* program) {
             }
             return new LinearEnumeration(solver, *programInfo, seed, linearBound);
         }
-        if (explorationStrategy.compare("maxCoverage") == 0) {
+        if (explorationStrategy == "MAX_COVERAGE") {
             return new IncrementalMaxCoverageStack(solver, *programInfo, seed);
         }
-        if (explorationStrategy.compare("randomAccessMaxCoverage") == 0) {
+        if (explorationStrategy == "RANDOM_ACCESS_MAX_COVERAGE") {
             // If the user mistakenly sets an invalid saddlePoint, we set it to 5.
-            int saddlePoint = TestgenOptions::get().saddlePoint;
+            auto saddlePoint = testgenOptions.saddlePoint;
             if (saddlePoint <= 1) {
                 ::warning("--saddle-point must be greater than 1; using default value of 5.\n");
                 saddlePoint = 5;
             }
             return new RandomAccessMaxCoverage(solver, *programInfo, seed, saddlePoint);
         }
-        if (!TestgenOptions::get().selectedBranches.empty()) {
-            std::string selectedBranchesStr = TestgenOptions::get().selectedBranches;
+        if (!testgenOptions.selectedBranches.empty()) {
+            std::string selectedBranchesStr = testgenOptions.selectedBranches;
             return new SelectedBranches(solver, *programInfo, seed, selectedBranchesStr);
         }
         return new IncrementalStack(solver, *programInfo, seed);
@@ -135,7 +136,7 @@ int Testgen::mainImpl(const IR::P4Program* program) {
         // Run the symbolic executor with given exploration strategy.
         symExec->run(callBack);
     } catch (...) {
-        if (TestgenOptions::get().trackBranches) {
+        if (testgenOptions.trackBranches) {
             // Print list of the selected branches and store all information into
             // dumpFolder/selectedBranches.txt file.
             // This printed list could be used for repeat this bug in arguments of --input-branches

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -90,7 +90,7 @@ int Testgen::mainImpl(const IR::P4Program* program) {
         auto explorationStrategy = testgenOptions.explorationStrategy;
         if (explorationStrategy == "RANDOM_ACCESS_STACK") {
             // If the user mistakenly specifies an invalid popLevel, we set it to 3.
-            int popLevel = testgenOptions.popLevel;
+            auto popLevel = testgenOptions.popLevel;
             if (popLevel <= 1) {
                 ::warning("--pop-level must be greater than 1; using default value of 3.\n");
                 popLevel = 3;
@@ -98,27 +98,15 @@ int Testgen::mainImpl(const IR::P4Program* program) {
             return new RandomAccessStack(solver, *programInfo, seed, popLevel);
         }
         if (explorationStrategy == "LINEAR_ENUMERATION") {
-            // If the user mistakenly specifies an invalid bound, we set it to 2
-            // to generate at least 2 tests.
-            int linearBound = testgenOptions.linearEnumeration;
-            if (linearBound <= 1) {
-                ::warning(
-                    "--linear-enumeration must be greater than 1; using default value of 2.\n");
-                linearBound = 2;
-            }
-            return new LinearEnumeration(solver, *programInfo, seed, linearBound);
+            return new LinearEnumeration(solver, *programInfo, seed,
+                                         testgenOptions.linearEnumeration);
         }
         if (explorationStrategy == "MAX_COVERAGE") {
             return new IncrementalMaxCoverageStack(solver, *programInfo, seed);
         }
         if (explorationStrategy == "RANDOM_ACCESS_MAX_COVERAGE") {
-            // If the user mistakenly sets an invalid saddlePoint, we set it to 5.
-            auto saddlePoint = testgenOptions.saddlePoint;
-            if (saddlePoint <= 1) {
-                ::warning("--saddle-point must be greater than 1; using default value of 5.\n");
-                saddlePoint = 5;
-            }
-            return new RandomAccessMaxCoverage(solver, *programInfo, seed, saddlePoint);
+            return new RandomAccessMaxCoverage(solver, *programInfo, seed,
+                                               testgenOptions.saddlePoint);
         }
         if (!testgenOptions.selectedBranches.empty()) {
             std::string selectedBranchesStr = testgenOptions.selectedBranches;


### PR DESCRIPTION
- Introduce a stop metric for P4Testgen en. If a stop metric argument is provided, P4Testgen will stop producing test if that particular metric is satisfied. 
- max-tests inputs with values less than 0 will cause P4Testgen to exhaustively generate tests.
- Sanitize inputs for various options and make sure to reject invalid inputs.

@hannelita I also modified the input valuation and arguments for exploration strategies since the options behave similar to stop metrics. Happy to hear suggestions on how to improve this.