### PR TITLE
[P4Testgen] Implement meter support for the BMv2 V1model PTF test back end

### DIFF
--- a/backends/bmv2/base_test.py
+++ b/backends/bmv2/base_test.py
@@ -3,8 +3,6 @@
 # repository. This file in turn was a modified version of
 # https://github.com/p4lang/PI/blob/ec6865edc770b42f22fea15e6da17ca58a83d3a6/proto/ptf/base_test.py.
 
-from collections import Counter
-from functools import wraps, partialmethod
 import logging
 import queue
 import re
@@ -12,7 +10,7 @@ import sys
 import threading
 import time
 from collections import Counter
-from functools import partial, wraps
+from functools import partialmethod, wraps
 from pathlib import Path
 
 import google.protobuf.text_format
@@ -29,6 +27,7 @@ FILE_DIR = Path(__file__).resolve().parent
 TOOLS_PATH = FILE_DIR.joinpath("../../tools")
 sys.path.append(str(TOOLS_PATH))
 import testutils
+
 
 def stringify(n, length=0):
     """Take a non-negative integer 'n' as the first parameter, and a
@@ -52,6 +51,7 @@ def stringify(n, length=0):
             length = n_size_bytes
     s = n.to_bytes(length, byteorder="big")
     return s
+
 
 # Used to indicate that the gRPC error Status object returned by the server has
 # an incorrect format.
@@ -267,8 +267,14 @@ class P4RuntimeTest(BaseTest):
     def import_p4info_names(self):
         suffix_count = Counter()
         for obj_type in [
-                "tables", "action_profiles", "actions", "counters", "direct_counters",
-                "controller_packet_metadata", "meters", "direct_meters",
+            "tables",
+            "action_profiles",
+            "actions",
+            "counters",
+            "direct_counters",
+            "controller_packet_metadata",
+            "meters",
+            "direct_meters",
         ]:
             for obj in getattr(self.p4info, obj_type):
                 pre = obj.preamble
@@ -1052,10 +1058,16 @@ class P4RuntimeTest(BaseTest):
 # wrappers around P4RuntimeTest.get_obj and P4RuntimeTest.get_obj_id.
 # For example: get_table(x) and get_table_id(x) respectively call
 # get_obj("tables", x) and get_obj_id("tables", x)
-for obj_type, nickname in [("tables", "table"), ("action_profiles", "ap"), ("actions", "action"),
-                           ("counters", "counter"), ("direct_counters", "direct_counter"),
-                           ("meters", "meter"), ("direct_meters", "direct_meter"),
-                           ("controller_packet_metadata", "controller_packet_metadata")]:
+for obj_type, nickname in [
+    ("tables", "table"),
+    ("action_profiles", "ap"),
+    ("actions", "action"),
+    ("counters", "counter"),
+    ("direct_counters", "direct_counter"),
+    ("meters", "meter"),
+    ("direct_meters", "direct_meter"),
+    ("controller_packet_metadata", "controller_packet_metadata"),
+]:
     name = "_".join(["get", nickname])
     setattr(P4RuntimeTest, name, partialmethod(P4RuntimeTest.get_obj, obj_type))
     name = "_".join(["get", nickname, "id"])

--- a/backends/bmv2/base_test.py
+++ b/backends/bmv2/base_test.py
@@ -931,7 +931,7 @@ class P4RuntimeTest(BaseTest):
         if table_entry is None:
             meter_write.table_entry.is_default_action = True
         else:
-            meter_write.table_entry.match.extend(table_entry.match)
+            meter_write.table_entry.CopyFrom(table_entry)
         meter_write.config.cir = meter_config.cir
         meter_write.config.cburst = meter_config.cburst
         meter_write.config.pir = meter_config.pir

--- a/backends/bmv2/run-bmv2-ptf-test.py
+++ b/backends/bmv2/run-bmv2-ptf-test.py
@@ -200,7 +200,7 @@ def run_test(options: Options) -> int:
     return result
 
 
-def create_options(test_args) -> Options:
+def create_options(test_args) -> testutils.Optional[Options]:
     """Parse the input arguments and create a processed options object."""
     options = Options()
     options.p4_file = Path(testutils.check_if_file(test_args.p4_file))
@@ -208,7 +208,10 @@ def create_options(test_args) -> Options:
     if not testfile:
         testutils.log.info("No test file provided. Checking for file in folder.")
         testfile = options.p4_file.with_suffix(".py")
-    options.testfile = Path(testutils.check_if_file(testfile))
+    result = testutils.check_if_file(testfile)
+    if not result:
+        return None
+    options.testfile = Path(result)
     testdir = test_args.testdir
     if not testdir:
         testutils.log.info("No test directory provided. Generating temporary folder.")
@@ -240,6 +243,8 @@ if __name__ == "__main__":
     args, argv = PARSER.parse_known_args()
 
     test_options = create_options(args)
+    if not test_options:
+        sys.exit(testutils.FAILURE)
     # Run the test with the extracted options
     test_result = run_test(test_options)
     if not (args.nocleanup or test_result != testutils.SUCCESS):

--- a/backends/p4tools/modules/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/execution_state.cpp
@@ -169,7 +169,7 @@ const std::stack<std::reference_wrapper<const ExecutionState::StackFrame>>
 }
 
 void ExecutionState::setProperty(cstring propertyName, Continuation::PropertyValue property) {
-    stateProperties[propertyName] = std::move(property);
+    stateProperties[propertyName] = property;
 }
 
 bool ExecutionState::hasProperty(cstring propertyName) const {

--- a/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
@@ -18,11 +18,12 @@ set(
   ${CMAKE_CURRENT_SOURCE_DIR}/constants.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/contrib/bmv2_hash/calculations.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/expr_stepper.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/map_direct_externs.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/p4_asserts_parser.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/p4_refers_to_parser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/program_info.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/table_stepper.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/target.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/p4_asserts_parser.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/p4_refers_to_parser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_backend.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_spec.cpp
   PARENT_SCOPE

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.cpp
@@ -66,7 +66,7 @@ inja::json Metadata::getVerify(const TestSpec *testSpec) {
     inja::json verifyData = inja::json::object();
     auto egressPacket = testSpec->getEgressPacket();
     if (egressPacket.has_value()) {
-        const auto *const packet = egressPacket.value();
+        const auto *packet = egressPacket.value();
         verifyData["eg_port"] = packet->getPort();
         const auto *payload = packet->getEvaluatedPayload();
         const auto *payloadMask = packet->getEvaluatedPayloadMask();
@@ -94,7 +94,7 @@ statement_coverage: {{coverage}}
 ## endfor
 
 # The input packet in hexadecimal.
-input_packet: \"{{send.pkt}}\"
+input_packet: "{{send.pkt}}"
 
 # Parsed headers and their offsets.
 header_offsets:
@@ -105,7 +105,7 @@ header_offsets:
 # Metadata results after this test has completed.
 metadata:
 ## for metadata_field in metadata_fields
-  {{metadata_field.name}}: [value: \"{{metadata_field.value}}\", offset: {{metadata_field.offset}}]
+  {{metadata_field.name}}: [value: "{{metadata_field.value}}", offset: {{metadata_field.offset}}]
 ## endfor
 )""");
     return TEST_CASE;

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
@@ -45,7 +45,7 @@ inja::json PTF::getClone(const TestObjectMap &cloneSpecs) {
     return cloneSpec;
 }
 
