### PR TITLE
Replace invalid clone id 0 with 1 for selected BMv2 programs

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -246,7 +246,7 @@ p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
   "At index"
   # At index 0: UNKNOWN, 'Error when adding match entry to target'
-  # enums are not supported in P4Runtime yey https://github.com/p4lang/behavioral-model/issues/1178
+  # enums are not supported in P4Runtime yet https://github.com/p4lang/behavioral-model/issues/1178
   issue1062-1-bmv2.p4
   v1model-p4runtime-most-types1.p4
   pins_fabric.p4

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -34,12 +34,6 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
-  "Unsupported type argument for Value Set"
-  pvs-nested-struct.p4
-)
-
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2-ptf"
   "Segmentation fault"
   # The error here is unclear.
   extract_for_header_union.p4
@@ -86,6 +80,12 @@ p4tools_add_xfail_reason(
   "Assume error"
   # Assert/Assume error: assert/assume(false).
   bmv2_assume.p4
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-ptf"
+  "Unsupported type argument for Value Set"
+  pvs-nested-struct.p4
 )
 
 p4tools_add_xfail_reason(
@@ -246,6 +246,7 @@ p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
   "At index"
   # At index 0: UNKNOWN, 'Error when adding match entry to target'
+  # enums are not supported in P4Runtime yey https://github.com/p4lang/behavioral-model/issues/1178
   issue1062-1-bmv2.p4
   v1model-p4runtime-most-types1.p4
   pins_fabric.p4
@@ -255,13 +256,6 @@ p4tools_add_xfail_reason(
   # At index 0: INVALID_ARGUMENT, 'Bytestring provided does not fit within 0 bits'
   pins_middleblock.p4
   issue2283_1-bmv2.p4
-
-  # At index 0: INVALID_ARGUMENT, '0 is not a valid session id'
-  issue1642-bmv2.p4
-  issue1653-bmv2.p4
-  issue1653-complex-bmv2.p4
-  issue1660-bmv2.p4
-  issue562-bmv2.p4
 )
 
 p4tools_add_xfail_reason(
@@ -279,11 +273,4 @@ p4tools_add_xfail_reason(
   "Error when importing p4info"
   v1model-digest-containing-ser-enum.p4
   v1model-digest-custom-type.p4
-)
-
-# Using a wildcard because the actual error is not shown. It is a packet mismatch.
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2-ptf"
-  "ATTENTION: SOME TESTS DID NOT PASS!!!"
-  issue383-bmv2.p4
 )

--- a/testdata/p4_16_samples/issue1642-bmv2.p4
+++ b/testdata/p4_16_samples/issue1642-bmv2.p4
@@ -39,7 +39,7 @@ control ingress(inout parsed_packet_t hdr,
         local_metadata.row.alt0 = local_metadata.row.alt1;
         local_metadata.row.alt0.valid = 1;
         local_metadata.row.alt1.port = local_metadata.row.alt1.port + 1;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 

--- a/testdata/p4_16_samples/issue1653-bmv2.p4
+++ b/testdata/p4_16_samples/issue1653-bmv2.p4
@@ -45,7 +45,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata,
     apply {
         // Copy another header's data to local variable.
         bh.x = h.bvh0.x;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 

--- a/testdata/p4_16_samples/issue1653-complex-bmv2.p4
+++ b/testdata/p4_16_samples/issue1653-complex-bmv2.p4
@@ -96,7 +96,7 @@ control ingress(inout parsed_packet_t h,
         h.bvh0.row.alt1.type = bh.row.alt1.type;
 
         local_metadata.row0.alt0.useHash = true;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 

--- a/testdata/p4_16_samples/issue1660-bmv2.p4
+++ b/testdata/p4_16_samples/issue1660-bmv2.p4
@@ -20,7 +20,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata,
     apply {
         HasBool b;
         b.x = true;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 

--- a/testdata/p4_16_samples/issue383-bmv2.p4
+++ b/testdata/p4_16_samples/issue383-bmv2.p4
@@ -106,7 +106,7 @@ control ingress(inout parsed_packet_t h,
         local_metadata.row0.alt0 = local_metadata.row1.alt1;
         local_metadata.row1.alt0.valid = 1;
         local_metadata.row1.alt1.port = local_metadata.row0.alt1.port + 1;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
 
 /*
         Cast support is TODO for bmv2.

--- a/testdata/p4_16_samples/issue562-bmv2.p4
+++ b/testdata/p4_16_samples/issue562-bmv2.p4
@@ -32,7 +32,7 @@ control ingress(inout parsed_packet_t hdr,
         local_metadata.row.alt0 = local_metadata.row.alt1;
         local_metadata.row.alt0.valid = 1;
         local_metadata.row.alt1.port = local_metadata.row.alt1.port + 1;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1642-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1642-bmv2-first.p4
@@ -38,7 +38,7 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata.row.alt0 = local_metadata.row.alt1;
         local_metadata.row.alt0.valid = 1w1;
         local_metadata.row.alt1.port = local_metadata.row.alt1.port + 7w1;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1642-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1642-bmv2-frontend.p4
@@ -38,7 +38,7 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata.row.alt0 = local_metadata.row.alt1;
         local_metadata.row.alt0.valid = 1w1;
         local_metadata.row.alt1.port = local_metadata.row.alt1.port + 7w1;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1642-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1642-bmv2-midend.p4
@@ -45,7 +45,7 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata._row_alt0_port2 = local_metadata._row_alt1_port4;
         local_metadata._row_alt0_valid1 = 1w1;
         local_metadata._row_alt1_port4 = local_metadata._row_alt1_port4 + 7w1;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
     @hidden table tbl_issue1642bmv2l37 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1642-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1642-bmv2.p4
@@ -38,7 +38,7 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata.row.alt0 = local_metadata.row.alt1;
         local_metadata.row.alt0.valid = 1;
         local_metadata.row.alt1.port = local_metadata.row.alt1.port + 1;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2-first.p4
@@ -26,7 +26,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
     bitvec_hdr bh;
     apply {
         bh.x = h.bvh0.x;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2-frontend.p4
@@ -26,7 +26,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
     @name("ingress.bh") bitvec_hdr bh_0;
     apply {
         bh_0.setInvalid();
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2-midend.p4
@@ -26,7 +26,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
     @name("ingress.bh") bitvec_hdr bh_0;
     @hidden action issue1653bmv2l43() {
         bh_0.setInvalid();
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
     @hidden table tbl_issue1653bmv2l43 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1653-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-bmv2.p4
@@ -26,7 +26,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
     bitvec_hdr bh;
     apply {
         bh.x = h.bvh0.x;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-first.p4
@@ -74,7 +74,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         bh.row.alt1.type = EthTypes.IPv4;
         h.bvh0.row.alt1.type = bh.row.alt1.type;
         local_metadata.row0.alt0.useHash = true;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-frontend.p4
@@ -76,7 +76,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         bh_0.row.alt1.type = EthTypes.IPv4;
         h.bvh0.row.alt1.type = bh_0.row.alt1.type;
         local_metadata.row0.alt0.useHash = true;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2-midend.p4
@@ -111,7 +111,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         bh_0._row_alt1_type10 = 16w0x800;
         h.bvh0._row_alt1_type10 = 16w0x800;
         local_metadata._row0_alt0_useHash3 = true;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
     @hidden table tbl_issue1653complexbmv2l72 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2.p4
@@ -72,7 +72,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         bh.row.alt1.type = EthTypes.IPv4;
         h.bvh0.row.alt1.type = bh.row.alt1.type;
         local_metadata.row0.alt0.useHash = true;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2-first.p4
@@ -23,7 +23,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
     apply {
         HasBool b;
         b.x = true;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2-frontend.p4
@@ -21,7 +21,7 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     apply {
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2-midend.p4
@@ -21,7 +21,7 @@ parser parse(packet_in pk, out parsed_packet_t h, inout local_metadata_t local_m
 
 control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, inout standard_metadata_t standard_metadata) {
     @hidden action issue1660bmv2l23() {
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
     @hidden table tbl_issue1660bmv2l23 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue1660-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue1660-bmv2.p4
@@ -23,7 +23,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
     apply {
         HasBool b;
         b.x = true;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-first.p4
@@ -80,7 +80,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         local_metadata.row0.alt0 = local_metadata.row1.alt1;
         local_metadata.row1.alt0.valid = 1w1;
         local_metadata.row1.alt1.port = local_metadata.row0.alt1.port + 7w1;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-frontend.p4
@@ -80,7 +80,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         local_metadata.row0.alt0 = local_metadata.row1.alt1;
         local_metadata.row1.alt0.valid = 1w1;
         local_metadata.row1.alt1.port = local_metadata.row0.alt1.port + 7w1;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2-midend.p4
@@ -100,7 +100,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         local_metadata._row0_alt0_port1 = local_metadata._row1_alt1_port7;
         local_metadata._row1_alt0_valid4 = 1w1;
         local_metadata._row1_alt1_port7 = local_metadata._row0_alt1_port3 + 7w1;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
     @hidden table tbl_issue383bmv2l75 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue383-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2.p4
@@ -78,7 +78,7 @@ control ingress(inout parsed_packet_t h, inout local_metadata_t local_metadata, 
         local_metadata.row0.alt0 = local_metadata.row1.alt1;
         local_metadata.row1.alt0.valid = 1;
         local_metadata.row1.alt1.port = local_metadata.row0.alt1.port + 1;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue562-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue562-bmv2-first.p4
@@ -31,7 +31,7 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata.row.alt0 = local_metadata.row.alt1;
         local_metadata.row.alt0.valid = 1w1;
         local_metadata.row.alt1.port = local_metadata.row.alt1.port + 7w1;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue562-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue562-bmv2-frontend.p4
@@ -31,7 +31,7 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata.row.alt0 = local_metadata.row.alt1;
         local_metadata.row.alt0.valid = 1w1;
         local_metadata.row.alt1.port = local_metadata.row.alt1.port + 7w1;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue562-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue562-bmv2-midend.p4
@@ -38,7 +38,7 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata._row_alt0_port1 = local_metadata._row_alt1_port3;
         local_metadata._row_alt0_valid0 = 1w1;
         local_metadata._row_alt1_port3 = local_metadata._row_alt1_port3 + 7w1;
-        clone_preserving_field_list(CloneType.I2E, 32w0, 8w0);
+        clone_preserving_field_list(CloneType.I2E, 32w1, 8w0);
     }
     @hidden table tbl_issue562bmv2l32 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue562-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/issue562-bmv2.p4
@@ -31,7 +31,7 @@ control ingress(inout parsed_packet_t hdr, inout local_metadata_t local_metadata
         local_metadata.row.alt0 = local_metadata.row.alt1;
         local_metadata.row.alt0.valid = 1;
         local_metadata.row.alt1.port = local_metadata.row.alt1.port + 1;
-        clone_preserving_field_list(CloneType.I2E, 0, 0);
+        clone_preserving_field_list(CloneType.I2E, 1, 0);
     }
 }
 


### PR DESCRIPTION
The P4Runtime specification [reserves](https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-clonesessionentry) session ID 0. Correspondingly, some of the test programs in the test suite do not configure the session ID correctly. It does not look like any of the tests was intended to validate this feature. 

 This PR changes the ID to 1 so that the tests can run using P4Runtime. 