### PR TITLE
Require action_run to be within a switch statement

### DIFF
--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -24,7 +24,7 @@ namespace P4 {
 
 cstring DoSimplifyExpressions::createTemporary(const IR::Type *type) {
     type = type->getP4Type();
-    BUG_CHECK(!type->is<IR::Type_Dontcare>(), "Can't create don't-care temps");
+    BUG_CHECK(type && !type->is<IR::Type_Dontcare>(), "Can't create don't-care temps");
     auto tmp = refMap->newName("tmp");
     auto decl = new IR::Declaration_Variable(IR::ID(tmp, nullptr), type);
     toInsert.push_back(decl);

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -3077,6 +3077,10 @@ const IR::Node *TypeInference::postorder(IR::Member *expression) {
 
         auto fieldType = getTypeType(field->type);
         if (fieldType == nullptr) return expression;
+        if (fieldType->is<IR::Type_ActionEnum>() && !getParent<IR::SwitchStatement>()) {
+            typeError("%1%: only allowed in switch statements", expression);
+            return expression;
+        }
         setType(getOriginal(), fieldType);
         setType(expression, fieldType);
         if (isLeftValue(expression->expr)) {

--- a/testdata/p4_16_errors/issue3847.p4
+++ b/testdata/p4_16_errors/issue3847.p4
@@ -1,0 +1,17 @@
+#include <core.p4>
+
+control c(in bit t)
+{
+  table tt {
+    actions = {}
+  }
+  apply {
+    if (tt.apply().action_run == tt.apply().action_run) {
+    }
+  }
+}
+
+control ct(in bit t);
+package pt(ct c);
+
+pt(c()) main;

--- a/testdata/p4_16_errors_outputs/issue3847.p4
+++ b/testdata/p4_16_errors_outputs/issue3847.p4
@@ -1,0 +1,16 @@
+#include <core.p4>
+
+control c(in bit<1> t) {
+    table tt {
+        actions = {
+        }
+    }
+    apply {
+        if (tt.apply().action_run == tt.apply().action_run) {
+        }
+    }
+}
+
+control ct(in bit<1> t);
+package pt(ct c);
+pt(c()) main;

--- a/testdata/p4_16_errors_outputs/issue3847.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3847.p4-stderr
@@ -1,0 +1,6 @@
+issue3847.p4(9): [--Werror=type-error] error: tt.apply.action_run: only allowed in switch statements
+    if (tt.apply().action_run == tt.apply().action_run) {
+        ^^^^^^^^^^^^^^^^^^^^^
+issue3847.p4(9): [--Werror=type-error] error: tt.apply.action_run: only allowed in switch statements
+    if (tt.apply().action_run == tt.apply().action_run) {
+                                 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #3847