### PR TITLE
Avoid hang in typechecking

### DIFF
--- a/frontends/p4/typeChecking/typeSubstitutionVisitor.cpp
+++ b/frontends/p4/typeChecking/typeSubstitutionVisitor.cpp
@@ -58,8 +58,9 @@ const IR::Node *TypeVariableSubstitutionVisitor::replacement(const IR::ITypeVar 
         replacement = type;
         if (!type->is<IR::ITypeVar>()) break;
         current = type->to<IR::ITypeVar>();
+        if (type == current->getNode()) break;
     }
-    if (replacement == nullptr) return node;
+    if (replacement == nullptr || replacement == original->getNode()) return node;
     LOG2("Replacing " << getOriginal() << " with " << replacement);
     return replacement;
 }

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -265,6 +265,8 @@ bool TypeUnification::unify(const BinaryConstraint *constraint) {
 
     if (src->is<IR::Type_Dontcare>() || dest->is<IR::Type_Dontcare>()) return true;
 
+    if (src->is<IR::Type_InfInt>() && dest->is<IR::Type_InfInt>()) return true;
+
     if (dest->is<IR::Type_ArchBlock>()) {
         // This case handles the comparison of Type_Parser with P4Parser
         // (and similarly for controls).

--- a/testdata/p4_16_samples/issue3886.p4
+++ b/testdata/p4_16_samples/issue3886.p4
@@ -1,0 +1,108 @@
+/*
+Copyright 2023 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+
+control C1(in bit<48> address, inout bit<4> val, in bool valid)(int Size)
+{
+  action A(bit<4> v) {val = v;}
+  action B() {val = 0;}
+  table lookup {
+    key = {address : exact;}
+    actions = {A; B;}
+    const default_action = A((((1<<4)-1)));
+    size = Size;
+  }
+  apply {
+    if(valid)
+      lookup.apply();
+    else A((((1<<4)-1)));
+  }
+}
+
+control C1b(in bit<48> address, inout bit<4> val)(int Size)
+{
+  action A(bit<4> v) {val = v;}
+  action B() {val = 0;}
+  table lookup {
+    key = {address : exact;}
+    actions = {A; B;}
+    const default_action = A((((1<<4)-1)));
+    size = Size;
+  }
+  apply {
+    lookup.apply();
+  }
+}
+
+control C2(
+  in bit<48> srcMacO, in bit<48> dstMacO, in bit<48> srcMacI, in bit<48> dstMacI,
+  in bool outerEthValid, in bool innerEthValid,
+  inout bit<4> valFinal)
+(int macSize, int macSizeI, int oSize)
+{
+  bit<4> val1 = 0;
+  bit<4> val2 = 0;
+  bit<4> val3 = 0;
+  bit<4> val4 = 0;
+  bit<4> val5 = 0;
+
+  C1(macSize) outerDst;
+  C1(macSize) outerSrc;
+  C1(macSizeI) innerDst;
+  C1(macSizeI) innerSrc;
+  C1b(oSize) other;
+
+  apply {
+    outerDst.apply(dstMacO,val1,outerEthValid);
+    outerSrc.apply(srcMacO,val2,outerEthValid);
+    innerDst.apply(dstMacI,val3,innerEthValid);
+    innerSrc.apply(srcMacI,val4,innerEthValid);
+    other.apply(srcMacI,val5);
+  }
+}
+
+header eth_t {
+  bit<48> dstAddr;
+  bit<48> srcAddr;
+  bit<16> etherType;
+}
+
+struct internal_t {
+  bit<4>  val;
+}
+
+struct headers_t {
+  eth_t baseEth;
+  eth_t extEth;
+  internal_t internal;
+}
+
+control ingress(inout headers_t hdr)
+{
+  C2(65536,65536,4096) c2;
+  apply {
+      c2.apply(hdr.baseEth.srcAddr,hdr.baseEth.dstAddr,hdr.extEth.srcAddr,hdr.extEth.dstAddr,
+               hdr.baseEth.isValid(), hdr.extEth.isValid(), hdr.internal.val);
+  }
+}
+
+control Ingress<H>(inout H hdr);
+package Pipeline<H>(Ingress<H> ingress);
+package Switch<H>(Pipeline<H> pipe);
+
+Pipeline(ingress()) ig;
+Switch(ig) main;

--- a/testdata/p4_16_samples_outputs/issue3886-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3886-first.p4
@@ -1,0 +1,100 @@
+#include <core.p4>
+
+control C1(in bit<48> address, inout bit<4> val, in bool valid)(int Size) {
+    action A(bit<4> v) {
+        val = v;
+    }
+    action B() {
+        val = 4w0;
+    }
+    table lookup {
+        key = {
+            address: exact @name("address");
+        }
+        actions = {
+            A();
+            B();
+        }
+        const default_action = A(4w15);
+        size = Size;
+    }
+    apply {
+        if (valid) {
+            lookup.apply();
+        } else {
+            A(4w15);
+        }
+    }
+}
+
+control C1b(in bit<48> address, inout bit<4> val)(int Size) {
+    action A(bit<4> v) {
+        val = v;
+    }
+    action B() {
+        val = 4w0;
+    }
+    table lookup {
+        key = {
+            address: exact @name("address");
+        }
+        actions = {
+            A();
+            B();
+        }
+        const default_action = A(4w15);
+        size = Size;
+    }
+    apply {
+        lookup.apply();
+    }
+}
+
+control C2(in bit<48> srcMacO, in bit<48> dstMacO, in bit<48> srcMacI, in bit<48> dstMacI, in bool outerEthValid, in bool innerEthValid, inout bit<4> valFinal)(int macSize, int macSizeI, int oSize) {
+    bit<4> val1 = 4w0;
+    bit<4> val2 = 4w0;
+    bit<4> val3 = 4w0;
+    bit<4> val4 = 4w0;
+    bit<4> val5 = 4w0;
+    C1(macSize) outerDst;
+    C1(macSize) outerSrc;
+    C1(macSizeI) innerDst;
+    C1(macSizeI) innerSrc;
+    C1b(oSize) other;
+    apply {
+        outerDst.apply(dstMacO, val1, outerEthValid);
+        outerSrc.apply(srcMacO, val2, outerEthValid);
+        innerDst.apply(dstMacI, val3, innerEthValid);
+        innerSrc.apply(srcMacI, val4, innerEthValid);
+        other.apply(srcMacI, val5);
+    }
+}
+
+header eth_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct internal_t {
+    bit<4> val;
+}
+
+struct headers_t {
+    eth_t      baseEth;
+    eth_t      extEth;
+    internal_t internal;
+}
+
+control ingress(inout headers_t hdr) {
+    C2(65536, 65536, 4096) c2;
+    apply {
+        c2.apply(hdr.baseEth.srcAddr, hdr.baseEth.dstAddr, hdr.extEth.srcAddr, hdr.extEth.dstAddr, hdr.baseEth.isValid(), hdr.extEth.isValid(), hdr.internal.val);
+    }
+}
+
+control Ingress<H>(inout H hdr);
+package Pipeline<H>(Ingress<H> ingress);
+package Switch<H>(Pipeline<H> pipe);
+Pipeline<headers_t>(ingress()) ig;
+Switch<headers_t>(ig) main;

--- a/testdata/p4_16_samples_outputs/issue3886-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue3886-frontend.p4
@@ -1,0 +1,132 @@
+#include <core.p4>
+
+header eth_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct internal_t {
+    bit<4> val;
+}
+
+struct headers_t {
+    eth_t      baseEth;
+    eth_t      extEth;
+    internal_t internal;
+}
+
+control ingress(inout headers_t hdr) {
+    @name("ingress.c2.outerDst.A") action c2_outerDst_A_0(@name("v") bit<4> v) {
+    }
+    @name("ingress.c2.outerDst.A") action c2_outerDst_A_1() {
+    }
+    @name("ingress.c2.outerDst.B") action c2_outerDst_B_0() {
+    }
+    @name("ingress.c2.outerDst.lookup") table c2_outerDst_lookup {
+        key = {
+            hdr.baseEth.dstAddr: exact @name("address");
+        }
+        actions = {
+            c2_outerDst_A_0();
+            c2_outerDst_B_0();
+        }
+        const default_action = c2_outerDst_A_0(4w15);
+        size = 65536;
+    }
+    @name("ingress.c2.outerSrc.A") action c2_outerSrc_A_0(@name("v") bit<4> v_3) {
+    }
+    @name("ingress.c2.outerSrc.A") action c2_outerSrc_A_1() {
+    }
+    @name("ingress.c2.outerSrc.B") action c2_outerSrc_B_0() {
+    }
+    @name("ingress.c2.outerSrc.lookup") table c2_outerSrc_lookup {
+        key = {
+            hdr.baseEth.srcAddr: exact @name("address");
+        }
+        actions = {
+            c2_outerSrc_A_0();
+            c2_outerSrc_B_0();
+        }
+        const default_action = c2_outerSrc_A_0(4w15);
+        size = 65536;
+    }
+    @name("ingress.c2.innerDst.A") action c2_innerDst_A_0(@name("v") bit<4> v_5) {
+    }
+    @name("ingress.c2.innerDst.A") action c2_innerDst_A_1() {
+    }
+    @name("ingress.c2.innerDst.B") action c2_innerDst_B_0() {
+    }
+    @name("ingress.c2.innerDst.lookup") table c2_innerDst_lookup {
+        key = {
+            hdr.extEth.dstAddr: exact @name("address");
+        }
+        actions = {
+            c2_innerDst_A_0();
+            c2_innerDst_B_0();
+        }
+        const default_action = c2_innerDst_A_0(4w15);
+        size = 65536;
+    }
+    @name("ingress.c2.innerSrc.A") action c2_innerSrc_A_0(@name("v") bit<4> v_7) {
+    }
+    @name("ingress.c2.innerSrc.A") action c2_innerSrc_A_1() {
+    }
+    @name("ingress.c2.innerSrc.B") action c2_innerSrc_B_0() {
+    }
+    @name("ingress.c2.innerSrc.lookup") table c2_innerSrc_lookup {
+        key = {
+            hdr.extEth.srcAddr: exact @name("address");
+        }
+        actions = {
+            c2_innerSrc_A_0();
+            c2_innerSrc_B_0();
+        }
+        const default_action = c2_innerSrc_A_0(4w15);
+        size = 65536;
+    }
+    @name("ingress.c2.other.A") action c2_other_A_0(@name("v") bit<4> v_9) {
+    }
+    @name("ingress.c2.other.B") action c2_other_B_0() {
+    }
+    @name("ingress.c2.other.lookup") table c2_other_lookup {
+        key = {
+            hdr.extEth.srcAddr: exact @name("address");
+        }
+        actions = {
+            c2_other_A_0();
+            c2_other_B_0();
+        }
+        const default_action = c2_other_A_0(4w15);
+        size = 4096;
+    }
+    apply {
+        if (hdr.baseEth.isValid()) {
+            c2_outerDst_lookup.apply();
+        } else {
+            c2_outerDst_A_1();
+        }
+        if (hdr.baseEth.isValid()) {
+            c2_outerSrc_lookup.apply();
+        } else {
+            c2_outerSrc_A_1();
+        }
+        if (hdr.extEth.isValid()) {
+            c2_innerDst_lookup.apply();
+        } else {
+            c2_innerDst_A_1();
+        }
+        if (hdr.extEth.isValid()) {
+            c2_innerSrc_lookup.apply();
+        } else {
+            c2_innerSrc_A_1();
+        }
+        c2_other_lookup.apply();
+    }
+}
+
+control Ingress<H>(inout H hdr);
+package Pipeline<H>(Ingress<H> ingress);
+package Switch<H>(Pipeline<H> pipe);
+Pipeline<headers_t>(ingress()) ig;
+Switch<headers_t>(ig) main;

--- a/testdata/p4_16_samples_outputs/issue3886-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue3886-midend.p4
@@ -1,0 +1,156 @@
+#include <core.p4>
+
+header eth_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct internal_t {
+    bit<4> val;
+}
+
+struct headers_t {
+    eth_t  _baseEth0;
+    eth_t  _extEth1;
+    bit<4> _internal_val2;
+}
+
+control ingress(inout headers_t hdr) {
+    @name("ingress.c2.outerDst.A") action c2_outerDst_A_0(@name("v") bit<4> v) {
+    }
+    @name("ingress.c2.outerDst.A") action c2_outerDst_A_1() {
+    }
+    @name("ingress.c2.outerDst.B") action c2_outerDst_B_0() {
+    }
+    @name("ingress.c2.outerDst.lookup") table c2_outerDst_lookup {
+        key = {
+            hdr._baseEth0.dstAddr: exact @name("address");
+        }
+        actions = {
+            c2_outerDst_A_0();
+            c2_outerDst_B_0();
+        }
+        const default_action = c2_outerDst_A_0(4w15);
+        size = 65536;
+    }
+    @name("ingress.c2.outerSrc.A") action c2_outerSrc_A_0(@name("v") bit<4> v_3) {
+    }
+    @name("ingress.c2.outerSrc.A") action c2_outerSrc_A_1() {
+    }
+    @name("ingress.c2.outerSrc.B") action c2_outerSrc_B_0() {
+    }
+    @name("ingress.c2.outerSrc.lookup") table c2_outerSrc_lookup {
+        key = {
+            hdr._baseEth0.srcAddr: exact @name("address");
+        }
+        actions = {
+            c2_outerSrc_A_0();
+            c2_outerSrc_B_0();
+        }
+        const default_action = c2_outerSrc_A_0(4w15);
+        size = 65536;
+    }
+    @name("ingress.c2.innerDst.A") action c2_innerDst_A_0(@name("v") bit<4> v_5) {
+    }
+    @name("ingress.c2.innerDst.A") action c2_innerDst_A_1() {
+    }
+    @name("ingress.c2.innerDst.B") action c2_innerDst_B_0() {
+    }
+    @name("ingress.c2.innerDst.lookup") table c2_innerDst_lookup {
+        key = {
+            hdr._extEth1.dstAddr: exact @name("address");
+        }
+        actions = {
+            c2_innerDst_A_0();
+            c2_innerDst_B_0();
+        }
+        const default_action = c2_innerDst_A_0(4w15);
+        size = 65536;
+    }
+    @name("ingress.c2.innerSrc.A") action c2_innerSrc_A_0(@name("v") bit<4> v_7) {
+    }
+    @name("ingress.c2.innerSrc.A") action c2_innerSrc_A_1() {
+    }
+    @name("ingress.c2.innerSrc.B") action c2_innerSrc_B_0() {
+    }
+    @name("ingress.c2.innerSrc.lookup") table c2_innerSrc_lookup {
+        key = {
+            hdr._extEth1.srcAddr: exact @name("address");
+        }
+        actions = {
+            c2_innerSrc_A_0();
+            c2_innerSrc_B_0();
+        }
+        const default_action = c2_innerSrc_A_0(4w15);
+        size = 65536;
+    }
+    @name("ingress.c2.other.A") action c2_other_A_0(@name("v") bit<4> v_9) {
+    }
+    @name("ingress.c2.other.B") action c2_other_B_0() {
+    }
+    @name("ingress.c2.other.lookup") table c2_other_lookup {
+        key = {
+            hdr._extEth1.srcAddr: exact @name("address");
+        }
+        actions = {
+            c2_other_A_0();
+            c2_other_B_0();
+        }
+        const default_action = c2_other_A_0(4w15);
+        size = 4096;
+    }
+    @hidden table tbl_c2_outerDst_A {
+        actions = {
+            c2_outerDst_A_1();
+        }
+        const default_action = c2_outerDst_A_1();
+    }
+    @hidden table tbl_c2_outerSrc_A {
+        actions = {
+            c2_outerSrc_A_1();
+        }
+        const default_action = c2_outerSrc_A_1();
+    }
+    @hidden table tbl_c2_innerDst_A {
+        actions = {
+            c2_innerDst_A_1();
+        }
+        const default_action = c2_innerDst_A_1();
+    }
+    @hidden table tbl_c2_innerSrc_A {
+        actions = {
+            c2_innerSrc_A_1();
+        }
+        const default_action = c2_innerSrc_A_1();
+    }
+    apply {
+        if (hdr._baseEth0.isValid()) {
+            c2_outerDst_lookup.apply();
+        } else {
+            tbl_c2_outerDst_A.apply();
+        }
+        if (hdr._baseEth0.isValid()) {
+            c2_outerSrc_lookup.apply();
+        } else {
+            tbl_c2_outerSrc_A.apply();
+        }
+        if (hdr._extEth1.isValid()) {
+            c2_innerDst_lookup.apply();
+        } else {
+            tbl_c2_innerDst_A.apply();
+        }
+        if (hdr._extEth1.isValid()) {
+            c2_innerSrc_lookup.apply();
+        } else {
+            tbl_c2_innerSrc_A.apply();
+        }
+        c2_other_lookup.apply();
+    }
+}
+
+control Ingress<H>(inout H hdr);
+package Pipeline<H>(Ingress<H> ingress);
+package Switch<H>(Pipeline<H> pipe);
+Pipeline<headers_t>(ingress()) ig;
+Switch<headers_t>(ig) main;

--- a/testdata/p4_16_samples_outputs/issue3886.p4
+++ b/testdata/p4_16_samples_outputs/issue3886.p4
@@ -1,0 +1,100 @@
+#include <core.p4>
+
+control C1(in bit<48> address, inout bit<4> val, in bool valid)(int Size) {
+    action A(bit<4> v) {
+        val = v;
+    }
+    action B() {
+        val = 0;
+    }
+    table lookup {
+        key = {
+            address: exact;
+        }
+        actions = {
+            A;
+            B;
+        }
+        const default_action = A((1 << 4) - 1);
+        size = Size;
+    }
+    apply {
+        if (valid) {
+            lookup.apply();
+        } else {
+            A((1 << 4) - 1);
+        }
+    }
+}
+
+control C1b(in bit<48> address, inout bit<4> val)(int Size) {
+    action A(bit<4> v) {
+        val = v;
+    }
+    action B() {
+        val = 0;
+    }
+    table lookup {
+        key = {
+            address: exact;
+        }
+        actions = {
+            A;
+            B;
+        }
+        const default_action = A((1 << 4) - 1);
+        size = Size;
+    }
+    apply {
+        lookup.apply();
+    }
+}
+
+control C2(in bit<48> srcMacO, in bit<48> dstMacO, in bit<48> srcMacI, in bit<48> dstMacI, in bool outerEthValid, in bool innerEthValid, inout bit<4> valFinal)(int macSize, int macSizeI, int oSize) {
+    bit<4> val1 = 0;
+    bit<4> val2 = 0;
+    bit<4> val3 = 0;
+    bit<4> val4 = 0;
+    bit<4> val5 = 0;
+    C1(macSize) outerDst;
+    C1(macSize) outerSrc;
+    C1(macSizeI) innerDst;
+    C1(macSizeI) innerSrc;
+    C1b(oSize) other;
+    apply {
+        outerDst.apply(dstMacO, val1, outerEthValid);
+        outerSrc.apply(srcMacO, val2, outerEthValid);
+        innerDst.apply(dstMacI, val3, innerEthValid);
+        innerSrc.apply(srcMacI, val4, innerEthValid);
+        other.apply(srcMacI, val5);
+    }
+}
+
+header eth_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct internal_t {
+    bit<4> val;
+}
+
+struct headers_t {
+    eth_t      baseEth;
+    eth_t      extEth;
+    internal_t internal;
+}
+
+control ingress(inout headers_t hdr) {
+    C2(65536, 65536, 4096) c2;
+    apply {
+        c2.apply(hdr.baseEth.srcAddr, hdr.baseEth.dstAddr, hdr.extEth.srcAddr, hdr.extEth.dstAddr, hdr.baseEth.isValid(), hdr.extEth.isValid(), hdr.internal.val);
+    }
+}
+
+control Ingress<H>(inout H hdr);
+package Pipeline<H>(Ingress<H> ingress);
+package Switch<H>(Pipeline<H> pipe);
+Pipeline(ingress()) ig;
+Switch(ig) main;


### PR DESCRIPTION
Ran into this issue into a program and stripped it down to a smaller testcase.  The problem is inferring a type of `int` for a constructor param that can't (yet) be inferred to a concrete type.  This avoids the hang, but it is not clear if something more is needed