### PR TITLE
Fix warnings in compilation using clang 15

### DIFF
--- a/backends/dpdk/dpdkContext.cpp
+++ b/backends/dpdk/dpdkContext.cpp
@@ -336,7 +336,6 @@ Util::JsonObject *DpdkContextGenerator::addMatchAttributes(const IR::P4Table *ta
         auto *immFldArray = new Util::JsonArray();
         if (attr.params) {
             int index = 0;
-            int position = 0;
             int param_width = 8;  // Minimum width for dpdk action params
             for (auto param : *(attr.params)) {
                 if (param->type->is<IR::Type_Bits>()) {
@@ -346,7 +345,6 @@ Util::JsonObject *DpdkContextGenerator::addMatchAttributes(const IR::P4Table *ta
                 }
                 addImmediateField(immFldArray, param->name.originalName, index / 8, param_width);
                 index += param_width;
-                position++;
             }
         }
         oneAction->emplace("immediate_fields", immFldArray);

--- a/backends/ubpf/ubpfTable.cpp
+++ b/backends/ubpf/ubpfTable.cpp
@@ -246,7 +246,6 @@ void UBPFTable::emitKeyType(EBPF::CodeBuilder *builder) {
     if (keyGenerator != nullptr) {
         // Use this to order elements by size
         std::multimap<size_t, const IR::KeyElement *> ordered;
-        unsigned fieldNumber = 0;
         for (auto c : keyGenerator->keyElements) {
             auto type = program->typeMap->getType(c->expression);
             auto ebpfType = UBPFTypeFactory::instance->create(type);
@@ -259,7 +258,6 @@ void UBPFTable::emitKeyType(EBPF::CodeBuilder *builder) {
             ordered.emplace(width, c);
             keyTypes.emplace(c, ebpfType);
             keyFieldNames.emplace(c, fieldName);
-            fieldNumber++;
         }
 
         // Emit key in decreasing order size - this way there will be no gaps

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -44,6 +44,12 @@ limitations under the License.
 #include "lib/cstring.h"
 #include "lib/source_file.h"
 
+#ifdef __clang__
+#if __clang_major__ >= 13
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#endif
+#endif
+
 namespace P4 {
 class AbstractP4Lexer;
 class P4ParserDriver;


### PR DESCRIPTION
Newer clang (13+) has some extra warnings for variables that are set and modified (e.g. `++`), but their value is never used. With these changes, build passes again with clang 15 and `-Werror`. I had to suppress the warning in `p4parser` as it is in generated code.