### PR TITLE
 Support "clone" function for BMV2 PTF

### DIFF
--- a/backends/bmv2/base_test.py
+++ b/backends/bmv2/base_test.py
@@ -340,9 +340,8 @@ class P4RuntimeTest(BaseTest):
             response = self.stub.SetForwardingPipelineConfig(request)
             logging.debug(f"Response {response}")
         except Exception as e:
-            logging.error("Error during SetForwardingPipelineConfig",
-                          file=sys.stderr)
-            logging.error(str(e), file=sys.stderr)
+            logging.error("Error during SetForwardingPipelineConfig")
+            logging.error(str(e))
             return False
         return True
 

--- a/backends/bmv2/base_test.py
+++ b/backends/bmv2/base_test.py
@@ -989,6 +989,22 @@ class P4RuntimeTest(BaseTest):
             replica.instance = x[1]
         return req, self.write_request(req, store=False)
 
+    def insert_pre_clone_session(self, session_id, ports, cos=0, packet_length_bytes=0):
+        req = self.get_new_write_request()
+        update = req.updates.add()
+        update.type = p4runtime_pb2.Update.INSERT
+        pre_entry = update.entity.packet_replication_engine_entry
+        clone_entry = pre_entry.clone_session_entry
+        clone_entry.session_id = session_id
+        clone_entry.class_of_service = cos
+        clone_entry.packet_length_bytes = packet_length_bytes
+        for port in ports:
+            replica = clone_entry.replicas.add()
+            replica.egress_port = port
+            replica.instance = 1
+        return req, self.write_request(req)
+
+
     def response_dump_helper(self, request):
         for response in self.stub.Read(request, timeout=2):
             yield response

--- a/backends/bmv2/run-bmv2-ptf-test.py
+++ b/backends/bmv2/run-bmv2-ptf-test.py
@@ -100,9 +100,7 @@ def create_runtime(options, json_name, info_name):
         f"{options.rootDir}/build/p4c-bm2-ss --target bmv2 --arch v1model "
         f"--p4runtime-files {info_name} {options.p4_file} -o {json_name}"
     )
-    p = subprocess.Popen(
-        p4c_bm2_ss, shell=True, stdin=subprocess.PIPE, universal_newlines=True
-    )
+    p = subprocess.Popen(p4c_bm2_ss, shell=True, stdin=subprocess.PIPE, universal_newlines=True)
 
     p.communicate()
     if p.returncode != 0:
@@ -113,11 +111,9 @@ def create_runtime(options, json_name, info_name):
         raise SystemExit("p4c-bm2-ss ended with errors")
 
 
-def _run_proc_in_background(bridge, cmd):
+def run_proc_in_background(bridge, cmd):
     namedCmd = bridge.get_ns_prefix() + " " + cmd
-    return subprocess.Popen(
-        namedCmd, shell=True, stdin=subprocess.PIPE, universal_newlines=True
-    )
+    return subprocess.Popen(namedCmd, shell=True, stdin=subprocess.PIPE, universal_newlines=True)
 
 
 def run_simple_switch_grpc(bridge, thrift_port, grpc_port):
@@ -130,16 +126,17 @@ def run_simple_switch_grpc(bridge, thrift_port, grpc_port):
         sys.stdout,
         "---------------------- Start simple_switch_grpc ----------------------",
     )
-
+    log = options.testdir.joinpath("simple_switch_grpc.log")
     simple_switch_grpc = (
-        f"simple_switch_grpc --thrift-port {thrift_port} --log-console -i 0@0 "
+        f"simple_switch_grpc --thrift-port {thrift_port} --log-file {log} --log-flush -i 0@0 "
         f"-i 1@1 -i 2@2 -i 3@3 -i 4@4 -i 5@5 -i 6@6 -i 7@7 --no-p4 "
         f"-- --grpc-server-addr localhost:{grpc_port}"
     )
