### PR TITLE
P4Testgen: Try out a simpler advance expression calculation

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
@@ -29,9 +29,7 @@
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 #include "backends/p4tools/modules/testgen/options.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 void ExprStepper::setFields(ExecutionState *nextState,
                             const std::vector<const IR::Member *> &flatFields,
@@ -103,18 +101,13 @@ ExprStepper::PacketCursorAdvanceInfo ExprStepper::calculateAdvanceExpression(
     // The packet size must be larger than the current parser cursor minus what is already
     // present in the buffer. The advance expression, i.e., the size of the advance can be freely
     // chosen.
-    auto *cond = new IR::LAnd(
-        new IR::Geq(IR::Type::Boolean::get(), advanceSum, bufferSizeConst),
-        new IR::Geq(IR::Type::Boolean::get(), ExecutionState::getInputPacketSizeVar(), minSize));
+    auto *cond =
+        new IR::Geq(IR::Type::Boolean::get(), ExecutionState::getInputPacketSizeVar(), minSize);
 
     // Compute the accept case.
     int advanceVal = 0;
     const auto *advanceCond = new IR::LAnd(cond, restrictions);
     const auto *advanceConst = evaluateExpression(advanceExpr, advanceCond);
-    // Compute the reject case.
-    int notAdvanceVal = 0;
-    const auto *notAdvanceCond = new IR::LAnd(new IR::LNot(cond), restrictions);
-    const auto *notAdvanceConst = evaluateExpression(advanceExpr, notAdvanceCond);
     // If we can not satisfy the advance, set the condition to nullptr.
     if (advanceConst == nullptr) {
         advanceCond = nullptr;
@@ -125,6 +118,10 @@ ExprStepper::PacketCursorAdvanceInfo ExprStepper::calculateAdvanceExpression(
         advanceVal = advanceConst->checkedTo<IR::Constant>()->asInt();
         advanceCond = new IR::LAnd(advanceCond, new IR::Equ(advanceConst, advanceExpr));
     }
+    // Compute the reject case.
+    int notAdvanceVal = 0;
+    const auto *notAdvanceCond = new IR::LAnd(new IR::LNot(cond), restrictions);
+    const auto *notAdvanceConst = evaluateExpression(advanceExpr, notAdvanceCond);
     // If we can not satisfy the reject, set the condition to nullptr.
     if (notAdvanceConst == nullptr) {
         notAdvanceCond = nullptr;
@@ -1075,6 +1072,4 @@ void ExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
     }
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -231,6 +231,7 @@ p4tools_add_xfail_reason(
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
   "Expected packet was not received on device"
+  # The packet is too short and is dropped by PTF.
   issue2314.p4
   issue281.p4
   bmv2_lookahead_2.p4
@@ -238,8 +239,8 @@ p4tools_add_xfail_reason(
   parser-unroll-issue3537.p4
   parser-unroll-test2.p4
   header-stack-ops-bmv2.p4
-  # The packet is too short and is dropped by PTF.
   fabric.p4
+  issue3702-bmv2.p4
 )
 
 # The test framework has a bug where it swallows the test output if the last test failed.


### PR DESCRIPTION
We do not need the restriction that the advance size must be larger than the buffer. In fact, it can lead to incorrect tests. 