### PR TITLE
Remove the inja submodule and replace it with a CMake fetchcontent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,6 +12,3 @@
 [submodule "backends/p4tools/submodules/gsl-lite"]
 	path = backends/p4tools/submodules/gsl-lite
 	url = https://github.com/gsl-lite/gsl-lite.git
-[submodule "backends/p4tools/submodules/inja"]
-	path = backends/p4tools/submodules/inja
-	url = https://github.com/pantor/inja.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,12 @@ else()
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
   set (P4C_VERSION "${P4C_SEM_VERSION_STRING} (SHA: ${P4C_GIT_SHA} BUILD: ${CMAKE_BUILD_TYPE})")
 endif()
+# P4 General Utilities
 include(P4CUtils)
-# TODO: Remove this deprecated include.
+# CMake Utilities to fetch dependencies.
+include(FetchContent)
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+# TODO: Remove this deprecated include eventually.
 include(UnifiedBuild)
 
 # # search in /usr/local first

--- a/backends/p4tools/CMakeLists.txt
+++ b/backends/p4tools/CMakeLists.txt
@@ -50,9 +50,18 @@ endif()
 # GSL-lite is needed for testgen.
 add_subdirectory(submodules/gsl-lite EXCLUDE_FROM_ALL)
 
+# Inja is needed to produce test templates.
 set(INJA_BUILD_TESTS OFF CACHE BOOL "Build unit tests when BUILD_TESTING is enabled.")
 set(BUILD_BENCHMARK OFF CACHE BOOL "Build benchmark.")
-add_subdirectory(submodules/inja)
+FetchContent_Declare(
+  inja
+  GIT_REPOSITORY https://github.com/pantor/inja.git
+  GIT_TAG        3741c73ba78babd2ed88f2acf2fcd6dafdb878e8
+  GIT_PROGRESS TRUE
+)
+FetchContent_MakeAvailable(inja)
+include_directories(SYSTEM ${inja_SOURCE_DIR}/include)
+
 
 # Import common definitions.
 include(common)


### PR DESCRIPTION
This makes sure that we only pull the dependency conditionally when P4Tools is enabled, not all the time. 

This also introduces CMake's [fetchcontent](https://cmake.org/cmake/help/latest/module/FetchContent.html) to our scripts, which is a useful CMake submodule. It makes Git submodule dependency management much easier. 