### PR TITLE
Make {#} a single token

### DIFF
--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -942,13 +942,16 @@ bool ToP4::preorder(const IR::StructExpression* e) {
 
 bool ToP4::preorder(const IR::InvalidHeader* e) {
     if (expressionPrecedence > DBPrint::Prec_Prefix) builder.append("(");
-    if (e->headerType != nullptr) {
-        builder.append("(");
-        visit(e->headerType);
-        builder.append(")");
-    }
+    builder.append("(");
+    visit(e->headerType);
+    builder.append(")");
     builder.append("{#}");
     if (expressionPrecedence > DBPrint::Prec_Prefix) builder.append(")");
+    return false;
+}
+
+bool ToP4::preorder(const IR::Invalid*) {
+    builder.append("{#}");
     return false;
 }
 

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -197,6 +197,7 @@ class ToP4 : public Inspector {
     bool preorder(const IR::P4ListExpression* e) override;
     bool preorder(const IR::StructExpression* e) override;
     bool preorder(const IR::InvalidHeader* e) override;
+    bool preorder(const IR::Invalid* e) override;
     bool preorder(const IR::MethodCallExpression* e) override;
     bool preorder(const IR::DefaultExpression* e) override;
     bool preorder(const IR::This* e) override;

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -306,6 +306,7 @@ class TypeInference : public Transform {
     const IR::Node* postorder(IR::TypeNameExpression* expression) override;
     const IR::Node* postorder(IR::ListExpression* expression) override;
     const IR::Node* postorder(IR::InvalidHeader* expression) override;
+    const IR::Node* postorder(IR::Invalid* expression) override;
     const IR::Node* postorder(IR::P4ListExpression* expression) override;
     const IR::Node* postorder(IR::StructExpression* expression) override;
     const IR::Node* postorder(IR::MethodCallExpression* expression) override;

--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -272,7 +272,7 @@ using Parser = P4::P4Parser;
 "++"    { BEGIN(driver.saveState); driver.template_args = false; return makeToken(PP); }
 
 "+"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(PLUS); }
-"#"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(SHARP); }
+"{#}"   { BEGIN(driver.saveState); driver.template_args = false; return makeToken(INVALID); }
 "|+|"   { BEGIN(driver.saveState); driver.template_args = false; return makeToken(PLUS_SAT); }
 "-"     { BEGIN(driver.saveState); driver.template_args = false; return makeToken(MINUS); }
 "|-|"   { BEGIN(driver.saveState); driver.template_args = false; return makeToken(MINUS_SAT); }

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -184,7 +184,7 @@ inline std::ostream& operator<<(std::ostream& out, const P4::Token& t) {
 %token<Token>      PLUS_SAT "|+|"
 %token<Token>      MINUS_SAT "|-|"
 %token<Token>      MUL "*"
-%token<Token>      SHARP "#"
+%token<Token>      INVALID "{#}"
 %token<Token>      DIV "/"
 %token<Token>      MOD "%"
 %token<Token>      BIT_OR "|"
@@ -1436,8 +1436,7 @@ expression
     | expression "[" expression "]"      { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | expression "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
     | "{" expressionList optTrailingComma "}" { $$ = new IR::ListExpression(@1 + @4, *$2); }
-    | "{" SHARP "}"                      { $$ = new IR::InvalidHeader(
-                                                  @1 + @3, IR::Type::Unknown::get(), nullptr); }
+    | INVALID                            { $$ = new IR::Invalid(@1, IR::Type::Unknown::get()); }
     | "{" kvList optTrailingComma "}"    { $$ = new IR::StructExpression(
                                                   @1 + @4, IR::Type::Unknown::get(), (IR::Type_Name*)nullptr, *$2); }
     | "(" expression ")"                 { $$ = $2; }

--- a/ir/dbprint-expression.cpp
+++ b/ir/dbprint-expression.cpp
@@ -250,10 +250,9 @@ void IR::ConstructorCallExpression::dbprint(std::ostream& out) const {
     dbsetflags(out, flags);
 }
 
-void IR::InvalidHeader::dbprint(std::ostream& out) const {
-    out << "(" << type << "){#}"
-        << ";";
-}
+void IR::InvalidHeader::dbprint(std::ostream& out) const { out << "(" << type << "){#}"; }
+
+void IR::Invalid::dbprint(std::ostream& out) const { out << "{#}"; }
 
 void IR::ListExpression::dbprint(std::ostream& out) const {
     int prec = getprec(out);

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -453,10 +453,13 @@ class StructExpression : Expression {
     size_t size() const { return components.size(); }
 }
 
+/// Can be an invalid header or header_union
+class Invalid : Expression {
+}
+
 /// An expression that evaluates to an invalid header with the specified type.
 class InvalidHeader : Expression {
-    /// May only be known after type checking; so it can be nullptr.
-    NullOK Type headerType;
+    Type headerType;
 }
 
 /// A ListExpression where all the components are compile-time values.

--- a/testdata/p4_16_errors/invalid-invalid.p4
+++ b/testdata/p4_16_errors/invalid-invalid.p4
@@ -1,0 +1,2 @@
+header H {}
+const H h = { # };

--- a/testdata/p4_16_errors_outputs/invalid-invalid.p4-stderr
+++ b/testdata/p4_16_errors_outputs/invalid-invalid.p4-stderr
@@ -1,0 +1,4 @@
+invalid-invalid.p4(2):syntax error, unexpected UNEXPECTED_TOKEN, expecting }
+const H h = { #
+              ^
+[--Werror=overlimit] error: 1 errors encountered, aborting compilation


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
As discussed during the January 2023 LDWG meeting.
https://github.com/p4lang/p4-spec/pull/1184 will have to be updated.
This PR also refactors the IR to make it easier to add invalid header unions in a future PR.