### PR TITLE
Drop flawed input-packet-only option.

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -369,24 +369,6 @@ bool CmdStepper::preorder(const IR::P4Program* /*program*/) {
     }
 
     const auto* topLevelBlocks = programInfo.getPipelineSequence();
-    // If we are just producing input packets, remove anything appearing after the first parser.
-    // TODO: Move this into getPipelineSequence? Also, clean up.
-    if (TestgenOptions::get().inputPacketOnly) {
-        auto* blocks = new std::vector<Continuation::Command>();
-        for (const auto& block : *topLevelBlocks) {
-            blocks->push_back(block);
-            const auto* p4Node = boost::get<const IR::Node*>(&block);
-            if (p4Node == nullptr) {
-                continue;
-            }
-            if (const auto* cce = (*p4Node)->to<IR::ConstructorCallExpression>()) {
-                if (cce->type->is<IR::Type_Parser>()) {
-                    break;
-                }
-            }
-        }
-        topLevelBlocks = blocks;
-    }
 
     // In between pipe lines we may drop packets or exit.
     // This segment inserts a special exception to deal with this case.

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -31,14 +31,6 @@ TestgenOptions::TestgenOptions()
         "Fail on unimplemented features instead of trying the next branch.");
 
     registerOption(
-        "--input-packet-only", nullptr,
-        [this](const char*) {
-            inputPacketOnly = true;
-            return true;
-        },
-        "Only produce the input packet for each test");
-
-    registerOption(
         "--max-tests", "maxTests",
         [this](const char* arg) {
             maxTests = std::atoi(arg);

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -11,9 +11,6 @@ namespace P4Tools {
 /// Encapsulates and processes command-line options for p4testgen.
 class TestgenOptions : public AbstractP4cToolOptions {
  public:
-    /// Whether to produce just the input packet for each test.
-    bool inputPacketOnly = false;
-
     /// Maximum number of tests to be generated. Defaults to 1.
     int maxTests = 1;
 


### PR DESCRIPTION
This option is flawed and will not produce useful output. Better to remove it and add it back once we have a proper implementation.

Fixes #3560. 