### PR TITLE
SplitFlowVisitor to better capture split/join in ControlFlowVisitor

### DIFF
--- a/ir/expression.def
+++ b/ir/expression.def
@@ -338,10 +338,7 @@ class Mux : Operation_Ternary {
     precedence = DBPrint::Prec_Low;
     visit_children {
         v.visit(e0, "e0");
-        auto &clone(v.flow_clone());
-        v.visit(e1, "e1");
-        clone.visit(e2, "e2");
-        v.flow_merge(clone); }
+        SplitFlowVisit<Expression>(v, e1, e2).run_visit(); }
     Mux { if (type->is<Type::Unknown>() && e1 && e2 && e1->type == e2->type) type = e1->type; }
 }
 
@@ -378,7 +375,7 @@ class SelectExpression : Expression {
     inline Vector<SelectCase> selectCases;
     visit_children {
         v.visit(select, "select");
-        v.parallel_visit(selectCases, "selectCases"); }
+        SplitFlowVisitVector<SelectCase>(v, selectCases).run_visit(); }
 }
 
 class MethodCallExpression : Expression {

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -446,11 +446,7 @@ class IfStatement : Statement {
     NullOK Statement ifFalse;
     visit_children {
         v.visit(condition, "condition");
-        auto &clone(v.flow_clone());
-        v.visit(ifTrue, "ifTrue");
-        clone.visit(ifFalse, "ifFalse");
-        v.flow_merge(clone);
-    }
+        SplitFlowVisit<Statement>(v, ifTrue, ifFalse).run_visit(); }
 }
 
 class BlockStatement : Statement, ISimpleNamespace, IAnnotated {
@@ -494,7 +490,9 @@ class SwitchStatement : Statement {
     inline Vector<SwitchCase> cases;
     visit_children {
         v.visit(expression, "expression");
-        v.parallel_visit(cases, "cases"); }
+        SplitFlowVisit<SwitchCase> split(v);
+        for (auto &c : cases) split.addNode(c);
+        split.run_visit(); }
 }
 
 class Function : Declaration, IFunctional, ISimpleNamespace, INestedNamespace {

--- a/ir/v1.def
+++ b/ir/v1.def
@@ -143,10 +143,7 @@ class If :  Expression {
     NullOK Vector<Expression>    ifFalse;
     visit_children {
         v.visit(pred, "pred");
-        auto &clone(v.flow_clone());
-        v.visit(ifTrue, "ifTrue");
-        clone.visit(ifFalse, "ifFalse");
-        v.flow_merge(clone);
+        SplitFlowVisit<Vector<Expression>>(v, ifTrue, ifFalse).run_visit();
         Expression::visit_children(v);
     }
 }

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -185,6 +185,15 @@ void DoLocalCopyPropagation::flow_merge(Visitor &a_) {
     }
     need_key_rewrite |= a.need_key_rewrite;
 }
+void DoLocalCopyPropagation::flow_copy(ControlFlowVisitor &a_) {
+    auto &a = dynamic_cast<DoLocalCopyPropagation &>(a_);
+    BUG_CHECK(working == a.working, "inconsistent DoLocalCopyPropagation state on copy");
+    available = a.available;
+    need_key_rewrite = a.need_key_rewrite;
+    BUG_CHECK(inferForTable == a.inferForTable,
+              "inconsistent DoLocalCopyPropagation state on copy");
+    BUG_CHECK(inferForFunc == a.inferForFunc, "inconsistent DoLocalCopyPropagation state on copy");
+}
 
 /// test to see if names denote overlapping locations
 bool DoLocalCopyPropagation::name_overlap(cstring name1, cstring name2) {

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -86,6 +86,7 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
 
     DoLocalCopyPropagation *clone() const override { return new DoLocalCopyPropagation(*this); }
     void flow_merge(Visitor &) override;
+    void flow_copy(ControlFlowVisitor &) override;
     bool name_overlap(cstring, cstring);
     void forOverlapAvail(cstring, std::function<void(cstring, VarInfo *)>);
     void dropValuesUsing(cstring);


### PR DESCRIPTION
- SplitFlowVisitor manages the flow_clone/flow_merge calls for nodes that want to visit children "in parallel".
- join_flows can visit other parallel branches on the stack in order to (try to) visit all parents before visiting the child.
- flow_copy method needed for ControlFlowVisitors to update(replace) the state rather than merging.
- BackwardCompatibleBroken flag to preserve/restore old behavior, for incremental update