### PR TITLE
Dpdk backend: Add support for toeplitz hash

### DIFF
--- a/backends/dpdk/constants.h
+++ b/backends/dpdk/constants.h
@@ -45,7 +45,7 @@ const cstring tdiSchemaVersion = "0.1";
 #define CRC3 3
 #define CRC4 4
 #define JHASH5 5
-
+#define TOEPLITZ 6
 // Initial values for group_id and member_id for action selector and action profile tables
 const unsigned initial_member_id = 0;
 const unsigned initial_group_id = 0xFFFFFFFF;

--- a/backends/dpdk/dpdk.def
+++ b/backends/dpdk/dpdk.def
@@ -509,7 +509,15 @@ class DpdkChecksumClearStatement : DpdkAsmStatement, IDPDKNode {
 #nodbprint
 }
 
+class DpdkHashDeclStatement: DpdkAsmStatement {
+    cstring hash;
+    std::ostream& toSpec(std::ostream& out) const override;
+#nodbprint
+}
+
+
 class DpdkGetHashStatement : DpdkAsmStatement, IDPDKNode {
+    cstring instr;
     cstring hash;
     Expression fields;
     Expression dst;

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -679,6 +679,11 @@ class CollectExternDeclaration : public Inspector {
                     ::error(ErrorType::ERR_EXPECTED,
                             "%1%: expected size and optionally init_val as arguments", d);
                 }
+            } else if (externTypeName == "Hash") {
+                if (d->arguments->size() != 1) {
+                    ::error(ErrorType::ERR_EXPECTED,
+                            "%1%: expected hash algorithm as the only argument", d);
+                }
             } else {
                 // unsupported extern type
                 return false;

--- a/p4include/dpdk/pna.p4
+++ b/p4include/dpdk/pna.p4
@@ -271,6 +271,13 @@ match_kind {
 // BEGIN:Hash_algorithms
 enum PNA_HashAlgorithm_t {
   // TBD what this type's values will be for PNA
+  IDENTITY,
+  CRC32,
+  CRC32_CUSTOM,
+  CRC16,
+  CRC16_CUSTOM,
+  ONES_COMPLEMENT16,  /// One's complement 16-bit sum used for IPv4 headers,
+  TOEPLITZ,
   TARGET_DEFAULT      /// target implementation defined
 }
 // END:Hash_algorithms

--- a/testdata/p4_16_dpdk_errors_outputs/pna-example-ipsec-err3.p4-error
+++ b/testdata/p4_16_dpdk_errors_outputs/pna-example-ipsec-err3.p4-error
@@ -2,11 +2,11 @@ pna-example-ipsec-err3.p4(144): [--Werror=type-error] error: ipsec.set_sa_index
   ipsec.set_sa_index<bit<32>, bit<8>>(sa_index);
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:
-pna.p4(516): set_sa_index: 1 type parameters expected, but 2 type arguments supplied
+pna.p4(523): set_sa_index: 1 type parameters expected, but 2 type arguments supplied
    void set_sa_index<T>(in T sa_index);
         ^^^^^^^^^^^^
   ---- Originating from:
-pna.p4(516): Function type 'set_sa_index' does not match invocation type '<Method call>'
+pna.p4(523): Function type 'set_sa_index' does not match invocation type '<Method call>'
    void set_sa_index<T>(in T sa_index);
         ^^^^^^^^^^^^
 pna-example-ipsec-err3.p4(144)

--- a/testdata/p4_16_pna_errors_outputs/pna-dpdk-direct-counter-err-3.p4-error
+++ b/testdata/p4_16_pna_errors_outputs/pna-dpdk-direct-counter-err-3.p4-error
@@ -1,3 +1,3 @@
-pna.p4(393): [--Werror=unexpected] error: count method of per_prefix_pkt_bytes_count extern can only be invoked from within action of ownertable
+pna.p4(400): [--Werror=unexpected] error: count method of per_prefix_pkt_bytes_count extern can only be invoked from within action of ownertable
   void count(in bit<32> pkt_len);
        ^^^^^

--- a/testdata/p4_16_samples/pna-dpdk-toeplitz-hash-1.p4
+++ b/testdata/p4_16_samples/pna-dpdk-toeplitz-hash-1.p4
@@ -1,0 +1,120 @@
+/*
+Copyright 2023 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct main_metadata_t {
+    bit<32> port;
+    bit<32> hash;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+        }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+Hash<bit<32>>(PNA_HashAlgorithm_t.CRC32) rss0;
+
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t main_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    apply {
+        main_meta.hash = rss0.get_hash({hdr.ipv4.srcAddr, hdr.ipv4.dstAddr});
+        main_meta.hash = main_meta.hash & 3;
+        main_meta.port = main_meta.hash;
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;

--- a/testdata/p4_16_samples/pna-dpdk-toeplitz-hash.p4
+++ b/testdata/p4_16_samples/pna-dpdk-toeplitz-hash.p4
@@ -1,0 +1,142 @@
+/*
+Copyright 2023 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+
+//////////////////////////////////////////////////////////////////////
+// Struct types for holding user-defined collections of headers and
+// metadata in the P4 developer's program.
+//
+// Note: The names of these struct types are completely up to the P4
+// developer, as are their member fields, with the only restriction
+// being that the structs intended to contain headers should only
+// contain members whose types are header, header stack, or
+// header_union.
+//////////////////////////////////////////////////////////////////////
+
+struct main_metadata_t {
+    // empty for this skeleton
+    bit<16> data;
+}
+
+// User-defined struct containing all of those headers parsed in the
+// main parser.
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+        }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout main_metadata_t main_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout main_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    Hash<bit<16>>(PNA_HashAlgorithm_t.TOEPLITZ) h;
+    action a1() {
+        user_meta.data = h.get_hash(hdr.ethernet);
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr : exact;
+        }
+        actions = { NoAction; a1; }
+    }
+
+    apply {
+        tbl.apply();
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;

--- a/testdata/p4_16_samples_outputs/pna-action-selector-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-action-selector-1.p4.spec
@@ -52,7 +52,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action a1 args instanceof a1_arg_t {
 	mov h.ethernet.dstAddr t.param
 	return

--- a/testdata/p4_16_samples_outputs/pna-action-selector.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-action-selector.p4.spec
@@ -48,7 +48,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-add-on-miss.p4.spec
@@ -41,7 +41,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-add_on_miss_action_name.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-add_on_miss_action_name.p4.spec
@@ -39,7 +39,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action ct_next_hop_0 args instanceof ct_next_hop_0_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-direction-main-parser-err.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-direction-main-parser-err.p4.spec
@@ -38,7 +38,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop_0 args instanceof next_hop_0_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-direction.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-direction.p4.spec
@@ -36,7 +36,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-dpdk-bvec_union.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-bvec_union.p4.spec
@@ -30,7 +30,6 @@ struct Meta {
 metadata instanceof Meta
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	extract h.h1

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter-learner.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter-learner.p4.spec
@@ -45,9 +45,7 @@ header ipv4 instanceof ipv4_t
 regarray per_prefix_pkt_bytes_count_0_packets size 0x40001 initval 0x0
 
 regarray per_prefix_pkt_bytes_count_0_bytes size 0x40001 initval 0x0
-
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-counter.p4.spec
@@ -33,15 +33,11 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray per_prefix_bytes_count_0 size 0x401 initval 0x0
-
 regarray per_prefix_pkt_bytes_count_0_packets size 0x401 initval 0x0
 
 regarray per_prefix_pkt_bytes_count_0_bytes size 0x401 initval 0x0
-
 regarray per_prefix_pkt_count_0 size 0x401 initval 0x0
-
 regarray direction size 0x100 initval 0
-
 action count_1 args none {
 	jmpneq LABEL_END m.local_metadata_data 0x8
 	entryid m.table_entry_index 

--- a/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-direct-meter-learner.p4.spec
@@ -47,9 +47,7 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 metarray meter0_0 size 0x40001
-
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-state-err.p4.spec
@@ -70,7 +70,6 @@ header ipv4 instanceof ipv4_t
 header tcp instanceof tcp_t
 
 regarray direction size 0x100 initval 0
-
 action do_range_checks_1 args instanceof do_range_checks_1_arg_t {
 	jmpgt LABEL_FALSE_2 t.min1 h.tcp.srcPort
 	jmpgt LABEL_FALSE_2 h.tcp.srcPort t.max1

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-1.p4.spec
@@ -43,7 +43,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-3.p4.spec
@@ -41,7 +41,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-4.p4.spec
@@ -45,7 +45,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-5.p4.spec
@@ -44,7 +44,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-6.p4.spec
@@ -44,7 +44,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-consolidation-learner-7.p4.spec
@@ -46,7 +46,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-table-key-use-annon.p4.spec
@@ -42,7 +42,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1-first.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct main_metadata_t {
+    bit<32> port;
+    bit<32> hash;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+Hash<bit<32>>(PNA_HashAlgorithm_t.CRC32) rss0;
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t main_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    apply {
+        main_meta.hash = rss0.get_hash<tuple<bit<32>, bit<32>>>({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        main_meta.hash = main_meta.hash & 32w3;
+        main_meta.port = main_meta.hash;
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1-frontend.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct main_metadata_t {
+    bit<32> port;
+    bit<32> hash;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+Hash<bit<32>>(PNA_HashAlgorithm_t.CRC32) rss0;
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t main_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    apply {
+        main_meta.hash = rss0.get_hash<tuple<bit<32>, bit<32>>>({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        main_meta.hash = main_meta.hash & 32w3;
+        main_meta.port = main_meta.hash;
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1-midend.p4
@@ -1,0 +1,93 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct main_metadata_t {
+    bit<32> port;
+    bit<32> hash;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+Hash<bit<32>>(PNA_HashAlgorithm_t.CRC32) rss0;
+struct tuple_0 {
+    bit<32> f0;
+    bit<32> f1;
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t main_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdktoeplitzhash1l94() {
+        main_meta.hash = rss0.get_hash<tuple_0>((tuple_0){f0 = hdr.ipv4.srcAddr,f1 = hdr.ipv4.dstAddr});
+        main_meta.hash = main_meta.hash & 32w3;
+        main_meta.port = main_meta.hash;
+    }
+    @hidden table tbl_pnadpdktoeplitzhash1l94 {
+        actions = {
+            pnadpdktoeplitzhash1l94();
+        }
+        const default_action = pnadpdktoeplitzhash1l94();
+    }
+    apply {
+        tbl_pnadpdktoeplitzhash1l94.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdktoeplitzhash1l107() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnadpdktoeplitzhash1l107 {
+        actions = {
+            pnadpdktoeplitzhash1l107();
+        }
+        const default_action = pnadpdktoeplitzhash1l107();
+    }
+    apply {
+        tbl_pnadpdktoeplitzhash1l107.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct main_metadata_t {
+    bit<32> port;
+    bit<32> hash;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+Hash<bit<32>>(PNA_HashAlgorithm_t.CRC32) rss0;
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t main_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    apply {
+        main_meta.hash = rss0.get_hash({ hdr.ipv4.srcAddr, hdr.ipv4.dstAddr });
+        main_meta.hash = main_meta.hash & 3;
+        main_meta.port = main_meta.hash;
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1.p4.bfrt.json
@@ -1,0 +1,5 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-1.p4.spec
@@ -1,0 +1,51 @@
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<32> local_metadata_port
+	bit<32> local_metadata_hash
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_0
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+regarray direction size 0x100 initval 0
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	mov m.MainControlT_tmp h.ipv4.srcAddr
+	mov m.MainControlT_tmp_0 h.ipv4.dstAddr
+	hash crc32 m.local_metadata_hash  m.MainControlT_tmp m.MainControlT_tmp_0
+	and m.local_metadata_hash 0x3
+	mov m.local_metadata_port m.local_metadata_hash
+	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-first.p4
@@ -1,0 +1,84 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    bit<16> data;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    Hash<bit<16>>(PNA_HashAlgorithm_t.TOEPLITZ) h;
+    action a1() {
+        user_meta.data = h.get_hash<ethernet_t>(hdr.ethernet);
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr");
+        }
+        actions = {
+            NoAction();
+            a1();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-frontend.p4
@@ -1,0 +1,86 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    bit<16> data;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.h") Hash<bit<16>>(PNA_HashAlgorithm_t.TOEPLITZ) h_0;
+    @name("MainControlImpl.a1") action a1() {
+        user_meta.data = h_0.get_hash<ethernet_t>(hdr.ethernet);
+    }
+    @name("MainControlImpl.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr");
+        }
+        actions = {
+            NoAction_1();
+            a1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash-midend.p4
@@ -1,0 +1,94 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    bit<16> data;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.h") Hash<bit<16>>(PNA_HashAlgorithm_t.TOEPLITZ) h_0;
+    @name("MainControlImpl.a1") action a1() {
+        user_meta.data = h_0.get_hash<ethernet_t>(hdr.ethernet);
+    }
+    @name("MainControlImpl.tbl") table tbl_0 {
+        key = {
+            hdr.ethernet.srcAddr: exact @name("hdr.ethernet.srcAddr");
+        }
+        actions = {
+            NoAction_1();
+            a1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tbl_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdktoeplitzhash129() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnadpdktoeplitzhash129 {
+        actions = {
+            pnadpdktoeplitzhash129();
+        }
+        const default_action = pnadpdktoeplitzhash129();
+    }
+    apply {
+        tbl_pnadpdktoeplitzhash129.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash.p4
@@ -1,0 +1,83 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct empty_metadata_t {
+}
+
+struct main_metadata_t {
+    bit<16> data;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout main_metadata_t main_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    Hash<bit<16>>(PNA_HashAlgorithm_t.TOEPLITZ) h;
+    action a1() {
+        user_meta.data = h.get_hash(hdr.ethernet);
+    }
+    table tbl {
+        key = {
+            hdr.ethernet.srcAddr: exact;
+        }
+        actions = {
+            NoAction;
+            a1;
+        }
+    }
+    apply {
+        tbl.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash.p4.bfrt.json
@@ -1,0 +1,48 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.tbl",
+      "id" : 40555198,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ethernet.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 48
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 21288828,
+          "name" : "MainControlImpl.a1",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-toeplitz-hash.p4.spec
@@ -1,0 +1,68 @@
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<16> local_metadata_data
+	bit<32> pna_main_output_metadata_output_port
+}
+metadata instanceof main_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+
+rss h_0
+regarray direction size 0x100 initval 0
+action NoAction args none {
+	return
+}
+
+action a1 args none {
+	rss h_0 m.local_metadata_data  h.ethernet.dstAddr h.ethernet.etherType
+	return
+}
+
+table tbl {
+	key {
+		h.ethernet.srcAddr exact
+	}
+	actions {
+		NoAction
+		a1
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	MAINPARSERIMPL_ACCEPT :	table tbl
+	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-dpdk-union-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-union-bmv2.p4.spec
@@ -18,7 +18,6 @@ struct Meta {
 metadata instanceof Meta
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	extract h.h1

--- a/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-elim-hdr-copy-dpdk.p4.spec
@@ -35,7 +35,6 @@ header ipv4 instanceof ipv4_t
 header ethernet1 instanceof ethernet_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	jmpnv LABEL_FALSE_1 h.ethernet
 	validate h.ethernet1

--- a/testdata/p4_16_samples_outputs/pna-example-SelectByDirection.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-SelectByDirection.p4.spec
@@ -34,7 +34,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-example-SelectByDirection1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-SelectByDirection1.p4.spec
@@ -34,7 +34,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-example-SelectByDirection2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-SelectByDirection2.p4.spec
@@ -35,7 +35,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action forward args instanceof forward_arg_t {
 	mov m.local_metadata_meta t.addr
 	return

--- a/testdata/p4_16_samples_outputs/pna-example-bAnd-in-tableKey.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-bAnd-in-tableKey.p4.spec
@@ -33,7 +33,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-optional.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-optional.p4.spec
@@ -32,7 +32,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit-1.p4.spec
@@ -56,7 +56,6 @@ header MainParserT_parser_tmp instanceof option_t
 header MainParserT_parser_lookahead_0 instanceof lookahead_tmp_hdr
 
 regarray direction size 0x100 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-dpdk-varbit.p4.spec
@@ -58,7 +58,6 @@ header MainParserT_parser_tmp_hdr instanceof option_t
 header MainParserT_parser_lookahead_0 instanceof lookahead_tmp_hdr
 
 regarray direction size 0x100 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/pna-example-header-union.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-header-union.p4.spec
@@ -25,7 +25,6 @@ struct metadata {
 metadata instanceof metadata
 
 regarray direction size 0x100 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/pna-example-header-union1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-header-union1.p4.spec
@@ -29,7 +29,6 @@ struct metadata {
 metadata instanceof metadata
 
 regarray direction size 0x100 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/pna-example-ipsec.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-ipsec.p4.spec
@@ -77,15 +77,10 @@ struct metadata_t {
 metadata instanceof metadata_t
 
 regarray ipsec_port_out_inbound size 0x1 initval 0
-
 regarray ipsec_port_out_outbound size 0x1 initval 0
-
 regarray ipsec_port_in_inbound size 0x1 initval 0
-
 regarray ipsec_port_in_outbound size 0x1 initval 0
-
 regarray direction size 0x100 initval 0
-
 action ipsec_enable args instanceof ipsec_enable_arg_t {
 	validate h.ipsec_hdr
 	mov h.ipsec_hdr.sa_id t.sa_index

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet-1.p4.spec
@@ -40,7 +40,6 @@ struct main_metadata_t {
 metadata instanceof main_metadata_t
 
 regarray direction size 0x100 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-mirror-packet.p4.spec
@@ -39,7 +39,6 @@ struct main_metadata_t {
 metadata instanceof main_metadata_t
 
 regarray direction size 0x100 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/pna-example-pass-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-pass-1.p4.spec
@@ -37,7 +37,6 @@ header ipv4 instanceof ipv4_t
 header udp instanceof udp_t
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/pna-example-pass-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-pass-2.p4.spec
@@ -35,7 +35,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	recircid m.pna_main_input_metadata_pass
 	jmpneq LABEL_FALSE_1 m.pna_main_input_metadata_pass 0x0

--- a/testdata/p4_16_samples_outputs/pna-example-pass-3.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-pass-3.p4.spec
@@ -39,7 +39,6 @@ header ipv4 instanceof ipv4_t
 header udp instanceof udp_t
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/pna-example-pass-parser.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-pass-parser.p4.spec
@@ -42,7 +42,6 @@ header ipv4 instanceof ipv4_t
 header udp instanceof udp_t
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/pna-example-pass.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-pass.p4.spec
@@ -37,7 +37,6 @@ header ipv4 instanceof ipv4_t
 header udp instanceof udp_t
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/pna-example-recirculate.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-recirculate.p4.spec
@@ -37,7 +37,6 @@ header ipv4 instanceof ipv4_t
 header udp instanceof udp_t
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	extract h.ethernet

--- a/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-tcp-connection-tracking.p4.spec
@@ -55,7 +55,6 @@ header ipv4 instanceof ipv4_t
 header tcp instanceof tcp_t
 
 regarray direction size 0x100 initval 0
-
 action tcp_syn_packet args none {
 	mov m.MainControlT_do_add_on_miss 1
 	mov m.MainControlT_update_aging_info 1

--- a/testdata/p4_16_samples_outputs/pna-example-template.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-template.p4.spec
@@ -32,7 +32,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	mov m.pna_main_output_metadata_output_port t.vport
 	return

--- a/testdata/p4_16_samples_outputs/pna-example-tunnel.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-tunnel.p4.spec
@@ -49,7 +49,6 @@ struct local_metadata_t {
 metadata instanceof local_metadata_t
 
 regarray direction size 0x100 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex-1.p4.spec
@@ -56,7 +56,6 @@ struct main_metadata_t {
 metadata instanceof main_metadata_t
 
 regarray direction size 0x100 initval 0
-
 action execute_1 args none {
 	jmpneq LABEL_FALSE_2 m.local_metadata_depth 0x0
 	mov m.MainControlT_tmp_1 m.local_metadata_depth

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex-2.p4.spec
@@ -51,7 +51,6 @@ struct main_metadata_t {
 metadata instanceof main_metadata_t
 
 regarray direction size 0x100 initval 0
-
 action execute_1 args none {
 	jmpneq LABEL_FALSE_1 m.local_metadata_depth 0x0
 	mov m.MainControlT_tmp_7 h.vlan_tag_0.pcp_cfi_vid

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex.p4.spec
@@ -62,7 +62,6 @@ struct main_metadata_t {
 metadata instanceof main_metadata_t
 
 regarray direction size 0x100 initval 0
-
 action execute_1 args none {
 	mov m.MainControlT_tmp_1 m.local_metadata_depth
 	add m.MainControlT_tmp_1 0x3

--- a/testdata/p4_16_samples_outputs/pna-extract-local-header.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-extract-local-header.p4.spec
@@ -16,7 +16,6 @@ header h2 instanceof my_header_t
 header MainParserT_parser_local_hdr instanceof my_header_t
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	invalidate h.MainParserT_parser_local_hdr

--- a/testdata/p4_16_samples_outputs/pna-issue3041.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-issue3041.p4.spec
@@ -55,7 +55,6 @@ header ipv4_option_timestamp instanceof ipv4_option_timestamp_t
 header option instanceof option_t
 
 regarray direction size 0x100 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/pna-lookahead-structure-bit-field.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-lookahead-structure-bit-field.p4.spec
@@ -26,7 +26,6 @@ header h2 instanceof header2_t
 header MainParserT_parser_lookahead_0 instanceof lookahead_tmp_hdr
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	lookahead h.MainParserT_parser_lookahead_0

--- a/testdata/p4_16_samples_outputs/pna-lookahead-structure.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-lookahead-structure.p4.spec
@@ -40,7 +40,6 @@ header MainParserT_parser_lookahead_0 instanceof lookahead_tmp_hdr
 header MainParserT_parser_lookahead_1 instanceof lookahead_tmp_hdr_0
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	lookahead h.MainParserT_parser_lookahead_1

--- a/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-mux-dismantle.p4.spec
@@ -70,7 +70,6 @@ header ipv4 instanceof ipv4_t
 header tcp instanceof tcp_t
 
 regarray direction size 0x100 initval 0
-
 action do_range_checks_1 args instanceof do_range_checks_1_arg_t {
 	jmpgt LABEL_FALSE_1 t.min1 h.tcp.srcPort
 	jmpgt LABEL_FALSE_1 h.tcp.srcPort t.max1

--- a/testdata/p4_16_samples_outputs/pna-subparser.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-subparser.p4.spec
@@ -28,7 +28,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	invalidate h.ethernet

--- a/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-too-big-label-name-dpdk.p4.spec
@@ -35,7 +35,6 @@ header ipv4 instanceof ipv4_dddddddddddddddddddddddddddddddddddddddddd_t
 header ethernet1 instanceof ethernet_t
 
 regarray direction size 0x100 initval 0
-
 action next_hop args instanceof next_hop_arg_t {
 	jmpnv LABEL_FALSE_1 h.ethernet
 	validate h.ethernet1

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.spec
@@ -40,7 +40,6 @@ metadata instanceof metadata_t
 header ethernet instanceof ethernet_t
 
 regarray counter_0 size 0x400 initval 0x0
-
 action execute_1 args none {
 	regadd counter_0 0x100 1
 	return

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4.spec
@@ -36,7 +36,6 @@ metadata instanceof EMPTY
 header ethernet instanceof ethernet_t
 
 regarray counter_0 size 0x400 initval 0x0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4.spec
@@ -37,9 +37,7 @@ metadata instanceof EMPTY
 header ethernet instanceof ethernet_t
 
 regarray counter0_0 size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-counter3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter3.p4.spec
@@ -37,9 +37,7 @@ metadata instanceof EMPTY
 header ethernet instanceof ethernet_t
 
 regarray counter0_0 size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x1

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4.spec
@@ -36,7 +36,6 @@ metadata instanceof EMPTY
 header ethernet instanceof ethernet_t
 
 regarray counter0_0 size 0x10001 initval 0x0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.spec
@@ -36,7 +36,6 @@ metadata instanceof EMPTY
 header ethernet instanceof ethernet_t
 
 regarray counter_0 size 0x400 initval 0x0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-end-of-ingress-test-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-end-of-ingress-test-bmv2.p4.spec
@@ -57,7 +57,6 @@ header ethernet instanceof ethernet_t
 header output_data instanceof output_data_t
 
 regarray egress_pkt_seen_0 size 0x100 initval 0
-
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x1

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.spec
@@ -86,15 +86,10 @@ header ipv4 instanceof ipv4_t
 regarray counter0_0_packets size 0x400 initval 0x0
 
 regarray counter0_0_bytes size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 regarray counter2_0 size 0x400 initval 0x0
-
 regarray reg_0 size 0x400 initval 0
-
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4.spec
@@ -83,15 +83,10 @@ header ipv4 instanceof ipv4_t
 regarray counter0_0_packets size 0x400 initval 0x0
 
 regarray counter0_0_bytes size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 regarray counter2_0 size 0x400 initval 0x0
-
 regarray reg_0 size 0x400 initval 0
-
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.spec
@@ -88,15 +88,10 @@ header ipv4 instanceof ipv4_t
 regarray counter0_0_packets size 0x400 initval 0x0
 
 regarray counter0_0_bytes size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 regarray counter2_0 size 0x400 initval 0x0
-
 regarray reg_0 size 0x400 initval 0
-
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.spec
@@ -81,15 +81,10 @@ header ipv4 instanceof ipv4_t
 regarray counter0_0_packets size 0x400 initval 0x0
 
 regarray counter0_0_bytes size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 regarray counter2_0 size 0x400 initval 0x0
-
 regarray reg_0 size 0x400 initval 0
-
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.spec
@@ -89,15 +89,10 @@ header ipv4 instanceof ipv4_t
 regarray counter0_0_packets size 0x400 initval 0x0
 
 regarray counter0_0_bytes size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 regarray counter2_0 size 0x400 initval 0x0
-
 regarray reg_0 size 0x400 initval 0
-
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.spec
@@ -94,15 +94,10 @@ header ipv4 instanceof ipv4_t
 regarray counter0_0_packets size 0x400 initval 0x0
 
 regarray counter0_0_bytes size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 regarray counter2_0 size 0x400 initval 0x0
-
 regarray reg_0 size 0x400 initval 0
-
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.spec
@@ -91,15 +91,10 @@ header ipv4 instanceof ipv4_t
 regarray counter0_0_packets size 0x400 initval 0x0
 
 regarray counter0_0_bytes size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 regarray counter2_0 size 0x400 initval 0x0
-
 regarray reg_0 size 0x400 initval 0
-
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.spec
@@ -86,15 +86,10 @@ header ipv4 instanceof ipv4_t
 regarray counter0_0_packets size 0x400 initval 0x0
 
 regarray counter0_0_bytes size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 regarray counter2_0 size 0x400 initval 0x0
-
 regarray reg_0 size 0x400 initval 0
-
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-counter.p4.spec
@@ -40,11 +40,8 @@ header ethernet instanceof ethernet_t
 regarray counter0_0_packets size 0x400 initval 0x0
 
 regarray counter0_0_bytes size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 regarray counter2_0 size 0x400 initval 0x0
-
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x1

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter.p4.spec
@@ -41,7 +41,6 @@ struct metadata_t {
 metadata instanceof metadata_t
 
 metarray meter0_0 size 0x10001
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.spec
@@ -64,15 +64,10 @@ header ipv4 instanceof ipv4_t
 regarray counter0_0_packets size 0x400 initval 0x0
 
 regarray counter0_0_bytes size 0x400 initval 0x0
-
 regarray counter1_0 size 0x400 initval 0x0
-
 regarray counter2_0 size 0x400 initval 0x0
-
 regarray reg_0 size 0x400 initval 0
-
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.spec
@@ -57,7 +57,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.spec
@@ -58,7 +58,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 metarray meter0_0 size 0x400
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum.p4.spec
@@ -121,7 +121,6 @@ header cksum_state instanceof cksum_state_t
 header dpdk_pseudo_header instanceof dpdk_pseudo_header_t
 
 regarray parser_error_counts_0 size 0x10001 initval 0x0
-
 action set_error_idx args instanceof set_error_idx_arg_t {
 	entryid m.table_entry_index 
 	regadd parser_error_counts_0 m.table_entry_index 1

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.spec
@@ -64,7 +64,6 @@ header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
 
 regarray port_pkt_ip_bytes_in_0 size 0x200 initval 0
-
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x1

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4.spec
@@ -36,7 +36,6 @@ metadata instanceof EMPTY
 header ethernet instanceof ethernet_t
 
 metarray meter0_0 size 0x10001
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4.spec
@@ -36,7 +36,6 @@ metadata instanceof EMPTY
 header ethernet instanceof ethernet_t
 
 metarray meter0_0 size 0x10001
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-complex-bmv2.p4.spec
@@ -46,7 +46,6 @@ metadata instanceof metadata_t
 header ethernet instanceof ethernet_t
 
 regarray regfile_0 size 0x80 initval 0
-
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x1

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-2-bmv2.p4.spec
@@ -68,7 +68,6 @@ struct metadata_t {
 metadata instanceof metadata_t
 
 regarray reg_0 size 0x6 initval 0
-
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x1

--- a/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register-read-write-bmv2.p4.spec
@@ -41,7 +41,6 @@ metadata instanceof metadata_t
 header ethernet instanceof ethernet_t
 
 regarray regfile_0 size 0x80 initval 0
-
 apply {
 	rx m.psa_ingress_input_metadata_ingress_port
 	mov m.psa_ingress_output_metadata_drop 0x1

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.spec
@@ -40,7 +40,6 @@ metadata instanceof EMPTY
 header ethernet instanceof ethernet_t
 
 regarray reg_0 size 0x400 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.spec
@@ -41,7 +41,6 @@ metadata instanceof user_meta_t
 header ethernet instanceof ethernet_t
 
 regarray reg_0 size 0x400 initval 0
-
 action NoAction args none {
 	return
 }

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.spec
@@ -41,7 +41,6 @@ metadata instanceof user_meta_t
 header ethernet instanceof ethernet_t
 
 regarray reg_0 size 0x200 initval 0
-
 action NoAction args none {
 	return
 }


### PR DESCRIPTION
		
To support TOEPLITZ hash for RSS, DPDK target has introduced a new instruction called "rss" 
This instruction is similar to the already supported "hash" instruction but takes the rss type object instead of the hash algorithm.

The signature of hash extern remains the same. The algorithm should be specified as TOEPLITZ

**Existing instruction**: hash <hash_algo_name> dst srcfirst srclast
**New instruction**  :    rss <hash_object_name> dst srcfirst srclast

Reference dpdk patch : https://patches.dpdk.org/project/dpdk/patch/20230207164145.652805-1-cristian.dumitrescu@intel.com/
