### PR TITLE
Add a metadata collection mode to the STF back end.

### DIFF
--- a/backends/p4tools/modules/testgen/cmake/TestUtils.cmake
+++ b/backends/p4tools/modules/testgen/cmake/TestUtils.cmake
@@ -2,9 +2,6 @@
 # from the testsuite patterns by calling p4c_find_test_names then pass the list
 # to p4tools_add_test_list
 # Arguments:
-#   - template_file The path to the extension/target file that implements
-#     the logic of the target test. "p4tools_add_tests" includes this file and then
-#     executes the logic defined "p4tools_add_test_with_args".
 #   - tag is a label for the set of test suite where this test belongs
 #     (for example, p4ctest)
 #   - driver is the script that is used to run the tests and compare the results
@@ -21,7 +18,7 @@
 #
 macro(p4tools_add_tests)
   set(options "")
-  set(oneValueArgs TEMPLATE_FILE TAG DRIVER)
+  set(oneValueArgs TAG DRIVER)
   set(multiValueArgs TESTSUITES)
   cmake_parse_arguments(
     TOOLS_TESTS "${options}" "${oneValueArgs}"
@@ -31,7 +28,6 @@ macro(p4tools_add_tests)
   set(__tests "")
   p4c_find_test_names("${TOOLS_TESTS_TESTSUITES}" __tests)
 
-  include(${TOOLS_TESTS_TEMPLATE_FILE})
   list(LENGTH __tests __nTests)
   foreach(t ${__tests})
     get_filename_component(p4name ${t} NAME)

--- a/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
@@ -9,6 +9,7 @@ set(
   TESTGEN_SOURCES
   ${TESTGEN_SOURCES}
   ${CMAKE_CURRENT_SOURCE_DIR}/backend/protobuf/protobuf.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/backend/metadata/metadata.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/backend/ptf/ptf.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/backend/stf/stf.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/bmv2.cpp

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.cpp
@@ -1,0 +1,166 @@
+#include "backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.h"
+
+#include <iomanip>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/none.hpp>
+#include <boost/variant/apply_visitor.hpp>
+#include <boost/variant/static_visitor.hpp>
+#include <inja/inja.hpp>
+
+#include "backends/p4tools/common/lib/format_int.h"
+#include "backends/p4tools/common/lib/trace_events.h"
+#include "backends/p4tools/common/lib/util.h"
+#include "gsl/gsl-lite.hpp"
+#include "ir/declaration.h"
+#include "ir/ir.h"
+#include "ir/vector.h"
+#include "lib/big_int_util.h"
+#include "lib/error.h"
+#include "lib/error_catalog.h"
+#include "lib/exceptions.h"
+#include "lib/log.h"
+#include "lib/null.h"
+#include "nlohmann/json.hpp"
+
+#include "backends/p4tools/modules/testgen/lib/tf.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
+
+namespace P4Tools::P4Testgen::Bmv2 {
+
+Metadata::Metadata(cstring testName, boost::optional<unsigned int> seed = boost::none)
+    : TF(testName, seed) {}
+
+std::vector<std::pair<size_t, size_t>> Metadata::getIgnoreMasks(const IR::Constant *mask) {
+    std::vector<std::pair<size_t, size_t>> ignoreMasks;
+    if (mask == nullptr) {
+        return ignoreMasks;
+    }
+    auto maskBinStr = formatBinExpr(mask, false, true, false);
+    int countZeroes = 0;
+    size_t offset = 0;
+    for (; offset < maskBinStr.size(); ++offset) {
+        if (maskBinStr.at(offset) == '0') {
+            countZeroes++;
+        } else {
+            if (countZeroes > 0) {
+                ignoreMasks.emplace_back(offset - countZeroes, countZeroes);
+                countZeroes = 0;
+            }
+        }
+    }
+    if (countZeroes > 0) {
+        ignoreMasks.emplace_back(offset - countZeroes, countZeroes);
+    }
+    return ignoreMasks;
+}
+
+inja::json Metadata::getSend(const TestSpec *testSpec) {
+    const auto *iPacket = testSpec->getIngressPacket();
+    const auto *payload = iPacket->getEvaluatedPayload();
+    inja::json sendJson;
+    sendJson["ig_port"] = iPacket->getPort();
+    auto dataStr = formatHexExpr(payload);
+    sendJson["pkt"] = dataStr;
+    sendJson["pkt_size"] = payload->type->width_bits();
+    return sendJson;
+}
+
+inja::json Metadata::getVerify(const TestSpec *testSpec) {
+    inja::json verifyData = inja::json::object();
+    if (testSpec->getEgressPacket() != boost::none) {
+        const auto &packet = **testSpec->getEgressPacket();
+        verifyData["eg_port"] = packet.getPort();
+        const auto *payload = packet.getEvaluatedPayload();
+        const auto *payloadMask = packet.getEvaluatedPayloadMask();
+        verifyData["ignore_mask"] = formatHexExpr(payloadMask);
+        verifyData["exp_pkt"] = formatHexExpr(payload);
+    }
+    return verifyData;
+}
+
+std::string Metadata::getTestCaseTemplate() {
+    static std::string TEST_CASE(
+        R"""(# A P4TestGen-generated test case for {{test_name}}.p4
+# p4testgen seed: {{ default(seed, "none") }}
+# Date generated: {{timestamp}}
+## if length(selected_branches) > 0
+# {{selected_branches}}
+## endif
+# Current statement coverage: {{coverage}}
+
+## for trace_item in trace
+# "{{trace_item}}"
+## endfor
+
+input_packet: {{send.pkt}}
+input_port: {{send.ig_port}}
+
+## if verify
+output_packet: "{{verify.exp_pkt}}"
+output_port: {{verify.eg_port}}
+output_packet_mask: "{{verify.ignore_mask}}"
+## endif
+
+
+## for metadata_field in metadata_fields
+Metadata: {{metadata_field.name}}:{{metadata_field.value}}
+## endfor
+
+)""");
+    return TEST_CASE;
+}
+
+void Metadata::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
+                            const std::string &testCase, float currentCoverage) {
+    inja::json dataJson;
+    if (selectedBranches != nullptr) {
+        dataJson["selected_branches"] = selectedBranches.c_str();
+    }
+    boost::filesystem::path testFile(testName + ".proto");
+    cstring testNameOnly(testFile.stem().c_str());
+    if (seed) {
+        dataJson["seed"] = *seed;
+    }
+    dataJson["test_name"] = testNameOnly.c_str();
+    dataJson["test_id"] = testId + 1;
+    dataJson["trace"] = getTrace(testSpec);
+    dataJson["send"] = getSend(testSpec);
+    dataJson["verify"] = getVerify(testSpec);
+    dataJson["timestamp"] = Utils::getTimeStamp();
+    std::stringstream coverageStr;
+    coverageStr << std::setprecision(2) << currentCoverage;
+    dataJson["coverage"] = coverageStr.str();
+    dataJson["metadata_fields"] = inja::json::array();
+    const auto *metadataCollection =
+        testSpec->getTestObject("metadata_collection", "metadata_collection", true)
+            ->checkedTo<MetadataCollection>();
+    for (auto const &metadataField : metadataCollection->getMetadataFields()) {
+        inja::json jsonField;
+        jsonField["name"] = metadataField.first;
+        jsonField["value"] = formatHexExpr(metadataField.second);
+        dataJson["metadata_fields"].push_back(jsonField);
+    }
+
+    LOG5("Metadata back end: emitting testcase:" << std::setw(4) << dataJson);
+
+    inja::render_to(metadataFile, testCase, dataJson);
+    metadataFile.flush();
+}
+
+void Metadata::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+                          float currentCoverage) {
+    auto incrementedTestName = testName + "_" + std::to_string(testIdx);
+
+    metadataFile = std::ofstream(incrementedTestName + ".metadata");
+    std::string testCase = getTestCaseTemplate();
+    emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);
+}
+
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.h
@@ -1,0 +1,73 @@
+#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_BACKEND_METADATA_METADATA_H_
+#define BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_BACKEND_METADATA_METADATA_H_
+
+#include <cstddef>
+#include <fstream>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <boost/optional/optional.hpp>
+#include <inja/inja.hpp>
+
+#include "ir/ir.h"
+#include "lib/cstring.h"
+
+#include "backends/p4tools/modules/testgen/lib/test_spec.h"
+#include "backends/p4tools/modules/testgen/lib/tf.h"
+
+namespace P4Tools::P4Testgen::Bmv2 {
+
+/// Extracts information from the @testSpec to emit a Metadata test case.
+class Metadata : public TF {
+    /// The output file.
+    std::ofstream metadataFile;
+
+ public:
+    virtual ~Metadata() = default;
+
+    Metadata(const Metadata &) = delete;
+
+    Metadata(Metadata &&) = delete;
+
+    Metadata &operator=(const Metadata &) = delete;
+
+    Metadata &operator=(Metadata &&) = delete;
+
+    Metadata(cstring testName, boost::optional<unsigned int> seed);
+
+    /// Produce a Metadata test.
+    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testIdx,
+                    float currentCoverage) override;
+
+ private:
+    /// Emits the test preamble. This is only done once for all generated tests.
+    /// For the Metadata back end this is the "p4testgen.proto" file.
+    void emitPreamble(const std::string &preamble);
+
+    /// Emits a test case.
+    /// @param testId specifies the test name.
+    /// @param selectedBranches enumerates the choices the interpreter made for this path.
+    /// @param currentCoverage contains statistics  about the current coverage of this test and its
+    /// preceding tests.
+    void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
+                      const std::string &testCase, float currentCoverage);
+
+    /// @returns the inja test case template as a string.
+    static std::string getTestCaseTemplate();
+
+    /// Converts the input packet and port into Inja format.
+    static inja::json getSend(const TestSpec *testSpec);
+
+    /// Converts the output packet, port, and mask into Inja format.
+    static inja::json getVerify(const TestSpec *testSpec);
+
+    /// Helper function for @getVerify. Matches the mask value against the input packet value and
+    /// generates the appropriate ignore ranges.
+    static std::vector<std::pair<size_t, size_t>> getIgnoreMasks(const IR::Constant *mask);
+};
+
+}  // namespace P4Tools::P4Testgen::Bmv2
+
+#endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_BACKEND_METADATA_METADATA_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
@@ -13,11 +13,7 @@
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 class BMv2_V1ModelProgramInfo : public ProgramInfo {
  private:
@@ -69,10 +65,6 @@ class BMv2_V1ModelProgramInfo : public ProgramInfo {
                                         size_t paramIndex, cstring paramLabel) const override;
 };
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_PROGRAM_INFO_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -399,13 +399,15 @@ void BMv2_V1ModelTableStepper::evalTargetTable(
         auto testBackend = TestgenOptions::get().testBackend;
         if (testBackend == "STF" && !properties.defaultIsImmutable) {
             setTableDefaultEntries(tableActionList);
-        } else {
-            ::warning(
-                "Overriding default actions not supported for test back end %1%. Choosing default "
-                "action",
-                testBackend);
-            addDefaultAction(boost::none);
+            return;
         }
+        if (!properties.defaultIsImmutable) {
+            ::warning(
+                "Table %1%: Overriding default actions not supported for test back end %2%. "
+                "Choosing default action",
+                properties.tableName, testBackend);
+        }
+        addDefaultAction(boost::none);
         return;
     }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/AssumeAssertTests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/AssumeAssertTests.cmake
