### PR TITLE
Testgen: allow block param initialization with taintexpr

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
@@ -377,7 +377,8 @@ void AbstractStepper::setTargetUninitialized(ExecutionState* nextState, const IR
 }
 
 void AbstractStepper::declareStructLike(ExecutionState* nextState, const IR::Expression* parentExpr,
-                                        const IR::Type_StructLike* structType) const {
+                                        const IR::Type_StructLike* structType,
+                                        bool forceTaint) const {
     std::vector<const IR::Member*> validFields;
     auto fields = nextState->getFlatFields(parentExpr, structType, &validFields);
     // We also need to initialize the validity bits of the headers. These are false.
@@ -388,7 +389,7 @@ void AbstractStepper::declareStructLike(ExecutionState* nextState, const IR::Exp
     // If the variable does not have an initializer we need to create a new zombie for it.
     // For now we just use the name directly.
     for (const auto* field : fields) {
-        nextState->set(field, programInfo.createTargetUninitialized(field->type, false));
+        nextState->set(field, programInfo.createTargetUninitialized(field->type, forceTaint));
     }
 }
 

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h
@@ -172,7 +172,7 @@ class AbstractStepper : public Inspector {
     /// This also is used to declare the members of a stack. This function is primarily used by the
     /// Declaration_Variable preorder function.
     void declareStructLike(ExecutionState* nextState, const IR::Expression* parentExpr,
-                           const IR::Type_StructLike* structType) const;
+                           const IR::Type_StructLike* structType, bool forceTaint = false) const;
 
     /// This is a helper function to declare base type variables. Because all variables need to be a
     /// member in the execution state environment, this helper function suffixes a "*".

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -103,7 +103,7 @@ void CmdStepper::initializeBlockParams(const IR::Type_Declaration* typeDecl,
         paramType = nextState->resolveType(paramType);
         const auto* paramPath = new IR::PathExpression(paramType, new IR::Path(archRef));
         if (const auto* ts = paramType->to<IR::Type_StructLike>()) {
-            declareStructLike(nextState, paramPath, ts);
+            declareStructLike(nextState, paramPath, ts, forceTaint);
         } else if (const auto* tb = paramType->to<IR::Type_Base>()) {
             // If the type is a flat Type_Base, postfix it with a "*".
             const auto& paramRef = Utils::addZombiePostfix(paramPath, tb);

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -81,7 +81,7 @@ void CmdStepper::declareVariable(ExecutionState* nextState, const IR::Declaratio
 
 void CmdStepper::initializeBlockParams(const IR::Type_Declaration* typeDecl,
                                        const std::vector<cstring>* blockParams,
-                                       ExecutionState* nextState) const {
+                                       ExecutionState* nextState, bool forceTaint) const {
     // Collect parameters.
     const auto* iApply = typeDecl->to<IR::IApply>();
     BUG_CHECK(iApply != nullptr, "Constructed type %s of type %s not supported.", typeDecl,
@@ -107,7 +107,7 @@ void CmdStepper::initializeBlockParams(const IR::Type_Declaration* typeDecl,
         } else if (const auto* tb = paramType->to<IR::Type_Base>()) {
             // If the type is a flat Type_Base, postfix it with a "*".
             const auto& paramRef = Utils::addZombiePostfix(paramPath, tb);
-            nextState->set(paramRef, programInfo.createTargetUninitialized(paramType, false));
+            nextState->set(paramRef, programInfo.createTargetUninitialized(paramType, forceTaint));
         } else {
             P4C_UNIMPLEMENTED("Unsupported initialization type %1%", paramType->node_type_name());
         }

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h
@@ -68,8 +68,8 @@ class CmdStepper : public AbstractStepper {
     /// cstring list as prefixes.All the members of the Type_Declaration are initialized using the
     /// createTargetUninitialized of the respective target.
     void initializeBlockParams(const IR::Type_Declaration* typeDecl,
-                               const std::vector<cstring>* blockParams,
-                               ExecutionState* nextState) const;
+                               const std::vector<cstring>* blockParams, ExecutionState* nextState,
+                               bool forceTaint = false) const;
 
     /// Add a variable to the symbolic interpreter. This looks up the full control-plane name of a
     /// variable defined in @param decl and declares in the symbolic environment of @param


### PR DESCRIPTION
initializeBlockParams default (zero) initializes all parameters, however most fields of our target have unspecified/uncontrollable initial value. To avoid double-initialization, this PR allows for optional intialization with tainted expressions.