### PR TITLE
add a feature to control logging via an annotation on annotated IR ob…

### DIFF
--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -74,7 +74,7 @@ class P4TestOptions : public CompilerOptions {
             "read previously dumped json instead of P4 source code");
         registerOption(
             "--turn-off-logn", nullptr,
-            [this](const char *) {
+            [](const char *) {
                 ::Log::Detail::enableLoggingGlobally = false;
                 return true;
             },

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -72,6 +72,14 @@ class P4TestOptions : public CompilerOptions {
                 return true;
             },
             "read previously dumped json instead of P4 source code");
+        registerOption(
+            "--turn-off-logn", nullptr,
+            [this](const char *) {
+                ::Log::Detail::enableLoggingGlobally = false;
+                return true;
+            },
+            "Turn off LOGN() statements in the compiler.\n"
+            "Use '@__debug' annotation to enable LOGN on the annotated P4 object within the source code.\n");
     }
 };
 

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -79,7 +79,8 @@ class P4TestOptions : public CompilerOptions {
                 return true;
             },
             "Turn off LOGN() statements in the compiler.\n"
-            "Use '@__debug' annotation to enable LOGN on the annotated P4 object within the source code.\n");
+            "Use '@__debug' annotation to enable LOGN on "
+            "the annotated P4 object within the source code.\n");
     }
 };
 

