### PR TITLE
ebpf/PSA: Support for wide fields in Register and Meter

### DIFF
--- a/backends/ebpf/codeGen.h
+++ b/backends/ebpf/codeGen.h
@@ -126,6 +126,15 @@ class CodeGenInspector : public Inspector {
     void widthCheck(const IR::Node *node) const;
 };
 
+class EBPFInitializerUtils {
+ public:
+    // return *real* number of bits required by type
+    static unsigned ebpfTypeWidth(P4::TypeMap *typeMap, const IR::Expression *expr);
+
+    // Generate hex string and prepend it with zeroes when shorter than required width
+    static cstring genHexStr(const big_int &value, unsigned width, const IR::Expression *expr);
+};
+
 }  // namespace EBPF
 
 #endif /* _BACKENDS_EBPF_CODEGEN_H_ */

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -305,9 +305,9 @@ void StateTranslationVisitor::compileExtractField(const IR::Expression *expr,
             //   0x112233445566778890
             // To correctly insert that padding, the length of field must be known, but tools like
             // nikss-ctl (and the nikss library) don't consume P4info.txt to have such knowledge.
-            // There is also a bug in (de)parser causing that such fields aren't deparsed correctly.
+            // There is also a bug in (de)parser causing such fields to be deparsed incorrectly.
             ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
-                    "%1%: fields wider than 64 bits must have size in multiply of 8 bits (1 byte) "
+                    "%1%: fields wider than 64 bits must have a size multiple of 8 bits (1 byte) "
                     "due to ambiguous padding in the LSB byte when the condition is not met",
                     field);
         }

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -242,13 +242,15 @@ bool StateTranslationVisitor::preorder(const IR::SelectCase *selectCase) {
     return false;
 }
 