-
-    switchProc = _run_proc_in_background(bridge, simple_switch_grpc)
+    switchProc = run_proc_in_background(bridge, simple_switch_grpc)
     if switchProc.poll() is not None:
         kill_process(switchProc)
+        print("HIIIIIII")
+        exit(1)
         testutils.report_err(
             sys.stderr,
             "---------------------- End simple_switch_grpc with errors ----------------------",
@@ -150,9 +147,7 @@ def run_simple_switch_grpc(bridge, thrift_port, grpc_port):
 
 
 def run_ptf(bridge, grpc_port, json_name, info_name):
-    testutils.report_output(
-        sys.stdout, "---------------------- Start ptf ----------------------"
-    )
+    testutils.report_output(sys.stdout, "---------------------- Start ptf ----------------------")
     # Add the file location to the python path.
     pypath = FILE_DIR
     # Show list of the tests
@@ -160,9 +155,7 @@ def run_ptf(bridge, grpc_port, json_name, info_name):
     bridge.ns_exec(testLostCmd)
 
     ifaces = "-i 0@br_0 -i 1@br_1 -i 2@br_2 -i 3@br_3 -i 4@br_4 -i 5@br_5 -i 6@br_6 -i 7@br_7"
-    test_params = (
-        f"grpcaddr='localhost:{grpc_port}';p4info='{info_name}';config='{json_name}';"
-    )
+    test_params = f"grpcaddr='localhost:{grpc_port}';p4info='{info_name}';config='{json_name}';"
     ptf = f'ptf --verbose --pypath {pypath} {ifaces} --test-params=\\"{test_params}\\" --test-dir {options.testdir}'
     return bridge.ns_exec(ptf)
 
@@ -215,9 +208,7 @@ if __name__ == "__main__":
     options.p4_file = Path(testutils.check_if_file(args.p4_file))
     testfile = args.testfile
     if not testfile:
-        testutils.report_output(
-            sys.stdout, "No test file provided. Checking for file in folder."
-        )
+        testutils.report_output(sys.stdout, "No test file provided. Checking for file in folder.")
         testfile = options.p4_file.with_suffix(".py")
     options.testfile = Path(testutils.check_if_file(testfile))
     testdir = args.testdir
@@ -226,7 +217,7 @@ if __name__ == "__main__":
             sys.stdout, "No test directory provided. Generating temporary folder."
         )
         testdir = tempfile.mkdtemp(dir=os.path.abspath("./"))
-        os.chmod(testdir, 0o744)
+        os.chmod(testdir, 0o755)
     options.testdir = Path(testdir)
     options.rootDir = Path(args.rootdir)
     # Run the test with the extracted options

--- a/backends/bmv2/run-bmv2-ptf-test.py
+++ b/backends/bmv2/run-bmv2-ptf-test.py
@@ -34,6 +34,13 @@ PARSER.add_argument(
     dest="testdir",
     help="The location of the test directory.",
 )
+PARSER.add_argument(
+    "-b",
+    "--nocleanup",
+    action="store_true",
+    dest="nocleanup",
+    help="Do not remove temporary results for failing tests.",
+)
 
 
 def is_port_in_use(port: int) -> bool:
@@ -47,7 +54,7 @@ class Options:
         self.testfile = None  # path to ptf test file that is used
         # Actual location of the test framework
         self.testdir = None
-        self.rootDir = "."
+        self.rootdir = "."
 
 
 def create_bridge():
@@ -86,18 +93,12 @@ def open_proc(bridge):
     return proc
 
 
-def kill_process(proc):
-    # kill process
-    os.kill(proc.pid, 15)
-    os.kill(proc.pid, 9)
-
-
 def create_runtime(options, json_name, info_name):
     testutils.report_output(
         sys.stdout, "---------------------- Start p4c-bm2-ss ----------------------"
     )
     p4c_bm2_ss = (
-        f"{options.rootDir}/build/p4c-bm2-ss --target bmv2 --arch v1model "
+        f"{options.rootdir}/build/p4c-bm2-ss --target bmv2 --arch v1model "
         f"--p4runtime-files {info_name} {options.p4_file} -o {json_name}"
     )
     p = subprocess.Popen(p4c_bm2_ss, shell=True, stdin=subprocess.PIPE, universal_newlines=True)