--- a/ir/base.def
+++ b/ir/base.def
@@ -289,6 +289,7 @@ class Annotation {
     static const cstring noWarnAnnotation;  /// noWarn annotation.
     static const cstring matchAnnotation;  /// Match annotation (for value sets).
     static const cstring fieldListAnnotation;  /// Used for recirculate, etc.
+    static const cstring debugLoggingAnnotation;  /// Used by compiler implementer to limit debug log to the annotated IR context.
     toString{ return cstring("@") + name; }
     validate{
         BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name");

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -70,6 +70,7 @@ const cstring IR::Annotation::noSideEffectsAnnotation = "noSideEffects";
 const cstring IR::Annotation::noWarnAnnotation = "noWarn";
 const cstring IR::Annotation::matchAnnotation = "match";
 const cstring IR::Annotation::fieldListAnnotation = "field_list";
+const cstring IR::Annotation::debugLoggingAnnotation = "__debug";
 
 int Type_Declaration::nextId = 0;
 int Type_InfInt::nextId = 0;

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -553,12 +553,12 @@ class SplitFlowVisit : public SplitFlowVisit_base {
         const_nodes.emplace_back(&node);
     }
     template <class T1, class T2, class... Args>
-    void addNode(T1 &&t1, T2 &&t2, Args &&...args) {
+    void addNode(T1 &&t1, T2 &&t2, Args &&... args) {
         addNode(std::forward<T1>(t1));
         addNode(std::forward<T2>(t2), std::forward<Args>(args)...);
     }
     template <class... Args>
-    explicit SplitFlowVisit(Visitor &v, Args &&...args) : SplitFlowVisit(v) {
+    explicit SplitFlowVisit(Visitor &v, Args &&... args) : SplitFlowVisit(v) {
         addNode(std::forward<Args>(args)...);
     }
     void do_visit() override {

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -553,12 +553,12 @@ class SplitFlowVisit : public SplitFlowVisit_base {
         const_nodes.emplace_back(&node);
     }
     template <class T1, class T2, class... Args>
-    void addNode(T1 &&t1, T2 &&t2, Args &&... args) {
+    void addNode(T1 &&t1, T2 &&t2, Args &&...args) {
         addNode(std::forward<T1>(t1));
         addNode(std::forward<T2>(t2), std::forward<Args>(args)...);
     }
     template <class... Args>
-    explicit SplitFlowVisit(Visitor &v, Args &&... args) : SplitFlowVisit(v) {
+    explicit SplitFlowVisit(Visitor &v, Args &&...args) : SplitFlowVisit(v) {
         addNode(std::forward<Args>(args)...);
     }
     void do_visit() override {

--- a/lib/log.cpp
+++ b/lib/log.cpp
@@ -43,6 +43,8 @@ namespace Detail {
 
 int verbosity = 0;
 int maximumLogLevel = 0;
+bool enableLoggingGlobally = true;
+bool enableLoggingInContext = false;
 
 // The time at which logging was initialized; used so that log messages can have
 // relative rather than absolute timestamps.

--- a/lib/log.h
+++ b/lib/log.h
@@ -106,7 +106,7 @@ void increaseVerbosity();
 
 #define LOGGING(N)                                                            \
     ((N) <= MAX_LOGGING_LEVEL && ::Log::fileLogLevelIsAtLeast(__FILE__, N) && \
-    ::Log::enableLogging())
+     ::Log::enableLogging())
 #define LOGN(N, X)                                                        \
     (LOGGING(N) ? ::Log::Detail::fileLogOutput(__FILE__)                  \
                       << ::Log::Detail::OutputLogPrefix(__FILE__, N) << X \

--- a/lib/log.h
+++ b/lib/log.h
@@ -37,6 +37,10 @@ extern int verbosity;
 // A cache of the maximum log level requested for any file.
 extern int maximumLogLevel;
 
+// Used to restrict logging to a specific IR context.
+extern bool enableLoggingGlobally;
+extern bool enableLoggingInContext;  // if enableLoggingGlobally is true, this is ignored.
+
 // Look up the log level of @file.
 int fileLogLevel(const char *file);
 std::ostream &fileLogOutput(const char *file);
@@ -88,6 +92,9 @@ void addDebugSpec(const char *spec);
 
 inline bool verbose() { return Detail::verbosity > 0; }
 inline int verbosity() { return Detail::verbosity; }
+inline bool enableLogging() {
+    return Detail::enableLoggingGlobally || Detail::enableLoggingInContext;
+}
 void increaseVerbosity();
 
 }  // namespace Log
@@ -97,7 +104,9 @@ void increaseVerbosity();
 #define MAX_LOGGING_LEVEL 10
 #endif
 
-#define LOGGING(N) ((N) <= MAX_LOGGING_LEVEL && ::Log::fileLogLevelIsAtLeast(__FILE__, N))
+#define LOGGING(N)                                                            \
+    ((N) <= MAX_LOGGING_LEVEL && ::Log::fileLogLevelIsAtLeast(__FILE__, N) && \
+    ::Log::enableLogging())
 #define LOGN(N, X)                                                        \
     (LOGGING(N) ? ::Log::Detail::fileLogOutput(__FILE__)                  \
                       << ::Log::Detail::OutputLogPrefix(__FILE__, N) << X \

--- a/testdata/p4_16_samples/basic2-bmv2.p4
+++ b/testdata/p4_16_samples/basic2-bmv2.p4
@@ -78,6 +78,7 @@ control MyIngress(inout headers hdr,
     action ipv4_forward() {
     }
     
+    @__debug
     table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: ternary;

--- a/testdata/p4_16_samples_outputs/basic2-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/basic2-bmv2-first.p4
@@ -52,7 +52,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     action ipv4_forward() {
     }
-    table ipv4_lpm {
+    @__debug table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: ternary @name("hdr.ipv4.dstAddr");
             hdr.ipv4.srcAddr: lpm @name("hdr.ipv4.srcAddr");

--- a/testdata/p4_16_samples_outputs/basic2-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/basic2-bmv2-frontend.p4
@@ -52,7 +52,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @name("MyIngress.ipv4_forward") action ipv4_forward() {
     }
-    @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
+    @__debug @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
         key = {
             hdr.ipv4.dstAddr: ternary @name("hdr.ipv4.dstAddr");
             hdr.ipv4.srcAddr: lpm @name("hdr.ipv4.srcAddr");

--- a/testdata/p4_16_samples_outputs/basic2-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/basic2-bmv2-midend.p4
@@ -50,7 +50,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     @name("MyIngress.ipv4_forward") action ipv4_forward() {
     }
-    @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
+    @__debug @name("MyIngress.ipv4_lpm") table ipv4_lpm_0 {
         key = {
             hdr.ipv4.dstAddr: ternary @name("hdr.ipv4.dstAddr");
             hdr.ipv4.srcAddr: lpm @name("hdr.ipv4.srcAddr");

--- a/testdata/p4_16_samples_outputs/basic2-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/basic2-bmv2.p4
@@ -52,7 +52,7 @@ control MyIngress(inout headers hdr, inout metadata meta, inout standard_metadat
     }
     action ipv4_forward() {
     }
-    table ipv4_lpm {
+    @__debug table ipv4_lpm {
         key = {
             hdr.ipv4.dstAddr: ternary;
             hdr.ipv4.srcAddr: lpm;

--- a/testdata/p4_16_samples_outputs/basic2-bmv2.p4.p4info.txt
+++ b/testdata/p4_16_samples_outputs/basic2-bmv2.p4.p4info.txt
@@ -6,6 +6,7 @@ tables {
     id: 37375156
     name: "MyIngress.ipv4_lpm"
     alias: "ipv4_lpm"
+    annotations: "@__debug"
   }
   match_fields {
     id: 1


### PR DESCRIPTION
…ject only

To use this feature, backend can set the enableLoggingGlobally to false based on a command line flag or a custom annotation, and set the enableLoggingInContext to true on the annotated IR class. 

This helps to filter excessive logging in our backend to focus on certain instance of IR class that is touched by a pass.