### PR TITLE
Fix flawed code in up4.p4 and the pins switch models.

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -134,6 +134,7 @@ set (BMV2_V1MODEL_TEST_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_16_bmv_errors/*-bmv2.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/fabric_*/fabric.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/pins/*.p4"
+  "${P4C_SOURCE_DIR}/testdata/p4_16_samples/omec/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_14_samples/switch_*/switch.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_14_samples/*.p4"
   ${v1tests}

--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -63,6 +63,7 @@ set (P4TEST_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/fabric_*/fabric.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/pins/*.p4"
+  "${P4C_SOURCE_DIR}/testdata/p4_16_samples/omec/*.p4"
   )
 
 # Builds a list of tests for which P4Info generation is not supported. It makes

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -261,8 +261,6 @@ p4tools_add_xfail_reason(
   pins_middleblock.p4
   issue2283_1-bmv2.p4
 
-  # At index 0: INVALID_ARGUMENT, 'Unexpected number of action parameters'
-  up4.p4
   # At index 0: INVALID_ARGUMENT, '0 is not a valid session id'
   issue1642-bmv2.p4
   issue1653-bmv2.p4

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufXfail.cmake
@@ -134,5 +134,4 @@ p4tools_add_xfail_reason(
   issue2345-multiple_dependencies.p4
   issue2345-with_nested_if.p4
   issue2345.p4
-  up4.p4
 )

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2Xfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2Xfail.cmake
@@ -84,6 +84,7 @@ p4tools_add_xfail_reason(
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2"
   "Match type range not implemented for table keys"
+  up4.p4
 )
 
 p4tools_add_xfail_reason(
@@ -264,5 +265,4 @@ p4tools_add_xfail_reason(
   issue2345-multiple_dependencies.p4
   issue2345-with_nested_if.p4
   issue2345.p4
-  up4.p4
 )

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
@@ -29,6 +29,7 @@ set(
   TESTGEN_BMV2_P416_TESTS
   "${CMAKE_CURRENT_LIST_DIR}/p4-programs/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/pins/*.p4"
+  "${P4C_SOURCE_DIR}/testdata/p4_16_samples/omec/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/fabric_*/fabric.p4"
 )
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/up4.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/up4.p4
@@ -736,7 +736,9 @@ control PreQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta
                 }
             }
         }
-        Routing.apply(hdr, local_meta, std_meta);
+        if (hdr.ipv4.isValid()) {
+            Routing.apply(hdr, local_meta, std_meta);
+        }
         Acl.apply(hdr, local_meta, std_meta);
     }
 }

--- a/testdata/p4_16_samples/omec/README.md
+++ b/testdata/p4_16_samples/omec/README.md
@@ -1,0 +1,3 @@
+# OMEC P4 Programs
+The P4 programs contained here model a virtual User Plane Function (UPF) pipeline as part of the SD-Fabric project. up4.p4 is a One-Big-UPF abstraction, a program that doesn't run on switches, but is used as the schema to define the content of the P4Runtime messages that can be exchanged with the UP4 app.
+These P4 programs define . They are sourced from https://github.com/omec-project/up4. For more information, please see https://docs.sd-fabric.org/master/advanced/p4-upf.html.

--- a/testdata/p4_16_samples/omec/up4.p4
+++ b/testdata/p4_16_samples/omec/up4.p4
@@ -1,0 +1,762 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+const bit<4> IP_VERSION_4 = 4;
+const bit<8> DEFAULT_IPV4_TTL = 64;
+typedef bit<48> mac_addr_t;
+typedef bit<32> ipv4_addr_t;
+typedef bit<16> l4_port_t;
+typedef bit<8> ip_proto_t;
+typedef bit<16> eth_type_t;
+const bit<16> UDP_PORT_GTPU = 2152;
+const bit<3> GTP_V1 = 0x1;
+const bit<1> GTP_PROTOCOL_TYPE_GTP = 0x1;
+const bit<8> GTP_MESSAGE_TYPE_UPDU = 0xff;
+const bit<8> GTPU_NEXT_EXT_NONE = 0x0;
+const bit<8> GTPU_NEXT_EXT_PSC = 0x85;
+const bit<4> GTPU_EXT_PSC_TYPE_DL = 4w0;
+const bit<4> GTPU_EXT_PSC_TYPE_UL = 4w1;
+const bit<8> GTPU_EXT_PSC_LEN = 8w1;
+typedef bit<32> teid_t;
+typedef bit<6> qfi_t;
+typedef bit<32> counter_index_t;
+typedef bit<8> tunnel_peer_id_t;
+typedef bit<32> app_meter_idx_t;
+typedef bit<32> session_meter_idx_t;
+typedef bit<6> slice_tc_meter_idx_t;
+typedef bit<4> slice_id_t;
+typedef bit<2> tc_t;
+const qfi_t DEFAULT_QFI = 0;
+const bit<8> APP_ID_UNKNOWN = 0;
+const session_meter_idx_t DEFAULT_SESSION_METER_IDX = 0;
+const app_meter_idx_t DEFAULT_APP_METER_IDX = 0;
+enum bit<8> GTPUMessageType {
+    GPDU = 255
+}
+
+enum bit<16> EtherType {
+    IPV4 = 0x800,
+    IPV6 = 0x86dd
+}
+
+enum bit<8> IpProtocol {
+    ICMP = 1,
+    TCP = 6,
+    UDP = 17
+}
+
+enum bit<16> L4Port {
+    DHCP_SERV = 67,
+    DHCP_CLIENT = 68,
+    GTP_GPDU = 2152,
+    IPV4_IN_UDP = 9875
+}
+
+enum bit<8> Direction {
+    UNKNOWN = 0x0,
+    UPLINK = 0x1,
+    DOWNLINK = 0x2,
+    OTHER = 0x3
+}
+
+enum bit<8> InterfaceType {
+    UNKNOWN = 0x0,
+    ACCESS = 0x1,
+    CORE = 0x2
+}
+
+enum bit<4> Slice {
+    DEFAULT = 0x0
+}
+
+enum bit<2> TrafficClass {
+    BEST_EFFORT = 0,
+    CONTROL = 1,
+    REAL_TIME = 2,
+    ELASTIC = 3
+}
+
+enum bit<2> MeterColor {
+    GREEN = 0,
+    YELLOW = 1,
+    RED = 2
+}
+
+header ethernet_t {
+    mac_addr_t dst_addr;
+    mac_addr_t src_addr;
+    eth_type_t ether_type;
+}
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<6>      dscp;
+    bit<2>      ecn;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     frag_offset;
+    bit<8>      ttl;
+    ip_proto_t  proto;
+    bit<16>     checksum;
+    ipv4_addr_t src_addr;
+    ipv4_addr_t dst_addr;
+}
+
+header tcp_t {
+    l4_port_t sport;
+    l4_port_t dport;
+    bit<32>   seq_no;
+    bit<32>   ack_no;
+    bit<4>    data_offset;
+    bit<3>    res;
+    bit<3>    ecn;
+    bit<6>    ctrl;
+    bit<16>   window;
+    bit<16>   checksum;
+    bit<16>   urgent_ptr;
+}
+
+header udp_t {
+    l4_port_t sport;
+    l4_port_t dport;
+    bit<16>   len;
+    bit<16>   checksum;
+}
+
+header icmp_t {
+    bit<8>  icmp_type;
+    bit<8>  icmp_code;
+    bit<16> checksum;
+    bit<16> identifier;
+    bit<16> sequence_number;
+    bit<64> timestamp;
+}
+
+header gtpu_t {
+    bit<3>  version;
+    bit<1>  pt;
+    bit<1>  spare;
+    bit<1>  ex_flag;
+    bit<1>  seq_flag;
+    bit<1>  npdu_flag;
+    bit<8>  msgtype;
+    bit<16> msglen;
+    teid_t  teid;
+}
+
+header gtpu_options_t {
+    bit<16> seq_num;
+    bit<8>  n_pdu_num;
+    bit<8>  next_ext;
+}
+
+header gtpu_ext_psc_t {
+    bit<8> len;
+    bit<4> type;
+    bit<4> spare0;
+    bit<1> ppp;
+    bit<1> rqi;
+    bit<6> qfi;
+    bit<8> next_ext;
+}
+
+@controller_header("packet_out") header packet_out_t {
+    bit<8> reserved;
+}
+
+@controller_header("packet_in") header packet_in_t {
+    PortId_t ingress_port;
+    bit<7>   _pad;
+}
+
+struct parsed_headers_t {
+    packet_out_t   packet_out;
+    packet_in_t    packet_in;
+    ethernet_t     ethernet;
+    ipv4_t         ipv4;
+    udp_t          udp;
+    tcp_t          tcp;
+    icmp_t         icmp;
+    gtpu_t         gtpu;
+    gtpu_options_t gtpu_options;
+    gtpu_ext_psc_t gtpu_ext_psc;
+    ipv4_t         inner_ipv4;
+    udp_t          inner_udp;
+    tcp_t          inner_tcp;
+    icmp_t         inner_icmp;
+}
+
+struct ddn_digest_t {
+    ipv4_addr_t ue_address;
+}
+
+struct local_metadata_t {
+    Direction           direction;
+    teid_t              teid;
+    slice_id_t          slice_id;
+    tc_t                tc;
+    ipv4_addr_t         next_hop_ip;
+    ipv4_addr_t         ue_addr;
+    ipv4_addr_t         inet_addr;
+    l4_port_t           ue_l4_port;
+    l4_port_t           inet_l4_port;
+    l4_port_t           l4_sport;
+    l4_port_t           l4_dport;
+    ip_proto_t          ip_proto;
+    bit<8>              application_id;
+    bit<8>              src_iface;
+    bool                needs_gtpu_decap;
+    bool                needs_tunneling;
+    bool                needs_buffering;
+    bool                needs_dropping;
+    bool                terminations_hit;
+    counter_index_t     ctr_idx;
+    tunnel_peer_id_t    tunnel_peer_id;
+    ipv4_addr_t         tunnel_out_src_ipv4_addr;
+    ipv4_addr_t         tunnel_out_dst_ipv4_addr;
+    l4_port_t           tunnel_out_udp_sport;
+    teid_t              tunnel_out_teid;
+    qfi_t               tunnel_out_qfi;
+    session_meter_idx_t session_meter_idx_internal;
+    app_meter_idx_t     app_meter_idx_internal;
+    MeterColor          session_color;
+    MeterColor          app_color;
+    MeterColor          slice_tc_color;
+    @field_list(0)
+    PortId_t            preserved_ingress_port;
+}
+
+parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    state start {
+        transition select(std_meta.ingress_port) {
+            255: parse_packet_out;
+            default: parse_ethernet;
+        }
+    }
+    state parse_packet_out {
+        packet.extract(hdr.packet_out);
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            EtherType.IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition select(hdr.ipv4.proto) {
+            IpProtocol.UDP: parse_udp;
+            IpProtocol.TCP: parse_tcp;
+            IpProtocol.ICMP: parse_icmp;
+            default: accept;
+        }
+    }
+    state parse_udp {
+        packet.extract(hdr.udp);
+        local_meta.l4_sport = hdr.udp.sport;
+        local_meta.l4_dport = hdr.udp.dport;
+        gtpu_t gtpu = packet.lookahead<gtpu_t>();
+        transition select(hdr.udp.dport, gtpu.version, gtpu.msgtype) {
+            (L4Port.IPV4_IN_UDP, default, default): parse_inner_ipv4;
+            (L4Port.GTP_GPDU, GTP_V1, GTPUMessageType.GPDU): parse_gtpu;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        packet.extract(hdr.tcp);
+        local_meta.l4_sport = hdr.tcp.sport;
+        local_meta.l4_dport = hdr.tcp.dport;
+        transition accept;
+    }
+    state parse_icmp {
+        packet.extract(hdr.icmp);
+        transition accept;
+    }
+    state parse_gtpu {
+        packet.extract(hdr.gtpu);
+        local_meta.teid = hdr.gtpu.teid;
+        transition select(hdr.gtpu.ex_flag, hdr.gtpu.seq_flag, hdr.gtpu.npdu_flag) {
+            (0, 0, 0): parse_inner_ipv4;
+            default: parse_gtpu_options;
+        }
+    }
+    state parse_gtpu_options {
+        packet.extract(hdr.gtpu_options);
+        bit<8> gtpu_ext_len = packet.lookahead<bit<8>>();
+        transition select(hdr.gtpu_options.next_ext, gtpu_ext_len) {
+            (GTPU_NEXT_EXT_PSC, GTPU_EXT_PSC_LEN): parse_gtpu_ext_psc;
+            default: accept;
+        }
+    }
+    state parse_gtpu_ext_psc {
+        packet.extract(hdr.gtpu_ext_psc);
+        transition select(hdr.gtpu_ext_psc.next_ext) {
+            GTPU_NEXT_EXT_NONE: parse_inner_ipv4;
+            default: accept;
+        }
+    }
+    state parse_inner_ipv4 {
+        packet.extract(hdr.inner_ipv4);
+        transition select(hdr.inner_ipv4.proto) {
+            IpProtocol.UDP: parse_inner_udp;
+            IpProtocol.TCP: parse_inner_tcp;
+            IpProtocol.ICMP: parse_inner_icmp;
+            default: accept;
+        }
+    }
+    state parse_inner_udp {
+        packet.extract(hdr.inner_udp);
+        local_meta.l4_sport = hdr.inner_udp.sport;
+        local_meta.l4_dport = hdr.inner_udp.dport;
+        transition accept;
+    }
+    state parse_inner_tcp {
+        packet.extract(hdr.inner_tcp);
+        local_meta.l4_sport = hdr.inner_tcp.sport;
+        local_meta.l4_dport = hdr.inner_tcp.dport;
+        transition accept;
+    }
+    state parse_inner_icmp {
+        packet.extract(hdr.inner_icmp);
+        transition accept;
+    }
+}
+
+control DeparserImpl(packet_out packet, in parsed_headers_t hdr) {
+    apply {
+        packet.emit(hdr.packet_in);
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.udp);
+        packet.emit(hdr.tcp);
+        packet.emit(hdr.icmp);
+        packet.emit(hdr.gtpu);
+        packet.emit(hdr.gtpu_options);
+        packet.emit(hdr.gtpu_ext_psc);
+        packet.emit(hdr.inner_ipv4);
+        packet.emit(hdr.inner_udp);
+        packet.emit(hdr.inner_tcp);
+        packet.emit(hdr.inner_icmp);
+    }
+}
+
+control VerifyChecksumImpl(inout parsed_headers_t hdr, inout local_metadata_t meta) {
+    apply {
+        verify_checksum(hdr.ipv4.isValid(), { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.dscp, hdr.ipv4.ecn, hdr.ipv4.total_len, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.frag_offset, hdr.ipv4.ttl, hdr.ipv4.proto, hdr.ipv4.src_addr, hdr.ipv4.dst_addr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        verify_checksum(hdr.inner_ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.dscp, hdr.inner_ipv4.ecn, hdr.inner_ipv4.total_len, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.frag_offset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.proto, hdr.inner_ipv4.src_addr, hdr.inner_ipv4.dst_addr }, hdr.inner_ipv4.checksum, HashAlgorithm.csum16);
+    }
+}
+
+control ComputeChecksumImpl(inout parsed_headers_t hdr, inout local_metadata_t local_meta) {
+    apply {
+        update_checksum(hdr.ipv4.isValid(), { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.dscp, hdr.ipv4.ecn, hdr.ipv4.total_len, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.frag_offset, hdr.ipv4.ttl, hdr.ipv4.proto, hdr.ipv4.src_addr, hdr.ipv4.dst_addr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        update_checksum(hdr.inner_ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.dscp, hdr.inner_ipv4.ecn, hdr.inner_ipv4.total_len, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.frag_offset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.proto, hdr.inner_ipv4.src_addr, hdr.inner_ipv4.dst_addr }, hdr.inner_ipv4.checksum, HashAlgorithm.csum16);
+    }
+}
+
+control Acl(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    action set_port(PortId_t port) {
+        std_meta.egress_spec = port;
+    }
+    action punt() {
+        set_port(255);
+    }
+    action clone_to_cpu() {
+        clone_preserving_field_list(CloneType.I2E, 99, 0);
+    }
+    action drop() {
+        mark_to_drop(std_meta);
+        exit;
+    }
+    table acls {
+        key = {
+            std_meta.ingress_port  : ternary @name("inport") ;
+            local_meta.src_iface   : ternary @name("src_iface") ;
+            hdr.ethernet.src_addr  : ternary @name("eth_src") ;
+            hdr.ethernet.dst_addr  : ternary @name("eth_dst") ;
+            hdr.ethernet.ether_type: ternary @name("eth_type") ;
+            hdr.ipv4.src_addr      : ternary @name("ipv4_src") ;
+            hdr.ipv4.dst_addr      : ternary @name("ipv4_dst") ;
+            hdr.ipv4.proto         : ternary @name("ipv4_proto") ;
+            local_meta.l4_sport    : ternary @name("l4_sport") ;
+            local_meta.l4_dport    : ternary @name("l4_dport") ;
+        }
+        actions = {
+            set_port;
+            punt;
+            clone_to_cpu;
+            drop;
+            NoAction;
+        }
+        const default_action = NoAction;
+        @name("acls") counters = direct_counter(CounterType.packets_and_bytes);
+    }
+    apply {
+        if (hdr.ethernet.isValid() && hdr.ipv4.isValid()) {
+            acls.apply();
+        }
+    }
+}
+
+control Routing(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    action drop() {
+        mark_to_drop(std_meta);
+    }
+    action route(mac_addr_t src_mac, mac_addr_t dst_mac, PortId_t egress_port) {
+        std_meta.egress_spec = egress_port;
+        hdr.ethernet.src_addr = src_mac;
+        hdr.ethernet.dst_addr = dst_mac;
+    }
+    table routes_v4 {
+        key = {
+            hdr.ipv4.dst_addr  : lpm @name("dst_prefix") ;
+            hdr.ipv4.src_addr  : selector;
+            hdr.ipv4.proto     : selector;
+            local_meta.l4_sport: selector;
+            local_meta.l4_dport: selector;
+        }
+        actions = {
+            route;
+        }
+        @name("hashed_selector") implementation = action_selector(HashAlgorithm.crc16, 32w1024, 32w16);
+        size = 1024;
+    }
+    apply {
+        if (!hdr.ipv4.isValid()) {
+            return;
+        }
+        hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
+        if (hdr.ipv4.ttl == 0) {
+            drop();
+        } else {
+            routes_v4.apply();
+        }
+    }
+}
+
+control PreQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    counter<counter_index_t>(1024, CounterType.packets_and_bytes) pre_qos_counter;
+    meter<app_meter_idx_t>(1024, MeterType.bytes) app_meter;
+    meter<session_meter_idx_t>(1024, MeterType.bytes) session_meter;
+    meter<slice_tc_meter_idx_t>(1 << 6, MeterType.bytes) slice_tc_meter;
+    action _initialize_metadata() {
+        local_meta.session_meter_idx_internal = DEFAULT_SESSION_METER_IDX;
+        local_meta.app_meter_idx_internal = DEFAULT_APP_METER_IDX;
+        local_meta.application_id = APP_ID_UNKNOWN;
+        local_meta.preserved_ingress_port = std_meta.ingress_port;
+    }
+    table my_station {
+        key = {
+            hdr.ethernet.dst_addr: exact @name("dst_mac") ;
+        }
+        actions = {
+            NoAction;
+        }
+    }
+    action set_source_iface(InterfaceType src_iface, Direction direction, Slice slice_id) {
+        local_meta.src_iface = src_iface;
+        local_meta.direction = direction;
+        local_meta.slice_id = slice_id;
+    }
+    table interfaces {
+        key = {
+            hdr.ipv4.dst_addr: lpm @name("ipv4_dst_prefix") ;
+        }
+        actions = {
+            set_source_iface;
+        }
+        const default_action = set_source_iface(InterfaceType.UNKNOWN, Direction.UNKNOWN, Slice.DEFAULT);
+    }
+    @hidden action gtpu_decap() {
+        hdr.ipv4 = hdr.inner_ipv4;
+        hdr.inner_ipv4.setInvalid();
+        hdr.udp = hdr.inner_udp;
+        hdr.inner_udp.setInvalid();
+        hdr.tcp = hdr.inner_tcp;
+        hdr.inner_tcp.setInvalid();
+        hdr.icmp = hdr.inner_icmp;
+        hdr.inner_icmp.setInvalid();
+        hdr.gtpu.setInvalid();
+        hdr.gtpu_options.setInvalid();
+        hdr.gtpu_ext_psc.setInvalid();
+    }
+    @hidden action do_buffer() {
+        digest<ddn_digest_t>(1, { local_meta.ue_addr });
+        mark_to_drop(std_meta);
+        exit;
+    }
+    action do_drop() {
+        mark_to_drop(std_meta);
+        exit;
+    }
+    action set_session_uplink(session_meter_idx_t session_meter_idx) {
+        local_meta.needs_gtpu_decap = true;
+        local_meta.session_meter_idx_internal = session_meter_idx;
+    }
+    action set_session_uplink_drop() {
+        local_meta.needs_dropping = true;
+    }
+    action set_session_downlink(tunnel_peer_id_t tunnel_peer_id, session_meter_idx_t session_meter_idx) {
+        local_meta.tunnel_peer_id = tunnel_peer_id;
+        local_meta.session_meter_idx_internal = session_meter_idx;
+    }
+    action set_session_downlink_drop() {
+        local_meta.needs_dropping = true;
+    }
+    action set_session_downlink_buff(session_meter_idx_t session_meter_idx) {
+        local_meta.needs_buffering = true;
+        local_meta.session_meter_idx_internal = session_meter_idx;
+    }
+    table sessions_uplink {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("n3_address") ;
+            local_meta.teid  : exact @name("teid") ;
+        }
+        actions = {
+            set_session_uplink;
+            set_session_uplink_drop;
+            @defaultonly do_drop;
+        }
+        const default_action = do_drop;
+    }
+    table sessions_downlink {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("ue_address") ;
+        }
+        actions = {
+            set_session_downlink;
+            set_session_downlink_drop;
+            set_session_downlink_buff;
+            @defaultonly do_drop;
+        }
+        const default_action = do_drop;
+    }
+    @hidden action common_term(counter_index_t ctr_idx) {
+        local_meta.ctr_idx = ctr_idx;
+        local_meta.terminations_hit = true;
+    }
+    action uplink_term_fwd(counter_index_t ctr_idx, TrafficClass tc, app_meter_idx_t app_meter_idx) {
+        common_term(ctr_idx);
+        local_meta.app_meter_idx_internal = app_meter_idx;
+        local_meta.tc = tc;
+    }
+    action uplink_term_drop(counter_index_t ctr_idx) {
+        common_term(ctr_idx);
+        local_meta.needs_dropping = true;
+    }
+    action downlink_term_fwd(counter_index_t ctr_idx, teid_t teid, qfi_t qfi, TrafficClass tc, app_meter_idx_t app_meter_idx) {
+        common_term(ctr_idx);
+        local_meta.tunnel_out_teid = teid;
+        local_meta.tunnel_out_qfi = qfi;
+        local_meta.app_meter_idx_internal = app_meter_idx;
+        local_meta.tc = tc;
+    }
+    action downlink_term_drop(counter_index_t ctr_idx) {
+        common_term(ctr_idx);
+        local_meta.needs_dropping = true;
+    }
+    table terminations_uplink {
+        key = {
+            local_meta.ue_addr       : exact @name("ue_address") ;
+            local_meta.application_id: exact @name("app_id") ;
+        }
+        actions = {
+            uplink_term_fwd;
+            uplink_term_drop;
+            @defaultonly do_drop;
+        }
+        const default_action = do_drop;
+    }
+    table terminations_downlink {
+        key = {
+            local_meta.ue_addr       : exact @name("ue_address") ;
+            local_meta.application_id: exact @name("app_id") ;
+        }
+        actions = {
+            downlink_term_fwd;
+            downlink_term_drop;
+            @defaultonly do_drop;
+        }
+        const default_action = do_drop;
+    }
+    action set_app_id(bit<8> app_id) {
+        local_meta.application_id = app_id;
+    }
+    table applications {
+        key = {
+            local_meta.slice_id    : exact @name("slice_id") ;
+            local_meta.inet_addr   : lpm @name("app_ip_addr") ;
+            local_meta.inet_l4_port: range @name("app_l4_port") ;
+            local_meta.ip_proto    : ternary @name("app_ip_proto") ;
+        }
+        actions = {
+            set_app_id;
+        }
+        const default_action = set_app_id(APP_ID_UNKNOWN);
+    }
+    action load_tunnel_param(ipv4_addr_t src_addr, ipv4_addr_t dst_addr, l4_port_t sport) {
+        local_meta.tunnel_out_src_ipv4_addr = src_addr;
+        local_meta.tunnel_out_dst_ipv4_addr = dst_addr;
+        local_meta.tunnel_out_udp_sport = sport;
+        local_meta.needs_tunneling = true;
+    }
+    table tunnel_peers {
+        key = {
+            local_meta.tunnel_peer_id: exact @name("tunnel_peer_id") ;
+        }
+        actions = {
+            load_tunnel_param;
+        }
+    }
+    @hidden action _udp_encap(ipv4_addr_t src_addr, ipv4_addr_t dst_addr, l4_port_t udp_sport, L4Port udp_dport, bit<16> ipv4_total_len, bit<16> udp_len) {
+        hdr.inner_udp = hdr.udp;
+        hdr.udp.setInvalid();
+        hdr.inner_tcp = hdr.tcp;
+        hdr.tcp.setInvalid();
+        hdr.inner_icmp = hdr.icmp;
+        hdr.icmp.setInvalid();
+        hdr.udp.setValid();
+        hdr.udp.sport = udp_sport;
+        hdr.udp.dport = udp_dport;
+        hdr.udp.len = udp_len;
+        hdr.udp.checksum = 0;
+        hdr.inner_ipv4 = hdr.ipv4;
+        hdr.ipv4.setValid();
+        hdr.ipv4.version = IP_VERSION_4;
+        hdr.ipv4.ihl = 5;
+        hdr.ipv4.dscp = 0;
+        hdr.ipv4.ecn = 0;
+        hdr.ipv4.total_len = ipv4_total_len;
+        hdr.ipv4.identification = 0x1513;
+        hdr.ipv4.flags = 0;
+        hdr.ipv4.frag_offset = 0;
+        hdr.ipv4.ttl = DEFAULT_IPV4_TTL;
+        hdr.ipv4.proto = IpProtocol.UDP;
+        hdr.ipv4.src_addr = src_addr;
+        hdr.ipv4.dst_addr = dst_addr;
+        hdr.ipv4.checksum = 0;
+    }
+    @hidden action _gtpu_encap(teid_t teid) {
+        hdr.gtpu.setValid();
+        hdr.gtpu.version = GTP_V1;
+        hdr.gtpu.pt = GTP_PROTOCOL_TYPE_GTP;
+        hdr.gtpu.spare = 0;
+        hdr.gtpu.ex_flag = 0;
+        hdr.gtpu.seq_flag = 0;
+        hdr.gtpu.npdu_flag = 0;
+        hdr.gtpu.msgtype = GTPUMessageType.GPDU;
+        hdr.gtpu.msglen = hdr.inner_ipv4.total_len;
+        hdr.gtpu.teid = teid;
+    }
+    action do_gtpu_tunnel() {
+        _udp_encap(local_meta.tunnel_out_src_ipv4_addr, local_meta.tunnel_out_dst_ipv4_addr, local_meta.tunnel_out_udp_sport, L4Port.GTP_GPDU, hdr.ipv4.total_len + 20 + 8 + 8, hdr.ipv4.total_len + 8 + 8);
+        _gtpu_encap(local_meta.tunnel_out_teid);
+    }
+    action do_gtpu_tunnel_with_psc() {
+        _udp_encap(local_meta.tunnel_out_src_ipv4_addr, local_meta.tunnel_out_dst_ipv4_addr, local_meta.tunnel_out_udp_sport, L4Port.GTP_GPDU, hdr.ipv4.total_len + 20 + 8 + 8 + 4 + 4, hdr.ipv4.total_len + 8 + 8 + 4 + 4);
+        _gtpu_encap(local_meta.tunnel_out_teid);
+        hdr.gtpu.msglen = hdr.inner_ipv4.total_len + 4 + 4;
+        hdr.gtpu.ex_flag = 1;
+        hdr.gtpu_options.setValid();
+        hdr.gtpu_options.seq_num = 0;
+        hdr.gtpu_options.n_pdu_num = 0;
+        hdr.gtpu_options.next_ext = GTPU_NEXT_EXT_PSC;
+        hdr.gtpu_ext_psc.setValid();
+        hdr.gtpu_ext_psc.len = GTPU_EXT_PSC_LEN;
+        hdr.gtpu_ext_psc.type = GTPU_EXT_PSC_TYPE_DL;
+        hdr.gtpu_ext_psc.spare0 = 0;
+        hdr.gtpu_ext_psc.ppp = 0;
+        hdr.gtpu_ext_psc.rqi = 0;
+        hdr.gtpu_ext_psc.qfi = local_meta.tunnel_out_qfi;
+        hdr.gtpu_ext_psc.next_ext = GTPU_NEXT_EXT_NONE;
+    }
+    apply {
+        _initialize_metadata();
+        if (hdr.packet_out.isValid()) {
+            hdr.packet_out.setInvalid();
+        } else {
+            if (!my_station.apply().hit) {
+                return;
+            }
+            if (interfaces.apply().hit) {
+                if (local_meta.direction == Direction.UPLINK) {
+                    local_meta.ue_addr = hdr.inner_ipv4.src_addr;
+                    local_meta.inet_addr = hdr.inner_ipv4.dst_addr;
+                    local_meta.ue_l4_port = local_meta.l4_sport;
+                    local_meta.inet_l4_port = local_meta.l4_dport;
+                    local_meta.ip_proto = hdr.inner_ipv4.proto;
+                    sessions_uplink.apply();
+                } else if (local_meta.direction == Direction.DOWNLINK) {
+                    local_meta.ue_addr = hdr.ipv4.dst_addr;
+                    local_meta.inet_addr = hdr.ipv4.src_addr;
+                    local_meta.ue_l4_port = local_meta.l4_dport;
+                    local_meta.inet_l4_port = local_meta.l4_sport;
+                    local_meta.ip_proto = hdr.ipv4.proto;
+                    sessions_downlink.apply();
+                    tunnel_peers.apply();
+                }
+                applications.apply();
+                if (local_meta.direction == Direction.UPLINK) {
+                    terminations_uplink.apply();
+                } else if (local_meta.direction == Direction.DOWNLINK) {
+                    terminations_downlink.apply();
+                }
+                if (local_meta.terminations_hit) {
+                    pre_qos_counter.count(local_meta.ctr_idx);
+                }
+                app_meter.execute_meter<MeterColor>(local_meta.app_meter_idx_internal, local_meta.app_color);
+                if (local_meta.app_color == MeterColor.RED) {
+                    local_meta.needs_dropping = true;
+                } else {
+                    session_meter.execute_meter<MeterColor>(local_meta.session_meter_idx_internal, local_meta.session_color);
+                    if (local_meta.session_color == MeterColor.RED) {
+                        local_meta.needs_dropping = true;
+                    } else {
+                        slice_tc_meter.execute_meter<MeterColor>(local_meta.slice_id ++ local_meta.tc, local_meta.slice_tc_color);
+                        if (local_meta.slice_tc_color == MeterColor.RED) {
+                            local_meta.needs_dropping = true;
+                        }
+                    }
+                }
+                if (local_meta.needs_gtpu_decap) {
+                    gtpu_decap();
+                }
+                if (local_meta.needs_buffering) {
+                    do_buffer();
+                }
+                if (local_meta.needs_tunneling) {
+                    if (local_meta.tunnel_out_qfi == 0) {
+                        do_gtpu_tunnel();
+                    } else {
+                        do_gtpu_tunnel_with_psc();
+                    }
+                }
+                if (local_meta.needs_dropping) {
+                    do_drop();
+                }
+            }
+        }
+        Routing.apply(hdr, local_meta, std_meta);
+        Acl.apply(hdr, local_meta, std_meta);
+    }
+}
+
+control PostQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    counter<counter_index_t>(1024, CounterType.packets_and_bytes) post_qos_counter;
+    apply {
+        post_qos_counter.count(local_meta.ctr_idx);
+        if (std_meta.egress_port == 255) {
+            hdr.packet_in.setValid();
+            hdr.packet_in.ingress_port = local_meta.preserved_ingress_port;
+            exit;
+        }
+    }
+}
+
+V1Switch(ParserImpl(), VerifyChecksumImpl(), PreQosPipe(), PostQosPipe(), ComputeChecksumImpl(), DeparserImpl()) main;
+