-inja::json::array_t getMeter(const std::map<cstring, const TestObject *> &meterValues) {
+inja::json::array_t PTF::getMeter(const TestObjectMap &meterValues) {
     auto meterJson = inja::json::array_t();
     for (auto meterValueInfoTuple : meterValues) {
         const auto *meterValue = meterValueInfoTuple.second->checkedTo<Bmv2V1ModelMeterValue>();

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
@@ -45,6 +45,28 @@ inja::json PTF::getClone(const TestObjectMap &cloneSpecs) {
     return cloneSpec;
 }
 
+inja::json::array_t getMeter(const std::map<cstring, const TestObject *> &meterValues) {
+    auto meterJson = inja::json::array_t();
+    for (auto meterValueInfoTuple : meterValues) {
+        const auto *meterValue = meterValueInfoTuple.second->checkedTo<Bmv2V1ModelMeterValue>();
+
+        const auto meterEntries = meterValue->unravelMap();
+        for (const auto &meterEntry : meterEntries) {
+            inja::json meterInfoJson;
+            meterInfoJson["name"] = meterValueInfoTuple.first;
+            meterInfoJson["value"] = formatHexExpr(meterEntry.second.second);
+            meterInfoJson["index"] = formatHex(meterEntry.first, meterEntry.second.first);
+            if (meterValue->isDirectMeter()) {
+                meterInfoJson["is_direct"] = "True";
+            } else {
+                meterInfoJson["is_direct"] = "False";
+            }
+            meterJson.push_back(meterInfoJson);
+        }
+    }
+    return meterJson;
+}
+
 std::vector<std::pair<size_t, size_t>> PTF::getIgnoreMasks(const IR::Constant *mask) {
     std::vector<std::pair<size_t, size_t>> ignoreMasks;
     if (mask == nullptr) {
@@ -189,11 +211,12 @@ inja::json PTF::getSend(const TestSpec *testSpec) {
 
 inja::json PTF::getVerify(const TestSpec *testSpec) {
     inja::json verifyData = inja::json::object();
-    if (testSpec->getEgressPacket() != std::nullopt) {
-        const auto &packet = **testSpec->getEgressPacket();
-        verifyData["eg_port"] = packet.getPort();
-        const auto *payload = packet.getEvaluatedPayload();
-        const auto *payloadMask = packet.getEvaluatedPayloadMask();
+    auto egressPacket = testSpec->getEgressPacket();
+    if (egressPacket.has_value()) {
+        const auto *packet = egressPacket.value();
+        verifyData["eg_port"] = packet->getPort();
+        const auto *payload = packet->getEvaluatedPayload();
+        const auto *payloadMask = packet->getEvaluatedPayloadMask();
         verifyData["ignore_masks"] = getIgnoreMasks(payloadMask);
 
         auto dataStr = formatHexExpr(payload, false, true, false);
@@ -202,14 +225,12 @@ inja::json PTF::getVerify(const TestSpec *testSpec) {
     return verifyData;
 }
 
-static std::string getPreamble() {
+void PTF::emitPreamble() {
     static const std::string PREAMBLE(
         R"""(# P4Runtime PTF test for {{test_name}}
 # p4testgen seed: {{ default(seed, "none") }}
 
-import logging
-import sys
-import os
+from enum import Enum
 
 from ptf.mask import Mask
 
@@ -219,7 +240,9 @@ from ptf import testutils as ptfutils
 
 import base_test as bt
 
+
 class AbstractTest(bt.P4RuntimeTest):
+    EnumColor = Enum("EnumColor", ["GREEN", "YELLOW", "RED"], start=0)
 
     @bt.autocleanup
     def setUp(self):
@@ -246,19 +269,33 @@ class AbstractTest(bt.P4RuntimeTest):
         bt.testutils.log.info("Verifying Packet ...")
         self.verifyPackets()
 
-
+    def meter_write_with_predefined_config(self, meter_name, index, value, direct):
+        """Since we can not blast the target with packets, we have to carefully craft an artificial scenario where the meter will return the color we want. We do this by setting the meter config in such a way that the meter is forced to assign the desired color. For example, for RED to the lowest threshold values, to force a RED assignment."""
+        value = self.EnumColor(value)
+        if value == self.EnumColor.GREEN:
+            meter_config = bt.p4runtime_pb2.MeterConfig(
+                cir=4294967295, cburst=4294967295, pir=4294967295, pburst=4294967295
+            )
+        elif value == self.EnumColor.YELLOW:
+            meter_config = bt.p4runtime_pb2.MeterConfig(
+                cir=1, cburst=1, pir=4294967295, pburst=4294967295
+            )
+        elif value == self.EnumColor.RED:
+            meter_config = bt.p4runtime_pb2.MeterConfig(
+                cir=1, cburst=1, pir=1, pburst=1
+            )
+        else:
+            raise self.failureException(f"Unsupported meter value {value}")
+        return self.meter_write(meter_name, index, meter_config, direct)
 )""");
-    return PREAMBLE;
-}
 
-void PTF::emitPreamble(const std::string &preamble) {
     inja::json dataJson;
     dataJson["test_name"] = basePath.stem();
     if (seed) {
         dataJson["seed"] = *seed;
     }
 
-    inja::render_to(ptfFileStream, preamble, dataJson);
+    inja::render_to(ptfFileStream, PREAMBLE, dataJson);
     ptfFileStream.flush();
 }
 
@@ -319,6 +356,10 @@ class Test{{test_id}}(AbstractTest):
         self.insert_pre_clone_session({{clone_pkt.session_id}}, [{{clone_pkt.clone_port}}])
 ## endfor
 ## endif
+## for meter_value in meter_values
+        self.meter_write_with_predefined_config("{{meter_value.name}}", {{meter_value.index}}, {{meter_value.value}}, {{meter_value.is_direct}})
+## endfor
+
 
     def sendPacket(self):
 ## if send
@@ -385,6 +426,8 @@ void PTF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_
     if (!cloneSpecs.empty()) {
         dataJson["clone_specs"] = getClone(cloneSpecs);
     }
+    auto meterValues = testSpec->getTestObjectCategory("meter_values");
+    dataJson["meter_values"] = getMeter(meterValues);
 
     LOG5("PTF backend: emitting testcase:" << std::setw(4) << dataJson);
 
@@ -398,8 +441,7 @@ void PTF::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t 
         auto ptfFile = basePath;
         ptfFile.replace_extension(".py");
         ptfFileStream = std::ofstream(ptfFile);
-        std::string preamble = getPreamble();
-        emitPreamble(preamble);
+        emitPreamble();
         preambleEmitted = true;
     }
     std::string testCase = getTestCaseTemplate();

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
@@ -71,7 +71,10 @@ class PTF : public TF {
     /// Converts the output packet, port, and mask into Inja format.
     static inja::json getVerify(const TestSpec *testSpec);
 
-    /// Returns the configuration for a cloned packet configuration.
+    /// @returns the configuration for a meter call (may set the meter to GREEN, YELLOW, or RED)
+    static inja::json::array_t getMeter(const TestObjectMap &meterValues);
+
+    /// @returns the configuration for a cloned packet configuration.
     static inja::json getClone(const TestObjectMap &cloneSpecs);
 
     /// Helper function for @getVerify. Matches the mask value against the input packet value and

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
@@ -47,9 +47,6 @@ class PTF : public TF {
                     float currentCoverage) override;
 
  private:
-    /// @returns the static preamble string used by inja to serialize the test preamble.
-    static std::string getPreamble();
-
     /// Emits the test preamble. This is only done once for all generated tests.
     /// For the PTF back end this is the test setup Python script..
     void emitPreamble();

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
@@ -47,9 +47,12 @@ class PTF : public TF {
                     float currentCoverage) override;
 
  private:
+    /// @returns the static preamble string used by inja to serialize the test preamble.
+    static std::string getPreamble();
+
     /// Emits the test preamble. This is only done once for all generated tests.
     /// For the PTF back end this is the test setup Python script..
-    void emitPreamble(const std::string &preamble);
+    void emitPreamble();
 
     /// Emits a test case.
     /// @param testIdx specifies the test name.

--- a/backends/p4tools/modules/testgen/targets/bmv2/constants.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/constants.h
@@ -36,6 +36,8 @@ class BMv2Constants {
     static constexpr int STF_MIN_PKT_SIZE = 22;
     static constexpr int ETH_HDR_SIZE = 112;
     static constexpr int DROP_PORT = 511;
+
+    enum METER_COLOR { GREEN = 0, YELLOW = 1, RED = 2 };
 };
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -904,7 +904,7 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
                  const IR::Member *meterResult = nullptr;
                  const auto *expr = args->at(1)->expression;
                  if (const auto *pathRef = expr->to<IR::PathExpression>()) {
-                     meterResult = state.convertPathExpr(pathRef);
+                     meterResult = ExecutionState::convertPathExpr(pathRef);
                  } else if (const auto *member = expr->to<IR::Member>()) {
                      meterResult = member;
                  } else {
@@ -946,7 +946,7 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
              const auto *meterState =
                  state.getTestObject("meter_values", externInstance->controlPlaneName(), false);
              Bmv2V1ModelMeterValue *meterValue = nullptr;
-             const auto &inputValue = nextState.createZombieConst(
+             const auto &inputValue = nextState.createSymbolicVariable(
                  meterResult->type, "meter_value" + std::to_string(call->clone_id));
              // Make sure we do not accidentally get "3" as enum assignment...
              auto *cond = new IR::Lss(inputValue, IR::getConstant(meterResult->type, 3));
@@ -1027,7 +1027,7 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
              const auto *expr = args->at(0)->expression;
              const IR::Member *meterResult = nullptr;
              if (const auto *pathRef = expr->to<IR::PathExpression>()) {
-                 meterResult = state.convertPathExpr(pathRef);
+                 meterResult = ExecutionState::convertPathExpr(pathRef);
              } else if (const auto *member = expr->to<IR::Member>()) {
                  meterResult = member;
              } else {
@@ -1055,7 +1055,7 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
              const auto *meterState =
                  state.getTestObject("meter_values", externInstance->controlPlaneName(), false);
              Bmv2V1ModelMeterValue *meterValue = nullptr;
-             const auto &inputValue = nextState.createZombieConst(
+             const auto &inputValue = nextState.createSymbolicVariable(
                  meterResult->type, "meter_value" + std::to_string(call->clone_id));
              // Make sure we do not accidentally get "3" as enum assignment...
              auto *cond = new IR::Lss(inputValue, IR::getConstant(meterResult->type, 3));

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -1007,11 +1007,10 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
                 IR::ID & /*methodName*/, const IR::Vector<IR::Argument> *args,
                 const ExecutionState &state, SmallStepEvaluator::Result &result) {
              // Check whether table that the extern is attached to has an entry.
-             const auto *progInfo = getProgramInfo().checkedTo<BMv2_V1ModelProgramInfo>();
+             const auto *progInfo = getProgramInfo().checkedTo<Bmv2V1ModelProgramInfo>();
              const auto *receiverPath = receiver->checkedTo<IR::PathExpression>();
              const auto *externInstance = state.findDecl(receiverPath);
              const auto *table = progInfo->getTableofDirectExtern(externInstance);
-             CHECK_NULL(table);
              const auto *tableEntry =
                  state.getTestObject("tableconfigs", table->controlPlaneName(), false);
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.cpp
@@ -8,6 +8,7 @@ bool MapDirectExterns::preorder(const IR::Declaration_Instance *declInstance) {
 }
 
 bool MapDirectExterns::preorder(const IR::P4Table *table) {
+    // Try to either get counters or meters from the table.
     const auto *impl = table->properties->getProperty("meters");
     if (impl == nullptr) {
         impl = table->properties->getProperty("counters");
@@ -15,30 +16,34 @@ bool MapDirectExterns::preorder(const IR::P4Table *table) {
     if (impl == nullptr) {
         return false;
     }
+    // Cannot map a temporary mapped direct extern without a counter.
     const auto *selectorExpr = impl->value->checkedTo<IR::ExpressionValue>();
-    if (const auto *implCall = selectorExpr->expression->to<IR::ConstructorCallExpression>()) {
+    if (selectorExpr->expression->is<IR::ConstructorCallExpression>()) {
         return true;
     }
+    // Try to find the extern in the declared instances.
     const auto *implPath = selectorExpr->expression->to<IR::PathExpression>();
     auto implementationLabel = implPath->path->name.name;
 
+    // If the extern is not in the list of declared instances, move on.
     auto it = declaredExterns.find(implementationLabel);
     if (it == declaredExterns.end()) {
         return true;
     }
+    // BMv2 does not support direct externs attached to multiple tables.
     const auto *declInstance = it->second;
     if (directExternMap.find(declInstance) != directExternMap.end()) {
+        FATAL_ERROR(
+            "Direct extern was already mapped to a table. It can not be attached to two tables. ");
         return true;
     }
     directExternMap.emplace(declInstance, table);
-
     return true;
 }
 
-std::map<const IR::IDeclaration *, const IR::P4Table *> MapDirectExterns::getdirectExternMap() {
+const std::map<const IR::IDeclaration *, const IR::P4Table *>
+    &MapDirectExterns::getdirectExternMap() {
     return directExternMap;
 }
-
-MapDirectExterns::MapDirectExterns() = default;
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.cpp
@@ -1,0 +1,44 @@
+#include "backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h"
+
+namespace P4Tools::P4Testgen::Bmv2 {
+
+bool MapDirectExterns::preorder(const IR::Declaration_Instance *declInstance) {
+    declaredExterns[declInstance->name] = declInstance;
+    return true;
+}
+
+bool MapDirectExterns::preorder(const IR::P4Table *table) {
+    const auto *impl = table->properties->getProperty("meters");
+    if (impl == nullptr) {
+        impl = table->properties->getProperty("counters");
+    }
+    if (impl == nullptr) {
+        return false;
+    }
+    const auto *selectorExpr = impl->value->checkedTo<IR::ExpressionValue>();
+    if (const auto *implCall = selectorExpr->expression->to<IR::ConstructorCallExpression>()) {
+        return true;
+    }
+    const auto *implPath = selectorExpr->expression->to<IR::PathExpression>();
+    auto implementationLabel = implPath->path->name.name;
+
+    auto it = declaredExterns.find(implementationLabel);
+    if (it == declaredExterns.end()) {
+        return true;
+    }
+    const auto *declInstance = it->second;
+    if (directExternMap.find(declInstance) != directExternMap.end()) {
+        return true;
+    }
+    directExternMap.emplace(declInstance, table);
+
+    return true;
+}
+
+std::map<const IR::IDeclaration *, const IR::P4Table *> MapDirectExterns::getdirectExternMap() {
+    return directExternMap;
+}
+
+MapDirectExterns::MapDirectExterns() = default;
+
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h
@@ -8,20 +8,24 @@
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
+/// A lightweight visitor, which collects all the declarations in the program then checks whether a
+/// table is referencing the declaration as an direct extern. The direct externs are collected in a
+/// map. Currently checks for "counters" or "meters" properties in the table.
 class MapDirectExterns : public Inspector {
  private:
-    std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap;
-
+    /// List of the declared instances in the program.
     std::map<cstring, const IR::Declaration_Instance *> declaredExterns;
 
- public:
-    MapDirectExterns();
+    /// Maps direct extern declarations to the table they are attached to.
+    std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap;
 
+ public:
     bool preorder(const IR::Declaration_Instance *declInstance) override;
 
     bool preorder(const IR::P4Table *table) override;
 
-    std::map<const IR::IDeclaration *, const IR::P4Table *> getdirectExternMap();
+    /// @returns the list of direct externs and their corresponding table.
+    const std::map<const IR::IDeclaration *, const IR::P4Table *> &getdirectExternMap();
 };
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h
@@ -1,0 +1,29 @@
+#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_MAP_DIRECT_EXTERNS_H_
+#define BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_MAP_DIRECT_EXTERNS_H_
+
+#include <map>
+
+#include "ir/ir.h"
+#include "ir/visitor.h"
+
+namespace P4Tools::P4Testgen::Bmv2 {
+
+class MapDirectExterns : public Inspector {
+ private:
+    std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap;
+
+    std::map<cstring, const IR::Declaration_Instance *> declaredExterns;
+
+ public:
+    MapDirectExterns();
+
+    bool preorder(const IR::Declaration_Instance *declInstance) override;
+
+    bool preorder(const IR::P4Table *table) override;
+
+    std::map<const IR::IDeclaration *, const IR::P4Table *> getdirectExternMap();
+};
+
+}  // namespace P4Tools::P4Testgen::Bmv2
+
+#endif /*BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_MAP_DIRECT_EXTERNS_H_*/

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -30,6 +30,7 @@
 #include "backends/p4tools/modules/testgen/options.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/concolic.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/constants.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.h"
 
@@ -89,8 +90,21 @@ Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(
             constraint = new IR::LAnd(constraint, restriction);
         }
     }
+    auto directExternMapper = MapDirectExterns();
+    program->apply(directExternMapper);
 
+    auto mappedDirectExterns = directExternMapper.getdirectExternMap();
+    directExternMap.insert(mappedDirectExterns.begin(), mappedDirectExterns.end());
     targetConstraints = constraint;
+}
+
+const IR::P4Table *BMv2_V1ModelProgramInfo::getTableofDirectExtern(
+    const IR::IDeclaration *decl) const {
+    auto it = directExternMap.find(decl);
+    if (it == directExternMap.end()) {
+        return nullptr;
+    }
+    return it->second;
 }
 
 const ordered_map<cstring, const IR::Type_Declaration *>

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -101,11 +101,12 @@ Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(
     targetConstraints = constraint;
 }
 
-const IR::P4Table *BMv2_V1ModelProgramInfo::getTableofDirectExtern(
-    const IR::IDeclaration *decl) const {
-    auto it = directExternMap.find(decl);
+const IR::P4Table *Bmv2V1ModelProgramInfo::getTableofDirectExtern(
+    const IR::IDeclaration *directExternDecl) const {
+    auto it = directExternMap.find(directExternDecl);
     if (it == directExternMap.end()) {
-        return nullptr;
+        BUG("No table associated with this direct extern %1%. The extern should have been removed.",
+            directExternDecl);
     }
     return it->second;
 }

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -77,24 +77,27 @@ Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(
     const IR::Expression *constraint =
         new IR::Grt(IR::Type::Boolean::get(), ExecutionState::getInputPacketSizeVar(),
                     IR::getConstant(&PacketVars::PACKET_SIZE_VAR_TYPE, minPktSize));
-    /// Vector containing pairs of restrictions and nodes to which these restrictions apply.
+    // Vector containing pairs of restrictions and nodes to which these restrictions apply.
     std::vector<std::vector<const IR::Expression *>> restrictionsVec;
-    /// Defines all "entry_restriction" and then converts restrictions from string to IR
-    /// expressions, and stores them in restrictionsVec to move targetConstraints further.
+    // Defines all "entry_restriction" and then converts restrictions from string to IR
+    // expressions, and stores them in restrictionsVec to move targetConstraints further.
     program->apply(AssertsParser::AssertsParser(restrictionsVec));
-    /// Defines all "refers_to" and then converts restrictions from string to IR expressions,
-    /// and stores them in restrictionsVec to move targetConstraints further.
+    // Defines all "refers_to" and then converts restrictions from string to IR expressions,
+    // and stores them in restrictionsVec to move targetConstraints further.
     program->apply(RefersToParser::RefersToParser(restrictionsVec));
     for (const auto &element : restrictionsVec) {
         for (const auto *restriction : element) {
             constraint = new IR::LAnd(constraint, restriction);
         }
     }
+    // Try to map all instances of direct externs to the table they are attached to.
+    // Save the map in @var directExternMap.
     auto directExternMapper = MapDirectExterns();
     program->apply(directExternMapper);
-
     auto mappedDirectExterns = directExternMapper.getdirectExternMap();
     directExternMap.insert(mappedDirectExterns.begin(), mappedDirectExterns.end());
+
+    /// Finally, set the target constraints.
     targetConstraints = constraint;
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
@@ -31,6 +31,8 @@ class Bmv2V1ModelProgramInfo : public ProgramInfo {
     std::vector<Continuation::Command> processDeclaration(const IR::Type_Declaration *typeDecl,
                                                           size_t blockIdx) const;
 
+    std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap;
+
  public:
     Bmv2V1ModelProgramInfo(const IR::P4Program *program,
                            ordered_map<cstring, const IR::Type_Declaration *> inputBlocks,
@@ -38,6 +40,8 @@ class Bmv2V1ModelProgramInfo : public ProgramInfo {
 
     /// @returns the gress associated with the given parser.
     int getGress(const IR::Type_Declaration *) const;
+
+    const IR::P4Table *getTableofDirectExtern(const IR::IDeclaration *decl) const;
 
     /// @returns the programmable blocks of the program. Should be 6.
     [[nodiscard]] const ordered_map<cstring, const IR::Type_Declaration *> *getProgrammableBlocks()

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
@@ -41,7 +41,8 @@ class Bmv2V1ModelProgramInfo : public ProgramInfo {
     /// @returns the gress associated with the given parser.
     int getGress(const IR::Type_Declaration *) const;
 
-    const IR::P4Table *getTableofDirectExtern(const IR::IDeclaration *decl) const;
+    /// @returns the table associated with the direct extern
+    const IR::P4Table *getTableofDirectExtern(const IR::IDeclaration *directExternDecl) const;
 
     /// @returns the programmable blocks of the program. Should be 6.
     [[nodiscard]] const ordered_map<cstring, const IR::Type_Declaration *> *getProgrammableBlocks()

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -304,7 +304,7 @@ bool Bmv2V1ModelTableStepper::checkForActionProfile() {
     }
 
     const auto *testObject =
-        state->getTestObject("action_profile", implExtern->controlPlaneName(), false);
+        state->getTestObject("action_profile", implDecl->controlPlaneName(), false);
     if (testObject == nullptr) {
         // This means, for every possible control plane entry (and with that, new execution state)
         // add the generated action profile.
@@ -347,7 +347,7 @@ bool Bmv2V1ModelTableStepper::checkForActionSelector() {
     // Treat action selectors like action profiles for now.
     // The behavioral model P4Runtime is unclear how to configure action selectors.
     const auto *testObject =
-        state->getTestObject("action_profile", selectorExtern->controlPlaneName(), false);
+        state->getTestObject("action_profile", selectorDecl->controlPlaneName(), false);
     if (testObject == nullptr) {
         // This means, for every possible control plane entry (and with that, new execution state)
         // add the generated action profile.

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_direct_meter_1.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_direct_meter_1.p4
@@ -1,0 +1,82 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> color_status;
+    bit<32> idx;
+}
+
+struct headers {
+    ethernet_t eth_hdr;
+    H h;
+}
+
+enum bit<2> MeterColor {
+    GREEN = 0,
+    YELLOW = 1,
+    RED = 2
+}
+
+struct Meta {}
+
+parser p(packet_in pkt, out headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h);
+        transition accept;
+    }
+}
+
+control ingress(inout headers h, inout Meta m, inout standard_metadata_t sm) {
+    direct_meter<MeterColor>(MeterType.bytes) table_attached_meter;
+    MeterColor color = (MeterColor) 0;
+
+    action meter_assign() {
+        table_attached_meter.read(color);
+    }
+    table meter_table {
+        actions = {
+            meter_assign;
+            NoAction;
+        }
+        key = {
+            h.eth_hdr.dst_addr: exact;
+        }
+        size = 16384;
+        default_action = NoAction();
+        meters = table_attached_meter;
+    }
+
+    apply {
+        meter_table.apply();
+        if (color == MeterColor.RED) {
+            h.h.color_status = 2;
+        } else if (color == MeterColor.YELLOW) {
+            h.h.color_status = 1;
+        } else {
+            h.h.color_status = 0;
+        }
+    }
+}
+
+control vrfy(inout headers h, inout Meta m) { apply {} }
+
+control update(inout headers h, inout Meta m) { apply {} }
+
+control egress(inout headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out pkt, in headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_direct_meter_1.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_direct_meter_1.p4
@@ -48,7 +48,7 @@ control ingress(inout headers h, inout Meta m, inout standard_metadata_t sm) {
             meter_assign;
         }
         key = {
-            h.eth_hdr.dst_addr: exact;
+            h.eth_hdr.dst_addr: ternary;
         }
         size = 16384;
         default_action = meter_assign();

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_direct_meter_1.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_direct_meter_1.p4
@@ -46,13 +46,12 @@ control ingress(inout headers h, inout Meta m, inout standard_metadata_t sm) {
     table meter_table {
         actions = {
             meter_assign;
-            NoAction;
         }
         key = {
             h.eth_hdr.dst_addr: exact;
         }
         size = 16384;
-        default_action = NoAction();
+        default_action = meter_assign();
         meters = table_attached_meter;
     }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_meter_1.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_meter_1.p4
@@ -1,0 +1,65 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> color_status;
+    bit<32> idx;
+}
+
+struct headers {
+    ethernet_t eth_hdr;
+    H h;
+}
+
+enum bit<2> MeterColor {
+    GREEN = 0,
+    YELLOW = 1,
+    RED = 2
+}
+
+struct Meta {}
+
+parser p(packet_in pkt, out headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h);
+        transition accept;
+    }
+}
+
+control ingress(inout headers h, inout Meta m, inout standard_metadata_t sm) {
+    meter(1024, MeterType.bytes) simple_meter;
+    apply {
+        MeterColor color;
+        simple_meter.execute_meter<MeterColor>(h.h.idx, color);
+        if (color == MeterColor.RED) {
+            h.h.color_status = 2;
+        } else if (color == MeterColor.YELLOW) {
+            h.h.color_status = 1;
+        } else {
+            h.h.color_status = 0;
+        }
+    }
+}
+
+control vrfy(inout headers h, inout Meta m) { apply {} }
+
+control update(inout headers h, inout Meta m) { apply {} }
+
+control egress(inout headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out pkt, in headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_meter_2.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_meter_2.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> color_status;
+    bit<8> color_status_2;
+    bit<32> idx;
+}
+
+struct headers {
+    ethernet_t eth_hdr;
+    H h;
+}
+
+enum bit<2> MeterColor {
+    GREEN = 0,
+    YELLOW = 1,
+    RED = 2
+}
+
+struct Meta {}
+
+parser p(packet_in pkt, out headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h);
+        transition accept;
+    }
+}
+
+control ingress(inout headers h, inout Meta m, inout standard_metadata_t sm) {
+    meter(1024, MeterType.bytes) simple_meter;
+    apply {
+        MeterColor color;
+        simple_meter.execute_meter<MeterColor>(0, color);
+        if (color == MeterColor.RED) {
+            h.h.color_status = 2;
+        } else if (color == MeterColor.YELLOW) {
+            h.h.color_status = 1;
+        } else {
+            h.h.color_status = 0;
+        }
+        simple_meter.execute_meter<MeterColor>(1, color);
+        if (color == MeterColor.RED) {
+            h.h.color_status_2 = 2;
+        } else if (color == MeterColor.YELLOW) {
+            h.h.color_status_2 = 1;
+        } else {
+            h.h.color_status_2 = 0;
+        }
+    }
+}
+
+control vrfy(inout headers h, inout Meta m) { apply {} }
+
+control update(inout headers h, inout Meta m) { apply {} }
+
+control egress(inout headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out pkt, in headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
@@ -155,6 +155,14 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
         testSpec->addTestObject("clone_specs", sessionId, evaluatedInfo);
     }
 
+    const auto meterInfos = executionState->getTestObjectCategory("meter_values");
+    for (const auto &testObject : meterInfos) {
+        const auto meterName = testObject.first;
+        const auto *meterInfo = testObject.second->checkedTo<Bmv2V1ModelMeterValue>();
+        const auto *evaluateMeterValue = meterInfo->evaluate(*completedModel);
+        testSpec->addTestObject("meter_values", meterName, evaluateMeterValue);
+    }
+
     return testSpec;
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
@@ -94,7 +94,6 @@ cstring Bmv2V1ModelRegisterValue::getObjectName() const { return "Bmv2V1ModelReg
 const Bmv2V1ModelRegisterValue *Bmv2V1ModelRegisterValue::evaluate(const Model &model) const {
     const auto *evaluatedValue = model.evaluate(getInitialValue());
     auto *evaluatedRegisterValue = new Bmv2V1ModelRegisterValue(evaluatedValue);
-    const std::vector<ActionArg> evaluatedConditions;
     for (const auto &cond : indexConditions) {
         const auto *evaluatedCond = cond.evaluate(model);
         evaluatedRegisterValue->writeToIndex(evaluatedCond->getEvaluatedIndex(),
@@ -115,7 +114,6 @@ cstring Bmv2V1ModelMeterValue::getObjectName() const { return "Bmv2V1ModelMeterV
 const Bmv2V1ModelMeterValue *Bmv2V1ModelMeterValue::evaluate(const Model &model) const {
     const auto *evaluatedValue = model.evaluate(getInitialValue());
     auto *evaluatedMeterValue = new Bmv2V1ModelMeterValue(evaluatedValue, isDirect);
-    const std::vector<ActionArg> evaluatedConditions;
     for (const auto &cond : indexConditions) {
         const auto *evaluatedCond = cond.evaluate(model);
         evaluatedMeterValue->writeToIndex(evaluatedCond->getEvaluatedIndex(),

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
@@ -8,73 +8,123 @@
 namespace P4Tools::P4Testgen::Bmv2 {
 
 /* =========================================================================================
- *  Bmv2Register
+ *  IndexExpression
  * ========================================================================================= */
 
-Bmv2RegisterValue::Bmv2RegisterValue(const IR::Expression *initialValue)
-    : initialValue(initialValue) {}
-
-void Bmv2RegisterValue::addRegisterCondition(Bmv2RegisterCondition cond) {
-    registerConditions.push_back(cond);
-}
-
-const IR::Expression *Bmv2RegisterValue::getInitialValue() const { return initialValue; }
-
-cstring Bmv2RegisterValue::getObjectName() const { return "Bmv2RegisterValue"; }
-
-const IR::Expression *Bmv2RegisterValue::getCurrentValue(const IR::Expression *index) const {
-    const IR::Expression *baseExpr = initialValue;
-    for (const auto &bmv2registerValue : registerConditions) {
-        const auto *storedIndex = bmv2registerValue.index;
-        const auto *storedVal = bmv2registerValue.value;
-        baseExpr =
-            new IR::Mux(baseExpr->type, new IR::Equ(storedIndex, index), storedVal, baseExpr);
-    }
-    return baseExpr;
-}
-
-const IR::Constant *Bmv2RegisterValue::getEvaluatedValue() const {
-    const auto *constant = initialValue->to<IR::Constant>();
-    BUG_CHECK(constant, "Variable is not a constant, has the test object %1% been evaluated?",
-              getObjectName());
-    return constant;
-}
-
-const Bmv2RegisterValue *Bmv2RegisterValue::evaluate(const Model &model) const {
-    const auto *evaluatedValue = model.evaluate(initialValue);
-    auto *evaluatedRegisterValue = new Bmv2RegisterValue(evaluatedValue);
-    const std::vector<ActionArg> evaluatedConditions;
-    for (const auto &cond : registerConditions) {
-        evaluatedRegisterValue->addRegisterCondition(*cond.evaluate(model));
-    }
-    return evaluatedRegisterValue;
-}
-
-Bmv2RegisterCondition::Bmv2RegisterCondition(const IR::Expression *index,
-                                             const IR::Expression *value)
+IndexExpression::IndexExpression(const IR::Expression *index, const IR::Expression *value)
     : index(index), value(value) {}
 
-const IR::Constant *Bmv2RegisterCondition::getEvaluatedValue() const {
+const IR::Constant *IndexExpression::getEvaluatedValue() const {
     const auto *constant = value->to<IR::Constant>();
     BUG_CHECK(constant, "Variable is not a constant, has the test object %1% been evaluated?",
               getObjectName());
     return constant;
 }
 
-const IR::Constant *Bmv2RegisterCondition::getEvaluatedIndex() const {
+const IR::Constant *IndexExpression::getEvaluatedIndex() const {
     const auto *constant = index->to<IR::Constant>();
     BUG_CHECK(constant, "Variable is not a constant, has the test object %1% been evaluated?",
               getObjectName());
     return constant;
 }
 
-const Bmv2RegisterCondition *Bmv2RegisterCondition::evaluate(const Model &model) const {
+const IR::Expression *IndexExpression::getIndex() const { return index; }
+
+const IR::Expression *IndexExpression::getValue() const { return value; }
+
+cstring IndexExpression::getObjectName() const { return "IndexExpression"; }
+
+const IndexExpression *IndexExpression::evaluate(const Model &model) const {
     const auto *evaluatedIndex = model.evaluate(index);
     const auto *evaluatedValue = model.evaluate(value);
-    return new Bmv2RegisterCondition(evaluatedIndex, evaluatedValue);
+    return new IndexExpression(evaluatedIndex, evaluatedValue);
 }
 
-cstring Bmv2RegisterCondition::getObjectName() const { return "Bmv2RegisterCondition"; }
+std::map<big_int, std::pair<int, const IR::Constant *>> IndexMap::unravelMap() const {
+    std::map<big_int, std::pair<int, const IR::Constant *>> valueMap;
+    for (auto it = indexConditions.rbegin(); it != indexConditions.rend(); ++it) {
+        const auto *storedIndex = it->getEvaluatedIndex();
+        const auto *storedVal = it->getEvaluatedValue();
+        // Important, if the element already exists in the map, ignore it.
+        // That index has been overwritten.
+        valueMap.insert({storedIndex->value, {storedIndex->type->width_bits(), storedVal}});
+    }
+    return valueMap;
+}
+
+/* =========================================================================================
+ *  Bmv2Register
+ * ========================================================================================= */
+
+IndexMap::IndexMap(const IR::Expression *initialValue) : initialValue(initialValue) {}
+
+void IndexMap::writeToIndex(const IR::Expression *index, const IR::Expression *value) {
+    indexConditions.emplace_back(index, value);
+}
+
+const IR::Expression *IndexMap::getInitialValue() const { return initialValue; }
+
+const IR::Expression *IndexMap::getValueAtIndex(const IR::Expression *index) const {
+    const IR::Expression *baseExpr = initialValue;
+    for (const auto &indexMap : indexConditions) {
+        const auto *storedIndex = indexMap.getIndex();
+        const auto *storedVal = indexMap.getValue();
+        baseExpr =
+            new IR::Mux(baseExpr->type, new IR::Equ(storedIndex, index), storedVal, baseExpr);
+    }
+    return baseExpr;
+}
+
+const IR::Constant *IndexMap::getEvaluatedInitialValue() const {
+    const auto *constant = initialValue->to<IR::Constant>();
+    BUG_CHECK(constant, "Variable is not a constant, has the test object %1% been evaluated?",
+              getObjectName());
+    return constant;
+}
+
+/* =========================================================================================
+ *  Bmv2V1ModelMeterValue
+ * ========================================================================================= */
+
+Bmv2V1ModelRegisterValue::Bmv2V1ModelRegisterValue(const IR::Expression *initialValue)
+    : IndexMap(initialValue) {}
+
+cstring Bmv2V1ModelRegisterValue::getObjectName() const { return "Bmv2V1ModelRegisterValue"; }
+
+const Bmv2V1ModelRegisterValue *Bmv2V1ModelRegisterValue::evaluate(const Model &model) const {
+    const auto *evaluatedValue = model.evaluate(getInitialValue());
+    auto *evaluatedRegisterValue = new Bmv2V1ModelRegisterValue(evaluatedValue);
+    const std::vector<ActionArg> evaluatedConditions;
+    for (const auto &cond : indexConditions) {
+        const auto *evaluatedCond = cond.evaluate(model);
+        evaluatedRegisterValue->writeToIndex(evaluatedCond->getEvaluatedIndex(),
+                                             evaluatedCond->getEvaluatedValue());
+    }
+    return evaluatedRegisterValue;
+}
+
+/* =========================================================================================
+ *  Bmv2V1ModelMeterValue
+ * ========================================================================================= */
+
+Bmv2V1ModelMeterValue::Bmv2V1ModelMeterValue(const IR::Expression *initialValue, bool isDirect)
+    : IndexMap(initialValue), isDirect(isDirect) {}
+
+cstring Bmv2V1ModelMeterValue::getObjectName() const { return "Bmv2V1ModelMeterValue"; }
+
+const Bmv2V1ModelMeterValue *Bmv2V1ModelMeterValue::evaluate(const Model &model) const {
+    const auto *evaluatedValue = model.evaluate(getInitialValue());
+    auto *evaluatedMeterValue = new Bmv2V1ModelMeterValue(evaluatedValue, isDirect);
+    const std::vector<ActionArg> evaluatedConditions;
+    for (const auto &cond : indexConditions) {
+        const auto *evaluatedCond = cond.evaluate(model);
+        evaluatedMeterValue->writeToIndex(evaluatedCond->getEvaluatedIndex(),
+                                          evaluatedCond->getEvaluatedValue());
+    }
+    return evaluatedMeterValue;
+}
+
+bool Bmv2V1ModelMeterValue::isDirectMeter() const { return isDirect; }
 
 /* =========================================================================================
  *  Bmv2V1ModelActionProfile

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
@@ -83,7 +83,7 @@ const IR::Constant *IndexMap::getEvaluatedInitialValue() const {
 }
 
 /* =========================================================================================
- *  Bmv2V1ModelMeterValue
+ *  Bmv2V1ModelRegisterValue
  * ========================================================================================= */
 
 Bmv2V1ModelRegisterValue::Bmv2V1ModelRegisterValue(const IR::Expression *initialValue)

--- a/backends/p4tools/modules/testgen/targets/pna/backend/metadata/metadata.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/backend/metadata/metadata.cpp
@@ -66,7 +66,7 @@ inja::json Metadata::getVerify(const TestSpec *testSpec) {
     inja::json verifyData = inja::json::object();
     auto egressPacket = testSpec->getEgressPacket();
     if (egressPacket.has_value()) {
-        const auto *const packet = egressPacket.value();
+        const auto *packet = egressPacket.value();
         verifyData["eg_port"] = packet->getPort();
         const auto *payload = packet->getEvaluatedPayload();
         const auto *payloadMask = packet->getEvaluatedPayloadMask();
@@ -94,7 +94,7 @@ statement_coverage: {{coverage}}
 ## endfor
 
 # The input packet in hexadecimal.
-input_packet: \"{{send.pkt}}\"
+input_packet: "{{send.pkt}}"
 
 # Parsed headers and their offsets.
 header_offsets:
@@ -105,7 +105,7 @@ header_offsets:
 # Metadata results after this test has completed.
 metadata:
 ## for metadata_field in metadata_fields
-  {{metadata_field.name}}: [value: \"{{metadata_field.value}}\", offset: {{metadata_field.offset}}]
+  {{metadata_field.name}}: [value: "{{metadata_field.value}}", offset: {{metadata_field.offset}}]
 ## endfor
 )""");
     return TEST_CASE;


### PR DESCRIPTION
Implement P4Testgen BMv2 support for meters and direct meters.

- Add an interface to the `base_test.py` file to configure meters.
- Also add a helper function to the PTF test back end to make sure we are able to set the color we want. For green, we set the thresholds to the maximum, for red we set the thresholds to the minimum, for yellow we use a mix.
- direct meters can only be used if they are attached to a table and the table has an entry. Implement a new pass that creates a direct meter <-> table mapping. Look up this mapping when executing the extern. If there is no table entry in the table associated with the meter, skip meter execution since we can not configure it. 