-void StateTranslationVisitor::compileExtractField(const IR::Expression *expr, cstring field,
-                                                  unsigned alignment, EBPFType *type) {
+void StateTranslationVisitor::compileExtractField(const IR::Expression *expr,
+                                                  const IR::StructField *field, unsigned alignment,
+                                                  EBPFType *type) {
     unsigned widthToExtract = dynamic_cast<IHasWidth *>(type)->widthInBits();
     auto program = state->parser->program;
     cstring msgStr;
+    cstring fieldName = field->name.name;
 
-    msgStr = Util::printf_format("Parser: extracting field %s", field);
+    msgStr = Util::printf_format("Parser: extracting field %s", fieldName);
     builder->target->emitTraceMessage(builder, msgStr.c_str());
 
     if (widthToExtract <= 64) {
@@ -277,7 +279,7 @@ void StateTranslationVisitor::compileExtractField(const IR::Expression *expr, cs
         unsigned shift = loadSize - alignment - widthToExtract;
         builder->emitIndent();
         visit(expr);
-        builder->appendFormat(".%s = (", field.c_str());
+        builder->appendFormat(".%s = (", fieldName.c_str());
         type->emit(builder);
         builder->appendFormat(")((%s(%s, BYTES(%s))", helper, program->packetStartVar.c_str(),
                               program->offsetVar.c_str());
@@ -293,6 +295,23 @@ void StateTranslationVisitor::compileExtractField(const IR::Expression *expr, cs
         builder->append(")");
         builder->endOfStatement(true);
     } else {
+        if (program->options.arch == "psa" && widthToExtract % 8 != 0) {
+            // To explain the problem in error lets assume that we have bit<68> field with value:
+            //   0x11223344556677889
+            //                     ^ this digit will be parsed into a half of byte
+            // Such fields are parsed into a table of bytes in network byte order, so possible
+            // values in dataplane are (note the position of additional '0' at the end):
+            //   0x112233445566778809
+            //   0x112233445566778890
+            // To correctly insert that padding, the length of field must be known, but tools like
+            // nikss-ctl (and the nikss library) don't consume P4info.txt to have such knowledge.
+            // There is also a bug in (de)parser causing that such fields aren't deparsed correctly.
+            ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
+                    "%1%: fields wider than 64 bits must have size in multiply of 8 bits (1 byte) "
+                    "due to ambiguous padding in the LSB byte when the condition is not met",
+                    field);
+        }
+
         // wide values; read all bytes one by one.
         unsigned shift;
         if (alignment == 0)
@@ -310,7 +329,7 @@ void StateTranslationVisitor::compileExtractField(const IR::Expression *expr, cs
         for (unsigned i = 0; i < bytes; i++) {
             builder->emitIndent();
             visit(expr);
-            builder->appendFormat(".%s[%d] = (", field.c_str(), i);
+            builder->appendFormat(".%s[%d] = (", fieldName.c_str(), i);
             bt->emit(builder);
             builder->appendFormat(")((%s(%s, BYTES(%s) + %d) >> %d)", helper,
                                   program->packetStartVar.c_str(), program->offsetVar.c_str(), i,
@@ -343,13 +362,13 @@ void StateTranslationVisitor::compileExtractField(const IR::Expression *expr, cs
                 expr->to<IR::Member>()->expr->to<IR::PathExpression>()->path->name.name)) {
             exprStr = exprStr.replace(".", "->");
         }
-        cstring tmp = Util::printf_format("(unsigned long long) %s.%s", exprStr, field);
+        cstring tmp = Util::printf_format("(unsigned long long) %s.%s", exprStr, fieldName);
 
-        msgStr =
-            Util::printf_format("Parser: extracted %s=0x%%llx (%u bits)", field, widthToExtract);
+        msgStr = Util::printf_format("Parser: extracted %s=0x%%llx (%u bits)", fieldName,
+                                     widthToExtract);
         builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, tmp.c_str());
     } else {
-        msgStr = Util::printf_format("Parser: extracted %s (%u bits)", field, widthToExtract);
+        msgStr = Util::printf_format("Parser: extracted %s (%u bits)", fieldName, widthToExtract);
         builder->target->emitTraceMessage(builder, msgStr.c_str());
     }
 
@@ -428,7 +447,7 @@ void StateTranslationVisitor::compileExtract(const IR::Expression *destination) 
                     "Only headers with fixed widths supported %1%", f);
             return;
         }
-        compileExtractField(destination, f->name, alignment, etype);
+        compileExtractField(destination, f, alignment, etype);
         alignment += et->widthInBits();
         alignment %= 8;
     }

--- a/backends/ebpf/ebpfParser.h
+++ b/backends/ebpf/ebpfParser.h
@@ -36,8 +36,8 @@ class StateTranslationVisitor : public CodeGenInspector {
     P4::P4CoreLibrary &p4lib;
     const EBPFParserState *state;
 
-    void compileExtractField(const IR::Expression *expr, cstring name, unsigned alignment,
-                             EBPFType *type);
+    void compileExtractField(const IR::Expression *expr, const IR::StructField *field,
+                             unsigned alignment, EBPFType *type);
     virtual void compileExtract(const IR::Expression *destination);
     void compileLookahead(const IR::Expression *destination);
     void compileAdvance(const P4::ExternMethod *ext);

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -129,7 +129,7 @@ void EBPFScalarType::declare(CodeBuilder *builder, cstring id, bool asPointer) {
         builder->append(id);
     } else {
         if (asPointer)
-            builder->append("u8*");
+            builder->appendFormat("u8* %s", id.c_str());
         else
             builder->appendFormat("u8 %s[%d]", id.c_str(), bytesRequired());
     }
@@ -144,9 +144,17 @@ void EBPFScalarType::declareInit(CodeBuilder *builder, cstring id, bool asPointe
         builder->append(id);
     } else {
         if (asPointer)
-            builder->append("u8*");
+            builder->appendFormat("u8* %s = NULL", id.c_str());
         else
-            builder->appendFormat("uint8_t %s[%d]", id.c_str(), bytesRequired());
+            builder->appendFormat("u8 %s[%d] = {0}", id.c_str(), bytesRequired());
+    }
+}
+
+void EBPFScalarType::emitInitializer(CodeBuilder *builder) {
+    if (generatesScalar(width)) {
+        builder->append("0");
+    } else {
+        builder->append("{ 0 }");
     }
 }
 

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -112,7 +112,7 @@ class EBPFScalarType : public EBPFType, public IHasWidth {
     void emit(CodeBuilder *builder) override;
     void declare(CodeBuilder *builder, cstring id, bool asPointer) override;
     void declareInit(CodeBuilder *builder, cstring id, bool asPointer) override;
-    void emitInitializer(CodeBuilder *builder) override { builder->append("0"); }
+    void emitInitializer(CodeBuilder *builder) override;
     unsigned widthInBits() override { return width; }
     unsigned implementationWidthInBits() override { return bytesRequired() * 8; }
     // True if this width is small enough to store in a machine scalar

--- a/backends/ebpf/psa/README.md
+++ b/backends/ebpf/psa/README.md
@@ -619,7 +619,8 @@ table caching pass `--table-caching` to the compiler.
 
 We list the known bugs/limitations below. Refer to the Roadmap section for features planned in the near future.
 
-- Larger bit fields (e.g. IPv6 addresses) may not work properly.
+- Fields wider than 64 bits must have size multiply of 8 bits, otherwise they may have unexpected value in the LSB byte.
+  These fields may not work with all the externs and not all the operations on them are possible.
 - We noticed that `bpf_xdp_adjust_meta()` isn't implemented by some NIC drivers, so the `meta` XDP2TC mode may not work 
 with some NICs. So far, we have verified the correct behavior with Intel 82599ES. If a NIC doesn't support the `meta` XDP2TC mode you can use `head` or `cpumap` modes.
 - `lookahead()` with bit fields (e.g., `bit<16>`) doesn't work.

--- a/backends/ebpf/psa/README.md
+++ b/backends/ebpf/psa/README.md
@@ -619,7 +619,7 @@ table caching pass `--table-caching` to the compiler.
 
 We list the known bugs/limitations below. Refer to the Roadmap section for features planned in the near future.
 
-- Fields wider than 64 bits must have size multiply of 8 bits, otherwise they may have unexpected value in the LSB byte.
+- Fields wider than 64 bits must have size multiple of 8 bits, otherwise they may have unexpected value in the LSB byte.
   These fields may not work with all the externs and not all the operations on them are possible.
 - We noticed that `bpf_xdp_adjust_meta()` isn't implemented by some NIC drivers, so the `meta` XDP2TC mode may not work 
 with some NICs. So far, we have verified the correct behavior with Intel 82599ES. If a NIC doesn't support the `meta` XDP2TC mode you can use `head` or `cpumap` modes.

--- a/backends/ebpf/tests/p4testdata/wide-field-meters.p4
+++ b/backends/ebpf/tests/p4testdata/wide-field-meters.p4
@@ -1,0 +1,114 @@
+/*
+Copyright 2022-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv6_t           ipv6;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout empty_t user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_t resubmit_meta,
+                         in empty_t recirculate_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x86DD: parse_ipv6;
+            default: accept;
+        }
+    }
+
+    state parse_ipv6 {
+        buffer.extract(parsed_hdr.ipv6);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout empty_t user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    Meter<bit<128>>(16, PSA_MeterType_t.BYTES) meter1;
+    PSA_MeterColor_t color1;
+
+    apply {
+         color1 = meter1.execute(hdr.ipv6.srcAddr);
+
+         if (color1 != PSA_MeterColor_t.RED) {
+             send_to_port(ostd, (PortId_t) PORT1);
+         } else {
+             ingress_drop(ostd);
+         }
+    }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_t clone_i2e_meta,
+                            out empty_t resubmit_meta,
+                            out empty_t normal_meta,
+                            inout headers hdr,
+                            in empty_t meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv6);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout empty_t user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_t normal_meta,
+                        in empty_t clone_i2e_meta,
+                        in empty_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout empty_t user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_t clone_e2e_meta,
+                           out empty_t recirculate_meta,
+                           inout headers hdr,
+                           in empty_t meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply { }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/p4testdata/wide-field-register.p4
+++ b/backends/ebpf/tests/p4testdata/wide-field-register.p4
@@ -1,0 +1,124 @@
+/*
+Copyright 2022-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+// little modified IPv6 header - 104 bit address
+header ipv6c_t {
+    bit<4>   version;
+    bit<8>   trafficClass;
+    bit<20>  flowLabel;
+    bit<16>  payloadLength;
+    bit<8>   nextHeader;
+    bit<8>   hopLimit;
+    bit<104> srcAddr;
+    bit<24>  _pad1;
+    bit<104> dstAddr;
+    bit<24>  _pad3;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv6c_t          ipv6;
+}
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout empty_t user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_t resubmit_meta,
+                         in empty_t recirculate_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x86DD: parse_ipv6;
+            default: accept;
+        }
+    }
+
+    state parse_ipv6 {
+        buffer.extract(parsed_hdr.ipv6);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout empty_t user_meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    Register<bit<104>, bit<104>>(10) reg;
+
+    apply {
+        bit<104> tmp = reg.read(hdr.ipv6.dstAddr);
+        reg.write(hdr.ipv6.dstAddr, hdr.ipv6.srcAddr);
+        hdr.ipv6.srcAddr = tmp;
+
+        send_to_port(ostd, (PortId_t) PORT1);
+    }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_t clone_i2e_meta,
+                            out empty_t resubmit_meta,
+                            out empty_t normal_meta,
+                            inout headers hdr,
+                            in empty_t meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv6);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout empty_t user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_t normal_meta,
+                        in empty_t clone_i2e_meta,
+                        in empty_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout empty_t user_meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_t clone_e2e_meta,
+                           out empty_t recirculate_meta,
+                           inout headers hdr,
+                           in empty_t meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply { }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/ptf/common.py
+++ b/backends/ebpf/tests/ptf/common.py
@@ -483,6 +483,13 @@ class P4EbpfTest(BaseTest):
         entry = entries[0]
         self._do_counter_verify(bytes=bytes, packets=packets, entry_value=entry["value"], counter_type=counter["type"])
 
+    def meter_get(self, name, index=None):
+        cmd = "nikss-ctl meter get pipe {} {}".format(TEST_PIPELINE_ID, name)
+        if index:
+            cmd = cmd + " index {}".format(index)
+        _, stdout, _ = self.exec_ns_cmd(cmd, "Meter get failed")
+        return json.loads(stdout)[name]['entries']
+
     def meter_update(self, name, index, pir, pbs, cir, cbs):
         cmd = "nikss-ctl meter update pipe {} {} " \
               "index {} {}:{} {}:{}".format(TEST_PIPELINE_ID, name,

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -140,7 +140,7 @@ function install_ptf_ebpf_test_deps() (
     sudo apt-get install -y --no-install-recommends ${LINUX_TOOLS}
   fi
 
-  git clone --depth 1 --recursive --branch v0.3.0 https://github.com/NIKSS-vSwitch/nikss /tmp/nikss
+  git clone --depth 1 --recursive --branch v0.3.1 https://github.com/NIKSS-vSwitch/nikss /tmp/nikss
   pushd /tmp/nikss
   ./build_libbpf.sh
   mkdir build


### PR DESCRIPTION
This commit allows to use Registers and Meters with fields wider than 64 bits.

CC: @osinstom 