### PR TITLE
ebpf/PSA: Add support for wide fields in parser value_set

### DIFF
--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -463,8 +463,8 @@ unsigned EBPFInitializerUtils::ebpfTypeWidth(P4::TypeMap *typeMap, const IR::Exp
     if (type == nullptr) type = expr->type;
     if (type->is<IR::Type_InfInt>()) return 32;  // let's assume 32 bit for int type
     if (type->is<IR::Type_Set>()) type = type->to<IR::Type_Set>()->elementType;
-    // FIXME: When select expression from parser supports more than one field then only the first
-    //        component will taken into account.
+    // FIXME: When a select expression from the parser supports more than one field then condition
+    //        below takes into account only the first component, remaining fields will be ignored.
     if (type->is<IR::Type_List>()) type = type->to<IR::Type_List>()->components.front();
 
     auto ebpfType = EBPFTypeFactory::instance->create(type);

--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -462,6 +462,11 @@ unsigned EBPFInitializerUtils::ebpfTypeWidth(P4::TypeMap *typeMap, const IR::Exp
     auto type = typeMap->getType(expr);
     if (type == nullptr) type = expr->type;
     if (type->is<IR::Type_InfInt>()) return 32;  // let's assume 32 bit for int type
+    if (type->is<IR::Type_Set>()) type = type->to<IR::Type_Set>()->elementType;
+    // FIXME: When select expression from parser supports more than one field then only the first
+    //        component will taken into account.
+    if (type->is<IR::Type_List>()) type = type->to<IR::Type_List>()->components.front();
+
     auto ebpfType = EBPFTypeFactory::instance->create(type);
     if (auto scalar = ebpfType->to<EBPFScalarType>()) {
         unsigned width = scalar->implementationWidthInBits();

--- a/backends/ebpf/ebpfTable.cpp
+++ b/backends/ebpf/ebpfTable.cpp
@@ -1192,7 +1192,7 @@ void EBPFValueSet::emitKeyInitializer(CodeBuilder *builder, const IR::SelectExpr
                 Util::printf_format("%s.%s", keyVarName.c_str(), fieldNames.at(i).first.c_str());
             builder->appendFormat("__builtin_memcpy(&%s, &(", dst.c_str());
             codeGen->visit(keyExpr);
-            builder->appendFormat("), sizeof(%s))", dst.c_str());
+            builder->appendFormat("[0]), sizeof(%s))", dst.c_str());
         } else {
             builder->appendFormat("%s.%s = ", keyVarName.c_str(), fieldNames.at(i).first.c_str());
             if (auto mask = keyExpr->to<IR::Mask>()) {

--- a/backends/ebpf/tests/p4testdata/wide-field-pvs.p4
+++ b/backends/ebpf/tests/p4testdata/wide-field-pvs.p4
@@ -1,0 +1,112 @@
+/*
+Copyright 2023-present Orange
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+struct headers {
+    ethernet_t ethernet;
+    ipv6_t     ipv6;
+}
+
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout empty_t meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_t resubmit_meta,
+                         in empty_t recirculate_meta)
+{
+    value_set<bit<128>>(4) pvs;
+
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x86DD: parse_ipv6;
+            default: accept;
+        }
+    }
+
+    state parse_ipv6 {
+        buffer.extract(parsed_hdr.ipv6);
+
+        transition select(parsed_hdr.ipv6.dstAddr) {
+            pvs: accept;
+            default: reject;
+        }
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout empty_t meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_t normal_meta,
+                        in empty_t clone_i2e_meta,
+                        in empty_t clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout empty_t meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    apply {
+        send_to_port(ostd, (PortId_t) PORT0);
+    }
+}
+
+control egress(inout headers hdr,
+               inout empty_t meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out buffer,
+                            out empty_t clone_i2e_meta,
+                            out empty_t resubmit_meta,
+                            out empty_t normal_meta,
+                            inout headers hdr,
+                            in empty_t meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        buffer.emit(hdr.ethernet);
+        buffer.emit(hdr.ipv6);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           out empty_t clone_e2e_meta,
+                           out empty_t recirculate_meta,
+                           inout headers hdr,
+                           in empty_t meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply { }
+}
+
+IngressPipeline(IngressParserImpl(), ingress(), IngressDeparserImpl()) ip;
+EgressPipeline(EgressParserImpl(), egress(), EgressDeparserImpl()) ep;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/ptf/test.py
+++ b/backends/ebpf/tests/ptf/test.py
@@ -455,6 +455,29 @@ class ParserValueSetPSATest(P4EbpfTest):
         testutils.verify_no_other_packets(self)
 
 
+class ParserValueSetPSAWideField(P4EbpfTest):
+    """
+    Test support for fields wider than 64 bits in value_set using IPv6 protocol.
+    """
+    p4_file_path = "p4testdata/wide-field-pvs.p4"
+
+    def runTest(self):
+        ip = "1111:2222:3333:4444:5555:6666:7777:8888"
+        pkt = testutils.simple_ipv6ip_packet(ipv6_dst=ip)
+
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_no_other_packets(self)
+
+        self.value_set_insert(name="IngressParserImpl_pvs", value=[ip])
+
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_packet_any_port(self, pkt, PTF_PORTS)
+
+        pkt[IPv6].dst = '2::2'
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_no_other_packets(self)
+
+
 # xdp2tc=head is not supported because pkt_len of test packet (Ethernet+RandomHeader) < 34 B
 @xdp2tc_head_not_supported
 class RandomPSATest(P4EbpfTest):


### PR DESCRIPTION
This PR adds ability to match fields wider than 64 bits in parser value set.

CC: @osinstom 