### PR TITLE
Refactor P4Testgen strategies - Part 1. Add a new strategy - greedy search.

### DIFF
--- a/backends/bmv2/run-bmv2-ptf-test.py
+++ b/backends/bmv2/run-bmv2-ptf-test.py
@@ -173,8 +173,9 @@ def run_test(options: Options) -> int:
     if result != testutils.SUCCESS:
         # Terminate the switch process and emit its output in case of failure.
         testutils.kill_proc_group(switch_proc)
-        switchout = switchlog.with_suffix(".txt").read_text()
-        testutils.log.error("######## Switch log ########\n%s", switchout)
+        if switchlog.with_suffix('.txt').exists():
+            switchout = switchlog.with_suffix(".txt").read_text()
+            testutils.log.error("######## Switch log ########\n%s", switchout)
         if switch_proc.stdout:
             out = switch_proc.stdout.read()
             testutils.log.error("######## Switch output ######## \n%s", out)

--- a/backends/p4tools/benchmarks/plots.py
+++ b/backends/p4tools/benchmarks/plots.py
@@ -4,7 +4,6 @@ import argparse
 from pathlib import Path
 import sys
 import re
-from glob import glob
 from operator import attrgetter
 
 import pandas as pd

--- a/backends/p4tools/benchmarks/plots.py
+++ b/backends/p4tools/benchmarks/plots.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+import sys
+import re
+from glob import glob
+from operator import attrgetter
+
+import pandas as pd
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+import tikzplotlib
+
+# Append tools to the import path.
+FILE_DIR = Path(__file__).resolve().parent
+TOOLS_PATH = FILE_DIR.joinpath("../../../tools")
+sys.path.append(str(TOOLS_PATH))
+import testutils
+
+OUTPUT_DIR = FILE_DIR.joinpath("../../../build/plots")
+
+PARSER = argparse.ArgumentParser()
+
+PARSER.add_argument("-i",
+                    "--input-dir",
+                    dest="input_dir",
+                    help="The folder containing measurement data.",
+                    required=True)
+
+PARSER.add_argument(
+    "-o",
+    "--out-dir",
+    dest="out_dir",
+    default=OUTPUT_DIR,
+    help="The output folder where all plots are dumped.",
+)
+
+
+def plot_preconditions():
+
+    # Load the example car crash dataset
+    preconditions = [
+        "None", "1500B pkt", "P4-constraints", "P4-constraints + 1500B pkt",
+        "P4-constraints + 1500B IPv4 pkt",
+        "P4-constraints + 1500B IPv4-TCP pkt"
+    ]
+    data = [237846, 178384, 135719, 101789, 50231, 12557]
+    target_frame = pd.DataFrame({
+        "Precondition": preconditions,
+        "Number of tests": data
+    })
+    _, ax = plt.subplots(figsize=(4, 1.2))
+    ax = sns.barplot(
+        x="Number of tests",
+        y="Precondition",
+        data=target_frame,
+        width=1,
+        linewidth=0.5,
+        palette=sns.color_palette("RdYlGn"),
+        # facecolor=(0,0,0,0),
+        edgecolor="0")
+    hatches = ["/", ".", "//", "o", "x", "\\", "-", "+", "*", "O"]
+    for idx, plot_bar in enumerate(ax.patches):
+        # plot_bar.set_hatch(hatches[idx])
+        ax.text(plot_bar.get_width() + 3000,
+                plot_bar.get_y() + 0.22,
+                preconditions[idx],
+                ha="left",
+                va="top")
+    ax.set(yticklabels=[], yticks=[])
+    plt.savefig("precondition_reduction.png", bbox_inches="tight")
+    plt.savefig("precondition_reduction.pdf", bbox_inches="tight")
+    plt.gcf().clear()
+
+
+def get_strategy_data(input_dir):
+    input_dir = Path(testutils.check_if_dir(input_dir))
+
+    folders = input_dir.glob("*/")
+    program_data = {}
+    for folder in folders:
+        folder = Path(folder)
+        program_name = folder.stem
+        strategy_files = folder.glob("*_coverage_over_time.csv")
+        strategy_data = {}
+        for strategy_file in strategy_files:
+            m = re.search(f"{program_name}_(.+?)_coverage_over_time",
+                          strategy_file.stem)
+            if m:
+                strategy_name = m.group(1)
+            else:
+                print("Invalid strategy data file {strategy_file}.")
+                sys.exit(1)
+            df = pd.read_csv(strategy_file)
+            df["Time"] = pd.to_timedelta(df["Time"], unit="milliseconds")
+            strategy_data[strategy_name] = df
+        program_data[program_name] = strategy_data
+    return program_data
+
+
+def plot_strategies(args, extra_args):
+    program_data = get_strategy_data(args.input_dir)
+    program_data = program_data["tna_simple_switch"]
+    pruned_data = []
+    for strategy, candidate_data in program_data.items():
+        candidate_data = candidate_data.drop("Seed", axis=1)
+        candidate_data["Strategy"] = strategy
+        candidate_data.Time = pd.to_numeric(candidate_data.Time)
+        candidate_data = candidate_data.sort_values(by=["Time"])
+        bins = np.arange(
+            0,
+            candidate_data.Time.max() + candidate_data.Time.max() / 1000,
+            candidate_data.Time.max() / 1000)
+        candidate_data["Minutes"] = pd.cut(candidate_data.Time,
+                                           bins.astype(np.int64),
+                                           include_lowest=True).map(
+                                               attrgetter('right'))
+        candidate_data.Minutes = pd.to_timedelta(candidate_data.Minutes,
+                                                 unit="nanoseconds")
+        candidate_data.Minutes = candidate_data.Minutes / pd.Timedelta(
+            minutes=1)
+        candidate_data = candidate_data[candidate_data.Minutes <= 60]
+        pruned_data.append(candidate_data)
+    concat_data = pd.concat(pruned_data)
+    ax = sns.lineplot(x="Minutes",
+                      y="Coverage",
+                      hue="Strategy",
+                      data=concat_data,
+                      errorbar="sd")
+    sns.move_legend(ax,
+                    "lower center",
+                    bbox_to_anchor=(.5, 0.98),
+                    ncol=2,
+                    title=None)
+    plt.savefig("strategy_coverage.png", bbox_inches="tight")
+    plt.savefig("strategy_coverage.pdf", bbox_inches="tight")
+    plt.gcf().clear()
+
+
+def main(args, extra_args):
+    sns.set_theme(
+        context="paper",
+        style="ticks",
+        rc={
+            "lines.linewidth": 1,
+            "hatch.linewidth": 0.3,
+            "axes.spines.right": False,
+            "axes.spines.top": False,
+            "lines.markeredgewidth": 0.1,
+            "axes.labelsize": 8,  # -> axis labels
+            "font.size": 8,  # Set font size to 8pt
+            "xtick.labelsize": 8,  # -> tick labels
+            "ytick.labelsize": 8,  # -> tick labels
+            "legend.fontsize": 8,  # -> legends
+        },
+    )
+    plot_preconditions()
+    plot_strategies(args, extra_args)
+
+
+if __name__ == "__main__":
+    # Parse options and process argv
+    arguments, argv = PARSER.parse_known_args()
+    main(arguments, argv)

--- a/backends/p4tools/benchmarks/test_coverage.py
+++ b/backends/p4tools/benchmarks/test_coverage.py
@@ -3,12 +3,17 @@
 import argparse
 import subprocess
 import random
-import csv
 import sys
 import re
+import time
+import logging
 import tempfile
 from pathlib import Path
 import datetime
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import numpy as np
 
 # Append tools to the import path.
 FILE_DIR = Path(__file__).resolve().parent
@@ -24,12 +29,14 @@ MAX_TESTS = 0
 TEST_BACKEND = "PROTOBUF"
 
 PARSER = argparse.ArgumentParser()
