### PR TITLE
CMake build tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,14 +456,12 @@ set_source_files_properties(${IR_GENERATOR} PROPERTIES GENERATED TRUE)
 # tree when small changes to the .def files affect only the .cpp file and
 # not the headers.
 set (fixup_file "${CMAKE_CURRENT_BINARY_DIR}/irgen-fixup.awk")
-set_source_files_properties (${fixup_file} PROPERTIES GENERATED TRUE)
 file(WRITE "${fixup_file}" "/^#\$/ { printf \"#line %d \\\"${CMAKE_CURRENT_BINARY_DIR}/ir/%s\\\"\\n\", NR+1, name; next; } 1\n")
 set(temp_ir_genfiles
   ir/ir-generated.cpp.tmp ir/ir-generated.cpp.fixup
   ir/ir-generated.h.tmp   ir/ir-generated.h.fixup
   ir/gen-tree-macro.h.tmp ir/gen-tree-macro.h.fixup
   )
-set_source_files_properties (${temp_ir_genfiles} PROPERTIES GENERATED TRUE)
 
 add_custom_command (OUTPUT ${IR_GENERATED_SRCS}
   COMMAND ${IR_GENERATOR} -i ir/ir-generated.cpp.tmp -o ir/ir-generated.h.tmp -t ir/gen-tree-macro.h.tmp ${IR_DEF_FILES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 
 # If unity builds are enabled, choose an aggressive batch size.
 if (CMAKE_UNITY_BUILD)
-  set(CMAKE_UNITY_BUILD_BATCH_SIZE 16 CACHE UNINITIALIZED "Set the unity build batch size.")
+  set(CMAKE_UNITY_BUILD_BATCH_SIZE 10 CACHE UNINITIALIZED "Set the unity build batch size.")
 endif ()
 # set the required options for a static release build
 if (BUILD_STATIC_RELEASE)

--- a/backends/dpdk/CMakeLists.txt
+++ b/backends/dpdk/CMakeLists.txt
@@ -46,7 +46,6 @@ add_custom_command(
   )
 
 add_library(dpdk_runtime STATIC ${DPDK_P4RUNTIME_INFO_GEN_SRCS})
-set_source_files_properties (${DPDK_P4RUNTIME_INFO_GEN_SRCS} PROPERTIES GENERATED TRUE)
 
 set(P4C_DPDK_SOURCES
     ../bmv2/common/lower.cpp

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -100,8 +100,8 @@ set (CONTROLPLANE_HDRS
 
 include_directories (${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 # Silence -Warray-bounds as the root issue is out of our control: https://github.com/protocolbuffers/protobuf/issues/7140
-set_source_files_properties (${CONTROLPLANE_SOURCES} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds")
-set_source_files_properties (${P4RUNTIME_GEN_SRCS} PROPERTIES GENERATED TRUE)
+set_source_files_properties (${P4RUNTIME_GEN_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds")
+
 add_library (controlplane STATIC ${CONTROLPLANE_SOURCES} )
 target_link_libraries (controlplane ${PROTOBUF_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 add_dependencies (controlplane mkP4configdir genIR frontend)

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -216,7 +216,6 @@ macro(add_parser pname)
 
   # regardless of the output name, flex puts out yy.lex.c, so we use a custom command to generate
   # the file to stdout and redirect to the desired name
-  # FLEX_TARGET (${pname}Lexer parsers/${pname}/${pname}lexer.ll ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}lexer.cc)
   set (FLEX_${pname}Lexer_OUTPUTS ${CMAKE_CURRENT_BINARY_DIR}/parsers/${pname}/${pname}lexer.cc)
   set (FLEX_${pname}_INPUT ${CMAKE_CURRENT_SOURCE_DIR}/parsers/${pname}/${pname}lexer.ll)
   add_custom_command (OUTPUT ${FLEX_${pname}Lexer_OUTPUTS}
@@ -228,19 +227,12 @@ macro(add_parser pname)
     ${FLEX_${pname}Lexer_OUTPUTS}
     ${BISON_${pname}Parser_OUTPUTS}
     )
-  set_source_files_properties(${pname}PARSER_GEN_SRCS PROPERTIES GENERATED TRUE)
+  set_source_files_properties(${${pname}PARSER_GEN_SRCS} PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
+
 endmacro(add_parser)
 
 add_parser(v1)
 add_parser(p4)
-
-# BUILT_SOURCES += \
-# 	parsers/p4/p4parser.hpp \
-# 	parsers/v1/v1parser.hpp
-
-# noinst_HEADERS += \
-# 	parsers/p4/p4lexer.hpp \
-# 	parsers/v1/v1lexer.hpp
 
 set (FRONTEND_SOURCES
   ${IR_GENERATED_SRCS}
@@ -251,9 +243,6 @@ set (FRONTEND_SOURCES
   ${p4PARSER_GEN_SRCS}
   ${v1PARSER_GEN_SRCS}
   )
-
-set_source_files_properties(${p4PARSER_GEN_SRCS} PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
-set_source_files_properties(${v1PARSER_GEN_SRCS} PROPERTIES SKIP_UNITY_BUILD_INCLUSION TRUE)
 
 set_source_files_properties(${IR_GENERATED_SRCS} PROPERTIES GENERATED TRUE)
 

--- a/tools/ir-generator/CMakeLists.txt
+++ b/tools/ir-generator/CMakeLists.txt
@@ -37,7 +37,6 @@ set (IRGENERATOR_GEN_SRCS
   )
 
 include_directories (${CMAKE_CURRENT_BINARY_DIR})
-set_source_files_properties(${IRGENERATOR_GEN_SRCS} PROPERTIES GENERATED TRUE)
 set_source_files_properties(${IRGENERATOR_GEN_SRCS} PROPERTIES OBJECT_DEPENDS ${FLEX_IRgenLexer_OUTPUTS})
 add_executable (irgenerator ${IRGENERATOR_SRCS} ${IRGENERATOR_GEN_SRCS})
 # Unconditionally set the output directory for the irgenerator to the path


### PR DESCRIPTION
A smaller chunk size can help with compilation performance, it seems. Remove some commands that are no longer needed. 