### PR TITLE
Dpdk Backend: Add support for assignments to and from large (>64-bit) operand

### DIFF
--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -2917,14 +2917,64 @@ MoveNonHeaderFieldsToPseudoHeader::addAssignmentStmt(const IR::Expression *e) {
     } else {
         type = typeMap->getType(e, true)->to<IR::Type_Bits>();
     }
+    if (e->is<IR::Constant>() && (type->width_bits() > 64)) {
+        type = IR::Type_Bits::get(64);
+    }
     auto name = refMap->newName("pseudo");
     auto aligned_type = getEightBitAlignedType(type);
     pseudoFieldNameType.push_back(std::pair<cstring, const IR::Type *>(name, aligned_type));
     auto mem0 = new IR::Member(new IR::PathExpression(IR::ID("h")),
                                IR::ID(DpdkAddPseudoHeaderDecl::pseudoHeaderInstanceName));
     auto mem1 = new IR::Member(mem0, IR::ID(name));
-    auto cast1 = new IR::Cast(aligned_type, e);
+    if (auto cst = e->to<IR::Constant>()) {
+        return {new IR::AssignmentStatement(mem1, new IR::Constant(aligned_type, cst->value)),
+                mem1};
+    }
+    const IR::Expression *cast1 = e;
+    if (type->width_bits() != aligned_type->width_bits()) cast1 = new IR::Cast(aligned_type, e);
     return {new IR::AssignmentStatement(mem1, cast1), mem1};