+
 PARSER.add_argument(
     "-p",
-    "--p4-program",
-    dest="p4_program",
-    required=True,
-    help="The P4 file to measure coverage on.",
+    "--p4-programs",
+    dest="p4_programs",
+    nargs='+',
+    help='The P4 files to measure coverage on.',
+    required=True
 )
 PARSER.add_argument(
     "-o",
@@ -77,25 +84,55 @@ PARSER.add_argument(
     type=str,
     help="Which test back end to generate tests for.",
 )
+PARSER.add_argument(
+    "-tm",
+    "--test-mode",
+    dest="test_mode",
+    default="bmv2",
+    type=str,
+    help="The target configuration.",
+)
+PARSER.add_argument(
+    "-ea",
+    "--extra-args",
+    dest="extra_args",
+    default="",
+    type=str,
+    help="Any extra args to append.",
+)
+PARSER.add_argument(
+    "-ll",
+    "--log_level",
+    dest="log_level",
+    default="WARNING",
+    choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"],
+    help="The log level to choose.",
+)
 
 
 class Options:
 
     def __init__(self):
-        self.p4testgen_bin = None # The P4Testgen binary.
-        self.p4_program = None    # P4 Program that is being measured.
-        self.out_dir = None       # The output directory.
-        self.seed = None          # Program seed.
-        self.max_tests = None     # The max tests parameter.
+        self.p4testgen_bin = None  # The P4Testgen binary.
+        self.p4_programs = None  # P4 Programs that are being measured.
+        self.out_dir = None  # The output directory.
+        self.seed = None  # Program seed.
+        self.max_tests = None  # The max tests parameter.
         self.test_backend = None  # The test back end to generate tests for.
+        self.test_mode = "bmv2"  # Generic test config.
+        self.target = "bmv2"  # The target.
+        self.arch = "v1model"  # The architecture.
+
 
 class TestArgs:
 
     def __init__(self):
-        self.seed = None       # The seed for this particular run.
-        self.extra_args = None # Extra arguments for P4Testgen execution.
-        self.test_dir = None   # The testing directory associated with this test run.
-        self.strategy = None   # The exploration strategy to execute.
+        self.seed = None  # The seed for this particular run.
+        self.extra_args = None  # Extra arguments for P4Testgen execution.
+        # The testing directory associated with this test run.
+        self.test_dir = None
+        self.p4_program = None  # The P4 program to run tests on.
+        self.strategy = None  # The exploration strategy to execute.
 
 
 def get_test_files(input_dir, extension):
@@ -108,75 +145,135 @@ def get_test_files(input_dir, extension):
     return test_files
 
 
-def parse_stmt_cov(test_file):
-    with test_file.open("r") as file_handle:
-        for line in file_handle.readlines():
-            if "Current statement coverage:" in line:
-                covstr = line.replace('metadata: "Current statement coverage: ', "")
-                covstr = covstr.replace('"\n', "")
-                return covstr
-    return None
+def parse_coverage_and_timestamps(test_files, parse_type):
+    datestrs = []
+    cov_percentages = []
+    for test_file in test_files:
+        with test_file.open("r") as file_handle:
+            for line in file_handle.readlines():
+                if "Date generated" in line:
+                    if parse_type == "PROTOBUF":
+                        datestr = line.replace(
+                            'metadata: "Date generated: ', "")
+                        datestr = datestr.replace('"\n', "")
+                    else:
+                        datestr = line.replace("# Date generated: ", "")
+                        datestr = datestr.replace("\n", "")
+                    datestr = datestr.strip()
+                    datestrs.append(datestr)
+                if "Current statement coverage:" in line:
+                    if parse_type == "PROTOBUF":
+                        covstr = line.replace(
+                            'metadata: "Current statement coverage: ', "")
+                        covstr = covstr.replace('"\n', "")
+                    else:
+                        covstr = line.replace(
+                            "# Current statement coverage: ", "")
+                    covstr = covstr.replace("\n", "")
+                    cov_percentages.append(float(covstr))
+    return cov_percentages, datestrs
 
 
-def parse_timestamp(test_file):
-    with test_file.open("r") as file_handle:
-        for line in file_handle.readlines():
-            if "Date generated" in line:
-                datestr = line.replace('metadata: "Date generated: ', "")
-                datestr = datestr.replace('"\n', "")
-                datestr = datestr.strip()
-                return datestr
-    return None
+def collect_data_from_folder(input_dir, parse_type):
+    if parse_type == "PTF":
+        files = get_test_files(input_dir, "*.py")
+    elif parse_type == "PROTOBUF":
+        files = get_test_files(input_dir, "*.proto")
+    else:
+        files = get_test_files(input_dir, "*.stf")
+    return parse_coverage_and_timestamps(files, parse_type)
 
 
-def run_strategies_for_max_tests(data_row, options, test_args):
+def convert_timestamps_to_timedelta(timestamps):
+    time_df = pd.to_datetime(pd.Series(timestamps), unit="ns")
+    time_df = time_df - time_df.iat[0]
+    time_df = pd.to_timedelta(time_df, unit="nanoseconds")
+    return time_df
 
-    cmd = (f"{options.p4testgen_bin} --target bmv2 --arch v1model --std p4-16"
-           f" -I/p4/p4c/build/p4include --test-backend {options.test_backend} --seed {test_args.seed} "
-           f"--max-tests {options.max_tests}  --out-dir {test_args.test_dir}"
-           f" --exploration-strategy {test_args.strategy} --stop-metric MAX_STATEMENT_COVERAGE "
-           f" {test_args.extra_args} {options.p4_program}")
+
+def run_strategies_for_max_tests(options, test_args):
+
+    cmd = [str(options.p4testgen_bin)]
+    sub_cmd = (
+        f"--target {options.target} --arch {options.arch} --std p4-16"
+        f" -I/p4/p4c/build/p4include --test-backend {options.test_backend}"
+        f" --seed {test_args.seed} --print-performance-report"
+        f" --max-tests {options.max_tests} --out-dir {test_args.test_dir}"
+        f" --exploration-strategy {test_args.strategy} --stop-metric MAX_STATEMENT_COVERAGE"
+        f"{test_args.extra_args} {test_args.p4_program}"
+    ).split(" ")
+    cmd.extend(sub_cmd)
     start_timestamp = datetime.datetime.now()
-    try:
-        # TODO: Use result
-        _ = subprocess.run(
-            cmd,
-            shell=True,
-            universal_newlines=True,
-            capture_output=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        returncode = e.returncode
-        print(f"Error executing {e.cmd} {returncode}:\n{e.stdout}\n{e.stderr}")
-        sys.exit(1)
+
+    # TODO: Use result
+    testutils.exec_process(cmd, "Error executing", 3600)
     end_timestamp = datetime.datetime.now()
 
-    test_files = get_test_files(test_args.test_dir, "*.proto")
-    # Get the statement coverage of the last test generated.
-    last_test = test_files[-1]
-    statements_cov = parse_stmt_cov(last_test)
-
+    statements_cov, timestamps = collect_data_from_folder(
+        test_args.test_dir, options.test_backend)
+    if not statements_cov:
+        print("No errors found!")
+        return [], [], []
+    num_tests = len(timestamps)
+    final_cov = str(statements_cov[-1])
     time_needed = (end_timestamp - start_timestamp).total_seconds()
-    num_tests = len(test_files)
-    data_row.append(statements_cov)
-    data_row.append(str(num_tests))
-    data_row.append(time_needed)
     print(
-        f"Pct Statements Covered: {statements_cov} Number of tests: {num_tests} Time needed: {time_needed}"
+        f"Pct Statements Covered: {final_cov} Number of tests: {num_tests} Time needed: {time_needed}"
     )
-    return data_row
+
+    perf_file = test_args.test_dir.joinpath(
+        test_args.p4_program.stem + "_perf").with_suffix(".csv")
+    perf = pd.read_csv(perf_file, index_col=0)
+    summarized_data = [float(final_cov) * 100, num_tests, time_needed, perf["Percentage"]
+                       ["z3"], perf["Percentage"]["step"], perf["Percentage"]["backend"]]
+    return summarized_data, statements_cov, timestamps
 
 
-def main(args):
+def plot_coverage(out_dir, coverage_pairs):
+    df = pd.DataFrame()
+
+    for (label, coverage) in coverage_pairs.items():
+        df_series = pd.Series(coverage, name="Coverage")
+        df_series = df_series.to_frame()
+        df[label] = df_series
+    axes = sns.lineplot(data=df, ci=None, legend=False)
+    axes.set(xlabel="Generated tests", ylabel="Percentage covered")
+    fig = axes.get_figure()
+    fig.autofmt_xdate()
+    plt_name = out_dir.joinpath("plot")
+    plt_name = Path(str(plt_name) + "_coverage")
+    plt.savefig(plt_name.with_suffix(".pdf"), bbox_inches="tight")
+    plt.savefig(plt_name.with_suffix(".png"), bbox_inches="tight")
+    plt.gcf().clear()
+
+
+def main(args, extra_args):
 
     options = Options()
-    options.p4_program = Path(testutils.check_if_file(args.p4_program))
+    options.p4_programs = args.p4_programs
     options.max_tests = args.max_tests
     options.out_dir = Path(args.out_dir).absolute()
     options.seed = args.seed
     options.p4testgen_bin = Path(testutils.check_if_file(args.p4testgen_bin))
     options.test_backend = args.test_backend.upper()
+    options.extra_args = extra_args
+    options.test_mode = args.test_mode.upper()
+
+    # Configure logging.
+    logging.basicConfig(
+        filename=options.out_dir.joinpath("coverage.log"),
+        format="%(levelname)s:%(message)s",
+        level=getattr(logging, args.log_level),
+        filemode="w",
+    )
+    stderr_log = logging.StreamHandler()
+    stderr_log.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+    logging.getLogger().addHandler(stderr_log)
+
+    if options.test_mode == "TOFINO":
+        options.target = "tofino"
+        options.arch = "tna"
+        options.test_backend = "PTF"
 
     # 7189 is an example of a good seed, which gets cov 1 with less than 100 tests
     # in random access stack.
@@ -186,44 +283,86 @@ def main(args):
         seed = random.randint(0, sys.maxsize)
         seeds.append(seed)
     print(f"Chosen seeds: {seeds}")
-    p4_program_name = options.p4_program.stem
 
-    header = [
-        "seed",
-        "coverage",
-        "num_tests",
-        "time (s)",
-    ]
-
-    strategies = ["RANDOM_ACCESS_STACK", "RANDOM_ACCESS_MAX_COVERAGE", "INCREMENTAL_STACK"]
+    strategies = ["GREEDY_POTENTIAL", "UNBOUNDED_RANDOM_ACCESS",
+                  "RANDOM_ACCESS_MAX_COVERAGE", "INCREMENTAL_STACK"]
     config = {
         "INCREMENTAL_STACK": "",
-        "RANDOM_ACCESS_STACK": "--pop-level 3",
-        "RANDOM_ACCESS_MAX_COVERAGE": "--saddle-point 5",
+        "RANDOM_ACCESS_STACK": " --pop-level 3",
+        "UNBOUNDED_RANDOM_ACCESS_STACK": " --pop-level 3",
+        "RANDOM_ACCESS_MAX_COVERAGE": " --saddle-point 5",
+        "GREEDY_POTENTIAL": "",
     }
+    p4_program = options.p4_programs[0]
+    p4_program = Path(testutils.check_if_file(p4_program))
+    p4_program_name = p4_program.stem
     # csv results file path
     for strategy in strategies:
-        test_dir = options.out_dir.joinpath(f"{strategy}")
+        test_dir = options.out_dir.joinpath(f"{strategy.lower()}")
         testutils.check_and_create_dir(test_dir)
-        results_path_max = test_dir.joinpath(f"coverage_results_{p4_program_name}_{strategy}.csv")
-        with open(results_path_max, "w", encoding="utf-8") as f:
-            writer = csv.writer(f)
-            writer.writerow(header)
-            for seed in seeds:
-                data_row = [seed]
-                print(
-                    f"Seed {seed} Generating metrics for {strategy} up to {options.max_tests} tests"
-                )
-                test_args = TestArgs()
-                test_args.seed = seed
-                test_args.test_dir = Path(tempfile.mkdtemp(dir=test_dir))
-                test_args.strategy = strategy
-                test_args.extra_args = config[strategy]
-                data_row = run_strategies_for_max_tests(data_row, options, test_args)
-                writer.writerow(data_row)
+        summary_frame = pd.DataFrame(columns=["Program", "Seed",
+                                              "Coverage",
+                                              "Generated tests",
+                                              "Total time (s)",
+                                              "% Z3",
+                                              "% stepper",
+                                              "% test generation",
+                                              ])
+        coverage_pairs = {}
+        timeseries_data = {}
+        timeseries_frame = pd.DataFrame(columns=["Seed", "Time",
+                                                 "Coverage"])
+        for seed in seeds:
+            data_row = [p4_program_name, seed]
+            print(
+                f"Seed {seed} Generating metrics for {strategy} up to {options.max_tests} tests"
+            )
+            test_args = TestArgs()
+            test_args.seed = seed
+            test_args.test_dir = Path(tempfile.mkdtemp(dir=test_dir))
+            test_args.p4_program = p4_program
+            test_args.strategy = strategy
+            test_args.extra_args = config[strategy]
+            if options.extra_args:
+                test_args.extra_args += " " + " ".join(options.extra_args[1:])
+            summarized_data, statements_cov, timestamps = run_strategies_for_max_tests(
+                options, test_args)
+            data_row.extend(summarized_data)
+            summary_frame.loc[len(summary_frame)] = data_row
+            coverage_pairs[str(seed)] = statements_cov
+            sub_frame = pd.DataFrame()
+            sub_frame["Seed"] = [seed] * len(statements_cov)
+            sub_frame["Coverage"] = statements_cov
+            sub_frame["Time"] = convert_timestamps_to_timedelta(timestamps)
+            sub_frame["Time"] = sub_frame["Time"] / \
+                pd.Timedelta(milliseconds=1)
+
+            timeseries_frame = pd.concat([timeseries_frame, sub_frame])
+        # timeseries_frame.set_index(["Seed"], inplace=True)
+        summary_frame.set_index(["Program", "Seed"], inplace=True)
+        timeseries_frame.set_index(["Seed"], inplace=True)
+        sns.lineplot(x="Time", y="Coverage", data=timeseries_frame)
+        summary_frame["Time per test (s)"] = summary_frame["Total time (s)"] / \
+            summary_frame["Generated tests"]
+        summary_frame.loc["Mean"] = summary_frame.mean(
+            numeric_only=True, axis=0, skipna=True)
+        summary_frame.loc["Median"] = summary_frame.median(
+            numeric_only=True, axis=0, skipna=True)
+        summary_frame.loc["Min"] = summary_frame.min(
+            numeric_only=True, axis=0, skipna=True)
+        summary_frame.loc["Max"] = summary_frame.max(
+            numeric_only=True, axis=0, skipna=True)
+
+        summary_results_path = options.out_dir.joinpath(
+            f"{p4_program_name}_{strategy.lower()}_summary_results.csv")
+        summary_frame.to_csv(summary_results_path)
+        timeseries_results_path = options.out_dir.joinpath(
+            f"{p4_program_name}_{strategy.lower()}_coverage_over_time.csv")
+        timeseries_frame.to_csv(timeseries_results_path)
 
 
 if __name__ == "__main__":
     # Parse options and process argv
     arguments, argv = PARSER.parse_known_args()
-    main(arguments)
+
+    main(arguments, argv)

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -31,6 +31,7 @@ set(
   core/exploration_strategy/exploration_strategy.cpp
   core/target.cpp
 
+  lib/collect_latent_statements.cpp
   lib/concolic.cpp
   lib/continuation.cpp
   lib/execution_state.cpp

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -24,6 +24,7 @@ set(
   core/exploration_strategy/selected_branches.cpp
   core/exploration_strategy/random_access_stack.cpp
   core/exploration_strategy/linear_enumeration.cpp
+  core/exploration_strategy/greedy_potential.cpp
   core/exploration_strategy/rnd_access_max_coverage.cpp
   core/exploration_strategy/inc_max_coverage_stack.cpp
   core/exploration_strategy/unbounded_rnd_ac_stack.cpp

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
@@ -28,9 +28,7 @@
 #include "backends/p4tools/modules/testgen/lib/final_state.h"
 #include "backends/p4tools/modules/testgen/lib/logging.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 ExplorationStrategy::StepResult ExplorationStrategy::step(ExecutionState &state) {
     Util::ScopedTimer st("step");
@@ -112,6 +110,4 @@ void ExplorationStrategy::printCurrentTraceAndBranches(std::ostream &out) {
     out << strBranches << ")";
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.cpp
@@ -33,14 +33,6 @@ namespace P4Tools::P4Testgen {
 ExplorationStrategy::StepResult ExplorationStrategy::step(ExecutionState &state) {
     Util::ScopedTimer st("step");
     StepResult successors = evaluator.step(state);
-    // Assign branch ids to the branches. These integer branch ids are used by track-branches
-    // and selected (input) branches features.
-    if (successors->size() > 1) {
-        for (uint64_t bIdx = 0; bIdx < successors->size(); ++bIdx) {
-            auto &succ = (*successors)[bIdx];
-            succ.nextState->pushBranchDecision(bIdx + 1);
-        }
-    }
     return successors;
 }
 

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h
@@ -16,9 +16,7 @@
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 #include "backends/p4tools/modules/testgen/lib/final_state.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// Base abstract class for exploration strategy. It requires the implementation of
 /// the run method, and carries the base Branch struct, to be reused in inherited
@@ -68,7 +66,7 @@ class ExplorationStrategy {
     AbstractSolver &solver;
 
     /// @returns a pseudorandom integer in the range of [0, branches.size() - 1]
-    uint64_t selectBranch(const std::vector<Branch> &branches);
+    static uint64_t selectBranch(const std::vector<Branch> &branches);
 
     /// Handles processing at the end of a P4 program.
     ///
@@ -92,8 +90,6 @@ class ExplorationStrategy {
     SmallStepEvaluator evaluator;
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_EXPLORATION_STRATEGY_EXPLORATION_STRATEGY_H_ */

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h
@@ -54,8 +54,11 @@ class ExplorationStrategy {
     /// Writes a list of the selected branches into @param out.
     void printCurrentTraceAndBranches(std::ostream &out);
 
-    /// Getter to access visitedStatements
+    /// Getter to access visitedStatements.
     const P4::Coverage::CoverageSet &getVisitedStatements();
+
+    /// Update the set of visited statements.
+    void updateVisitedStatements(const P4::Coverage::CoverageSet &newStatements);
 
  protected:
     /// Target-specific information about the P4 program.

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h
@@ -39,6 +39,7 @@ class ExplorationStrategy {
     using Callback = std::function<bool(const FinalState &)>;
 
     using Branch = SmallStepEvaluator::Branch;
+
     using StepResult = SmallStepEvaluator::Result;
 
     /// Executes the P4 program along a randomly chosen path. When the program terminates, the
@@ -80,7 +81,7 @@ class ExplorationStrategy {
     /// The current execution state.
     ExecutionState *executionState = nullptr;
 
-    /// Set of all stetements, to be retrieved from programInfo.
+    /// Set of all statements, to be retrieved from programInfo.
     const P4::Coverage::CoverageSet &allStatements;
 
     /// Set of all statements executed in any testcase that has been outputted.

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.cpp
@@ -1,0 +1,191 @@
+#include "backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h"
+
+#include <vector>
+
+#include <boost/none.hpp>
+
+#include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/util.h"
+#include "gsl/gsl-lite.hpp"
+#include "ir/ir.h"
+#include "lib/error.h"
+#include "lib/timer.h"
+
+#include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
+#include "backends/p4tools/modules/testgen/core/program_info.h"
+#include "backends/p4tools/modules/testgen/core/small_step/small_step.h"
+#include "backends/p4tools/modules/testgen/lib/exceptions.h"
+#include "backends/p4tools/modules/testgen/lib/execution_state.h"
+#include "backends/p4tools/modules/testgen/options.h"
+
+namespace P4Tools::P4Testgen {
+
+void GreedyPotential::run(const Callback &callback) {
+    while (true) {
+        try {
+            if (executionState->isTerminal()) {
+                // We've reached the end of the program. Call back and (if desired) end execution.
+                bool terminate = handleTerminalState(callback, *executionState);
+                if (terminate) {
+                    return;
+                }
+            } else {
+                // Take a step in the program, choose a random branch, and continue execution. If
+                // branch selection fails, fall through to the roll-back code below. To help reduce
+                // calls into the solver, only guarantee viability of the selected branch if more
+                // than one branch was produced.
+                // State successors are accompanied by branch constraint which should be evaluated
+                // in the state before the step was taken - we copy the current symbolic state.
+                StepResult successors = step(*executionState);
+                ExecutionState *next = nullptr;
+                if (successors->size() > 1) {
+                    unexploredBranches.push(successors);
+                    next = chooseBranch(true, false);
+                } else if (successors->size() == 1) {
+                    next = successors->at(0).nextState;
+                }
+                if (next != nullptr) {
+                    executionState = next;
+                    continue;
+                }
+            }
+        } catch (TestgenUnimplemented &e) {
+            // If strict is enabled, bubble the exception up.
+            if (TestgenOptions::get().strict) {
+                throw;
+            }
+            // Otherwise we try to roll back as we typically do.
+            ::warning("Path encountered unimplemented feature. Message: %1%\n", e.what());
+        }
+
+        // Roll back to a previous branch and continue execution from there, but if there are no
+        // more branches to explore, finish execution. Not all branches are viable, so we loop
+        // until either we run out of unexplored branches or we find a viable branch.
+        while (true) {
+            if (unexploredBranches.empty()) {
+                return;
+            }
+            Util::ScopedTimer chooseBranchtimer("branch_selection");
+            ExecutionState *next = chooseBranch(true, true);
+            if (next != nullptr) {
+                executionState = next;
+                break;
+            }
+        }
+    }
+}
+
+GreedyPotential::GreedyPotential(AbstractSolver &solver, const ProgramInfo &programInfo)
+    : ExplorationStrategy(solver, programInfo) {}
+
+ExecutionState *GreedyPotential::chooseBranch(bool guaranteeViability, bool search) {
+    while (true) {
+        if (unexploredBranches.empty()) {
+            return nullptr;
+        }
+        auto branch = unexploredBranches.pop(&threshold, getVisitedStatements(), search);
+
+        // Do not bother invoking the solver for a trivial case.
+        // In either case (true or false), we do not need to add the assertion and check.
+        if (const auto *boolLiteral = branch.constraint->to<IR::BoolLiteral>()) {
+            guaranteeViability = false;
+            if (!boolLiteral->value) {
+                continue;
+            }
+        }
+
+        if (guaranteeViability) {
+            // Check the consistency of the path constraints asserted so far.
+            auto solverResult = solver.checkSat(branch.nextState->getPathConstraint());
+            if (solverResult == boost::none) {
+                ::warning("Solver timed out");
+            }
+            if (solverResult == boost::none || !solverResult.get()) {
+                // Solver timed out or path constraints were not satisfiable. Need to choose a
+                // different branch. Roll back our branch selection and try again.
+                continue;
+            }
+        }
+
+        // Branch selection succeeded.
+        return branch.nextState;
+    }
+}
+
+bool GreedyPotential::UnexploredBranches::empty() const { return unexploredBranches.empty(); }
+
+void GreedyPotential::UnexploredBranches::push(GreedyPotential::StepResult branches) {
+    unexploredBranches.emplace_back(branches);
+}
+
+int findBranch(std::vector<ExplorationStrategy::StepResult> &unexploredBranches,
+               uint64_t *threshold, const P4::Coverage::CoverageSet &coveredStatements,
+               bool search) {
+    if (search) {
+        if (*threshold % 50 == 0) {
+            for (size_t jdx = 0; jdx < unexploredBranches.size(); ++jdx) {
+                auto *branches = unexploredBranches.at(jdx);
+                for (size_t idx = 0; idx < branches->size(); ++idx) {
+                    auto branch = branches->at(idx);
+                    for (const auto &stmt : branch.potentialStatements) {
+                        // We need to take into account the set of visitedStatements.
+                        // We also need to ensure the statement is in coveredStatements.
+                        if (stmt->getSourceInfo().isValid() &&
+                            coveredStatements.count(stmt) == 0U) {
+                            *threshold = 0;
+                            if (jdx != unexploredBranches.size() - 1) {
+                                std::swap(unexploredBranches[jdx], unexploredBranches.back());
+                            }
+                            return idx;
+                        }
+                    }
+                }
+            }
+        }
+        auto idx = Utils::getRandInt(unexploredBranches.size() - 1);
+        if (unexploredBranches.size() > 1) {
+            std::swap(unexploredBranches[idx], unexploredBranches.back());
+        }
+        (*threshold)++;
+    } else {
+        auto *branches = unexploredBranches.back();
+        for (size_t idx = 0; idx < branches->size(); ++idx) {
+            auto branch = branches->at(idx);
+            for (const auto &stmt : branch.potentialStatements) {
+                // We need to take into account the set of visitedStatements.
+                // We also need to ensure the statement is in coveredStatements.
+                if (stmt->getSourceInfo().isValid() && coveredStatements.count(stmt) == 0U) {
+                    *threshold = 0;
+                    return idx;
+                }
+            }
+        }
+    }
+
+    return Utils::getRandInt(unexploredBranches.back()->size() - 1);
+}
+
+ExplorationStrategy::Branch GreedyPotential::UnexploredBranches::pop(
+    uint64_t *threshold, const P4::Coverage::CoverageSet &allStatements, bool search) {
+    std::vector<Branch> *candidateBranches = nullptr;
+
+    int branchIdx = 0;
+    branchIdx = findBranch(unexploredBranches, threshold, allStatements, search);
+    candidateBranches = unexploredBranches.back();
+    auto branch = candidateBranches->at(branchIdx);
+    // Note: This could be improved, because we should remove only succeeded selection.
+    // Unsatisfiable branches could be covered in other tests after backtracking.
+    candidateBranches->erase(candidateBranches->begin() + branchIdx);
+
+    if (candidateBranches->empty()) {
+        unexploredBranches.pop_back();
+    }
+    return branch;
+}
+
+size_t GreedyPotential::UnexploredBranches::size() { return unexploredBranches.size(); }
+
+GreedyPotential::UnexploredBranches::UnexploredBranches() = default;
+
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h
@@ -33,7 +33,6 @@ class GreedyPotential : public ExplorationStrategy {
     GreedyPotential(AbstractSolver &solver, const ProgramInfo &programInfo);
 
  protected:
-    uint64_t threshold = 0;
     /// This variable keeps track of how many branch decisions we have made without producing a
     /// test. This is a safety guard in case the strategy gets stuck in parser loops because of its
     /// greediness.
@@ -45,13 +44,16 @@ class GreedyPotential : public ExplorationStrategy {
      public:
         [[nodiscard]] bool empty() const;
         void push(StepResult branches);
-        Branch pop(uint64_t *threshold, const P4::Coverage::CoverageSet &coveredStatements,
-                   bool search, bool fallBackToRandom);
+        Branch pop(const P4::Coverage::CoverageSet &coveredStatements, bool search,
+                   bool fallBackToRandom);
         size_t size();
 
         UnexploredBranches();
 
      private:
+        /// The threshold increments every time we are in search modes, but can not find an
+        /// execution state with uncovered statements.
+        uint64_t threshold = 0;
         /// Each element on this stack represents a set of alternative choices that could have been
         /// made along the current execution path.
         ///
@@ -59,6 +61,8 @@ class GreedyPotential : public ExplorationStrategy {
         ///   - Each element of this stack is non-empty.
         ///   - Each time we push or pop this stack, we also push or pop on the SMT solver.
         std::vector<StepResult> unexploredBranches;
+
+        int findBranch(const P4::Coverage::CoverageSet &coveredStatements, bool search);
     };
 
     /// A stack, wherein each element represents a set of alternative choices that could have been

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h
@@ -34,6 +34,10 @@ class GreedyPotential : public ExplorationStrategy {
 
  protected:
     uint64_t threshold = 0;
+    /// This variable keeps track of how many branch decisions we have made without producing a
+    /// test. This is a safety guard in case the strategy gets stuck in parser loops because of its
+    /// greediness.
+    uint64_t stepsWithoutTest = 0;
     /// Encapsulates a stack of unexplored branches. This exists to help enforce the invariant that
     /// any push or pop operation on this stack should be paired with a corresponding push/pop
     /// operation on the solver.
@@ -42,7 +46,7 @@ class GreedyPotential : public ExplorationStrategy {
         [[nodiscard]] bool empty() const;
         void push(StepResult branches);
         Branch pop(uint64_t *threshold, const P4::Coverage::CoverageSet &coveredStatements,
-                   bool search);
+                   bool search, bool fallBackToRandom);
         size_t size();
 
         UnexploredBranches();
@@ -77,7 +81,8 @@ class GreedyPotential : public ExplorationStrategy {
     /// stack of unexplored branches and the solver's state will be unchanged.
     ///
     /// @returns next execution state to be examined on success, nullptr on failure.
-    ExecutionState *chooseBranch(bool guaranteeViability, bool search);
+    ExecutionState *chooseBranch(bool guaranteeViability, bool search,
+                                 bool fallBackToRandom = false);
 };
 
 }  // namespace P4Testgen

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h
@@ -46,43 +46,12 @@ class GreedyPotential : public ExplorationStrategy {
     /// The maximum number of steps without generating a test before falling back to random.
     static const uint64_t MAX_STEPS_WITHOUT_TEST = 1000;
 
-    /// Encapsulates a stack of unexplored branches. This exists to help enforce the invariant that
-    /// any push or pop operation on this stack should be paired with a corresponding push/pop
-    /// operation on the solver.
-    class UnexploredBranches {
-     public:
-        [[nodiscard]] bool empty() const;
-        void push(StepResult branches);
-        Branch pop();
-        size_t size();
-
-        /// Iterate over all unexplored branches and pick the first branch which may cover new
-        /// statements.
-        /// If no such branch is found, pick a branch at random.
-        ExplorationStrategy::Branch backtrackAndPop(
-            const P4::Coverage::CoverageSet &coveredStatements);
-
-        UnexploredBranches();
-
-     private:
-        /// The threshold increments every time we are in search modes, but can not find an
-        /// execution state with uncovered statements.
-        uint64_t threshold = 0;
-        /// Each element on this stack represents a set of alternative choices that could have been
-        /// made along the current execution path.
-        ///
-        /// Invariants:
-        ///   - Each element of this stack is non-empty.
-        ///   - Each time we push or pop this stack, we also push or pop on the SMT solver.
-        std::vector<Branch> unexploredBranches;
-
-        /// Pick the next branch from the back of the unexplored branches.
-        /// Prioritize branches that cover new statements.
-    };
-
-    /// A stack, wherein each element represents a set of alternative choices that could have been
+    /// Each element on this stack represents a set of alternative choices that could have been
     /// made along the current execution path.
-    UnexploredBranches unexploredBranches;
+    ///
+    /// Invariants:
+    ///   - Each element of this stack is non-empty.
+    std::vector<Branch> unexploredBranches;
 };
 
 }  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h
@@ -53,8 +53,14 @@ class GreedyPotential : public ExplorationStrategy {
      public:
         [[nodiscard]] bool empty() const;
         void push(StepResult branches);
-        Branch pop(const P4::Coverage::CoverageSet &coveredStatements, bool doBacktrack);
+        Branch pop();
         size_t size();
+
+        /// Iterate over all unexplored branches and pick the first branch which may cover new
+        /// statements.
+        /// If no such branch is found, pick a branch at random.
+        ExplorationStrategy::Branch backtrackAndPop(
+            const P4::Coverage::CoverageSet &coveredStatements);
 
         UnexploredBranches();
 
@@ -68,35 +74,15 @@ class GreedyPotential : public ExplorationStrategy {
         /// Invariants:
         ///   - Each element of this stack is non-empty.
         ///   - Each time we push or pop this stack, we also push or pop on the SMT solver.
-        std::vector<StepResult> unexploredBranches;
+        std::vector<Branch> unexploredBranches;
 
-        size_t pickBranch(const P4::Coverage::CoverageSet &coveredStatements);
-
-        size_t backtrack(const P4::Coverage::CoverageSet &coveredStatements);
+        /// Pick the next branch from the back of the unexplored branches.
+        /// Prioritize branches that cover new statements.
     };
 
     /// A stack, wherein each element represents a set of alternative choices that could have been
     /// made along the current execution path.
     UnexploredBranches unexploredBranches;
-
-    /// Chooses a branch to take, sets the current execution state to be that branch, and asserts
-    /// the corresponding path constraint to the solver.
-    ///
-    /// If @arg guaranteeViability is true, then the cumulative path condition is guaranteed to be
-    /// satisfiable after taking into account the path constraint associated with the chosen
-    /// branch. Any unviable branches encountered during branch selection are discarded.
-    ///
-    /// Branch selection fails if the given set of branches is empty. It also fails if @arg
-    /// guaranteeViability is true, but none of the given branches are viable.
-    ///
-    /// On success, the remaining branches to explore are pushed onto the stack of unexplored
-    /// branches, and the solver's state before the branch selection is saved with a `push`
-    /// operation. This happens even if the set of remaining branches is empty. On failure, the
-    /// stack of unexplored branches and the solver's state will be unchanged.
-    ///
-    /// @returns next execution state to be examined on success, nullptr on failure.
-    ExecutionState *chooseBranch(bool guaranteeViability, bool doBacktrack,
-                                 bool fallBackToRandom = false);
 };
 
 }  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h
@@ -1,0 +1,87 @@
+#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_EXPLORATION_STRATEGY_GREEDY_POTENTIAL_H_
+#define BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_EXPLORATION_STRATEGY_GREEDY_POTENTIAL_H_
+
+#include <cstdint>
+#include <ctime>
+#include <stack>
+#include <vector>
+
+#include <boost/optional/optional.hpp>
+
+#include "backends/p4tools/common/core/solver.h"
+
+#include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
+#include "backends/p4tools/modules/testgen/core/program_info.h"
+#include "backends/p4tools/modules/testgen/lib/execution_state.h"
+
+namespace P4Tools {
+
+namespace P4Testgen {
+
+/// Simple incremental stack strategy. It explores paths and stores them in a stack
+/// encapsulated in UnexploredBranches inner class. This strategy aims to match
+/// the solver incremental feature, which also uses a stack. We push and pop single
+/// elements accordingly.
+class GreedyPotential : public ExplorationStrategy {
+ public:
+    /// Executes the P4 program along a randomly chosen path. When the program terminates, the
+    /// given callback is invoked. If the callback returns true, then the executor terminates.
+    /// Otherwise, execution of the P4 program continues on a different random path.
+    void run(const Callback &callBack) override;
+
+    /// Constructor for this strategy, considering inheritance
+    GreedyPotential(AbstractSolver &solver, const ProgramInfo &programInfo);
+
+ protected:
+    uint64_t threshold = 0;
+    /// Encapsulates a stack of unexplored branches. This exists to help enforce the invariant that
+    /// any push or pop operation on this stack should be paired with a corresponding push/pop
+    /// operation on the solver.
+    class UnexploredBranches {
+     public:
+        [[nodiscard]] bool empty() const;
+        void push(StepResult branches);
+        Branch pop(uint64_t *threshold, const P4::Coverage::CoverageSet &coveredStatements,
+                   bool search);
+        size_t size();
+
+        UnexploredBranches();
+
+     private:
+        /// Each element on this stack represents a set of alternative choices that could have been
+        /// made along the current execution path.
+        ///
+        /// Invariants:
+        ///   - Each element of this stack is non-empty.
+        ///   - Each time we push or pop this stack, we also push or pop on the SMT solver.
+        std::vector<StepResult> unexploredBranches;
+    };
+
+    /// A stack, wherein each element represents a set of alternative choices that could have been
+    /// made along the current execution path.
+    UnexploredBranches unexploredBranches;
+
+    /// Chooses a branch to take, sets the current execution state to be that branch, and asserts
+    /// the corresponding path constraint to the solver.
+    ///
+    /// If @arg guaranteeViability is true, then the cumulative path condition is guaranteed to be
+    /// satisfiable after taking into account the path constraint associated with the chosen
+    /// branch. Any unviable branches encountered during branch selection are discarded.
+    ///
+    /// Branch selection fails if the given set of branches is empty. It also fails if @arg
+    /// guaranteeViability is true, but none of the given branches are viable.
+    ///
+    /// On success, the remaining branches to explore are pushed onto the stack of unexplored
+    /// branches, and the solver's state before the branch selection is saved with a `push`
+    /// operation. This happens even if the set of remaining branches is empty. On failure, the
+    /// stack of unexplored branches and the solver's state will be unchanged.
+    ///
+    /// @returns next execution state to be examined on success, nullptr on failure.
+    ExecutionState *chooseBranch(bool guaranteeViability, bool search);
+};
+
+}  // namespace P4Testgen
+
+}  // namespace P4Tools
+
+#endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_EXPLORATION_STRATEGY_GREEDY_POTENTIAL_H_ */

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/incremental_stack.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/incremental_stack.cpp
@@ -98,7 +98,6 @@ ExecutionState *IncrementalStack::chooseBranch(std::vector<Branch> &branches,
         if (const auto *boolLiteral = branch.constraint->to<IR::BoolLiteral>()) {
             guaranteeViability = false;
             if (!boolLiteral->value) {
-                unexploredBranches.pop();
                 continue;
             }
         }
@@ -112,7 +111,6 @@ ExecutionState *IncrementalStack::chooseBranch(std::vector<Branch> &branches,
             if (solverResult == boost::none || !solverResult.get()) {
                 // Solver timed out or path constraints were not satisfiable. Need to choose a
                 // different branch. Roll back our branch selection and try again.
-                unexploredBranches.pop();
                 continue;
             }
         }

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/path_selection.h
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/path_selection.h
@@ -1,0 +1,26 @@
+#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_EXPLORATION_STRATEGY_PATH_SELECTION_H_
+#define BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_EXPLORATION_STRATEGY_PATH_SELECTION_H_
+
+#include <set>
+
+namespace P4Tools::P4Testgen {
+
+enum class PathSelectionPolicy {
+    IncrementalStack,
+    RandomAccessStack,
+    GreedyPotential,
+    LinearEnumeration,
+    MaxCoverage,
+    RandomAccessMaxCoverage,
+    UnboundedRandomAccessStack
+};
+
+inline bool requiresLookahead(PathSelectionPolicy &pathSelectionPolicy) {
+    static const std::set LOOKAHEAD_STRATEGYIES = {PathSelectionPolicy::GreedyPotential,
+                                                   PathSelectionPolicy::RandomAccessMaxCoverage};
+    return LOOKAHEAD_STRATEGYIES.find(pathSelectionPolicy) != LOOKAHEAD_STRATEGYIES.end();
+}
+
+}  // namespace P4Tools::P4Testgen
+
+#endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_EXPLORATION_STRATEGY_PATH_SELECTION_H_ */

--- a/backends/p4tools/modules/testgen/core/exploration_strategy/rnd_access_max_coverage.cpp
+++ b/backends/p4tools/modules/testgen/core/exploration_strategy/rnd_access_max_coverage.cpp
@@ -172,24 +172,16 @@ void RandomAccessMaxCoverage::updateBufferRankings() {
 void RandomAccessMaxCoverage::sortBranchesByCoverage(std::vector<Branch> &branches) {
     // Transfers branches to rankedBranches and sorts them by coverage
     for (const auto &localBranch : branches) {
-        ExecutionState *branchState = localBranch.nextState;
         // Calculate coverage for each branch:
-        uint64_t coverage = 0;
-        if (branchState != nullptr) {
-            uint64_t lookAheadCoverage = 0;
-            for (const auto &stmt : branchState->getVisited()) {
-                // We need to take into account the set of visitedStatements.
-                // We also need to ensure the statement is in allStatements.
-                if (visitedStatements.count(stmt) == 0U && allStatements.count(stmt) != 0U) {
-                    lookAheadCoverage++;
-                }
+        uint64_t lookAheadCoverage = 0;
+        for (const auto &stmt : localBranch.potentialStatements) {
+            // We need to take into account the set of visitedStatements.
+            // We also need to ensure the statement is in allStatements.
+            if (visitedStatements.count(stmt) == 0U && stmt->getSourceInfo().isValid()) {
+                lookAheadCoverage++;
             }
-            coverage = lookAheadCoverage + visitedStatements.size();
-        } else {
-            // If the branch does not have a nextState, then don't look ahead
-            // and use other existing information for ranking.
-            coverage = visitedStatements.size();
         }
+        auto coverage = lookAheadCoverage + visitedStatements.size();
 
         // If there's no element in bufferUnexploredBranches with the particular coverage
         // we calculate, we'll insert a new key at bufferUnexploredBranches.

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h
@@ -16,9 +16,7 @@
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// Implements small-step operational semantics for commands.
 class CmdStepper : public AbstractStepper {
@@ -77,8 +75,6 @@ class CmdStepper : public AbstractStepper {
     void declareVariable(ExecutionState *nextState, const IR::Declaration_Variable *decl);
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_SMALL_STEP_CMD_STEPPER_H_ */

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -26,10 +26,9 @@
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 #include "backends/p4tools/modules/testgen/lib/gen_eq.h"
+#include "backends/p4tools/modules/testgen/options.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 ExprStepper::ExprStepper(ExecutionState &state, AbstractSolver &solver,
                          const ProgramInfo &programInfo)
@@ -239,8 +238,12 @@ bool ExprStepper::preorder(const IR::Mux *mux) {
         const auto *expr = entry.second;
 
         auto *nextState = new ExecutionState(state);
+        // Some path selection strategies depend on looking ahead and collecting potential
+        // statements. If that is the case, apply the CollectLatentStatements visitor.
         P4::Coverage::CoverageSet coveredStmts;
-        expr->apply(CollectLatentStatements(coveredStmts, state));
+        if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
+            expr->apply(CollectLatentStatements(coveredStmts, state));
+        }
         nextState->replaceTopBody(Continuation::Return(expr));
         result->emplace_back(cond, state, nextState, coveredStmts);
     }
@@ -398,11 +401,15 @@ bool ExprStepper::preorder(const IR::SelectExpression *selectExpression) {
                 " P4Testgen currently does not support this case.",
                 selectExpression);
         }
-        const auto *decl = state.findDecl(selectCase->state)->getNode();
 
         nextState->replaceTopBody(Continuation::Return(selectCase->state));
+        // Some path selection strategies depend on looking ahead and collecting potential
+        // statements. If that is the case, apply the CollectLatentStatements visitor.
         P4::Coverage::CoverageSet coveredStmts;
-        decl->apply(CollectLatentStatements(coveredStmts, state));
+        if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
+            const auto *decl = state.findDecl(selectCase->state)->getNode();
+            decl->apply(CollectLatentStatements(coveredStmts, state));
+        }
         result->emplace_back(new IR::LAnd(missCondition, matchCondition), state, nextState,
                              coveredStmts);
         missCondition = new IR::LAnd(new IR::LNot(matchCondition), missCondition);
@@ -457,6 +464,4 @@ bool ExprStepper::preorder(const IR::Slice *slice) {
 
 void ExprStepper::stepNoMatch() { stepToException(Continuation::Exception::NoMatch); }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -21,6 +21,7 @@
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h"
 #include "backends/p4tools/modules/testgen/core/small_step/table_stepper.h"
+#include "backends/p4tools/modules/testgen/lib/collect_latent_statements.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
@@ -239,7 +240,7 @@ bool ExprStepper::preorder(const IR::Mux *mux) {
 
         auto *nextState = new ExecutionState(state);
         P4::Coverage::CoverageSet coveredStmts;
-        expr->apply(CollectStatements2(coveredStmts, state));
+        expr->apply(CollectLatentStatements(coveredStmts, state));
         nextState->replaceTopBody(Continuation::Return(expr));
         result->emplace_back(cond, state, nextState, coveredStmts);
     }
@@ -401,7 +402,7 @@ bool ExprStepper::preorder(const IR::SelectExpression *selectExpression) {
 
         nextState->replaceTopBody(Continuation::Return(selectCase->state));
         P4::Coverage::CoverageSet coveredStmts;
-        decl->apply(CollectStatements2(coveredStmts, state));
+        decl->apply(CollectLatentStatements(coveredStmts, state));
         result->emplace_back(new IR::LAnd(missCondition, matchCondition), state, nextState,
                              coveredStmts);
         missCondition = new IR::LAnd(new IR::LNot(matchCondition), missCondition);

--- a/backends/p4tools/modules/testgen/core/small_step/small_step.h
+++ b/backends/p4tools/modules/testgen/core/small_step/small_step.h
@@ -14,31 +14,7 @@
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-/// CollectStatements2 iterates across all assignment, method call, and exit statements in the P4
-/// program and collects them in a "CoverageSet".
-class CollectStatements2 : public Inspector {
-    P4::Coverage::CoverageSet &statements;
-    const ExecutionState &state;
-    std::set<int> seenParserIds;
-
- public:
-    explicit CollectStatements2(P4::Coverage::CoverageSet &output, const ExecutionState &state);
-
-    explicit CollectStatements2(P4::Coverage::CoverageSet &output, const ExecutionState &state,
-                                const std::set<int> &seenParserIds);
-
-    bool preorder(const IR::ParserState *parserState) override;
-
-    bool preorder(const IR::AssignmentStatement *stmt) override;
-
-    bool preorder(const IR::MethodCallStatement *stmt) override;
-
-    bool preorder(const IR::ExitStatement *stmt) override;
-};
+namespace P4Tools::P4Testgen {
 
 /// The main class that implements small-step operational semantics. Delegates to implementations
 /// of AbstractStepper.
@@ -93,8 +69,6 @@ class SmallStepEvaluator {
     SmallStepEvaluator(AbstractSolver &solver, const ProgramInfo &programInfo);
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_SMALL_STEP_SMALL_STEP_H_ */

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -27,6 +27,7 @@
 #include "backends/p4tools/modules/testgen/core/constants.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/expr_stepper.h"
+#include "backends/p4tools/modules/testgen/lib/collect_latent_statements.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
@@ -271,7 +272,7 @@ const IR::Expression *TableStepper::evalTableConstEntries() {
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
         P4::Coverage::CoverageSet coveredStmts;
         nextState->getActionDecl(tableAction->method)
-            ->apply(CollectStatements2(coveredStmts, stepper->state));
+            ->apply(CollectLatentStatements(coveredStmts, stepper->state));
 
         // Add some tracing information.
         std::stringstream tableStream;
@@ -368,7 +369,7 @@ void TableStepper::setTableDefaultEntries(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
         P4::Coverage::CoverageSet coveredStmts;
         nextState->getActionDecl(tableAction->method)
-            ->apply(CollectStatements2(coveredStmts, stepper->state));
+            ->apply(CollectLatentStatements(coveredStmts, stepper->state));
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(false));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
         std::stringstream tableStream;
@@ -443,7 +444,7 @@ void TableStepper::evalTableControlEntries(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
         P4::Coverage::CoverageSet coveredStmts;
         nextState->getActionDecl(tableAction->method)
-            ->apply(CollectStatements2(coveredStmts, stepper->state));
+            ->apply(CollectLatentStatements(coveredStmts, stepper->state));
 
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(true));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
@@ -636,7 +637,7 @@ void TableStepper::addDefaultAction(boost::optional<const IR::Expression *> tabl
     replacements.emplace_back(new IR::MethodCallStatement(Util::SourceInfo(), tableAction));
     P4::Coverage::CoverageSet coveredStmts;
     nextState->getActionDecl(tableAction->method)
-        ->apply(CollectStatements2(coveredStmts, stepper->state));
+        ->apply(CollectLatentStatements(coveredStmts, stepper->state));
     nextState->set(getTableHitVar(table), IR::getBoolLiteral(false));
     nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
     nextState->replaceTopBody(&replacements);

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -266,9 +266,12 @@ const IR::Expression *TableStepper::evalTableConstEntries() {
 
         // Update all the tracking variables for tables.
         std::vector<Continuation::Command> replacements;
-        replacements.emplace_back(new IR::MethodCallStatement(tableAction));
+        replacements.emplace_back(new IR::MethodCallStatement(Util::SourceInfo(), tableAction));
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(true));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
+        P4::Coverage::CoverageSet coveredStmts;
+        nextState->getActionDecl(tableAction->method)
+            ->apply(CollectStatements2(coveredStmts, stepper->state));
 
         // Add some tracing information.
         std::stringstream tableStream;
@@ -303,7 +306,7 @@ const IR::Expression *TableStepper::evalTableConstEntries() {
         // The default condition can only be triggered, if we do not hit this match.
         // We encode this constraint in this expression.
         stepper->result->emplace_back(new IR::LAnd(tableMissCondition, hitCondition),
-                                      stepper->state, nextState);
+                                      stepper->state, nextState, coveredStmts);
         tableMissCondition = new IR::LAnd(new IR::LNot(hitCondition), tableMissCondition);
     }
     return tableMissCondition;
@@ -361,8 +364,11 @@ void TableStepper::setTableDefaultEntries(
 
         // Update all the tracking variables for tables.
         std::vector<Continuation::Command> replacements;
-        replacements.emplace_back(new IR::MethodCallStatement(synthesizedAction));
-
+        replacements.emplace_back(
+            new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
+        P4::Coverage::CoverageSet coveredStmts;
+        nextState->getActionDecl(tableAction->method)
+            ->apply(CollectStatements2(coveredStmts, stepper->state));
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(false));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
         std::stringstream tableStream;
@@ -370,7 +376,7 @@ void TableStepper::setTableDefaultEntries(
         tableStream << "| Overriding default action: " << actionName;
         nextState->add(new TraceEvent::Generic(tableStream.str()));
         nextState->replaceTopBody(&replacements);
-        stepper->result->emplace_back(nextState);
+        stepper->result->emplace_back(boost::none, stepper->state, nextState, coveredStmts);
     }
 }
 
@@ -433,7 +439,11 @@ void TableStepper::evalTableControlEntries(
 
         // Update all the tracking variables for tables.
         std::vector<Continuation::Command> replacements;
-        replacements.emplace_back(new IR::MethodCallStatement(synthesizedAction));
+        replacements.emplace_back(
+            new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
+        P4::Coverage::CoverageSet coveredStmts;
+        nextState->getActionDecl(tableAction->method)
+            ->apply(CollectStatements2(coveredStmts, stepper->state));
 
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(true));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
@@ -454,7 +464,7 @@ void TableStepper::evalTableControlEntries(
         tableStream << "| Chosen action: " << actionName;
         nextState->add(new TraceEvent::Generic(tableStream.str()));
         nextState->replaceTopBody(&replacements);
-        stepper->result->emplace_back(hitCondition, stepper->state, nextState);
+        stepper->result->emplace_back(hitCondition, stepper->state, nextState, coveredStmts);
     }
 }
 
@@ -485,7 +495,7 @@ void TableStepper::evalTaintedTable() {
                   "Unknown format of an action '%1%' in the table '%2%'", action, table);
         const auto *tableAction = action->to<IR::MethodCallExpression>();
         BUG_CHECK(tableAction, "Invalid action '%1%' in the table '%2%'", action, table);
-        replacements.emplace_back(new IR::MethodCallStatement(tableAction));
+        replacements.emplace_back(new IR::MethodCallStatement(Util::SourceInfo(), tableAction));
     }
     // Since we do not know which table action was selected because of the tainted key, we also
     // set the selected action variable tainted.
@@ -623,11 +633,14 @@ void TableStepper::addDefaultAction(boost::optional<const IR::Expression *> tabl
     tableStream << "Table Branch: " << properties.tableName;
     tableStream << " Choosing default action: " << actionPath;
     nextState->add(new TraceEvent::Generic(tableStream.str()));
-    replacements.emplace_back(new IR::MethodCallStatement(tableAction));
+    replacements.emplace_back(new IR::MethodCallStatement(Util::SourceInfo(), tableAction));
+    P4::Coverage::CoverageSet coveredStmts;
+    nextState->getActionDecl(tableAction->method)
+        ->apply(CollectStatements2(coveredStmts, stepper->state));
     nextState->set(getTableHitVar(table), IR::getBoolLiteral(false));
     nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
     nextState->replaceTopBody(&replacements);
-    stepper->result->emplace_back(tableMissCondition, stepper->state, nextState);
+    stepper->result->emplace_back(tableMissCondition, stepper->state, nextState, coveredStmts);
 }
 
 void TableStepper::checkTargetProperties(

--- a/backends/p4tools/modules/testgen/lib/collect_latent_statements.cpp
+++ b/backends/p4tools/modules/testgen/lib/collect_latent_statements.cpp
@@ -1,0 +1,70 @@
+#include "backends/p4tools/modules/testgen/lib/collect_latent_statements.h"
+
+namespace P4Tools::P4Testgen {
+
+bool CollectLatentStatements::preorder(const IR::ParserState *parserState) {
+    // Only bother looking up cases that are not accept or reject.
+    if (parserState->name == IR::ParserState::accept ||
+        parserState->name == IR::ParserState::reject) {
+        return true;
+    }
+
+    // Already have seen this state. We might be in a loop.
+    if (seenParserIds.count(parserState->clone_id) != 0) {
+        return true;
+    }
+
+    seenParserIds.emplace(parserState->clone_id);
+    CHECK_NULL(parserState->selectExpression);
+
+    parserState->components.apply(CollectLatentStatements(statements, state, seenParserIds));
+
+    if (const auto *selectExpr = parserState->selectExpression->to<IR::SelectExpression>()) {
+        for (const auto *selectCase : selectExpr->selectCases) {
+            const auto *decl = state.findDecl(selectCase->state)->getNode();
+            decl->apply(CollectLatentStatements(statements, state, seenParserIds));
+        }
+    } else if (const auto *pathExpression =
+                   parserState->selectExpression->to<IR::PathExpression>()) {
+        // Only bother looking up cases that are not accept or reject.
+        // If we are referencing a parser state, step into the state.
+        const auto *decl = state.findDecl(pathExpression)->getNode();
+        decl->apply(CollectLatentStatements(statements, state, seenParserIds));
+    }
+    return true;
+}
+
+bool CollectLatentStatements::preorder(const IR::AssignmentStatement *stmt) {
+    // Only track statements, which have a valid source position in the P4 program.
+    if (stmt->getSourceInfo().isValid()) {
+        statements.insert(stmt);
+    }
+    return true;
+}
+
+bool CollectLatentStatements::preorder(const IR::MethodCallStatement *stmt) {
+    // Only track statements, which have a valid source position in the P4 program.
+    if (stmt->getSourceInfo().isValid()) {
+        statements.insert(stmt);
+    }
+    return true;
+}
+
+bool CollectLatentStatements::preorder(const IR::ExitStatement *stmt) {
+    // Only track statements, which have a valid source position in the P4 program.
+    if (stmt->getSourceInfo().isValid()) {
+        statements.insert(stmt);
+    }
+    return true;
+}
+
+CollectLatentStatements::CollectLatentStatements(P4::Coverage::CoverageSet &output,
+                                                 const ExecutionState &state)
+    : statements(output), state(state) {}
+
+CollectLatentStatements::CollectLatentStatements(P4::Coverage::CoverageSet &output,
+                                                 const ExecutionState &state,
+                                                 const std::set<int> &seenParserIds)
+    : statements(output), state(state), seenParserIds(seenParserIds) {}
+
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/collect_latent_statements.h
+++ b/backends/p4tools/modules/testgen/lib/collect_latent_statements.h
@@ -1,0 +1,38 @@
+#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_COLLECT_LATENT_STATEMENTS_H_
+#define BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_COLLECT_LATENT_STATEMENTS_H_
+
+#include <cstdint>
+#include <set>
+
+#include "backends/p4tools/modules/testgen/lib/execution_state.h"
+
+namespace P4Tools::P4Testgen {
+
+/// CollectLatentStatements is similar to @ref CollectStatements. It collects all the statements
+/// present in a particular node. However, compared to CollectStatements, it traverses the entire
+/// subsequent parser DAG for a particular parser state. If there is a loop in the parser state, it
+/// will terminate.
+class CollectLatentStatements : public Inspector {
+    P4::Coverage::CoverageSet &statements;
+    const ExecutionState &state;
+    std::set<int> seenParserIds;
+
+ public:
+    explicit CollectLatentStatements(P4::Coverage::CoverageSet &output,
+                                     const ExecutionState &state);
+
+    explicit CollectLatentStatements(P4::Coverage::CoverageSet &output, const ExecutionState &state,
+                                     const std::set<int> &seenParserIds);
+
+    bool preorder(const IR::ParserState *parserState) override;
+
+    bool preorder(const IR::AssignmentStatement *stmt) override;
+
+    bool preorder(const IR::MethodCallStatement *stmt) override;
+
+    bool preorder(const IR::ExitStatement *stmt) override;
+};
+
+}  // namespace P4Tools::P4Testgen
+
+#endif /*BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_COLLECT_LATENT_STATEMENTS_H_*/

--- a/backends/p4tools/modules/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/execution_state.cpp
@@ -127,11 +127,13 @@ const IR::Expression *ExecutionState::get(const StateVariable &var) const {
     return expr;
 }
 
-void ExecutionState::markVisited(const IR::Statement *stmt) { visitedStatements.push_back(stmt); }
-
-const std::vector<const IR::Statement *> &ExecutionState::getVisited() const {
-    return visitedStatements;
+void ExecutionState::markVisited(const IR::Statement *stmt) {
+    if (stmt->getSourceInfo().isValid()) {
+        visitedStatements.emplace(stmt);
+    }
 }
+
+const P4::Coverage::CoverageSet &ExecutionState::getVisited() const { return visitedStatements; }
 
 bool ExecutionState::hasTaint(const IR::Expression *expr) const {
     return Taint::hasTaint(env.getInternalMap(), expr);

--- a/backends/p4tools/modules/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/execution_state.cpp
@@ -128,6 +128,7 @@ const IR::Expression *ExecutionState::get(const StateVariable &var) const {
 }
 
 void ExecutionState::markVisited(const IR::Statement *stmt) {
+    // Only track statements, which have a valid source position in the P4 program.
     if (stmt->getSourceInfo().isValid()) {
         visitedStatements.emplace(stmt);
     }

--- a/backends/p4tools/modules/testgen/lib/execution_state.h
+++ b/backends/p4tools/modules/testgen/lib/execution_state.h
@@ -24,6 +24,7 @@
 #include "ir/node.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
+#include "midend/coverage.h"
 
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/namespace_context.h"
@@ -95,8 +96,8 @@ class ExecutionState {
     /// The program trace for the current program point (i.e., how we got to the current state).
     std::vector<gsl::not_null<const TraceEvent *>> trace;
 
-    /// List of visited statements. Used for code coverage.
-    std::vector<const IR::Statement *> visitedStatements;
+    /// Set of visited statements. Used for code coverage.
+    P4::Coverage::CoverageSet visitedStatements;
 
     /// The remaining body of the current function being executed.
     ///
@@ -180,7 +181,7 @@ class ExecutionState {
     void markVisited(const IR::Statement *stmt);
 
     /// @returns list of all statements visited before reaching this state.
-    const std::vector<const IR::Statement *> &getVisited() const;
+    const P4::Coverage::CoverageSet &getVisited() const;
 
     /// Sets the symbolic value of the given state variable to the given value. Constant folding
     /// is done on the given value before updating the symbolic state.

--- a/backends/p4tools/modules/testgen/lib/final_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/final_state.cpp
@@ -20,7 +20,6 @@ FinalState::FinalState(AbstractSolver *solver, const ExecutionState &inputState)
     for (const auto &event : inputState.getTrace()) {
         trace.emplace_back(event->evaluate(completedModel));
     }
-    visitedStatements = inputState.getVisited();
 }
 
 Model FinalState::completeModel(const ExecutionState &executionState, const Model *model) {
@@ -52,9 +51,7 @@ const std::vector<gsl::not_null<const TraceEvent *>> *FinalState::getTraces() co
     return &trace;
 }
 
-const std::vector<const IR::Statement *> &FinalState::getVisited() const {
-    return visitedStatements;
-}
+const P4::Coverage::CoverageSet &FinalState::getVisited() const { return state.getVisited(); }
 
 }  // namespace P4Testgen
 

--- a/backends/p4tools/modules/testgen/lib/final_state.h
+++ b/backends/p4tools/modules/testgen/lib/final_state.h
@@ -21,14 +21,15 @@ class FinalState {
     /// The solver associated with this final state. We need the solver to resolve  under new
     /// constraints in the case of concolic execution.
     gsl::not_null<AbstractSolver *> solver;
+
     /// The final state of the execution.
     const ExecutionState state;
+
     /// The final model which has been augmented with environment completions.
     const Model completedModel;
+
     /// The final program trace.
     std::vector<gsl::not_null<const TraceEvent *>> trace;
-    /// The final list of visited statements.
-    std::vector<const IR::Statement *> visitedStatements;
 
  public:
     FinalState(AbstractSolver *solver, const ExecutionState &inputState);
@@ -50,8 +51,8 @@ class FinalState {
     /// @returns the computed traces of this final state.
     const std::vector<gsl::not_null<const TraceEvent *>> *getTraces() const;
 
-    /// @returns the list of visited statements.
-    const std::vector<const IR::Statement *> &getVisited() const;
+    /// @returns the list of visited statements of this state.
+    const P4::Coverage::CoverageSet &getVisited() const;
 };
 
 }  // namespace P4Testgen

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -259,8 +259,6 @@ bool TestBackEnd::printTestInfo(const ExecutionState *executionState, const Test
     printTraces("=======================================");
 
     if (testInfo.packetIsDropped) {
-        // Update the visited statements.
-        symbex.updateVisitedStatements(executionState->getVisited());
         printTraces("============ Output packet dropped for Test %1% ============", testCount);
         return false;
     }

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -283,17 +283,7 @@ bool TestBackEnd::printTestInfo(const ExecutionState *executionState, const Test
     return false;
 }
 
-void TestBackEnd::printPerformanceReport() {
-    printFeature("performance", 4, "============ Timers ============");
-    for (const auto &c : Util::getTimers()) {
-        if (c.timerName.empty()) {
-            printFeature("performance", 4, "Total: %i ms", c.milliseconds);
-        } else {
-            printFeature("performance", 4, "%s: %i ms (%0.2f %% of parent)", c.timerName,
-                         c.milliseconds, c.relativeToParent * 100);
-        }
-    }
-}
+void TestBackEnd::printPerformanceReport() const { testWriter->printPerformanceReport(); }
 
 int64_t TestBackEnd::getTestCount() const { return testCount; }
 

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -105,6 +105,8 @@ bool TestBackEnd::run(const FinalState &state) {
         const auto *completedModel = state.getCompletedModel();
         const auto *outputPortExpr = executionState->get(programInfo.getTargetOutputPortVar());
         const auto &allStatements = programInfo.getAllStatements();
+        // Update the visited statements.
+        symbex.updateVisitedStatements(state.getVisited());
         const P4::Coverage::CoverageSet &visitedStatements = symbex.getVisitedStatements();
 
         auto *solver = state.getSolver()->to<Z3Solver>();
@@ -259,6 +261,8 @@ bool TestBackEnd::printTestInfo(const ExecutionState *executionState, const Test
     printTraces("=======================================");
 
     if (testInfo.packetIsDropped) {
+        // Update the visited statements.
+        symbex.updateVisitedStatements(executionState->getVisited());
         printTraces("============ Output packet dropped for Test %1% ============", testCount);
         return false;
     }

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -131,7 +131,7 @@ bool TestBackEnd::run(const FinalState &state) {
                                                              outputPacketExpr, outputPortExpr);
         if (concolicModel == nullptr) {
             testCount++;
-            printPerformanceReport();
+            printPerformanceReport(false);
             return needsToTerminate(testCount);
         }
         completedModel = concolicModel;
@@ -149,7 +149,7 @@ bool TestBackEnd::run(const FinalState &state) {
         abort = printTestInfo(executionState, testInfo, outputPortExpr);
         if (abort) {
             testCount++;
-            printPerformanceReport();
+            printPerformanceReport(false);
             return needsToTerminate(testCount);
         }
         const auto *testSpec = createTestSpec(executionState, completedModel, testInfo);
@@ -173,7 +173,7 @@ bool TestBackEnd::run(const FinalState &state) {
         printTraces("============ End Test %1% ============\n", testCount);
         testCount++;
         P4::Coverage::coverageReportFinal(allStatements, visitedStatements);
-        printPerformanceReport();
+        printPerformanceReport(false);
 
         // If MAX_STATEMENT_COVERAGE is enabled, terminate early if we hit max coverage already.
         if (TestgenOptions::get().stopMetric == "MAX_STATEMENT_COVERAGE" && coverage == 1.0) {
@@ -279,7 +279,9 @@ bool TestBackEnd::printTestInfo(const ExecutionState *executionState, const Test
     return false;
 }
 
-void TestBackEnd::printPerformanceReport() const { testWriter->printPerformanceReport(); }
+void TestBackEnd::printPerformanceReport(bool write) const {
+    testWriter->printPerformanceReport(write);
+}
 
 int64_t TestBackEnd::getTestCount() const { return testCount; }
 

--- a/backends/p4tools/modules/testgen/lib/test_backend.h
+++ b/backends/p4tools/modules/testgen/lib/test_backend.h
@@ -114,7 +114,7 @@ class TestBackEnd {
     virtual bool run(const FinalState &state);
 
     /// Print out some performance numbers if logging feature "performance" is enabled.
-    static void printPerformanceReport();
+    void printPerformanceReport() const;
 
     /// Accessors.
     [[nodiscard]] int64_t getTestCount() const;

--- a/backends/p4tools/modules/testgen/lib/test_backend.h
+++ b/backends/p4tools/modules/testgen/lib/test_backend.h
@@ -18,9 +18,7 @@
 #include "backends/p4tools/modules/testgen/lib/tf.h"
 #include "backends/p4tools/modules/testgen/options.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 class TestBackEnd {
  private:
@@ -114,13 +112,14 @@ class TestBackEnd {
     virtual bool run(const FinalState &state);
 
     /// Print out some performance numbers if logging feature "performance" is enabled.
-    void printPerformanceReport() const;
+    /// Also log performance numbers to a separate file in the test folder if @param write is
+    /// enabled.
+    void printPerformanceReport(bool write) const;
 
     /// Accessors.
     [[nodiscard]] int64_t getTestCount() const;
 };
 
-}  // namespace P4Testgen
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_TEST_BACKEND_H_ */

--- a/backends/p4tools/modules/testgen/lib/tf.cpp
+++ b/backends/p4tools/modules/testgen/lib/tf.cpp
@@ -2,12 +2,53 @@
 
 #include <boost/none.hpp>
 
+#include "backends/p4tools/common/lib/util.h"
+#include "lib/timer.h"
+
 namespace P4Tools {
 
 namespace P4Testgen {
 
 TF::TF(cstring testName, boost::optional<unsigned int> seed = boost::none)
     : testName(testName), seed(seed) {}
+
+void TF::printPerformanceReport() const {
+    // Do not emit a report if performance logging is not enabled.
+    if (!Log::fileLogLevelIsAtLeast("performance", 4)) {
+        return;
+    }
+    printFeature("performance", 4, "============ Timers ============");
+    inja::json dataJson;
+    inja::json timerList = inja::json::array();
+    for (const auto &c : Util::getTimers()) {
+        inja::json timerData;
+        timerData["time"] = c.milliseconds;
+        if (c.timerName.empty()) {
+            printFeature("performance", 4, "Total: %i ms", c.milliseconds);
+            timerData["pct"] = "100";
+            timerData["name"] = "total";
+        } else {
+            timerData["pct"] = c.relativeToParent * 100;
+            printFeature("performance", 4, "%s: %i ms (%0.2f %% of parent)", c.timerName,
+                         c.milliseconds, c.relativeToParent * 100);
+            auto prunedName = c.timerName;
+            prunedName.erase(remove_if(prunedName.begin(), prunedName.end(), isspace),
+                             prunedName.end());
+            timerData["name"] = prunedName;
+        }
+        timerList.emplace_back(timerData);
+    }
+    dataJson["timers"] = timerList;
+    static const std::string TEST_CASE(R"""(Timer,Total Time,Percentage
+## for timer in timers
+{{timer.name}},{{timer.time}},{{timer.pct}}
+## endfor
+)""");
+
+    auto perfFile = std::ofstream(testName + "_perf.csv");
+    inja::render_to(perfFile, TEST_CASE, dataJson);
+    perfFile.flush();
+}
 
 }  // namespace P4Testgen
 

--- a/backends/p4tools/modules/testgen/lib/tf.cpp
+++ b/backends/p4tools/modules/testgen/lib/tf.cpp
@@ -5,14 +5,12 @@
 #include "backends/p4tools/common/lib/util.h"
 #include "lib/timer.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 TF::TF(cstring testName, boost::optional<unsigned int> seed = boost::none)
     : testName(testName), seed(seed) {}
 
-void TF::printPerformanceReport() const {
+void TF::printPerformanceReport(bool write) const {
     // Do not emit a report if performance logging is not enabled.
     if (!Log::fileLogLevelIsAtLeast("performance", 4)) {
         return;
@@ -38,18 +36,18 @@ void TF::printPerformanceReport() const {
         }
         timerList.emplace_back(timerData);
     }
-    dataJson["timers"] = timerList;
-    static const std::string TEST_CASE(R"""(Timer,Total Time,Percentage
+    if (write) {
+        dataJson["timers"] = timerList;
+        static const std::string TEST_CASE(R"""(Timer,Total Time,Percentage
 ## for timer in timers
 {{timer.name}},{{timer.time}},{{timer.pct}}
 ## endfor
 )""");
 
-    auto perfFile = std::ofstream(testName + "_perf.csv");
-    inja::render_to(perfFile, TEST_CASE, dataJson);
-    perfFile.flush();
+        auto perfFile = std::ofstream(testName + "_perf.csv");
+        inja::render_to(perfFile, TEST_CASE, dataJson);
+        perfFile.flush();
+    }
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/tf.h
+++ b/backends/p4tools/modules/testgen/lib/tf.h
@@ -136,6 +136,10 @@ class TF {
     // attaches arbitrary string data to the test preamble.
     virtual void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testIdx,
                             float currentCoverage) = 0;
+
+    /// Log performance numbers to a separate file in the test folder.
+    /// Also print out some performance numbers if logging feature "performance" is enabled.
+    void printPerformanceReport() const;
 };
 
 }  // namespace P4Testgen

--- a/backends/p4tools/modules/testgen/lib/tf.h
+++ b/backends/p4tools/modules/testgen/lib/tf.h
@@ -11,9 +11,7 @@
 
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// THe default base class for the various test frameworks (TF). Every test framework has a test
 /// name and a seed associated with it. Also contains a variety of common utility functions.
@@ -137,13 +135,12 @@ class TF {
     virtual void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testIdx,
                             float currentCoverage) = 0;
 
-    /// Log performance numbers to a separate file in the test folder.
-    /// Also print out some performance numbers if logging feature "performance" is enabled.
-    void printPerformanceReport() const;
+    /// Print out some performance numbers if logging feature "performance" is enabled.
+    /// Also log performance numbers to a separate file in the test folder if @param write is
+    /// enabled.
+    void printPerformanceReport(bool write) const;
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_TF_H_ */

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -22,8 +22,13 @@ const char *TestgenOptions::getIncludePath() {
 
 const std::set<cstring> TestgenOptions::SUPPORTED_STOP_METRICS = {"MAX_STATEMENT_COVERAGE"};
 const std::set<cstring> TestgenOptions::SUPPORTED_EXPLORATION_STRATEGIES = {
-    "INCREMENTAL_STACK", "RANDOM_ACCESS_STACK",        "LINEAR_ENUMERATION",
-    "MAX_COVERAGE",      "RANDOM_ACCESS_MAX_COVERAGE", "UNBOUNDED_RANDOM_ACCESS_STACK"};
+    "INCREMENTAL_STACK",
+    "RANDOM_ACCESS_STACK",
+    "GREEDY_POTENTIAL",
+    "LINEAR_ENUMERATION",
+    "MAX_COVERAGE",
+    "RANDOM_ACCESS_MAX_COVERAGE",
+    "UNBOUNDED_RANDOM_ACCESS_STACK"};
 
 TestgenOptions::TestgenOptions()
     : AbstractP4cToolOptions("Generate packet tests for a P4 program.") {
@@ -182,9 +187,9 @@ TestgenOptions::TestgenOptions()
             return true;
         },
         "Selects a specific exploration strategy for test generation. Options are: "
-        "INCREMENTAL_STACK, RANDOM_ACCESS_STACK, LINEAR_ENUMERATION, MAX_COVERAGE, and "
-        "RANDOM_ACCESS_MAX_COVERAGE, UNBOUNDED_RANDOM_ACCESS_STACK. Defaults to "
-        "INCREMENTAL_STACK.");
+        "INCREMENTAL_STACK, RANDOM_ACCESS_STACK, LINEAR_ENUMERATION, MAX_COVERAGE, "
+        "GREEDY_POTENTIAL, RANDOM_ACCESS_MAX_COVERAGE, and UNBOUNDED_RANDOM_ACCESS_STACK. "
+        "Defaults to INCREMENTAL_STACK.");
 
     registerOption(
         "--pop-level", "popLevel",

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -6,24 +6,26 @@
 #include "backends/p4tools/common/options.h"
 #include "lib/cstring.h"
 
+#include "backends/p4tools/modules/testgen/core/exploration_strategy/path_selection.h"
+
 namespace P4Tools {
 
-/// Encapsulates and processes command-line options for p4testgen.
+/// Encapsulates and processes command-line options for P4Testgen.
 class TestgenOptions : public AbstractP4cToolOptions {
  public:
+    virtual ~TestgenOptions() = default;
+
     /// Maximum number of tests to be generated. Defaults to 1.
     int64_t maxTests = 1;
 
-    /// List of the supported exploration strategies.
-    static const std::set<cstring> SUPPORTED_EXPLORATION_STRATEGIES;
-
-    /// Selects the exploration strategy for test generation
-    cstring explorationStrategy;
+    /// Selects the path selection policy for test generation
+    P4Testgen::PathSelectionPolicy pathSelectionPolicy =
+        P4Testgen::PathSelectionPolicy::IncrementalStack;
 
     /// List of the supported stop metrics.
     static const std::set<cstring> SUPPORTED_STOP_METRICS;
 
-    // Stops generating tests when a particular metric is satisifed. Currently supported options are
+    // Stops generating tests when a particular metric is satisfied. Currently supported options are
     // listed in @var SUPPORTED_STOP_METRICS.
     cstring stopMetric;
 
@@ -55,7 +57,7 @@ class TestgenOptions : public AbstractP4cToolOptions {
     /// Fail on unimplemented features instead of trying the next branch
     bool strict = false;
 
-    /// The test back end that P4Testgen will generate test for. Examples, STF, PTF or Protobuf.
+    /// The test back end that P4Testgen will generate test for. Examples are STF, PTF or Protobuf.
     cstring testBackend;
 
     /// String of selected branches separated by comma.

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -22,6 +22,7 @@
 #include "lib/safe_vector.h"
 
 #include "backends/p4tools/modules/testgen/core/small_step/table_stepper.h"
+#include "backends/p4tools/modules/testgen/lib/collect_latent_statements.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
@@ -157,7 +158,7 @@ void BMv2_V1ModelTableStepper::evalTableActionProfile(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
         P4::Coverage::CoverageSet coveredStmts;
         nextState->getActionDecl(tableAction->method)
-            ->apply(CollectStatements2(coveredStmts, *state));
+            ->apply(CollectLatentStatements(coveredStmts, *state));
 
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(true));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
@@ -253,7 +254,7 @@ void BMv2_V1ModelTableStepper::evalTableActionSelector(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
         P4::Coverage::CoverageSet coveredStmts;
         nextState->getActionDecl(tableAction->method)
-            ->apply(CollectStatements2(coveredStmts, *state));
+            ->apply(CollectLatentStatements(coveredStmts, *state));
 
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(true));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -156,9 +156,13 @@ void BMv2_V1ModelTableStepper::evalTableActionProfile(
         std::vector<Continuation::Command> replacements;
         replacements.emplace_back(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
+        // Some path selection strategies depend on looking ahead and collecting potential
+        // statements. If that is the case, apply the CollectLatentStatements visitor.
         P4::Coverage::CoverageSet coveredStmts;
-        nextState->getActionDecl(tableAction->method)
-            ->apply(CollectLatentStatements(coveredStmts, *state));
+        if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
+            nextState->getActionDecl(tableAction->method)
+                ->apply(CollectLatentStatements(coveredStmts, *state));
+        }
 
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(true));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
@@ -252,9 +256,13 @@ void BMv2_V1ModelTableStepper::evalTableActionSelector(
         std::vector<Continuation::Command> replacements;
         replacements.emplace_back(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
+        // Some path selection strategies depend on looking ahead and collecting potential
+        // statements. If that is the case, apply the CollectLatentStatements visitor.
         P4::Coverage::CoverageSet coveredStmts;
-        nextState->getActionDecl(tableAction->method)
-            ->apply(CollectLatentStatements(coveredStmts, *state));
+        if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
+            nextState->getActionDecl(tableAction->method)
+                ->apply(CollectLatentStatements(coveredStmts, *state));
+        }
 
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(true));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -153,7 +153,11 @@ void BMv2_V1ModelTableStepper::evalTableActionProfile(
 
         // Update all the tracking variables for tables.
         std::vector<Continuation::Command> replacements;
-        replacements.emplace_back(new IR::MethodCallStatement(synthesizedAction));
+        replacements.emplace_back(
+            new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
+        P4::Coverage::CoverageSet coveredStmts;
+        nextState->getActionDecl(tableAction->method)
+            ->apply(CollectStatements2(coveredStmts, *state));
 
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(true));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
@@ -162,7 +166,7 @@ void BMv2_V1ModelTableStepper::evalTableActionProfile(
         tableStream << " Chosen action: " << actionName;
         nextState->add(new TraceEvent::Generic(tableStream.str()));
         nextState->replaceTopBody(&replacements);
-        getResult()->emplace_back(hitCondition, *state, nextState);
+        getResult()->emplace_back(hitCondition, *state, nextState, coveredStmts);
     }
 }
 
@@ -245,7 +249,11 @@ void BMv2_V1ModelTableStepper::evalTableActionSelector(
 
         // Update all the tracking variables for tables.
         std::vector<Continuation::Command> replacements;
-        replacements.emplace_back(new IR::MethodCallStatement(synthesizedAction));
+        replacements.emplace_back(
+            new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
+        P4::Coverage::CoverageSet coveredStmts;
+        nextState->getActionDecl(tableAction->method)
+            ->apply(CollectStatements2(coveredStmts, *state));
 
         nextState->set(getTableHitVar(table), IR::getBoolLiteral(true));
         nextState->set(getTableReachedVar(table), IR::getBoolLiteral(true));
@@ -254,7 +262,7 @@ void BMv2_V1ModelTableStepper::evalTableActionSelector(
         tableStream << " Chosen action: " << actionName;
         nextState->add(new TraceEvent::Generic(tableStream.str()));
         nextState->replaceTopBody(&replacements);
-        getResult()->emplace_back(hitCondition, *state, nextState);
+        getResult()->emplace_back(hitCondition, *state, nextState, coveredStmts);
     }
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
@@ -13,7 +13,7 @@ if(NOT P4TOOLS_BMV2_PATH)
   set(P4TOOLS_BMV2_PATH ${CMAKE_HOME_DIRECTORY}/build)
 endif()
 
-set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10 --path-selection GREEDY_POTENTIAL ")
+set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10 ")
 
 set(V1_SEARCH_PATTERNS "include.*v1model.p4" "main|common_v1_test")
 set(P4TESTDATA ${P4C_SOURCE_DIR}/testdata)

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
@@ -13,7 +13,7 @@ if(NOT P4TOOLS_BMV2_PATH)
   set(P4TOOLS_BMV2_PATH ${CMAKE_HOME_DIRECTORY}/build)
 endif()
 
-set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10 ")
+set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10 --path-selection GREEDY_POTENTIAL ")
 
 set(V1_SEARCH_PATTERNS "include.*v1model.p4" "main|common_v1_test")
 set(P4TESTDATA ${P4C_SOURCE_DIR}/testdata)

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
@@ -13,11 +13,7 @@ if(NOT P4TOOLS_BMV2_PATH)
   set(P4TOOLS_BMV2_PATH ${CMAKE_HOME_DIRECTORY}/build)
 endif()
 
-if(NOT NIGHTLY)
-  set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10")
-else()
-  set(EXTRA_OPTS "--strict --print-traces --max-tests 10")
-endif()
+set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10 ")
 
 set(V1_SEARCH_PATTERNS "include.*v1model.p4" "main|common_v1_test")
 set(P4TESTDATA ${P4C_SOURCE_DIR}/testdata)

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -19,6 +19,7 @@
 #include "lib/error.h"
 
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/exploration_strategy.h"
+#include "backends/p4tools/modules/testgen/core/exploration_strategy/greedy_potential.h"
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/inc_max_coverage_stack.h"
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/incremental_stack.h"
 #include "backends/p4tools/modules/testgen/core/exploration_strategy/linear_enumeration.h"
@@ -94,6 +95,9 @@ int Testgen::mainImpl(const IR::P4Program *program) {
                 popLevel = 3;
             }
             return new RandomAccessStack(solver, *programInfo, popLevel);
+        }
+        if (explorationStrategy == "GREEDY_POTENTIAL") {
+            return new GreedyPotential(solver, *programInfo);
         }
         if (explorationStrategy == "UNBOUNDED_RANDOM_ACCESS_STACK") {
             return new UnboundedRandomAccessStack(solver, *programInfo);

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -137,6 +137,8 @@ int Testgen::mainImpl(const IR::P4Program *program) {
         }
         throw;
     }
+    // Emit a performance report, if desired.
+    testBackend->printPerformanceReport(true);
 
     // Do not print this warning if assertion mode is enabled.
     if (testBackend->getTestCount() == 0 && !testgenOptions.assertionModeEnabled) {

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -34,16 +34,46 @@
 #include "backends/p4tools/modules/testgen/options.h"
 #include "backends/p4tools/modules/testgen/register.h"
 
-namespace fs = boost::filesystem;
-
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 void Testgen::registerTarget() {
     // Register all available compiler targets.
     // These are discovered by CMAKE, which fills out the register.h.in file.
     registerCompilerTargets();
+}
+
+ExplorationStrategy *pickExecutionEngine(const TestgenOptions &testgenOptions,
+                                         const ProgramInfo *programInfo, AbstractSolver &solver) {
+    const auto &pathSelectionPolicy = testgenOptions.pathSelectionPolicy;
+    if (pathSelectionPolicy == PathSelectionPolicy::RandomAccessStack) {
+        // If the user mistakenly specifies an invalid popLevel, we set it to 3.
+        auto popLevel = testgenOptions.popLevel;
+        if (popLevel <= 1) {
+            ::warning("--pop-level must be greater than 1; using default value of 3.\n");
+            popLevel = 3;
+        }
+        return new RandomAccessStack(solver, *programInfo, popLevel);
+    }
+    if (pathSelectionPolicy == PathSelectionPolicy::GreedyPotential) {
+        return new GreedyPotential(solver, *programInfo);
+    }
+    if (pathSelectionPolicy == PathSelectionPolicy::UnboundedRandomAccessStack) {
+        return new UnboundedRandomAccessStack(solver, *programInfo);
+    }
+    if (pathSelectionPolicy == PathSelectionPolicy::LinearEnumeration) {
+        return new LinearEnumeration(solver, *programInfo, testgenOptions.linearEnumeration);
+    }
+    if (pathSelectionPolicy == PathSelectionPolicy::MaxCoverage) {
+        return new IncrementalMaxCoverageStack(solver, *programInfo);
+    }
+    if (pathSelectionPolicy == PathSelectionPolicy::RandomAccessMaxCoverage) {
+        return new RandomAccessMaxCoverage(solver, *programInfo, testgenOptions.saddlePoint);
+    }
+    if (!testgenOptions.selectedBranches.empty()) {
+        std::string selectedBranchesStr = testgenOptions.selectedBranches;
+        return new SelectedBranches(solver, *programInfo, selectedBranchesStr);
+    }
+    return new IncrementalStack(solver, *programInfo);
 }
 
 int Testgen::mainImpl(const IR::P4Program *program) {
@@ -74,54 +104,25 @@ int Testgen::mainImpl(const IR::P4Program *program) {
 
     // Get the basename of the input file and remove the extension
     // This assumes that inputFile is not null.
-    auto programName = fs::path(inputFile).filename().replace_extension("");
+    auto programName = boost::filesystem::path(inputFile).filename().replace_extension("");
     // Create the directory, if the directory string is valid and if it does not exist.
     auto testPath = programName;
     if (!testDirStr.isNullOrEmpty()) {
-        auto testDir = fs::path(testDirStr);
-        fs::create_directories(testDir);
-        testPath = fs::path(testDir) / testPath;
+        auto testDir = boost::filesystem::path(testDirStr);
+        boost::filesystem::create_directories(testDir);
+        testPath = boost::filesystem::path(testDir) / testPath;
     }
-
+    // Need to declare the solver here to ensure its lifetime.
     Z3Solver solver;
-
-    auto *symExec = [&solver, &programInfo, &testgenOptions]() -> ExplorationStrategy * {
-        auto explorationStrategy = testgenOptions.explorationStrategy;
-        if (explorationStrategy == "RANDOM_ACCESS_STACK") {
-            // If the user mistakenly specifies an invalid popLevel, we set it to 3.
-            auto popLevel = testgenOptions.popLevel;
-            if (popLevel <= 1) {
-                ::warning("--pop-level must be greater than 1; using default value of 3.\n");
-                popLevel = 3;
-            }
-            return new RandomAccessStack(solver, *programInfo, popLevel);
-        }
-        if (explorationStrategy == "GREEDY_POTENTIAL") {
-            return new GreedyPotential(solver, *programInfo);
-        }
-        if (explorationStrategy == "UNBOUNDED_RANDOM_ACCESS_STACK") {
-            return new UnboundedRandomAccessStack(solver, *programInfo);
-        }
-        if (explorationStrategy == "LINEAR_ENUMERATION") {
-            return new LinearEnumeration(solver, *programInfo, testgenOptions.linearEnumeration);
-        }
-        if (explorationStrategy == "MAX_COVERAGE") {
-            return new IncrementalMaxCoverageStack(solver, *programInfo);
-        }
-        if (explorationStrategy == "RANDOM_ACCESS_MAX_COVERAGE") {
-            return new RandomAccessMaxCoverage(solver, *programInfo, testgenOptions.saddlePoint);
-        }
-        if (!testgenOptions.selectedBranches.empty()) {
-            std::string selectedBranchesStr = testgenOptions.selectedBranches;
-            return new SelectedBranches(solver, *programInfo, selectedBranchesStr);
-        }
-        return new IncrementalStack(solver, *programInfo);
-    }();
+    auto *symExec = pickExecutionEngine(testgenOptions, programInfo, solver);
 
     // Define how to handle the final state for each test. This is target defined.
     auto *testBackend = TestgenTarget::getTestBackend(*programInfo, *symExec, testPath, seed);
-    ExplorationStrategy::Callback callBack =
-        std::bind(&TestBackEnd::run, testBackend, std::placeholders::_1);
+    // Each test back end has a different run function.
+    // We delegate execution to the symbolic executor.
+    auto callBack = [testBackend](auto &&finalState) {
+        return testBackend->run(std::forward<decltype(finalState)>(finalState));
+    };
 
     try {
         // Run the symbolic executor with given exploration strategy.
@@ -147,6 +148,4 @@ int Testgen::mainImpl(const IR::P4Program *program) {
     return ::errorCount() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/testgen.h
+++ b/backends/p4tools/modules/testgen/testgen.h
@@ -6,9 +6,7 @@
 
 #include "backends/p4tools/modules/testgen/options.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// This is main implementation of the P4Testgen tool.
 class Testgen : public AbstractP4cTool<TestgenOptions> {
@@ -16,10 +14,11 @@ class Testgen : public AbstractP4cTool<TestgenOptions> {
     void registerTarget() override;
 
     int mainImpl(const IR::P4Program *program) override;
+
+ public:
+    virtual ~Testgen() = default;
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TESTGEN_H_ */

--- a/midend/coverage.cpp
+++ b/midend/coverage.cpp
@@ -11,37 +11,45 @@ namespace Coverage {
 CollectStatements::CollectStatements(CoverageSet &output) : statements(output) {}
 
 bool CollectStatements::preorder(const IR::AssignmentStatement *stmt) {
-    statements.insert(stmt);
+    if (stmt->getSourceInfo().isValid()) {
+        statements.insert(stmt);
+    }
     return true;
 }
 
 bool CollectStatements::preorder(const IR::MethodCallStatement *stmt) {
-    statements.insert(stmt);
+    if (stmt->getSourceInfo().isValid()) {
+        statements.insert(stmt);
+    }
     return true;
 }
 
 bool CollectStatements::preorder(const IR::ExitStatement *stmt) {
-    statements.insert(stmt);
+    if (stmt->getSourceInfo().isValid()) {
+        statements.insert(stmt);
+    }
     return true;
 }
 
 void coverageReportFinal(const CoverageSet &all, const CoverageSet &visited) {
     LOG_FEATURE("coverage", 4, "Not covered statements:");
-    for (const IR::Statement *stmt : all) {
+    for (const auto *stmt : all) {
         if (visited.count(stmt) == 0) {
-            LOG_FEATURE("coverage", 4,
-                        '\t' << stmt->getSourceInfo().toPosition().sourceLine << ": " << *stmt);
+            int sourceLine = -1;
+            if (stmt->getSourceInfo().isValid()) {
+                sourceLine = stmt->getSourceInfo().toPosition().sourceLine;
+            }
+            LOG_FEATURE("coverage", 4, '\t' << sourceLine << ": " << *stmt);
         }
     }
-    LOG_FEATURE("coverage", 4, "Covered statements:");
-    for (const IR::Statement *stmt : visited) {
-        LOG_FEATURE("coverage", 4,
-                    '\t' << stmt->getSourceInfo().toPosition().sourceLine << ": " << *stmt);
-    }
+    // LOG_FEATURE("coverage", 4, "Covered statements:");
+    // for (const IR::Statement *stmt : visited) {
+    //     LOG_FEATURE("coverage", 4,
+    //                 '\t' << stmt->getSourceInfo().toPosition().sourceLine << ": " << *stmt);
+    // }
 }
 
-void logCoverage(const CoverageSet &all, const CoverageSet &visited,
-                 const std::vector<const IR::Statement *> &new_) {
+void logCoverage(const CoverageSet &all, const CoverageSet &visited, const CoverageSet &new_) {
     for (const IR::Statement *stmt : new_) {
         if (all.count(stmt) == 0) {
             // Do not log internal statements, which don't correspond to any statement

--- a/midend/coverage.cpp
+++ b/midend/coverage.cpp
@@ -14,10 +14,12 @@ bool CollectStatements::preorder(const IR::AssignmentStatement *stmt) {
     statements.insert(stmt);
     return true;
 }
+
 bool CollectStatements::preorder(const IR::MethodCallStatement *stmt) {
     statements.insert(stmt);
     return true;
 }
+
 bool CollectStatements::preorder(const IR::ExitStatement *stmt) {
     statements.insert(stmt);
     return true;
@@ -27,12 +29,14 @@ void coverageReportFinal(const CoverageSet &all, const CoverageSet &visited) {
     LOG_FEATURE("coverage", 4, "Not covered statements:");
     for (const IR::Statement *stmt : all) {
         if (visited.count(stmt) == 0) {
-            LOG2('\t' << *stmt);
+            LOG_FEATURE("coverage", 4,
+                        '\t' << stmt->getSourceInfo().toPosition().sourceLine << ": " << *stmt);
         }
     }
     LOG_FEATURE("coverage", 4, "Covered statements:");
     for (const IR::Statement *stmt : visited) {
-        LOG_FEATURE("coverage", 4, '\t' << *stmt);
+        LOG_FEATURE("coverage", 4,
+                    '\t' << stmt->getSourceInfo().toPosition().sourceLine << ": " << *stmt);
     }
 }
 

--- a/midend/coverage.h
+++ b/midend/coverage.h
@@ -13,9 +13,7 @@
 /// to walk the IR of the P4 program and track which percentage of statement they have visited. The
 /// p4tools (backends/p4tools) framework uses this coverage visitor.
 
-namespace P4 {
-
-namespace Coverage {
+namespace P4::Coverage {
 
 struct SourceIdCmp {
     bool operator()(const IR::Statement *s1, const IR::Statement *s2) const {
@@ -44,8 +42,6 @@ void coverageReportFinal(const CoverageSet &all, const CoverageSet &visited);
 
 /// Logs statements from @p new_ which have not yet been visited (are not members of @p visited).
 void logCoverage(const CoverageSet &all, const CoverageSet &visited, const CoverageSet &new_);
-
-}  // namespace Coverage
 
 }  // namespace P4
 

--- a/midend/coverage.h
+++ b/midend/coverage.h
@@ -43,6 +43,6 @@ void coverageReportFinal(const CoverageSet &all, const CoverageSet &visited);
 /// Logs statements from @p new_ which have not yet been visited (are not members of @p visited).
 void logCoverage(const CoverageSet &all, const CoverageSet &visited, const CoverageSet &new_);
 
-}  // namespace P4
+}  // namespace P4::Coverage
 
 #endif /* MIDEND_COVERAGE_H_ */

--- a/midend/coverage.h
+++ b/midend/coverage.h
@@ -43,8 +43,7 @@ class CollectStatements : public Inspector {
 void coverageReportFinal(const CoverageSet &all, const CoverageSet &visited);
 
 /// Logs statements from @p new_ which have not yet been visited (are not members of @p visited).
-void logCoverage(const CoverageSet &all, const CoverageSet &visited,
-                 const std::vector<const IR::Statement *> &new_);
+void logCoverage(const CoverageSet &all, const CoverageSet &visited, const CoverageSet &new_);
 
 }  // namespace Coverage
 

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -197,11 +197,13 @@ def exec_process(args: str, **extra_args) -> ProcessResult:
         args = list(filter(None, args))
 
     # Set up log pipes for both stdout and stderr.
-    outpipe = LogPipe(logging.INFO)
-    output_args["stdout"] = outpipe
-    errpipe = LogPipe(logging.WARNING)
-    output_args["stderr"] = errpipe
-
+    if "capture_output" not in extra_args:
+        if "stdout" not in extra_args:
+            outpipe = LogPipe(logging.INFO)
+            output_args["stdout"] = outpipe
+        if "stderr" not in extra_args:
+            errpipe = LogPipe(logging.WARNING)
+            output_args["stderr"] = errpipe
     try:
         result = subprocess.run(args, check=True, **output_args)
         out = result.stdout
@@ -223,8 +225,11 @@ def exec_process(args: str, **extra_args) -> ProcessResult:
             cmd = " ".join(cmd)
         log.error("Timed out when executing %s.", cmd)
     finally:
-        outpipe.close()
-        errpipe.close()
+        if "capture_output" not in extra_args:
+            if "stdout" not in extra_args:
+                outpipe.close()
+            if "stderr" not in extra_args:
+                errpipe.close()
     return ProcessResult(out, returncode)
 
 


### PR DESCRIPTION
- Add a lookahead visitor to P4Testgen. This visitor collects the statements that could potentially be visited for a particular statement. These latent statements are added to the branch state and are consumed by some strategies. The difference of this visitor to the normal coverage visitor is that it fully traverses the parser DAG.
- The lookahead visitor needs to be applied manually in crucial spots. For example, when a table adds an action, or when an if statements adds a branch. I have not found a better solution for this particular lookahead yet. 
- Only add statements if their source info is valid. This implies that they can be found in the original P4 program. 
- Introduce a new strategy - greedy potential (name is tentative). This strategy greedily selects the first execution state that may cover a new statement in the program. 
- Improve the way performance reports are generated - use an inja template.
- Add a plotting script to the benchmarking folder. Refactor the coverage script. 

There will be a second part, which brings some of the improvements of the new strategy to existing strategies. The second part will also rename the strategies appropriately. 