### PR TITLE
Add an explanation for unity builds. Add a deprecation warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ else()
   set (P4C_VERSION "${P4C_SEM_VERSION_STRING} (SHA: ${P4C_GIT_SHA} BUILD: ${CMAKE_BUILD_TYPE})")
 endif()
 include(P4CUtils)
+# TODO: Remove this deprecated include.
+include(UnifiedBuild)
 
 # # search in /usr/local first
 # set (CMAKE_FIND_ROOT_PATH "/usr/local/bin" "${CMAKE_FIND_ROOT_PATH}")

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ sudo dpkg -i /path/to/package.deb
      - `-DBUILD_LINK_WITH_LLD=ON|OFF`. Use LLD linker for build if available (overrides BUILD_LINK_WITH_GOLD).
      - `-DENABLE_LTO=ON|OFF`. Use Link Time Optimization (LTO).  Default is OFF.
      - `-DENABLE_WERROR=ON|OFF`. Treat warnings as errors.  Default is OFF.
+     - `-DCMAKE_UNITY_BUILD=ON|OFF `. Enable [unity builds](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html) for faster compilation.  Default is OFF.
 
     If adding new targets to this build system, please see
     [instructions](#defining-new-cmake-targets).

--- a/cmake/UnifiedBuild.cmake
+++ b/cmake/UnifiedBuild.cmake
@@ -82,6 +82,10 @@ endfunction(write_chunk_file)
 #     dependency tracking, while the NONUNIFIED property allows callers
 #     fine-grained control over which files get unified.
 function(build_unified sources)
+  message(
+    WARNING
+    "build_unified has been deprecated. Please use CMake's unity builds instead."
+  )
   # The ENABLE_UNIFIED_COMPILATION option is a global switch that turns this
   # feature off. By just returning here, `sources` remains unchanged, and we'll
   # build each file in it individually.


### PR DESCRIPTION
Addresses #3913.

Reinclude the deprecated unified build code, but add a warning. 