@@ -117,30 +118,27 @@ def run_proc_in_background(bridge, cmd):
 
 
 def run_simple_switch_grpc(bridge, thrift_port, grpc_port):
-    proc = open_proc(bridge)
-    # Remove the log file.
-    removeLogFileCmd = "/bin/rm -f ss-log.txt"
-    bridge.ns_exec(removeLogFileCmd)
-
     testutils.report_output(
         sys.stdout,
         "---------------------- Start simple_switch_grpc ----------------------",
     )
-    log = options.testdir.joinpath("simple_switch_grpc.log")
+    switch_log = options.testdir.joinpath("simple_switch_grpc.log")
     simple_switch_grpc = (
-        f"simple_switch_grpc --thrift-port {thrift_port} --log-file {log} --log-flush -i 0@0 "
+        f"simple_switch_grpc --thrift-port {thrift_port} --log-console -i 0@0 "
         f"-i 1@1 -i 2@2 -i 3@3 -i 4@4 -i 5@5 -i 6@6 -i 7@7 --no-p4 "
         f"-- --grpc-server-addr localhost:{grpc_port}"
     )
     switchProc = run_proc_in_background(bridge, simple_switch_grpc)
     if switchProc.poll() is not None:
-        kill_process(switchProc)
-        print("HIIIIIII")
-        exit(1)
         testutils.report_err(
             sys.stderr,
-            "---------------------- End simple_switch_grpc with errors ----------------------",
+            "---------------------- simple_switch_grpc terminated with an error ----------------------",
         )
+        with switch_log.open("r", encoding="utf8") as simple_switch_log_file:
+            testutils.report_err(
+                sys.stderr,
+                simple_switch_log_file.read(),
+            )
         raise SystemExit("simple_switch_grpc ended with errors")
 
     return switchProc
@@ -216,9 +214,14 @@ if __name__ == "__main__":
         testutils.report_output(
             sys.stdout, "No test directory provided. Generating temporary folder."
         )
-        testdir = tempfile.mkdtemp(dir=os.path.abspath("./"))
+        testdir = tempfile.mkdtemp(dir=Path(".").absolute())
+        # Generous permissions because the program is usually edited by sudo.
         os.chmod(testdir, 0o755)
     options.testdir = Path(testdir)
-    options.rootDir = Path(args.rootdir)
+    options.rootdir = Path(args.rootdir)
     # Run the test with the extracted options
-    sys.exit(run_test(options))
+    result = run_test(options)
+    if not (args.nocleanup or result != testutils.SUCCESS):
+        testutils.report_output(sys.stdout, "Removing temporary test directory.")
+        testutils.del_dir(options.testdir)
+    sys.exit(result)

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
@@ -37,6 +37,17 @@ PTF::PTF(cstring testName, boost::optional<unsigned int> seed = boost::none) : T
     cstring testNameOnly(testFile.stem().c_str());
 }
 