@@ -1,35 +1,35 @@
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_1.p4"
-  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_1.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_1.p4" DRIVER ${P4TESTGEN_DRIVER}
   TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE DISABLE_ASSUME_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )
 
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_2.p4"
-  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_2.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_2.p4" DRIVER ${P4TESTGEN_DRIVER}
   TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE DISABLE_ASSUME_MODE CHECK_EMPTY TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )
 
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_1.p4"
-  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_1.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_1.p4" DRIVER ${P4TESTGEN_DRIVER}
   TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE USE_ASSUME_MODE CHECK_EMPTY TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )
 
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_1.p4"
-  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_1_neg.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_1_neg.p4" DRIVER ${P4TESTGEN_DRIVER}
   TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE DISABLE_ASSUME_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )
 
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_2.p4"
-  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_2.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_2.p4" DRIVER ${P4TESTGEN_DRIVER}
   TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE CHECK_EMPTY TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )
 
 p4tools_add_test_with_args(
   P4TEST "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/assert_assume_tests/bmv2_testgen_assert_assume_3.p4"
-  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_3.p4" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
+  TAG "testgen-p4c-bmv2-assert" ALIAS "bmv2_testgen_assert_assume_3.p4" DRIVER ${P4TESTGEN_DRIVER}
   TARGET "bmv2" ARCH "v1model" USE_ASSERT_MODE TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF --print-traces --max-tests 10 "
 )

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
@@ -1,0 +1,137 @@
+# XFAILS: tests that *temporarily* fail
+# ================================================
+# Xfails are _temporary_ failures: the tests should work but we haven't fixed p4testgen yet.
+
+
+
+####################################################################################################
+# 2. P4Testgen Issues
+####################################################################################################
+# These are failures in P4Testgen that need to be fixed.
+
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Unknown or unimplemented extern method: recirculate_preserving_field_list"
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Unknown or unimplemented extern method: extract"
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Non-numeric, non-boolean member expression"
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "with type .* is not a Constant"
+  # Most of these come from varbits
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Cast failed"
+  # push front can not handled tainted header validity.
+  header-stack-ops-bmv2.p4
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "is trying to match on a tainted key set"
+  invalid-hdr-warnings1.p4 # unimlemented feature (for select statement)
+  issue692-bmv2.p4
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Only registers with bit or int types are currently supported"
+  issue907-bmv2.p4
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Could not find type for"
+  # Related to postorder(IR::Member* expression) in ParserUnroll,
+  # and more specifically when member is passed to getTypeArray
+)
+
+####################################################################################################
+# 3. WONTFIX
+####################################################################################################
+# These are failures that can not be solved by changing P4Testgen
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Assert/assume can not be executed under a tainted condition"
+  # Assert/Assume error: assert/assume(false).
+  bmv2_assert.p4
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Computations are not supported in update_checksum"
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Error compiling"
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Checksum16.get is deprecated and not supported."
+  issue841.p4 # Not supported
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Unknown or unimplemented extern method: increment"
+  issue1882-1-bmv2.p4  # user defined extern
+  issue1882-bmv2.p4  # user defined extern
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Unknown or unimplemented extern method: update"
+  issue2664-bmv2.p4  # user defined extern
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Unknown extern method count from type jnf_counter"
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Unknown or unimplemented extern method: fn_foo"
+  issue3091.p4  # user defined extern
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "with type Type_Specialized is not a Type_Declaration"
+  # Pipeline as a parameter of a switch, not a valid v1model program
+  issue1304.p4
+)
+
+####################################################################################################
+# 4. PARAMETERS NEEDED
+####################################################################################################
+# These tests require additional input parameters to compile properly.
+
+# TODO: For these test we should add the --permissive flag.
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "The validity bit of .* is tainted"
+  control-hs-index-test3.p4
+  control-hs-index-test5.p4
+  gauntlet_hdr_function_cast-bmv2.p4
+  issue2345-1.p4
+  issue2345-2.p4
+  issue2345-multiple_dependencies.p4
+  issue2345-with_nested_if.p4
+  issue2345.p4
+)

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
@@ -1,84 +1,91 @@
+# General test utilities.
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/TestUtils.cmake)
-
-# Add v1model tests from the p4c submodule
-set(P4TOOLS_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
-set(P4TESTGEN_DIR ${CMAKE_SOURCE_DIR}/build/testgen)
-set(P4TESTGEN_DRIVER "${P4TOOLS_BINARY_DIR}/p4testgen")
-
 # This file defines how we write the tests we generate.
-set(TEMPLATE_FILE ${CMAKE_CURRENT_LIST_DIR}/TestTemplate.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/TestTemplate.cmake)
 
-
-if(NOT P4TOOLS_BMV2_PATH)
-  set(P4TOOLS_BMV2_PATH ${CMAKE_HOME_DIRECTORY}/build)
-endif()
-
-set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10 ")
-
+#############################################################################
+# TEST PROGRAMS
+#############################################################################
 set(V1_SEARCH_PATTERNS "include.*v1model.p4" "main|common_v1_test")
-set(P4TESTDATA ${P4C_SOURCE_DIR}/testdata)
-set(P4TESTS_FOR_BMV2 "${P4TESTDATA}/p4_16_samples/*.p4")
-p4c_find_tests("${P4TESTS_FOR_BMV2}" P4_16_V1_TESTS INCLUDE "${V1_SEARCH_PATTERNS}" EXCLUDE "")
-p4tools_find_tests("${P4_16_V1_TESTS}" v1tests EXCLUDE "")
-
+# General BMv2 tests supplied by the compiler.
 set(
-  TESTGEN_BMV2_P416_TESTS
-  "${CMAKE_CURRENT_LIST_DIR}/p4-programs/*.p4"
+  P4TESTS_FOR_BMV2 "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/dash/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/fabric_*/fabric.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/omec/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/pins/*.p4"
 )
+p4c_find_tests("${P4TESTS_FOR_BMV2}" P4_16_V1_TESTS INCLUDE "${V1_SEARCH_PATTERNS}" EXCLUDE "")
+p4tools_find_tests("${P4_16_V1_TESTS}" v1tests EXCLUDE "")
 
+# Custom BMv2 tests.
+set(TESTGEN_BMV2_P416_TESTS "${CMAKE_CURRENT_LIST_DIR}/p4-programs/*.p4")
 p4c_find_tests("${TESTGEN_BMV2_P416_TESTS}" BMV2_P4_16_V1_TESTS INCLUDE "${V1_SEARCH_PATTERNS}" EXCLUDE "")
 p4tools_find_tests("${BMV2_P4_16_V1_TESTS}" bmv2v1tests EXCLUDE "")
 
-
-# Add bmv2 tests from p4c and from testgen/test/p4-programs/bmv2
+# Add BMv2 tests from p4c and from testgen/test/p4-programs/bmv2
 set(P4C_V1_TEST_SUITES_P416 ${v1tests} ${bmv2v1tests})
 
-p4tools_add_tests(
-  TESTSUITES "${P4C_V1_TEST_SUITES_P416}"
-  TAG "testgen-p4c-bmv2" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-  TARGET "bmv2" ARCH "v1model" ENABLE_RUNNER TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF ${EXTRA_OPTS} "
-)
 
 #############################################################################
-# ASSERT_ASSUME TESTS
+# TEST SUITES
 #############################################################################
+option(P4TOOLS_TESTGEN_BMV2_TEST_METADATA "Run tests on the Metadata test back end" ON)
+option(P4TOOLS_TESTGEN_BMV2_TEST_PROTOBUF "Run tests on the Protobuf test back end" OFF)
+option(P4TOOLS_TESTGEN_BMV2_TEST_PTF "Run tests on the PTF test back end" ON)
+option(P4TOOLS_TESTGEN_BMV2_TEST_STF "Run tests on the STF test back end" ON)
+# Test settings.
+set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10 ")
+set(P4TESTGEN_DRIVER "${P4TOOLS_BINARY_DIR}/p4testgen")
+
+# ASSERT_ASSUME TESTS
 include(${CMAKE_CURRENT_LIST_DIR}/AssumeAssertTests.cmake)
 
-#############################################################################
-# TEST PROPERTIES
-#############################################################################
-
-# Add bmv2 PTF tests from p4c and from testgen/test/p4-programs/bmv2
-set(P4C_V1_TEST_SUITES_P416_PTF ${bmv2v1tests})
-
-execute_process(
-  COMMAND bash -c "printf \"import google.rpc\nimport google.protobuf\" | python3" RESULT_VARIABLE result
-)
-if(result AND NOT result EQUAL 0)
-  message(
-    WARNING
-      "BMv2 PTF tests are enabled, but the Python3 module 'google.rpc' can not be found. BMv2 PTF tests will fail."
+# Protobuf
+if(P4TOOLS_TESTGEN_BMV2_TEST_PROTOBUF)
+  p4tools_add_tests(
+    TESTSUITES "${P4C_V1_TEST_SUITES_P416}"
+    TAG "testgen-p4c-bmv2-protobuf" DRIVER ${P4TESTGEN_DRIVER}
+    TARGET "bmv2" ARCH "v1model" VALIDATE_PROTOBUF TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend PROTOBUF ${EXTRA_OPTS} "
   )
+  include(${CMAKE_CURRENT_LIST_DIR}/BMV2ProtobufXfail.cmake)
 endif()
 
+# Metadata
+if(P4TOOLS_TESTGEN_BMV2_TEST_METADATA)
+  p4tools_add_tests(
+    TESTSUITES "${P4C_V1_TEST_SUITES_P416}"
+    TAG "testgen-p4c-bmv2-metadata" DRIVER ${P4TESTGEN_DRIVER}
+    TARGET "bmv2" ARCH "v1model" TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend METADATA ${EXTRA_OPTS} "
+  )
+  include(${CMAKE_CURRENT_LIST_DIR}/BMV2MetadataXfail.cmake)
+endif()
+
+# PTF
 # TODO: The PTF test back end currently does not support packet sizes over 12000 bits, so we limit
 # the range.
-p4tools_add_tests(
-  TESTSUITES "${P4C_V1_TEST_SUITES_P416}"
-  TAG "testgen-p4c-bmv2-ptf" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-  TARGET "bmv2" ARCH "v1model" P416_PTF TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend PTF --packet-size-range 0:12000 ${EXTRA_OPTS} "
-)
+if(P4TOOLS_TESTGEN_BMV2_TEST_PTF)
+  execute_process(COMMAND bash -c "printf \"import google.rpc\nimport google.protobuf\" | python3" RESULT_VARIABLE result)
+  if(result AND NOT result EQUAL 0)
+    message(
+      WARNING
+      "BMv2 PTF tests are enabled, but the Python3 module 'google.rpc' can not be found. BMv2 PTF tests will fail."
+    )
+  endif()
+  p4tools_add_tests(
+    TESTSUITES "${P4C_V1_TEST_SUITES_P416}"
+    TAG "testgen-p4c-bmv2-ptf" DRIVER ${P4TESTGEN_DRIVER}
+    TARGET "bmv2" ARCH "v1model" P416_PTF TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend PTF --packet-size-range 0:12000 ${EXTRA_OPTS} "
+  )
+  include(${CMAKE_CURRENT_LIST_DIR}/BMV2PTFXfail.cmake)
+endif()
 
-p4tools_add_tests(
-  TESTSUITES "${P4C_V1_TEST_SUITES_P416}"
-  TAG "testgen-p4c-bmv2-protobuf" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-  TARGET "bmv2" ARCH "v1model" VALIDATE_PROTOBUF TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend PROTOBUF ${EXTRA_OPTS} "
-)
-
- include(${CMAKE_CURRENT_LIST_DIR}/BMV2Xfail.cmake)
- include(${CMAKE_CURRENT_LIST_DIR}/BMV2PTFXfail.cmake)
- include(${CMAKE_CURRENT_LIST_DIR}/BMV2ProtobufXfail.cmake)
+# STF
+if(P4TOOLS_TESTGEN_BMV2_TEST_STF)
+  p4tools_add_tests(
+    TESTSUITES "${P4C_V1_TEST_SUITES_P416}"
+    TAG "testgen-p4c-bmv2" DRIVER ${P4TESTGEN_DRIVER}
+    TARGET "bmv2" ARCH "v1model" ENABLE_RUNNER TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF ${EXTRA_OPTS} "
+  )
+  include(${CMAKE_CURRENT_LIST_DIR}/BMV2Xfail.cmake)
+endif()

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
@@ -1,5 +1,7 @@
 # This file defines how a test should be written for a particular target. This is used by testutils
 
+set(P4TOOLS_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
+set(P4TESTGEN_DIR ${CMAKE_SOURCE_DIR}/build/testgen)
 
 # Write the script to check BMv2 STF tests to the designated test file.
 # Arguments:

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.h
@@ -20,11 +20,7 @@
 #include "backends/p4tools/modules/testgen/lib/test_backend.h"
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 class Bmv2TestBackend : public TestBackEnd {
  private:
@@ -52,10 +48,6 @@ class Bmv2TestBackend : public TestBackEnd {
                                    const Model *completedModel, const TestInfo &testInfo) override;
 };
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_TEST_BACKEND_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
@@ -221,6 +221,30 @@ const Range *Range::evaluate(const Model &model) const {
     return new Range(getKey(), evaluatedLow, evaluatedHigh);
 }
 
+/* =========================================================================================
+ *  MetadataCollection
+ * ========================================================================================= */
+
+MetadataCollection::MetadataCollection() = default;
+
+cstring MetadataCollection::getObjectName() const { return "MetadataCollection"; }
+
+const MetadataCollection *MetadataCollection::evaluate(const Model & /*model*/) const {
+    P4C_UNIMPLEMENTED("%1% has no implementation for \"evaluate\".", getObjectName());
+}
+
+const std::map<cstring, const IR::Literal *> &MetadataCollection::getMetadataFields() const {
+    return metadataFields;
+}
+
+const IR::Literal *MetadataCollection::getMetadataField(cstring name) {
+    return metadataFields.at(name);
+}
+
+void MetadataCollection::addMetaDataField(cstring name, const IR::Literal *metadataField) {
+    metadataFields[name] = metadataField;
+}
+
 cstring Range::getObjectName() const { return "Range"; }
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.h
@@ -30,15 +30,15 @@ class Bmv2RegisterCondition : public TestObject {
 
     /// @returns the evaluated register index. This means it must be a constant.
     /// The function will throw a bug if this is not the case.
-    const IR::Constant *getEvaluatedIndex() const;
+    [[nodiscard]] const IR::Constant *getEvaluatedIndex() const;
 
     /// @returns the evaluated condition of the register. This means it must be a constant.
     /// The function will throw a bug if this is not the case.
-    const IR::Constant *getEvaluatedValue() const;
+    [[nodiscard]] const IR::Constant *getEvaluatedValue() const;
 
-    const Bmv2RegisterCondition *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2RegisterCondition *evaluate(const Model &model) const override;
 
-    cstring getObjectName() const override;
+    [[nodiscard]] cstring getObjectName() const override;
 };
 
 /// This object tracks the list of writes that have been performed to a particular register. The
@@ -60,13 +60,13 @@ class Bmv2RegisterValue : public TestObject {
  public:
     explicit Bmv2RegisterValue(const IR::Expression *initialValue);
 
-    cstring getObjectName() const override;
+    [[nodiscard]] cstring getObjectName() const override;
 
     /// Each element is an API name paired with a match rule.
     void addRegisterCondition(Bmv2RegisterCondition cond);
 
     /// @returns the value with which this register has been initialized.
-    const IR::Expression *getInitialValue() const;
+    [[nodiscard]] const IR::Expression *getInitialValue() const;
 
     /// @returns the current value of this register after writes have been performed according to a
     /// provided index.
@@ -74,9 +74,9 @@ class Bmv2RegisterValue : public TestObject {
 
     /// @returns the evaluated register value. This means it must be a constant.
     /// The function will throw a bug if this is not the case.
-    const IR::Constant *getEvaluatedValue() const;
+    [[nodiscard]] const IR::Constant *getEvaluatedValue() const;
 
-    const Bmv2RegisterValue *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2RegisterValue *evaluate(const Model &model) const override;
 };
 
 /* =========================================================================================
@@ -93,13 +93,13 @@ class Bmv2_V1ModelActionProfile : public TestObject {
  public:
     explicit Bmv2_V1ModelActionProfile(const IR::IDeclaration *profileDecl);
 
-    cstring getObjectName() const override;
+    [[nodiscard]] cstring getObjectName() const override;
 
     /// @returns the action map of this profile.
-    const std::vector<std::pair<cstring, std::vector<ActionArg>>> *getActions() const;
+    [[nodiscard]] const std::vector<std::pair<cstring, std::vector<ActionArg>>> *getActions() const;
 
     /// @returns the associated action profile declaration.
-    const IR::IDeclaration *getProfileDecl() const;
+    [[nodiscard]] const IR::IDeclaration *getProfileDecl() const;
 
     /// @returns the current amount of actions associated with this profile.
     size_t getActionMapSize() const;
@@ -107,7 +107,7 @@ class Bmv2_V1ModelActionProfile : public TestObject {
     /// Add an action (its name) and the arguments to the action map of this profile.
     void addToActionMap(cstring actionName, std::vector<ActionArg> actionArgs);
 
-    const Bmv2_V1ModelActionProfile *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2_V1ModelActionProfile *evaluate(const Model &model) const override;
 };
 
 /* =========================================================================================
@@ -125,15 +125,15 @@ class Bmv2_V1ModelActionSelector : public TestObject {
     explicit Bmv2_V1ModelActionSelector(const IR::IDeclaration *selectorDecl,
                                         const Bmv2_V1ModelActionProfile *actionProfile);
 
-    cstring getObjectName() const override;
+    [[nodiscard]] cstring getObjectName() const override;
 
     /// @returns the associated action selector declaration.
-    const IR::IDeclaration *getSelectorDecl() const;
+    [[nodiscard]] const IR::IDeclaration *getSelectorDecl() const;
 
     /// @returns the associated action profile.
-    const Bmv2_V1ModelActionProfile *getActionProfile() const;
+    [[nodiscard]] const Bmv2_V1ModelActionProfile *getActionProfile() const;
 
-    const Bmv2_V1ModelActionSelector *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2_V1ModelActionSelector *evaluate(const Model &model) const override;
 };
 
 /* =========================================================================================
@@ -155,26 +155,48 @@ class Bmv2_CloneInfo : public TestObject {
     explicit Bmv2_CloneInfo(const IR::Expression *sessionId, const IR::Expression *clonePort,
                             bool isClone);
 
-    cstring getObjectName() const override;
+    [[nodiscard]] cstring getObjectName() const override;
 
-    const Bmv2_CloneInfo *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2_CloneInfo *evaluate(const Model &model) const override;
 
     /// @returns the associated session ID with this cloned packet.
-    const IR::Expression *getSessionId() const;
+    [[nodiscard]] const IR::Expression *getSessionId() const;
 
     /// @returns the clone port expression.
-    const IR::Expression *getClonePort() const;
+    [[nodiscard]] const IR::Expression *getClonePort() const;
 
     /// @returns information whether we are dealing with the packet clone or the real output packet.
-    bool isClonedPacket() const;
+    [[nodiscard]] bool isClonedPacket() const;
 
     /// @returns the evaluated clone port. This means it must be a constant.
     /// The function will throw a bug if this is not the case.
-    const IR::Constant *getEvaluatedClonePort() const;
+    [[nodiscard]] const IR::Constant *getEvaluatedClonePort() const;
 
     /// @returns the evaluated session id. This means it must be a constant.
     /// The function will throw a bug if this is not the case.
-    const IR::Constant *getEvaluatedSessionId() const;
+    [[nodiscard]] const IR::Constant *getEvaluatedSessionId() const;
+};
+
+/* =========================================================================================
+ *  MetadataCollection
+ * ========================================================================================= */
+class MetadataCollection : public TestObject {
+ private:
+    std::map<cstring, const IR::Literal *> metadataFields;
+
+ public:
+    MetadataCollection();
+
+    [[nodiscard]] cstring getObjectName() const override;
+
+    [[nodiscard]] const MetadataCollection *evaluate(const Model & /*model*/) const override;
+
+    /// @returns the clone port expression.
+    [[nodiscard]] const std::map<cstring, const IR::Literal *> &getMetadataFields() const;
+
+    void addMetaDataField(cstring name, const IR::Literal *metadataField);
+
+    const IR::Literal *getMetadataField(cstring name);
 };
 
 /* =========================================================================================

--- a/backends/p4tools/modules/testgen/targets/ebpf/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test/P4Tests.cmake
@@ -1,23 +1,11 @@
+# General test utilities.
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/TestUtils.cmake)
-
-# Add eBPF tests from the p4c submodule
-set(P4TOOLS_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
-set(P4TESTGEN_DIR ${CMAKE_SOURCE_DIR}/build/testgen)
-set(P4TESTGEN_DRIVER "${P4TOOLS_BINARY_DIR}/p4testgen")
-
 # This file defines how we write the tests we generate.
-set(TEMPLATE_FILE ${CMAKE_CURRENT_LIST_DIR}/TestTemplate.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/TestTemplate.cmake)
 
-if(NOT P4TOOLS_EBPF_PATH)
-  set(P4TOOLS_EBPF_PATH ${CMAKE_HOME_DIRECTORY}/build)
-endif()
-
-if(NOT NIGHTLY)
-  set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10")
-else()
-  set(EXTRA_OPTS "--strict --print-traces --max-tests 10")
-endif()
-
+#############################################################################
+# TEST PROGRAMS
+#############################################################################
 set(
   P4TESTGEN_EBPF_EXCLUDES
   "ebpf_checksum_extern\\.p4"
@@ -25,40 +13,42 @@ set(
 )
 
 set(EBPF_SEARCH_PATTERNS "include.*ebpf_model.p4")
-set(P4TESTDATA ${P4C_SOURCE_DIR}/testdata)
-set(P4TESTS_FOR_EBPF "${P4TESTDATA}/p4_16_samples/*.p4")
+set(P4TESTS_FOR_EBPF "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*.p4")
 p4c_find_tests("${P4TESTS_FOR_EBPF}" EBPF_TESTS INCLUDE "${EBPF_SEARCH_PATTERNS}" EXCLUDE "")
 p4tools_find_tests("${EBPF_TESTS}" ebpftests EXCLUDE "${P4TESTGEN_EBPF_EXCLUDES}")
 
-
 # Add ebpf tests from p4c
 set(P4C_EBPF_TEST_SUITES_P416 ${ebpftests})
-
-p4tools_add_tests(
-  TESTSUITES "${P4C_EBPF_TEST_SUITES_P416}"
-  TAG "testgen-p4c-ebpf" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-  TARGET "ebpf" ARCH "ebpf" ENABLE_RUNNER RUNNER_ARGS "" TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF ${EXTRA_OPTS} "
-)
-
-# These tests need special arguments.
-# TODO: This test is disabled because the z3 solver times out on it. Figure out why.
-# We can not use the solver timeout because it crashes, the solver does not interact well with GC.
-# p4tools_add_tests(
-#   TESTSUITES "${P4TESTDATA}/p4_16_samples/ebpf_checksum_extern.p4;"
-#   TAG "testgen-p4c-ebpf" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-#   TARGET "ebpf" ARCH "ebpf" ENABLE_RUNNER RUNNER_ARGS "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-checksum-ebpf.c"
-#   TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF ${EXTRA_OPTS} "
-# )
-
-p4tools_add_tests(
-  TESTSUITES "${P4TESTDATA}/p4_16_samples/ebpf_conntrack_extern.p4;"
-  TAG "testgen-p4c-ebpf" DRIVER ${P4TESTGEN_DRIVER} TEMPLATE_FILE ${TEMPLATE_FILE}
-  TARGET "ebpf" ARCH "ebpf" ENABLE_RUNNER RUNNER_ARGS "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-conntrack-ebpf.c"
-  TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF ${EXTRA_OPTS} "
-)
-
 #############################################################################
-# TEST PROPERTIES
+# TEST SUITES
 #############################################################################
+option(P4TOOLS_TESTGEN_EBPF_TEST_STF "Run tests on the STF test back end" ON)
+# Test settings.
+set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10")
+set(P4TESTGEN_DRIVER "${P4TOOLS_BINARY_DIR}/p4testgen")
 
-include(${CMAKE_CURRENT_LIST_DIR}/EBPFXfail.cmake)
+if(P4TOOLS_TESTGEN_EBPF_TEST_STF)
+  p4tools_add_tests(
+    TESTSUITES "${P4C_EBPF_TEST_SUITES_P416}"
+    TAG "testgen-p4c-ebpf" DRIVER ${P4TESTGEN_DRIVER}
+    TARGET "ebpf" ARCH "ebpf" ENABLE_RUNNER RUNNER_ARGS "" TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF ${EXTRA_OPTS} "
+  )
+
+  # These tests need special arguments.
+  # TODO: This test is disabled because the z3 solver times out on it. Figure out why.
+  # We can not use the solver timeout because it crashes, the solver does not interact well with GC.
+  # p4tools_add_tests(
+  #   TESTSUITES "${P4TESTDATA}/p4_16_samples/ebpf_checksum_extern.p4;"
+  #   TAG "testgen-p4c-ebpf" DRIVER ${P4TESTGEN_DRIVER}
+  #   TARGET "ebpf" ARCH "ebpf" ENABLE_RUNNER RUNNER_ARGS "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-checksum-ebpf.c"
+  #   TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF ${EXTRA_OPTS} "
+  # )
+
+  p4tools_add_tests(
+    TESTSUITES "${P4TESTDATA}/p4_16_samples/ebpf_conntrack_extern.p4;"
+    TAG "testgen-p4c-ebpf" DRIVER ${P4TESTGEN_DRIVER}
+    TARGET "ebpf" ARCH "ebpf" ENABLE_RUNNER RUNNER_ARGS "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-conntrack-ebpf.c"
+    TEST_ARGS "-I${P4C_BINARY_DIR}/p4include --test-backend STF ${EXTRA_OPTS} "
+  )
+  include(${CMAKE_CURRENT_LIST_DIR}/EBPFXfail.cmake)
+endif()

--- a/backends/p4tools/modules/testgen/targets/ebpf/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test/TestTemplate.cmake
@@ -1,5 +1,7 @@
 # This file defines how a test should be written for a particular target. This is used by testutils
 
+set(P4TOOLS_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
+set(P4TESTGEN_DIR ${CMAKE_SOURCE_DIR}/build/testgen)
 
 # Write the script to check eBPF Kernel STF tests to the designated test file.
 # Arguments:


### PR DESCRIPTION
This pull request adds a new test back end that only serializes user metadata from the appropriate target. For v1model, this is the `meta` variable. We can refine this output as needed. 

For example, for `pins_middleblock.p4` which has the local metadata
```
struct local_metadata_t {
    bool                admit_to_l3;
    vrf_id_t            vrf_id;
    packet_rewrites_t   packet_rewrites;
    bit<16>             l4_src_port;
    bit<16>             l4_dst_port;
    bit<16>             wcmp_selector_input;
    bool                apply_tunnel_encap_at_egress;
    ipv6_addr_t         tunnel_encap_src_ipv6;
    ipv6_addr_t         tunnel_encap_dst_ipv6;
    bool                mirror_session_id_valid;
    mirror_session_id_t mirror_session_id_value;
    @field_list(PreservedFieldList.CLONE_I2E)
    ipv4_addr_t         mirroring_src_ip;
    @field_list(PreservedFieldList.CLONE_I2E)
    ipv4_addr_t         mirroring_dst_ip;
    @field_list(PreservedFieldList.CLONE_I2E)
    ethernet_addr_t     mirroring_src_mac;
    @field_list(PreservedFieldList.CLONE_I2E)
    ethernet_addr_t     mirroring_dst_mac;
    @field_list(PreservedFieldList.CLONE_I2E)
    bit<8>              mirroring_ttl;
    @field_list(PreservedFieldList.CLONE_I2E)
    bit<8>              mirroring_tos;
    MeterColor_t        color;
    port_id_t           ingress_port;
    route_metadata_t    route_metadata;
}
```
the output will be: 

```
# A P4TestGen-generated test case for pins_middleblock.p4
# p4testgen seed: 8
# Date generated: 2023-03-21-09:13:49.993
# Current statement coverage: 0.57

input_packet: 0x02EB6C1F2EBF3B941568
input_port: 440

output_packet: "0x00000000000000000000000008004500002200004000002F7AAE0000000000000000000088BE02EB6C1F2EBF3B941568"
output_port: 0
output_packet_mask: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"


Metadata: *meta.admit_to_l3:0x0
Metadata: *meta.apply_tunnel_encap_at_egress:0x0
Metadata: *meta.color:0x0
Metadata: *meta.ingress_port:0x1B8
Metadata: *meta.l4_dst_port:0x0000
Metadata: *meta.l4_src_port:0x0000
Metadata: *meta.mirror_session_id_valid:0x0
Metadata: *meta.mirror_session_id_value:0x000
Metadata: *meta.mirroring_dst_ip:0x00000000
Metadata: *meta.mirroring_dst_mac:0x000000000000
Metadata: *meta.mirroring_src_ip:0x00000000
Metadata: *meta.mirroring_src_mac:0x000000000000
Metadata: *meta.mirroring_tos:0x00
Metadata: *meta.mirroring_ttl:0x00
Metadata: *meta.packet_rewrites.dst_mac:0x000000000000
Metadata: *meta.packet_rewrites.src_mac:0x000000000000
Metadata: *meta.route_metadata:0x00
Metadata: *meta.tunnel_encap_dst_ipv6:0x00000000000000000000000000000000
Metadata: *meta.tunnel_encap_src_ipv6:0x00000000000000000000000000000000
Metadata: *meta.vrf_id:0x000
Metadata: *meta.wcmp_selector_input:0x0000
```

This PR also cleans up the P4Tests.cmake files for the BMv2 and eBPF back end and adds options to disable/enable specific test back ends. In this case, we disable the protobuf in favor of the "dummy" metadata back end. 