### PR TITLE
Install & use GCC 9 in Ubuntu 18 build

### DIFF
--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -100,6 +100,8 @@ if [[ "${DISTRIB_RELEASE}" == "18.04" ]] || [[ "$(which simple_switch 2> /dev/nu
   sudo apt-get update && sudo apt-get install -y software-properties-common
   sudo add-apt-repository -uy ppa:ubuntu-toolchain-r/test
   P4C_DEPS+=" libprotobuf-dev protobuf-compiler gcc-9 g++-9"
+  export CC=gcc-9
+  export CXX=g++-9
 else
   sudo apt-get update && sudo apt-get install -y curl gnupg
   echo "deb https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/ /" | sudo tee /etc/apt/sources.list.d/home:p4lang.list

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -96,7 +96,10 @@ P4C_RUNTIME_DEPS="cpp \
 
 # TODO: Remove this check once 18.04 is deprecated.
 if [[ "${DISTRIB_RELEASE}" == "18.04" ]] || [[ "$(which simple_switch 2> /dev/null)" != "" ]] ; then
-  P4C_DEPS+=" libprotobuf-dev protobuf-compiler"
+  # Use GCC 9 from https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
+  sudo apt-get update && sudo apt-get install -y software-properties-common
+  sudo add-apt-repository -uy ppa:ubuntu-toolchain-r/test
+  P4C_DEPS+=" libprotobuf-dev protobuf-compiler gcc-9 g++-9"
 else
   sudo apt-get update && sudo apt-get install -y curl gnupg
   echo "deb https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/ /" | sudo tee /etc/apt/sources.list.d/home:p4lang.list


### PR DESCRIPTION
Ubuntu 18 comes with GCC 7, but we don't officianlly support it, our support start with GCC 9. Therefore, it is expected that anyone using Ubuntu 18 will have to use GCC from elsewhere. The https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test PPA seems like the most likely source.