### PR TITLE
Fix mask calculation for concat operator in bmv2/dpdk expression lowering

### DIFF
--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -153,7 +153,7 @@ const IR::Node *LowerExpressions::postorder(IR::Concat *expression) {
     auto cast1 = new IR::Cast(expression->right->srcInfo, resulttype, expression->right);
     auto sizefb0 = new IR::Constant(new IR::Type_InfInt(), sizeofb);
     auto sh = new IR::Shl(cast0->srcInfo, cast0, sizefb0);
-    big_int m = Util::maskFromSlice(sizeofb, 0);
+    big_int m = Util::maskFromSlice(sizeofb - 1, 0);
     auto mask = new IR::Constant(expression->right->srcInfo, resulttype, m, 16);
     auto and0 = new IR::BAnd(expression->right->srcInfo, cast1, mask);
     auto result = new IR::BOr(expression->srcInfo, sh, and0);

--- a/testdata/p4_16_samples/psa-dpdk-binary-operations.p4
+++ b/testdata/p4_16_samples/psa-dpdk-binary-operations.p4
@@ -87,6 +87,7 @@ control MyIC(
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;
+        b.meta = b.meta2 ++ b.meta7;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-first.p4
@@ -76,6 +76,7 @@ control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;
+        b.meta = b.meta2 ++ b.meta7;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-frontend.p4
@@ -75,6 +75,7 @@ control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;
+        b.meta = b.meta2 ++ b.meta7;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-midend.p4
@@ -73,6 +73,7 @@ control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;
+        b.meta = b.meta2 ++ (16w0xf0 + b.meta2);
     }
     @hidden table tbl_psadpdkbinaryoperations79 {
         actions = {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations.p4
@@ -75,6 +75,7 @@ control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;
+        b.meta = b.meta2 ++ b.meta7;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations.p4.spec
@@ -32,6 +32,9 @@ struct metadata {
 	bit<32> local_metadata_meta6
 	bit<16> local_metadata_meta7
 	bit<16> Ingress_tmp
+	bit<32> Ingress_tmp_1
+	bit<16> Ingress_tmp_2
+	bit<32> Ingress_tmp_4
 }
 metadata instanceof metadata
 
@@ -80,6 +83,14 @@ apply {
 	mov h.dstAddr m.local_metadata_meta
 	mov h.srcAddr m.local_metadata_meta1
 	mov h.etherType m.local_metadata_meta2
+	mov m.Ingress_tmp_1 m.local_metadata_meta2
+	shl m.Ingress_tmp_1 0x10
+	mov m.Ingress_tmp_2 0xF0
+	add m.Ingress_tmp_2 m.local_metadata_meta2
+	mov m.Ingress_tmp_4 m.Ingress_tmp_2
+	and m.Ingress_tmp_4 0xFFFF
+	mov m.local_metadata_meta m.Ingress_tmp_1
+	or m.local_metadata_meta m.Ingress_tmp_4
 	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	tx m.psa_ingress_output_metadata_egress_port
 	LABEL_DROP :	drop


### PR DESCRIPTION
` bit<16> word0 = hdr.ipv4.version_ihl ++ hdr.ipv4.diffserv;`

is translated to

` word0_0 = (bit<16>)hdr.ipv4.version_ihl << 8 | (bit<16>)hdr.ipv4.diffserv & 16w0x1ff;`

The mask value should be **0xff** instead of **0x1ff**