### PR TITLE
[P4Testgen] Fix hardcoded test search line.

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
@@ -20,7 +20,7 @@ else()
 endif()
 
 set(V1_SEARCH_PATTERNS "include.*v1model.p4" "main|common_v1_test")
-set(P4TESTDATA ${P4C_SOURCE_DIR}/../p4c/testdata)
+set(P4TESTDATA ${P4C_SOURCE_DIR}/testdata)
 set(P4TESTS_FOR_BMV2 "${P4TESTDATA}/p4_16_samples/*.p4")
 p4c_find_tests("${P4TESTS_FOR_BMV2}" P4_16_V1_TESTS INCLUDE "${V1_SEARCH_PATTERNS}" EXCLUDE "")
 p4tools_find_tests("${P4_16_V1_TESTS}" v1tests EXCLUDE "")

--- a/backends/p4tools/modules/testgen/targets/ebpf/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test/P4Tests.cmake
@@ -25,7 +25,7 @@ set(
 )
 
 set(EBPF_SEARCH_PATTERNS "include.*ebpf_model.p4")
-set(P4TESTDATA ${P4C_SOURCE_DIR}/../p4c/testdata)
+set(P4TESTDATA ${P4C_SOURCE_DIR}/testdata)
 set(P4TESTS_FOR_EBPF "${P4TESTDATA}/p4_16_samples/*.p4")
 p4c_find_tests("${P4TESTS_FOR_EBPF}" EBPF_TESTS INCLUDE "${EBPF_SEARCH_PATTERNS}" EXCLUDE "")
 p4tools_find_tests("${EBPF_TESTS}" ebpftests EXCLUDE "${P4TESTGEN_EBPF_EXCLUDES}")


### PR DESCRIPTION
A circular, hard-coded test path was left in the CMake test script. This will break if the folder is not named `p4c.`