+inja::json PTF::getCloneInfo(const TestSpec *testSpec) {
+    inja::json cloneJson = inja::json::object();
+    auto cloneMethod = testSpec->getTestObjectCategory("clone_infos");
+    if (!cloneMethod.empty()) {
+        cloneJson["clone"] = "F";
+    } else {
+        cloneJson["clone"] = "T";
+    }
+    return cloneJson;
+}
+
 std::vector<std::pair<size_t, size_t>> PTF::getIgnoreMasks(const IR::Constant *mask) {
     std::vector<std::pair<size_t, size_t>> ignoreMasks;
     if (mask == nullptr) {
@@ -365,6 +376,7 @@ void PTF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_
     dataJson["trace"] = getTrace(testSpec);
     dataJson["control_plane"] = getControlPlane(testSpec);
     dataJson["send"] = getSend(testSpec);
+    dataJson["clone"] = getCloneInfo(testSpec);
     dataJson["verify"] = getVerify(testSpec);
     dataJson["timestamp"] = Utils::getTimeStamp();
     std::stringstream coverageStr;

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
@@ -362,11 +362,11 @@ class Test{{test_id}}(AbstractTest):
         ptfutils.verify_packet(self, exp_pkt, eg_port)
 ##endfor
 ##endif
-##endif
 ## else 
         ptfutils.verify_packet(self, exp_pkt, eg_port)
         logger.info("Verifying no other packets ...")
         ptfutils.verify_no_other_packets(self, self.device_id, timeout=2)
+## endif
 ## else
         pass
 ## endif

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
@@ -18,11 +18,7 @@
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 #include "backends/p4tools/modules/testgen/lib/tf.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 /// Extracts information from the @testSpec to emit a PTF test case.
 class PTF : public TF {
@@ -62,9 +58,6 @@ class PTF : public TF {
     void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                       const std::string &testCase, float currentCoverage);
 
-    /// Adds a label about the clone function to the Inja format object.
-    static inja::json getCloneInfo(const TestSpec *testSpec);
-
     /// Converts all the control plane objects into Inja format.
     static inja::json getControlPlane(const TestSpec *testSpec);
 
@@ -73,6 +66,9 @@ class PTF : public TF {
 
     /// Converts the output packet, port, and mask into Inja format.
     static inja::json getVerify(const TestSpec *testSpec);
+
+    /// Returns the configuration for a cloned packet configuration.
+    static inja::json::array_t getClone(const std::map<cstring, const TestObject *> &cloneInfos);
 
     /// Helper function for @getVerify. Matches the mask value against the input packet value and
     /// generates the appropriate ignore ranges.
@@ -83,10 +79,6 @@ class PTF : public TF {
                                               const std::vector<ActionArg> &args);
 };
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_BACKEND_PTF_PTF_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
@@ -62,6 +62,9 @@ class PTF : public TF {
     void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                       const std::string &testCase, float currentCoverage);
 
+    /// Adds a label about the clone function to the Inja format object.
+    static inja::json getCloneInfo(const TestSpec *testSpec);
+
     /// Converts all the control plane objects into Inja format.
     static inja::json getControlPlane(const TestSpec *testSpec);
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
@@ -108,6 +108,12 @@ boost::optional<const Constraint *> BMv2_V1ModelCmdStepper::startParser_impl(
         programInfo.getParserParamVar(parser, programInfo.getParserErrorType(), 3, "parser_error");
     nextState->setParserErrorLabel(errVar);
 
+    /// Set the restriction on the input port for PTF tests.
+    /// This is necessary since the PTF framework only allows a specific port range.
+    if (TestgenOptions::get().testBackend == "PTF") {
+        const auto &portVar = programInfo.getTargetInputPortVar();
+        return new IR::Lss(portVar, new IR::Constant(portVar->type, 8));
+    }
     return boost::none;
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/constants.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/constants.h
@@ -19,11 +19,10 @@ class BMv2Constants {
     static constexpr const char *MATCH_KIND_SELECTOR = "selector";
     /// Entries that can match a range.
     static constexpr const char *MATCH_KIND_RANGE = "range";
-
-    // These definitions are derived from the numerical values of the enum
-    // named "PktInstanceType" in the p4lang/behavioral-model source file
-    // targets/simple_switch/simple_switch.h
-    // https://github.com/p4lang/behavioral-model/blob/main/targets/simple_switch/simple_switch.h#L146
+    /// These definitions are derived from the numerical values of the enum
+    /// named "PktInstanceType" in the p4lang/behavioral-model source file
+    /// targets/simple_switch/simple_switch.h
+    /// https://github.com/p4lang/behavioral-model/blob/main/targets/simple_switch/simple_switch.h#L146
     static constexpr uint64_t PKT_INSTANCE_TYPE_NORMAL = 0x0000;
     static constexpr uint64_t PKT_INSTANCE_TYPE_INGRESS_CLONE = 0x0001;
     static constexpr uint64_t PKT_INSTANCE_TYPE_EGRESS_CLONE = 0x0002;
@@ -31,10 +30,10 @@ class BMv2Constants {
     static constexpr uint64_t PKT_INSTANCE_TYPE_RECIRC = 0x0004;
     static constexpr uint64_t PKT_INSTANCE_TYPE_REPLICATION = 0x005;
     static constexpr uint64_t PKT_INSTANCE_TYPE_RESUBMIT = 0x006;
-    // Clone type is derived from v1model.p4
+    /// Clone type is derived from v1model.p4
     static constexpr int CLONE_TYPE_I2E = 0x0000;
     static constexpr int CLONE_TYPE_E2E = 0x0001;
-
+    /// Other useful constants
     static constexpr int STF_MIN_PKT_SIZE = 22;
     static constexpr int ETH_HDR_SIZE = 112;
     static constexpr int DROP_PORT = 511;

--- a/backends/p4tools/modules/testgen/targets/bmv2/constants.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/constants.h
@@ -37,6 +37,7 @@ class BMv2Constants {
 
     static constexpr int STF_MIN_PKT_SIZE = 22;
     static constexpr int ETH_HDR_SIZE = 112;
+    static constexpr int DROP_PORT = 511;
 };
 
 }  // namespace Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -862,7 +862,9 @@ void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpressio
                  const auto *egressPortVar = programInfo.getTargetOutputPortVar();
                  const auto &clonePortVar = Utils::getZombieConst(
                      egressPortVar->type, 0, "clone_port_var" + std::to_string(call->clone_id));
-                 cond = new IR::Neq(egressPortVar, clonePortVar);
+                 cond = new IR::LAnd(
+                     new IR::Neq(egressPortVar, clonePortVar),
+                     new IR::Lss(clonePortVar, IR::getConstant(clonePortVar->type, 8)));
                  // clone_preserving_field_list has a default state where the packet continues as
                  // is.
                  {
@@ -1147,7 +1149,9 @@ void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpressio
                  const auto *egressPortVar = programInfo.getTargetOutputPortVar();
                  const auto &clonePortVar = Utils::getZombieConst(
                      egressPortVar->type, 0, "clone_port_var" + std::to_string(call->clone_id));
-                 cond = new IR::Neq(egressPortVar, clonePortVar);
+                 cond = new IR::LAnd(
+                     new IR::Neq(egressPortVar, clonePortVar),
+                     new IR::Lss(clonePortVar, IR::getConstant(clonePortVar->type, 8)));
                  // clone_preserving_field_list has a default state where the packet continues as
                  // is.
                  {
@@ -1289,7 +1293,9 @@ void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpressio
                  const auto *egressPortVar = programInfo.getTargetOutputPortVar();
                  const auto &clonePortVar = Utils::getZombieConst(
                      egressPortVar->type, 0, "clone_port_var" + std::to_string(call->clone_id));
-                 const auto *cond = new IR::Neq(egressPortVar, clonePortVar);
+                 const auto *cond = new IR::LAnd(
+                     new IR::Neq(egressPortVar, clonePortVar),
+                     new IR::Lss(clonePortVar, IR::getConstant(clonePortVar->type, 8)));
                  const auto *sessionIdExpr =
                      state.getProperty<const IR::Expression *>("clone_session_id");
                  // clone_preserving_field_list has a default state where the packet continues as

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -73,7 +73,7 @@ BMv2_V1ModelProgramInfo::BMv2_V1ModelProgramInfo(
     if (options.testBackend == "PTF") {
         minPktSize = BMv2Constants::ETH_HDR_SIZE;
     }
-    const IR::Operation_Binary *constraint =
+    const IR::Expression *constraint =
         new IR::Grt(IR::Type::Boolean::get(), ExecutionState::getInputPacketSizeVar(),
                     IR::getConstant(ExecutionState::getPacketSizeVarType(), minPktSize));
     /// Vector containing pairs of restrictions and nodes to which these restrictions apply.
@@ -90,11 +90,6 @@ BMv2_V1ModelProgramInfo::BMv2_V1ModelProgramInfo(
         }
     }
 
-    /// Set the restriction on the input port for PTF tests.
-    /// This is necessary since the PTF framework only allows a specific port range.
-    if (options.testBackend == "PTF") {
-        constraint = new IR::LAnd(constraint, getPortConstraint(getTargetInputPortVar()));
-    }
     targetConstraints = constraint;
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -60,6 +60,9 @@ BMv2_V1ModelProgramInfo::BMv2_V1ModelProgramInfo(
     /// individual component instantiations.
     int pipeIdx = 0;
 
+    /// Set the restriction on the input port,
+    /// this is necessary since ptf tests use ports from 0 to 7
+    pipelineSequence.emplace_back(Continuation::Guard(getPortConstraint(getTargetInputPortVar())));
     for (const auto &declTuple : programmableBlocks) {
         // Iterate through the (ordered) pipes of the target architecture.
         auto subResult = processDeclaration(declTuple.second, pipeIdx);
@@ -89,10 +92,6 @@ BMv2_V1ModelProgramInfo::BMv2_V1ModelProgramInfo(
             constraint = new IR::LAnd(constraint, restriction);
         }
     }
-
-    /// Set the restriction on the input port,
-    /// this is necessary since ptf tests use ports from 0 to 7
-    constraint = new IR::LAnd(constraint, getPortConstraint(getTargetInputPortVar()));
 
     targetConstraints = constraint;
 }

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
@@ -53,8 +53,8 @@ class BMv2_V1ModelProgramInfo : public ProgramInfo {
 
     const IR::Member *getTargetInputPortVar() const override;
 
-    /// @returns the constraint expression for a given port variable
-    const IR::Expression *getPortConstraint(const IR::Member *portVar) const;
+    /// @returns the constraint expression for a given port variable.
+    static const IR::Expression *getPortConstraint(const IR::Member *portVar);
 
     const IR::Member *getTargetOutputPortVar() const override;
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -211,8 +211,8 @@ p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
   "headers: the type should be a struct of headers, stacks, or unions"
   parser-unroll-test3.p4
-  parser-unroll-test5.p4
   parser-unroll-test4.p4
+  parser-unroll-test5.p4
 )
 
 p4tools_add_xfail_reason(
@@ -236,26 +236,22 @@ p4tools_add_xfail_reason(
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
   "Expected packet was not received on device"
+  issue1642-bmv2.p4
+  issue1653-bmv2.p4
   issue1653-complex-bmv2.p4
+  issue1660-bmv2.p4
+  issue1755-1-bmv2.p4
   issue2314.p4
-  issue3702-bmv2.p4
-  parser-if.p4
+  issue281.p4
+  issue562-bmv2.p4
+  bmv2_lookahead_2.p4
+  xor_test.p4
+  v1model-special-ops-bmv2.p4
   parser-unroll-issue3537-1.p4
   parser-unroll-issue3537.p4
   parser-unroll-t1-cond.p4
   parser-unroll-test2.p4
-  v1model-p4runtime-enumint-types1.p4
-  xor_test.p4
-  bmv2_lookahead_2.p4
-  bmv2_parse_1.p4
-  fabric.p4
   header-stack-ops-bmv2.p4
-  basic_routing-bmv2.p4
-  issue914-bmv2.p4
-  v1model-special-ops-bmv2.p4
-  up4.p4
-  same_name_for_table_and_action.p4
-  issue1478-bmv2.p4
 )
 
 p4tools_add_xfail_reason(
@@ -265,17 +261,18 @@ p4tools_add_xfail_reason(
   issue1062-1-bmv2.p4
   v1model-p4runtime-most-types1.p4
   pins_fabric.p4
-  pins_middleblock.p4
   pins_wbb.p4
+  v1model-p4runtime-enumint-types1.p4
 
   # At index 0: INVALID_ARGUMENT, 'Bytestring provided does not fit within 0 bits'
+  pins_middleblock.p4
   issue2283_1-bmv2.p4
 )
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
-  "TypeError: _log()"
-  # TypeError: _log() got an unexpected keyword argument 'file'
+  "Unexpected error in RPC handling"
+  # Unexpected error in RPC handling
   issue3374.p4
   control-hs-index-test6.p4
   parser-unroll-test1.p4

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -236,17 +236,10 @@ p4tools_add_xfail_reason(
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
   "Expected packet was not received on device"
-  issue1642-bmv2.p4
-  issue1653-bmv2.p4
-  issue1653-complex-bmv2.p4
-  issue1660-bmv2.p4
-  issue1755-1-bmv2.p4
   issue2314.p4
   issue281.p4
-  issue562-bmv2.p4
   bmv2_lookahead_2.p4
   xor_test.p4
-  v1model-special-ops-bmv2.p4
   parser-unroll-issue3537-1.p4
   parser-unroll-issue3537.p4
   parser-unroll-t1-cond.p4
@@ -267,6 +260,15 @@ p4tools_add_xfail_reason(
   # At index 0: INVALID_ARGUMENT, 'Bytestring provided does not fit within 0 bits'
   pins_middleblock.p4
   issue2283_1-bmv2.p4
+
+  # At index 0: INVALID_ARGUMENT, 'Unexpected number of action parameters'
+  up4.p4
+  # At index 0: INVALID_ARGUMENT, '0 is not a valid session id'
+  issue1642-bmv2.p4
+  issue1653-bmv2.p4
+  issue1653-complex-bmv2.p4
+  issue1660-bmv2.p4
+  issue562-bmv2.p4
 )
 
 p4tools_add_xfail_reason(

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -246,8 +246,6 @@ p4tools_add_xfail_reason(
   parser-unroll-test2.p4
   v1model-p4runtime-enumint-types1.p4
   xor_test.p4
-  bmv2_clone_preserving_field_list_eg.p4
-  bmv2_clone_preserving_field_list_ig.p4
   bmv2_lookahead_2.p4
   bmv2_parse_1.p4
   fabric.p4

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2Xfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2Xfail.cmake
@@ -34,12 +34,15 @@ p4tools_add_xfail_reason(
   # terminate called after throwing an instance of 'std::runtime_error'
   # in Json::Value::operator[](ArrayIndex)const: requires arrayValue
   control-hs-index-test6.p4
+  control-hs-index-test6.p4
   issue3374.p4
 
   # terminate called after throwing an instance of 'std::runtime_error'
   # Type is not convertible to string
   control-hs-index-test3.p4
   parser-unroll-test1.p4
+  # terminate called after throwing an instance of 'std::out_of_range'
+  control-hs-index-test2.p4
 )
 
 p4tools_add_xfail_reason(
@@ -53,7 +56,6 @@ p4tools_add_xfail_reason(
   "Exception"
   #  Running simple_switch_CLI: Exception  Unexpected key field &
   match-on-exprs2-bmv2.p4
-  v1model-special-ops-bmv2.p4
 )
 
 p4tools_add_xfail_reason(

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -195,6 +195,7 @@ def del_dir(directory):
     except OSError as e:
         report_err(sys.stderr, f"Could not delete directory, reason:\n{e.filename} - {e.strerror}.")
 
+
 def copy_file(src, dst):
     try:
         if isinstance(src, list):


### PR DESCRIPTION
Work on adding support for external clone function for BMV2 PTF tests. We are based on the idea that with `clone` two packets will be sent to one port, but we need to check one, so we used `verify_any_packet_any_port` which will check all packets on the specified port, and will give a positive result if there is an expected packet