### PR TITLE
ebpf/PSA: Support for wide fields in Digest

### DIFF
--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -46,6 +46,7 @@ set (P4C_EBPF_SRCS
   psa/backend.cpp
   psa/externs/ebpfPsaCounter.cpp
   psa/externs/ebpfPsaChecksum.cpp
+  psa/externs/ebpfPsaDigest.cpp
   psa/externs/ebpfPsaHashAlgorithm.cpp
   psa/externs/ebpfPsaTableImplementation.cpp
   psa/externs/ebpfPsaRandom.cpp
@@ -81,6 +82,7 @@ set (P4C_EBPF_HDRS
   psa/ebpfPsaTable.h
   psa/externs/ebpfPsaCounter.h
   psa/externs/ebpfPsaChecksum.h
+  psa/externs/ebpfPsaDigest.h
   psa/externs/ebpfPsaHashAlgorithm.h
   psa/externs/ebpfPsaTableImplementation.h
   psa/externs/ebpfPsaRegister.h

--- a/backends/ebpf/codeGen.h
+++ b/backends/ebpf/codeGen.h
@@ -115,6 +115,8 @@ class CodeGenInspector : public Inspector {
 
     bool preorder(const IR::Type_Typedef *type) override;
     bool preorder(const IR::Type_Enum *type) override;
+    void emitAssignStatement(const IR::Type *ltype, const IR::Expression *lexpr, cstring lpath,
+                             const IR::Expression *rexpr);
     bool preorder(const IR::AssignmentStatement *s) override;
     bool preorder(const IR::BlockStatement *s) override;
     bool preorder(const IR::MethodCallStatement *s) override;

--- a/backends/ebpf/psa/ebpfPsaGen.h
+++ b/backends/ebpf/psa/ebpfPsaGen.h
@@ -199,17 +199,15 @@ class ConvertToEBPFDeparserPSA : public Inspector {
 
     const IR::Parameter *parserHeaders;
     const IR::Parameter *istd;
-    P4::TypeMap *typemap;
     EBPF::EBPFDeparserPSA *deparser;
 
  public:
     ConvertToEBPFDeparserPSA(EBPFProgram *program, const IR::Parameter *parserHeaders,
-                             const IR::Parameter *istd, P4::TypeMap *typemap, pipeline_type type)
+                             const IR::Parameter *istd, pipeline_type type)
         : program(program),
           pipelineType(type),
           parserHeaders(parserHeaders),
           istd(istd),
-          typemap(typemap),
           deparser(nullptr) {}
 
     bool preorder(const IR::ControlBlock *) override;

--- a/backends/ebpf/psa/externs/ebpfPsaDigest.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaDigest.cpp
@@ -1,0 +1,177 @@
+/*
+Copyright 2022-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "ebpfPsaDigest.h"
+
+#include "backends/ebpf/ebpfType.h"
+#include "backends/ebpf/psa/ebpfPsaDeparser.h"
+
+namespace EBPF {
+
+class EBPFDigestPSAValueVisitor : public CodeGenInspector {
+ protected:
+    cstring digestMapInstance;
+    CodeGenInspector *codegen;
+    EBPFType *valueType;
+
+ public:
+    EBPFDigestPSAValueVisitor(P4::ReferenceMap *refMap, P4::TypeMap *typeMap,
+                              cstring digestMapInstance, CodeGenInspector *codegen,
+                              EBPFType *valueType)
+        : CodeGenInspector(refMap, typeMap),
+          digestMapInstance(digestMapInstance),
+          codegen(codegen),
+          valueType(valueType) {}
+
+    void pushExistingElem(const IR::Expression *expr) {
+        builder->emitIndent();
+        builder->appendFormat("bpf_map_push_elem(&%s, &", digestMapInstance);
+        codegen->visit(expr);
+        builder->append(", BPF_EXIST)");
+        builder->endOfStatement(true);
+    }
+
+    // handle expression like: "digest.pack(msg)"
+    bool preorder(const IR::PathExpression *pe) override {
+        pushExistingElem(pe);
+        return false;
+    }
+
+    // handle expression like: "digest.pack(metadata.msg)"
+    bool preorder(const IR::Member *member) override {
+        pushExistingElem(member);
+        return false;
+    }
+
+    // handle expression like: "digest.pack(value)"
+    bool preorder(const IR::Constant *c) override {
+        cstring tmpVar = refMap->newName("digest_entry");
+
+        builder->emitIndent();
+        builder->blockStart();
+
+        builder->emitIndent();
+        valueType->declare(builder, tmpVar, false);
+        builder->append(" = ");
+        codegen->visit(c);
+        builder->endOfStatement(true);
+
+        builder->emitIndent();
+        builder->appendFormat("bpf_map_push_elem(&%s, &%s, BPF_EXIST)", digestMapInstance, tmpVar);
+        builder->endOfStatement(true);
+
+        builder->blockEnd(true);
+        return false;
+    }
+
+    // handle expression like: "digest.pack({ value1, value2 })"
+    bool preorder(const IR::StructExpression *se) override {
+        cstring tmpVar = refMap->newName("digest_entry");
+
+        builder->emitIndent();
+        builder->blockStart();
+
+        builder->emitIndent();
+        valueType->declare(builder, tmpVar, false);
+        builder->endOfStatement(true);
+
+        for (const auto *f : se->components) {
+            unsigned width = EBPFInitializerUtils::ebpfTypeWidth(typeMap, f->expression);
+            builder->emitIndent();
+
+            if (EBPFScalarType::generatesScalar(width)) {
+                builder->appendFormat("%s.", tmpVar);
+                builder->append(f->name);
+                builder->append(" = ");
+                codegen->visit(f->expression);
+            } else {
+                builder->appendFormat("__builtin_memcpy(%s.", tmpVar);
+                builder->append(f->name);
+                builder->append(", ");
+                if (f->expression->is<IR::Constant>()) {
+                    builder->appendFormat("&(u8[%u])", width / 8);
+                }
+                codegen->visit(f->expression);
+                builder->appendFormat(", %u)", width / 8);
+            }
+            builder->endOfStatement(true);
+        }
+
+        builder->emitIndent();
+        builder->appendFormat("bpf_map_push_elem(&%s, &%s, BPF_EXIST)", digestMapInstance, tmpVar);
+        builder->endOfStatement(true);
+
+        builder->blockEnd(true);
+        return false;
+    }
+};
+
+EBPFDigestPSA::EBPFDigestPSA(const EBPFProgram *program, const IR::Declaration_Instance *di)
+    : program(program), declaration(di) {
+    instanceName = EBPFObject::externalName(di);
+
+    auto typeSpec = declaration->type->to<IR::Type_Specialized>();
+    auto messageArg = typeSpec->arguments->front();
+    auto messageType = program->typeMap->getType(messageArg);
+    valueType = EBPFTypeFactory::instance->create(messageType->to<IR::Type_Type>()->type);
+
+    // if message digest type is an array underlay, it's name (like "u8 [16]") can't be simply
+    // passed to map instance definition because there is defined as a pointer. This cause
+    // compilation error, so in this case typedef must be used.
+    if (valueType->is<EBPFScalarType>()) {
+        unsigned width = valueType->to<EBPFScalarType>()->implementationWidthInBits();
+        if (!EBPFScalarType::generatesScalar(width)) {
+            valueTypeName = instanceName + "_value";
+        }
+    }
+}
+
+void EBPFDigestPSA::emitTypes(CodeBuilder *builder) {
+    if (!valueTypeName.isNullOrEmpty()) {
+        builder->append("typedef ");
+        valueType->declare(builder, valueTypeName, false);
+        builder->endOfStatement();
+    }
+}
+
+void EBPFDigestPSA::emitInstance(CodeBuilder *builder) const {
+    builder->appendFormat("REGISTER_TABLE_NO_KEY_TYPE(%s, BPF_MAP_TYPE_QUEUE, 0, ", instanceName);
+
+    if (valueTypeName.isNullOrEmpty()) {
+        valueType->declare(builder, "", false);
+    } else {
+        builder->append(valueTypeName);
+    }
+    builder->appendFormat(", %d)", maxDigestQueueSize);
+    builder->newline();
+}
+
+void EBPFDigestPSA::processMethod(CodeBuilder *builder, cstring method,
+                                  const IR::MethodCallExpression *expr,
+                                  DeparserBodyTranslatorPSA *visitor) {
+    if (method == "pack") {
+        auto arg = expr->arguments->front();
+        EBPFDigestPSAValueVisitor dg(program->refMap, program->typeMap, instanceName, visitor,
+                                     valueType);
+        dg.setBuilder(builder);
+        arg->apply(dg);
+    } else {
+        ::error(ErrorType::ERR_UNSUPPORTED, "%1%: unsupported method call for Digest",
+                expr->method);
+    }
+}
+
+}  // namespace EBPF

--- a/backends/ebpf/psa/externs/ebpfPsaDigest.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaDigest.cpp
@@ -44,19 +44,21 @@ class EBPFDigestPSAValueVisitor : public CodeGenInspector {
         builder->endOfStatement(true);
     }
 
-    // handle expression like: "digest.pack(msg)"
+    // handle expression like: "digest.pack(msg)", where "msg" is an existing variable
     bool preorder(const IR::PathExpression *pe) override {
         pushExistingElem(pe);
         return false;
     }
 
-    // handle expression like: "digest.pack(metadata.msg)"
+    // handle expression like: "digest.pack(metadata.msg)", where "metadata.msg" is a member from an
+    // instance of struct or header
     bool preorder(const IR::Member *member) override {
         pushExistingElem(member);
         return false;
     }
 
-    // handle expression like: "digest.pack(value)"
+    // handle expression like: "digest.pack(value)", where "value" is compile time known constant
+    // value
     bool preorder(const IR::Constant *c) override {
         cstring tmpVar = refMap->newName("digest_entry");
 
@@ -77,7 +79,8 @@ class EBPFDigestPSAValueVisitor : public CodeGenInspector {
         return false;
     }
 
-    // handle expression like: "digest.pack({ value1, value2 })"
+    // handle expression like: "digest.pack({ expr1, expr2, ... })", where "exprN" is an any valid
+    // expression at this context
     bool preorder(const IR::StructExpression *se) override {
         cstring tmpVar = refMap->newName("digest_entry");
 

--- a/backends/ebpf/psa/externs/ebpfPsaDigest.h
+++ b/backends/ebpf/psa/externs/ebpfPsaDigest.h
@@ -42,6 +42,10 @@ class EBPFDigestPSA : public EBPFObject {
     void emitInstance(CodeBuilder *builder) const;
     void processMethod(CodeBuilder *builder, cstring method, const IR::MethodCallExpression *expr,
                        DeparserBodyTranslatorPSA *visitor);
+
+    void emitPushElement(CodeBuilder *builder, const IR::Expression *elem,
+                         Inspector *codegen) const;
+    void emitPushElement(CodeBuilder *builder, cstring elem) const;
 };
 
 }  // namespace EBPF

--- a/backends/ebpf/psa/externs/ebpfPsaDigest.h
+++ b/backends/ebpf/psa/externs/ebpfPsaDigest.h
@@ -1,0 +1,49 @@
+/*
+Copyright 2022-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef BACKENDS_EBPF_PSA_EXTERNS_EBPFPSADIGEST_H_
+#define BACKENDS_EBPF_PSA_EXTERNS_EBPFPSADIGEST_H_
+
+#include "backends/ebpf/ebpfObject.h"
+#include "backends/ebpf/ebpfProgram.h"
+
+namespace EBPF {
+
+class DeparserBodyTranslatorPSA;
+
+class EBPFDigestPSA : public EBPFObject {
+ private:
+    cstring instanceName;
+    const EBPFProgram *program;
+    EBPFType *valueType;
+    cstring valueTypeName;
+    const IR::Declaration_Instance *declaration;
+    // arbitrary value for max queue size
+    // TODO: make it configurable
+    int maxDigestQueueSize = 128;
+
+ public:
+    EBPFDigestPSA(const EBPFProgram *program, const IR::Declaration_Instance *di);
+
+    void emitTypes(CodeBuilder *builder);
+    void emitInstance(CodeBuilder *builder) const;
+    void processMethod(CodeBuilder *builder, cstring method, const IR::MethodCallExpression *expr,
+                       DeparserBodyTranslatorPSA *visitor);
+};
+
+}  // namespace EBPF
+
+#endif /* BACKENDS_EBPF_PSA_EXTERNS_EBPFPSADIGEST_H_ */

--- a/backends/ebpf/tests/p4testdata/wide-field-digest.p4
+++ b/backends/ebpf/tests/p4testdata/wide-field-digest.p4
@@ -1,0 +1,113 @@
+/*
+Copyright 2023-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+struct headers {
+    ethernet_t ethernet;
+    ipv6_t     ipv6;
+}
+
+struct digest_t {
+    bit<128> srcAddr;
+    bit<16>  info;
+}
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout empty_t meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_t resubmit_meta,
+                         in empty_t recirculate_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x86DD: parse_ipv6;
+            default: accept;
+        }
+    }
+
+    state parse_ipv6 {
+        buffer.extract(parsed_hdr.ipv6);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout empty_t meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    apply {
+        send_to_port(ostd, (PortId_t) PORT0);
+    }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_t clone_i2e_meta,
+                            out empty_t resubmit_meta,
+                            out empty_t normal_meta,
+                            inout headers hdr,
+                            in empty_t meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    Digest<digest_t>() d;
+    apply {
+        d.pack({ hdr.ipv6.srcAddr, 1023 });
+
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv6);
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout empty_t meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_t normal_meta,
+                        in empty_t clone_i2e_meta,
+                        in empty_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout empty_t meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply {}
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_t clone_e2e_meta,
+                           out empty_t recirculate_meta,
+                           inout headers hdr,
+                           in empty_t meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {}
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/ptf/test.py
+++ b/backends/ebpf/tests/ptf/test.py
@@ -363,6 +363,24 @@ class DigestPSATest(P4EbpfTest):
             if d["srcAddr"] != "0xfafbfcfdfef0" or int(d["ingress_port"], 0) != DP_PORTS[0]:
                 self.fail("Digest map stored wrong values: mac->{}, port->{}".format(d["srcAddr"], d["ingress_port"]))
 
+
+class WideFieldDigest(P4EbpfTest):
+
+    p4_file_path = "p4testdata/wide-field-digest.p4"
+
+    def runTest(self):
+        pkt = testutils.simple_ipv6ip_packet(ipv6_src="::2", ipv6_dst="::1", ipv6_hlim=64)
+        exp_pkt = pkt.copy()
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_packet_any_port(self, exp_pkt, PTF_PORTS)
+
+        digests = self.digest_get("IngressDeparserImpl_d")
+        if len(digests) != 1:
+            self.fail("Expected 1 digest messages, got {}".format(len(digests)))
+        for d in digests:
+            if int(d["srcAddr"], 0) != 2 or int(d["info"], 0) != 1023:
+                self.fail("Digest map stored wrong values: addr->{}, info->{}".format(d["srcAddr"], d["info"]))
+
                 
 class CountersPSATest(P4EbpfTest):
     p4_file_path = "p4testdata/counters.p4"


### PR DESCRIPTION
This PR adds support for wide fields in Digest extern.

Also small refactor has been done - Digest implementation was placed in a separate file, like any other PSA externs.

CC: @osinstom 