### PR TITLE
Direct cast is possible between equivalent types

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -690,6 +690,7 @@ const IR::Node *TypeInference::postorder(IR::Declaration_Variable *decl) {
 bool TypeInference::canCastBetween(const IR::Type *dest, const IR::Type *src) const {
     if (src->is<IR::Type_Action>()) return false;
     if (src == dest) return true;
+    if (typeMap->equivalent(src, dest)) return true;
 
     if (dest->is<IR::Type_Newtype>()) {
         auto dt = getTypeType(dest->to<IR::Type_Newtype>()->type);


### PR DESCRIPTION
The issue was that the following code ended with a `CompilerBug`:
```
bit_var0 = (bit<1>) (bool) (bool) bit_var1;
```
The problem is with the double cast to `bool` (more specifically casting `bool` into `bool`). The problem was that the source and destination types were two different objects of the same class:
```
[9144] Type_Boolean
[9142] Type_Boolean
```
Therefore the original check for `canCastBetween` did not match those as the same type (since the pointers are not equal):
https://github.com/p4lang/p4c/blob/1b47d14d072887bdc3970ed84e6bccee37a69981/frontends/p4/typeChecking/typeChecker.cpp#L690-L692
Which lead to a new cast being introduced (so essentially there were 3 casts to `bool` instead of 2), while one of the original ones was not added into the type map:
https://github.com/p4lang/p4c/blob/1b47d14d072887bdc3970ed84e6bccee37a69981/frontends/p4/typeChecking/typeChecker.cpp#L2810-L2828