--- a/testdata/p4_16_samples/pins/pins_fabric.p4
+++ b/testdata/p4_16_samples/pins/pins_fabric.p4
@@ -96,6 +96,15 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
+type bit<10> nexthop_id_t;
+type bit<10> tunnel_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
+const vrf_id_t kDefaultVrf = 0;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 0,

--- a/testdata/p4_16_samples/pins/pins_fabric.p4
+++ b/testdata/p4_16_samples/pins/pins_fabric.p4
@@ -96,15 +96,6 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<10> tunnel_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
-const vrf_id_t kDefaultVrf = 0;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 0,

--- a/testdata/p4_16_samples/pins/pins_middleblock.p4
+++ b/testdata/p4_16_samples/pins/pins_middleblock.p4
@@ -96,15 +96,15 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<10> tunnel_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
+type bit<10> nexthop_id_t;
+type bit<10> tunnel_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
 const vrf_id_t kDefaultVrf = 0;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 0,

--- a/testdata/p4_16_samples/pins/pins_wbb.p4
+++ b/testdata/p4_16_samples/pins/pins_wbb.p4
@@ -96,15 +96,15 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<10> tunnel_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
+type bit<10> nexthop_id_t;
+type bit<10> tunnel_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
 const vrf_id_t kDefaultVrf = 0;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 0,

