### PR TITLE
Better logging for lists/sets of things that take multiple lines

### DIFF
--- a/lib/indent.h
+++ b/lib/indent.h
@@ -97,6 +97,22 @@ class TempIndent {
         ti.streams.push_back(&out);
         return out << indent;
     }
+    friend std::ostream &operator<<(std::ostream &out, TempIndent &&ti) {
+        ti.streams.push_back(&out);
+        return out << indent;
+    }
+    const char *pop_back() {
+        if (!streams.empty()) {
+            *streams.back() << unindent;
+            streams.pop_back();
+        }
+        return "";
+    }
+    const char *reset() {
+        for (auto *out : streams) *out << unindent;
+        streams.clear();
+        return "";
+    }
     ~TempIndent() {
         for (auto *out : streams) *out << unindent;
     }

--- a/lib/log.h
+++ b/lib/log.h
@@ -169,13 +169,35 @@ inline auto operator<<(std::ostream &out, const T *obj) -> decltype((void)obj->d
 /// classes.
 template <class Cont>
 std::ostream &format_container(std::ostream &out, const Cont &container, char lbrace, char rbrace) {
-    const char *sep = " ";
-    out << lbrace;
+    std::vector<std::string> elems;
+    bool foundnl = false;
     for (auto &el : container) {
-        out << sep << el;
-        sep = ", ";
+        std::stringstream tmp;
+        tmp << el;
+        elems.emplace_back(tmp.str());
+        if (!foundnl) foundnl = elems.back().find('\n') != std::string::npos;
     }
-    out << (sep + 1) << rbrace;
+    if (foundnl) {
+        for (auto &el : elems) {
+            out << Log::endl << Log::indent;
+            for (auto &ch : el) {
+                if (ch == '\n')
+                    out << Log::endl;
+                else
+                    out << ch;
+            }
+            out << Log::unindent;
+        }
+    } else {
+        const char *sep = " ";
+        out << lbrace;
+        for (auto &el : elems) {
+            out << sep << el;
+            sep = ", ";
+        }
+        out << (sep + 1) << rbrace;
+    }
+
     return out;
 }
 


### PR DESCRIPTION
Basically the idea is to identify objects that take multiple lines when they appear in a log (using ostream `<<` or dbprint) and tweak the set/vector overload of `<<` to display them more cleanly.