### PR TITLE
Add an explicit optional match key type.

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
@@ -138,16 +138,16 @@ class TableStepper {
     /// match or does not match at all. The table stepper first checks these custom match types. If
     /// these do not match it steps through the default implementation. If it does not match either,
     /// a P4C_UNIMPLEMENTED is thrown.
-    virtual const IR::Expression *computeTargetMatchType(
-        ExecutionState *nextState, const KeyProperties &keyProperties,
-        std::map<cstring, const FieldMatch> *matches, const IR::Expression *hitCondition);
+    virtual const IR::Expression *computeTargetMatchType(ExecutionState *nextState,
+                                                         const KeyProperties &keyProperties,
+                                                         TableMatchMap *matches,
+                                                         const IR::Expression *hitCondition);
 
     /// A helper function that computes whether a control-plane/table-key hits or not. This does not
     /// handle constant entries, it is specialized for control plane entries.
     /// The function also tracks the list of field matches created to achieve a  hit. We later use
     /// this to insert table entries using the STF/PTF framework.
-    const IR::Expression *computeHit(ExecutionState *nextState,
-                                     std::map<cstring, const FieldMatch> *matches);
+    const IR::Expression *computeHit(ExecutionState *nextState, TableMatchMap *matches);
 
     /// Collects properties that may be set per table. Target back end may have different semantics
     /// for table execution that need to be collect before evaluation the table.

--- a/backends/p4tools/modules/testgen/lib/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_spec.cpp
@@ -214,6 +214,27 @@ const Exact *Exact::evaluate(const Model &model) const {
 
 cstring Exact::getObjectName() const { return "Exact"; }
 
+Optional::Optional(const IR::KeyElement *key, const IR::Expression *val, bool addMatch)
+    : TableMatch(key), value(val), addMatch(addMatch) {}
+
+const IR::Constant *Optional::getEvaluatedValue() const {
+    const auto *constant = value->to<IR::Constant>();
+    BUG_CHECK(constant,
+              "Variable is not a constant. It has type %1% instead. Has the test object %2% "
+              "been evaluated?",
+              value->type->node_type_name(), getObjectName());
+    return constant;
+}
+
+const Optional *Optional::evaluate(const Model &model) const {
+    const auto *evaluatedValue = model.evaluate(value);
+    return new Optional(getKey(), evaluatedValue, addMatch);
+}
+
+cstring Optional::getObjectName() const { return "Optional"; }
+
+bool Optional::addAsExactMatch() const { return addMatch; }
+
 TableRule::TableRule(std::map<cstring, const FieldMatch> matches, int priority, ActionCall action,
                      int ttl)
     : matches(std::move(matches)), priority(priority), action(std::move(action)), ttl(ttl) {}

--- a/backends/p4tools/modules/testgen/lib/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_spec.cpp
@@ -13,9 +13,7 @@
 #include "ir/irutils.h"
 #include "lib/exceptions.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /* =========================================================================================
  *  Test Specification Objects
@@ -167,35 +165,6 @@ const LPM *LPM::evaluate(const Model &model) const {
 
 cstring LPM::getObjectName() const { return "LPM"; }
 
-Range::Range(const IR::KeyElement *key, const IR::Expression *low, const IR::Expression *high)
-    : TableMatch(key), low(low), high(high) {}
-
-const IR::Constant *Range::getEvaluatedLow() const {
-    const auto *constant = low->to<IR::Constant>();
-    BUG_CHECK(constant,
-              "Variable is not a constant. It has type %1% instead. Has the test object %2% "
-              "been evaluated?",
-              low->type->node_type_name(), getObjectName());
-    return constant;
-}
-
-const IR::Constant *Range::getEvaluatedHigh() const {
-    const auto *constant = high->to<IR::Constant>();
-    BUG_CHECK(constant,
-              "Variable is not a constant. It has type %1% instead. Has the test object %2% "
-              "been evaluated?",
-              high->type->node_type_name(), getObjectName());
-    return constant;
-}
-
-const Range *Range::evaluate(const Model &model) const {
-    const auto *evaluatedLow = model.evaluate(low);
-    const auto *evaluatedHigh = model.evaluate(high);
-    return new Range(getKey(), evaluatedLow, evaluatedHigh);
-}
-
-cstring Range::getObjectName() const { return "Range"; }
-
 Exact::Exact(const IR::KeyElement *key, const IR::Expression *val) : TableMatch(key), value(val) {}
 
 const IR::Constant *Exact::getEvaluatedValue() const {
@@ -214,32 +183,10 @@ const Exact *Exact::evaluate(const Model &model) const {
 
 cstring Exact::getObjectName() const { return "Exact"; }
 
-Optional::Optional(const IR::KeyElement *key, const IR::Expression *val, bool addMatch)
-    : TableMatch(key), value(val), addMatch(addMatch) {}
-
-const IR::Constant *Optional::getEvaluatedValue() const {
-    const auto *constant = value->to<IR::Constant>();
-    BUG_CHECK(constant,
-              "Variable is not a constant. It has type %1% instead. Has the test object %2% "
-              "been evaluated?",
-              value->type->node_type_name(), getObjectName());
-    return constant;
-}
-
-const Optional *Optional::evaluate(const Model &model) const {
-    const auto *evaluatedValue = model.evaluate(value);
-    return new Optional(getKey(), evaluatedValue, addMatch);
-}
-
-cstring Optional::getObjectName() const { return "Optional"; }
-
-bool Optional::addAsExactMatch() const { return addMatch; }
-
-TableRule::TableRule(std::map<cstring, const FieldMatch> matches, int priority, ActionCall action,
-                     int ttl)
+TableRule::TableRule(TableMatchMap matches, int priority, ActionCall action, int ttl)
     : matches(std::move(matches)), priority(priority), action(std::move(action)), ttl(ttl) {}
 
-const std::map<cstring, const FieldMatch> *TableRule::getMatches() const { return &matches; }
+const TableMatchMap *TableRule::getMatches() const { return &matches; }
 
 int TableRule::getPriority() const { return priority; }
 
@@ -250,14 +197,13 @@ int TableRule::getTTL() const { return ttl; }
 cstring TableRule::getObjectName() const { return "TableRule"; }
 
 const TableRule *TableRule::evaluate(const Model &model) const {
-    std::map<cstring, const FieldMatch> evaluatedMatches;
+    TableMatchMap evaluatedMatches;
     for (const auto &matchTuple : matches) {
         auto name = matchTuple.first;
-        auto match = matchTuple.second;
+        const auto &match = matchTuple.second;
         // This is a lambda function that applies the visitor to each variant.
-        const auto evaluatedMatch = boost::apply_visitor(
-            [model](auto const &obj) -> FieldMatch { return *obj.evaluate(model); }, match);
-        evaluatedMatches.insert({name, evaluatedMatch});
+        const auto *evaluatedMatch = match->evaluate(model)->checkedTo<TableMatch>();
+        evaluatedMatches[name] = evaluatedMatch;
     }
     const auto *evaluatedAction = action.evaluate(model);
     return new TableRule(evaluatedMatches, priority, *evaluatedAction, ttl);
@@ -361,6 +307,4 @@ std::map<cstring, const TestObject *> TestSpec::getTestObjectCategory(cstring ca
     return {};
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/test_spec.h
+++ b/backends/p4tools/modules/testgen/lib/test_spec.h
@@ -244,7 +244,30 @@ class Exact : public TableMatch {
     const IR::Constant *getEvaluatedValue() const;
 };
 
-using FieldMatch = boost::variant<Exact, Ternary, LPM, Range>;
+class Optional : public TableMatch {
+ private:
+    /// The value the key is matched with.
+    const IR::Expression *value;
+
+    /// Whether to add this optional match as an exact match.
+    bool addMatch;
+
+ public:
+    explicit Optional(const IR::KeyElement *key, const IR::Expression *value, bool addMatch);
+
+    const Optional *evaluate(const Model &model) const override;
+
+    cstring getObjectName() const override;
+
+    /// @returns the match value. It is expected to be a constant at this point.
+    /// A BUG is thrown otherwise.
+    const IR::Constant *getEvaluatedValue() const;
+
+    /// @returns whether to add this optional match as an exact match.
+    bool addAsExactMatch() const;
+};
+
+using FieldMatch = boost::variant<Exact, Ternary, LPM, Range, Optional>;
 
 class TableRule : public TestObject {
  private:

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
@@ -236,6 +236,13 @@ inja::json Protobuf::getControlPlaneForTable(const std::map<cstring, const Field
                 j["id"] = *p4RuntimeId;
                 rulesJson["lpm_matches"].push_back(j);
             }
+            void operator()(const Optional &elem) const {
+                inja::json j;
+                j["field_name"] = fieldName;
+                j["value"] = formatHexExpr(elem.getEvaluatedValue()).c_str();
+                rulesJson["needs_priority"] = true;
+                rulesJson["optional_matches"].push_back(j);
+            }
         };
         boost::apply_visitor(GetRange(rulesJson, fieldName), fieldMatch);
     }
@@ -323,6 +330,15 @@ entities : [
           value: "{{r.value}}"
         }
       }
+## endfor
+## for r in rule.rules.optional_matches
+    # Match field {{r.field_name}}
+    match {
+      field_id: {{r.id}}
+      optional {
+        value: "{{r.value}}"
+      }
+    }
 ## endfor
 ## for r in rule.rules.range_matches
       # Match field {{r.field_name}}

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
@@ -31,6 +31,7 @@
 #include "lib/null.h"
 #include "nlohmann/json.hpp"
 
+#include "backends/p4tools/modules/testgen/lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/lib/tf.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
 
@@ -165,7 +166,7 @@ inja::json Protobuf::getControlPlane(const TestSpec *testSpec) {
     return controlPlaneJson;
 }
 
-inja::json Protobuf::getControlPlaneForTable(const std::map<cstring, const FieldMatch> &matches,
+inja::json Protobuf::getControlPlaneForTable(const TableMatchMap &matches,
                                              const std::vector<ActionArg> &args) {
     inja::json rulesJson;
 
@@ -182,69 +183,39 @@ inja::json Protobuf::getControlPlaneForTable(const std::map<cstring, const Field
         auto const fieldName = match.first;
         auto const &fieldMatch = match.second;
 
+        inja::json j;
+        j["field_name"] = fieldName;
+        auto p4RuntimeId = getIdAnnotation(fieldMatch->getKey());
+        BUG_CHECK(p4RuntimeId, "Id not present for key. Can not generate test.");
+        j["id"] = *p4RuntimeId;
         // Iterate over the match fields and segregate them.
-        struct GetRange : public boost::static_visitor<void> {
-            cstring fieldName;
-            inja::json &rulesJson;
-
-            GetRange(inja::json &rulesJson, cstring fieldName)
-                : fieldName(fieldName), rulesJson(rulesJson) {}
-
-            void operator()(const Exact &elem) const {
-                inja::json j;
-                j["field_name"] = fieldName;
-                j["value"] = formatHexExprWithSep(elem.getEvaluatedValue());
-                auto p4RuntimeId = getIdAnnotation(elem.getKey());
-                BUG_CHECK(p4RuntimeId, "Id not present for key. Can not generate test.");
-                j["id"] = *p4RuntimeId;
-                rulesJson["single_exact_matches"].push_back(j);
-            }
-            void operator()(const Range &elem) const {
-                inja::json j;
-                j["field_name"] = fieldName;
-                j["lo"] = formatHexExprWithSep(elem.getEvaluatedLow());
-                j["hi"] = formatHexExprWithSep(elem.getEvaluatedHigh());
-                auto p4RuntimeId = getIdAnnotation(elem.getKey());
-                BUG_CHECK(p4RuntimeId, "Id not present for key. Can not generate test.");
-                j["id"] = *p4RuntimeId;
-                rulesJson["range_matches"].push_back(j);
-                // If the rule has a range match we need to add the priority.
-                rulesJson["needs_priority"] = true;
-            }
-            void operator()(const Ternary &elem) const {
-                inja::json j;
-                j["field_name"] = fieldName;
-                j["value"] = formatHexExprWithSep(elem.getEvaluatedValue());
-                j["mask"] = formatHexExprWithSep(elem.getEvaluatedMask());
-                auto p4RuntimeId = getIdAnnotation(elem.getKey());
-                BUG_CHECK(p4RuntimeId, "Id not present for key. Can not generate test.");
-                j["id"] = *p4RuntimeId;
-                rulesJson["ternary_matches"].push_back(j);
-                // If the rule has a range match we need to add the priority.
-                rulesJson["needs_priority"] = true;
-            }
-            void operator()(const LPM &elem) const {
-                inja::json j;
-                j["field_name"] = fieldName;
-                j["value"] = formatHexExprWithSep(elem.getEvaluatedValue());
-                j["prefix_len"] = elem.getEvaluatedPrefixLength()->value.str();
-                auto p4RuntimeId = getIdAnnotation(elem.getKey());
-                BUG_CHECK(p4RuntimeId, "Id not present for key. Can not generate test.");
-                j["id"] = *p4RuntimeId;
-                rulesJson["lpm_matches"].push_back(j);
-            }
-            void operator()(const Optional &elem) const {
-                inja::json j;
-                j["field_name"] = fieldName;
-                j["value"] = formatHexExpr(elem.getEvaluatedValue()).c_str();
-                auto p4RuntimeId = getIdAnnotation(elem.getKey());
-                BUG_CHECK(p4RuntimeId, "Id not present for key. Can not generate test.");
-                j["id"] = *p4RuntimeId;
-                rulesJson["needs_priority"] = true;
-                rulesJson["optional_matches"].push_back(j);
-            }
-        };
-        boost::apply_visitor(GetRange(rulesJson, fieldName), fieldMatch);
+        if (const auto *elem = fieldMatch->to<Exact>()) {
+            j["value"] = formatHexExprWithSep(elem->getEvaluatedValue());
+            rulesJson["single_exact_matches"].push_back(j);
+        } else if (const auto *elem = fieldMatch->to<Range>()) {
+            j["lo"] = formatHexExprWithSep(elem->getEvaluatedLow());
+            j["hi"] = formatHexExprWithSep(elem->getEvaluatedHigh());
+            rulesJson["range_matches"].push_back(j);
+            // If the rule has a range match we need to add the priority.
+            rulesJson["needs_priority"] = true;
+        } else if (const auto *elem = fieldMatch->to<Ternary>()) {
+            j["value"] = formatHexExprWithSep(elem->getEvaluatedValue());
+            j["mask"] = formatHexExprWithSep(elem->getEvaluatedMask());
+            rulesJson["ternary_matches"].push_back(j);
+            // If the rule has a range match we need to add the priority.
+            rulesJson["needs_priority"] = true;
+        } else if (const auto *elem = fieldMatch->to<LPM>()) {
+            j["value"] = formatHexExprWithSep(elem->getEvaluatedValue());
+            j["prefix_len"] = elem->getEvaluatedPrefixLength()->value.str();
+            rulesJson["lpm_matches"].push_back(j);
+        } else if (const auto *elem = fieldMatch->to<Optional>()) {
+            j["value"] = formatHexExpr(elem->getEvaluatedValue()).c_str();
+            rulesJson["needs_priority"] = true;
+            rulesJson["optional_matches"].push_back(j);
+        } else {
+            TESTGEN_UNIMPLEMENTED("Unsupported table key match type \"%1%\"",
+                                  fieldMatch->getObjectName());
+        }
     }
 
     for (const auto &actArg : args) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
@@ -34,11 +34,7 @@
 #include "backends/p4tools/modules/testgen/lib/tf.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 /// Wrapper helper function that automatically inserts separators for hex strings.
 std::string formatHexExprWithSep(const IR::Expression *expr) {
@@ -178,6 +174,7 @@ inja::json Protobuf::getControlPlaneForTable(const std::map<cstring, const Field
     rulesJson["range_matches"] = inja::json::array();
     rulesJson["ternary_matches"] = inja::json::array();
     rulesJson["lpm_matches"] = inja::json::array();
+    rulesJson["optional_matches"] = inja::json::array();
     rulesJson["act_args"] = inja::json::array();
     rulesJson["needs_priority"] = false;
 
@@ -240,6 +237,9 @@ inja::json Protobuf::getControlPlaneForTable(const std::map<cstring, const Field
                 inja::json j;
                 j["field_name"] = fieldName;
                 j["value"] = formatHexExpr(elem.getEvaluatedValue()).c_str();
+                auto p4RuntimeId = getIdAnnotation(elem.getKey());
+                BUG_CHECK(p4RuntimeId, "Id not present for key. Can not generate test.");
+                j["id"] = *p4RuntimeId;
                 rulesJson["needs_priority"] = true;
                 rulesJson["optional_matches"].push_back(j);
             }
@@ -449,8 +449,4 @@ void Protobuf::outputTest(const TestSpec *testSpec, cstring selectedBranches, si
     emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);
 }
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.h
@@ -79,7 +79,7 @@ class Protobuf : public TF {
     static std::vector<std::pair<size_t, size_t>> getIgnoreMasks(const IR::Constant *mask);
 
     /// Helper function for the control plane table inja objects.
-    static inja::json getControlPlaneForTable(const std::map<cstring, const FieldMatch> &matches,
+    static inja::json getControlPlaneForTable(const TableMatchMap &matches,
                                               const std::vector<ActionArg> &args);
 
     /// @return the id allocated to the object through the @id annotation if any, or

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
@@ -124,6 +124,7 @@ inja::json PTF::getControlPlaneForTable(const std::map<cstring, const FieldMatch
     rulesJson["range_matches"] = inja::json::array();
     rulesJson["ternary_matches"] = inja::json::array();
     rulesJson["lpm_matches"] = inja::json::array();
+    rulesJson["optional_matches"] = inja::json::array();
 
     rulesJson["act_args"] = inja::json::array();
     rulesJson["needs_priority"] = false;

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
@@ -78,7 +78,7 @@ class PTF : public TF {
     static std::vector<std::pair<size_t, size_t>> getIgnoreMasks(const IR::Constant *mask);
 
     /// Helper function for the control plane table inja objects.
-    static inja::json getControlPlaneForTable(const std::map<cstring, const FieldMatch> &matches,
+    static inja::json getControlPlaneForTable(const TableMatchMap &matches,
                                               const std::vector<ActionArg> &args);
 };
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.cpp
@@ -84,7 +84,7 @@ inja::json STF::getControlPlane(const TestSpec *testSpec) {
     return controlPlaneJson;
 }
 
-inja::json STF::getControlPlaneForTable(const std::map<cstring, const FieldMatch> &matches,
+inja::json STF::getControlPlaneForTable(const TableMatchMap &matches,
                                         const std::vector<ActionArg> &args) {
     inja::json rulesJson;
 
@@ -92,86 +92,65 @@ inja::json STF::getControlPlaneForTable(const std::map<cstring, const FieldMatch
     rulesJson["act_args"] = inja::json::array();
     rulesJson["needs_priority"] = false;
 
+    // Iterate over the match fields and segregate them.
     for (const auto &match : matches) {
         const auto fieldName = match.first;
         const auto &fieldMatch = match.second;
 
-        // Iterate over the match fields and segregate them.
-        struct GetRange : public boost::static_visitor<void> {
-            cstring fieldName;
-            inja::json &rulesJson;
-
-            GetRange(inja::json &rulesJson, cstring fieldName)
-                : fieldName(fieldName), rulesJson(rulesJson) {}
-
-            void operator()(const Exact &elem) const {
-                inja::json j;
-                j["field_name"] = fieldName;
-                j["value"] = formatHexExpr(elem.getEvaluatedValue());
-                rulesJson["matches"].push_back(j);
-            }
-            void operator()(const Range & /*elem*/) const {
-                TESTGEN_UNIMPLEMENTED("Match type range not implemented.");
-            }
-            void operator()(const Ternary &elem) const {
-                inja::json j;
-                j["field_name"] = fieldName;
-                const auto *dataValue = elem.getEvaluatedValue();
-                const auto *maskField = elem.getEvaluatedMask();
-                BUG_CHECK(dataValue->type->width_bits() == maskField->type->width_bits(),
-                          "Data value and its mask should have the same bit width.");
-                // Using the width from mask - should be same as data
-                auto dataStr = formatBinExpr(dataValue, false, true, false);
-                auto maskStr = formatBinExpr(maskField, false, true, false);
-                std::string data = "0b";
-                for (size_t dataPos = 0; dataPos < dataStr.size(); ++dataPos) {
-                    if (maskStr.at(dataPos) == '0') {
-                        data += "*";
-                    } else {
-                        data += dataStr.at(dataPos);
-                    }
+        inja::json j;
+        j["field_name"] = fieldName;
+        if (const auto *elem = fieldMatch->to<Exact>()) {
+            j["value"] = formatHexExpr(elem->getEvaluatedValue());
+        } else if (const auto *elem = fieldMatch->to<Ternary>()) {
+            const auto *dataValue = elem->getEvaluatedValue();
+            const auto *maskField = elem->getEvaluatedMask();
+            BUG_CHECK(dataValue->type->width_bits() == maskField->type->width_bits(),
+                      "Data value and its mask should have the same bit width.");
+            // Using the width from mask - should be same as data
+            auto dataStr = formatBinExpr(dataValue, false, true, false);
+            auto maskStr = formatBinExpr(maskField, false, true, false);
+            std::string data = "0b";
+            for (size_t dataPos = 0; dataPos < dataStr.size(); ++dataPos) {
+                if (maskStr.at(dataPos) == '0') {
+                    data += "*";
+                } else {
+                    data += dataStr.at(dataPos);
                 }
-                j["value"] = data;
-                rulesJson["matches"].push_back(j);
-                // If the rule has a ternary match we need to add the priority.
-                rulesJson["needs_priority"] = true;
             }
-            void operator()(const LPM &elem) const {
-                inja::json j;
-                j["field_name"] = fieldName;
-                const auto *dataValue = elem.getEvaluatedValue();
-                auto prefixLen = elem.getEvaluatedPrefixLength()->asInt();
-                auto fieldWidth = dataValue->type->width_bits();
-                auto maxVal = IR::getMaxBvVal(prefixLen);
-                const auto *maskField =
-                    IR::getConstant(dataValue->type, maxVal << (fieldWidth - prefixLen));
-                BUG_CHECK(dataValue->type->width_bits() == maskField->type->width_bits(),
-                          "Data value and its mask should have the same bit width.");
-                // Using the width from mask - should be same as data
-                auto dataStr = formatBinExpr(dataValue, false, true, false);
-                auto maskStr = formatBinExpr(maskField, false, true, false);
-                std::string data = "0b";
-                for (size_t dataPos = 0; dataPos < dataStr.size(); ++dataPos) {
-                    if (maskStr.at(dataPos) == '0') {
-                        data += "*";
-                    } else {
-                        data += dataStr.at(dataPos);
-                    }
+            j["value"] = data;
+            // If the rule has a ternary match we need to add the priority.
+            rulesJson["needs_priority"] = true;
+        } else if (const auto *elem = fieldMatch->to<LPM>()) {
+            const auto *dataValue = elem->getEvaluatedValue();
+            auto prefixLen = elem->getEvaluatedPrefixLength()->asInt();
+            auto fieldWidth = dataValue->type->width_bits();
+            auto maxVal = IR::getMaxBvVal(prefixLen);
+            const auto *maskField =
+                IR::getConstant(dataValue->type, maxVal << (fieldWidth - prefixLen));
+            BUG_CHECK(dataValue->type->width_bits() == maskField->type->width_bits(),
+                      "Data value and its mask should have the same bit width.");
+            // Using the width from mask - should be same as data
+            auto dataStr = formatBinExpr(dataValue, false, true, false);
+            auto maskStr = formatBinExpr(maskField, false, true, false);
+            std::string data = "0b";
+            for (size_t dataPos = 0; dataPos < dataStr.size(); ++dataPos) {
+                if (maskStr.at(dataPos) == '0') {
+                    data += "*";
+                } else {
+                    data += dataStr.at(dataPos);
                 }
-                j["value"] = data;
-                rulesJson["matches"].push_back(j);
-                // If the rule has a ternary match we need to add the priority.
-                rulesJson["needs_priority"] = true;
             }
-            void operator()(const Optional &elem) const {
-                inja::json j;
-                j["field_name"] = fieldName;
-                j["value"] = formatHexExpr(elem.getEvaluatedValue()).c_str();
-                rulesJson["needs_priority"] = true;
-                rulesJson["matches"].push_back(j);
-            }
-        };
-        boost::apply_visitor(GetRange(rulesJson, fieldName), fieldMatch);
+            j["value"] = data;
+            // If the rule has a ternary match we need to add the priority.
+            rulesJson["needs_priority"] = true;
+        } else if (const auto *elem = fieldMatch->to<Optional>()) {
+            j["value"] = formatHexExpr(elem->getEvaluatedValue()).c_str();
+            rulesJson["needs_priority"] = true;
+        } else {
+            TESTGEN_UNIMPLEMENTED("Unsupported table key match type \"%1%\"",
+                                  fieldMatch->getObjectName());
+        }
+        rulesJson["matches"].push_back(j);
     }
 
     for (const auto &actArg : args) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.cpp
@@ -167,6 +167,13 @@ inja::json STF::getControlPlaneForTable(const std::map<cstring, const FieldMatch
                 // If the rule has a ternary match we need to add the priority.
                 rulesJson["needs_priority"] = true;
             }
+            void operator()(const Optional &elem) const {
+                inja::json j;
+                j["field_name"] = fieldName;
+                j["value"] = formatHexExpr(elem.getEvaluatedValue()).c_str();
+                rulesJson["needs_priority"] = true;
+                rulesJson["matches"].push_back(j);
+            }
         };
         boost::apply_visitor(GetRange(rulesJson, fieldName), fieldMatch);
     }

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.cpp
@@ -32,11 +32,7 @@
 #include "backends/p4tools/modules/testgen/lib/tf.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 STF::STF(cstring testName, boost::optional<unsigned int> seed = boost::none) : TF(testName, seed) {
     boost::filesystem::path testFile(testName + ".stf");
@@ -339,8 +335,4 @@ void STF::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t 
     emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);
 }
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.h
@@ -68,7 +68,7 @@ class STF : public TF {
     static inja::json::array_t getClone(const std::map<cstring, const TestObject *> &cloneInfos);
 
     /// Helper function for the control plane table inja objects.
-    static inja::json getControlPlaneForTable(const std::map<cstring, const FieldMatch> &matches,
+    static inja::json getControlPlaneForTable(const TableMatchMap &matches,
                                               const std::vector<ActionArg> &args);
 };
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.h
@@ -64,7 +64,7 @@ class BMv2_V1ModelTableStepper : public TableStepper {
  protected:
     const IR::Expression *computeTargetMatchType(ExecutionState *nextState,
                                                  const KeyProperties &keyProperties,
-                                                 std::map<cstring, const FieldMatch> *matches,
+                                                 TableMatchMap *matches,
                                                  const IR::Expression *hitCondition) override;
 
     void checkTargetProperties(

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -265,8 +265,6 @@ p4tools_add_xfail_reason(
   # At index 0: INVALID_ARGUMENT, 'Bytestring provided does not fit within 0 bits'
   pins_middleblock.p4
   issue2283_1-bmv2.p4
-  # INVALID_ARGUMENT, 'Zero priority for ternary match'
-  dash-pipeline.p4
 )
 
 p4tools_add_xfail_reason(

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_table_opt.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_table_opt.p4
@@ -1,0 +1,94 @@
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16>         ether_type;
+}
+
+header ipv4_t {
+    bit<4>      version;
+    bit<4>      ihl;
+    bit<6>      dscp;
+    bit<2>      ecn;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<1>      reserved;
+    bit<1>      do_not_fragment;
+    bit<1>      more_fragments;
+    bit<13>     frag_offset;
+    bit<8>      ttl;
+    bit<8>      protocol;
+    bit<16>     header_checksum;
+    bit<32> src_addr;
+    bit<32> dst_addr;
+}
+
+struct local_metadata_t {
+}
+
+struct Headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+
+parser p(packet_in pkt, out Headers h, inout local_metadata_t local_metadata, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(h.ethernet);
+        pkt.extract(h.ipv4);
+        transition accept;
+    }
+
+}
+
+control vrfy(inout Headers h, inout local_metadata_t local_metadata) {
+    apply { }
+}
+
+
+control ingress(inout Headers h, inout local_metadata_t local_metadata, inout standard_metadata_t s) {
+    action acl_drop(inout standard_metadata_t standard_metadata) {
+        mark_to_drop(standard_metadata);
+    }
+
+    table acl_ingress_table {
+        key = {
+            h.ethernet.dst_addr                       : exact @name("dst_mac");
+            h.ipv4.src_addr                           : exact @name("src_ip");
+            h.ipv4.dst_addr                           : exact @name("dst_ip");
+            h.ipv4.ttl                                : optional @name("ttl");
+            h.ipv4.dscp                               : optional @name("dscp");
+            h.ipv4.ecn                                : optional @name("ecn");
+            h.ipv4.protocol                           : optional @name("ip_protocol");
+        }
+        actions = {
+            acl_drop(s);
+            @defaultonly NoAction;
+        }
+        const default_action = NoAction;
+    }
+    apply {
+        if (h.ipv4.isValid()) {
+            acl_ingress_table.apply();
+        }
+    }
+
+}
+
+control egress(inout Headers h, inout local_metadata_t local_metadata, inout standard_metadata_t s) {
+    apply { }
+}
+
+control update(inout Headers h, inout local_metadata_t local_metadata) {
+    apply { }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
@@ -169,4 +169,58 @@ const Bmv2_CloneInfo *Bmv2_CloneInfo::evaluate(const Model &model) const {
 
 bool Bmv2_CloneInfo::isClonedPacket() const { return isClone; }
 
+/* =========================================================================================
+ * Table Key Match Types
+ * ========================================================================================= */
+
+Optional::Optional(const IR::KeyElement *key, const IR::Expression *val, bool addMatch)
+    : TableMatch(key), value(val), addMatch(addMatch) {}
+
+const IR::Constant *Optional::getEvaluatedValue() const {
+    const auto *constant = value->to<IR::Constant>();
+    BUG_CHECK(constant,
+              "Variable is not a constant. It has type %1% instead. Has the test object %2% "
+              "been evaluated?",
+              value->type->node_type_name(), getObjectName());
+    return constant;
+}
+
+const Optional *Optional::evaluate(const Model &model) const {
+    const auto *evaluatedValue = model.evaluate(value);
+    return new Optional(getKey(), evaluatedValue, addMatch);
+}
+
+cstring Optional::getObjectName() const { return "Optional"; }
+
+bool Optional::addAsExactMatch() const { return addMatch; }
+
+Range::Range(const IR::KeyElement *key, const IR::Expression *low, const IR::Expression *high)
+    : TableMatch(key), low(low), high(high) {}
+
+const IR::Constant *Range::getEvaluatedLow() const {
+    const auto *constant = low->to<IR::Constant>();
+    BUG_CHECK(constant,
+              "Variable is not a constant. It has type %1% instead. Has the test object %2% "
+              "been evaluated?",
+              low->type->node_type_name(), getObjectName());
+    return constant;
+}
+
+const IR::Constant *Range::getEvaluatedHigh() const {
+    const auto *constant = high->to<IR::Constant>();
+    BUG_CHECK(constant,
+              "Variable is not a constant. It has type %1% instead. Has the test object %2% "
+              "been evaluated?",
+              high->type->node_type_name(), getObjectName());
+    return constant;
+}
+
+const Range *Range::evaluate(const Model &model) const {
+    const auto *evaluatedLow = model.evaluate(low);
+    const auto *evaluatedHigh = model.evaluate(high);
+    return new Range(getKey(), evaluatedLow, evaluatedHigh);
+}
+
+cstring Range::getObjectName() const { return "Range"; }
+
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
@@ -5,11 +5,7 @@
 
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 /* =========================================================================================
  *  Bmv2Register
@@ -173,8 +169,4 @@ const Bmv2_CloneInfo *Bmv2_CloneInfo::evaluate(const Model &model) const {
 
 bool Bmv2_CloneInfo::isClonedPacket() const { return isClone; }
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.h
@@ -12,11 +12,7 @@
 
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 /* =========================================================================================
  *  Bmv2Register
@@ -181,10 +177,6 @@ class Bmv2_CloneInfo : public TestObject {
     const IR::Constant *getEvaluatedSessionId() const;
 };
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_TEST_SPEC_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.h
@@ -177,6 +177,58 @@ class Bmv2_CloneInfo : public TestObject {
     const IR::Constant *getEvaluatedSessionId() const;
 };
 
+/* =========================================================================================
+ * Table Key Match Types
+ * ========================================================================================= */
+
+class Optional : public TableMatch {
+ private:
+    /// The value the key is matched with.
+    const IR::Expression *value;
+
+    /// Whether to add this optional match as an exact match.
+    bool addMatch;
+
+ public:
+    explicit Optional(const IR::KeyElement *key, const IR::Expression *value, bool addMatch);
+
+    const Optional *evaluate(const Model &model) const override;
+
+    cstring getObjectName() const override;
+
+    /// @returns the match value. It is expected to be a constant at this point.
+    /// A BUG is thrown otherwise.
+    const IR::Constant *getEvaluatedValue() const;
+
+    /// @returns whether to add this optional match as an exact match.
+    bool addAsExactMatch() const;
+};
+
+class Range : public TableMatch {
+ private:
+    /// The inclusive start of the range.
+    const IR::Expression *low;
+
+    /// The inclusive end of the range.
+    const IR::Expression *high;
+
+ public:
+    explicit Range(const IR::KeyElement *key, const IR::Expression *low,
+                   const IR::Expression *high);
+
+    const Range *evaluate(const Model &model) const override;
+
+    cstring getObjectName() const override;
+
+    /// @returns the inclusive start of the range. It is expected to be a constant at this point.
+    /// A BUG is thrown otherwise.
+    const IR::Constant *getEvaluatedLow() const;
+
+    /// @returns the inclusive end of the range. It is expected to be a constant at this point.
+    /// A BUG is thrown otherwise.
+    const IR::Constant *getEvaluatedHigh() const;
+};
+
 }  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_TEST_SPEC_H_ */

--- a/backends/p4tools/modules/testgen/targets/ebpf/backend/stf/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/backend/stf/stf.cpp
@@ -164,6 +164,13 @@ inja::json STF::getControlPlaneForTable(const std::map<cstring, const FieldMatch
                 // If the rule has a ternary match we need to add the priority.
                 rulesJson["needs_priority"] = true;
             }
+            void operator()(const Optional &elem) const {
+                inja::json j;
+                j["field_name"] = fieldName;
+                j["value"] = formatHexExpr(elem.getEvaluatedValue()).c_str();
+                rulesJson["needs_priority"] = true;
+                rulesJson["optional_matches"].push_back(j);
+            }
         };
         boost::apply_visitor(GetRange(rulesJson, fieldName), fieldMatch);
     }

--- a/backends/p4tools/modules/testgen/targets/ebpf/backend/stf/stf.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/backend/stf/stf.h
@@ -15,11 +15,7 @@
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 #include "backends/p4tools/modules/testgen/lib/tf.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {
+namespace P4Tools::P4Testgen::EBPF {
 
 /// Extracts information from the @testSpec to emit a STF test case.
 class STF : public TF {
@@ -65,14 +61,10 @@ class STF : public TF {
     static inja::json getVerify(const TestSpec *testSpec);
 
     /// Helper function for the control plane table inja objects.
-    static inja::json getControlPlaneForTable(const std::map<cstring, const FieldMatch> &matches,
+    static inja::json getControlPlaneForTable(const TableMatchMap &matches,
                                               const std::vector<ActionArg> &args);
 };
 
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_EBPF_BACKEND_STF_STF_H_ */

--- a/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.cpp
@@ -14,15 +14,12 @@
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 #include "backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.h"
 
-namespace P4Tools {
+namespace P4Tools::P4Testgen::EBPF {
 
-namespace P4Testgen {
-
-namespace EBPF {
-
-const IR::Expression *EBPFTableStepper::computeTargetMatchType(
-    ExecutionState *nextState, const KeyProperties &keyProperties,
-    std::map<cstring, const FieldMatch> *matches, const IR::Expression *hitCondition) {
+const IR::Expression *EBPFTableStepper::computeTargetMatchType(ExecutionState *nextState,
+                                                               const KeyProperties &keyProperties,
+                                                               TableMatchMap *matches,
+                                                               const IR::Expression *hitCondition) {
     // If the custom match type does not match, delete to the core match types.
     return TableStepper::computeTargetMatchType(nextState, keyProperties, matches, hitCondition);
 }
@@ -84,8 +81,4 @@ void EBPFTableStepper::evalTargetTable(
 EBPFTableStepper::EBPFTableStepper(EBPFExprStepper *stepper, const IR::P4Table *table)
     : TableStepper(stepper, table) {}
 
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.h
@@ -12,11 +12,7 @@
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 #include "backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {
+namespace P4Tools::P4Testgen::EBPF {
 
 class EBPFTableStepper : public TableStepper {
  private:
@@ -36,7 +32,7 @@ class EBPFTableStepper : public TableStepper {
  protected:
     const IR::Expression *computeTargetMatchType(ExecutionState *nextState,
                                                  const KeyProperties &keyProperties,
-                                                 std::map<cstring, const FieldMatch> *matches,
+                                                 TableMatchMap *matches,
                                                  const IR::Expression *hitCondition) override;
 
     void checkTargetProperties(
@@ -49,10 +45,6 @@ class EBPFTableStepper : public TableStepper {
     explicit EBPFTableStepper(EBPFExprStepper *stepper, const IR::P4Table *table);
 };
 
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF
 
 #endif /* TESTGEN_TARGETS_EBPF_TABLE_STEPPER_H_ */


### PR DESCRIPTION
As per discussion in https://github.com/p4lang/PI/issues/587 P4Testgen should handle optional matches explicitly instead of ignoring them. If the optional match is tainted, ignore it, but still add the priority. 

This PR also makes match keys target-independent. Now every target extension can add their own match key types without affecting other back ends. 