### PR TITLE
Remove boost variant from P4Tools

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
@@ -3,9 +3,8 @@
 #include <cstddef>
 #include <optional>
 #include <ostream>
+#include <variant>
 #include <vector>
-
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/compiler/convert_hs_index.h"
 #include "backends/p4tools/common/core/solver.h"

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -5,10 +5,10 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <boost/multiprecision/cpp_int.hpp>
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/compiler/convert_hs_index.h"
 #include "backends/p4tools/common/core/solver.h"

--- a/backends/p4tools/modules/testgen/core/small_step/small_step.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/small_step.cpp
@@ -3,11 +3,8 @@
 #include <iosfwd>
 #include <optional>
 #include <utility>
+#include <variant>
 #include <vector>
-
-#include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/static_visitor.hpp>
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/compiler/reachability.h"
 #include "backends/p4tools/common/core/solver.h"
@@ -78,170 +75,169 @@ SmallStepEvaluator::SmallStepEvaluator(AbstractSolver &solver, const ProgramInfo
     }
 }
 
+void SmallStepEvaluator::renginePostprocessing(ReachabilityResult &result,
+                                               std::vector<SmallStepEvaluator::Branch> *branches) {
+    // All Reachability engine state for branch should be copied.
+    if (branches->size() > 1 || result.second != nullptr) {
+        for (auto &n : *branches) {
+            if (result.second != nullptr) {
+                n.constraint = new IR::BAnd(IR::Type_Boolean::get(), n.constraint, result.second);
+            }
+            if (branches->size() > 1) {
+                // Copy reachability engine state
+                n.nextState->setReachabilityEngineState(
+                    n.nextState->getReachabilityEngineState()->copy());
+            }
+        }
+    }
+}
+
+SmallStepEvaluator::REngineType SmallStepEvaluator::renginePreprocessing(
+    SmallStepEvaluator &stepper, const ExecutionState &nextState, const IR::Node *node) {
+    ReachabilityResult rresult = std::make_pair(true, nullptr);
+    std::vector<SmallStepEvaluator::Branch> *branches = nullptr;
+    // Current node should be inside DCG.
+    if (stepper.reachabilityEngine->getDCG()->isCaller(node)) {
+        // Move reachability engine to next state.
+        rresult = stepper.reachabilityEngine->next(nextState.getReachabilityEngineState(), node);
+        if (!rresult.first) {
+            // Reachability property was failed.
+            branches = new std::vector<SmallStepEvaluator::Branch>({});
+        }
+    } else if (const auto *method = node->to<IR::MethodCallStatement>()) {
+        return renginePreprocessing(stepper, nextState, method->methodCall);
+    }
+    return std::make_pair(rresult, branches);
+}
+
+class CommandVisitor {
+ private:
+    SmallStepEvaluator &self;
+    ExecutionState &state;
+    using Branch = SmallStepEvaluator::Branch;
+    using Result = SmallStepEvaluator::Result;
+
+ public:
+    Result operator()(const IR::Node *node) {
+        // Step on the given node as a command.
+        BUG_CHECK(node, "Attempted to evaluate null node.");
+        SmallStepEvaluator::REngineType r;
+        if (self.reachabilityEngine != nullptr) {
+            r = self.renginePreprocessing(self, state, node);
+            if (r.second != nullptr) {
+                return r.second;
+            }
+        }
+        auto *stepper = TestgenTarget::getCmdStepper(state, self.solver, self.programInfo);
+        auto *result = stepper->step(node);
+        if (self.reachabilityEngine != nullptr) {
+            SmallStepEvaluator::renginePostprocessing(r.first, result);
+        }
+        return result;
+    }
+
+    Result operator()(const TraceEvent *event) {
+        CHECK_NULL(event);
+        event = event->subst(state.getSymbolicEnv());
+
+        state.add(event);
+        state.popBody();
+        return new std::vector<Branch>({Branch(&state)});
+    }
+
+    Result operator()(Continuation::Return ret) {
+        if (ret.expr) {
+            // Step on the returned expression.
+            const auto *expr = *ret.expr;
+            BUG_CHECK(expr, "Attempted to evaluate null expr.");
+            // Do not bother with the stepper, if the expression is already symbolic.
+            if (SymbolicEnv::isSymbolicValue(expr)) {
+                state.popContinuation(expr);
+                return new std::vector<Branch>({Branch(&state)});
+            }
+            auto *stepper = TestgenTarget::getExprStepper(state, self.solver, self.programInfo);
+            auto *result = stepper->step(expr);
+            if (self.reachabilityEngine != nullptr) {
+                ReachabilityResult rresult = std::make_pair(true, nullptr);
+                SmallStepEvaluator::renginePostprocessing(rresult, result);
+            }
+            return result;
+        }
+
+        // Step on valueless return.
+        state.popContinuation();
+        return new std::vector<Branch>({Branch(&state)});
+    }
+
+    Result operator()(Continuation::Exception e) {
+        state.handleException(e);
+        return new std::vector<Branch>({Branch(&state)});
+    }
+
+    Result operator()(const Continuation::PropertyUpdate &e) {
+        state.setProperty(e.propertyName, e.property);
+        state.popBody();
+        return new std::vector<Branch>({Branch(&state)});
+    }
+
+    Result operator()(const Continuation::Guard &guard) {
+        // Check whether we exceed the number of maximum permitted guard violations.
+        // This usually indicates that we have many branches that produce an invalid
+        // state. The P4 program should be fixed in that case, because we can not
+        // generate useful tests.
+        if (self.violatedGuardConditions > SmallStepEvaluator::MAX_GUARD_VIOLATIONS) {
+            BUG("Condition %1% exceeded the maximum number of permitted guard "
+                "violations for this run."
+                " This implies that the P4 program produces an output that violates"
+                " test variants. For example, it may set an output port that is not "
+                "testable.",
+                guard.cond);
+        }
+
+        // Evaluate the guard condition by directly using the solver.
+        const auto *cond = guard.cond;
+        std::optional<bool> solverResult = std::nullopt;
+
+        // If the guard condition is tainted, treat it equivalent to an invalid state.
+        if (!state.hasTaint(cond)) {
+            cond = state.getSymbolicEnv().subst(cond);
+            cond = P4::optimizeExpression(cond);
+            // Check whether the condition is satisfiable in the current execution
+            // state.
+            auto pathConstraints = state.getPathConstraint();
+            pathConstraints.push_back(cond);
+            solverResult = self.solver.checkSat(pathConstraints);
+        }
+
+        auto *nextState = new ExecutionState(state);
+        nextState->popBody();
+        // If we can not solve the guard (either we time out or the solver can not solve
+        // the problem) we increment the count of violatedGuardConditions and stop
+        // executing this branch.
+        if (solverResult == std::nullopt || !solverResult.value()) {
+            std::stringstream condStream;
+            guard.cond->dbprint(condStream);
+            ::warning(
+                "Guard %1% was not satisfiable."
+                " Incrementing number of guard violations.",
+                condStream.str().c_str());
+            self.violatedGuardConditions++;
+            return new std::vector<Branch>({{IR::getBoolLiteral(false), state, nextState}});
+        }
+        // Otherwise, we proceed as usual.
+        return new std::vector<Branch>({{cond, state, nextState}});
+    }
+
+    explicit CommandVisitor(SmallStepEvaluator &self, ExecutionState &state)
+        : self(self), state(state) {}
+};
+
 SmallStepEvaluator::Result SmallStepEvaluator::step(ExecutionState &state) {
     BUG_CHECK(!state.isTerminal(), "Tried to step from a terminal state.");
 
     if (const auto cmdOpt = state.getNextCmd()) {
-        struct CommandVisitor : public boost::static_visitor<Result> {
-         private:
-            SmallStepEvaluator &self;
-            ExecutionState &state;
-
-         public:
-            using REngineType = std::pair<ReachabilityResult, std::vector<Branch> *>;
-            REngineType renginePreprocessing(const IR::Node *node) {
-                ReachabilityResult rresult = std::make_pair(true, nullptr);
-                std::vector<Branch> *branches = nullptr;
-                // Current node should be inside DCG.
-                if (self.reachabilityEngine->getDCG()->isCaller(node)) {
-                    // Move reachability engine to next state.
-                    rresult = self.reachabilityEngine->next(state.reachabilityEngineState, node);
-                    if (!rresult.first) {
-                        // Reachability property was failed.
-                        branches = new std::vector<Branch>({});
-                    }
-                } else if (const auto *method = node->to<IR::MethodCallStatement>()) {
-                    return renginePreprocessing(method->methodCall);
-                }
-                return std::make_pair(rresult, branches);
-            }
-
-            static void renginePostprocessing(ReachabilityResult &result,
-                                              std::vector<Branch> *branches) {
-                // All Reachability engine state for branch should be copied.
-                if (branches->size() > 1 || result.second != nullptr) {
-                    for (auto &n : *branches) {
-                        if (result.second != nullptr) {
-                            n.constraint =
-                                new IR::BAnd(IR::Type_Boolean::get(), n.constraint, result.second);
-                        }
-                        if (branches->size() > 1) {
-                            // Copy reachability engine state
-                            n.nextState->reachabilityEngineState =
-                                n.nextState->reachabilityEngineState->copy();
-                        }
-                    }
-                }
-            }
-
-            Result operator()(const IR::Node *node) {
-                // Step on the given node as a command.
-                BUG_CHECK(node, "Attempted to evaluate null node.");
-                REngineType r;
-                if (self.reachabilityEngine != nullptr) {
-                    r = renginePreprocessing(node);
-                    if (r.second != nullptr) {
-                        return r.second;
-                    }
-                }
-                auto *stepper = TestgenTarget::getCmdStepper(state, self.solver, self.programInfo);
-                auto *result = stepper->step(node);
-                if (self.reachabilityEngine != nullptr) {
-                    renginePostprocessing(r.first, result);
-                }
-                return result;
-            }
-
-            Result operator()(const TraceEvent *event) {
-                CHECK_NULL(event);
-                event = event->subst(state.getSymbolicEnv());
-
-                state.add(event);
-                state.popBody();
-                return new std::vector<Branch>({Branch(&state)});
-            }
-
-            Result operator()(Continuation::Return ret) {
-                if (ret.expr) {
-                    // Step on the returned expression.
-                    const auto *expr = *ret.expr;
-                    BUG_CHECK(expr, "Attempted to evaluate null expr.");
-                    // Do not bother with the stepper, if the expression is already symbolic.
-                    if (SymbolicEnv::isSymbolicValue(expr)) {
-                        state.popContinuation(expr);
-                        return new std::vector<Branch>({Branch(&state)});
-                    }
-                    auto *stepper =
-                        TestgenTarget::getExprStepper(state, self.solver, self.programInfo);
-                    auto *result = stepper->step(expr);
-                    if (self.reachabilityEngine != nullptr) {
-                        ReachabilityResult rresult = std::make_pair(true, nullptr);
-                        renginePostprocessing(rresult, result);
-                    }
-                    return result;
-                }
-
-                // Step on valueless return.
-                state.popContinuation();
-                return new std::vector<Branch>({Branch(&state)});
-            }
-
-            Result operator()(Continuation::Exception e) {
-                state.handleException(e);
-                return new std::vector<Branch>({Branch(&state)});
-            }
-
-            Result operator()(const Continuation::PropertyUpdate &e) {
-                state.setProperty(e.propertyName, e.property);
-                state.popBody();
-                return new std::vector<Branch>({Branch(&state)});
-            }
-
-            Result operator()(const Continuation::Guard &guard) {
-                // Check whether we exceed the number of maximum permitted guard violations.
-                // This usually indicates that we have many branches that produce an invalid
-                // state. The P4 program should be fixed in that case, because we can not
-                // generate useful tests.
-                if (self.violatedGuardConditions > SmallStepEvaluator::MAX_GUARD_VIOLATIONS) {
-                    BUG("Condition %1% exceeded the maximum number of permitted guard "
-                        "violations for this run."
-                        " This implies that the P4 program produces an output that violates"
-                        " test variants. For example, it may set an output port that is not "
-                        "testable.",
-                        guard.cond);
-                }
-
-                // Evaluate the guard condition by directly using the solver.
-                const auto *cond = guard.cond;
-                std::optional<bool> solverResult = std::nullopt;
-
-                // If the guard condition is tainted, treat it equivalent to an invalid state.
-                if (!state.hasTaint(cond)) {
-                    cond = state.getSymbolicEnv().subst(cond);
-                    cond = P4::optimizeExpression(cond);
-                    // Check whether the condition is satisfiable in the current execution
-                    // state.
-                    auto pathConstraints = state.getPathConstraint();
-                    pathConstraints.push_back(cond);
-                    solverResult = self.solver.checkSat(pathConstraints);
-                }
-
-                auto *nextState = new ExecutionState(state);
-                nextState->popBody();
-                // If we can not solve the guard (either we time out or the solver can not solve
-                // the problem) we increment the count of violatedGuardConditions and stop
-                // executing this branch.
-                if (solverResult == std::nullopt || !solverResult.value()) {
-                    std::stringstream condStream;
-                    guard.cond->dbprint(condStream);
-                    ::warning(
-                        "Guard %1% was not satisfiable."
-                        " Incrementing number of guard violations.",
-                        condStream.str().c_str());
-                    self.violatedGuardConditions++;
-                    return new std::vector<Branch>({{IR::getBoolLiteral(false), state, nextState}});
-                }
-                // Otherwise, we proceed as usual.
-                return new std::vector<Branch>({{cond, state, nextState}});
-            }
-
-            explicit CommandVisitor(SmallStepEvaluator &self, ExecutionState &state)
-                : self(self), state(state) {}
-        } cmdVisitor(*this, state);
-
-        return boost::apply_visitor(cmdVisitor, *cmdOpt);
+        return std::visit(CommandVisitor(*this, state), *cmdOpt);
     }
-
     // State has an empty body. Pop the continuation stack.
     state.popContinuation();
     return new std::vector<Branch>({Branch(&state)});

--- a/backends/p4tools/modules/testgen/core/small_step/small_step.h
+++ b/backends/p4tools/modules/testgen/core/small_step/small_step.h
@@ -19,6 +19,8 @@ namespace P4Tools::P4Testgen {
 /// The main class that implements small-step operational semantics. Delegates to implementations
 /// of AbstractStepper.
 class SmallStepEvaluator {
+    friend class CommandVisitor;
+
  public:
     /// A branch is an execution state paired with an optional path constraint representing the
     /// choice made to take the branch.
@@ -62,6 +64,14 @@ class SmallStepEvaluator {
 
     /// Reachability engine.
     ReachabilityEngine *reachabilityEngine = nullptr;
+
+    using REngineType = std::pair<ReachabilityResult, std::vector<SmallStepEvaluator::Branch> *>;
+
+    static void renginePostprocessing(ReachabilityResult &result,
+                                      std::vector<SmallStepEvaluator::Branch> *branches);
+
+    REngineType renginePreprocessing(SmallStepEvaluator &stepper, const ExecutionState &nextState,
+                                     const IR::Node *node);
 
  public:
     Result step(ExecutionState &state);

--- a/backends/p4tools/modules/testgen/lib/concolic.h
+++ b/backends/p4tools/modules/testgen/lib/concolic.h
@@ -7,9 +7,8 @@
 #include <list>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
-
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/model.h"
@@ -22,17 +21,15 @@
 
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// TODO: This is a very ugly data structure. Essentially, you can store both state variables and
 /// entire expression as keys. State variables can actually compared, expressions are always unique
 /// keys. Using this map, you can look up particular state variables and check whether they actually
 /// are present, but not expressions. The reason expressions need to be keys is that sometimes
 /// entire expressions are mapped to a particular constant.
-using ConcolicVariableMap = ordered_map<boost::variant<const StateVariable, const IR::Expression *>,
-                                        const IR::Expression *>;
+using ConcolicVariableMap =
+    ordered_map<std::variant<const StateVariable, const IR::Expression *>, const IR::Expression *>;
 
 /// Encapsulates a set of concolic method implementations.
 class ConcolicMethodImpls {
@@ -93,8 +90,6 @@ class Concolic {
     static const ConcolicMethodImpls::ImplList *getCoreConcolicMethodImpls();
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_CONCOLIC_H_ */

--- a/backends/p4tools/modules/testgen/lib/continuation.cpp
+++ b/backends/p4tools/modules/testgen/lib/continuation.cpp
@@ -1,9 +1,7 @@
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 
+#include <variant>
 #include <vector>
-
-#include <boost/variant/apply_visitor.hpp>
-#include <boost/variant/static_visitor.hpp>
 
 #include "backends/p4tools/common/lib/trace_events.h"
 #include "ir/id.h"
@@ -12,9 +10,7 @@
 
 #include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 Continuation::Return::Return(const IR::Node *expr) : expr(expr) {}
 
@@ -132,7 +128,7 @@ Continuation::Body Continuation::apply(std::optional<const IR::Node *> value_opt
     // parameter.
     Body result;
 
-    struct SubstVisitor : public boost::static_visitor<Command> {
+    struct SubstVisitor {
         VariableSubstitution subst;
 
         Command operator()(const IR::Node *node) { return node->apply(subst); }
@@ -159,7 +155,7 @@ Continuation::Body Continuation::apply(std::optional<const IR::Node *> value_opt
     } subst(*parameterOpt, *value_opt);
 
     for (const auto &cmd : body.cmds) {
-        result.cmds.push_back(boost::apply_visitor(subst, cmd));
+        result.cmds.push_back(std::visit(subst, cmd));
     }
 
     return result;
@@ -171,6 +167,4 @@ const Continuation::Parameter *Continuation::genParameter(const IR::Type *type, 
     return new Parameter(new IR::PathExpression(type, new IR::Path(varName)));
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/continuation.h
+++ b/backends/p4tools/modules/testgen/lib/continuation.h
@@ -9,9 +9,8 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
-
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/lib/trace_events.h"
 #include "ir/ir.h"
@@ -86,7 +85,7 @@ class Continuation {
 
     /// Alias for various property types that can be set. We restrict these to keep the feature
     /// simple.
-    using PropertyValue = boost::variant<cstring, uint64_t, int64_t, bool, const IR::Expression *>;
+    using PropertyValue = std::variant<cstring, uint64_t, int64_t, bool, const IR::Expression *>;
 
     struct PropertyUpdate {
         /// The name of the property that is being set.
@@ -114,7 +113,7 @@ class Continuation {
         explicit Guard(const IR::Expression *cond);
     };
 
-    using Command = boost::variant<
+    using Command = std::variant<
         /// Executes a statement-like IR node.
         const IR::Node *,
         /// Registers a trace event.

--- a/backends/p4tools/modules/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/execution_state.cpp
@@ -7,11 +7,10 @@
 #include <stack>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
-#include <boost/container/vector.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/compiler/convert_hs_index.h"
 #include "backends/p4tools/common/compiler/reachability.h"
@@ -32,9 +31,7 @@
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 #include "backends/p4tools/modules/testgen/options.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 const IR::Member ExecutionState::inputPacketLabel =
     IR::Member(new IR::PathExpression("*"), "inputPacket");
@@ -209,6 +206,14 @@ std::map<cstring, const TestObject *> ExecutionState::getTestObjectCategory(
         return it->second;
     }
     return {};
+}
+
+void ExecutionState::setReachabilityEngineState(ReachabilityEngineState *newEngineState) {
+    reachabilityEngineState = newEngineState;
+}
+
+ReachabilityEngineState *ExecutionState::getReachabilityEngineState() const {
+    return reachabilityEngineState;
 }
 
 /* =============================================================================================
@@ -614,6 +619,4 @@ const StateVariable &ExecutionState::convertPathExpr(const IR::PathExpression *p
     BUG("Unsupported declaration %1% of type %2%.", decl, decl->node_type_name());
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -4,9 +4,7 @@
 #include <list>
 #include <optional>
 #include <utility>
-
-#include <boost/variant/get.hpp>
-#include <boost/variant/variant.hpp>
+#include <variant>
 
 #include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/core/z3_solver.h"
@@ -66,12 +64,11 @@ const Model *TestBackEnd::computeConcolicVariables(const ExecutionState *executi
             const auto *concolicAssignment = resolvedConcolicVariable.second;
             const IR::Expression *pathConstraint = nullptr;
             // We need to differentiate between state variables and expressions here.
-            auto concolicType = concolicVariable.which();
-            if (concolicType == 0) {
-                pathConstraint = new IR::Equ(boost::get<const StateVariable>(concolicVariable),
+            if (std::holds_alternative<const StateVariable>(concolicVariable)) {
+                pathConstraint = new IR::Equ(std::get<const StateVariable>(concolicVariable),
                                              concolicAssignment);
-            } else if (concolicType == 1) {
-                pathConstraint = new IR::Equ(boost::get<const IR::Expression *>(concolicVariable),
+            } else if (std::holds_alternative<const IR::Expression *>(concolicVariable)) {
+                pathConstraint = new IR::Equ(std::get<const IR::Expression *>(concolicVariable),
                                              concolicAssignment);
             }
             CHECK_NULL(pathConstraint);

--- a/backends/p4tools/modules/testgen/targets/bmv2/concolic.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/concolic.cpp
@@ -5,6 +5,7 @@
 #include <list>
 #include <map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <boost/multiprecision/cpp_int.hpp>
@@ -13,7 +14,6 @@
 #include <boost/multiprecision/detail/et_ops.hpp>
 #include <boost/multiprecision/number.hpp>
 #include <boost/multiprecision/traits/explicit_conversion.hpp>
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/model.h"

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -8,7 +8,6 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/multiprecision/number.hpp>
-#include <boost/variant/get.hpp>
 
 #include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/lib/formulae.h"
@@ -41,11 +40,7 @@
 #include "backends/p4tools/modules/testgen/targets/bmv2/target.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 std::string BMv2_V1ModelExprStepper::getClassName() { return "BMv2_V1ModelExprStepper"; }
 
@@ -1308,11 +1303,11 @@ void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpressio
                  size_t egressDelim = 0;
                  for (; egressDelim < topLevelBlocks->size(); ++egressDelim) {
                      auto block = topLevelBlocks->at(egressDelim);
-                     const auto *p4Node = boost::get<const IR::Node *>(&block);
-                     if (p4Node == nullptr) {
+                     if (!std::holds_alternative<const IR::Node *>(block)) {
                          continue;
                      }
-                     if (const auto *ctrl = (*p4Node)->to<IR::P4Control>()) {
+                     const auto *p4Node = std::get<const IR::Node *>(block);
+                     if (const auto *ctrl = p4Node->to<IR::P4Control>()) {
                          if (progInfo->getGress(ctrl) == BMV2_EGRESS) {
                              break;
                          }
@@ -1759,8 +1754,4 @@ bool BMv2_V1ModelExprStepper::preorder(const IR::P4Table *table) {
     return tableStepper.eval();
 }
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -5,10 +5,10 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <boost/multiprecision/cpp_int.hpp>
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/util.h"

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
@@ -3,10 +3,10 @@
 #include <list>
 #include <optional>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <boost/multiprecision/cpp_int.hpp>
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/util.h"

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
@@ -2,9 +2,8 @@
 
 #include <list>
 #include <utility>
+#include <variant>
 #include <vector>
-
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"

--- a/backends/p4tools/modules/testgen/test/small-step/util.h
+++ b/backends/p4tools/modules/testgen/test/small-step/util.h
@@ -7,9 +7,8 @@
 #include <optional>
 #include <stack>
 #include <string>
+#include <variant>
 #include <vector>
-
-#include <boost/variant/variant.hpp>
 
 #include "backends/p4tools/common/core/z3_solver.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"


### PR DESCRIPTION
We can replace all calls to boost::variant with its std equivalent. This PR also slightly cleans up the small stepper, which had a large visitor class defined within a function. That is not necessary. 