--- a/testdata/p4_16_samples_outputs/omec/up4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/omec/up4-frontend.p4
@@ -1,0 +1,825 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+typedef bit<48> mac_addr_t;
+typedef bit<32> ipv4_addr_t;
+typedef bit<16> l4_port_t;
+typedef bit<8> ip_proto_t;
+typedef bit<16> eth_type_t;
+typedef bit<32> teid_t;
+typedef bit<6> qfi_t;
+typedef bit<32> counter_index_t;
+typedef bit<8> tunnel_peer_id_t;
+typedef bit<32> app_meter_idx_t;
+typedef bit<32> session_meter_idx_t;
+typedef bit<6> slice_tc_meter_idx_t;
+typedef bit<4> slice_id_t;
+typedef bit<2> tc_t;
+enum bit<8> GTPUMessageType {
+    GPDU = 8w255
+}
+
+enum bit<16> EtherType {
+    IPV4 = 16w0x800,
+    IPV6 = 16w0x86dd
+}
+
+enum bit<8> IpProtocol {
+    ICMP = 8w1,
+    TCP = 8w6,
+    UDP = 8w17
+}
+
+enum bit<16> L4Port {
+    DHCP_SERV = 16w67,
+    DHCP_CLIENT = 16w68,
+    GTP_GPDU = 16w2152,
+    IPV4_IN_UDP = 16w9875
+}
+
+enum bit<8> Direction {
+    UNKNOWN = 8w0x0,
+    UPLINK = 8w0x1,
+    DOWNLINK = 8w0x2,
+    OTHER = 8w0x3
+}
+
+enum bit<8> InterfaceType {
+    UNKNOWN = 8w0x0,
+    ACCESS = 8w0x1,
+    CORE = 8w0x2
+}
+
+enum bit<4> Slice {
+    DEFAULT = 4w0x0
+}
+
+enum bit<2> TrafficClass {
+    BEST_EFFORT = 2w0,
+    CONTROL = 2w1,
+    REAL_TIME = 2w2,
+    ELASTIC = 2w3
+}
+
+enum bit<2> MeterColor {
+    GREEN = 2w0,
+    YELLOW = 2w1,
+    RED = 2w2
+}
+
+header ethernet_t {
+    mac_addr_t dst_addr;
+    mac_addr_t src_addr;
+    eth_type_t ether_type;
+}
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<6>      dscp;
+    bit<2>      ecn;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     frag_offset;
+    bit<8>      ttl;
+    ip_proto_t  proto;
+    bit<16>     checksum;
+    ipv4_addr_t src_addr;
+    ipv4_addr_t dst_addr;
+}
+
+header tcp_t {
+    l4_port_t sport;
+    l4_port_t dport;
+    bit<32>   seq_no;
+    bit<32>   ack_no;
+    bit<4>    data_offset;
+    bit<3>    res;
+    bit<3>    ecn;
+    bit<6>    ctrl;
+    bit<16>   window;
+    bit<16>   checksum;
+    bit<16>   urgent_ptr;
+}
+
+header udp_t {
+    l4_port_t sport;
+    l4_port_t dport;
+    bit<16>   len;
+    bit<16>   checksum;
+}
+
+header icmp_t {
+    bit<8>  icmp_type;
+    bit<8>  icmp_code;
+    bit<16> checksum;
+    bit<16> identifier;
+    bit<16> sequence_number;
+    bit<64> timestamp;
+}
+
+header gtpu_t {
+    bit<3>  version;
+    bit<1>  pt;
+    bit<1>  spare;
+    bit<1>  ex_flag;
+    bit<1>  seq_flag;
+    bit<1>  npdu_flag;
+    bit<8>  msgtype;
+    bit<16> msglen;
+    teid_t  teid;
+}
+
+header gtpu_options_t {
+    bit<16> seq_num;
+    bit<8>  n_pdu_num;
+    bit<8>  next_ext;
+}
+
+header gtpu_ext_psc_t {
+    bit<8> len;
+    bit<4> type;
+    bit<4> spare0;
+    bit<1> ppp;
+    bit<1> rqi;
+    bit<6> qfi;
+    bit<8> next_ext;
+}
+
+@controller_header("packet_out") header packet_out_t {
+    bit<8> reserved;
+}
+
+@controller_header("packet_in") header packet_in_t {
+    PortId_t ingress_port;
+    bit<7>   _pad;
+}
+
+struct parsed_headers_t {
+    packet_out_t   packet_out;
+    packet_in_t    packet_in;
+    ethernet_t     ethernet;
+    ipv4_t         ipv4;
+    udp_t          udp;
+    tcp_t          tcp;
+    icmp_t         icmp;
+    gtpu_t         gtpu;
+    gtpu_options_t gtpu_options;
+    gtpu_ext_psc_t gtpu_ext_psc;
+    ipv4_t         inner_ipv4;
+    udp_t          inner_udp;
+    tcp_t          inner_tcp;
+    icmp_t         inner_icmp;
+}
+
+struct ddn_digest_t {
+    ipv4_addr_t ue_address;
+}
+
+struct local_metadata_t {
+    Direction           direction;
+    teid_t              teid;
+    slice_id_t          slice_id;
+    tc_t                tc;
+    ipv4_addr_t         next_hop_ip;
+    ipv4_addr_t         ue_addr;
+    ipv4_addr_t         inet_addr;
+    l4_port_t           ue_l4_port;
+    l4_port_t           inet_l4_port;
+    l4_port_t           l4_sport;
+    l4_port_t           l4_dport;
+    ip_proto_t          ip_proto;
+    bit<8>              application_id;
+    bit<8>              src_iface;
+    bool                needs_gtpu_decap;
+    bool                needs_tunneling;
+    bool                needs_buffering;
+    bool                needs_dropping;
+    bool                terminations_hit;
+    counter_index_t     ctr_idx;
+    tunnel_peer_id_t    tunnel_peer_id;
+    ipv4_addr_t         tunnel_out_src_ipv4_addr;
+    ipv4_addr_t         tunnel_out_dst_ipv4_addr;
+    l4_port_t           tunnel_out_udp_sport;
+    teid_t              tunnel_out_teid;
+    qfi_t               tunnel_out_qfi;
+    session_meter_idx_t session_meter_idx_internal;
+    app_meter_idx_t     app_meter_idx_internal;
+    MeterColor          session_color;
+    MeterColor          app_color;
+    MeterColor          slice_tc_color;
+    @field_list(0)
+    PortId_t            preserved_ingress_port;
+}
+
+parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    @name("ParserImpl.gtpu") gtpu_t gtpu_0;
+    @name("ParserImpl.gtpu_ext_len") bit<8> gtpu_ext_len_0;
+    state start {
+        transition select(std_meta.ingress_port) {
+            9w255: parse_packet_out;
+            default: parse_ethernet;
+        }
+    }
+    state parse_packet_out {
+        packet.extract<packet_out_t>(hdr.packet_out);
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            EtherType.IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.proto) {
+            IpProtocol.UDP: parse_udp;
+            IpProtocol.TCP: parse_tcp;
+            IpProtocol.ICMP: parse_icmp;
+            default: accept;
+        }
+    }
+    state parse_udp {
+        packet.extract<udp_t>(hdr.udp);
+        local_meta.l4_sport = hdr.udp.sport;
+        local_meta.l4_dport = hdr.udp.dport;
+        gtpu_0 = packet.lookahead<gtpu_t>();
+        transition select(hdr.udp.dport, gtpu_0.version, gtpu_0.msgtype) {
+            (L4Port.IPV4_IN_UDP, default, default): parse_inner_ipv4;
+            (L4Port.GTP_GPDU, 3w0x1, GTPUMessageType.GPDU): parse_gtpu;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        packet.extract<tcp_t>(hdr.tcp);
+        local_meta.l4_sport = hdr.tcp.sport;
+        local_meta.l4_dport = hdr.tcp.dport;
+        transition accept;
+    }
+    state parse_icmp {
+        packet.extract<icmp_t>(hdr.icmp);
+        transition accept;
+    }
+    state parse_gtpu {
+        packet.extract<gtpu_t>(hdr.gtpu);
+        local_meta.teid = hdr.gtpu.teid;
+        transition select(hdr.gtpu.ex_flag, hdr.gtpu.seq_flag, hdr.gtpu.npdu_flag) {
+            (1w0, 1w0, 1w0): parse_inner_ipv4;
+            default: parse_gtpu_options;
+        }
+    }
+    state parse_gtpu_options {
+        packet.extract<gtpu_options_t>(hdr.gtpu_options);
+        gtpu_ext_len_0 = packet.lookahead<bit<8>>();
+        transition select(hdr.gtpu_options.next_ext, gtpu_ext_len_0) {
+            (8w0x85, 8w1): parse_gtpu_ext_psc;
+            default: accept;
+        }
+    }
+    state parse_gtpu_ext_psc {
+        packet.extract<gtpu_ext_psc_t>(hdr.gtpu_ext_psc);
+        transition select(hdr.gtpu_ext_psc.next_ext) {
+            8w0x0: parse_inner_ipv4;
+            default: accept;
+        }
+    }
+    state parse_inner_ipv4 {
+        packet.extract<ipv4_t>(hdr.inner_ipv4);
+        transition select(hdr.inner_ipv4.proto) {
+            IpProtocol.UDP: parse_inner_udp;
+            IpProtocol.TCP: parse_inner_tcp;
+            IpProtocol.ICMP: parse_inner_icmp;
+            default: accept;
+        }
+    }
+    state parse_inner_udp {
+        packet.extract<udp_t>(hdr.inner_udp);
+        local_meta.l4_sport = hdr.inner_udp.sport;
+        local_meta.l4_dport = hdr.inner_udp.dport;
+        transition accept;
+    }
+    state parse_inner_tcp {
+        packet.extract<tcp_t>(hdr.inner_tcp);
+        local_meta.l4_sport = hdr.inner_tcp.sport;
+        local_meta.l4_dport = hdr.inner_tcp.dport;
+        transition accept;
+    }
+    state parse_inner_icmp {
+        packet.extract<icmp_t>(hdr.inner_icmp);
+        transition accept;
+    }
+}
+
+control DeparserImpl(packet_out packet, in parsed_headers_t hdr) {
+    apply {
+        packet.emit<packet_in_t>(hdr.packet_in);
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<udp_t>(hdr.udp);
+        packet.emit<tcp_t>(hdr.tcp);
+        packet.emit<icmp_t>(hdr.icmp);
+        packet.emit<gtpu_t>(hdr.gtpu);
+        packet.emit<gtpu_options_t>(hdr.gtpu_options);
+        packet.emit<gtpu_ext_psc_t>(hdr.gtpu_ext_psc);
+        packet.emit<ipv4_t>(hdr.inner_ipv4);
+        packet.emit<udp_t>(hdr.inner_udp);
+        packet.emit<tcp_t>(hdr.inner_tcp);
+        packet.emit<icmp_t>(hdr.inner_icmp);
+    }
+}
+
+control VerifyChecksumImpl(inout parsed_headers_t hdr, inout local_metadata_t meta) {
+    apply {
+        verify_checksum<tuple<bit<4>, bit<4>, bit<6>, bit<2>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.dscp, hdr.ipv4.ecn, hdr.ipv4.total_len, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.frag_offset, hdr.ipv4.ttl, hdr.ipv4.proto, hdr.ipv4.src_addr, hdr.ipv4.dst_addr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        verify_checksum<tuple<bit<4>, bit<4>, bit<6>, bit<2>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.dscp, hdr.inner_ipv4.ecn, hdr.inner_ipv4.total_len, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.frag_offset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.proto, hdr.inner_ipv4.src_addr, hdr.inner_ipv4.dst_addr }, hdr.inner_ipv4.checksum, HashAlgorithm.csum16);
+    }
+}
+
+control ComputeChecksumImpl(inout parsed_headers_t hdr, inout local_metadata_t local_meta) {
+    apply {
+        update_checksum<tuple<bit<4>, bit<4>, bit<6>, bit<2>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.ipv4.isValid(), { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.dscp, hdr.ipv4.ecn, hdr.ipv4.total_len, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.frag_offset, hdr.ipv4.ttl, hdr.ipv4.proto, hdr.ipv4.src_addr, hdr.ipv4.dst_addr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        update_checksum<tuple<bit<4>, bit<4>, bit<6>, bit<2>, bit<16>, bit<16>, bit<3>, bit<13>, bit<8>, bit<8>, bit<32>, bit<32>>, bit<16>>(hdr.inner_ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.dscp, hdr.inner_ipv4.ecn, hdr.inner_ipv4.total_len, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.frag_offset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.proto, hdr.inner_ipv4.src_addr, hdr.inner_ipv4.dst_addr }, hdr.inner_ipv4.checksum, HashAlgorithm.csum16);
+    }
+}
+
+control PreQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    @name("PreQosPipe.hasReturned_0") bool hasReturned_0;
+    @name("PreQosPipe.Routing.hasReturned") bool Routing_hasReturned;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_2() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_3() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_4() {
+    }
+    @name("PreQosPipe.Routing.drop") action Routing_drop_0() {
+        mark_to_drop(std_meta);
+    }
+    @name("PreQosPipe.Routing.route") action Routing_route_0(@name("src_mac") mac_addr_t src_mac, @name("dst_mac") mac_addr_t dst_mac, @name("egress_port") PortId_t egress_port_1) {
+        std_meta.egress_spec = egress_port_1;
+        hdr.ethernet.src_addr = src_mac;
+        hdr.ethernet.dst_addr = dst_mac;
+    }
+    @name("PreQosPipe.Routing.routes_v4") table Routing_routes_v4 {
+        key = {
+            hdr.ipv4.dst_addr  : lpm @name("dst_prefix");
+            hdr.ipv4.src_addr  : selector @name("hdr.ipv4.src_addr");
+            hdr.ipv4.proto     : selector @name("hdr.ipv4.proto");
+            local_meta.l4_sport: selector @name("local_meta.l4_sport");
+            local_meta.l4_dport: selector @name("local_meta.l4_dport");
+        }
+        actions = {
+            Routing_route_0();
+            @defaultonly NoAction_1();
+        }
+        @name("hashed_selector") implementation = action_selector(HashAlgorithm.crc16, 32w1024, 32w16);
+        size = 1024;
+        default_action = NoAction_1();
+    }
+    @name("PreQosPipe.Acl.set_port") action Acl_set_port_0(@name("port") PortId_t port) {
+        std_meta.egress_spec = port;
+    }
+    @name("PreQosPipe.Acl.punt") action Acl_punt_0() {
+        std_meta.egress_spec = 9w255;
+    }
+    @name("PreQosPipe.Acl.clone_to_cpu") action Acl_clone_to_cpu_0() {
+        clone_preserving_field_list(CloneType.I2E, 32w99, 8w0);
+    }
+    @name("PreQosPipe.Acl.drop") action Acl_drop_0() {
+        mark_to_drop(std_meta);
+        exit;
+    }
+    @name("PreQosPipe.Acl.acls") table Acl_acls {
+        key = {
+            std_meta.ingress_port  : ternary @name("inport");
+            local_meta.src_iface   : ternary @name("src_iface");
+            hdr.ethernet.src_addr  : ternary @name("eth_src");
+            hdr.ethernet.dst_addr  : ternary @name("eth_dst");
+            hdr.ethernet.ether_type: ternary @name("eth_type");
+            hdr.ipv4.src_addr      : ternary @name("ipv4_src");
+            hdr.ipv4.dst_addr      : ternary @name("ipv4_dst");
+            hdr.ipv4.proto         : ternary @name("ipv4_proto");
+            local_meta.l4_sport    : ternary @name("l4_sport");
+            local_meta.l4_dport    : ternary @name("l4_dport");
+        }
+        actions = {
+            Acl_set_port_0();
+            Acl_punt_0();
+            Acl_clone_to_cpu_0();
+            Acl_drop_0();
+            NoAction_2();
+        }
+        const default_action = NoAction_2();
+        @name("acls") counters = direct_counter(CounterType.packets_and_bytes);
+    }
+    @name("PreQosPipe.pre_qos_counter") counter<counter_index_t>(32w1024, CounterType.packets_and_bytes) pre_qos_counter_0;
+    @name("PreQosPipe.app_meter") meter<app_meter_idx_t>(32w1024, MeterType.bytes) app_meter_0;
+    @name("PreQosPipe.session_meter") meter<session_meter_idx_t>(32w1024, MeterType.bytes) session_meter_0;
+    @name("PreQosPipe.slice_tc_meter") meter<slice_tc_meter_idx_t>(32w64, MeterType.bytes) slice_tc_meter_0;
+    @name("PreQosPipe._initialize_metadata") action _initialize_metadata() {
+        local_meta.session_meter_idx_internal = 32w0;
+        local_meta.app_meter_idx_internal = 32w0;
+        local_meta.application_id = 8w0;
+        local_meta.preserved_ingress_port = std_meta.ingress_port;
+    }
+    @name("PreQosPipe.my_station") table my_station_0 {
+        key = {
+            hdr.ethernet.dst_addr: exact @name("dst_mac");
+        }
+        actions = {
+            NoAction_3();
+        }
+        default_action = NoAction_3();
+    }
+    @name("PreQosPipe.set_source_iface") action set_source_iface(@name("src_iface") InterfaceType src_iface_1, @name("direction") Direction direction_1, @name("slice_id") Slice slice_id_1) {
+        local_meta.src_iface = src_iface_1;
+        local_meta.direction = direction_1;
+        local_meta.slice_id = slice_id_1;
+    }
+    @name("PreQosPipe.interfaces") table interfaces_0 {
+        key = {
+            hdr.ipv4.dst_addr: lpm @name("ipv4_dst_prefix");
+        }
+        actions = {
+            set_source_iface();
+        }
+        const default_action = set_source_iface(InterfaceType.UNKNOWN, Direction.UNKNOWN, Slice.DEFAULT);
+    }
+    @hidden @name("PreQosPipe.gtpu_decap") action gtpu_decap() {
+        hdr.ipv4 = hdr.inner_ipv4;
+        hdr.inner_ipv4.setInvalid();
+        hdr.udp = hdr.inner_udp;
+        hdr.inner_udp.setInvalid();
+        hdr.tcp = hdr.inner_tcp;
+        hdr.inner_tcp.setInvalid();
+        hdr.icmp = hdr.inner_icmp;
+        hdr.inner_icmp.setInvalid();
+        hdr.gtpu.setInvalid();
+        hdr.gtpu_options.setInvalid();
+        hdr.gtpu_ext_psc.setInvalid();
+    }
+    @hidden @name("PreQosPipe.do_buffer") action do_buffer() {
+        digest<ddn_digest_t>(32w1, (ddn_digest_t){ue_address = local_meta.ue_addr});
+        mark_to_drop(std_meta);
+        exit;
+    }
+    @name("PreQosPipe.do_drop") action do_drop() {
+        mark_to_drop(std_meta);
+        exit;
+    }
+    @name("PreQosPipe.do_drop") action do_drop_1() {
+        mark_to_drop(std_meta);
+        exit;
+    }
+    @name("PreQosPipe.do_drop") action do_drop_2() {
+        mark_to_drop(std_meta);
+        exit;
+    }
+    @name("PreQosPipe.do_drop") action do_drop_3() {
+        mark_to_drop(std_meta);
+        exit;
+    }
+    @name("PreQosPipe.do_drop") action do_drop_4() {
+        mark_to_drop(std_meta);
+        exit;
+    }
+    @name("PreQosPipe.set_session_uplink") action set_session_uplink(@name("session_meter_idx") session_meter_idx_t session_meter_idx) {
+        local_meta.needs_gtpu_decap = true;
+        local_meta.session_meter_idx_internal = session_meter_idx;
+    }
+    @name("PreQosPipe.set_session_uplink_drop") action set_session_uplink_drop() {
+        local_meta.needs_dropping = true;
+    }
+    @name("PreQosPipe.set_session_downlink") action set_session_downlink(@name("tunnel_peer_id") tunnel_peer_id_t tunnel_peer_id_1, @name("session_meter_idx") session_meter_idx_t session_meter_idx_3) {
+        local_meta.tunnel_peer_id = tunnel_peer_id_1;
+        local_meta.session_meter_idx_internal = session_meter_idx_3;
+    }
+    @name("PreQosPipe.set_session_downlink_drop") action set_session_downlink_drop() {
+        local_meta.needs_dropping = true;
+    }
+    @name("PreQosPipe.set_session_downlink_buff") action set_session_downlink_buff(@name("session_meter_idx") session_meter_idx_t session_meter_idx_4) {
+        local_meta.needs_buffering = true;
+        local_meta.session_meter_idx_internal = session_meter_idx_4;
+    }
+    @name("PreQosPipe.sessions_uplink") table sessions_uplink_0 {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("n3_address");
+            local_meta.teid  : exact @name("teid");
+        }
+        actions = {
+            set_session_uplink();
+            set_session_uplink_drop();
+            @defaultonly do_drop();
+        }
+        const default_action = do_drop();
+    }
+    @name("PreQosPipe.sessions_downlink") table sessions_downlink_0 {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("ue_address");
+        }
+        actions = {
+            set_session_downlink();
+            set_session_downlink_drop();
+            set_session_downlink_buff();
+            @defaultonly do_drop_1();
+        }
+        const default_action = do_drop_1();
+    }
+    @name("PreQosPipe.uplink_term_fwd") action uplink_term_fwd(@name("ctr_idx") counter_index_t ctr_idx_0, @name("tc") TrafficClass tc_2, @name("app_meter_idx") app_meter_idx_t app_meter_idx) {
+        @hidden {
+            local_meta.ctr_idx = ctr_idx_0;
+            local_meta.terminations_hit = true;
+        }
+        local_meta.app_meter_idx_internal = app_meter_idx;
+        local_meta.tc = tc_2;
+    }
+    @name("PreQosPipe.uplink_term_drop") action uplink_term_drop(@name("ctr_idx") counter_index_t ctr_idx_5) {
+        @hidden {
+            local_meta.ctr_idx = ctr_idx_5;
+            local_meta.terminations_hit = true;
+        }
+        local_meta.needs_dropping = true;
+    }
+    @name("PreQosPipe.downlink_term_fwd") action downlink_term_fwd(@name("ctr_idx") counter_index_t ctr_idx_6, @name("teid") teid_t teid_1, @name("qfi") qfi_t qfi_1, @name("tc") TrafficClass tc_3, @name("app_meter_idx") app_meter_idx_t app_meter_idx_2) {
+        @hidden {
+            local_meta.ctr_idx = ctr_idx_6;
+            local_meta.terminations_hit = true;
+        }
+        local_meta.tunnel_out_teid = teid_1;
+        local_meta.tunnel_out_qfi = qfi_1;
+        local_meta.app_meter_idx_internal = app_meter_idx_2;
+        local_meta.tc = tc_3;
+    }
+    @name("PreQosPipe.downlink_term_drop") action downlink_term_drop(@name("ctr_idx") counter_index_t ctr_idx_7) {
+        @hidden {
+            local_meta.ctr_idx = ctr_idx_7;
+            local_meta.terminations_hit = true;
+        }
+        local_meta.needs_dropping = true;
+    }
+    @name("PreQosPipe.terminations_uplink") table terminations_uplink_0 {
+        key = {
+            local_meta.ue_addr       : exact @name("ue_address");
+            local_meta.application_id: exact @name("app_id");
+        }
+        actions = {
+            uplink_term_fwd();
+            uplink_term_drop();
+            @defaultonly do_drop_2();
+        }
+        const default_action = do_drop_2();
+    }
+    @name("PreQosPipe.terminations_downlink") table terminations_downlink_0 {
+        key = {
+            local_meta.ue_addr       : exact @name("ue_address");
+            local_meta.application_id: exact @name("app_id");
+        }
+        actions = {
+            downlink_term_fwd();
+            downlink_term_drop();
+            @defaultonly do_drop_3();
+        }
+        const default_action = do_drop_3();
+    }
+    @name("PreQosPipe.set_app_id") action set_app_id(@name("app_id") bit<8> app_id) {
+        local_meta.application_id = app_id;
+    }
+    @name("PreQosPipe.applications") table applications_0 {
+        key = {
+            local_meta.slice_id    : exact @name("slice_id");
+            local_meta.inet_addr   : lpm @name("app_ip_addr");
+            local_meta.inet_l4_port: range @name("app_l4_port");
+            local_meta.ip_proto    : ternary @name("app_ip_proto");
+        }
+        actions = {
+            set_app_id();
+        }
+        const default_action = set_app_id(8w0);
+    }
+    @name("PreQosPipe.load_tunnel_param") action load_tunnel_param(@name("src_addr") ipv4_addr_t src_addr_1, @name("dst_addr") ipv4_addr_t dst_addr_1, @name("sport") l4_port_t sport_1) {
+        local_meta.tunnel_out_src_ipv4_addr = src_addr_1;
+        local_meta.tunnel_out_dst_ipv4_addr = dst_addr_1;
+        local_meta.tunnel_out_udp_sport = sport_1;
+        local_meta.needs_tunneling = true;
+    }
+    @name("PreQosPipe.tunnel_peers") table tunnel_peers_0 {
+        key = {
+            local_meta.tunnel_peer_id: exact @name("tunnel_peer_id");
+        }
+        actions = {
+            load_tunnel_param();
+            @defaultonly NoAction_4();
+        }
+        default_action = NoAction_4();
+    }
+    @name("PreQosPipe.do_gtpu_tunnel") action do_gtpu_tunnel() {
+        @hidden {
+            hdr.inner_udp = hdr.udp;
+            hdr.udp.setInvalid();
+            hdr.inner_tcp = hdr.tcp;
+            hdr.tcp.setInvalid();
+            hdr.inner_icmp = hdr.icmp;
+            hdr.icmp.setInvalid();
+            hdr.udp.setValid();
+            hdr.udp.sport = local_meta.tunnel_out_udp_sport;
+            hdr.udp.dport = L4Port.GTP_GPDU;
+            hdr.udp.len = hdr.ipv4.total_len + 16w16;
+            hdr.udp.checksum = 16w0;
+            hdr.inner_ipv4 = hdr.ipv4;
+            hdr.ipv4.setValid();
+            hdr.ipv4.version = 4w4;
+            hdr.ipv4.ihl = 4w5;
+            hdr.ipv4.dscp = 6w0;
+            hdr.ipv4.ecn = 2w0;
+            hdr.ipv4.total_len = hdr.ipv4.total_len + 16w36;
+            hdr.ipv4.identification = 16w0x1513;
+            hdr.ipv4.flags = 3w0;
+            hdr.ipv4.frag_offset = 13w0;
+            hdr.ipv4.ttl = 8w64;
+            hdr.ipv4.proto = IpProtocol.UDP;
+            hdr.ipv4.src_addr = local_meta.tunnel_out_src_ipv4_addr;
+            hdr.ipv4.dst_addr = local_meta.tunnel_out_dst_ipv4_addr;
+            hdr.ipv4.checksum = 16w0;
+        }
+        @hidden {
+            hdr.gtpu.setValid();
+            hdr.gtpu.version = 3w0x1;
+            hdr.gtpu.pt = 1w0x1;
+            hdr.gtpu.spare = 1w0;
+            hdr.gtpu.ex_flag = 1w0;
+            hdr.gtpu.seq_flag = 1w0;
+            hdr.gtpu.npdu_flag = 1w0;
+            hdr.gtpu.msgtype = GTPUMessageType.GPDU;
+            hdr.gtpu.msglen = hdr.inner_ipv4.total_len;
+            hdr.gtpu.teid = local_meta.tunnel_out_teid;
+        }
+    }
+    @name("PreQosPipe.do_gtpu_tunnel_with_psc") action do_gtpu_tunnel_with_psc() {
+        @hidden {
+            hdr.inner_udp = hdr.udp;
+            hdr.udp.setInvalid();
+            hdr.inner_tcp = hdr.tcp;
+            hdr.tcp.setInvalid();
+            hdr.inner_icmp = hdr.icmp;
+            hdr.icmp.setInvalid();
+            hdr.udp.setValid();
+            hdr.udp.sport = local_meta.tunnel_out_udp_sport;
+            hdr.udp.dport = L4Port.GTP_GPDU;
+            hdr.udp.len = hdr.ipv4.total_len + 16w24;
+            hdr.udp.checksum = 16w0;
+            hdr.inner_ipv4 = hdr.ipv4;
+            hdr.ipv4.setValid();
+            hdr.ipv4.version = 4w4;
+            hdr.ipv4.ihl = 4w5;
+            hdr.ipv4.dscp = 6w0;
+            hdr.ipv4.ecn = 2w0;
+            hdr.ipv4.total_len = hdr.ipv4.total_len + 16w44;
+            hdr.ipv4.identification = 16w0x1513;
+            hdr.ipv4.flags = 3w0;
+            hdr.ipv4.frag_offset = 13w0;
+            hdr.ipv4.ttl = 8w64;
+            hdr.ipv4.proto = IpProtocol.UDP;
+            hdr.ipv4.src_addr = local_meta.tunnel_out_src_ipv4_addr;
+            hdr.ipv4.dst_addr = local_meta.tunnel_out_dst_ipv4_addr;
+            hdr.ipv4.checksum = 16w0;
+        }
+        @hidden {
+            hdr.gtpu.setValid();
+            hdr.gtpu.version = 3w0x1;
+            hdr.gtpu.pt = 1w0x1;
+            hdr.gtpu.spare = 1w0;
+            hdr.gtpu.seq_flag = 1w0;
+            hdr.gtpu.npdu_flag = 1w0;
+            hdr.gtpu.msgtype = GTPUMessageType.GPDU;
+            hdr.gtpu.teid = local_meta.tunnel_out_teid;
+        }
+        hdr.gtpu.msglen = hdr.inner_ipv4.total_len + 16w8;
+        hdr.gtpu.ex_flag = 1w1;
+        hdr.gtpu_options.setValid();
+        hdr.gtpu_options.seq_num = 16w0;
+        hdr.gtpu_options.n_pdu_num = 8w0;
+        hdr.gtpu_options.next_ext = 8w0x85;
+        hdr.gtpu_ext_psc.setValid();
+        hdr.gtpu_ext_psc.len = 8w1;
+        hdr.gtpu_ext_psc.type = 4w0;
+        hdr.gtpu_ext_psc.spare0 = 4w0;
+        hdr.gtpu_ext_psc.ppp = 1w0;
+        hdr.gtpu_ext_psc.rqi = 1w0;
+        hdr.gtpu_ext_psc.qfi = local_meta.tunnel_out_qfi;
+        hdr.gtpu_ext_psc.next_ext = 8w0x0;
+    }
+    apply {
+        hasReturned_0 = false;
+        _initialize_metadata();
+        if (hdr.packet_out.isValid()) {
+            hdr.packet_out.setInvalid();
+        } else {
+            if (my_station_0.apply().hit) {
+                ;
+            } else {
+                hasReturned_0 = true;
+            }
+            if (hasReturned_0) {
+                ;
+            } else if (interfaces_0.apply().hit) {
+                if (local_meta.direction == Direction.UPLINK) {
+                    local_meta.ue_addr = hdr.inner_ipv4.src_addr;
+                    local_meta.inet_addr = hdr.inner_ipv4.dst_addr;
+                    local_meta.ue_l4_port = local_meta.l4_sport;
+                    local_meta.inet_l4_port = local_meta.l4_dport;
+                    local_meta.ip_proto = hdr.inner_ipv4.proto;
+                    sessions_uplink_0.apply();
+                } else if (local_meta.direction == Direction.DOWNLINK) {
+                    local_meta.ue_addr = hdr.ipv4.dst_addr;
+                    local_meta.inet_addr = hdr.ipv4.src_addr;
+                    local_meta.ue_l4_port = local_meta.l4_dport;
+                    local_meta.inet_l4_port = local_meta.l4_sport;
+                    local_meta.ip_proto = hdr.ipv4.proto;
+                    sessions_downlink_0.apply();
+                    tunnel_peers_0.apply();
+                }
+                applications_0.apply();
+                if (local_meta.direction == Direction.UPLINK) {
+                    terminations_uplink_0.apply();
+                } else if (local_meta.direction == Direction.DOWNLINK) {
+                    terminations_downlink_0.apply();
+                }
+                if (local_meta.terminations_hit) {
+                    pre_qos_counter_0.count(local_meta.ctr_idx);
+                }
+                app_meter_0.execute_meter<MeterColor>(local_meta.app_meter_idx_internal, local_meta.app_color);
+                if (local_meta.app_color == MeterColor.RED) {
+                    local_meta.needs_dropping = true;
+                } else {
+                    session_meter_0.execute_meter<MeterColor>(local_meta.session_meter_idx_internal, local_meta.session_color);
+                    if (local_meta.session_color == MeterColor.RED) {
+                        local_meta.needs_dropping = true;
+                    } else {
+                        slice_tc_meter_0.execute_meter<MeterColor>(local_meta.slice_id ++ local_meta.tc, local_meta.slice_tc_color);
+                        if (local_meta.slice_tc_color == MeterColor.RED) {
+                            local_meta.needs_dropping = true;
+                        }
+                    }
+                }
+                if (local_meta.needs_gtpu_decap) {
+                    gtpu_decap();
+                }
+                if (local_meta.needs_buffering) {
+                    do_buffer();
+                }
+                if (local_meta.needs_tunneling) {
+                    if (local_meta.tunnel_out_qfi == 6w0) {
+                        do_gtpu_tunnel();
+                    } else {
+                        do_gtpu_tunnel_with_psc();
+                    }
+                }
+                if (local_meta.needs_dropping) {
+                    do_drop_4();
+                }
+            }
+        }
+        if (hasReturned_0) {
+            ;
+        } else {
+            Routing_hasReturned = false;
+            if (hdr.ipv4.isValid()) {
+                ;
+            } else {
+                Routing_hasReturned = true;
+            }
+            if (Routing_hasReturned) {
+                ;
+            } else {
+                hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
+                if (hdr.ipv4.ttl == 8w0) {
+                    Routing_drop_0();
+                } else {
+                    Routing_routes_v4.apply();
+                }
+            }
+            if (hdr.ethernet.isValid() && hdr.ipv4.isValid()) {
+                Acl_acls.apply();
+            }
+        }
+    }
+}
+
+control PostQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    @name("PostQosPipe.post_qos_counter") counter<counter_index_t>(32w1024, CounterType.packets_and_bytes) post_qos_counter_0;
+    apply {
+        post_qos_counter_0.count(local_meta.ctr_idx);
+        if (std_meta.egress_port == 9w255) {
+            hdr.packet_in.setValid();
+            hdr.packet_in.ingress_port = local_meta.preserved_ingress_port;
+            exit;
+        }
+    }
+}
+
+V1Switch<parsed_headers_t, local_metadata_t>(ParserImpl(), VerifyChecksumImpl(), PreQosPipe(), PostQosPipe(), ComputeChecksumImpl(), DeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/omec/up4-midend.p4
+++ b/testdata/p4_16_samples_outputs/omec/up4-midend.p4
@@ -1,0 +1,986 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> ether_type;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<6>  dscp;
+    bit<2>  ecn;
+    bit<16> total_len;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> frag_offset;
+    bit<8>  ttl;
+    bit<8>  proto;
+    bit<16> checksum;
+    bit<32> src_addr;
+    bit<32> dst_addr;
+}
+
+header tcp_t {
+    bit<16> sport;
+    bit<16> dport;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+header udp_t {
+    bit<16> sport;
+    bit<16> dport;
+    bit<16> len;
+    bit<16> checksum;
+}
+
+header icmp_t {
+    bit<8>  icmp_type;
+    bit<8>  icmp_code;
+    bit<16> checksum;
+    bit<16> identifier;
+    bit<16> sequence_number;
+    bit<64> timestamp;
+}
+
+header gtpu_t {
+    bit<3>  version;
+    bit<1>  pt;
+    bit<1>  spare;
+    bit<1>  ex_flag;
+    bit<1>  seq_flag;
+    bit<1>  npdu_flag;
+    bit<8>  msgtype;
+    bit<16> msglen;
+    bit<32> teid;
+}
+
+header gtpu_options_t {
+    bit<16> seq_num;
+    bit<8>  n_pdu_num;
+    bit<8>  next_ext;
+}
+
+header gtpu_ext_psc_t {
+    bit<8> len;
+    bit<4> type;
+    bit<4> spare0;
+    bit<1> ppp;
+    bit<1> rqi;
+    bit<6> qfi;
+    bit<8> next_ext;
+}
+
+@controller_header("packet_out") header packet_out_t {
+    bit<8> reserved;
+}
+
+@controller_header("packet_in") header packet_in_t {
+    bit<9> ingress_port;
+    bit<7> _pad;
+}
+
+struct parsed_headers_t {
+    packet_out_t   packet_out;
+    packet_in_t    packet_in;
+    ethernet_t     ethernet;
+    ipv4_t         ipv4;
+    udp_t          udp;
+    tcp_t          tcp;
+    icmp_t         icmp;
+    gtpu_t         gtpu;
+    gtpu_options_t gtpu_options;
+    gtpu_ext_psc_t gtpu_ext_psc;
+    ipv4_t         inner_ipv4;
+    udp_t          inner_udp;
+    tcp_t          inner_tcp;
+    icmp_t         inner_icmp;
+}
+
+struct ddn_digest_t {
+    bit<32> ue_address;
+}
+
+struct local_metadata_t {
+    bit<8>  direction;
+    bit<32> teid;
+    bit<4>  slice_id;
+    bit<2>  tc;
+    bit<32> next_hop_ip;
+    bit<32> ue_addr;
+    bit<32> inet_addr;
+    bit<16> ue_l4_port;
+    bit<16> inet_l4_port;
+    bit<16> l4_sport;
+    bit<16> l4_dport;
+    bit<8>  ip_proto;
+    bit<8>  application_id;
+    bit<8>  src_iface;
+    bool    needs_gtpu_decap;
+    bool    needs_tunneling;
+    bool    needs_buffering;
+    bool    needs_dropping;
+    bool    terminations_hit;
+    bit<32> ctr_idx;
+    bit<8>  tunnel_peer_id;
+    bit<32> tunnel_out_src_ipv4_addr;
+    bit<32> tunnel_out_dst_ipv4_addr;
+    bit<16> tunnel_out_udp_sport;
+    bit<32> tunnel_out_teid;
+    bit<6>  tunnel_out_qfi;
+    bit<32> session_meter_idx_internal;
+    bit<32> app_meter_idx_internal;
+    bit<2>  session_color;
+    bit<2>  app_color;
+    bit<2>  slice_tc_color;
+    @field_list(0)
+    bit<9>  preserved_ingress_port;
+}
+
+parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    @name("ParserImpl.gtpu") gtpu_t gtpu_0;
+    @name("ParserImpl.gtpu_ext_len") bit<8> gtpu_ext_len_0;
+    bit<64> tmp;
+    state start {
+        transition select(std_meta.ingress_port) {
+            9w255: parse_packet_out;
+            default: parse_ethernet;
+        }
+    }
+    state parse_packet_out {
+        packet.extract<packet_out_t>(hdr.packet_out);
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract<ipv4_t>(hdr.ipv4);
+        transition select(hdr.ipv4.proto) {
+            8w17: parse_udp;
+            8w6: parse_tcp;
+            8w1: parse_icmp;
+            default: accept;
+        }
+    }
+    state parse_udp {
+        packet.extract<udp_t>(hdr.udp);
+        local_meta.l4_sport = hdr.udp.sport;
+        local_meta.l4_dport = hdr.udp.dport;
+        tmp = packet.lookahead<bit<64>>();
+        gtpu_0.setValid();
+        gtpu_0.version = tmp[63:61];
+        gtpu_0.pt = tmp[60:60];
+        gtpu_0.spare = tmp[59:59];
+        gtpu_0.ex_flag = tmp[58:58];
+        gtpu_0.seq_flag = tmp[57:57];
+        gtpu_0.npdu_flag = tmp[56:56];
+        gtpu_0.msgtype = tmp[55:48];
+        gtpu_0.msglen = tmp[47:32];
+        gtpu_0.teid = tmp[31:0];
+        transition select(hdr.udp.dport, tmp[63:61], tmp[55:48]) {
+            (16w9875, default, default): parse_inner_ipv4;
+            (16w2152, 3w0x1, 8w255): parse_gtpu;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        packet.extract<tcp_t>(hdr.tcp);
+        local_meta.l4_sport = hdr.tcp.sport;
+        local_meta.l4_dport = hdr.tcp.dport;
+        transition accept;
+    }
+    state parse_icmp {
+        packet.extract<icmp_t>(hdr.icmp);
+        transition accept;
+    }
+    state parse_gtpu {
+        packet.extract<gtpu_t>(hdr.gtpu);
+        local_meta.teid = hdr.gtpu.teid;
+        transition select(hdr.gtpu.ex_flag, hdr.gtpu.seq_flag, hdr.gtpu.npdu_flag) {
+            (1w0, 1w0, 1w0): parse_inner_ipv4;
+            default: parse_gtpu_options;
+        }
+    }
+    state parse_gtpu_options {
+        packet.extract<gtpu_options_t>(hdr.gtpu_options);
+        gtpu_ext_len_0 = packet.lookahead<bit<8>>();
+        transition select(hdr.gtpu_options.next_ext, gtpu_ext_len_0) {
+            (8w0x85, 8w1): parse_gtpu_ext_psc;
+            default: accept;
+        }
+    }
+    state parse_gtpu_ext_psc {
+        packet.extract<gtpu_ext_psc_t>(hdr.gtpu_ext_psc);
+        transition select(hdr.gtpu_ext_psc.next_ext) {
+            8w0x0: parse_inner_ipv4;
+            default: accept;
+        }
+    }
+    state parse_inner_ipv4 {
+        packet.extract<ipv4_t>(hdr.inner_ipv4);
+        transition select(hdr.inner_ipv4.proto) {
+            8w17: parse_inner_udp;
+            8w6: parse_inner_tcp;
+            8w1: parse_inner_icmp;
+            default: accept;
+        }
+    }
+    state parse_inner_udp {
+        packet.extract<udp_t>(hdr.inner_udp);
+        local_meta.l4_sport = hdr.inner_udp.sport;
+        local_meta.l4_dport = hdr.inner_udp.dport;
+        transition accept;
+    }
+    state parse_inner_tcp {
+        packet.extract<tcp_t>(hdr.inner_tcp);
+        local_meta.l4_sport = hdr.inner_tcp.sport;
+        local_meta.l4_dport = hdr.inner_tcp.dport;
+        transition accept;
+    }
+    state parse_inner_icmp {
+        packet.extract<icmp_t>(hdr.inner_icmp);
+        transition accept;
+    }
+}
+
+control DeparserImpl(packet_out packet, in parsed_headers_t hdr) {
+    apply {
+        packet.emit<packet_in_t>(hdr.packet_in);
+        packet.emit<ethernet_t>(hdr.ethernet);
+        packet.emit<ipv4_t>(hdr.ipv4);
+        packet.emit<udp_t>(hdr.udp);
+        packet.emit<tcp_t>(hdr.tcp);
+        packet.emit<icmp_t>(hdr.icmp);
+        packet.emit<gtpu_t>(hdr.gtpu);
+        packet.emit<gtpu_options_t>(hdr.gtpu_options);
+        packet.emit<gtpu_ext_psc_t>(hdr.gtpu_ext_psc);
+        packet.emit<ipv4_t>(hdr.inner_ipv4);
+        packet.emit<udp_t>(hdr.inner_udp);
+        packet.emit<tcp_t>(hdr.inner_tcp);
+        packet.emit<icmp_t>(hdr.inner_icmp);
+    }
+}
+
+struct tuple_0 {
+    bit<4>  f0;
+    bit<4>  f1;
+    bit<6>  f2;
+    bit<2>  f3;
+    bit<16> f4;
+    bit<16> f5;
+    bit<3>  f6;
+    bit<13> f7;
+    bit<8>  f8;
+    bit<8>  f9;
+    bit<32> f10;
+    bit<32> f11;
+}
+
+control VerifyChecksumImpl(inout parsed_headers_t hdr, inout local_metadata_t meta) {
+    apply {
+        verify_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), (tuple_0){f0 = hdr.ipv4.version,f1 = hdr.ipv4.ihl,f2 = hdr.ipv4.dscp,f3 = hdr.ipv4.ecn,f4 = hdr.ipv4.total_len,f5 = hdr.ipv4.identification,f6 = hdr.ipv4.flags,f7 = hdr.ipv4.frag_offset,f8 = hdr.ipv4.ttl,f9 = hdr.ipv4.proto,f10 = hdr.ipv4.src_addr,f11 = hdr.ipv4.dst_addr}, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        verify_checksum<tuple_0, bit<16>>(hdr.inner_ipv4.isValid(), (tuple_0){f0 = hdr.inner_ipv4.version,f1 = hdr.inner_ipv4.ihl,f2 = hdr.inner_ipv4.dscp,f3 = hdr.inner_ipv4.ecn,f4 = hdr.inner_ipv4.total_len,f5 = hdr.inner_ipv4.identification,f6 = hdr.inner_ipv4.flags,f7 = hdr.inner_ipv4.frag_offset,f8 = hdr.inner_ipv4.ttl,f9 = hdr.inner_ipv4.proto,f10 = hdr.inner_ipv4.src_addr,f11 = hdr.inner_ipv4.dst_addr}, hdr.inner_ipv4.checksum, HashAlgorithm.csum16);
+    }
+}
+
+control ComputeChecksumImpl(inout parsed_headers_t hdr, inout local_metadata_t local_meta) {
+    apply {
+        update_checksum<tuple_0, bit<16>>(hdr.ipv4.isValid(), (tuple_0){f0 = hdr.ipv4.version,f1 = hdr.ipv4.ihl,f2 = hdr.ipv4.dscp,f3 = hdr.ipv4.ecn,f4 = hdr.ipv4.total_len,f5 = hdr.ipv4.identification,f6 = hdr.ipv4.flags,f7 = hdr.ipv4.frag_offset,f8 = hdr.ipv4.ttl,f9 = hdr.ipv4.proto,f10 = hdr.ipv4.src_addr,f11 = hdr.ipv4.dst_addr}, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        update_checksum<tuple_0, bit<16>>(hdr.inner_ipv4.isValid(), (tuple_0){f0 = hdr.inner_ipv4.version,f1 = hdr.inner_ipv4.ihl,f2 = hdr.inner_ipv4.dscp,f3 = hdr.inner_ipv4.ecn,f4 = hdr.inner_ipv4.total_len,f5 = hdr.inner_ipv4.identification,f6 = hdr.inner_ipv4.flags,f7 = hdr.inner_ipv4.frag_offset,f8 = hdr.inner_ipv4.ttl,f9 = hdr.inner_ipv4.proto,f10 = hdr.inner_ipv4.src_addr,f11 = hdr.inner_ipv4.dst_addr}, hdr.inner_ipv4.checksum, HashAlgorithm.csum16);
+    }
+}
+
+control PreQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    bool hasExited;
+    @name("PreQosPipe.hasReturned_0") bool hasReturned_0;
+    @name("PreQosPipe.Routing.hasReturned") bool Routing_hasReturned;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_2() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_3() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_4() {
+    }
+    @name("PreQosPipe.Routing.drop") action Routing_drop_0() {
+        mark_to_drop(std_meta);
+    }
+    @name("PreQosPipe.Routing.route") action Routing_route_0(@name("src_mac") bit<48> src_mac, @name("dst_mac") bit<48> dst_mac, @name("egress_port") bit<9> egress_port_1) {
+        std_meta.egress_spec = egress_port_1;
+        hdr.ethernet.src_addr = src_mac;
+        hdr.ethernet.dst_addr = dst_mac;
+    }
+    @name("PreQosPipe.Routing.routes_v4") table Routing_routes_v4 {
+        key = {
+            hdr.ipv4.dst_addr  : lpm @name("dst_prefix");
+            hdr.ipv4.src_addr  : selector @name("hdr.ipv4.src_addr");
+            hdr.ipv4.proto     : selector @name("hdr.ipv4.proto");
+            local_meta.l4_sport: selector @name("local_meta.l4_sport");
+            local_meta.l4_dport: selector @name("local_meta.l4_dport");
+        }
+        actions = {
+            Routing_route_0();
+            @defaultonly NoAction_1();
+        }
+        @name("hashed_selector") implementation = action_selector(HashAlgorithm.crc16, 32w1024, 32w16);
+        size = 1024;
+        default_action = NoAction_1();
+    }
+    @name("PreQosPipe.Acl.set_port") action Acl_set_port_0(@name("port") bit<9> port) {
+        std_meta.egress_spec = port;
+    }
+    @name("PreQosPipe.Acl.punt") action Acl_punt_0() {
+        std_meta.egress_spec = 9w255;
+    }
+    @name("PreQosPipe.Acl.clone_to_cpu") action Acl_clone_to_cpu_0() {
+        clone_preserving_field_list(CloneType.I2E, 32w99, 8w0);
+    }
+    @name("PreQosPipe.Acl.drop") action Acl_drop_0() {
+        mark_to_drop(std_meta);
+        hasExited = true;
+    }
+    @name("PreQosPipe.Acl.acls") table Acl_acls {
+        key = {
+            std_meta.ingress_port  : ternary @name("inport");
+            local_meta.src_iface   : ternary @name("src_iface");
+            hdr.ethernet.src_addr  : ternary @name("eth_src");
+            hdr.ethernet.dst_addr  : ternary @name("eth_dst");
+            hdr.ethernet.ether_type: ternary @name("eth_type");
+            hdr.ipv4.src_addr      : ternary @name("ipv4_src");
+            hdr.ipv4.dst_addr      : ternary @name("ipv4_dst");
+            hdr.ipv4.proto         : ternary @name("ipv4_proto");
+            local_meta.l4_sport    : ternary @name("l4_sport");
+            local_meta.l4_dport    : ternary @name("l4_dport");
+        }
+        actions = {
+            Acl_set_port_0();
+            Acl_punt_0();
+            Acl_clone_to_cpu_0();
+            Acl_drop_0();
+            NoAction_2();
+        }
+        const default_action = NoAction_2();
+        @name("acls") counters = direct_counter(CounterType.packets_and_bytes);
+    }
+    @name("PreQosPipe.pre_qos_counter") counter<bit<32>>(32w1024, CounterType.packets_and_bytes) pre_qos_counter_0;
+    @name("PreQosPipe.app_meter") meter<bit<32>>(32w1024, MeterType.bytes) app_meter_0;
+    @name("PreQosPipe.session_meter") meter<bit<32>>(32w1024, MeterType.bytes) session_meter_0;
+    @name("PreQosPipe.slice_tc_meter") meter<bit<6>>(32w64, MeterType.bytes) slice_tc_meter_0;
+    @name("PreQosPipe._initialize_metadata") action _initialize_metadata() {
+        local_meta.session_meter_idx_internal = 32w0;
+        local_meta.app_meter_idx_internal = 32w0;
+        local_meta.application_id = 8w0;
+        local_meta.preserved_ingress_port = std_meta.ingress_port;
+    }
+    @name("PreQosPipe.my_station") table my_station_0 {
+        key = {
+            hdr.ethernet.dst_addr: exact @name("dst_mac");
+        }
+        actions = {
+            NoAction_3();
+        }
+        default_action = NoAction_3();
+    }
+    @name("PreQosPipe.set_source_iface") action set_source_iface(@name("src_iface") bit<8> src_iface_1, @name("direction") bit<8> direction_1, @name("slice_id") bit<4> slice_id_1) {
+        local_meta.src_iface = src_iface_1;
+        local_meta.direction = direction_1;
+        local_meta.slice_id = slice_id_1;
+    }
+    @name("PreQosPipe.interfaces") table interfaces_0 {
+        key = {
+            hdr.ipv4.dst_addr: lpm @name("ipv4_dst_prefix");
+        }
+        actions = {
+            set_source_iface();
+        }
+        const default_action = set_source_iface(8w0x0, 8w0x0, 4w0x0);
+    }
+    @hidden @name("PreQosPipe.gtpu_decap") action gtpu_decap() {
+        hdr.ipv4 = hdr.inner_ipv4;
+        hdr.inner_ipv4.setInvalid();
+        hdr.udp = hdr.inner_udp;
+        hdr.inner_udp.setInvalid();
+        hdr.tcp = hdr.inner_tcp;
+        hdr.inner_tcp.setInvalid();
+        hdr.icmp = hdr.inner_icmp;
+        hdr.inner_icmp.setInvalid();
+        hdr.gtpu.setInvalid();
+        hdr.gtpu_options.setInvalid();
+        hdr.gtpu_ext_psc.setInvalid();
+    }
+    @hidden @name("PreQosPipe.do_buffer") action do_buffer() {
+        digest<ddn_digest_t>(32w1, (ddn_digest_t){ue_address = local_meta.ue_addr});
+        mark_to_drop(std_meta);
+        hasExited = true;
+    }
+    @name("PreQosPipe.do_drop") action do_drop() {
+        mark_to_drop(std_meta);
+        hasExited = true;
+    }
+    @name("PreQosPipe.do_drop") action do_drop_1() {
+        mark_to_drop(std_meta);
+        hasExited = true;
+    }
+    @name("PreQosPipe.do_drop") action do_drop_2() {
+        mark_to_drop(std_meta);
+        hasExited = true;
+    }
+    @name("PreQosPipe.do_drop") action do_drop_3() {
+        mark_to_drop(std_meta);
+        hasExited = true;
+    }
+    @name("PreQosPipe.do_drop") action do_drop_4() {
+        mark_to_drop(std_meta);
+        hasExited = true;
+    }
+    @name("PreQosPipe.set_session_uplink") action set_session_uplink(@name("session_meter_idx") bit<32> session_meter_idx) {
+        local_meta.needs_gtpu_decap = true;
+        local_meta.session_meter_idx_internal = session_meter_idx;
+    }
+    @name("PreQosPipe.set_session_uplink_drop") action set_session_uplink_drop() {
+        local_meta.needs_dropping = true;
+    }
+    @name("PreQosPipe.set_session_downlink") action set_session_downlink(@name("tunnel_peer_id") bit<8> tunnel_peer_id_1, @name("session_meter_idx") bit<32> session_meter_idx_3) {
+        local_meta.tunnel_peer_id = tunnel_peer_id_1;
+        local_meta.session_meter_idx_internal = session_meter_idx_3;
+    }
+    @name("PreQosPipe.set_session_downlink_drop") action set_session_downlink_drop() {
+        local_meta.needs_dropping = true;
+    }
+    @name("PreQosPipe.set_session_downlink_buff") action set_session_downlink_buff(@name("session_meter_idx") bit<32> session_meter_idx_4) {
+        local_meta.needs_buffering = true;
+        local_meta.session_meter_idx_internal = session_meter_idx_4;
+    }
+    @name("PreQosPipe.sessions_uplink") table sessions_uplink_0 {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("n3_address");
+            local_meta.teid  : exact @name("teid");
+        }
+        actions = {
+            set_session_uplink();
+            set_session_uplink_drop();
+            @defaultonly do_drop();
+        }
+        const default_action = do_drop();
+    }
+    @name("PreQosPipe.sessions_downlink") table sessions_downlink_0 {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("ue_address");
+        }
+        actions = {
+            set_session_downlink();
+            set_session_downlink_drop();
+            set_session_downlink_buff();
+            @defaultonly do_drop_1();
+        }
+        const default_action = do_drop_1();
+    }
+    @name("PreQosPipe.uplink_term_fwd") action uplink_term_fwd(@name("ctr_idx") bit<32> ctr_idx_0, @name("tc") bit<2> tc_2, @name("app_meter_idx") bit<32> app_meter_idx) {
+        local_meta.ctr_idx = ctr_idx_0;
+        local_meta.terminations_hit = true;
+        local_meta.app_meter_idx_internal = app_meter_idx;
+        local_meta.tc = tc_2;
+    }
+    @name("PreQosPipe.uplink_term_drop") action uplink_term_drop(@name("ctr_idx") bit<32> ctr_idx_5) {
+        local_meta.ctr_idx = ctr_idx_5;
+        local_meta.terminations_hit = true;
+        local_meta.needs_dropping = true;
+    }
+    @name("PreQosPipe.downlink_term_fwd") action downlink_term_fwd(@name("ctr_idx") bit<32> ctr_idx_6, @name("teid") bit<32> teid_1, @name("qfi") bit<6> qfi_1, @name("tc") bit<2> tc_3, @name("app_meter_idx") bit<32> app_meter_idx_2) {
+        local_meta.ctr_idx = ctr_idx_6;
+        local_meta.terminations_hit = true;
+        local_meta.tunnel_out_teid = teid_1;
+        local_meta.tunnel_out_qfi = qfi_1;
+        local_meta.app_meter_idx_internal = app_meter_idx_2;
+        local_meta.tc = tc_3;
+    }
+    @name("PreQosPipe.downlink_term_drop") action downlink_term_drop(@name("ctr_idx") bit<32> ctr_idx_7) {
+        local_meta.ctr_idx = ctr_idx_7;
+        local_meta.terminations_hit = true;
+        local_meta.needs_dropping = true;
+    }
+    @name("PreQosPipe.terminations_uplink") table terminations_uplink_0 {
+        key = {
+            local_meta.ue_addr       : exact @name("ue_address");
+            local_meta.application_id: exact @name("app_id");
+        }
+        actions = {
+            uplink_term_fwd();
+            uplink_term_drop();
+            @defaultonly do_drop_2();
+        }
+        const default_action = do_drop_2();
+    }
+    @name("PreQosPipe.terminations_downlink") table terminations_downlink_0 {
+        key = {
+            local_meta.ue_addr       : exact @name("ue_address");
+            local_meta.application_id: exact @name("app_id");
+        }
+        actions = {
+            downlink_term_fwd();
+            downlink_term_drop();
+            @defaultonly do_drop_3();
+        }
+        const default_action = do_drop_3();
+    }
+    @name("PreQosPipe.set_app_id") action set_app_id(@name("app_id") bit<8> app_id) {
+        local_meta.application_id = app_id;
+    }
+    @name("PreQosPipe.applications") table applications_0 {
+        key = {
+            local_meta.slice_id    : exact @name("slice_id");
+            local_meta.inet_addr   : lpm @name("app_ip_addr");
+            local_meta.inet_l4_port: range @name("app_l4_port");
+            local_meta.ip_proto    : ternary @name("app_ip_proto");
+        }
+        actions = {
+            set_app_id();
+        }
+        const default_action = set_app_id(8w0);
+    }
+    @name("PreQosPipe.load_tunnel_param") action load_tunnel_param(@name("src_addr") bit<32> src_addr_1, @name("dst_addr") bit<32> dst_addr_1, @name("sport") bit<16> sport_1) {
+        local_meta.tunnel_out_src_ipv4_addr = src_addr_1;
+        local_meta.tunnel_out_dst_ipv4_addr = dst_addr_1;
+        local_meta.tunnel_out_udp_sport = sport_1;
+        local_meta.needs_tunneling = true;
+    }
+    @name("PreQosPipe.tunnel_peers") table tunnel_peers_0 {
+        key = {
+            local_meta.tunnel_peer_id: exact @name("tunnel_peer_id");
+        }
+        actions = {
+            load_tunnel_param();
+            @defaultonly NoAction_4();
+        }
+        default_action = NoAction_4();
+    }
+    @name("PreQosPipe.do_gtpu_tunnel") action do_gtpu_tunnel() {
+        hdr.inner_udp = hdr.udp;
+        hdr.udp.setInvalid();
+        hdr.inner_tcp = hdr.tcp;
+        hdr.tcp.setInvalid();
+        hdr.inner_icmp = hdr.icmp;
+        hdr.icmp.setInvalid();
+        hdr.udp.setValid();
+        hdr.udp.sport = local_meta.tunnel_out_udp_sport;
+        hdr.udp.dport = 16w2152;
+        hdr.udp.len = hdr.ipv4.total_len + 16w16;
+        hdr.udp.checksum = 16w0;
+        hdr.inner_ipv4 = hdr.ipv4;
+        hdr.ipv4.setValid();
+        hdr.ipv4.version = 4w4;
+        hdr.ipv4.ihl = 4w5;
+        hdr.ipv4.dscp = 6w0;
+        hdr.ipv4.ecn = 2w0;
+        hdr.ipv4.total_len = hdr.ipv4.total_len + 16w36;
+        hdr.ipv4.identification = 16w0x1513;
+        hdr.ipv4.flags = 3w0;
+        hdr.ipv4.frag_offset = 13w0;
+        hdr.ipv4.ttl = 8w64;
+        hdr.ipv4.proto = 8w17;
+        hdr.ipv4.src_addr = local_meta.tunnel_out_src_ipv4_addr;
+        hdr.ipv4.dst_addr = local_meta.tunnel_out_dst_ipv4_addr;
+        hdr.ipv4.checksum = 16w0;
+        hdr.gtpu.setValid();
+        hdr.gtpu.version = 3w0x1;
+        hdr.gtpu.pt = 1w0x1;
+        hdr.gtpu.spare = 1w0;
+        hdr.gtpu.ex_flag = 1w0;
+        hdr.gtpu.seq_flag = 1w0;
+        hdr.gtpu.npdu_flag = 1w0;
+        hdr.gtpu.msgtype = 8w255;
+        hdr.gtpu.msglen = hdr.inner_ipv4.total_len;
+        hdr.gtpu.teid = local_meta.tunnel_out_teid;
+    }
+    @name("PreQosPipe.do_gtpu_tunnel_with_psc") action do_gtpu_tunnel_with_psc() {
+        hdr.inner_udp = hdr.udp;
+        hdr.udp.setInvalid();
+        hdr.inner_tcp = hdr.tcp;
+        hdr.tcp.setInvalid();
+        hdr.inner_icmp = hdr.icmp;
+        hdr.icmp.setInvalid();
+        hdr.udp.setValid();
+        hdr.udp.sport = local_meta.tunnel_out_udp_sport;
+        hdr.udp.dport = 16w2152;
+        hdr.udp.len = hdr.ipv4.total_len + 16w24;
+        hdr.udp.checksum = 16w0;
+        hdr.inner_ipv4 = hdr.ipv4;
+        hdr.ipv4.setValid();
+        hdr.ipv4.version = 4w4;
+        hdr.ipv4.ihl = 4w5;
+        hdr.ipv4.dscp = 6w0;
+        hdr.ipv4.ecn = 2w0;
+        hdr.ipv4.total_len = hdr.ipv4.total_len + 16w44;
+        hdr.ipv4.identification = 16w0x1513;
+        hdr.ipv4.flags = 3w0;
+        hdr.ipv4.frag_offset = 13w0;
+        hdr.ipv4.ttl = 8w64;
+        hdr.ipv4.proto = 8w17;
+        hdr.ipv4.src_addr = local_meta.tunnel_out_src_ipv4_addr;
+        hdr.ipv4.dst_addr = local_meta.tunnel_out_dst_ipv4_addr;
+        hdr.ipv4.checksum = 16w0;
+        hdr.gtpu.setValid();
+        hdr.gtpu.version = 3w0x1;
+        hdr.gtpu.pt = 1w0x1;
+        hdr.gtpu.spare = 1w0;
+        hdr.gtpu.seq_flag = 1w0;
+        hdr.gtpu.npdu_flag = 1w0;
+        hdr.gtpu.msgtype = 8w255;
+        hdr.gtpu.teid = local_meta.tunnel_out_teid;
+        hdr.gtpu.msglen = hdr.inner_ipv4.total_len + 16w8;
+        hdr.gtpu.ex_flag = 1w1;
+        hdr.gtpu_options.setValid();
+        hdr.gtpu_options.seq_num = 16w0;
+        hdr.gtpu_options.n_pdu_num = 8w0;
+        hdr.gtpu_options.next_ext = 8w0x85;
+        hdr.gtpu_ext_psc.setValid();
+        hdr.gtpu_ext_psc.len = 8w1;
+        hdr.gtpu_ext_psc.type = 4w0;
+        hdr.gtpu_ext_psc.spare0 = 4w0;
+        hdr.gtpu_ext_psc.ppp = 1w0;
+        hdr.gtpu_ext_psc.rqi = 1w0;
+        hdr.gtpu_ext_psc.qfi = local_meta.tunnel_out_qfi;
+        hdr.gtpu_ext_psc.next_ext = 8w0x0;
+    }
+    @hidden action act() {
+        hasExited = false;
+        hasReturned_0 = false;
+    }
+    @hidden action up4l681() {
+        hdr.packet_out.setInvalid();
+    }
+    @hidden action up4l684() {
+        hasReturned_0 = true;
+    }
+    @hidden action up4l688() {
+        local_meta.ue_addr = hdr.inner_ipv4.src_addr;
+        local_meta.inet_addr = hdr.inner_ipv4.dst_addr;
+        local_meta.ue_l4_port = local_meta.l4_sport;
+        local_meta.inet_l4_port = local_meta.l4_dport;
+        local_meta.ip_proto = hdr.inner_ipv4.proto;
+    }
+    @hidden action up4l695() {
+        local_meta.ue_addr = hdr.ipv4.dst_addr;
+        local_meta.inet_addr = hdr.ipv4.src_addr;
+        local_meta.ue_l4_port = local_meta.l4_dport;
+        local_meta.inet_l4_port = local_meta.l4_sport;
+        local_meta.ip_proto = hdr.ipv4.proto;
+    }
+    @hidden action up4l710() {
+        pre_qos_counter_0.count(local_meta.ctr_idx);
+    }
+    @hidden action up4l714() {
+        local_meta.needs_dropping = true;
+    }
+    @hidden action up4l718() {
+        local_meta.needs_dropping = true;
+    }
+    @hidden action up4l722() {
+        local_meta.needs_dropping = true;
+    }
+    @hidden action up4l720() {
+        slice_tc_meter_0.execute_meter<bit<2>>(local_meta.slice_id ++ local_meta.tc, local_meta.slice_tc_color);
+    }
+    @hidden action up4l716() {
+        session_meter_0.execute_meter<bit<2>>(local_meta.session_meter_idx_internal, local_meta.session_color);
+    }
+    @hidden action up4l712() {
+        app_meter_0.execute_meter<bit<2>>(local_meta.app_meter_idx_internal, local_meta.app_color);
+    }
+    @hidden action up4l431() {
+        Routing_hasReturned = true;
+    }
+    @hidden action act_0() {
+        Routing_hasReturned = false;
+    }
+    @hidden action up4l433() {
+        hdr.ipv4.ttl = hdr.ipv4.ttl + 8w255;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    @hidden table tbl__initialize_metadata {
+        actions = {
+            _initialize_metadata();
+        }
+        const default_action = _initialize_metadata();
+    }
+    @hidden table tbl_up4l681 {
+        actions = {
+            up4l681();
+        }
+        const default_action = up4l681();
+    }
+    @hidden table tbl_up4l684 {
+        actions = {
+            up4l684();
+        }
+        const default_action = up4l684();
+    }
+    @hidden table tbl_up4l688 {
+        actions = {
+            up4l688();
+        }
+        const default_action = up4l688();
+    }
+    @hidden table tbl_up4l695 {
+        actions = {
+            up4l695();
+        }
+        const default_action = up4l695();
+    }
+    @hidden table tbl_up4l710 {
+        actions = {
+            up4l710();
+        }
+        const default_action = up4l710();
+    }
+    @hidden table tbl_up4l712 {
+        actions = {
+            up4l712();
+        }
+        const default_action = up4l712();
+    }
+    @hidden table tbl_up4l714 {
+        actions = {
+            up4l714();
+        }
+        const default_action = up4l714();
+    }
+    @hidden table tbl_up4l716 {
+        actions = {
+            up4l716();
+        }
+        const default_action = up4l716();
+    }
+    @hidden table tbl_up4l718 {
+        actions = {
+            up4l718();
+        }
+        const default_action = up4l718();
+    }
+    @hidden table tbl_up4l720 {
+        actions = {
+            up4l720();
+        }
+        const default_action = up4l720();
+    }
+    @hidden table tbl_up4l722 {
+        actions = {
+            up4l722();
+        }
+        const default_action = up4l722();
+    }
+    @hidden table tbl_gtpu_decap {
+        actions = {
+            gtpu_decap();
+        }
+        const default_action = gtpu_decap();
+    }
+    @hidden table tbl_do_buffer {
+        actions = {
+            do_buffer();
+        }
+        const default_action = do_buffer();
+    }
+    @hidden table tbl_do_gtpu_tunnel {
+        actions = {
+            do_gtpu_tunnel();
+        }
+        const default_action = do_gtpu_tunnel();
+    }
+    @hidden table tbl_do_gtpu_tunnel_with_psc {
+        actions = {
+            do_gtpu_tunnel_with_psc();
+        }
+        const default_action = do_gtpu_tunnel_with_psc();
+    }
+    @hidden table tbl_do_drop {
+        actions = {
+            do_drop_4();
+        }
+        const default_action = do_drop_4();
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    @hidden table tbl_up4l431 {
+        actions = {
+            up4l431();
+        }
+        const default_action = up4l431();
+    }
+    @hidden table tbl_up4l433 {
+        actions = {
+            up4l433();
+        }
+        const default_action = up4l433();
+    }
+    @hidden table tbl_Routing_drop {
+        actions = {
+            Routing_drop_0();
+        }
+        const default_action = Routing_drop_0();
+    }
+    apply {
+        tbl_act.apply();
+        tbl__initialize_metadata.apply();
+        if (hdr.packet_out.isValid()) {
+            tbl_up4l681.apply();
+        } else {
+            if (my_station_0.apply().hit) {
+                ;
+            } else {
+                tbl_up4l684.apply();
+            }
+            if (hasReturned_0) {
+                ;
+            } else if (interfaces_0.apply().hit) {
+                if (local_meta.direction == 8w0x1) {
+                    tbl_up4l688.apply();
+                    sessions_uplink_0.apply();
+                } else if (local_meta.direction == 8w0x2) {
+                    tbl_up4l695.apply();
+                    sessions_downlink_0.apply();
+                    if (hasExited) {
+                        ;
+                    } else {
+                        tunnel_peers_0.apply();
+                    }
+                }
+                if (hasExited) {
+                    ;
+                } else {
+                    applications_0.apply();
+                    if (local_meta.direction == 8w0x1) {
+                        terminations_uplink_0.apply();
+                    } else if (local_meta.direction == 8w0x2) {
+                        terminations_downlink_0.apply();
+                    }
+                }
+                if (hasExited) {
+                    ;
+                } else {
+                    if (local_meta.terminations_hit) {
+                        tbl_up4l710.apply();
+                    }
+                    tbl_up4l712.apply();
+                    if (local_meta.app_color == 2w2) {
+                        tbl_up4l714.apply();
+                    } else {
+                        tbl_up4l716.apply();
+                        if (local_meta.session_color == 2w2) {
+                            tbl_up4l718.apply();
+                        } else {
+                            tbl_up4l720.apply();
+                            if (local_meta.slice_tc_color == 2w2) {
+                                tbl_up4l722.apply();
+                            }
+                        }
+                    }
+                    if (local_meta.needs_gtpu_decap) {
+                        tbl_gtpu_decap.apply();
+                    }
+                    if (local_meta.needs_buffering) {
+                        tbl_do_buffer.apply();
+                    }
+                }
+                if (hasExited) {
+                    ;
+                } else {
+                    if (local_meta.needs_tunneling) {
+                        if (local_meta.tunnel_out_qfi == 6w0) {
+                            tbl_do_gtpu_tunnel.apply();
+                        } else {
+                            tbl_do_gtpu_tunnel_with_psc.apply();
+                        }
+                    }
+                    if (local_meta.needs_dropping) {
+                        tbl_do_drop.apply();
+                    }
+                }
+            }
+        }
+        if (hasExited) {
+            ;
+        } else if (hasReturned_0) {
+            ;
+        } else {
+            tbl_act_0.apply();
+            if (hdr.ipv4.isValid()) {
+                ;
+            } else {
+                tbl_up4l431.apply();
+            }
+            if (Routing_hasReturned) {
+                ;
+            } else {
+                tbl_up4l433.apply();
+                if (hdr.ipv4.ttl == 8w0) {
+                    tbl_Routing_drop.apply();
+                } else {
+                    Routing_routes_v4.apply();
+                }
+            }
+            if (hdr.ethernet.isValid() && hdr.ipv4.isValid()) {
+                Acl_acls.apply();
+            }
+        }
+    }
+}
+
+control PostQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    bool hasExited_0;
+    @name("PostQosPipe.post_qos_counter") counter<bit<32>>(32w1024, CounterType.packets_and_bytes) post_qos_counter_0;
+    @hidden action up4l754() {
+        hdr.packet_in.setValid();
+        hdr.packet_in.ingress_port = local_meta.preserved_ingress_port;
+        hasExited_0 = true;
+    }
+    @hidden action up4l752() {
+        hasExited_0 = false;
+        post_qos_counter_0.count(local_meta.ctr_idx);
+    }
+    @hidden table tbl_up4l752 {
+        actions = {
+            up4l752();
+        }
+        const default_action = up4l752();
+    }
+    @hidden table tbl_up4l754 {
+        actions = {
+            up4l754();
+        }
+        const default_action = up4l754();
+    }
+    apply {
+        tbl_up4l752.apply();
+        if (std_meta.egress_port == 9w255) {
+            tbl_up4l754.apply();
+        }
+    }
+}
+
+V1Switch<parsed_headers_t, local_metadata_t>(ParserImpl(), VerifyChecksumImpl(), PreQosPipe(), PostQosPipe(), ComputeChecksumImpl(), DeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/omec/up4.p4
+++ b/testdata/p4_16_samples_outputs/omec/up4.p4
@@ -1,0 +1,761 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20200408
+#include <v1model.p4>
+
+const bit<4> IP_VERSION_4 = 4;
+const bit<8> DEFAULT_IPV4_TTL = 64;
+typedef bit<48> mac_addr_t;
+typedef bit<32> ipv4_addr_t;
+typedef bit<16> l4_port_t;
+typedef bit<8> ip_proto_t;
+typedef bit<16> eth_type_t;
+const bit<16> UDP_PORT_GTPU = 2152;
+const bit<3> GTP_V1 = 0x1;
+const bit<1> GTP_PROTOCOL_TYPE_GTP = 0x1;
+const bit<8> GTP_MESSAGE_TYPE_UPDU = 0xff;
+const bit<8> GTPU_NEXT_EXT_NONE = 0x0;
+const bit<8> GTPU_NEXT_EXT_PSC = 0x85;
+const bit<4> GTPU_EXT_PSC_TYPE_DL = 4w0;
+const bit<4> GTPU_EXT_PSC_TYPE_UL = 4w1;
+const bit<8> GTPU_EXT_PSC_LEN = 8w1;
+typedef bit<32> teid_t;
+typedef bit<6> qfi_t;
+typedef bit<32> counter_index_t;
+typedef bit<8> tunnel_peer_id_t;
+typedef bit<32> app_meter_idx_t;
+typedef bit<32> session_meter_idx_t;
+typedef bit<6> slice_tc_meter_idx_t;
+typedef bit<4> slice_id_t;
+typedef bit<2> tc_t;
+const qfi_t DEFAULT_QFI = 0;
+const bit<8> APP_ID_UNKNOWN = 0;
+const session_meter_idx_t DEFAULT_SESSION_METER_IDX = 0;
+const app_meter_idx_t DEFAULT_APP_METER_IDX = 0;
+enum bit<8> GTPUMessageType {
+    GPDU = 255
+}
+
+enum bit<16> EtherType {
+    IPV4 = 0x800,
+    IPV6 = 0x86dd
+}
+
+enum bit<8> IpProtocol {
+    ICMP = 1,
+    TCP = 6,
+    UDP = 17
+}
+
+enum bit<16> L4Port {
+    DHCP_SERV = 67,
+    DHCP_CLIENT = 68,
+    GTP_GPDU = 2152,
+    IPV4_IN_UDP = 9875
+}
+
+enum bit<8> Direction {
+    UNKNOWN = 0x0,
+    UPLINK = 0x1,
+    DOWNLINK = 0x2,
+    OTHER = 0x3
+}
+
+enum bit<8> InterfaceType {
+    UNKNOWN = 0x0,
+    ACCESS = 0x1,
+    CORE = 0x2
+}
+
+enum bit<4> Slice {
+    DEFAULT = 0x0
+}
+
+enum bit<2> TrafficClass {
+    BEST_EFFORT = 0,
+    CONTROL = 1,
+    REAL_TIME = 2,
+    ELASTIC = 3
+}
+
+enum bit<2> MeterColor {
+    GREEN = 0,
+    YELLOW = 1,
+    RED = 2
+}
+
+header ethernet_t {
+    mac_addr_t dst_addr;
+    mac_addr_t src_addr;
+    eth_type_t ether_type;
+}
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<6>      dscp;
+    bit<2>      ecn;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     frag_offset;
+    bit<8>      ttl;
+    ip_proto_t  proto;
+    bit<16>     checksum;
+    ipv4_addr_t src_addr;
+    ipv4_addr_t dst_addr;
+}
+
+header tcp_t {
+    l4_port_t sport;
+    l4_port_t dport;
+    bit<32>   seq_no;
+    bit<32>   ack_no;
+    bit<4>    data_offset;
+    bit<3>    res;
+    bit<3>    ecn;
+    bit<6>    ctrl;
+    bit<16>   window;
+    bit<16>   checksum;
+    bit<16>   urgent_ptr;
+}
+
+header udp_t {
+    l4_port_t sport;
+    l4_port_t dport;
+    bit<16>   len;
+    bit<16>   checksum;
+}
+
+header icmp_t {
+    bit<8>  icmp_type;
+    bit<8>  icmp_code;
+    bit<16> checksum;
+    bit<16> identifier;
+    bit<16> sequence_number;
+    bit<64> timestamp;
+}
+
+header gtpu_t {
+    bit<3>  version;
+    bit<1>  pt;
+    bit<1>  spare;
+    bit<1>  ex_flag;
+    bit<1>  seq_flag;
+    bit<1>  npdu_flag;
+    bit<8>  msgtype;
+    bit<16> msglen;
+    teid_t  teid;
+}
+
+header gtpu_options_t {
+    bit<16> seq_num;
+    bit<8>  n_pdu_num;
+    bit<8>  next_ext;
+}
+
+header gtpu_ext_psc_t {
+    bit<8> len;
+    bit<4> type;
+    bit<4> spare0;
+    bit<1> ppp;
+    bit<1> rqi;
+    bit<6> qfi;
+    bit<8> next_ext;
+}
+
+@controller_header("packet_out") header packet_out_t {
+    bit<8> reserved;
+}
+
+@controller_header("packet_in") header packet_in_t {
+    PortId_t ingress_port;
+    bit<7>   _pad;
+}
+
+struct parsed_headers_t {
+    packet_out_t   packet_out;
+    packet_in_t    packet_in;
+    ethernet_t     ethernet;
+    ipv4_t         ipv4;
+    udp_t          udp;
+    tcp_t          tcp;
+    icmp_t         icmp;
+    gtpu_t         gtpu;
+    gtpu_options_t gtpu_options;
+    gtpu_ext_psc_t gtpu_ext_psc;
+    ipv4_t         inner_ipv4;
+    udp_t          inner_udp;
+    tcp_t          inner_tcp;
+    icmp_t         inner_icmp;
+}
+
+struct ddn_digest_t {
+    ipv4_addr_t ue_address;
+}
+
+struct local_metadata_t {
+    Direction           direction;
+    teid_t              teid;
+    slice_id_t          slice_id;
+    tc_t                tc;
+    ipv4_addr_t         next_hop_ip;
+    ipv4_addr_t         ue_addr;
+    ipv4_addr_t         inet_addr;
+    l4_port_t           ue_l4_port;
+    l4_port_t           inet_l4_port;
+    l4_port_t           l4_sport;
+    l4_port_t           l4_dport;
+    ip_proto_t          ip_proto;
+    bit<8>              application_id;
+    bit<8>              src_iface;
+    bool                needs_gtpu_decap;
+    bool                needs_tunneling;
+    bool                needs_buffering;
+    bool                needs_dropping;
+    bool                terminations_hit;
+    counter_index_t     ctr_idx;
+    tunnel_peer_id_t    tunnel_peer_id;
+    ipv4_addr_t         tunnel_out_src_ipv4_addr;
+    ipv4_addr_t         tunnel_out_dst_ipv4_addr;
+    l4_port_t           tunnel_out_udp_sport;
+    teid_t              tunnel_out_teid;
+    qfi_t               tunnel_out_qfi;
+    session_meter_idx_t session_meter_idx_internal;
+    app_meter_idx_t     app_meter_idx_internal;
+    MeterColor          session_color;
+    MeterColor          app_color;
+    MeterColor          slice_tc_color;
+    @field_list(0)
+    PortId_t            preserved_ingress_port;
+}
+
+parser ParserImpl(packet_in packet, out parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    state start {
+        transition select(std_meta.ingress_port) {
+            255: parse_packet_out;
+            default: parse_ethernet;
+        }
+    }
+    state parse_packet_out {
+        packet.extract(hdr.packet_out);
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            EtherType.IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition select(hdr.ipv4.proto) {
+            IpProtocol.UDP: parse_udp;
+            IpProtocol.TCP: parse_tcp;
+            IpProtocol.ICMP: parse_icmp;
+            default: accept;
+        }
+    }
+    state parse_udp {
+        packet.extract(hdr.udp);
+        local_meta.l4_sport = hdr.udp.sport;
+        local_meta.l4_dport = hdr.udp.dport;
+        gtpu_t gtpu = packet.lookahead<gtpu_t>();
+        transition select(hdr.udp.dport, gtpu.version, gtpu.msgtype) {
+            (L4Port.IPV4_IN_UDP, default, default): parse_inner_ipv4;
+            (L4Port.GTP_GPDU, GTP_V1, GTPUMessageType.GPDU): parse_gtpu;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        packet.extract(hdr.tcp);
+        local_meta.l4_sport = hdr.tcp.sport;
+        local_meta.l4_dport = hdr.tcp.dport;
+        transition accept;
+    }
+    state parse_icmp {
+        packet.extract(hdr.icmp);
+        transition accept;
+    }
+    state parse_gtpu {
+        packet.extract(hdr.gtpu);
+        local_meta.teid = hdr.gtpu.teid;
+        transition select(hdr.gtpu.ex_flag, hdr.gtpu.seq_flag, hdr.gtpu.npdu_flag) {
+            (0, 0, 0): parse_inner_ipv4;
+            default: parse_gtpu_options;
+        }
+    }
+    state parse_gtpu_options {
+        packet.extract(hdr.gtpu_options);
+        bit<8> gtpu_ext_len = packet.lookahead<bit<8>>();
+        transition select(hdr.gtpu_options.next_ext, gtpu_ext_len) {
+            (GTPU_NEXT_EXT_PSC, GTPU_EXT_PSC_LEN): parse_gtpu_ext_psc;
+            default: accept;
+        }
+    }
+    state parse_gtpu_ext_psc {
+        packet.extract(hdr.gtpu_ext_psc);
+        transition select(hdr.gtpu_ext_psc.next_ext) {
+            GTPU_NEXT_EXT_NONE: parse_inner_ipv4;
+            default: accept;
+        }
+    }
+    state parse_inner_ipv4 {
+        packet.extract(hdr.inner_ipv4);
+        transition select(hdr.inner_ipv4.proto) {
+            IpProtocol.UDP: parse_inner_udp;
+            IpProtocol.TCP: parse_inner_tcp;
+            IpProtocol.ICMP: parse_inner_icmp;
+            default: accept;
+        }
+    }
+    state parse_inner_udp {
+        packet.extract(hdr.inner_udp);
+        local_meta.l4_sport = hdr.inner_udp.sport;
+        local_meta.l4_dport = hdr.inner_udp.dport;
+        transition accept;
+    }
+    state parse_inner_tcp {
+        packet.extract(hdr.inner_tcp);
+        local_meta.l4_sport = hdr.inner_tcp.sport;
+        local_meta.l4_dport = hdr.inner_tcp.dport;
+        transition accept;
+    }
+    state parse_inner_icmp {
+        packet.extract(hdr.inner_icmp);
+        transition accept;
+    }
+}
+
+control DeparserImpl(packet_out packet, in parsed_headers_t hdr) {
+    apply {
+        packet.emit(hdr.packet_in);
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+        packet.emit(hdr.udp);
+        packet.emit(hdr.tcp);
+        packet.emit(hdr.icmp);
+        packet.emit(hdr.gtpu);
+        packet.emit(hdr.gtpu_options);
+        packet.emit(hdr.gtpu_ext_psc);
+        packet.emit(hdr.inner_ipv4);
+        packet.emit(hdr.inner_udp);
+        packet.emit(hdr.inner_tcp);
+        packet.emit(hdr.inner_icmp);
+    }
+}
+
+control VerifyChecksumImpl(inout parsed_headers_t hdr, inout local_metadata_t meta) {
+    apply {
+        verify_checksum(hdr.ipv4.isValid(), { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.dscp, hdr.ipv4.ecn, hdr.ipv4.total_len, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.frag_offset, hdr.ipv4.ttl, hdr.ipv4.proto, hdr.ipv4.src_addr, hdr.ipv4.dst_addr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        verify_checksum(hdr.inner_ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.dscp, hdr.inner_ipv4.ecn, hdr.inner_ipv4.total_len, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.frag_offset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.proto, hdr.inner_ipv4.src_addr, hdr.inner_ipv4.dst_addr }, hdr.inner_ipv4.checksum, HashAlgorithm.csum16);
+    }
+}
+
+control ComputeChecksumImpl(inout parsed_headers_t hdr, inout local_metadata_t local_meta) {
+    apply {
+        update_checksum(hdr.ipv4.isValid(), { hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.dscp, hdr.ipv4.ecn, hdr.ipv4.total_len, hdr.ipv4.identification, hdr.ipv4.flags, hdr.ipv4.frag_offset, hdr.ipv4.ttl, hdr.ipv4.proto, hdr.ipv4.src_addr, hdr.ipv4.dst_addr }, hdr.ipv4.checksum, HashAlgorithm.csum16);
+        update_checksum(hdr.inner_ipv4.isValid(), { hdr.inner_ipv4.version, hdr.inner_ipv4.ihl, hdr.inner_ipv4.dscp, hdr.inner_ipv4.ecn, hdr.inner_ipv4.total_len, hdr.inner_ipv4.identification, hdr.inner_ipv4.flags, hdr.inner_ipv4.frag_offset, hdr.inner_ipv4.ttl, hdr.inner_ipv4.proto, hdr.inner_ipv4.src_addr, hdr.inner_ipv4.dst_addr }, hdr.inner_ipv4.checksum, HashAlgorithm.csum16);
+    }
+}
+
+control Acl(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    action set_port(PortId_t port) {
+        std_meta.egress_spec = port;
+    }
+    action punt() {
+        set_port(255);
+    }
+    action clone_to_cpu() {
+        clone_preserving_field_list(CloneType.I2E, 99, 0);
+    }
+    action drop() {
+        mark_to_drop(std_meta);
+        exit;
+    }
+    table acls {
+        key = {
+            std_meta.ingress_port  : ternary @name("inport");
+            local_meta.src_iface   : ternary @name("src_iface");
+            hdr.ethernet.src_addr  : ternary @name("eth_src");
+            hdr.ethernet.dst_addr  : ternary @name("eth_dst");
+            hdr.ethernet.ether_type: ternary @name("eth_type");
+            hdr.ipv4.src_addr      : ternary @name("ipv4_src");
+            hdr.ipv4.dst_addr      : ternary @name("ipv4_dst");
+            hdr.ipv4.proto         : ternary @name("ipv4_proto");
+            local_meta.l4_sport    : ternary @name("l4_sport");
+            local_meta.l4_dport    : ternary @name("l4_dport");
+        }
+        actions = {
+            set_port;
+            punt;
+            clone_to_cpu;
+            drop;
+            NoAction;
+        }
+        const default_action = NoAction;
+        @name("acls") counters = direct_counter(CounterType.packets_and_bytes);
+    }
+    apply {
+        if (hdr.ethernet.isValid() && hdr.ipv4.isValid()) {
+            acls.apply();
+        }
+    }
+}
+
+control Routing(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    action drop() {
+        mark_to_drop(std_meta);
+    }
+    action route(mac_addr_t src_mac, mac_addr_t dst_mac, PortId_t egress_port) {
+        std_meta.egress_spec = egress_port;
+        hdr.ethernet.src_addr = src_mac;
+        hdr.ethernet.dst_addr = dst_mac;
+    }
+    table routes_v4 {
+        key = {
+            hdr.ipv4.dst_addr  : lpm @name("dst_prefix");
+            hdr.ipv4.src_addr  : selector;
+            hdr.ipv4.proto     : selector;
+            local_meta.l4_sport: selector;
+            local_meta.l4_dport: selector;
+        }
+        actions = {
+            route;
+        }
+        @name("hashed_selector") implementation = action_selector(HashAlgorithm.crc16, 32w1024, 32w16);
+        size = 1024;
+    }
+    apply {
+        if (!hdr.ipv4.isValid()) {
+            return;
+        }
+        hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
+        if (hdr.ipv4.ttl == 0) {
+            drop();
+        } else {
+            routes_v4.apply();
+        }
+    }
+}
+
+control PreQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    counter<counter_index_t>(1024, CounterType.packets_and_bytes) pre_qos_counter;
+    meter<app_meter_idx_t>(1024, MeterType.bytes) app_meter;
+    meter<session_meter_idx_t>(1024, MeterType.bytes) session_meter;
+    meter<slice_tc_meter_idx_t>(1 << 6, MeterType.bytes) slice_tc_meter;
+    action _initialize_metadata() {
+        local_meta.session_meter_idx_internal = DEFAULT_SESSION_METER_IDX;
+        local_meta.app_meter_idx_internal = DEFAULT_APP_METER_IDX;
+        local_meta.application_id = APP_ID_UNKNOWN;
+        local_meta.preserved_ingress_port = std_meta.ingress_port;
+    }
+    table my_station {
+        key = {
+            hdr.ethernet.dst_addr: exact @name("dst_mac");
+        }
+        actions = {
+            NoAction;
+        }
+    }
+    action set_source_iface(InterfaceType src_iface, Direction direction, Slice slice_id) {
+        local_meta.src_iface = src_iface;
+        local_meta.direction = direction;
+        local_meta.slice_id = slice_id;
+    }
+    table interfaces {
+        key = {
+            hdr.ipv4.dst_addr: lpm @name("ipv4_dst_prefix");
+        }
+        actions = {
+            set_source_iface;
+        }
+        const default_action = set_source_iface(InterfaceType.UNKNOWN, Direction.UNKNOWN, Slice.DEFAULT);
+    }
+    @hidden action gtpu_decap() {
+        hdr.ipv4 = hdr.inner_ipv4;
+        hdr.inner_ipv4.setInvalid();
+        hdr.udp = hdr.inner_udp;
+        hdr.inner_udp.setInvalid();
+        hdr.tcp = hdr.inner_tcp;
+        hdr.inner_tcp.setInvalid();
+        hdr.icmp = hdr.inner_icmp;
+        hdr.inner_icmp.setInvalid();
+        hdr.gtpu.setInvalid();
+        hdr.gtpu_options.setInvalid();
+        hdr.gtpu_ext_psc.setInvalid();
+    }
+    @hidden action do_buffer() {
+        digest<ddn_digest_t>(1, { local_meta.ue_addr });
+        mark_to_drop(std_meta);
+        exit;
+    }
+    action do_drop() {
+        mark_to_drop(std_meta);
+        exit;
+    }
+    action set_session_uplink(session_meter_idx_t session_meter_idx) {
+        local_meta.needs_gtpu_decap = true;
+        local_meta.session_meter_idx_internal = session_meter_idx;
+    }
+    action set_session_uplink_drop() {
+        local_meta.needs_dropping = true;
+    }
+    action set_session_downlink(tunnel_peer_id_t tunnel_peer_id, session_meter_idx_t session_meter_idx) {
+        local_meta.tunnel_peer_id = tunnel_peer_id;
+        local_meta.session_meter_idx_internal = session_meter_idx;
+    }
+    action set_session_downlink_drop() {
+        local_meta.needs_dropping = true;
+    }
+    action set_session_downlink_buff(session_meter_idx_t session_meter_idx) {
+        local_meta.needs_buffering = true;
+        local_meta.session_meter_idx_internal = session_meter_idx;
+    }
+    table sessions_uplink {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("n3_address");
+            local_meta.teid  : exact @name("teid");
+        }
+        actions = {
+            set_session_uplink;
+            set_session_uplink_drop;
+            @defaultonly do_drop;
+        }
+        const default_action = do_drop;
+    }
+    table sessions_downlink {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("ue_address");
+        }
+        actions = {
+            set_session_downlink;
+            set_session_downlink_drop;
+            set_session_downlink_buff;
+            @defaultonly do_drop;
+        }
+        const default_action = do_drop;
+    }
+    @hidden action common_term(counter_index_t ctr_idx) {
+        local_meta.ctr_idx = ctr_idx;
+        local_meta.terminations_hit = true;
+    }
+    action uplink_term_fwd(counter_index_t ctr_idx, TrafficClass tc, app_meter_idx_t app_meter_idx) {
+        common_term(ctr_idx);
+        local_meta.app_meter_idx_internal = app_meter_idx;
+        local_meta.tc = tc;
+    }
+    action uplink_term_drop(counter_index_t ctr_idx) {
+        common_term(ctr_idx);
+        local_meta.needs_dropping = true;
+    }
+    action downlink_term_fwd(counter_index_t ctr_idx, teid_t teid, qfi_t qfi, TrafficClass tc, app_meter_idx_t app_meter_idx) {
+        common_term(ctr_idx);
+        local_meta.tunnel_out_teid = teid;
+        local_meta.tunnel_out_qfi = qfi;
+        local_meta.app_meter_idx_internal = app_meter_idx;
+        local_meta.tc = tc;
+    }
+    action downlink_term_drop(counter_index_t ctr_idx) {
+        common_term(ctr_idx);
+        local_meta.needs_dropping = true;
+    }
+    table terminations_uplink {
+        key = {
+            local_meta.ue_addr       : exact @name("ue_address");
+            local_meta.application_id: exact @name("app_id");
+        }
+        actions = {
+            uplink_term_fwd;
+            uplink_term_drop;
+            @defaultonly do_drop;
+        }
+        const default_action = do_drop;
+    }
+    table terminations_downlink {
+        key = {
+            local_meta.ue_addr       : exact @name("ue_address");
+            local_meta.application_id: exact @name("app_id");
+        }
+        actions = {
+            downlink_term_fwd;
+            downlink_term_drop;
+            @defaultonly do_drop;
+        }
+        const default_action = do_drop;
+    }
+    action set_app_id(bit<8> app_id) {
+        local_meta.application_id = app_id;
+    }
+    table applications {
+        key = {
+            local_meta.slice_id    : exact @name("slice_id");
+            local_meta.inet_addr   : lpm @name("app_ip_addr");
+            local_meta.inet_l4_port: range @name("app_l4_port");
+            local_meta.ip_proto    : ternary @name("app_ip_proto");
+        }
+        actions = {
+            set_app_id;
+        }
+        const default_action = set_app_id(APP_ID_UNKNOWN);
+    }
+    action load_tunnel_param(ipv4_addr_t src_addr, ipv4_addr_t dst_addr, l4_port_t sport) {
+        local_meta.tunnel_out_src_ipv4_addr = src_addr;
+        local_meta.tunnel_out_dst_ipv4_addr = dst_addr;
+        local_meta.tunnel_out_udp_sport = sport;
+        local_meta.needs_tunneling = true;
+    }
+    table tunnel_peers {
+        key = {
+            local_meta.tunnel_peer_id: exact @name("tunnel_peer_id");
+        }
+        actions = {
+            load_tunnel_param;
+        }
+    }
+    @hidden action _udp_encap(ipv4_addr_t src_addr, ipv4_addr_t dst_addr, l4_port_t udp_sport, L4Port udp_dport, bit<16> ipv4_total_len, bit<16> udp_len) {
+        hdr.inner_udp = hdr.udp;
+        hdr.udp.setInvalid();
+        hdr.inner_tcp = hdr.tcp;
+        hdr.tcp.setInvalid();
+        hdr.inner_icmp = hdr.icmp;
+        hdr.icmp.setInvalid();
+        hdr.udp.setValid();
+        hdr.udp.sport = udp_sport;
+        hdr.udp.dport = udp_dport;
+        hdr.udp.len = udp_len;
+        hdr.udp.checksum = 0;
+        hdr.inner_ipv4 = hdr.ipv4;
+        hdr.ipv4.setValid();
+        hdr.ipv4.version = IP_VERSION_4;
+        hdr.ipv4.ihl = 5;
+        hdr.ipv4.dscp = 0;
+        hdr.ipv4.ecn = 0;
+        hdr.ipv4.total_len = ipv4_total_len;
+        hdr.ipv4.identification = 0x1513;
+        hdr.ipv4.flags = 0;
+        hdr.ipv4.frag_offset = 0;
+        hdr.ipv4.ttl = DEFAULT_IPV4_TTL;
+        hdr.ipv4.proto = IpProtocol.UDP;
+        hdr.ipv4.src_addr = src_addr;
+        hdr.ipv4.dst_addr = dst_addr;
+        hdr.ipv4.checksum = 0;
+    }
+    @hidden action _gtpu_encap(teid_t teid) {
+        hdr.gtpu.setValid();
+        hdr.gtpu.version = GTP_V1;
+        hdr.gtpu.pt = GTP_PROTOCOL_TYPE_GTP;
+        hdr.gtpu.spare = 0;
+        hdr.gtpu.ex_flag = 0;
+        hdr.gtpu.seq_flag = 0;
+        hdr.gtpu.npdu_flag = 0;
+        hdr.gtpu.msgtype = GTPUMessageType.GPDU;
+        hdr.gtpu.msglen = hdr.inner_ipv4.total_len;
+        hdr.gtpu.teid = teid;
+    }
+    action do_gtpu_tunnel() {
+        _udp_encap(local_meta.tunnel_out_src_ipv4_addr, local_meta.tunnel_out_dst_ipv4_addr, local_meta.tunnel_out_udp_sport, L4Port.GTP_GPDU, hdr.ipv4.total_len + 20 + 8 + 8, hdr.ipv4.total_len + 8 + 8);
+        _gtpu_encap(local_meta.tunnel_out_teid);
+    }
+    action do_gtpu_tunnel_with_psc() {
+        _udp_encap(local_meta.tunnel_out_src_ipv4_addr, local_meta.tunnel_out_dst_ipv4_addr, local_meta.tunnel_out_udp_sport, L4Port.GTP_GPDU, hdr.ipv4.total_len + 20 + 8 + 8 + 4 + 4, hdr.ipv4.total_len + 8 + 8 + 4 + 4);
+        _gtpu_encap(local_meta.tunnel_out_teid);
+        hdr.gtpu.msglen = hdr.inner_ipv4.total_len + 4 + 4;
+        hdr.gtpu.ex_flag = 1;
+        hdr.gtpu_options.setValid();
+        hdr.gtpu_options.seq_num = 0;
+        hdr.gtpu_options.n_pdu_num = 0;
+        hdr.gtpu_options.next_ext = GTPU_NEXT_EXT_PSC;
+        hdr.gtpu_ext_psc.setValid();
+        hdr.gtpu_ext_psc.len = GTPU_EXT_PSC_LEN;
+        hdr.gtpu_ext_psc.type = GTPU_EXT_PSC_TYPE_DL;
+        hdr.gtpu_ext_psc.spare0 = 0;
+        hdr.gtpu_ext_psc.ppp = 0;
+        hdr.gtpu_ext_psc.rqi = 0;
+        hdr.gtpu_ext_psc.qfi = local_meta.tunnel_out_qfi;
+        hdr.gtpu_ext_psc.next_ext = GTPU_NEXT_EXT_NONE;
+    }
+    apply {
+        _initialize_metadata();
+        if (hdr.packet_out.isValid()) {
+            hdr.packet_out.setInvalid();
+        } else {
+            if (!my_station.apply().hit) {
+                return;
+            }
+            if (interfaces.apply().hit) {
+                if (local_meta.direction == Direction.UPLINK) {
+                    local_meta.ue_addr = hdr.inner_ipv4.src_addr;
+                    local_meta.inet_addr = hdr.inner_ipv4.dst_addr;
+                    local_meta.ue_l4_port = local_meta.l4_sport;
+                    local_meta.inet_l4_port = local_meta.l4_dport;
+                    local_meta.ip_proto = hdr.inner_ipv4.proto;
+                    sessions_uplink.apply();
+                } else if (local_meta.direction == Direction.DOWNLINK) {
+                    local_meta.ue_addr = hdr.ipv4.dst_addr;
+                    local_meta.inet_addr = hdr.ipv4.src_addr;
+                    local_meta.ue_l4_port = local_meta.l4_dport;
+                    local_meta.inet_l4_port = local_meta.l4_sport;
+                    local_meta.ip_proto = hdr.ipv4.proto;
+                    sessions_downlink.apply();
+                    tunnel_peers.apply();
+                }
+                applications.apply();
+                if (local_meta.direction == Direction.UPLINK) {
+                    terminations_uplink.apply();
+                } else if (local_meta.direction == Direction.DOWNLINK) {
+                    terminations_downlink.apply();
+                }
+                if (local_meta.terminations_hit) {
+                    pre_qos_counter.count(local_meta.ctr_idx);
+                }
+                app_meter.execute_meter<MeterColor>(local_meta.app_meter_idx_internal, local_meta.app_color);
+                if (local_meta.app_color == MeterColor.RED) {
+                    local_meta.needs_dropping = true;
+                } else {
+                    session_meter.execute_meter<MeterColor>(local_meta.session_meter_idx_internal, local_meta.session_color);
+                    if (local_meta.session_color == MeterColor.RED) {
+                        local_meta.needs_dropping = true;
+                    } else {
+                        slice_tc_meter.execute_meter<MeterColor>(local_meta.slice_id ++ local_meta.tc, local_meta.slice_tc_color);
+                        if (local_meta.slice_tc_color == MeterColor.RED) {
+                            local_meta.needs_dropping = true;
+                        }
+                    }
+                }
+                if (local_meta.needs_gtpu_decap) {
+                    gtpu_decap();
+                }
+                if (local_meta.needs_buffering) {
+                    do_buffer();
+                }
+                if (local_meta.needs_tunneling) {
+                    if (local_meta.tunnel_out_qfi == 0) {
+                        do_gtpu_tunnel();
+                    } else {
+                        do_gtpu_tunnel_with_psc();
+                    }
+                }
+                if (local_meta.needs_dropping) {
+                    do_drop();
+                }
+            }
+        }
+        Routing.apply(hdr, local_meta, std_meta);
+        Acl.apply(hdr, local_meta, std_meta);
+    }
+}
+
+control PostQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta, inout standard_metadata_t std_meta) {
+    counter<counter_index_t>(1024, CounterType.packets_and_bytes) post_qos_counter;
+    apply {
+        post_qos_counter.count(local_meta.ctr_idx);
+        if (std_meta.egress_port == 255) {
+            hdr.packet_in.setValid();
+            hdr.packet_in.ingress_port = local_meta.preserved_ingress_port;
+            exit;
+        }
+    }
+}
+
+V1Switch(ParserImpl(), VerifyChecksumImpl(), PreQosPipe(), PostQosPipe(), ComputeChecksumImpl(), DeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/omec/up4.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/omec/up4.p4.p4info.txt
@@ -1,0 +1,832 @@
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 39015874
+    name: "PreQosPipe.Routing.routes_v4"
+    alias: "routes_v4"
+  }
+  match_fields {
+    id: 1
+    name: "dst_prefix"
+    bitwidth: 32
+    match_type: LPM
+  }
+  action_refs {
+    id: 23965128
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  implementation_id: 297808402
+  size: 1024
+}
+tables {
+  preamble {
+    id: 47204971
+    name: "PreQosPipe.Acl.acls"
+    alias: "Acl.acls"
+  }
+  match_fields {
+    id: 1
+    name: "inport"
+    bitwidth: 9
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 2
+    name: "src_iface"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 3
+    name: "eth_src"
+    bitwidth: 48
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 4
+    name: "eth_dst"
+    bitwidth: 48
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 5
+    name: "eth_type"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 6
+    name: "ipv4_src"
+    bitwidth: 32
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 7
+    name: "ipv4_dst"
+    bitwidth: 32
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 8
+    name: "ipv4_proto"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 9
+    name: "l4_sport"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 10
+    name: "l4_dport"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 30494847
+  }
+  action_refs {
+    id: 26495283
+  }
+  action_refs {
+    id: 21596798
+  }
+  action_refs {
+    id: 18812293
+  }
+  action_refs {
+    id: 21257015
+  }
+  const_default_action_id: 21257015
+  direct_resource_ids: 325583051
+  size: 1024
+}
+tables {
+  preamble {
+    id: 40931612
+    name: "PreQosPipe.my_station"
+    alias: "my_station"
+  }
+  match_fields {
+    id: 1
+    name: "dst_mac"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  size: 1024
+}
+tables {
+  preamble {
+    id: 33923840
+    name: "PreQosPipe.interfaces"
+    alias: "interfaces"
+  }
+  match_fields {
+    id: 1
+    name: "ipv4_dst_prefix"
+    bitwidth: 32
+    match_type: LPM
+  }
+  action_refs {
+    id: 26090030
+  }
+  const_default_action_id: 26090030
+  size: 1024
+}
+tables {
+  preamble {
+    id: 44976597
+    name: "PreQosPipe.sessions_uplink"
+    alias: "sessions_uplink"
+  }
+  match_fields {
+    id: 1
+    name: "n3_address"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "teid"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  action_refs {
+    id: 19461580
+  }
+  action_refs {
+    id: 22196934
+  }
+  action_refs {
+    id: 28401267
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 28401267
+  size: 1024
+}
+tables {
+  preamble {
+    id: 34742049
+    name: "PreQosPipe.sessions_downlink"
+    alias: "sessions_downlink"
+  }
+  match_fields {
+    id: 1
+    name: "ue_address"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21848329
+  }
+  action_refs {
+    id: 20229579
+  }
+  action_refs {
+    id: 20249483
+  }
+  action_refs {
+    id: 28401267
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 28401267
+  size: 1024
+}
+tables {
+  preamble {
+    id: 37595532
+    name: "PreQosPipe.terminations_uplink"
+    alias: "terminations_uplink"
+  }
+  match_fields {
+    id: 1
+    name: "ue_address"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "app_id"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 28305359
+  }
+  action_refs {
+    id: 20977365
+  }
+  action_refs {
+    id: 28401267
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 28401267
+  size: 1024
+}
+tables {
+  preamble {
+    id: 34778590
+    name: "PreQosPipe.terminations_downlink"
+    alias: "terminations_downlink"
+  }
+  match_fields {
+    id: 1
+    name: "ue_address"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "app_id"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 32699713
+  }
+  action_refs {
+    id: 31264233
+  }
+  action_refs {
+    id: 28401267
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 28401267
+  size: 1024
+}
+tables {
+  preamble {
+    id: 46868458
+    name: "PreQosPipe.applications"
+    alias: "applications"
+  }
+  match_fields {
+    id: 1
+    name: "slice_id"
+    bitwidth: 4
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "app_ip_addr"
+    bitwidth: 32
+    match_type: LPM
+  }
+  match_fields {
+    id: 3
+    name: "app_l4_port"
+    bitwidth: 16
+    match_type: RANGE
+  }
+  match_fields {
+    id: 4
+    name: "app_ip_proto"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 23010411
+  }
+  const_default_action_id: 23010411
+  size: 1024
+}
+tables {
+  preamble {
+    id: 49497304
+    name: "PreQosPipe.tunnel_peers"
+    alias: "tunnel_peers"
+  }
+  match_fields {
+    id: 1
+    name: "tunnel_peer_id"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 32742981
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 31448256
+    name: "PreQosPipe.Routing.drop"
+    alias: "Routing.drop"
+  }
+}
+actions {
+  preamble {
+    id: 23965128
+    name: "PreQosPipe.Routing.route"
+    alias: "route"
+  }
+  params {
+    id: 1
+    name: "src_mac"
+    bitwidth: 48
+  }
+  params {
+    id: 2
+    name: "dst_mac"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "egress_port"
+    bitwidth: 9
+  }
+}
+actions {
+  preamble {
+    id: 30494847
+    name: "PreQosPipe.Acl.set_port"
+    alias: "set_port"
+  }
+  params {
+    id: 1
+    name: "port"
+    bitwidth: 9
+  }
+}
+actions {
+  preamble {
+    id: 26495283
+    name: "PreQosPipe.Acl.punt"
+    alias: "punt"
+  }
+}
+actions {
+  preamble {
+    id: 21596798
+    name: "PreQosPipe.Acl.clone_to_cpu"
+    alias: "clone_to_cpu"
+  }
+}
+actions {
+  preamble {
+    id: 18812293
+    name: "PreQosPipe.Acl.drop"
+    alias: "Acl.drop"
+  }
+}
+actions {
+  preamble {
+    id: 23766285
+    name: "PreQosPipe._initialize_metadata"
+    alias: "_initialize_metadata"
+  }
+}
+actions {
+  preamble {
+    id: 26090030
+    name: "PreQosPipe.set_source_iface"
+    alias: "set_source_iface"
+  }
+  params {
+    id: 1
+    name: "src_iface"
+    bitwidth: 8
+  }
+  params {
+    id: 2
+    name: "direction"
+    bitwidth: 8
+  }
+  params {
+    id: 3
+    name: "slice_id"
+    bitwidth: 4
+  }
+}
+actions {
+  preamble {
+    id: 28401267
+    name: "PreQosPipe.do_drop"
+    alias: "do_drop"
+  }
+}
+actions {
+  preamble {
+    id: 19461580
+    name: "PreQosPipe.set_session_uplink"
+    alias: "set_session_uplink"
+  }
+  params {
+    id: 1
+    name: "session_meter_idx"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 22196934
+    name: "PreQosPipe.set_session_uplink_drop"
+    alias: "set_session_uplink_drop"
+  }
+}
+actions {
+  preamble {
+    id: 21848329
+    name: "PreQosPipe.set_session_downlink"
+    alias: "set_session_downlink"
+  }
+  params {
+    id: 1
+    name: "tunnel_peer_id"
+    bitwidth: 8
+  }
+  params {
+    id: 2
+    name: "session_meter_idx"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 20229579
+    name: "PreQosPipe.set_session_downlink_drop"
+    alias: "set_session_downlink_drop"
+  }
+}
+actions {
+  preamble {
+    id: 20249483
+    name: "PreQosPipe.set_session_downlink_buff"
+    alias: "set_session_downlink_buff"
+  }
+  params {
+    id: 1
+    name: "session_meter_idx"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 28305359
+    name: "PreQosPipe.uplink_term_fwd"
+    alias: "uplink_term_fwd"
+  }
+  params {
+    id: 1
+    name: "ctr_idx"
+    bitwidth: 32
+  }
+  params {
+    id: 2
+    name: "tc"
+    bitwidth: 2
+  }
+  params {
+    id: 3
+    name: "app_meter_idx"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 20977365
+    name: "PreQosPipe.uplink_term_drop"
+    alias: "uplink_term_drop"
+  }
+  params {
+    id: 1
+    name: "ctr_idx"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 32699713
+    name: "PreQosPipe.downlink_term_fwd"
+    alias: "downlink_term_fwd"
+  }
+  params {
+    id: 1
+    name: "ctr_idx"
+    bitwidth: 32
+  }
+  params {
+    id: 2
+    name: "teid"
+    bitwidth: 32
+  }
+  params {
+    id: 3
+    name: "qfi"
+    bitwidth: 6
+  }
+  params {
+    id: 4
+    name: "tc"
+    bitwidth: 2
+  }
+  params {
+    id: 5
+    name: "app_meter_idx"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 31264233
+    name: "PreQosPipe.downlink_term_drop"
+    alias: "downlink_term_drop"
+  }
+  params {
+    id: 1
+    name: "ctr_idx"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 23010411
+    name: "PreQosPipe.set_app_id"
+    alias: "set_app_id"
+  }
+  params {
+    id: 1
+    name: "app_id"
+    bitwidth: 8
+  }
+}
+actions {
+  preamble {
+    id: 32742981
+    name: "PreQosPipe.load_tunnel_param"
+    alias: "load_tunnel_param"
+  }
+  params {
+    id: 1
+    name: "src_addr"
+    bitwidth: 32
+  }
+  params {
+    id: 2
+    name: "dst_addr"
+    bitwidth: 32
+  }
+  params {
+    id: 3
+    name: "sport"
+    bitwidth: 16
+  }
+}
+actions {
+  preamble {
+    id: 29247910
+    name: "PreQosPipe.do_gtpu_tunnel"
+    alias: "do_gtpu_tunnel"
+  }
+}
+actions {
+  preamble {
+    id: 31713420
+    name: "PreQosPipe.do_gtpu_tunnel_with_psc"
+    alias: "do_gtpu_tunnel_with_psc"
+  }
+}
+action_profiles {
+  preamble {
+    id: 297808402
+    name: "hashed_selector"
+    alias: "hashed_selector"
+  }
+  table_ids: 39015874
+  with_selector: true
+  size: 1024
+}
+counters {
+  preamble {
+    id: 315693181
+    name: "PreQosPipe.pre_qos_counter"
+    alias: "pre_qos_counter"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 302958180
+    name: "PostQosPipe.post_qos_counter"
+    alias: "post_qos_counter"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+direct_counters {
+  preamble {
+    id: 325583051
+    name: "acls"
+    alias: "acls"
+  }
+  spec {
+    unit: BOTH
+  }
+  direct_table_id: 47204971
+}
+meters {
+  preamble {
+    id: 338231090
+    name: "PreQosPipe.app_meter"
+    alias: "app_meter"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+meters {
+  preamble {
+    id: 347593234
+    name: "PreQosPipe.session_meter"
+    alias: "session_meter"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+meters {
+  preamble {
+    id: 336833095
+    name: "PreQosPipe.slice_tc_meter"
+    alias: "slice_tc_meter"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 64
+}
+controller_packet_metadata {
+  preamble {
+    id: 75327753
+    name: "packet_out"
+    alias: "packet_out"
+    annotations: "@controller_header(\"packet_out\")"
+  }
+  metadata {
+    id: 1
+    name: "reserved"
+    bitwidth: 8
+  }
+}
+controller_packet_metadata {
+  preamble {
+    id: 80671331
+    name: "packet_in"
+    alias: "packet_in"
+    annotations: "@controller_header(\"packet_in\")"
+  }
+  metadata {
+    id: 1
+    name: "ingress_port"
+    bitwidth: 9
+  }
+  metadata {
+    id: 2
+    name: "_pad"
+    bitwidth: 7
+  }
+}
+digests {
+  preamble {
+    id: 396224266
+    name: "ddn_digest_t"
+    alias: "ddn_digest_t"
+  }
+  type_spec {
+    struct {
+      name: "ddn_digest_t"
+    }
+  }
+}
+type_info {
+  structs {
+    key: "ddn_digest_t"
+    value {
+      members {
+        name: "ue_address"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 32
+            }
+          }
+        }
+      }
+    }
+  }
+  serializable_enums {
+    key: "Direction"
+    value {
+      underlying_type {
+        bitwidth: 8
+      }
+      members {
+        name: "UNKNOWN"
+        value: "\000"
+      }
+      members {
+        name: "UPLINK"
+        value: "\001"
+      }
+      members {
+        name: "DOWNLINK"
+        value: "\002"
+      }
+      members {
+        name: "OTHER"
+        value: "\003"
+      }
+    }
+  }
+  serializable_enums {
+    key: "InterfaceType"
+    value {
+      underlying_type {
+        bitwidth: 8
+      }
+      members {
+        name: "UNKNOWN"
+        value: "\000"
+      }
+      members {
+        name: "ACCESS"
+        value: "\001"
+      }
+      members {
+        name: "CORE"
+        value: "\002"
+      }
+    }
+  }
+  serializable_enums {
+    key: "Slice"
+    value {
+      underlying_type {
+        bitwidth: 4
+      }
+      members {
+        name: "DEFAULT"
+        value: "\000"
+      }
+    }
+  }
+  serializable_enums {
+    key: "TrafficClass"
+    value {
+      underlying_type {
+        bitwidth: 2
+      }
+      members {
+        name: "BEST_EFFORT"
+        value: "\000"
+      }
+      members {
+        name: "CONTROL"
+        value: "\001"
+      }
+      members {
+        name: "REAL_TIME"
+        value: "\002"
+      }
+      members {
+        name: "ELASTIC"
+        value: "\003"
+      }
+    }
+  }
+}

--- a/testdata/p4_16_samples_outputs/pins/pins_fabric-first.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_fabric-first.p4
@@ -96,15 +96,15 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<10> tunnel_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
+type bit<10> nexthop_id_t;
+type bit<10> tunnel_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
 const vrf_id_t kDefaultVrf = (vrf_id_t)10w0;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 2w0,

--- a/testdata/p4_16_samples_outputs/pins/pins_fabric-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_fabric-frontend.p4
@@ -96,13 +96,13 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
+type bit<10> nexthop_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 2w0,

--- a/testdata/p4_16_samples_outputs/pins/pins_fabric.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_fabric.p4
@@ -96,15 +96,15 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<10> tunnel_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
+type bit<10> nexthop_id_t;
+type bit<10> tunnel_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
 const vrf_id_t kDefaultVrf = 0;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 0,

--- a/testdata/p4_16_samples_outputs/pins/pins_fabric.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pins/pins_fabric.p4.p4info.txt
@@ -76,6 +76,7 @@ tables {
     id: 8
     name: "in_port"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT)"
+    bitwidth: 9
     match_type: OPTIONAL
     type_name {
       name: "port_id_t"
@@ -111,6 +112,7 @@ tables {
   match_fields {
     id: 2
     name: "in_port"
+    bitwidth: 9
     match_type: OPTIONAL
     type_name {
       name: "port_id_t"
@@ -139,6 +141,7 @@ tables {
     id: 1
     name: "router_interface_id"
     annotations: "@refers_to(router_interface_table , router_interface_id)"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "router_interface_id_t"
@@ -173,6 +176,7 @@ tables {
   match_fields {
     id: 1
     name: "router_interface_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "router_interface_id_t"
@@ -200,6 +204,7 @@ tables {
   match_fields {
     id: 1
     name: "nexthop_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "nexthop_id_t"
@@ -232,6 +237,7 @@ tables {
   match_fields {
     id: 1
     name: "wcmp_group_id"
+    bitwidth: 12
     match_type: EXACT
     type_name {
       name: "wcmp_group_id_t"
@@ -261,6 +267,7 @@ tables {
   match_fields {
     id: 1
     name: "vrf_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "vrf_id_t"
@@ -284,6 +291,7 @@ tables {
     id: 1
     name: "vrf_id"
     annotations: "@refers_to(vrf_table , vrf_id)"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "vrf_id_t"
@@ -338,6 +346,7 @@ tables {
     id: 1
     name: "vrf_id"
     annotations: "@refers_to(vrf_table , vrf_id)"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "vrf_id_t"
@@ -518,6 +527,7 @@ tables {
     id: 17
     name: "in_port"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT)"
+    bitwidth: 9
     match_type: OPTIONAL
     type_name {
       name: "port_id_t"
@@ -574,6 +584,7 @@ tables {
   match_fields {
     id: 1
     name: "mirror_session_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "mirror_session_id_t"
@@ -601,6 +612,7 @@ tables {
   match_fields {
     id: 1
     name: "mirror_port"
+    bitwidth: 9
     match_type: EXACT
     type_name {
       name: "port_id_t"
@@ -652,6 +664,7 @@ tables {
     id: 4
     name: "out_port"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_OUT_PORT)"
+    bitwidth: 9
     match_type: OPTIONAL
     type_name {
       name: "port_id_t"
@@ -726,6 +739,7 @@ actions {
     name: "vrf_id"
     annotations: "@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_VRF)"
     annotations: "@refers_to(vrf_table , vrf_id)"
+    bitwidth: 10
     type_name {
       name: "vrf_id_t"
     }
@@ -760,6 +774,7 @@ actions {
   params {
     id: 1
     name: "port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -782,6 +797,7 @@ actions {
     name: "router_interface_id"
     annotations: "@refers_to(router_interface_table , router_interface_id)"
     annotations: "@refers_to(neighbor_table , router_interface_id)"
+    bitwidth: 10
     type_name {
       name: "router_interface_id_t"
     }
@@ -806,6 +822,7 @@ actions {
     name: "router_interface_id"
     annotations: "@refers_to(router_interface_table , router_interface_id)"
     annotations: "@refers_to(neighbor_table , router_interface_id)"
+    bitwidth: 10
     type_name {
       name: "router_interface_id_t"
     }
@@ -828,6 +845,7 @@ actions {
     id: 1
     name: "nexthop_id"
     annotations: "@refers_to(nexthop_table , nexthop_id)"
+    bitwidth: 10
     type_name {
       name: "nexthop_id_t"
     }
@@ -843,6 +861,7 @@ actions {
     id: 1
     name: "nexthop_id"
     annotations: "@refers_to(nexthop_table , nexthop_id)"
+    bitwidth: 10
     type_name {
       name: "nexthop_id_t"
     }
@@ -877,6 +896,7 @@ actions {
     id: 1
     name: "wcmp_group_id"
     annotations: "@refers_to(wcmp_group_table , wcmp_group_id)"
+    bitwidth: 12
     type_name {
       name: "wcmp_group_id_t"
     }
@@ -892,6 +912,7 @@ actions {
     id: 1
     name: "wcmp_group_id"
     annotations: "@refers_to(wcmp_group_table , wcmp_group_id)"
+    bitwidth: 12
     type_name {
       name: "wcmp_group_id_t"
     }
@@ -934,6 +955,7 @@ actions {
     id: 1
     name: "qos_queue"
     annotations: "@sai_action_param(QOS_QUEUE)"
+    bitwidth: 8
     type_name {
       name: "qos_queue_t"
     }
@@ -952,6 +974,7 @@ actions {
     id: 1
     name: "qos_queue"
     annotations: "@sai_action_param(QOS_QUEUE)"
+    bitwidth: 8
     type_name {
       name: "qos_queue_t"
     }
@@ -970,6 +993,7 @@ actions {
     id: 1
     name: "qos_queue"
     annotations: "@sai_action_param(QOS_QUEUE)"
+    bitwidth: 8
     type_name {
       name: "qos_queue_t"
     }
@@ -997,6 +1021,7 @@ actions {
     name: "mirror_session_id"
     annotations: "@refers_to(mirror_session_table , mirror_session_id)"
     annotations: "@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS)"
+    bitwidth: 10
     type_name {
       name: "mirror_session_id_t"
     }
@@ -1011,6 +1036,7 @@ actions {
   params {
     id: 1
     name: "port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -1127,6 +1153,7 @@ controller_packet_metadata {
   metadata {
     id: 1
     name: "ingress_port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -1134,6 +1161,7 @@ controller_packet_metadata {
   metadata {
     id: 2
     name: "target_egress_port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -1149,6 +1177,7 @@ controller_packet_metadata {
   metadata {
     id: 1
     name: "egress_port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -1168,8 +1197,11 @@ type_info {
   new_types {
     key: "mirror_session_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -1177,8 +1209,11 @@ type_info {
   new_types {
     key: "nexthop_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -1186,8 +1221,11 @@ type_info {
   new_types {
     key: "port_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 9
+          }
         }
       }
     }
@@ -1195,8 +1233,11 @@ type_info {
   new_types {
     key: "qos_queue_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
         }
       }
     }
@@ -1204,8 +1245,11 @@ type_info {
   new_types {
     key: "router_interface_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -1213,8 +1257,11 @@ type_info {
   new_types {
     key: "vrf_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -1222,8 +1269,11 @@ type_info {
   new_types {
     key: "wcmp_group_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 12
+          }
         }
       }
     }

--- a/testdata/p4_16_samples_outputs/pins/pins_middleblock-first.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_middleblock-first.p4
@@ -96,15 +96,15 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<10> tunnel_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
+type bit<10> nexthop_id_t;
+type bit<10> tunnel_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
 const vrf_id_t kDefaultVrf = (vrf_id_t)10w0;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 2w0,

--- a/testdata/p4_16_samples_outputs/pins/pins_middleblock-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_middleblock-frontend.p4
@@ -96,13 +96,13 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
+type bit<10> nexthop_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 2w0,

--- a/testdata/p4_16_samples_outputs/pins/pins_middleblock.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_middleblock.p4
@@ -96,6 +96,15 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
+type bit<10> nexthop_id_t;
+type bit<10> tunnel_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
+const vrf_id_t kDefaultVrf = 0;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 0,

--- a/testdata/p4_16_samples_outputs/pins/pins_middleblock.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_middleblock.p4
@@ -96,15 +96,6 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<10> tunnel_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
-const vrf_id_t kDefaultVrf = 0;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 0,

--- a/testdata/p4_16_samples_outputs/pins/pins_middleblock.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pins/pins_middleblock.p4.p4info.txt
@@ -68,6 +68,7 @@ tables {
     id: 8
     name: "in_port"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_IN_PORT)"
+    bitwidth: 9
     match_type: OPTIONAL
     type_name {
       name: "port_id_t"
@@ -103,6 +104,7 @@ tables {
   match_fields {
     id: 2
     name: "in_port"
+    bitwidth: 9
     match_type: OPTIONAL
     type_name {
       name: "port_id_t"
@@ -131,6 +133,7 @@ tables {
     id: 1
     name: "router_interface_id"
     annotations: "@refers_to(router_interface_table , router_interface_id)"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "router_interface_id_t"
@@ -165,6 +168,7 @@ tables {
   match_fields {
     id: 1
     name: "router_interface_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "router_interface_id_t"
@@ -192,6 +196,7 @@ tables {
   match_fields {
     id: 1
     name: "nexthop_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "nexthop_id_t"
@@ -224,6 +229,7 @@ tables {
   match_fields {
     id: 1
     name: "wcmp_group_id"
+    bitwidth: 12
     match_type: EXACT
     type_name {
       name: "wcmp_group_id_t"
@@ -253,6 +259,7 @@ tables {
   match_fields {
     id: 1
     name: "vrf_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "vrf_id_t"
@@ -276,6 +283,7 @@ tables {
     id: 1
     name: "vrf_id"
     annotations: "@refers_to(vrf_table , vrf_id)"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "vrf_id_t"
@@ -326,6 +334,7 @@ tables {
     id: 1
     name: "vrf_id"
     annotations: "@refers_to(vrf_table , vrf_id)"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "vrf_id_t"
@@ -543,6 +552,7 @@ tables {
   match_fields {
     id: 1
     name: "mirror_session_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "mirror_session_id_t"
@@ -570,6 +580,7 @@ tables {
   match_fields {
     id: 1
     name: "mirror_port"
+    bitwidth: 9
     match_type: EXACT
     type_name {
       name: "port_id_t"
@@ -615,6 +626,7 @@ actions {
     name: "vrf_id"
     annotations: "@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_SET_VRF)"
     annotations: "@refers_to(vrf_table , vrf_id)"
+    bitwidth: 10
     type_name {
       name: "vrf_id_t"
     }
@@ -649,6 +661,7 @@ actions {
   params {
     id: 1
     name: "port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -671,6 +684,7 @@ actions {
     name: "router_interface_id"
     annotations: "@refers_to(router_interface_table , router_interface_id)"
     annotations: "@refers_to(neighbor_table , router_interface_id)"
+    bitwidth: 10
     type_name {
       name: "router_interface_id_t"
     }
@@ -695,6 +709,7 @@ actions {
     name: "router_interface_id"
     annotations: "@refers_to(router_interface_table , router_interface_id)"
     annotations: "@refers_to(neighbor_table , router_interface_id)"
+    bitwidth: 10
     type_name {
       name: "router_interface_id_t"
     }
@@ -717,6 +732,7 @@ actions {
     id: 1
     name: "nexthop_id"
     annotations: "@refers_to(nexthop_table , nexthop_id)"
+    bitwidth: 10
     type_name {
       name: "nexthop_id_t"
     }
@@ -732,6 +748,7 @@ actions {
     id: 1
     name: "nexthop_id"
     annotations: "@refers_to(nexthop_table , nexthop_id)"
+    bitwidth: 10
     type_name {
       name: "nexthop_id_t"
     }
@@ -766,6 +783,7 @@ actions {
     id: 1
     name: "wcmp_group_id"
     annotations: "@refers_to(wcmp_group_table , wcmp_group_id)"
+    bitwidth: 12
     type_name {
       name: "wcmp_group_id_t"
     }
@@ -781,6 +799,7 @@ actions {
     id: 1
     name: "wcmp_group_id"
     annotations: "@refers_to(wcmp_group_table , wcmp_group_id)"
+    bitwidth: 12
     type_name {
       name: "wcmp_group_id_t"
     }
@@ -811,6 +830,7 @@ actions {
     id: 1
     name: "qos_queue"
     annotations: "@sai_action_param(QOS_QUEUE)"
+    bitwidth: 8
     type_name {
       name: "qos_queue_t"
     }
@@ -829,6 +849,7 @@ actions {
     id: 1
     name: "qos_queue"
     annotations: "@sai_action_param(QOS_QUEUE)"
+    bitwidth: 8
     type_name {
       name: "qos_queue_t"
     }
@@ -847,6 +868,7 @@ actions {
     id: 1
     name: "qos_queue"
     annotations: "@sai_action_param(QOS_QUEUE)"
+    bitwidth: 8
     type_name {
       name: "qos_queue_t"
     }
@@ -874,6 +896,7 @@ actions {
     name: "mirror_session_id"
     annotations: "@refers_to(mirror_session_table , mirror_session_id)"
     annotations: "@sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS)"
+    bitwidth: 10
     type_name {
       name: "mirror_session_id_t"
     }
@@ -888,6 +911,7 @@ actions {
   params {
     id: 1
     name: "port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -993,6 +1017,7 @@ controller_packet_metadata {
   metadata {
     id: 1
     name: "ingress_port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -1000,6 +1025,7 @@ controller_packet_metadata {
   metadata {
     id: 2
     name: "target_egress_port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -1015,6 +1041,7 @@ controller_packet_metadata {
   metadata {
     id: 1
     name: "egress_port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -1034,8 +1061,11 @@ type_info {
   new_types {
     key: "mirror_session_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -1043,8 +1073,11 @@ type_info {
   new_types {
     key: "nexthop_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -1052,8 +1085,11 @@ type_info {
   new_types {
     key: "port_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 9
+          }
         }
       }
     }
@@ -1061,8 +1097,11 @@ type_info {
   new_types {
     key: "qos_queue_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 8
+          }
         }
       }
     }
@@ -1070,8 +1109,11 @@ type_info {
   new_types {
     key: "router_interface_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -1079,8 +1121,11 @@ type_info {
   new_types {
     key: "vrf_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -1088,8 +1133,11 @@ type_info {
   new_types {
     key: "wcmp_group_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 12
+          }
         }
       }
     }

--- a/testdata/p4_16_samples_outputs/pins/pins_wbb-first.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_wbb-first.p4
@@ -96,15 +96,15 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<10> tunnel_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
+type bit<10> nexthop_id_t;
+type bit<10> tunnel_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
 const vrf_id_t kDefaultVrf = (vrf_id_t)10w0;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 2w0,

--- a/testdata/p4_16_samples_outputs/pins/pins_wbb-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_wbb-frontend.p4
@@ -96,12 +96,12 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
+type bit<10> nexthop_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 2w0,

--- a/testdata/p4_16_samples_outputs/pins/pins_wbb.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_wbb.p4
@@ -96,6 +96,15 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
+type bit<10> nexthop_id_t;
+type bit<10> tunnel_id_t;
+type bit<12> wcmp_group_id_t;
+type bit<10> vrf_id_t;
+const vrf_id_t kDefaultVrf = 0;
+type bit<10> router_interface_id_t;
+type bit<9> port_id_t;
+type bit<10> mirror_session_id_t;
+type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 0,

--- a/testdata/p4_16_samples_outputs/pins/pins_wbb.p4
+++ b/testdata/p4_16_samples_outputs/pins/pins_wbb.p4
@@ -96,15 +96,6 @@ enum bit<8> PreservedFieldList {
     CLONE_I2E = 8w1
 }
 
-@p4runtime_translation("" , string) type bit<10> nexthop_id_t;
-@p4runtime_translation("" , string) type bit<10> tunnel_id_t;
-@p4runtime_translation("" , string) type bit<12> wcmp_group_id_t;
-@p4runtime_translation("" , string) @p4runtime_translation_mappings({ { "" , 0 } , }) type bit<10> vrf_id_t;
-const vrf_id_t kDefaultVrf = 0;
-@p4runtime_translation("" , string) type bit<10> router_interface_id_t;
-@p4runtime_translation("" , string) type bit<9> port_id_t;
-@p4runtime_translation("" , string) type bit<10> mirror_session_id_t;
-@p4runtime_translation("" , string) type bit<8> qos_queue_t;
 typedef bit<6> route_metadata_t;
 enum bit<2> MeterColor_t {
     GREEN = 0,

--- a/testdata/p4_16_samples_outputs/pins/pins_wbb.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/pins/pins_wbb.p4.p4info.txt
@@ -20,6 +20,7 @@ tables {
   match_fields {
     id: 2
     name: "in_port"
+    bitwidth: 9
     match_type: OPTIONAL
     type_name {
       name: "port_id_t"
@@ -48,6 +49,7 @@ tables {
     id: 1
     name: "router_interface_id"
     annotations: "@refers_to(router_interface_table , router_interface_id)"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "router_interface_id_t"
@@ -82,6 +84,7 @@ tables {
   match_fields {
     id: 1
     name: "router_interface_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "router_interface_id_t"
@@ -109,6 +112,7 @@ tables {
   match_fields {
     id: 1
     name: "nexthop_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "nexthop_id_t"
@@ -141,6 +145,7 @@ tables {
   match_fields {
     id: 1
     name: "wcmp_group_id"
+    bitwidth: 12
     match_type: EXACT
     type_name {
       name: "wcmp_group_id_t"
@@ -170,6 +175,7 @@ tables {
   match_fields {
     id: 1
     name: "vrf_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "vrf_id_t"
@@ -193,6 +199,7 @@ tables {
     id: 1
     name: "vrf_id"
     annotations: "@refers_to(vrf_table , vrf_id)"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "vrf_id_t"
@@ -243,6 +250,7 @@ tables {
     id: 1
     name: "vrf_id"
     annotations: "@refers_to(vrf_table , vrf_id)"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "vrf_id_t"
@@ -354,6 +362,7 @@ tables {
   match_fields {
     id: 1
     name: "mirror_session_id"
+    bitwidth: 10
     match_type: EXACT
     type_name {
       name: "mirror_session_id_t"
@@ -381,6 +390,7 @@ tables {
   match_fields {
     id: 1
     name: "mirror_port"
+    bitwidth: 9
     match_type: EXACT
     type_name {
       name: "port_id_t"
@@ -435,6 +445,7 @@ actions {
   params {
     id: 1
     name: "port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -457,6 +468,7 @@ actions {
     name: "router_interface_id"
     annotations: "@refers_to(router_interface_table , router_interface_id)"
     annotations: "@refers_to(neighbor_table , router_interface_id)"
+    bitwidth: 10
     type_name {
       name: "router_interface_id_t"
     }
@@ -481,6 +493,7 @@ actions {
     name: "router_interface_id"
     annotations: "@refers_to(router_interface_table , router_interface_id)"
     annotations: "@refers_to(neighbor_table , router_interface_id)"
+    bitwidth: 10
     type_name {
       name: "router_interface_id_t"
     }
@@ -503,6 +516,7 @@ actions {
     id: 1
     name: "nexthop_id"
     annotations: "@refers_to(nexthop_table , nexthop_id)"
+    bitwidth: 10
     type_name {
       name: "nexthop_id_t"
     }
@@ -518,6 +532,7 @@ actions {
     id: 1
     name: "nexthop_id"
     annotations: "@refers_to(nexthop_table , nexthop_id)"
+    bitwidth: 10
     type_name {
       name: "nexthop_id_t"
     }
@@ -552,6 +567,7 @@ actions {
     id: 1
     name: "wcmp_group_id"
     annotations: "@refers_to(wcmp_group_table , wcmp_group_id)"
+    bitwidth: 12
     type_name {
       name: "wcmp_group_id_t"
     }
@@ -567,6 +583,7 @@ actions {
     id: 1
     name: "wcmp_group_id"
     annotations: "@refers_to(wcmp_group_table , wcmp_group_id)"
+    bitwidth: 12
     type_name {
       name: "wcmp_group_id_t"
     }
@@ -609,6 +626,7 @@ actions {
   params {
     id: 1
     name: "port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -703,6 +721,7 @@ controller_packet_metadata {
   metadata {
     id: 1
     name: "ingress_port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -710,6 +729,7 @@ controller_packet_metadata {
   metadata {
     id: 2
     name: "target_egress_port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -725,6 +745,7 @@ controller_packet_metadata {
   metadata {
     id: 1
     name: "egress_port"
+    bitwidth: 9
     type_name {
       name: "port_id_t"
     }
@@ -744,8 +765,11 @@ type_info {
   new_types {
     key: "mirror_session_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -753,8 +777,11 @@ type_info {
   new_types {
     key: "nexthop_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -762,8 +789,11 @@ type_info {
   new_types {
     key: "port_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 9
+          }
         }
       }
     }
@@ -771,8 +801,11 @@ type_info {
   new_types {
     key: "router_interface_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -780,8 +813,11 @@ type_info {
   new_types {
     key: "vrf_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 10
+          }
         }
       }
     }
@@ -789,8 +825,11 @@ type_info {
   new_types {
     key: "wcmp_group_id_t"
     value {
-      translated_type {
-        sdn_string {
+      original_type {
+        bitstring {
+          bit {
+            bitwidth: 12
+          }
         }
       }
     }


### PR DESCRIPTION
`up.p4` was not checking whether the IPv4 header is valid before applying the routing control, which reads from the IPv4 header.

The PINS programs uses the `p4runtime_translation` annotation, which is currently not supported by PI (https://github.com/p4lang/behavioral-model/issues/1176). 