+}
+
+const IR::Node *MoveNonHeaderFieldsToPseudoHeader::postorder(IR::AssignmentStatement *assn) {
+    if (is_all_args_header) return assn;
+    auto result = new IR::IndexedVector<IR::StatOrDecl>();
+    if ((isLargeFieldOperand(assn->left) && !isLargeFieldOperand(assn->right) &&
+         !isHeader(assn->right)) ||
+        (isLargeFieldOperand(assn->left) && assn->right->is<IR::Constant>())) {
+        auto expr = assn->right;
+        if (auto base = assn->right->to<IR::Cast>()) expr = base->expr;
+        auto stm = addAssignmentStmt(expr);
+        result->push_back(stm.first);
+        if (auto base = assn->right->to<IR::Cast>()) {
+            auto assn1 = new IR::AssignmentStatement(assn->srcInfo, assn->left,
+                                                     new IR::Cast(base->destType, stm.second));
+            result->push_back(assn1);
+        } else if (assn->right->is<IR::Constant>()) {
+            auto assn1 = new IR::AssignmentStatement(assn->srcInfo, assn->left,
+                                                     new IR::Cast(assn->left->type, stm.second));
+            result->push_back(assn1);
+        } else {
+            assn->right = stm.second;
+            result->push_back(assn);
+        }
+        return result;
+    }
+    if (!isLargeFieldOperand(assn->left) && isLargeFieldOperand(assn->right) &&
+        !isHeader(assn->left)) {
+        auto expr = assn->right;
+        auto stm = addAssignmentStmt(expr);
+        result->push_back(stm.first);
+        if (auto base = assn->right->to<IR::Cast>()) {
+            auto assn1 = new IR::AssignmentStatement(assn->srcInfo, assn->left,
+                                                     new IR::Cast(base->destType, stm.second));
+            result->push_back(assn1);
+        } else {
+            assn->right = stm.second;
+            result->push_back(assn);
+        }
+        return result;
+    }
+    return assn;
 }
 
 const IR::Node *MoveNonHeaderFieldsToPseudoHeader::postorder(IR::MethodCallStatement *statement) {

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -1154,10 +1154,10 @@ class HaveNonHeaderLargeOperandAssignment : public Inspector {
     bool preorder(const IR::AssignmentStatement *assn) override {
         if (!is_all_arg_header_fields) return false;
         if ((isLargeFieldOperand(assn->left) && !isLargeFieldOperand(assn->right) &&
-             !isHeader(assn->right)) ||
+             !isInsideHeader(assn->right)) ||
             (isLargeFieldOperand(assn->left) && assn->right->is<IR::Constant>()) ||
             (!isLargeFieldOperand(assn->left) && isLargeFieldOperand(assn->right) &&
-             !isHeader(assn->left))) {
+             !isInsideHeader(assn->left))) {
             is_all_arg_header_fields &= false;
             return false;
         }

--- a/backends/dpdk/dpdkUtils.cpp
+++ b/backends/dpdk/dpdkUtils.cpp
@@ -85,7 +85,7 @@ bool isLargeFieldOperand(const IR::Expression *e) {
     return false;
 }
 
-bool isHeader(const IR::Expression *expr) {
+bool isInsideHeader(const IR::Expression *expr) {
     auto e = expr;
     if (auto base = expr->to<IR::Cast>()) e = base->expr;
     if (!e->is<IR::Member>()) return false;

--- a/backends/dpdk/dpdkUtils.cpp
+++ b/backends/dpdk/dpdkUtils.cpp
@@ -75,6 +75,24 @@ bool isEightBitAligned(const IR::Expression *e) {
     return true;
 }
 
+bool isLargeFieldOperand(const IR::Expression *e) {
+    auto expr = e;
+    if (auto base = e->to<IR::Cast>()) expr = base->expr;
+    if (auto type = expr->type->to<IR::Type_Bits>()) {
+        auto size = type->width_bits();
+        if (size > 64) return true;
+    }
+    return false;
+}
+
+bool isHeader(const IR::Expression *expr) {
+    auto e = expr;
+    if (auto base = expr->to<IR::Cast>()) e = base->expr;
+    if (!e->is<IR::Member>()) return false;
+    if (e->to<IR::Member>()->expr->type->is<IR::Type_Header>()) return true;
+    return false;
+}
+
 const IR::Type_Bits *getEightBitAlignedType(const IR::Type_Bits *tb) {
     auto width = (tb->width_bits() + 7) & (~7);
     return IR::Type_Bits::get(width);

--- a/backends/dpdk/dpdkUtils.h
+++ b/backends/dpdk/dpdkUtils.h
@@ -30,7 +30,7 @@ bool isEightBitAligned(const IR::Expression *e);
 bool isDirection(const IR::Member *m);
 bool isHeadersStruct(const IR::Type_Struct *st);
 bool isLargeFieldOperand(const IR::Expression *e);
-bool isHeader(const IR::Expression *e);
+bool isInsideHeader(const IR::Expression *e);
 
 const IR::Type_Bits *getEightBitAlignedType(const IR::Type_Bits *tb);
 

--- a/backends/dpdk/dpdkUtils.h
+++ b/backends/dpdk/dpdkUtils.h
@@ -29,6 +29,9 @@ bool isMetadataField(const IR::Expression *e);
 bool isEightBitAligned(const IR::Expression *e);
 bool isDirection(const IR::Member *m);
 bool isHeadersStruct(const IR::Type_Struct *st);
+bool isLargeFieldOperand(const IR::Expression *e);
+bool isHeader(const IR::Expression *e);
+
 const IR::Type_Bits *getEightBitAlignedType(const IR::Type_Bits *tb);
 
 // Check for reserved names for DPDK target

--- a/p4include/dpdk/pna.p4
+++ b/p4include/dpdk/pna.p4
@@ -264,7 +264,8 @@ enum PNA_IdleTimeout_t {
 // BEGIN:Match_kinds
 match_kind {
     range,   /// Used to represent min..max intervals
-    selector /// Used for dynamic action selection via the ActionSelector extern
+    selector, /// Used for dynamic action selection via the ActionSelector extern
+    optional  /// Either an exact match, or a wildcard matching any value for the entire field
 }
 // END:Match_kinds
 

--- a/testdata/p4_16_dpdk_errors/pna-dpdk-large-constants.p4
+++ b/testdata/p4_16_dpdk_errors/pna-dpdk-large-constants.p4
@@ -1,0 +1,196 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32>     IPv4Address;
+
+// standard Ethernet header
+header Ethernet_h
+{
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16> etherType;
+}
+
+// IPv4 header without options
+header IPv4_h {
+    bit<4>       version;
+    bit<4>       ihl;
+    bit<8>       diffserv;
+    bit<16>      totalLen;
+    bit<16>      identification;
+    bit<3>       flags;
+    bit<13>      fragOffset;
+    bit<8>       ttl;
+    bit<8>       protocol;
+    bit<16>      hdrChecksum;
+    IPv4Address  srcAddr;
+    IPv4Address  dstAddr;
+}
+
+header IPv6_h {
+    bit<4>       version;
+    bit<8>       trafficClass;
+    bit<20>      flowLabel;
+    bit<16>      payloadLen;
+    bit<8>       nextHdr;
+    bit<8>       hopLimit;
+    bit<128>     srcAddr;
+    bit<128>     dstAddr;
+}
+
+header mpls_h {
+    bit<20> label;
+    bit<3>  tc;
+    bit<1>  stack;
+    bit<8>  ttl;
+}
+
+struct headers_t
+{
+    Ethernet_h ethernet;
+    mpls_h     mpls;
+    IPv4_h     ipv4;
+    IPv6_h     ipv6;
+}
+
+struct main_metadata_t {}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in p,
+    out   headers_t       headers,
+    inout main_metadata_t meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        p.extract(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800 : ipv4;
+            0x86DD   : ipv6;
+            0x8847   : mpls;
+            default : reject;
+        }
+    }
+
+    state mpls {
+            p.extract(headers.mpls);
+            transition ipv4;
+    }
+
+    state ipv4 {
+        p.extract(headers.ipv4);
+        transition accept;
+    }
+
+    state ipv6 {
+        p.extract(headers.ipv6);
+        transition accept;
+    }
+
+}
+
+// BEGIN:Counter_Example_Part2
+control MainControlImpl(
+    inout headers_t       headers,           // from main parser
+    inout main_metadata_t meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    bit<128> tmp = 128w0x123456789abcdef12345678;
+    bit<32> tmp1;
+    action Reject() {
+        drop_packet();
+    }
+
+    action ipv6_modify_dstAddr(bit<32> dstAddr) {
+        headers.ipv6.dstAddr = (bit<128>)dstAddr;
+        tmp1 = (bit<32>)headers.ipv6.srcAddr;
+    }
+
+    action ipv6_swap_addr() {
+        headers.ipv6.dstAddr = headers.ipv6.srcAddr;
+        headers.ipv6.srcAddr = tmp;
+    }
+
+    action set_flowlabel(bit<20> label) {
+        headers.ipv6.flowLabel = label;
+    }
+
+    action set_traffic_class(bit<8> trafficClass) {
+        headers.ipv6.trafficClass = trafficClass;
+    }
+
+    action set_traffic_class_flow_label(bit<8> trafficClass, bit<20> label) {
+        headers.ipv6.trafficClass = trafficClass;
+        headers.ipv6.flowLabel = label;
+        headers.ipv6.srcAddr = (bit<128>)tmp1;
+    }
+
+    action set_ipv6_version(bit<4> version) {
+        headers.ipv6.version = version;
+    }
+
+    action set_next_hdr(bit<8> nextHdr) {
+        headers.ipv6.nextHdr = nextHdr;
+    }
+
+    action set_hop_limit(bit<8> hopLimit) {
+        headers.ipv6.hopLimit = hopLimit;
+    }
+
+    table filter_tbl {
+        key = {
+            headers.ipv6.srcAddr : exact;
+        }
+        actions = {
+            ipv6_modify_dstAddr;
+            ipv6_swap_addr;
+            set_flowlabel;
+            set_traffic_class_flow_label;
+            set_ipv6_version;
+            set_next_hdr;
+            set_hop_limit;
+            Reject;
+            NoAction;
+        }
+    }
+
+    apply {
+        filter_tbl.apply();
+    }
+}
+
+control MainDeparserImpl(
+    packet_out packet,
+    in    headers_t headers,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        packet.emit(headers.ethernet);
+        packet.emit(headers.mpls);
+        packet.emit(headers.ipv6);
+        packet.emit(headers.ipv4);
+    }
+}
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_dpdk_errors_outputs/pna-dpdk-large-constants.p4-error
+++ b/testdata/p4_16_dpdk_errors_outputs/pna-dpdk-large-constants.p4-error
@@ -1,0 +1,6 @@
+pna-dpdk-large-constants.p4(136): [--Wwarn=uninitialized_use] warning: tmp1 may be uninitialized
+        headers.ipv6.srcAddr = (bit<128>)tmp1;
+                                         ^^^^
+pna-dpdk-large-constants.p4(109): [--Werror=overlimit] error: DPDK target supports up-to 64-bit immediate values, 128w0x123456789abcdef12345678 exceeds the limit
+    bit<128> tmp = 128w0x123456789abcdef12345678;
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_dpdk_errors_outputs/pna-dpdk-large-constants.p4.bfrt.json
+++ b/testdata/p4_16_dpdk_errors_outputs/pna-dpdk-large-constants.p4.bfrt.json
@@ -1,0 +1,187 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.filter_tbl",
+      "id" : 34917681,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "headers.ipv6.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 128
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 29705768,
+          "name" : "MainControlImpl.ipv6_modify_dstAddr",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "dstAddr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 22459520,
+          "name" : "MainControlImpl.ipv6_swap_addr",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 23653337,
+          "name" : "MainControlImpl.set_flowlabel",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "label",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 20
+              }
+            }
+          ]
+        },
+        {
+          "id" : 31572308,
+          "name" : "MainControlImpl.set_traffic_class_flow_label",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "trafficClass",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 8
+              }
+            },
+            {
+              "id" : 2,
+              "name" : "label",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 20
+              }
+            }
+          ]
+        },
+        {
+          "id" : 28719183,
+          "name" : "MainControlImpl.set_ipv6_version",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "version",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 4
+              }
+            }
+          ]
+        },
+        {
+          "id" : 31932328,
+          "name" : "MainControlImpl.set_next_hdr",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "nextHdr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 8
+              }
+            }
+          ]
+        },
+        {
+          "id" : 20663179,
+          "name" : "MainControlImpl.set_hop_limit",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "hopLimit",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 8
+              }
+            }
+          ]
+        },
+        {
+          "id" : 29705564,
+          "name" : "MainControlImpl.Reject",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_dpdk_errors_outputs/pna-example-ipsec-err3.p4-error
+++ b/testdata/p4_16_dpdk_errors_outputs/pna-example-ipsec-err3.p4-error
@@ -2,11 +2,11 @@ pna-example-ipsec-err3.p4(144): [--Werror=type-error] error: ipsec.set_sa_index
   ipsec.set_sa_index<bit<32>, bit<8>>(sa_index);
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:
-pna.p4(523): set_sa_index: 1 type parameters expected, but 2 type arguments supplied
+pna.p4(524): set_sa_index: 1 type parameters expected, but 2 type arguments supplied
    void set_sa_index<T>(in T sa_index);
         ^^^^^^^^^^^^
   ---- Originating from:
-pna.p4(523): Function type 'set_sa_index' does not match invocation type '<Method call>'
+pna.p4(524): Function type 'set_sa_index' does not match invocation type '<Method call>'
    void set_sa_index<T>(in T sa_index);
         ^^^^^^^^^^^^
 pna-example-ipsec-err3.p4(144)

--- a/testdata/p4_16_pna_errors_outputs/pna-dpdk-direct-counter-err-3.p4-error
+++ b/testdata/p4_16_pna_errors_outputs/pna-dpdk-direct-counter-err-3.p4-error
@@ -1,3 +1,3 @@
-pna.p4(400): [--Werror=unexpected] error: count method of per_prefix_pkt_bytes_count extern can only be invoked from within action of ownertable
+pna.p4(401): [--Werror=unexpected] error: count method of per_prefix_pkt_bytes_count extern can only be invoked from within action of ownertable
   void count(in bit<32> pkt_len);
        ^^^^^

--- a/testdata/p4_16_samples/pna-ipv6-actions.p4
+++ b/testdata/p4_16_samples/pna-ipv6-actions.p4
@@ -1,0 +1,196 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32>     IPv4Address;
+
+// standard Ethernet header
+header Ethernet_h
+{
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16> etherType;
+}
+
+// IPv4 header without options
+header IPv4_h {
+    bit<4>       version;
+    bit<4>       ihl;
+    bit<8>       diffserv;
+    bit<16>      totalLen;
+    bit<16>      identification;
+    bit<3>       flags;
+    bit<13>      fragOffset;
+    bit<8>       ttl;
+    bit<8>       protocol;
+    bit<16>      hdrChecksum;
+    IPv4Address  srcAddr;
+    IPv4Address  dstAddr;
+}
+
+header IPv6_h {
+    bit<4>       version;
+    bit<8>       trafficClass;
+    bit<20>      flowLabel;
+    bit<16>      payloadLen;
+    bit<8>       nextHdr;
+    bit<8>       hopLimit;
+    bit<128>     srcAddr;
+    bit<128>     dstAddr;
+}
+
+header mpls_h {
+    bit<20> label;
+    bit<3>  tc;
+    bit<1>  stack;
+    bit<8>  ttl;
+}
+
+struct headers_t
+{
+    Ethernet_h ethernet;
+    mpls_h     mpls;
+    IPv4_h     ipv4;
+    IPv6_h     ipv6;
+}
+
+struct main_metadata_t {}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout main_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in p,
+    out   headers_t       headers,
+    inout main_metadata_t meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        p.extract(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800 : ipv4;
+            0x86DD   : ipv6;
+            0x8847   : mpls;
+            default : reject;
+        }
+    }
+
+    state mpls {
+            p.extract(headers.mpls);
+            transition ipv4;
+    }
+
+    state ipv4 {
+        p.extract(headers.ipv4);
+        transition accept;
+    }
+
+    state ipv6 {
+        p.extract(headers.ipv6);
+        transition accept;
+    }
+
+}
+
+// BEGIN:Counter_Example_Part2
+control MainControlImpl(
+    inout headers_t       headers,           // from main parser
+    inout main_metadata_t meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    bit<128> tmp = 0x76;
+    bit<32> tmp1;
+    action Reject() {
+        drop_packet();
+    }
+
+    action ipv6_modify_dstAddr(bit<32> dstAddr) {
+        headers.ipv6.dstAddr = (bit<128>)dstAddr;
+        tmp1 = (bit<32>)headers.ipv6.srcAddr;
+    }
+
+    action ipv6_swap_addr() {
+        headers.ipv6.dstAddr = headers.ipv6.srcAddr;
+        headers.ipv6.srcAddr = tmp;
+    }
+
+    action set_flowlabel(bit<20> label) {
+        headers.ipv6.flowLabel = label;
+    }
+
+    action set_traffic_class(bit<8> trafficClass) {
+        headers.ipv6.trafficClass = trafficClass;
+    }
+
+    action set_traffic_class_flow_label(bit<8> trafficClass, bit<20> label) {
+        headers.ipv6.trafficClass = trafficClass;
+        headers.ipv6.flowLabel = label;
+        headers.ipv6.srcAddr = (bit<128>)tmp1;
+    }
+
+    action set_ipv6_version(bit<4> version) {
+        headers.ipv6.version = version;
+    }
+
+    action set_next_hdr(bit<8> nextHdr) {
+        headers.ipv6.nextHdr = nextHdr;
+    }
+
+    action set_hop_limit(bit<8> hopLimit) {
+        headers.ipv6.hopLimit = hopLimit;
+    }
+
+    table filter_tbl {
+        key = {
+            headers.ipv6.srcAddr : exact;
+        }
+        actions = {
+            ipv6_modify_dstAddr;
+            ipv6_swap_addr;
+            set_flowlabel;
+            set_traffic_class_flow_label;
+            set_ipv6_version;
+            set_next_hdr;
+            set_hop_limit;
+            Reject;
+            NoAction;
+        }
+    }
+
+    apply {
+        filter_tbl.apply();
+    }
+}
+
+control MainDeparserImpl(
+    packet_out packet,
+    in    headers_t headers,                // from main control
+    in    main_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        packet.emit(headers.ethernet);
+        packet.emit(headers.mpls);
+        packet.emit(headers.ipv6);
+        packet.emit(headers.ipv4);
+    }
+}
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples_outputs/pna-dpdk-header-union-stack.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-header-union-stack.p4.spec
@@ -23,7 +23,6 @@ struct M {
 metadata instanceof M
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	validate h.u0_h1

--- a/testdata/p4_16_samples_outputs/pna-dpdk-header-union-stack1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-header-union-stack1.p4.spec
@@ -26,7 +26,6 @@ struct M {
 metadata instanceof M
 
 regarray direction size 0x100 initval 0
-
 apply {
 	rx m.pna_main_input_metadata_input_port
 	validate h.u0_h1

--- a/testdata/p4_16_samples_outputs/pna-ipv6-actions-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-ipv6-actions-first.p4
@@ -1,0 +1,149 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+header IPv6_h {
+    bit<4>   version;
+    bit<8>   trafficClass;
+    bit<20>  flowLabel;
+    bit<16>  payloadLen;
+    bit<8>   nextHdr;
+    bit<8>   hopLimit;
+    bit<128> srcAddr;
+    bit<128> dstAddr;
+}
+
+header mpls_h {
+    bit<20> label;
+    bit<3>  tc;
+    bit<1>  stack;
+    bit<8>  ttl;
+}
+
+struct headers_t {
+    Ethernet_h ethernet;
+    mpls_h     mpls;
+    IPv4_h     ipv4;
+    IPv6_h     ipv6;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in p, out headers_t headers, inout main_metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ipv4;
+            16w0x86dd: ipv6;
+            16w0x8847: mpls;
+            default: reject;
+        }
+    }
+    state mpls {
+        p.extract<mpls_h>(headers.mpls);
+        transition ipv4;
+    }
+    state ipv4 {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition accept;
+    }
+    state ipv6 {
+        p.extract<IPv6_h>(headers.ipv6);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t headers, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    bit<128> tmp = 128w0x76;
+    bit<32> tmp1;
+    action Reject() {
+        drop_packet();
+    }
+    action ipv6_modify_dstAddr(bit<32> dstAddr) {
+        headers.ipv6.dstAddr = (bit<128>)dstAddr;
+        tmp1 = (bit<32>)headers.ipv6.srcAddr;
+    }
+    action ipv6_swap_addr() {
+        headers.ipv6.dstAddr = headers.ipv6.srcAddr;
+        headers.ipv6.srcAddr = tmp;
+    }
+    action set_flowlabel(bit<20> label) {
+        headers.ipv6.flowLabel = label;
+    }
+    action set_traffic_class(bit<8> trafficClass) {
+        headers.ipv6.trafficClass = trafficClass;
+    }
+    action set_traffic_class_flow_label(bit<8> trafficClass, bit<20> label) {
+        headers.ipv6.trafficClass = trafficClass;
+        headers.ipv6.flowLabel = label;
+        headers.ipv6.srcAddr = (bit<128>)tmp1;
+    }
+    action set_ipv6_version(bit<4> version) {
+        headers.ipv6.version = version;
+    }
+    action set_next_hdr(bit<8> nextHdr) {
+        headers.ipv6.nextHdr = nextHdr;
+    }
+    action set_hop_limit(bit<8> hopLimit) {
+        headers.ipv6.hopLimit = hopLimit;
+    }
+    table filter_tbl {
+        key = {
+            headers.ipv6.srcAddr: exact @name("headers.ipv6.srcAddr");
+        }
+        actions = {
+            ipv6_modify_dstAddr();
+            ipv6_swap_addr();
+            set_flowlabel();
+            set_traffic_class_flow_label();
+            set_ipv6_version();
+            set_next_hdr();
+            set_hop_limit();
+            Reject();
+            NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        filter_tbl.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out packet, in headers_t headers, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        packet.emit<Ethernet_h>(headers.ethernet);
+        packet.emit<mpls_h>(headers.mpls);
+        packet.emit<IPv6_h>(headers.ipv6);
+        packet.emit<IPv4_h>(headers.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-ipv6-actions-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-ipv6-actions-frontend.p4
@@ -1,0 +1,148 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+header IPv6_h {
+    bit<4>   version;
+    bit<8>   trafficClass;
+    bit<20>  flowLabel;
+    bit<16>  payloadLen;
+    bit<8>   nextHdr;
+    bit<8>   hopLimit;
+    bit<128> srcAddr;
+    bit<128> dstAddr;
+}
+
+header mpls_h {
+    bit<20> label;
+    bit<3>  tc;
+    bit<1>  stack;
+    bit<8>  ttl;
+}
+
+struct headers_t {
+    Ethernet_h ethernet;
+    mpls_h     mpls;
+    IPv4_h     ipv4;
+    IPv6_h     ipv6;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in p, out headers_t headers, inout main_metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ipv4;
+            16w0x86dd: ipv6;
+            16w0x8847: mpls;
+            default: reject;
+        }
+    }
+    state mpls {
+        p.extract<mpls_h>(headers.mpls);
+        transition ipv4;
+    }
+    state ipv4 {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition accept;
+    }
+    state ipv6 {
+        p.extract<IPv6_h>(headers.ipv6);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t headers, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<128> tmp_0;
+    @name("MainControlImpl.tmp1") bit<32> tmp1_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.Reject") action Reject() {
+        drop_packet();
+    }
+    @name("MainControlImpl.ipv6_modify_dstAddr") action ipv6_modify_dstAddr(@name("dstAddr") bit<32> dstAddr_1) {
+        headers.ipv6.dstAddr = (bit<128>)dstAddr_1;
+    }
+    @name("MainControlImpl.ipv6_swap_addr") action ipv6_swap_addr() {
+        headers.ipv6.dstAddr = headers.ipv6.srcAddr;
+        headers.ipv6.srcAddr = tmp_0;
+    }
+    @name("MainControlImpl.set_flowlabel") action set_flowlabel(@name("label") bit<20> label_2) {
+        headers.ipv6.flowLabel = label_2;
+    }
+    @name("MainControlImpl.set_traffic_class_flow_label") action set_traffic_class_flow_label(@name("trafficClass") bit<8> trafficClass_1, @name("label") bit<20> label_3) {
+        headers.ipv6.trafficClass = trafficClass_1;
+        headers.ipv6.flowLabel = label_3;
+        headers.ipv6.srcAddr = (bit<128>)tmp1_0;
+    }
+    @name("MainControlImpl.set_ipv6_version") action set_ipv6_version(@name("version") bit<4> version_1) {
+        headers.ipv6.version = version_1;
+    }
+    @name("MainControlImpl.set_next_hdr") action set_next_hdr(@name("nextHdr") bit<8> nextHdr_1) {
+        headers.ipv6.nextHdr = nextHdr_1;
+    }
+    @name("MainControlImpl.set_hop_limit") action set_hop_limit(@name("hopLimit") bit<8> hopLimit_1) {
+        headers.ipv6.hopLimit = hopLimit_1;
+    }
+    @name("MainControlImpl.filter_tbl") table filter_tbl_0 {
+        key = {
+            headers.ipv6.srcAddr: exact @name("headers.ipv6.srcAddr");
+        }
+        actions = {
+            ipv6_modify_dstAddr();
+            ipv6_swap_addr();
+            set_flowlabel();
+            set_traffic_class_flow_label();
+            set_ipv6_version();
+            set_next_hdr();
+            set_hop_limit();
+            Reject();
+            NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tmp_0 = 128w0x76;
+        filter_tbl_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out packet, in headers_t headers, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        packet.emit<Ethernet_h>(headers.ethernet);
+        packet.emit<mpls_h>(headers.mpls);
+        packet.emit<IPv6_h>(headers.ipv6);
+        packet.emit<IPv4_h>(headers.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-ipv6-actions-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-ipv6-actions-midend.p4
@@ -1,0 +1,164 @@
+#include <core.p4>
+#include <pna.p4>
+
+header Ethernet_h {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header IPv4_h {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header IPv6_h {
+    bit<4>   version;
+    bit<8>   trafficClass;
+    bit<20>  flowLabel;
+    bit<16>  payloadLen;
+    bit<8>   nextHdr;
+    bit<8>   hopLimit;
+    bit<128> srcAddr;
+    bit<128> dstAddr;
+}
+
+header mpls_h {
+    bit<20> label;
+    bit<3>  tc;
+    bit<1>  stack;
+    bit<8>  ttl;
+}
+
+struct headers_t {
+    Ethernet_h ethernet;
+    mpls_h     mpls;
+    IPv4_h     ipv4;
+    IPv6_h     ipv6;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in p, out headers_t headers, inout main_metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        p.extract<Ethernet_h>(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ipv4;
+            16w0x86dd: ipv6;
+            16w0x8847: mpls;
+            default: reject;
+        }
+    }
+    state mpls {
+        p.extract<mpls_h>(headers.mpls);
+        transition ipv4;
+    }
+    state ipv4 {
+        p.extract<IPv4_h>(headers.ipv4);
+        transition accept;
+    }
+    state ipv6 {
+        p.extract<IPv6_h>(headers.ipv6);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t headers, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<128> tmp_0;
+    @name("MainControlImpl.tmp1") bit<32> tmp1_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.Reject") action Reject() {
+        drop_packet();
+    }
+    @name("MainControlImpl.ipv6_modify_dstAddr") action ipv6_modify_dstAddr(@name("dstAddr") bit<32> dstAddr_1) {
+        headers.ipv6.dstAddr = (bit<128>)dstAddr_1;
+    }
+    @name("MainControlImpl.ipv6_swap_addr") action ipv6_swap_addr() {
+        headers.ipv6.dstAddr = headers.ipv6.srcAddr;
+        headers.ipv6.srcAddr = tmp_0;
+    }
+    @name("MainControlImpl.set_flowlabel") action set_flowlabel(@name("label") bit<20> label_2) {
+        headers.ipv6.flowLabel = label_2;
+    }
+    @name("MainControlImpl.set_traffic_class_flow_label") action set_traffic_class_flow_label(@name("trafficClass") bit<8> trafficClass_1, @name("label") bit<20> label_3) {
+        headers.ipv6.trafficClass = trafficClass_1;
+        headers.ipv6.flowLabel = label_3;
+        headers.ipv6.srcAddr = (bit<128>)tmp1_0;
+    }
+    @name("MainControlImpl.set_ipv6_version") action set_ipv6_version(@name("version") bit<4> version_1) {
+        headers.ipv6.version = version_1;
+    }
+    @name("MainControlImpl.set_next_hdr") action set_next_hdr(@name("nextHdr") bit<8> nextHdr_1) {
+        headers.ipv6.nextHdr = nextHdr_1;
+    }
+    @name("MainControlImpl.set_hop_limit") action set_hop_limit(@name("hopLimit") bit<8> hopLimit_1) {
+        headers.ipv6.hopLimit = hopLimit_1;
+    }
+    @name("MainControlImpl.filter_tbl") table filter_tbl_0 {
+        key = {
+            headers.ipv6.srcAddr: exact @name("headers.ipv6.srcAddr");
+        }
+        actions = {
+            ipv6_modify_dstAddr();
+            ipv6_swap_addr();
+            set_flowlabel();
+            set_traffic_class_flow_label();
+            set_ipv6_version();
+            set_next_hdr();
+            set_hop_limit();
+            Reject();
+            NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action pnaipv6actions109() {
+        tmp_0 = 128w0x76;
+    }
+    @hidden table tbl_pnaipv6actions109 {
+        actions = {
+            pnaipv6actions109();
+        }
+        const default_action = pnaipv6actions109();
+    }
+    apply {
+        tbl_pnaipv6actions109.apply();
+        filter_tbl_0.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out packet, in headers_t headers, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnaipv6actions180() {
+        packet.emit<Ethernet_h>(headers.ethernet);
+        packet.emit<mpls_h>(headers.mpls);
+        packet.emit<IPv6_h>(headers.ipv6);
+        packet.emit<IPv4_h>(headers.ipv4);
+    }
+    @hidden table tbl_pnaipv6actions180 {
+        actions = {
+            pnaipv6actions180();
+        }
+        const default_action = pnaipv6actions180();
+    }
+    apply {
+        tbl_pnaipv6actions180.apply();
+    }
+}
+
+PNA_NIC<headers_t, main_metadata_t, headers_t, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4
+++ b/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4
@@ -1,0 +1,148 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+header Ethernet_h {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header IPv4_h {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<8>      diffserv;
+    bit<16>     totalLen;
+    bit<16>     identification;
+    bit<3>      flags;
+    bit<13>     fragOffset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     hdrChecksum;
+    IPv4Address srcAddr;
+    IPv4Address dstAddr;
+}
+
+header IPv6_h {
+    bit<4>   version;
+    bit<8>   trafficClass;
+    bit<20>  flowLabel;
+    bit<16>  payloadLen;
+    bit<8>   nextHdr;
+    bit<8>   hopLimit;
+    bit<128> srcAddr;
+    bit<128> dstAddr;
+}
+
+header mpls_h {
+    bit<20> label;
+    bit<3>  tc;
+    bit<1>  stack;
+    bit<8>  ttl;
+}
+
+struct headers_t {
+    Ethernet_h ethernet;
+    mpls_h     mpls;
+    IPv4_h     ipv4;
+    IPv6_h     ipv6;
+}
+
+struct main_metadata_t {
+}
+
+control PreControlImpl(in headers_t hdr, inout main_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in p, out headers_t headers, inout main_metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        p.extract(headers.ethernet);
+        transition select(headers.ethernet.etherType) {
+            16w0x800: ipv4;
+            0x86dd: ipv6;
+            0x8847: mpls;
+            default: reject;
+        }
+    }
+    state mpls {
+        p.extract(headers.mpls);
+        transition ipv4;
+    }
+    state ipv4 {
+        p.extract(headers.ipv4);
+        transition accept;
+    }
+    state ipv6 {
+        p.extract(headers.ipv6);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t headers, inout main_metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    bit<128> tmp = 0x76;
+    bit<32> tmp1;
+    action Reject() {
+        drop_packet();
+    }
+    action ipv6_modify_dstAddr(bit<32> dstAddr) {
+        headers.ipv6.dstAddr = (bit<128>)dstAddr;
+        tmp1 = (bit<32>)headers.ipv6.srcAddr;
+    }
+    action ipv6_swap_addr() {
+        headers.ipv6.dstAddr = headers.ipv6.srcAddr;
+        headers.ipv6.srcAddr = tmp;
+    }
+    action set_flowlabel(bit<20> label) {
+        headers.ipv6.flowLabel = label;
+    }
+    action set_traffic_class(bit<8> trafficClass) {
+        headers.ipv6.trafficClass = trafficClass;
+    }
+    action set_traffic_class_flow_label(bit<8> trafficClass, bit<20> label) {
+        headers.ipv6.trafficClass = trafficClass;
+        headers.ipv6.flowLabel = label;
+        headers.ipv6.srcAddr = (bit<128>)tmp1;
+    }
+    action set_ipv6_version(bit<4> version) {
+        headers.ipv6.version = version;
+    }
+    action set_next_hdr(bit<8> nextHdr) {
+        headers.ipv6.nextHdr = nextHdr;
+    }
+    action set_hop_limit(bit<8> hopLimit) {
+        headers.ipv6.hopLimit = hopLimit;
+    }
+    table filter_tbl {
+        key = {
+            headers.ipv6.srcAddr: exact;
+        }
+        actions = {
+            ipv6_modify_dstAddr;
+            ipv6_swap_addr;
+            set_flowlabel;
+            set_traffic_class_flow_label;
+            set_ipv6_version;
+            set_next_hdr;
+            set_hop_limit;
+            Reject;
+            NoAction;
+        }
+    }
+    apply {
+        filter_tbl.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out packet, in headers_t headers, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        packet.emit(headers.ethernet);
+        packet.emit(headers.mpls);
+        packet.emit(headers.ipv6);
+        packet.emit(headers.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4-error
@@ -1,0 +1,3 @@
+pna-ipv6-actions.p4(136): [--Wwarn=uninitialized_use] warning: tmp1 may be uninitialized
+        headers.ipv6.srcAddr = (bit<128>)tmp1;
+                                         ^^^^

--- a/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4-stderr
@@ -1,0 +1,3 @@
+pna-ipv6-actions.p4(136): [--Wwarn=uninitialized_use] warning: tmp1 may be uninitialized
+        headers.ipv6.srcAddr = (bit<128>)tmp1;
+                                         ^^^^

--- a/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4.bfrt.json
@@ -1,0 +1,187 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.filter_tbl",
+      "id" : 34917681,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : false,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "headers.ipv6.srcAddr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 128
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 29705768,
+          "name" : "MainControlImpl.ipv6_modify_dstAddr",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "dstAddr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 22459520,
+          "name" : "MainControlImpl.ipv6_swap_addr",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 23653337,
+          "name" : "MainControlImpl.set_flowlabel",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "label",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 20
+              }
+            }
+          ]
+        },
+        {
+          "id" : 31572308,
+          "name" : "MainControlImpl.set_traffic_class_flow_label",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "trafficClass",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 8
+              }
+            },
+            {
+              "id" : 2,
+              "name" : "label",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 20
+              }
+            }
+          ]
+        },
+        {
+          "id" : 28719183,
+          "name" : "MainControlImpl.set_ipv6_version",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "version",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 4
+              }
+            }
+          ]
+        },
+        {
+          "id" : 31932328,
+          "name" : "MainControlImpl.set_next_hdr",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "nextHdr",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 8
+              }
+            }
+          ]
+        },
+        {
+          "id" : 20663179,
+          "name" : "MainControlImpl.set_hop_limit",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "hopLimit",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 8
+              }
+            }
+          ]
+        },
+        {
+          "id" : 29705564,
+          "name" : "MainControlImpl.Reject",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4.spec
@@ -1,0 +1,208 @@
+
+struct Ethernet_h {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct mpls_h {
+	bit<24> label_tc_stack
+	bit<8> ttl
+}
+
+struct IPv4_h {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct IPv6_h {
+	bit<32> version_trafficClass_flowLabel
+	bit<16> payloadLen
+	bit<8> nextHdr
+	bit<8> hopLimit
+	bit<128> srcAddr
+	bit<128> dstAddr
+}
+
+struct dpdk_pseudo_header_t {
+	bit<32> pseudo
+	bit<32> pseudo_0
+	bit<64> pseudo_1
+}
+
+struct ipv6_modify_dstAddr_arg_t {
+	bit<32> dstAddr
+}
+
+struct set_flowlabel_arg_t {
+	bit<32> label
+}
+
+struct set_hop_limit_arg_t {
+	bit<8> hopLimit
+}
+
+struct set_ipv6_version_arg_t {
+	bit<32> version
+}
+
+struct set_next_hdr_arg_t {
+	bit<8> nextHdr
+}
+
+struct set_traffic_class_flow_label_arg_t {
+	bit<8> trafficClass
+	bit<32> label
+}
+
+header ethernet instanceof Ethernet_h
+header mpls instanceof mpls_h
+header ipv4 instanceof IPv4_h
+header ipv6 instanceof IPv6_h
+header dpdk_pseudo_header instanceof dpdk_pseudo_header_t
+
+struct main_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlT_tmp
+	bit<32> MainControlT_tmp_1
+	bit<32> MainControlT_tmp_2
+	bit<32> MainControlT_tmp_3
+	bit<32> MainControlT_tmp_5
+	bit<32> MainControlT_tmp_6
+	bit<32> MainControlT_tmp_7
+	bit<32> MainControlT_tmp_9
+	bit<32> MainControlT_tmp_10
+	bit<32> MainControlT_tmp_11
+	bit<32> MainControlT_tmp_13
+	bit<128> MainControlT_tmp_14
+	bit<32> MainControlT_tmp1
+}
+metadata instanceof main_metadata_t
+
+regarray direction size 0x100 initval 0
+action NoAction args none {
+	return
+}
+
+action Reject args none {
+	drop
+	return
+}
+
+action ipv6_modify_dstAddr args instanceof ipv6_modify_dstAddr_arg_t {
+	mov h.dpdk_pseudo_header.pseudo t.dstAddr
+	mov h.ipv6.dstAddr h.dpdk_pseudo_header.pseudo
+	return
+}
+
+action ipv6_swap_addr args none {
+	mov h.ipv6.dstAddr h.ipv6.srcAddr
+	mov h.ipv6.srcAddr m.MainControlT_tmp_14
+	return
+}
+
+action set_flowlabel args instanceof set_flowlabel_arg_t {
+	mov m.MainControlT_tmp h.ipv6.version_trafficClass_flowLabel
+	and m.MainControlT_tmp 0xFFF
+	mov m.MainControlT_tmp_1 t.label
+	shl m.MainControlT_tmp_1 0xC
+	mov m.MainControlT_tmp_2 m.MainControlT_tmp_1
+	and m.MainControlT_tmp_2 0xFFFFF000
+	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp
+	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_2
+	return
+}
+
+action set_traffic_class_flow_label args instanceof set_traffic_class_flow_label_arg_t {
+	mov m.MainControlT_tmp_3 h.ipv6.version_trafficClass_flowLabel
+	and m.MainControlT_tmp_3 0xFFFFF00F
+	mov m.MainControlT_tmp_5 t.trafficClass
+	shl m.MainControlT_tmp_5 0x4
+	mov m.MainControlT_tmp_6 m.MainControlT_tmp_5
+	and m.MainControlT_tmp_6 0xFF0
+	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_3
+	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_6
+	mov m.MainControlT_tmp_7 h.ipv6.version_trafficClass_flowLabel
+	and m.MainControlT_tmp_7 0xFFF
+	mov m.MainControlT_tmp_9 t.label
+	shl m.MainControlT_tmp_9 0xC
+	mov m.MainControlT_tmp_10 m.MainControlT_tmp_9
+	and m.MainControlT_tmp_10 0xFFFFF000
+	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_7
+	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_10
+	mov h.dpdk_pseudo_header.pseudo_0 m.MainControlT_tmp1
+	mov h.ipv6.srcAddr h.dpdk_pseudo_header.pseudo_0
+	return
+}
+
+action set_ipv6_version args instanceof set_ipv6_version_arg_t {
+	mov m.MainControlT_tmp_11 h.ipv6.version_trafficClass_flowLabel
+	and m.MainControlT_tmp_11 0xFFFFFFF0
+	mov m.MainControlT_tmp_13 t.version
+	and m.MainControlT_tmp_13 0xF
+	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_11
+	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_13
+	return
+}
+
+action set_next_hdr args instanceof set_next_hdr_arg_t {
+	mov h.ipv6.nextHdr t.nextHdr
+	return
+}
+
+action set_hop_limit args instanceof set_hop_limit_arg_t {
+	mov h.ipv6.hopLimit t.hopLimit
+	return
+}
+
+table filter_tbl {
+	key {
+		h.ipv6.srcAddr exact
+	}
+	actions {
+		ipv6_modify_dstAddr
+		ipv6_swap_addr
+		set_flowlabel
+		set_traffic_class_flow_label
+		set_ipv6_version
+		set_next_hdr
+		set_hop_limit
+		Reject
+		NoAction
+	}
+	default_action NoAction args none 
+	size 0x10000
+}
+
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_IPV4 h.ethernet.etherType 0x800
+	jmpeq MAINPARSERIMPL_IPV6 h.ethernet.etherType 0x86DD
+	jmpeq MAINPARSERIMPL_MPLS h.ethernet.etherType 0x8847
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_MPLS :	extract h.mpls
+	MAINPARSERIMPL_IPV4 :	extract h.ipv4
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_IPV6 :	extract h.ipv6
+	MAINPARSERIMPL_ACCEPT :	mov h.dpdk_pseudo_header.pseudo_1 0x76
+	mov m.MainControlT_tmp_14 h.dpdk_pseudo_header.pseudo_1
+	table filter_tbl
+	emit h.ethernet
+	emit h.mpls
+	emit h.ipv6
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-register2-bmv2.p4.spec
@@ -19,6 +19,13 @@ struct ipv4_t {
 	bit<32> dstAddr
 }
 
+struct dpdk_pseudo_header_t {
+	bit<32> pseudo
+	bit<32> pseudo_0
+	bit<48> pseudo_1
+	bit<48> pseudo_2
+}
+
 struct psa_ingress_output_metadata_t {
 	bit<8> class_of_service
 	bit<8> clone
@@ -62,6 +69,7 @@ metadata instanceof metadata
 
 header ethernet instanceof ethernet_t
 header ipv4 instanceof ipv4_t
+header dpdk_pseudo_header instanceof dpdk_pseudo_header_t
 
 regarray port_pkt_ip_bytes_in_0 size 0x200 initval 0
 apply {
@@ -85,8 +93,10 @@ apply {
 	and m.Ingress_tmp_1 0xFFFFFFFF
 	mov m.Ingress_tmp_2 m.Ingress_tmp_1
 	and m.Ingress_tmp_2 0xFFFFFFFF
+	mov h.dpdk_pseudo_header.pseudo m.Ingress_tmp_2
 	mov m.Ingress_tmp_4 m.Ingress_tmp_2
 	add m.Ingress_tmp_4 0x1
+	mov h.dpdk_pseudo_header.pseudo_0 m.Ingress_tmp_4
 	mov m.Ingress_tmp_6 m.Ingress_tmp_4
 	shl m.Ingress_tmp_6 0x30
 	mov m.Ingress_tmp_7 m.Ingress_tmp_6
@@ -99,8 +109,10 @@ apply {
 	and m.Ingress_tmp_9 0xFFFFFFFFFFFF
 	mov m.Ingress_tmp_10 m.Ingress_tmp_9
 	and m.Ingress_tmp_10 0xFFFFFFFFFFFF
+	mov h.dpdk_pseudo_header.pseudo_1 m.Ingress_tmp_10
 	mov m.Ingress_tmp_13 m.Ingress_tmp_10
 	add m.Ingress_tmp_13 h.ipv4.totalLen
+	mov h.dpdk_pseudo_header.pseudo_2 m.Ingress_tmp_13
 	mov m.Ingress_tmp_15 m.Ingress_tmp_13
 	and m.Ingress_tmp_15 0xFFFFFFFFFFFF
 	mov m.Ingress_s m.Ingress_tmp_8


### PR DESCRIPTION
To support assignments between variables <= 64-bit(small) and >64-bit (large) variables, the smaller operand must be a header field.

For ex:

```
bit<128> var1;
bit<32> var2;
var 1 = (bit<128>) var2  
```

var2 should be moved to a header to make this assignment work on the DPDK target.
Compiler creates a pseudo header for holding the variables that need to be a header field and inserts additional assignments to move the smaller operand in a pseudo header field

```
header pseudo_hdr {
bit<32> pseudo;
}

struct mainHeader{
....
pseudo_hdr p;
}

h.p.pseudo = var2
var1 = (bit<128>)h.p.pseudo;
```

In case, large operand is being assigned with a constant, the constant is capped to 64-bits and is moved in a header field. The new header field then replaces the constant in the assignment.

