### PR TITLE
Cleanup some P4Testgen code. 

### DIFF
--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -39,6 +39,7 @@ set(
   core/target.cpp
   core/z3_solver.cpp
 
+  lib/arch_spec.cpp
   lib/format_int.cpp
   lib/formulae.cpp
   lib/model.cpp

--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -43,6 +43,7 @@ set(
   lib/format_int.cpp
   lib/formulae.cpp
   lib/model.cpp
+  lib/namespace_context.cpp
   lib/symbolic_env.cpp
   lib/taint.cpp
   lib/trace_event.cpp

--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -5,11 +5,6 @@ include(common)
 
 project(p4tools-common)
 
-# Boost filesystem is required for path handling.
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
-find_package(Boost REQUIRED COMPONENTS filesystem system iostreams)
-
 # Store the current git commit hash as part of version information.
 execute_process(
   COMMAND git log --pretty=format:-%h -n 1
@@ -56,8 +51,6 @@ add_p4tools_library(p4tools-common ${P4C_TOOLS_COMMON_SOURCES})
 
 target_link_libraries(
   p4tools-common
-  PUBLIC ${Boost_SYSTEM_LIBRARY}
-  PUBLIC ${Boost_FILESYSTEM_LIBRARY}
   PUBLIC z3::z3
 )
 

--- a/backends/p4tools/common/compiler/compiler_target.cpp
+++ b/backends/p4tools/common/compiler/compiler_target.cpp
@@ -17,10 +17,10 @@
 
 namespace P4Tools {
 
-ICompileContext *CompilerTarget::makeContext() { return get().makeContext_impl(); }
+ICompileContext *CompilerTarget::makeContext() { return get().makeContextImpl(); }
 
 std::vector<const char *> *CompilerTarget::initCompiler(int argc, char **argv) {
-    return get().initCompiler_impl(argc, argv);
+    return get().initCompilerImpl(argc, argv);
 }
 
 std::optional<const IR::P4Program *> CompilerTarget::runCompiler() {
@@ -42,10 +42,10 @@ std::optional<const IR::P4Program *> CompilerTarget::runCompiler(const std::stri
 }
 
 std::optional<const IR::P4Program *> CompilerTarget::runCompiler(const IR::P4Program *program) {
-    return get().runCompiler_impl(program);
+    return get().runCompilerImpl(program);
 }
 
-std::optional<const IR::P4Program *> CompilerTarget::runCompiler_impl(
+std::optional<const IR::P4Program *> CompilerTarget::runCompilerImpl(
     const IR::P4Program *program) const {
     const auto &self = get();
 
@@ -67,11 +67,11 @@ std::optional<const IR::P4Program *> CompilerTarget::runCompiler_impl(
     return program;
 }
 
-ICompileContext *CompilerTarget::makeContext_impl() const {
+ICompileContext *CompilerTarget::makeContextImpl() const {
     return new CompileContext<CompilerOptions>();
 }
 
-std::vector<const char *> *CompilerTarget::initCompiler_impl(int argc, char **argv) const {
+std::vector<const char *> *CompilerTarget::initCompilerImpl(int argc, char **argv) const {
     auto *result = P4CContext::get().options().process(argc, argv);
     return ::errorCount() > 0 ? nullptr : result;
 }

--- a/backends/p4tools/common/compiler/compiler_target.cpp
+++ b/backends/p4tools/common/compiler/compiler_target.cpp
@@ -1,6 +1,7 @@
 #include "backends/p4tools/common/compiler/compiler_target.h"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "backends/p4tools/common/compiler/context.h"
@@ -120,7 +121,7 @@ const IR::P4Program *CompilerTarget::runMidEnd(const IR::P4Program *program) con
 }
 
 CompilerTarget::CompilerTarget(std::string deviceName, std::string archName)
-    : Target("compiler", deviceName, archName) {}
+    : Target("compiler", std::move(deviceName), std::move(archName)) {}
 
 const CompilerTarget &CompilerTarget::get() { return Target::get<CompilerTarget>("compiler"); }
 

--- a/backends/p4tools/common/compiler/compiler_target.h
+++ b/backends/p4tools/common/compiler/compiler_target.h
@@ -43,15 +43,15 @@ class CompilerTarget : public Target {
 
  protected:
     /// @see @makeContext.
-    virtual ICompileContext *makeContext_impl() const;
+    virtual ICompileContext *makeContextImpl() const;
 
     /// @see runCompiler.
-    virtual std::optional<const IR::P4Program *> runCompiler_impl(const IR::P4Program *) const;
+    virtual std::optional<const IR::P4Program *> runCompilerImpl(const IR::P4Program *) const;
 
     /// This implementation just forwards the given arguments to the compiler.
     ///
     /// @see @initCompiler.
-    virtual std::vector<const char *> *initCompiler_impl(int argc, char **argv) const;
+    virtual std::vector<const char *> *initCompilerImpl(int argc, char **argv) const;
 
     /// Parses the P4 program specified on the command line.
     ///
@@ -64,10 +64,10 @@ class CompilerTarget : public Target {
     const IR::P4Program *runFrontend(const IR::P4Program *program) const;
 
     /// A factory method for providing a target-specific mid end implementation.
-    virtual MidEnd mkMidEnd(const CompilerOptions &options) const;
+    [[nodiscard]] virtual MidEnd mkMidEnd(const CompilerOptions &options) const;
 
     /// A factory method for providing a target-specific front end implementation.
-    virtual P4::FrontEnd mkFrontEnd() const;
+    [[nodiscard]] virtual P4::FrontEnd mkFrontEnd() const;
 
     /// Runs the mid end provided by @mkMidEnd on the given program.
     ///

--- a/backends/p4tools/common/lib/arch_spec.cpp
+++ b/backends/p4tools/common/lib/arch_spec.cpp
@@ -1,12 +1,10 @@
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 
 #include <utility>
 
 #include "lib/exceptions.h"
 
 namespace P4Tools {
-
-namespace P4Testgen {
 
 ArchSpec::ArchSpec(cstring packageName, const std::vector<ArchMember> &archVectorInput)
     : packageName(packageName) {
@@ -52,6 +50,4 @@ const ArchSpec::ArchMember *ArchSpec::getArchMember(size_t blockIndex) const {
 size_t ArchSpec::getArchVectorSize() const { return archVector.size(); }
 
 cstring ArchSpec::getPackageName() const { return packageName; }
-}  // namespace P4Testgen
-
 }  // namespace P4Tools

--- a/backends/p4tools/common/lib/arch_spec.h
+++ b/backends/p4tools/common/lib/arch_spec.h
@@ -1,16 +1,13 @@
-#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_ARCH_SPEC_H_
-#define BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_ARCH_SPEC_H_
+#ifndef BACKENDS_P4TOOLS_COMMON_LIB_ARCH_SPEC_H_
+#define BACKENDS_P4TOOLS_COMMON_LIB_ARCH_SPEC_H_
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <map>
 #include <vector>
 
 #include "lib/cstring.h"
 
 namespace P4Tools {
-
-namespace P4Testgen {
 
 /// Specifies a canonical representation of the target pipeline as documented in P4 code.
 class ArchSpec {
@@ -37,30 +34,28 @@ class ArchSpec {
 
     /// @returns the index that corresponds to the given name in this architecture specification.
     /// A bug is thrown if the index does not exist.
-    size_t getBlockIndex(cstring blockName) const;
+    [[nodiscard]] size_t getBlockIndex(cstring blockName) const;
 
     /// @returns the architecture member that corresponds to the given index in this architecture
     /// specification. A bug is thrown if the index does not exist.
-    const ArchMember *getArchMember(size_t blockIndex) const;
+    [[nodiscard]] const ArchMember *getArchMember(size_t blockIndex) const;
 
     /// @returns name of the parameter for the given block and parameter index in this architecture
     /// specification. A bug is thrown if the indices are out of range.
-    cstring getParamName(size_t blockIndex, size_t paramIndex) const;
+    [[nodiscard]] cstring getParamName(size_t blockIndex, size_t paramIndex) const;
 
     /// @returns name of the parameter for the given block label and parameter index in this
     /// architecture specification. A bug is thrown if the index is out of range or the block label
     /// does not exist.
-    cstring getParamName(cstring blockName, size_t paramIndex) const;
+    [[nodiscard]] cstring getParamName(cstring blockName, size_t paramIndex) const;
 
     /// @returns the size of the architecture specification vector.
-    size_t getArchVectorSize() const;
+    [[nodiscard]] size_t getArchVectorSize() const;
 
     /// @returns the label of the architecture specification.
-    cstring getPackageName() const;
+    [[nodiscard]] cstring getPackageName() const;
 };
-
-}  // namespace P4Testgen
 
 }  // namespace P4Tools
 
-#endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_ARCH_SPEC_H_ */
+#endif /* BACKENDS_P4TOOLS_COMMON_LIB_ARCH_SPEC_H_ */

--- a/backends/p4tools/common/lib/namespace_context.cpp
+++ b/backends/p4tools/common/lib/namespace_context.cpp
@@ -1,4 +1,4 @@
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 
 #include <set>
 #include <vector>
@@ -7,7 +7,7 @@
 #include "lib/enumerator.h"
 #include "lib/exceptions.h"
 
-namespace P4Tools::P4Testgen {
+namespace P4Tools {
 
 const NamespaceContext *NamespaceContext::Empty = new NamespaceContext(nullptr, nullptr);
 
@@ -122,4 +122,4 @@ cstring NamespaceContext::genName(cstring name, char sep) const {
     return cstring::make_unique(getUsedNames(), name, sep);
 }
 
-}  // namespace P4Tools::P4Testgen
+}  // namespace P4Tools

--- a/backends/p4tools/common/lib/namespace_context.h
+++ b/backends/p4tools/common/lib/namespace_context.h
@@ -1,5 +1,5 @@
-#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_NAMESPACE_CONTEXT_H_
-#define BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_NAMESPACE_CONTEXT_H_
+#ifndef BACKENDS_P4TOOLS_COMMON_LIB_NAMESPACE_CONTEXT_H_
+#define BACKENDS_P4TOOLS_COMMON_LIB_NAMESPACE_CONTEXT_H_
 
 #include <optional>
 #include <set>
@@ -8,7 +8,7 @@
 #include "ir/ir.h"
 #include "lib/cstring.h"
 
-namespace P4Tools::P4Testgen {
+namespace P4Tools {
 
 /// Represents a stack of namespaces.
 class NamespaceContext {
@@ -50,6 +50,6 @@ class NamespaceContext {
     cstring genName(cstring name, char sep) const;
 };
 
-}  // namespace P4Tools::P4Testgen
+}  // namespace P4Tools
 
-#endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_NAMESPACE_CONTEXT_H_ */
+#endif /* BACKENDS_P4TOOLS_COMMON_LIB_NAMESPACE_CONTEXT_H_ */

--- a/backends/p4tools/common/lib/symbolic_env.h
+++ b/backends/p4tools/common/lib/symbolic_env.h
@@ -18,30 +18,30 @@ class SymbolicEnv {
     // Maybe coerce from Model for concrete execution?
 
     /// @returns the symbolic value for the given variable.
-    const IR::Expression *get(const StateVariable &var) const;
+    [[nodiscard]] const IR::Expression *get(const StateVariable &var) const;
 
     /// Checks whether the given variable exists in the symbolic environment.
-    bool exists(const StateVariable &var) const;
+    [[nodiscard]] bool exists(const StateVariable &var) const;
 
     /// Sets the symbolic value of the given state variable to the given value. Constant folding is
     /// done on the given value before updating the symbolic state.
     void set(const StateVariable &var, const IR::Expression *value);
 
     /// Completes the model with all variables referenced in the symbolic environment.
-    Model *complete(const Model &model) const;
+    [[nodiscard]] Model *complete(const Model &model) const;
 
     /// Evaluates this symbolic environment in the context of the given model.
     ///
     /// A BUG occurs if any symbolic value in this environment refers to a variable that is not
     /// bound by the given model.
-    Model *evaluate(const Model &model) const;
+    [[nodiscard]] Model *evaluate(const Model &model) const;
 
     /// Substitutes state variables in @expr for their symbolic value in this environment.
     /// Variables that are unbound by this environment are left untouched.
     const IR::Expression *subst(const IR::Expression *expr) const;
 
     /// @returns The immutable map that is internal to this symbolic environment.
-    const SymbolicMapType &getInternalMap() const;
+    [[nodiscard]] const SymbolicMapType &getInternalMap() const;
 
     /// Determines whether the given node represents a symbolic value. Symbolic values may be
     /// stored in the symbolic environment.

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -1,5 +1,4 @@
-# CMake file for Barefoot p4testgen.
-cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
+# CMake file for p4testgen.
 
 include(common)
 
@@ -11,7 +10,6 @@ set(
   options.cpp
   testgen.cpp
 
-  core/arch_spec.cpp
   core/externs.cpp
   core/program_info.cpp
   core/small_step/abstract_stepper.cpp
@@ -134,17 +132,6 @@ if(ENABLE_GTESTS)
     PRIVATE testgen
     PRIVATE gtest
   )
-
-  add_custom_target(
-    linkgtest
-    # Link P4 include files in a more convenient location.
-    COMMAND
-    for incl in p4include p4_14include \; do
-    ${CMAKE_COMMAND} -E create_symlink
-    ${P4C_BINARY_DIR}/\$$incl ${CMAKE_CURRENT_BINARY_DIR}/\$$incl \;
-    done
-  )
-  add_dependencies(testgen-gtest linkgtest)
 
   if(ENABLE_TESTING)
     add_definitions("-DGTEST_HAS_PTHREAD=0")

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -33,7 +33,6 @@ set(
   lib/final_state.cpp
   lib/gen_eq.cpp
   lib/logging.cpp
-  lib/namespace_context.cpp
   lib/test_backend.cpp
   lib/test_spec.cpp
   lib/tf.cpp

--- a/backends/p4tools/modules/testgen/core/constants.h
+++ b/backends/p4tools/modules/testgen/core/constants.h
@@ -3,9 +3,7 @@
 
 #include "ir/ir.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 class P4Constants {
  public:
@@ -33,8 +31,6 @@ class P4Constants {
     static constexpr const char *MATCH_KIND_LPM = "lpm";
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_CONSTANTS_H_ */

--- a/backends/p4tools/modules/testgen/core/externs.cpp
+++ b/backends/p4tools/modules/testgen/core/externs.cpp
@@ -13,9 +13,7 @@
 #include "backends/p4tools/modules/testgen/core/small_step/small_step.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 bool ExternMethodImpls::exec(const IR::MethodCallExpression *call, const IR::Expression *receiver,
                              IR::ID &name, const IR::Vector<IR::Argument> *args,
@@ -107,6 +105,4 @@ ExternMethodImpls::ExternMethodImpls(const ImplList &inputImplList) {
     }
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/externs.h
+++ b/backends/p4tools/modules/testgen/core/externs.h
@@ -18,9 +18,7 @@
 #include "backends/p4tools/modules/testgen/core/small_step/small_step.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// Encaspulates a set of extern method implementations.
 class ExternMethodImpls {
@@ -72,8 +70,6 @@ class ExternMethodImpls {
     explicit ExternMethodImpls(const ImplList &implList);
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_EXTERNS_H_ */

--- a/backends/p4tools/modules/testgen/core/externs.h
+++ b/backends/p4tools/modules/testgen/core/externs.h
@@ -20,7 +20,7 @@
 
 namespace P4Tools::P4Testgen {
 
-/// Encaspulates a set of extern method implementations.
+/// Encapsulates a set of extern method implementations.
 class ExternMethodImpls {
  public:
     /// Evaluates a call to an extern method. Upon return, the given result will be augmented with

--- a/backends/p4tools/modules/testgen/core/program_info.cpp
+++ b/backends/p4tools/modules/testgen/core/program_info.cpp
@@ -2,6 +2,7 @@
 
 #include "backends/p4tools/common/compiler/reachability.h"
 #include "backends/p4tools/common/lib/arch_spec.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
 #include "lib/cstring.h"
@@ -10,7 +11,6 @@
 
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 #include "backends/p4tools/modules/testgen/options.h"
 
 namespace P4Tools::P4Testgen {

--- a/backends/p4tools/modules/testgen/core/program_info.cpp
+++ b/backends/p4tools/modules/testgen/core/program_info.cpp
@@ -1,13 +1,13 @@
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 
 #include "backends/p4tools/common/compiler/reachability.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 #include "midend/coverage.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/namespace_context.h"
@@ -15,10 +15,7 @@
 
 namespace P4Tools::P4Testgen {
 
-ProgramInfo::ProgramInfo(const IR::P4Program *program)
-    : globalNameSpaceContext(NamespaceContext::Empty->push(program)),
-      concolicMethodImpls({}),
-      program(program) {
+ProgramInfo::ProgramInfo(const IR::P4Program *program) : concolicMethodImpls({}), program(program) {
     concolicMethodImpls.add(*Concolic::getCoreConcolicMethodImpls());
     if (TestgenOptions::get().dcg || !TestgenOptions::get().pattern.empty()) {
         // Create DCG.
@@ -34,17 +31,28 @@ ProgramInfo::ProgramInfo(const IR::P4Program *program)
  *  Namespaces and declarations
  * ============================================================================================= */
 
-const IR::IDeclaration *ProgramInfo::findProgramDecl(const IR::Path *path) const {
-    return globalNameSpaceContext->findDecl(path);
+const IR::IDeclaration *ProgramInfo::findProgramDecl(const IR::IGeneralNamespace *ns,
+                                                     const IR::Path *path) {
+    auto name = path->name.name;
+    const auto *decls = ns->getDeclsByName(name)->toVector();
+    if (!decls->empty()) {
+        // TODO: Figure out what to do with multiple results. Maybe return all of them and
+        // let the caller sort it out?
+        BUG_CHECK(decls->size() == 1, "Handling of overloaded names not implemented");
+        return decls->at(0);
+    }
+    BUG("Variable %1% not found in the available namespaces.", path);
 }
 
-const IR::IDeclaration *ProgramInfo::findProgramDecl(const IR::PathExpression *pathExpr) const {
-    return findProgramDecl(pathExpr->path);
+const IR::IDeclaration *ProgramInfo::findProgramDecl(const IR::IGeneralNamespace *ns,
+                                                     const IR::PathExpression *pathExpr) {
+    return findProgramDecl(ns, pathExpr->path);
 }
 
-const IR::Type_Declaration *ProgramInfo::resolveProgramType(const IR::Type_Name *type) const {
+const IR::Type_Declaration *ProgramInfo::resolveProgramType(const IR::IGeneralNamespace *ns,
+                                                            const IR::Type_Name *type) {
     const auto *path = type->path;
-    const auto *decl = findProgramDecl(path)->to<IR::Type_Declaration>();
+    const auto *decl = findProgramDecl(ns, path)->to<IR::Type_Declaration>();
     BUG_CHECK(decl, "Not a type: %1%", path);
     return decl;
 }
@@ -74,7 +82,7 @@ void ProgramInfo::produceCopyInOutCall(const IR::Parameter *param, size_t paramI
     const auto *paramType = param->type;
     // We need to resolve type names.
     if (const auto *tn = paramType->to<IR::Type_Name>()) {
-        paramType = resolveProgramType(tn);
+        paramType = resolveProgramType(program, tn);
     }
     // Retrieve the identifier of the global architecture map using the parameter
     // index.

--- a/backends/p4tools/modules/testgen/core/program_info.h
+++ b/backends/p4tools/modules/testgen/core/program_info.h
@@ -92,7 +92,7 @@ class ProgramInfo : public ICastable {
     static const IR::IDeclaration *findProgramDecl(const IR::IGeneralNamespace *ns,
                                                    const IR::PathExpression *pathExpr);
 
-    /// Resolves a Type_Name in the current environment.
+    /// Resolves a Type_Name in the top-level namespace.
     static const IR::Type_Declaration *resolveProgramType(const IR::IGeneralNamespace *ns,
                                                           const IR::Type_Name *type);
 

--- a/backends/p4tools/modules/testgen/core/program_info.h
+++ b/backends/p4tools/modules/testgen/core/program_info.h
@@ -8,6 +8,7 @@
 #include "backends/p4tools/common/compiler/reachability.h"
 #include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "ir/declaration.h"
 #include "ir/ir.h"
 #include "lib/castable.h"
@@ -15,7 +16,6 @@
 
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 
 namespace P4Tools::P4Testgen {
 

--- a/backends/p4tools/modules/testgen/core/program_info.h
+++ b/backends/p4tools/modules/testgen/core/program_info.h
@@ -6,13 +6,13 @@
 #include <vector>
 
 #include "backends/p4tools/common/compiler/reachability.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/formulae.h"
 #include "ir/declaration.h"
 #include "ir/ir.h"
 #include "lib/castable.h"
 #include "midend/coverage.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/namespace_context.h"
@@ -21,9 +21,6 @@ namespace P4Tools::P4Testgen {
 
 /// Stores target-specific information about a P4 program.
 class ProgramInfo : public ICastable {
- private:
-    const NamespaceContext *globalNameSpaceContext;
-
  protected:
     explicit ProgramInfo(const IR::P4Program *program);
 
@@ -56,21 +53,21 @@ class ProgramInfo : public ICastable {
     const NodesCallGraph *dcg;
 
     /// @returns the series of nodes that has been computed by this particular target.
-    const std::vector<Continuation::Command> *getPipelineSequence() const;
+    [[nodiscard]] const std::vector<Continuation::Command> *getPipelineSequence() const;
 
     /// @returns the constraints of this target.
     /// These constraints can influence the execution of the interpreter
-    std::optional<const Constraint *> getTargetConstraints() const;
+    [[nodiscard]] std::optional<const Constraint *> getTargetConstraints() const;
 
     /// @returns the metadata member corresponding to the ingress port
-    virtual const IR::Member *getTargetInputPortVar() const = 0;
+    [[nodiscard]] virtual const IR::Member *getTargetInputPortVar() const = 0;
 
     /// @returns the metadata member corresponding to the final output port
-    virtual const IR::Member *getTargetOutputPortVar() const = 0;
+    [[nodiscard]] virtual const IR::Member *getTargetOutputPortVar() const = 0;
 
     /// @returns an expression that checks whether the packet is to be dropped.
     /// The computation is target specific.
-    virtual const IR::Expression *dropIsActive() const = 0;
+    [[nodiscard]] virtual const IR::Expression *dropIsActive() const = 0;
 
     /// @returns the default value for uninitialized variables for this particular target. This can
     /// be a taint variable or simply 0 (bits) or false (booleans).
@@ -79,22 +76,25 @@ class ProgramInfo : public ICastable {
                                                             bool forceTaint) const = 0;
 
     /// Getter to access allStatements.
-    const P4::Coverage::CoverageSet &getAllStatements() const;
+    [[nodiscard]] const P4::Coverage::CoverageSet &getAllStatements() const;
 
     /// @returns the list of implemented concolic methods for this particular program.
-    const ConcolicMethodImpls *getConcolicMethodImpls() const;
+    [[nodiscard]] const ConcolicMethodImpls *getConcolicMethodImpls() const;
 
     // @returns the width of the parser error for this specific target.
-    virtual const IR::Type_Bits *getParserErrorType() const = 0;
+    [[nodiscard]] virtual const IR::Type_Bits *getParserErrorType() const = 0;
 
     /// Looks up a declaration from a path. A BUG occurs if no declaration is found.
-    const IR::IDeclaration *findProgramDecl(const IR::Path *path) const;
+    static const IR::IDeclaration *findProgramDecl(const IR::IGeneralNamespace *ns,
+                                                   const IR::Path *path);
 
     /// Looks up a declaration from a path expression. A BUG occurs if no declaration is found.
-    const IR::IDeclaration *findProgramDecl(const IR::PathExpression *pathExpr) const;
+    static const IR::IDeclaration *findProgramDecl(const IR::IGeneralNamespace *ns,
+                                                   const IR::PathExpression *pathExpr);
 
     /// Resolves a Type_Name in the current environment.
-    const IR::Type_Declaration *resolveProgramType(const IR::Type_Name *type) const;
+    static const IR::Type_Declaration *resolveProgramType(const IR::IGeneralNamespace *ns,
+                                                          const IR::Type_Name *type);
 
     /// Helper function to produce copy-in and copy-out helper calls.
     /// Copy-in and copy-out is needed to correctly model the value changes of data when it is

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h
@@ -17,9 +17,7 @@
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// A framework for implementing small-step operational semantics. Each instance is good for one
 /// small-step evaluation.
@@ -179,8 +177,6 @@ class AbstractStepper : public Inspector {
                          const IR::Type_Base *baseType) const;
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_SMALL_STEP_ABSTRACT_STEPPER_H_ */

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -513,7 +513,7 @@ const Constraint *CmdStepper::startParser(const IR::P4Parser *parser, ExecutionS
 
     // Call the implementation for the specific target.
     // If we get a constraint back, add it to the result.
-    if (auto constraintOpt = startParser_impl(parser, nextState)) {
+    if (auto constraintOpt = startParserImpl(parser, nextState)) {
         result = new IR::LAnd(boolType, result, *constraintOpt);
     }
 

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h
@@ -46,8 +46,8 @@ class CmdStepper : public AbstractStepper {
 
     /// @see startParser. Implementations can assume that the parser has been registered, and the
     /// cursor position has been initialized.
-    virtual std::optional<const Constraint *> startParser_impl(const IR::P4Parser *parser,
-                                                               ExecutionState &state) const = 0;
+    virtual std::optional<const Constraint *> startParserImpl(const IR::P4Parser *parser,
+                                                              ExecutionState &state) const = 0;
 
     /// Initializes variables and adds constraints for the program initialization, which is target
     /// specific.

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.h
@@ -13,9 +13,7 @@
 #include "backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// Implements small-step operational semantics for expressions.
 class ExprStepper : public AbstractStepper {
@@ -151,8 +149,6 @@ class ExprStepper : public AbstractStepper {
     bool preorder(const IR::P4Table *table) override;
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_SMALL_STEP_EXPR_STEPPER_H_ */

--- a/backends/p4tools/modules/testgen/core/symbolic_executor/greedy_stmt_cov.cpp
+++ b/backends/p4tools/modules/testgen/core/symbolic_executor/greedy_stmt_cov.cpp
@@ -1,7 +1,6 @@
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/greedy_stmt_cov.h"
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <optional>
@@ -45,7 +44,7 @@ std::optional<SymbolicExecutor::Branch> GreedyStmtSelection::popPotentialBranch(
             }
         }
     }
-    return {};
+    return std::nullopt;
 }
 
 bool GreedyStmtSelection::pickSuccessor(StepResult successors) {

--- a/backends/p4tools/modules/testgen/core/target.cpp
+++ b/backends/p4tools/modules/testgen/core/target.cpp
@@ -74,11 +74,11 @@ void TestgenTarget::argumentsToTypeDeclarations(
         if (const auto *ctorCall = expr->to<IR::ConstructorCallExpression>()) {
             const auto *constructedTypeName = ctorCall->constructedType->checkedTo<IR::Type_Name>();
 
-            // Find the corresponding type declaration in the namespace.
+            // Find the corresponding type declaration in the top-level namespace.
             declType = ProgramInfo::findProgramDecl(ns, constructedTypeName->path)
                            ->checkedTo<IR::Type_Declaration>();
         } else if (const auto *pathExpr = expr->to<IR::PathExpression>()) {
-            // Look up the path expression in the declaration map, and expect to find a
+            // Look up the path expression in the top-level namespace and expect to find a
             // declaration instance.
             const auto *declInstance = ProgramInfo::findProgramDecl(ns, pathExpr->path)
                                            ->checkedTo<IR::Declaration_Instance>();

--- a/backends/p4tools/modules/testgen/core/target.cpp
+++ b/backends/p4tools/modules/testgen/core/target.cpp
@@ -19,13 +19,13 @@ namespace P4Tools::P4Testgen {
 TestgenTarget::TestgenTarget(std::string deviceName, std::string archName)
     : Target("testgen", std::move(deviceName), std::move(archName)) {}
 
-const ProgramInfo *TestgenTarget::initProgram_impl(const IR::P4Program *program) const {
+const ProgramInfo *TestgenTarget::initProgramImpl(const IR::P4Program *program) const {
     // Check that the program has at least one main declaration.
     const auto mainCount = program->getDeclsByName(IR::P4Program::main)->count();
     BUG_CHECK(mainCount > 0, "Program doesn't have a main declaration.");
 
     // Resolve the program's main declaration instance and delegate to the version of
-    // initProgram_impl that takes the main declaration.
+    // initProgramImpl that takes the main declaration.
     const auto *mainIDecl = program->getDeclsByName(IR::P4Program::main)->single();
     BUG_CHECK(mainIDecl, "Program's main declaration not found: %1%", program->main);
 
@@ -34,13 +34,37 @@ const ProgramInfo *TestgenTarget::initProgram_impl(const IR::P4Program *program)
     BUG_CHECK(mainDecl, "%1%: Program's main declaration is a %2%, not a Declaration_Instance",
               mainNode, mainNode->node_type_name());
 
-    return initProgram_impl(program, mainDecl);
+    return initProgramImpl(program, mainDecl);
 }
 
 const TestgenTarget &TestgenTarget::get() { return Target::get<TestgenTarget>("testgen"); }
 
+int TestgenTarget::getPortNumWidthBits() { return get().getPortNumWidthBitsImpl(); }
+
+TestBackEnd *TestgenTarget::getTestBackend(const ProgramInfo &programInfo, SymbolicExecutor &symbex,
+                                           const std::filesystem::path &testPath,
+                                           std::optional<uint32_t> seed) {
+    return get().getTestBackendImpl(programInfo, symbex, testPath, seed);
+}
+
+const ProgramInfo *TestgenTarget::initProgram(const IR::P4Program *program) {
+    return get().initProgramImpl(program);
+}
+
+const ArchSpec *TestgenTarget::getArchSpec() { return get().getArchSpecImpl(); }
+
+ExprStepper *TestgenTarget::getExprStepper(ExecutionState &state, AbstractSolver &solver,
+                                           const ProgramInfo &programInfo) {
+    return get().getExprStepperImpl(state, solver, programInfo);
+}
+
+CmdStepper *TestgenTarget::getCmdStepper(ExecutionState &state, AbstractSolver &solver,
+                                         const ProgramInfo &programInfo) {
+    return get().getCmdStepperImpl(state, solver, programInfo);
+}
+
 void TestgenTarget::argumentsToTypeDeclarations(
-    const NamespaceContext *ns, const IR::Vector<IR::Argument> *inputArgs,
+    const IR::IGeneralNamespace *ns, const IR::Vector<IR::Argument> *inputArgs,
     std::vector<const IR::Type_Declaration *> &resultDecls) {
     for (const auto *arg : *inputArgs) {
         const auto *expr = arg->expression;
@@ -51,12 +75,13 @@ void TestgenTarget::argumentsToTypeDeclarations(
             const auto *constructedTypeName = ctorCall->constructedType->checkedTo<IR::Type_Name>();
 
             // Find the corresponding type declaration in the namespace.
-            declType = ns->findDecl(constructedTypeName->path)->checkedTo<IR::Type_Declaration>();
+            declType = ProgramInfo::findProgramDecl(ns, constructedTypeName->path)
+                           ->checkedTo<IR::Type_Declaration>();
         } else if (const auto *pathExpr = expr->to<IR::PathExpression>()) {
             // Look up the path expression in the declaration map, and expect to find a
             // declaration instance.
-            const auto *declInstance =
-                ns->findDecl(pathExpr->path)->checkedTo<IR::Declaration_Instance>();
+            const auto *declInstance = ProgramInfo::findProgramDecl(ns, pathExpr->path)
+                                           ->checkedTo<IR::Declaration_Instance>();
             declType = declInstance->type->checkedTo<IR::Type_Declaration>();
         } else {
             BUG("Unexpected main-declaration argument node type: %1%", expr->node_type_name());

--- a/backends/p4tools/modules/testgen/core/target.cpp
+++ b/backends/p4tools/modules/testgen/core/target.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "backends/p4tools/common/core/target.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "ir/declaration.h"
 #include "ir/ir.h"
 #include "ir/node.h"
@@ -12,7 +13,6 @@
 #include "lib/log.h"
 
 #include "backends/p4tools/modules/testgen/core/program_info.h"
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 
 namespace P4Tools::P4Testgen {
 

--- a/backends/p4tools/modules/testgen/core/target.h
+++ b/backends/p4tools/modules/testgen/core/target.h
@@ -9,10 +9,10 @@
 
 #include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/core/target.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "ir/ir.h"
 #include "ir/vector.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h"
 #include "backends/p4tools/modules/testgen/core/small_step/expr_stepper.h"
@@ -31,72 +31,64 @@ class TestgenTarget : public Target {
     /// Produces a @ProgramInfo for the given P4 program.
     ///
     /// @returns nullptr if the program is not supported by this target.
-    static const ProgramInfo *initProgram(const IR::P4Program *program) {
-        return get().initProgram_impl(program);
-    }
+    static const ProgramInfo *initProgram(const IR::P4Program *program);
 
     /// Returns the test back end associated with this P4Testgen target.
     static TestBackEnd *getTestBackend(const ProgramInfo &programInfo, SymbolicExecutor &symbex,
                                        const std::filesystem::path &testPath,
-                                       std::optional<uint32_t> seed) {
-        return get().getTestBackend_impl(programInfo, symbex, testPath, seed);
-    }
+                                       std::optional<uint32_t> seed);
 
     /// The width of a port number, in bits.
-    static int getPortNumWidth_bits() { return get().getPortNumWidth_bits_impl(); }
+    static int getPortNumWidthBits();
 
     /// Provides a CmdStepper implementation for this target.
     static CmdStepper *getCmdStepper(ExecutionState &state, AbstractSolver &solver,
-                                     const ProgramInfo &programInfo) {
-        return get().getCmdStepper_impl(state, solver, programInfo);
-    }
+                                     const ProgramInfo &programInfo);
 
     /// Provides a ExprStepper implementation for this target.
     static ExprStepper *getExprStepper(ExecutionState &state, AbstractSolver &solver,
-                                       const ProgramInfo &programInfo) {
-        return get().getExprStepper_impl(state, solver, programInfo);
-    }
+                                       const ProgramInfo &programInfo);
 
     /// A vector that maps the architecture parameters of each pipe to the corresponding
     /// global architecture variables. For example, this map specifies which parameter of each pipe
     /// refers to the input header.
     // The arch map needs to be public to be subclassed.
     /// @returns a reference to the architecture map defined in this target
-    static const ArchSpec *getArchSpec() { return get().getArchSpecImpl(); }
+    static const ArchSpec *getArchSpec();
 
  protected:
     /// @see @initProgram.
-    const ProgramInfo *initProgram_impl(const IR::P4Program *program) const;
+    const ProgramInfo *initProgramImpl(const IR::P4Program *program) const;
 
     /// @see @initProgram.
-    virtual const ProgramInfo *initProgram_impl(const IR::P4Program *program,
-                                                const IR::Declaration_Instance *mainDecl) const = 0;
+    virtual const ProgramInfo *initProgramImpl(const IR::P4Program *program,
+                                               const IR::Declaration_Instance *mainDecl) const = 0;
 
-    /// @see getPortNumWidth_bits.
-    virtual int getPortNumWidth_bits_impl() const = 0;
+    /// @see getPortNumWidthBits.
+    [[nodiscard]] virtual int getPortNumWidthBitsImpl() const = 0;
 
     /// @see getTestBackend.
-    virtual TestBackEnd *getTestBackend_impl(const ProgramInfo &programInfo,
-                                             SymbolicExecutor &symbex,
-                                             const std::filesystem::path &testPath,
-                                             std::optional<uint32_t> seed) const = 0;
+    virtual TestBackEnd *getTestBackendImpl(const ProgramInfo &programInfo,
+                                            SymbolicExecutor &symbex,
+                                            const std::filesystem::path &testPath,
+                                            std::optional<uint32_t> seed) const = 0;
 
     /// @see getCmdStepper.
-    virtual CmdStepper *getCmdStepper_impl(ExecutionState &state, AbstractSolver &solver,
-                                           const ProgramInfo &programInfo) const = 0;
+    virtual CmdStepper *getCmdStepperImpl(ExecutionState &state, AbstractSolver &solver,
+                                          const ProgramInfo &programInfo) const = 0;
 
     /// @see getExprStepper.
-    virtual ExprStepper *getExprStepper_impl(ExecutionState &state, AbstractSolver &solver,
-                                             const ProgramInfo &programInfo) const = 0;
+    virtual ExprStepper *getExprStepperImpl(ExecutionState &state, AbstractSolver &solver,
+                                            const ProgramInfo &programInfo) const = 0;
 
     /// @see getArchSpec
-    virtual const ArchSpec *getArchSpecImpl() const = 0;
+    [[nodiscard]] virtual const ArchSpec *getArchSpecImpl() const = 0;
 
     /// Utility function. Converts the list of arguments @inputArgs to a list of type declarations
     ///  and appends the result to @v. Any names appearing in the arguments are
     /// resolved with @ns.
     //
-    static void argumentsToTypeDeclarations(const NamespaceContext *ns,
+    static void argumentsToTypeDeclarations(const IR::IGeneralNamespace *ns,
                                             const IR::Vector<IR::Argument> *inputArgs,
                                             std::vector<const IR::Type_Declaration *> &resultDecls);
 

--- a/backends/p4tools/modules/testgen/core/target.h
+++ b/backends/p4tools/modules/testgen/core/target.h
@@ -10,6 +10,7 @@
 #include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/core/target.h"
 #include "backends/p4tools/common/lib/arch_spec.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "ir/ir.h"
 #include "ir/vector.h"
 
@@ -18,7 +19,6 @@
 #include "backends/p4tools/modules/testgen/core/small_step/expr_stepper.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 #include "backends/p4tools/modules/testgen/lib/test_backend.h"
 
 namespace P4Tools::P4Testgen {

--- a/backends/p4tools/modules/testgen/lib/collect_latent_statements.h
+++ b/backends/p4tools/modules/testgen/lib/collect_latent_statements.h
@@ -15,6 +15,7 @@ namespace P4Tools::P4Testgen {
 /// present in a particular node. However, compared to CollectStatements, it traverses the entire
 /// subsequent parser DAG for a particular parser state. If there is a loop in the parser state, it
 /// will terminate.
+/// TODO: Consider caching this information.
 class CollectLatentStatements : public Inspector {
     P4::Coverage::CoverageSet &statements;
     const ExecutionState &state;

--- a/backends/p4tools/modules/testgen/lib/concolic.cpp
+++ b/backends/p4tools/modules/testgen/lib/concolic.cpp
@@ -12,9 +12,7 @@
 
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 bool ConcolicMethodImpls::matches(const std::vector<cstring> &paramNames,
                                   const IR::Vector<IR::Argument> *args) {
@@ -135,6 +133,4 @@ const ConcolicMethodImpls::ImplList *Concolic::getCoreConcolicMethodImpls() {
     return &coreConcolicMethodImpls;
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/continuation.cpp
+++ b/backends/p4tools/modules/testgen/lib/continuation.cpp
@@ -3,12 +3,11 @@
 #include <variant>
 #include <vector>
 
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "backends/p4tools/common/lib/trace_event.h"
 #include "ir/id.h"
 #include "ir/visitor.h"
 #include "lib/exceptions.h"
-
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 
 namespace P4Tools::P4Testgen {
 

--- a/backends/p4tools/modules/testgen/lib/continuation.h
+++ b/backends/p4tools/modules/testgen/lib/continuation.h
@@ -12,12 +12,11 @@
 #include <variant>
 #include <vector>
 
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "backends/p4tools/common/lib/trace_event.h"
 #include "ir/ir.h"
 #include "ir/node.h"
 #include "lib/cstring.h"
-
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 
 namespace Test {
 class SmallStepTest;

--- a/backends/p4tools/modules/testgen/lib/exceptions.h
+++ b/backends/p4tools/modules/testgen/lib/exceptions.h
@@ -3,9 +3,7 @@
 
 #include "lib/exceptions.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// This class indicates a feature that is not implemented in P4Testgen.
 /// Paths with this unimplemented feature should be skipped
@@ -34,8 +32,6 @@ class TestgenUnimplemented final : public Util::P4CExceptionBase {
         throw TestgenUnimplemented(__LINE__, __FILE__, __VA_ARGS__); \
     } while (0)
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_EXCEPTIONS_H_ */

--- a/backends/p4tools/modules/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/execution_state.cpp
@@ -16,6 +16,7 @@
 #include "backends/p4tools/common/compiler/convert_hs_index.h"
 #include "backends/p4tools/common/compiler/reachability.h"
 #include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/taint.h"
 #include "backends/p4tools/common/lib/trace_event.h"
@@ -28,7 +29,6 @@
 #include "lib/source_file.h"
 
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 #include "backends/p4tools/modules/testgen/options.h"
 

--- a/backends/p4tools/modules/testgen/lib/execution_state.h
+++ b/backends/p4tools/modules/testgen/lib/execution_state.h
@@ -15,6 +15,7 @@
 
 #include "backends/p4tools/common/compiler/reachability.h"
 #include "backends/p4tools/common/lib/formulae.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/trace_event.h"
 #include "ir/declaration.h"
@@ -25,7 +26,6 @@
 #include "midend/coverage.h"
 
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
 
 namespace P4Tools::P4Testgen {

--- a/backends/p4tools/modules/testgen/lib/gen_eq.cpp
+++ b/backends/p4tools/modules/testgen/lib/gen_eq.cpp
@@ -8,9 +8,7 @@
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 const IR::Expression *GenEq::equate(const IR::Expression *target, const IR::Expression *keyset) {
     if (const auto *defaultKey = keyset->to<IR::DefaultExpression>()) {
@@ -115,6 +113,4 @@ const IR::Equ *GenEq::mkEq(const IR::Expression *e1, const IR::Expression *e2) {
     return new IR::Equ(IR::Type::Boolean::get(), e1, e2);
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/gen_eq.h
+++ b/backends/p4tools/modules/testgen/lib/gen_eq.h
@@ -3,9 +3,7 @@
 
 #include "ir/ir.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// Generates an equality on a target expression and a keyset expression, recursing into lists.
 /// This supports fuzzy matching on singleton lists: singleton lists are considered the same as
@@ -33,8 +31,6 @@ class GenEq {
     static const IR::Equ *mkEq(const IR::Expression *e1, const IR::Expression *e2);
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_GEN_EQ_H_ */

--- a/backends/p4tools/modules/testgen/lib/logging.cpp
+++ b/backends/p4tools/modules/testgen/lib/logging.cpp
@@ -3,9 +3,7 @@
 
 #include "lib/log.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 void enableTraceLogging() { Log::addDebugSpec("test_traces:4"); }
 
@@ -17,6 +15,4 @@ void enableCoverageLogging() { Log::addDebugSpec("coverage:4"); }
 
 void enablePerformanceLogging() { Log::addDebugSpec("performance:4"); }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/logging.h
+++ b/backends/p4tools/modules/testgen/lib/logging.h
@@ -6,9 +6,7 @@
 
 #include "backends/p4tools/common/lib/util.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// Helper functions that prints strings associated with verbose test information, for example
 /// traces, or the test values themselves.
@@ -40,8 +38,6 @@ void enableCoverageLogging();
 /// Enable printing of timing reports.
 void enablePerformanceLogging();
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_LOGGING_H_ */

--- a/backends/p4tools/modules/testgen/lib/namespace_context.cpp
+++ b/backends/p4tools/modules/testgen/lib/namespace_context.cpp
@@ -7,9 +7,7 @@
 #include "lib/enumerator.h"
 #include "lib/exceptions.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 const NamespaceContext *NamespaceContext::Empty = new NamespaceContext(nullptr, nullptr);
 
@@ -120,10 +118,8 @@ const std::set<cstring> &NamespaceContext::getUsedNames() const {
     return *usedNames;
 }
 
-const cstring NamespaceContext::genName(cstring name, char sep) const {
+cstring NamespaceContext::genName(cstring name, char sep) const {
     return cstring::make_unique(getUsedNames(), name, sep);
 }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/namespace_context.h
+++ b/backends/p4tools/modules/testgen/lib/namespace_context.h
@@ -8,9 +8,7 @@
 #include "ir/ir.h"
 #include "lib/cstring.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// Represents a stack of namespaces.
 class NamespaceContext {
@@ -49,11 +47,9 @@ class NamespaceContext {
 
     /// @returns a name that is fresh in this context. The given @name and @sep are passed to
     /// cstring::make_unique.
-    const cstring genName(cstring name, char sep) const;
+    cstring genName(cstring name, char sep) const;
 };
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_NAMESPACE_CONTEXT_H_ */

--- a/backends/p4tools/modules/testgen/main.cpp
+++ b/backends/p4tools/modules/testgen/main.cpp
@@ -7,6 +7,7 @@ int main(int argc, char **argv) {
     setup_signals();
 
     std::vector<const char *> args;
+    args.reserve(argc);
     for (int i = 0; i < argc; ++i) {
         args.push_back(argv[i]);
     }

--- a/backends/p4tools/modules/testgen/register.h.in
+++ b/backends/p4tools/modules/testgen/register.h.in
@@ -3,9 +3,7 @@
 
 @include_statements_var@
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 inline void registerCompilerTargets() {
 @compiler_targets_var@}
@@ -13,8 +11,6 @@ inline void registerCompilerTargets() {
 inline void registerTestgenTargets() {
 @testgen_targets_var@}
 
-}  // namespace P4Tools
-
-}  // namespace P4Testgen
+}  // namespace P4Tools::P4Testgen
 
 #endif  /* BACKENDS_P4TOOLS_MODULES_TESTGEN_REGISTER_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
@@ -145,7 +145,7 @@ inja::json Protobuf::getControlPlane(const TestSpec *testSpec) {
         }
 
         // Collect action profiles and selectors associated with the table.
-        checkForTableActionProfile<Bmv2_V1ModelActionProfile, Bmv2_V1ModelActionSelector>(
+        checkForTableActionProfile<Bmv2V1ModelActionProfile, Bmv2V1ModelActionSelector>(
             tblJson, apAsMap, tblConfig);
 
         // Check whether the default action is overridden for this table.
@@ -155,8 +155,7 @@ inja::json Protobuf::getControlPlane(const TestSpec *testSpec) {
     }
 
     // Collect declarations of action profiles.
-    collectActionProfileDeclarations<Bmv2_V1ModelActionProfile>(testSpec, controlPlaneJson,
-                                                                apAsMap);
+    collectActionProfileDeclarations<Bmv2V1ModelActionProfile>(testSpec, controlPlaneJson, apAsMap);
 
     return controlPlaneJson;
 }

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
@@ -92,7 +92,7 @@ inja::json PTF::getControlPlane(const TestSpec *testSpec) {
         }
 
         // Collect action profiles and selectors associated with the table.
-        checkForTableActionProfile<Bmv2_V1ModelActionProfile, Bmv2_V1ModelActionSelector>(
+        checkForTableActionProfile<Bmv2V1ModelActionProfile, Bmv2V1ModelActionSelector>(
             tblJson, apAsMap, tblConfig);
 
         // Check whether the default action is overridden for this table.
@@ -102,8 +102,7 @@ inja::json PTF::getControlPlane(const TestSpec *testSpec) {
     }
 
     // Collect declarations of action profiles.
-    collectActionProfileDeclarations<Bmv2_V1ModelActionProfile>(testSpec, controlPlaneJson,
-                                                                apAsMap);
+    collectActionProfileDeclarations<Bmv2V1ModelActionProfile>(testSpec, controlPlaneJson, apAsMap);
 
     return controlPlaneJson;
 }

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.cpp
@@ -59,7 +59,7 @@ inja::json STF::getControlPlane(const TestSpec *testSpec) {
         }
 
         // Collect action profiles and selectors associated with the table.
-        checkForTableActionProfile<Bmv2_V1ModelActionProfile, Bmv2_V1ModelActionSelector>(
+        checkForTableActionProfile<Bmv2V1ModelActionProfile, Bmv2V1ModelActionSelector>(
             tblJson, apAsMap, tblConfig);
 
         // Check whether the default action is overridden for this table.
@@ -69,8 +69,7 @@ inja::json STF::getControlPlane(const TestSpec *testSpec) {
     }
 
     // Collect declarations of action profiles.
-    collectActionProfileDeclarations<Bmv2_V1ModelActionProfile>(testSpec, controlPlaneJson,
-                                                                apAsMap);
+    collectActionProfileDeclarations<Bmv2V1ModelActionProfile>(testSpec, controlPlaneJson, apAsMap);
 
     return controlPlaneJson;
 }

--- a/backends/p4tools/modules/testgen/targets/bmv2/bmv2.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/bmv2.cpp
@@ -12,22 +12,18 @@
 
 #include "backends/p4tools/modules/testgen/options.h"
 
-namespace P4Tools {
+namespace P4Tools::P4Testgen::Bmv2 {
 
-namespace P4Testgen {
+Bmv2V1ModelCompilerTarget::Bmv2V1ModelCompilerTarget() : CompilerTarget("bmv2", "v1model") {}
 
-namespace Bmv2 {
-
-BMv2_V1ModelCompilerTarget::BMv2_V1ModelCompilerTarget() : CompilerTarget("bmv2", "v1model") {}
-
-void BMv2_V1ModelCompilerTarget::make() {
-    static BMv2_V1ModelCompilerTarget *INSTANCE = nullptr;
+void Bmv2V1ModelCompilerTarget::make() {
+    static Bmv2V1ModelCompilerTarget *INSTANCE = nullptr;
     if (INSTANCE == nullptr) {
-        INSTANCE = new BMv2_V1ModelCompilerTarget();
+        INSTANCE = new Bmv2V1ModelCompilerTarget();
     }
 }
 
-MidEnd BMv2_V1ModelCompilerTarget::mkMidEnd(const CompilerOptions &options) const {
+MidEnd Bmv2V1ModelCompilerTarget::mkMidEnd(const CompilerOptions &options) const {
     MidEnd midEnd(options);
     auto *refMap = midEnd.getRefMap();
     auto *typeMap = midEnd.getTypeMap();
@@ -46,8 +42,4 @@ MidEnd BMv2_V1ModelCompilerTarget::mkMidEnd(const CompilerOptions &options) cons
     return midEnd;
 }
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/bmv2.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/bmv2.h
@@ -5,13 +5,9 @@
 #include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
 
-namespace P4Tools {
+namespace P4Tools::P4Testgen::Bmv2 {
 
-namespace P4Testgen {
-
-namespace Bmv2 {
-
-class BMv2_V1ModelCompilerTarget : public CompilerTarget {
+class Bmv2V1ModelCompilerTarget : public CompilerTarget {
  public:
     /// Registers this target.
     static void make();
@@ -19,13 +15,9 @@ class BMv2_V1ModelCompilerTarget : public CompilerTarget {
  private:
     MidEnd mkMidEnd(const CompilerOptions &options) const override;
 
-    BMv2_V1ModelCompilerTarget();
+    Bmv2V1ModelCompilerTarget();
 };
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_BMV2_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
@@ -9,6 +9,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/formulae.h"
 #include "ir/id.h"
 #include "ir/ir.h"
@@ -18,7 +19,6 @@
 #include "lib/exceptions.h"
 #include "lib/ordered_map.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
@@ -30,15 +30,15 @@
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
-BMv2_V1ModelCmdStepper::BMv2_V1ModelCmdStepper(ExecutionState &state, AbstractSolver &solver,
-                                               const ProgramInfo &programInfo)
+Bmv2V1ModelCmdStepper::Bmv2V1ModelCmdStepper(ExecutionState &state, AbstractSolver &solver,
+                                             const ProgramInfo &programInfo)
     : CmdStepper(state, solver, programInfo) {}
 
-const BMv2_V1ModelProgramInfo &BMv2_V1ModelCmdStepper::getProgramInfo() const {
-    return *CmdStepper::getProgramInfo().checkedTo<BMv2_V1ModelProgramInfo>();
+const Bmv2V1ModelProgramInfo &Bmv2V1ModelCmdStepper::getProgramInfo() const {
+    return *CmdStepper::getProgramInfo().checkedTo<Bmv2V1ModelProgramInfo>();
 }
 
-void BMv2_V1ModelCmdStepper::initializeTargetEnvironment(ExecutionState &nextState) const {
+void Bmv2V1ModelCmdStepper::initializeTargetEnvironment(ExecutionState &nextState) const {
     // Associate intrinsic metadata with the packet. The input packet is prefixed with
     // ingress intrinsic metadata and port metadata.
     //
@@ -99,10 +99,10 @@ void BMv2_V1ModelCmdStepper::initializeTargetEnvironment(ExecutionState &nextSta
     nextState.set(packetSizeVar, packetSizeConst);
 }
 
-std::optional<const Constraint *> BMv2_V1ModelCmdStepper::startParser_impl(
+std::optional<const Constraint *> Bmv2V1ModelCmdStepper::startParserImpl(
     const IR::P4Parser *parser, ExecutionState &nextState) const {
     // We need to explicitly map the parser error
-    const auto *errVar = BMv2_V1ModelProgramInfo::getParserParamVar(
+    const auto *errVar = Bmv2V1ModelProgramInfo::getParserParamVar(
         parser, programInfo.getParserErrorType(), 3, "parser_error");
     nextState.setParserErrorLabel(errVar);
 
@@ -115,14 +115,14 @@ std::optional<const Constraint *> BMv2_V1ModelCmdStepper::startParser_impl(
     return std::nullopt;
 }
 
-std::map<Continuation::Exception, Continuation> BMv2_V1ModelCmdStepper::getExceptionHandlers(
+std::map<Continuation::Exception, Continuation> Bmv2V1ModelCmdStepper::getExceptionHandlers(
     const IR::P4Parser *parser, Continuation::Body /*normalContinuation*/,
     const ExecutionState & /*nextState*/) const {
     std::map<Continuation::Exception, Continuation> result;
     auto programInfo = getProgramInfo();
     auto gress = programInfo.getGress(parser);
 
-    const auto *errVar = BMv2_V1ModelProgramInfo::getParserParamVar(
+    const auto *errVar = Bmv2V1ModelProgramInfo::getParserParamVar(
         parser, programInfo.getParserErrorType(), 3, "parser_error");
 
     switch (gress) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.h
@@ -17,24 +17,24 @@
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
-class BMv2_V1ModelCmdStepper : public CmdStepper {
+class Bmv2V1ModelCmdStepper : public CmdStepper {
  protected:
-    std::string getClassName() override { return "BMv2_V1ModelCmdStepper"; }
+    std::string getClassName() override { return "Bmv2V1ModelCmdStepper"; }
 
-    const BMv2_V1ModelProgramInfo &getProgramInfo() const override;
+    const Bmv2V1ModelProgramInfo &getProgramInfo() const override;
 
     void initializeTargetEnvironment(ExecutionState &nextState) const override;
 
-    std::optional<const Constraint *> startParser_impl(const IR::P4Parser *parser,
-                                                       ExecutionState &nextState) const override;
+    std::optional<const Constraint *> startParserImpl(const IR::P4Parser *parser,
+                                                      ExecutionState &nextState) const override;
 
     std::map<Continuation::Exception, Continuation> getExceptionHandlers(
         const IR::P4Parser *parser, Continuation::Body normalContinuation,
         const ExecutionState &nextState) const override;
 
  public:
-    BMv2_V1ModelCmdStepper(ExecutionState &nextState, AbstractSolver &solver,
-                           const ProgramInfo &programInfo);
+    Bmv2V1ModelCmdStepper(ExecutionState &nextState, AbstractSolver &solver,
+                          const ProgramInfo &programInfo);
 };
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/constants.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/constants.cpp
@@ -1,11 +1,3 @@
 #include "backends/p4tools/modules/testgen/targets/bmv2/constants.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+namespace P4Tools::P4Testgen::Bmv2 {}

--- a/backends/p4tools/modules/testgen/targets/bmv2/constants.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/constants.h
@@ -3,11 +3,7 @@
 
 #include <cstdint>
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 enum bmv2_gress_t { BMV2_INGRESS, BMV2_EGRESS };
 
@@ -39,10 +35,6 @@ class BMv2Constants {
     static constexpr int DROP_PORT = 511;
 };
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_CONSTANTS_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/contrib/bmv2_hash/calculations.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/contrib/bmv2_hash/calculations.cpp
@@ -4,11 +4,7 @@
 
 #include <algorithm>
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 /* generating from my Python script gen_crc_tables inspired from the C code at:
    http://www.barrgroup.com/Embedded-Systems/How-To/CRC-Calculation-C-Code */
@@ -198,8 +194,4 @@ uint64_t BMv2Hash::identity(const char *buf, size_t len) {
     return res;
 }
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/contrib/bmv2_hash/calculations.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/contrib/bmv2_hash/calculations.h
@@ -24,11 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 class BMv2Hash {
     /* This code was adapted from:
@@ -65,10 +61,6 @@ class BMv2Hash {
     static uint64_t identity(const char *buf, size_t len);
 };
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /*BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_CONTRIB_BMV2_HASH_CALCULATIONS_H_*/

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -11,6 +11,7 @@
 #include <boost/multiprecision/number.hpp>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/trace_event_types.h"
@@ -25,7 +26,6 @@
 #include "lib/log.h"
 #include "lib/ordered_map.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/externs.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/expr_stepper.h"
@@ -43,10 +43,10 @@
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
-std::string BMv2_V1ModelExprStepper::getClassName() { return "BMv2_V1ModelExprStepper"; }
+std::string Bmv2V1ModelExprStepper::getClassName() { return "Bmv2V1ModelExprStepper"; }
 
-bool BMv2_V1ModelExprStepper::isPartOfFieldList(const IR::StructField *field,
-                                                uint64_t recirculateIndex) {
+bool Bmv2V1ModelExprStepper::isPartOfFieldList(const IR::StructField *field,
+                                               uint64_t recirculateIndex) {
     // Check whether the field has a "field_list" annotation associated with it.
     const auto *annotation = field->getAnnotation("field_list");
     if (annotation != nullptr) {
@@ -64,9 +64,9 @@ bool BMv2_V1ModelExprStepper::isPartOfFieldList(const IR::StructField *field,
     return false;
 }
 
-void BMv2_V1ModelExprStepper::resetPreservingFieldList(ExecutionState &nextState,
-                                                       const IR::PathExpression *ref,
-                                                       uint64_t recirculateIndex) const {
+void Bmv2V1ModelExprStepper::resetPreservingFieldList(ExecutionState &nextState,
+                                                      const IR::PathExpression *ref,
+                                                      uint64_t recirculateIndex) const {
     const auto *ts = ref->type->checkedTo<IR::Type_StructLike>();
     for (const auto *field : ts->fields) {
         // Check whether the field has a "field_list" annotation associated with it.
@@ -81,14 +81,14 @@ void BMv2_V1ModelExprStepper::resetPreservingFieldList(ExecutionState &nextState
     }
 }
 
-BMv2_V1ModelExprStepper::BMv2_V1ModelExprStepper(ExecutionState &state, AbstractSolver &solver,
-                                                 const ProgramInfo &programInfo)
+Bmv2V1ModelExprStepper::Bmv2V1ModelExprStepper(ExecutionState &state, AbstractSolver &solver,
+                                               const ProgramInfo &programInfo)
     : ExprStepper(state, solver, programInfo) {}
 
-void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
-                                                   const IR::Expression *receiver, IR::ID name,
-                                                   const IR::Vector<IR::Argument> *args,
-                                                   ExecutionState &state) {
+void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
+                                                  const IR::Expression *receiver, IR::ID name,
+                                                  const IR::Vector<IR::Argument> *args,
+                                                  ExecutionState &state) {
     const ExternMethodImpls::MethodImpl assertAssumeExecute =
         [](const IR::MethodCallExpression *call, const IR::Expression * /*receiver*/,
            IR::ID &methodName, const IR::Vector<IR::Argument> *args, const ExecutionState &state,
@@ -137,7 +137,7 @@ void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpressio
         };
 
     // Provides implementations of BMv2 externs.
-    static const ExternMethodImpls EXTERN_METHOD_IMPLS({
+    static const ExternMethodImpls EXTERN_METHODImplS({
         /* ======================================================================================
          *  mark_to_drop
          *  Mark to drop sets the BMv2 internal drop variable to true.
@@ -150,7 +150,7 @@ void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpressio
             const ExecutionState &state, SmallStepEvaluator::Result &result) {
              auto &nextState = state.clone();
              const auto *nineBitType =
-                 IR::getBitType(BMv2_V1ModelTestgenTarget::getPortNumWidth_bits());
+                 IR::getBitType(Bmv2V1ModelTestgenTarget::getPortNumWidthBits());
              const auto *metadataLabel = args->at(0)->expression;
              if (!(metadataLabel->is<IR::Member>() || metadataLabel->is<IR::PathExpression>())) {
                  TESTGEN_UNIMPLEMENTED("Drop input %1% of type %2% not supported", metadataLabel,
@@ -872,7 +872,7 @@ void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpressio
                  // by calling copyIn on the entire state again. We need a little bit of information
                  // for that, including the exact parameter names of the ingress block we are in.
                  // Just grab the ingress from the programmable blocks.
-                 const auto *progInfo = getProgramInfo().checkedTo<BMv2_V1ModelProgramInfo>();
+                 const auto *progInfo = getProgramInfo().checkedTo<Bmv2V1ModelProgramInfo>();
                  const auto *programmableBlocks = progInfo->getProgrammableBlocks();
                  const auto *typeDecl = programmableBlocks->at("Ingress");
                  const auto *applyBlock = typeDecl->checkedTo<IR::P4Control>();
@@ -1154,7 +1154,7 @@ void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpressio
                  }
                  // This is the clone state.
                  auto &nextState = state.clone();
-                 auto progInfo = getProgramInfo().checkedTo<BMv2_V1ModelProgramInfo>();
+                 auto progInfo = getProgramInfo().checkedTo<Bmv2V1ModelProgramInfo>();
 
                  // We need to reset everything to the state before the ingress call. We use a trick
                  // by calling copyIn on the entire state again. We need a little bit of information
@@ -1250,7 +1250,7 @@ void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpressio
                  IR::getConstant(pktSizeType, recState.getPacketBufferSize() / 8);
              recState.set(packetSizeVar, packetSizeConst);
 
-             const auto *progInfo = getProgramInfo().checkedTo<BMv2_V1ModelProgramInfo>();
+             const auto *progInfo = getProgramInfo().checkedTo<Bmv2V1ModelProgramInfo>();
              if (recState.hasProperty("recirculate_index")) {
                  // Get the index set by the recirculate/resubmit function. Will fail if no index is
                  // set.
@@ -1743,14 +1743,14 @@ void BMv2_V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpressio
          }},
     });
 
-    if (!EXTERN_METHOD_IMPLS.exec(call, receiver, name, args, state, result)) {
+    if (!EXTERN_METHODImplS.exec(call, receiver, name, args, state, result)) {
         ExprStepper::evalExternMethodCall(call, receiver, name, args, state);
     }
 }  // NOLINT
 
-bool BMv2_V1ModelExprStepper::preorder(const IR::P4Table *table) {
+bool Bmv2V1ModelExprStepper::preorder(const IR::P4Table *table) {
     // Delegate to the tableStepper.
-    BMv2_V1ModelTableStepper tableStepper(this, table);
+    Bmv2V1ModelTableStepper tableStepper(this, table);
 
     return tableStepper.eval();
 }

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -137,7 +137,7 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
         };
 
     // Provides implementations of BMv2 externs.
-    static const ExternMethodImpls EXTERN_METHODImplS({
+    static const ExternMethodImpls EXTERN_METHOD_IMPLS({
         /* ======================================================================================
          *  mark_to_drop
          *  Mark to drop sets the BMv2 internal drop variable to true.
@@ -1743,7 +1743,7 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
          }},
     });
 
-    if (!EXTERN_METHODImplS.exec(call, receiver, name, args, state, result)) {
+    if (!EXTERN_METHOD_IMPLS.exec(call, receiver, name, args, state, result)) {
         ExprStepper::evalExternMethodCall(call, receiver, name, args, state);
     }
 }  // NOLINT

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.h
@@ -1,8 +1,7 @@
 #ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_EXPR_STEPPER_H_
 #define BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_EXPR_STEPPER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 
 #include "backends/p4tools/common/core/solver.h"

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.h
@@ -14,13 +14,9 @@
 #include "backends/p4tools/modules/testgen/core/small_step/expr_stepper.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
-namespace P4Tools {
+namespace P4Tools::P4Testgen::Bmv2 {
 
-namespace P4Testgen {
-
-namespace Bmv2 {
-
-class BMv2_V1ModelExprStepper : public ExprStepper {
+class Bmv2V1ModelExprStepper : public ExprStepper {
  protected:
     std::string getClassName() override;
 
@@ -37,8 +33,8 @@ class BMv2_V1ModelExprStepper : public ExprStepper {
                                   uint64_t recirculateIndex) const;
 
  public:
-    BMv2_V1ModelExprStepper(ExecutionState &state, AbstractSolver &solver,
-                            const ProgramInfo &programInfo);
+    Bmv2V1ModelExprStepper(ExecutionState &state, AbstractSolver &solver,
+                           const ProgramInfo &programInfo);
 
     void evalExternMethodCall(const IR::MethodCallExpression *call, const IR::Expression *receiver,
                               IR::ID name, const IR::Vector<IR::Argument> *args,
@@ -46,10 +42,6 @@ class BMv2_V1ModelExprStepper : public ExprStepper {
 
     bool preorder(const IR::P4Table * /*table*/) override;
 };
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_EXPR_STEPPER_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
@@ -14,7 +14,7 @@
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
-class BMv2_V1ModelProgramInfo : public ProgramInfo {
+class Bmv2V1ModelProgramInfo : public ProgramInfo {
  private:
     /// The program's top level blocks: the parser, the checksum verifier, the MAU pipeline, the
     /// checksum calculator, and the deparser.
@@ -32,9 +32,9 @@ class BMv2_V1ModelProgramInfo : public ProgramInfo {
                                                           size_t blockIdx) const;
 
  public:
-    BMv2_V1ModelProgramInfo(const IR::P4Program *program,
-                            ordered_map<cstring, const IR::Type_Declaration *> inputBlocks,
-                            const std::map<int, int> declIdToGress);
+    Bmv2V1ModelProgramInfo(const IR::P4Program *program,
+                           ordered_map<cstring, const IR::Type_Declaration *> inputBlocks,
+                           std::map<int, int> declIdToGress);
 
     /// @returns the gress associated with the given parser.
     int getGress(const IR::Type_Declaration *) const;

--- a/backends/p4tools/modules/testgen/targets/bmv2/register.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/register.h
@@ -8,18 +8,14 @@
 #include "backends/p4tools/modules/testgen/targets/bmv2/target.h"
 #include "backends/p4tools/modules/testgen/testgen.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// Register the BMv2 compiler target with the tools framework.
-inline void bmv2_registerCompilerTarget() { Bmv2::BMv2_V1ModelCompilerTarget::make(); }
+inline void bmv2_registerCompilerTarget() { Bmv2::Bmv2V1ModelCompilerTarget::make(); }
 
 /// Register the BMv2 testgen target with the testgen framework.
-inline void bmv2_registerTestgenTarget() { Bmv2::BMv2_V1ModelTestgenTarget::make(); }
+inline void bmv2_registerTestgenTarget() { Bmv2::Bmv2V1ModelTestgenTarget::make(); }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_REGISTER_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -36,7 +36,7 @@
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
-const IR::Expression *BMv2_V1ModelTableStepper::computeTargetMatchType(
+const IR::Expression *Bmv2V1ModelTableStepper::computeTargetMatchType(
     ExecutionState &nextState, const KeyProperties &keyProperties, TableMatchMap *matches,
     const IR::Expression *hitCondition) {
     const IR::Expression *keyExpr = keyProperties.key->expression;
@@ -60,7 +60,7 @@ const IR::Expression *BMv2_V1ModelTableStepper::computeTargetMatchType(
     }
     // Action selector entries are not part of the match.
     if (keyProperties.matchType == BMv2Constants::MATCH_KIND_SELECTOR) {
-        bmv2_V1ModelProperties.actionSelectorKeys.emplace_back(keyExpr);
+        bmv2V1ModelProperties.actionSelectorKeys.emplace_back(keyExpr);
         return hitCondition;
     }
     // Ranges are not yet implemented for BMv2 STF tests.
@@ -88,7 +88,7 @@ const IR::Expression *BMv2_V1ModelTableStepper::computeTargetMatchType(
     return TableStepper::computeTargetMatchType(nextState, keyProperties, matches, hitCondition);
 }
 
-void BMv2_V1ModelTableStepper::evalTableActionProfile(
+void Bmv2V1ModelTableStepper::evalTableActionProfile(
     const std::vector<const IR::ActionListElement *> &tableActionList) {
     const auto *state = getExecutionState();
 
@@ -104,7 +104,7 @@ void BMv2_V1ModelTableStepper::evalTableActionProfile(
         // We get the control plane name of the action we are calling.
         cstring actionName = actionType->controlPlaneName();
         // Copy the previous action profile.
-        auto *actionProfile = new Bmv2_V1ModelActionProfile(*bmv2_V1ModelProperties.actionProfile);
+        auto *actionProfile = new Bmv2V1ModelActionProfile(*bmv2V1ModelProperties.actionProfile);
         // Synthesize arguments for the call based on the action parameters.
         const auto &parameters = actionType->parameters;
         auto *arguments = new IR::Vector<IR::Argument>();
@@ -177,7 +177,7 @@ void BMv2_V1ModelTableStepper::evalTableActionProfile(
     }
 }
 
-void BMv2_V1ModelTableStepper::evalTableActionSelector(
+void Bmv2V1ModelTableStepper::evalTableActionSelector(
     const std::vector<const IR::ActionListElement *> &tableActionList) {
     const auto *state = getExecutionState();
 
@@ -194,8 +194,8 @@ void BMv2_V1ModelTableStepper::evalTableActionSelector(
         cstring actionName = actionType->controlPlaneName();
 
         // Copy the previous action profile.
-        auto *actionProfile = new Bmv2_V1ModelActionProfile(
-            bmv2_V1ModelProperties.actionSelector->getActionProfile()->getProfileDecl());
+        auto *actionProfile = new Bmv2V1ModelActionProfile(
+            bmv2V1ModelProperties.actionSelector->getActionProfile()->getProfileDecl());
         // Synthesize arguments for the call based on the action parameters.
         const auto &parameters = actionType->parameters;
         auto *arguments = new IR::Vector<IR::Argument>();
@@ -220,8 +220,8 @@ void BMv2_V1ModelTableStepper::evalTableActionSelector(
         // TODO: Should we check if we exceed the maximum number of possible profile entries?
         actionProfile->addToActionMap(actionName, ctrlPlaneArgs);
 
-        auto *actionSelector = new Bmv2_V1ModelActionSelector(
-            bmv2_V1ModelProperties.actionSelector->getSelectorDecl(), actionProfile);
+        auto *actionSelector = new Bmv2V1ModelActionSelector(
+            bmv2V1ModelProperties.actionSelector->getSelectorDecl(), actionProfile);
 
         // Update the action profile in the execution state.
         nextState.addTestObject("action_profile", actionProfile->getObjectName(), actionProfile);
@@ -276,7 +276,7 @@ void BMv2_V1ModelTableStepper::evalTableActionSelector(
     }
 }
 
-bool BMv2_V1ModelTableStepper::checkForActionProfile() {
+bool Bmv2V1ModelTableStepper::checkForActionProfile() {
     const auto *impl = table->properties->getProperty("implementation");
     if (impl == nullptr) {
         return false;
@@ -309,16 +309,16 @@ bool BMv2_V1ModelTableStepper::checkForActionProfile() {
     if (testObject == nullptr) {
         // This means, for every possible control plane entry (and with that, new execution state)
         // add the generated action profile.
-        bmv2_V1ModelProperties.addProfileToState = true;
-        bmv2_V1ModelProperties.actionProfile = new Bmv2_V1ModelActionProfile(implDecl);
+        bmv2V1ModelProperties.addProfileToState = true;
+        bmv2V1ModelProperties.actionProfile = new Bmv2V1ModelActionProfile(implDecl);
         return true;
     }
-    bmv2_V1ModelProperties.actionProfile = testObject->checkedTo<Bmv2_V1ModelActionProfile>();
-    bmv2_V1ModelProperties.addProfileToState = false;
+    bmv2V1ModelProperties.actionProfile = testObject->checkedTo<Bmv2V1ModelActionProfile>();
+    bmv2V1ModelProperties.addProfileToState = false;
     return true;
 }
 
-bool BMv2_V1ModelTableStepper::checkForActionSelector() {
+bool Bmv2V1ModelTableStepper::checkForActionSelector() {
     const auto *impl = table->properties->getProperty("implementation");
     if (impl == nullptr) {
         return false;
@@ -352,16 +352,16 @@ bool BMv2_V1ModelTableStepper::checkForActionSelector() {
     if (testObject == nullptr) {
         // This means, for every possible control plane entry (and with that, new execution state)
         // add the generated action profile.
-        bmv2_V1ModelProperties.addProfileToState = true;
-        bmv2_V1ModelProperties.actionProfile = new Bmv2_V1ModelActionProfile(selectorDecl);
+        bmv2V1ModelProperties.addProfileToState = true;
+        bmv2V1ModelProperties.actionProfile = new Bmv2V1ModelActionProfile(selectorDecl);
         return true;
     }
-    bmv2_V1ModelProperties.actionProfile = testObject->checkedTo<Bmv2_V1ModelActionProfile>();
-    bmv2_V1ModelProperties.addProfileToState = false;
+    bmv2V1ModelProperties.actionProfile = testObject->checkedTo<Bmv2V1ModelActionProfile>();
+    bmv2V1ModelProperties.addProfileToState = false;
     return true;
 }
 
-void BMv2_V1ModelTableStepper::checkTargetProperties(
+void Bmv2V1ModelTableStepper::checkTargetProperties(
     const std::vector<const IR::ActionListElement *> & /*tableActionList*/) {
     // Iterate over the table keys and check whether we can mitigate taint.
     for (auto keyProperties : properties.resolvedKeys) {
@@ -379,19 +379,19 @@ void BMv2_V1ModelTableStepper::checkTargetProperties(
 
     // Check whether the table has an action profile associated with it.
     if (checkForActionProfile()) {
-        bmv2_V1ModelProperties.implementaton = TableImplementation::profile;
+        bmv2V1ModelProperties.implementaton = TableImplementation::profile;
         return;
     }
 
     // Check whether the table has an action selector associated with it.
     if (checkForActionSelector()) {
         // TODO: This should be a selector. Implement.
-        bmv2_V1ModelProperties.implementaton = TableImplementation::profile;
+        bmv2V1ModelProperties.implementaton = TableImplementation::profile;
         return;
     }
 }
 
-void BMv2_V1ModelTableStepper::evalTargetTable(
+void Bmv2V1ModelTableStepper::evalTargetTable(
     const std::vector<const IR::ActionListElement *> &tableActionList) {
     const auto *keys = table->getKey();
     // If we have no keys, there is nothing to match.
@@ -418,10 +418,10 @@ void BMv2_V1ModelTableStepper::evalTargetTable(
 
     // If the table is not immutable, we synthesize control plane entries and follow the paths.
     if (properties.tableIsImmutable) {
-        bmv2_V1ModelProperties.implementaton = TableImplementation::constant;
+        bmv2V1ModelProperties.implementaton = TableImplementation::constant;
     }
 
-    switch (bmv2_V1ModelProperties.implementaton) {
+    switch (bmv2V1ModelProperties.implementaton) {
         case TableImplementation::selector: {
             // If an action selector is attached to the table, do not assume normal control plane
             // behavior.
@@ -466,8 +466,8 @@ void BMv2_V1ModelTableStepper::evalTargetTable(
     addDefaultAction(tableMissCondition);
 }
 
-BMv2_V1ModelTableStepper::BMv2_V1ModelTableStepper(BMv2_V1ModelExprStepper *stepper,
-                                                   const IR::P4Table *table)
+Bmv2V1ModelTableStepper::Bmv2V1ModelTableStepper(Bmv2V1ModelExprStepper *stepper,
+                                                 const IR::P4Table *table)
     : TableStepper(stepper, table) {}
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.h
@@ -11,13 +11,9 @@
 #include "backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
 
-namespace P4Tools {
+namespace P4Tools::P4Testgen::Bmv2 {
 
-namespace P4Testgen {
-
-namespace Bmv2 {
-
-class BMv2_V1ModelTableStepper : public TableStepper {
+class Bmv2V1ModelTableStepper : public TableStepper {
  private:
     /// Specifies the type of the table implementation:
     /// standard: standard implementation - use normal control plane entries.
@@ -28,12 +24,12 @@ class BMv2_V1ModelTableStepper : public TableStepper {
     enum class TableImplementation { standard, selector, profile, constant, skip };
 
     /// BMv2 specific table properties.
-    struct BMv2_V1ModelProperties {
+    struct Bmv2V1ModelProperties {
         /// The table has an action profile associated with it.
-        const Bmv2_V1ModelActionProfile *actionProfile = nullptr;
+        const Bmv2V1ModelActionProfile *actionProfile = nullptr;
 
         /// The table has an action selector associated with it.
-        const Bmv2_V1ModelActionSelector *actionSelector = nullptr;
+        const Bmv2V1ModelActionSelector *actionSelector = nullptr;
 
         /// The selector keys that are part of the selector hash that is calculated.
         std::vector<const IR::Expression *> actionSelectorKeys;
@@ -43,7 +39,7 @@ class BMv2_V1ModelTableStepper : public TableStepper {
 
         /// The type of the table implementation.
         TableImplementation implementaton = TableImplementation::standard;
-    } bmv2_V1ModelProperties;
+    } bmv2V1ModelProperties;
 
     /// Check whether the table has an action profile implementation.
     bool checkForActionProfile();
@@ -72,13 +68,9 @@ class BMv2_V1ModelTableStepper : public TableStepper {
         const std::vector<const IR::ActionListElement *> &tableActionList) override;
 
  public:
-    explicit BMv2_V1ModelTableStepper(BMv2_V1ModelExprStepper *stepper, const IR::P4Table *table);
+    explicit Bmv2V1ModelTableStepper(Bmv2V1ModelExprStepper *stepper, const IR::P4Table *table);
 };
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_TABLE_STEPPER_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/target.cpp
@@ -1,7 +1,6 @@
 #include "backends/p4tools/modules/testgen/targets/bmv2/target.h"
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <map>
 #include <vector>
 
@@ -22,33 +21,28 @@
 #include "backends/p4tools/modules/testgen/targets/bmv2/program_info.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/test_backend.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace Bmv2 {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 /* =============================================================================================
- *  BMv2_V1ModelTestgenTarget implementation
+ *  Bmv2V1ModelTestgenTarget implementation
  * ============================================================================================= */
 
-BMv2_V1ModelTestgenTarget::BMv2_V1ModelTestgenTarget() : TestgenTarget("bmv2", "v1model") {}
+Bmv2V1ModelTestgenTarget::Bmv2V1ModelTestgenTarget() : TestgenTarget("bmv2", "v1model") {}
 
-void BMv2_V1ModelTestgenTarget::make() {
-    static BMv2_V1ModelTestgenTarget *INSTANCE = nullptr;
+void Bmv2V1ModelTestgenTarget::make() {
+    static Bmv2V1ModelTestgenTarget *INSTANCE = nullptr;
     if (INSTANCE == nullptr) {
-        INSTANCE = new BMv2_V1ModelTestgenTarget();
+        INSTANCE = new Bmv2V1ModelTestgenTarget();
     }
 }
 
-const BMv2_V1ModelProgramInfo *BMv2_V1ModelTestgenTarget::initProgram_impl(
+const Bmv2V1ModelProgramInfo *Bmv2V1ModelTestgenTarget::initProgramImpl(
     const IR::P4Program *program, const IR::Declaration_Instance *mainDecl) const {
     // The blocks in the main declaration are just the arguments in the constructor call.
     // Convert mainDecl->arguments into a vector of blocks, represented as constructor-call
     // expressions.
-    const auto *ns = NamespaceContext::Empty->push(program);
     std::vector<const IR::Type_Declaration *> blocks;
-    argumentsToTypeDeclarations(ns, mainDecl->arguments, blocks);
+    argumentsToTypeDeclarations(program, mainDecl->arguments, blocks);
 
     // We should have six arguments.
     BUG_CHECK(blocks.size() == 6, "%1%: The BMV2 architecture requires 6 pipes. Received %2%.",
@@ -61,7 +55,7 @@ const BMv2_V1ModelProgramInfo *BMv2_V1ModelTestgenTarget::initProgram_impl(
     for (size_t idx = 0; idx < blocks.size(); ++idx) {
         const auto *declType = blocks.at(idx);
 
-        auto canonicalName = archSpec.getArchMember(idx)->blockName;
+        auto canonicalName = ARCH_SPEC.getArchMember(idx)->blockName;
         programmableBlocks.emplace(canonicalName, declType);
 
         if (idx < 3) {
@@ -71,28 +65,29 @@ const BMv2_V1ModelProgramInfo *BMv2_V1ModelTestgenTarget::initProgram_impl(
         }
     }
 
-    return new BMv2_V1ModelProgramInfo(program, programmableBlocks, declIdToGress);
+    return new Bmv2V1ModelProgramInfo(program, programmableBlocks, declIdToGress);
 }
 
-Bmv2TestBackend *BMv2_V1ModelTestgenTarget::getTestBackend_impl(
-    const ProgramInfo &programInfo, SymbolicExecutor &symbex, const std::filesystem::path &testPath,
-    std::optional<uint32_t> seed) const {
+Bmv2TestBackend *Bmv2V1ModelTestgenTarget::getTestBackendImpl(const ProgramInfo &programInfo,
+                                                              SymbolicExecutor &symbex,
+                                                              const std::filesystem::path &testPath,
+                                                              std::optional<uint32_t> seed) const {
     return new Bmv2TestBackend(programInfo, symbex, testPath, seed);
 }
 
-int BMv2_V1ModelTestgenTarget::getPortNumWidth_bits_impl() const { return 9; }
+int Bmv2V1ModelTestgenTarget::getPortNumWidthBitsImpl() const { return 9; }
 
-BMv2_V1ModelCmdStepper *BMv2_V1ModelTestgenTarget::getCmdStepper_impl(
+Bmv2V1ModelCmdStepper *Bmv2V1ModelTestgenTarget::getCmdStepperImpl(
     ExecutionState &state, AbstractSolver &solver, const ProgramInfo &programInfo) const {
-    return new BMv2_V1ModelCmdStepper(state, solver, programInfo);
+    return new Bmv2V1ModelCmdStepper(state, solver, programInfo);
 }
 
-BMv2_V1ModelExprStepper *BMv2_V1ModelTestgenTarget::getExprStepper_impl(
+Bmv2V1ModelExprStepper *Bmv2V1ModelTestgenTarget::getExprStepperImpl(
     ExecutionState &state, AbstractSolver &solver, const ProgramInfo &programInfo) const {
-    return new BMv2_V1ModelExprStepper(state, solver, programInfo);
+    return new Bmv2V1ModelExprStepper(state, solver, programInfo);
 }
 
-const ArchSpec BMv2_V1ModelTestgenTarget::archSpec =
+const ArchSpec Bmv2V1ModelTestgenTarget::ARCH_SPEC =
     ArchSpec("V1Switch", {// parser Parser<H, M>(packet_in b,
                           //                     out H parsedHdr,
                           //                     inout M meta,
@@ -115,10 +110,6 @@ const ArchSpec BMv2_V1ModelTestgenTarget::archSpec =
                           // control Deparser<H>(packet_out b, in H hdr);
                           {"Deparser", {nullptr, "*hdr"}}});
 
-const ArchSpec *BMv2_V1ModelTestgenTarget::getArchSpecImpl() const { return &archSpec; }
+const ArchSpec *Bmv2V1ModelTestgenTarget::getArchSpecImpl() const { return &ARCH_SPEC; }
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/target.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
@@ -14,7 +15,6 @@
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/constants.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.h"

--- a/backends/p4tools/modules/testgen/targets/bmv2/target.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/target.h
@@ -1,15 +1,14 @@
 #ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_TARGET_H_
 #define BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_TARGET_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <filesystem>
 #include <optional>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "ir/ir.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
@@ -19,45 +18,37 @@
 #include "backends/p4tools/modules/testgen/targets/bmv2/program_info.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/test_backend.h"
 
-namespace P4Tools {
+namespace P4Tools::P4Testgen::Bmv2 {
 
-namespace P4Testgen {
-
-namespace Bmv2 {
-
-class BMv2_V1ModelTestgenTarget : public TestgenTarget {
+class Bmv2V1ModelTestgenTarget : public TestgenTarget {
  public:
     /// Registers this target.
     static void make();
 
  protected:
-    const BMv2_V1ModelProgramInfo *initProgram_impl(
+    const Bmv2V1ModelProgramInfo *initProgramImpl(
         const IR::P4Program *program, const IR::Declaration_Instance *mainDecl) const override;
 
-    int getPortNumWidth_bits_impl() const override;
+    [[nodiscard]] int getPortNumWidthBitsImpl() const override;
 
-    Bmv2TestBackend *getTestBackend_impl(const ProgramInfo &programInfo, SymbolicExecutor &symbex,
-                                         const std::filesystem::path &testPath,
-                                         std::optional<uint32_t> seed) const override;
+    Bmv2TestBackend *getTestBackendImpl(const ProgramInfo &programInfo, SymbolicExecutor &symbex,
+                                        const std::filesystem::path &testPath,
+                                        std::optional<uint32_t> seed) const override;
 
-    BMv2_V1ModelCmdStepper *getCmdStepper_impl(ExecutionState &state, AbstractSolver &solver,
+    Bmv2V1ModelCmdStepper *getCmdStepperImpl(ExecutionState &state, AbstractSolver &solver,
+                                             const ProgramInfo &programInfo) const override;
+
+    Bmv2V1ModelExprStepper *getExprStepperImpl(ExecutionState &state, AbstractSolver &solver,
                                                const ProgramInfo &programInfo) const override;
 
-    BMv2_V1ModelExprStepper *getExprStepper_impl(ExecutionState &state, AbstractSolver &solver,
-                                                 const ProgramInfo &programInfo) const override;
-
-    const ArchSpec *getArchSpecImpl() const override;
+    [[nodiscard]] const ArchSpec *getArchSpecImpl() const override;
 
  private:
-    BMv2_V1ModelTestgenTarget();
+    Bmv2V1ModelTestgenTarget();
 
-    static const ArchSpec archSpec;
+    static const ArchSpec ARCH_SPEC;
 };
 
-}  // namespace Bmv2
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_TARGET_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
@@ -103,7 +103,7 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
     // Save the values of all the fields in it and return.
     if (TestgenOptions::get().testBackend == "METADATA") {
         auto *metadataCollection = new MetadataCollection();
-        const auto *bmv2ProgInfo = programInfo.checkedTo<BMv2_V1ModelProgramInfo>();
+        const auto *bmv2ProgInfo = programInfo.checkedTo<Bmv2V1ModelProgramInfo>();
         const auto *localMetadataVar = bmv2ProgInfo->getBlockParam("Parser", 2);
         const auto *localMetadataType = executionState->resolveType(localMetadataVar->type);
         auto flatFields = executionState->getFlatFields(
@@ -134,7 +134,7 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
     const auto actionProfiles = executionState->getTestObjectCategory("action_profile");
     for (const auto &testObject : actionProfiles) {
         const auto profileName = testObject.first;
-        const auto *actionProfile = testObject.second->checkedTo<Bmv2_V1ModelActionProfile>();
+        const auto *actionProfile = testObject.second->checkedTo<Bmv2V1ModelActionProfile>();
         const auto *evaluatedProfile = actionProfile->evaluate(*completedModel);
         testSpec->addTestObject("action_profiles", profileName, evaluatedProfile);
     }
@@ -142,7 +142,7 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
     const auto actionSelectors = executionState->getTestObjectCategory("action_selector");
     for (const auto &testObject : actionSelectors) {
         const auto selectorName = testObject.first;
-        const auto *actionSelector = testObject.second->checkedTo<Bmv2_V1ModelActionSelector>();
+        const auto *actionSelector = testObject.second->checkedTo<Bmv2V1ModelActionSelector>();
         const auto *evaluatedSelector = actionSelector->evaluate(*completedModel);
         testSpec->addTestObject("action_selectors", selectorName, evaluatedSelector);
     }

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
@@ -77,29 +77,29 @@ const Bmv2RegisterCondition *Bmv2RegisterCondition::evaluate(const Model &model)
 cstring Bmv2RegisterCondition::getObjectName() const { return "Bmv2RegisterCondition"; }
 
 /* =========================================================================================
- *  Bmv2_V1ModelActionProfile
+ *  Bmv2V1ModelActionProfile
  * ========================================================================================= */
 
 const std::vector<std::pair<cstring, std::vector<ActionArg>>>
-    *Bmv2_V1ModelActionProfile::getActions() const {
+    *Bmv2V1ModelActionProfile::getActions() const {
     return &actions;
 }
 
-Bmv2_V1ModelActionProfile::Bmv2_V1ModelActionProfile(const IR::IDeclaration *profileDecl)
+Bmv2V1ModelActionProfile::Bmv2V1ModelActionProfile(const IR::IDeclaration *profileDecl)
     : profileDecl(profileDecl) {}
 
-cstring Bmv2_V1ModelActionProfile::getObjectName() const { return profileDecl->controlPlaneName(); }
+cstring Bmv2V1ModelActionProfile::getObjectName() const { return profileDecl->controlPlaneName(); }
 
-const IR::IDeclaration *Bmv2_V1ModelActionProfile::getProfileDecl() const { return profileDecl; }
+const IR::IDeclaration *Bmv2V1ModelActionProfile::getProfileDecl() const { return profileDecl; }
 
-void Bmv2_V1ModelActionProfile::addToActionMap(cstring actionName,
-                                               std::vector<ActionArg> actionArgs) {
+void Bmv2V1ModelActionProfile::addToActionMap(cstring actionName,
+                                              std::vector<ActionArg> actionArgs) {
     actions.emplace_back(actionName, actionArgs);
 }
-size_t Bmv2_V1ModelActionProfile::getActionMapSize() const { return actions.size(); }
+size_t Bmv2V1ModelActionProfile::getActionMapSize() const { return actions.size(); }
 
-const Bmv2_V1ModelActionProfile *Bmv2_V1ModelActionProfile::evaluate(const Model &model) const {
-    auto *profile = new Bmv2_V1ModelActionProfile(profileDecl);
+const Bmv2V1ModelActionProfile *Bmv2V1ModelActionProfile::evaluate(const Model &model) const {
+    auto *profile = new Bmv2V1ModelActionProfile(profileDecl);
     for (const auto &actionTuple : actions) {
         auto actionArgs = actionTuple.second;
         std::vector<ActionArg> evaluatedArgs;
@@ -113,24 +113,24 @@ const Bmv2_V1ModelActionProfile *Bmv2_V1ModelActionProfile::evaluate(const Model
 }
 
 /* =========================================================================================
- *  Bmv2_V1ModelActionSelector
+ *  Bmv2V1ModelActionSelector
  * ========================================================================================= */
 
-Bmv2_V1ModelActionSelector::Bmv2_V1ModelActionSelector(
-    const IR::IDeclaration *selectorDecl, const Bmv2_V1ModelActionProfile *actionProfile)
+Bmv2V1ModelActionSelector::Bmv2V1ModelActionSelector(const IR::IDeclaration *selectorDecl,
+                                                     const Bmv2V1ModelActionProfile *actionProfile)
     : selectorDecl(selectorDecl), actionProfile(actionProfile) {}
 
-cstring Bmv2_V1ModelActionSelector::getObjectName() const { return "Bmv2_V1ModelActionSelector"; }
+cstring Bmv2V1ModelActionSelector::getObjectName() const { return "Bmv2V1ModelActionSelector"; }
 
-const IR::IDeclaration *Bmv2_V1ModelActionSelector::getSelectorDecl() const { return selectorDecl; }
+const IR::IDeclaration *Bmv2V1ModelActionSelector::getSelectorDecl() const { return selectorDecl; }
 
-const Bmv2_V1ModelActionProfile *Bmv2_V1ModelActionSelector::getActionProfile() const {
+const Bmv2V1ModelActionProfile *Bmv2V1ModelActionSelector::getActionProfile() const {
     return actionProfile;
 }
 
-const Bmv2_V1ModelActionSelector *Bmv2_V1ModelActionSelector::evaluate(const Model &model) const {
+const Bmv2V1ModelActionSelector *Bmv2V1ModelActionSelector::evaluate(const Model &model) const {
     const auto *evaluatedProfile = actionProfile->evaluate(model);
-    return new Bmv2_V1ModelActionSelector(selectorDecl, evaluatedProfile);
+    return new Bmv2V1ModelActionSelector(selectorDecl, evaluatedProfile);
 }
 
 /* =========================================================================================

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.h
@@ -81,9 +81,9 @@ class Bmv2RegisterValue : public TestObject {
 };
 
 /* =========================================================================================
- *  Bmv2_V1ModelActionProfile
+ *  Bmv2V1ModelActionProfile
  * ========================================================================================= */
-class Bmv2_V1ModelActionProfile : public TestObject {
+class Bmv2V1ModelActionProfile : public TestObject {
  private:
     /// The list of actions associated with this profile.
     std::vector<std::pair<cstring, std::vector<ActionArg>>> actions;
@@ -92,7 +92,7 @@ class Bmv2_V1ModelActionProfile : public TestObject {
     const IR::IDeclaration *profileDecl;
 
  public:
-    explicit Bmv2_V1ModelActionProfile(const IR::IDeclaration *profileDecl);
+    explicit Bmv2V1ModelActionProfile(const IR::IDeclaration *profileDecl);
 
     [[nodiscard]] cstring getObjectName() const override;
 
@@ -103,28 +103,28 @@ class Bmv2_V1ModelActionProfile : public TestObject {
     [[nodiscard]] const IR::IDeclaration *getProfileDecl() const;
 
     /// @returns the current amount of actions associated with this profile.
-    size_t getActionMapSize() const;
+    [[nodiscard]] size_t getActionMapSize() const;
 
     /// Add an action (its name) and the arguments to the action map of this profile.
     void addToActionMap(cstring actionName, std::vector<ActionArg> actionArgs);
 
-    [[nodiscard]] const Bmv2_V1ModelActionProfile *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2V1ModelActionProfile *evaluate(const Model &model) const override;
 };
 
 /* =========================================================================================
  *  ActionSelector
  * ========================================================================================= */
-class Bmv2_V1ModelActionSelector : public TestObject {
+class Bmv2V1ModelActionSelector : public TestObject {
  private:
     /// The associated action selector declaration.
     const IR::IDeclaration *selectorDecl;
 
     /// The associated action profile.
-    const Bmv2_V1ModelActionProfile *actionProfile;
+    const Bmv2V1ModelActionProfile *actionProfile;
 
  public:
-    explicit Bmv2_V1ModelActionSelector(const IR::IDeclaration *selectorDecl,
-                                        const Bmv2_V1ModelActionProfile *actionProfile);
+    explicit Bmv2V1ModelActionSelector(const IR::IDeclaration *selectorDecl,
+                                       const Bmv2V1ModelActionProfile *actionProfile);
 
     [[nodiscard]] cstring getObjectName() const override;
 
@@ -132,9 +132,9 @@ class Bmv2_V1ModelActionSelector : public TestObject {
     [[nodiscard]] const IR::IDeclaration *getSelectorDecl() const;
 
     /// @returns the associated action profile.
-    [[nodiscard]] const Bmv2_V1ModelActionProfile *getActionProfile() const;
+    [[nodiscard]] const Bmv2V1ModelActionProfile *getActionProfile() const;
 
-    [[nodiscard]] const Bmv2_V1ModelActionSelector *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2V1ModelActionSelector *evaluate(const Model &model) const override;
 };
 
 /* =========================================================================================

--- a/backends/p4tools/modules/testgen/targets/ebpf/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/cmd_stepper.cpp
@@ -9,6 +9,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
@@ -17,7 +18,6 @@
 #include "lib/cstring.h"
 #include "lib/ordered_map.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
@@ -60,7 +60,7 @@ void EBPFCmdStepper::initializeTargetEnvironment(ExecutionState &nextState) cons
     nextState.setParserErrorLabel(errVar);
 }
 
-std::optional<const Constraint *> EBPFCmdStepper::startParser_impl(
+std::optional<const Constraint *> EBPFCmdStepper::startParserImpl(
     const IR::P4Parser * /*parser*/, ExecutionState & /*nextState*/) const {
     return std::nullopt;
 }

--- a/backends/p4tools/modules/testgen/targets/ebpf/cmd_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/cmd_stepper.h
@@ -25,8 +25,8 @@ class EBPFCmdStepper : public CmdStepper {
 
     void initializeTargetEnvironment(ExecutionState &nextState) const override;
 
-    std::optional<const Constraint *> startParser_impl(const IR::P4Parser *parser,
-                                                       ExecutionState &nextState) const override;
+    std::optional<const Constraint *> startParserImpl(const IR::P4Parser *parser,
+                                                      ExecutionState &nextState) const override;
 
     std::map<Continuation::Exception, Continuation> getExceptionHandlers(
         const IR::P4Parser *parser, Continuation::Body normalContinuation,

--- a/backends/p4tools/modules/testgen/targets/ebpf/concolic.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/concolic.cpp
@@ -2,20 +2,12 @@
 
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
 
-namespace P4Tools {
+namespace P4Tools::P4Testgen::EBPF {
 
-namespace P4Testgen {
-
-namespace EBPF {
-
-const ConcolicMethodImpls::ImplList EBPFConcolic::EBPFConcolicMethodImpls{};
+const ConcolicMethodImpls::ImplList EBPFConcolic::EBPF_CONCOLIC_METHOD_IMPLS{};
 
 const ConcolicMethodImpls::ImplList *EBPFConcolic::getEBPFConcolicMethodImpls() {
-    return &EBPFConcolicMethodImpls;
+    return &EBPF_CONCOLIC_METHOD_IMPLS;
 }
 
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/concolic.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/concolic.h
@@ -3,26 +3,18 @@
 
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {
+namespace P4Tools::P4Testgen::EBPF {
 
 class EBPFConcolic : public Concolic {
  private:
     /// This is the list of concolic functions that are implemented in this class.
-    static const ConcolicMethodImpls::ImplList EBPFConcolicMethodImpls;
+    static const ConcolicMethodImpls::ImplList EBPF_CONCOLIC_METHOD_IMPLS;
 
  public:
     /// @returns the concolic  functions that are implemented for this particular target.
     static const ConcolicMethodImpls::ImplList *getEBPFConcolicMethodImpls();
 };
 
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF
 
 #endif /* TESTGEN_TARGETS_EBPF_CONCOLIC_H_ */

--- a/backends/p4tools/modules/testgen/targets/ebpf/constants.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/constants.cpp
@@ -1,10 +1,3 @@
 #include "backends/p4tools/modules/testgen/targets/ebpf/constants.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {}  // namespace EBPF
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+namespace P4Tools::P4Testgen::EBPF {}  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/constants.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/constants.h
@@ -1,20 +1,12 @@
 #ifndef TESTGEN_TARGETS_EBPF_CONSTANTS_H_
 #define TESTGEN_TARGETS_EBPF_CONSTANTS_H_
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {
+namespace P4Tools::P4Testgen::EBPF {
 
 class EBPFConstants {
  public:
 };
 
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF
 
 #endif /* TESTGEN_TARGETS_EBPF_CONSTANTS_H_ */

--- a/backends/p4tools/modules/testgen/targets/ebpf/ebpf.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/ebpf.cpp
@@ -6,11 +6,7 @@
 #include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {
+namespace P4Tools::P4Testgen::EBPF {
 
 EBPFCompilerTarget::EBPFCompilerTarget() : CompilerTarget("ebpf", "ebpf") {}
 
@@ -29,8 +25,4 @@ MidEnd EBPFCompilerTarget::mkMidEnd(const CompilerOptions &options) const {
     return midEnd;
 }
 
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/ebpf.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/ebpf.h
@@ -5,11 +5,7 @@
 #include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {
+namespace P4Tools::P4Testgen::EBPF {
 
 class EBPFCompilerTarget : public CompilerTarget {
  public:
@@ -22,10 +18,6 @@ class EBPFCompilerTarget : public CompilerTarget {
     EBPFCompilerTarget();
 };
 
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF
 
 #endif /* TESTGEN_TARGETS_EBPF_EBPF_H_ */

--- a/backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.h
@@ -12,11 +12,7 @@
 #include "backends/p4tools/modules/testgen/core/small_step/expr_stepper.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {
+namespace P4Tools::P4Testgen::EBPF {
 
 class EBPFExprStepper : public ExprStepper {
  protected:
@@ -34,10 +30,6 @@ class EBPFExprStepper : public ExprStepper {
     /// @returns a method call statement that calls packet_out.emit on the provided input label.
     static const IR::MethodCallStatement *produceEmitCall(const IR::Member *fieldLabel);
 };
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF
 
 #endif /* TESTGEN_TARGETS_EBPF_EXPR_STEPPER_H_ */

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/formulae.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
@@ -17,7 +18,6 @@
 #include "lib/exceptions.h"
 
 #include "backends/p4tools/modules/testgen//lib/exceptions.h"
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
@@ -103,12 +103,12 @@ std::vector<Continuation::Command> EBPFProgramInfo::processDeclaration(
 }
 
 const IR::Member *EBPFProgramInfo::getTargetInputPortVar() const {
-    return new IR::Member(IR::getBitType(TestgenTarget::getPortNumWidth_bits()),
+    return new IR::Member(IR::getBitType(TestgenTarget::getPortNumWidthBits()),
                           new IR::PathExpression("*"), "input_port");
 }
 
 const IR::Member *EBPFProgramInfo::getTargetOutputPortVar() const {
-    return new IR::Member(IR::getBitType(TestgenTarget::getPortNumWidth_bits()),
+    return new IR::Member(IR::getBitType(TestgenTarget::getPortNumWidthBits()),
                           new IR::PathExpression("*"), "output_port");
 }
 

--- a/backends/p4tools/modules/testgen/targets/ebpf/register.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/register.h
@@ -8,9 +8,7 @@
 #include "backends/p4tools/modules/testgen/targets/ebpf/target.h"
 #include "backends/p4tools/modules/testgen/testgen.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// Register the ebpf compiler target with the tools framework.
 inline void ebpf_registerCompilerTarget() { EBPF::EBPFCompilerTarget::make(); }
@@ -18,8 +16,6 @@ inline void ebpf_registerCompilerTarget() { EBPF::EBPFCompilerTarget::make(); }
 /// Register the ebpf testgen target with the testgen framework.
 inline void ebpf_registerTestgenTarget() { EBPF::EBPFTestgenTarget::make(); }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* TESTGEN_TARGETS_EBPF_REGISTER_H_ */

--- a/backends/p4tools/modules/testgen/targets/ebpf/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/target.cpp
@@ -22,11 +22,7 @@
 #include "backends/p4tools/modules/testgen/targets/ebpf/program_info.h"
 #include "backends/p4tools/modules/testgen/targets/ebpf/test_backend.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {
+namespace P4Tools::P4Testgen::EBPF {
 
 /* =============================================================================================
  *  EBPFTestgenTarget implementation
@@ -41,14 +37,13 @@ void EBPFTestgenTarget::make() {
     }
 }
 
-const EBPFProgramInfo *EBPFTestgenTarget::initProgram_impl(
+const EBPFProgramInfo *EBPFTestgenTarget::initProgramImpl(
     const IR::P4Program *program, const IR::Declaration_Instance *mainDecl) const {
     // The blocks in the main declaration are just the arguments in the constructor call.
     // Convert mainDecl->arguments into a vector of blocks, represented as constructor-call
     // expressions.
-    const auto *ns = NamespaceContext::Empty->push(program);
     std::vector<const IR::Type_Declaration *> blocks;
-    argumentsToTypeDeclarations(ns, mainDecl->arguments, blocks);
+    argumentsToTypeDeclarations(program, mainDecl->arguments, blocks);
 
     // We should have six arguments.
     BUG_CHECK(blocks.size() == 2, "%1%: The EBPF architecture requires 2 blocks. Received %2%.",
@@ -73,23 +68,23 @@ const EBPFProgramInfo *EBPFTestgenTarget::initProgram_impl(
     return new EBPFProgramInfo(program, programmableBlocks);
 }
 
-EBPFTestBackend *EBPFTestgenTarget::getTestBackend_impl(const ProgramInfo &programInfo,
-                                                        SymbolicExecutor &symbex,
-                                                        const std::filesystem::path &testPath,
-                                                        std::optional<uint32_t> seed) const {
+EBPFTestBackend *EBPFTestgenTarget::getTestBackendImpl(const ProgramInfo &programInfo,
+                                                       SymbolicExecutor &symbex,
+                                                       const std::filesystem::path &testPath,
+                                                       std::optional<uint32_t> seed) const {
     return new EBPFTestBackend(programInfo, symbex, testPath, seed);
 }
 
-int EBPFTestgenTarget::getPortNumWidth_bits_impl() const { return 9; }
+int EBPFTestgenTarget::getPortNumWidthBitsImpl() const { return 9; }
 
-EBPFCmdStepper *EBPFTestgenTarget::getCmdStepper_impl(ExecutionState &state, AbstractSolver &solver,
-                                                      const ProgramInfo &programInfo) const {
+EBPFCmdStepper *EBPFTestgenTarget::getCmdStepperImpl(ExecutionState &state, AbstractSolver &solver,
+                                                     const ProgramInfo &programInfo) const {
     return new EBPFCmdStepper(state, solver, programInfo);
 }
 
-EBPFExprStepper *EBPFTestgenTarget::getExprStepper_impl(ExecutionState &state,
-                                                        AbstractSolver &solver,
-                                                        const ProgramInfo &programInfo) const {
+EBPFExprStepper *EBPFTestgenTarget::getExprStepperImpl(ExecutionState &state,
+                                                       AbstractSolver &solver,
+                                                       const ProgramInfo &programInfo) const {
     return new EBPFExprStepper(state, solver, programInfo);
 }
 
@@ -101,8 +96,4 @@ const ArchSpec EBPFTestgenTarget::archSpec =
 
 const ArchSpec *EBPFTestgenTarget::getArchSpecImpl() const { return &archSpec; }
 
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/target.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 #include "lib/error.h"
@@ -15,7 +16,6 @@
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 #include "backends/p4tools/modules/testgen/options.h"
 #include "backends/p4tools/modules/testgen/targets/ebpf/cmd_stepper.h"
 #include "backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.h"

--- a/backends/p4tools/modules/testgen/targets/ebpf/target.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/target.h
@@ -6,9 +6,9 @@
 #include <optional>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "ir/ir.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
@@ -18,11 +18,7 @@
 #include "backends/p4tools/modules/testgen/targets/ebpf/program_info.h"
 #include "backends/p4tools/modules/testgen/targets/ebpf/test_backend.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {
+namespace P4Tools::P4Testgen::EBPF {
 
 class EBPFTestgenTarget : public TestgenTarget {
  public:
@@ -30,20 +26,20 @@ class EBPFTestgenTarget : public TestgenTarget {
     static void make();
 
  protected:
-    const EBPFProgramInfo *initProgram_impl(
-        const IR::P4Program *program, const IR::Declaration_Instance *mainDecl) const override;
+    const EBPFProgramInfo *initProgramImpl(const IR::P4Program *program,
+                                           const IR::Declaration_Instance *mainDecl) const override;
 
-    int getPortNumWidth_bits_impl() const override;
+    int getPortNumWidthBitsImpl() const override;
 
-    EBPFTestBackend *getTestBackend_impl(const ProgramInfo &programInfo, SymbolicExecutor &symbex,
-                                         const std::filesystem::path &testPath,
-                                         std::optional<uint32_t> seed) const override;
+    EBPFTestBackend *getTestBackendImpl(const ProgramInfo &programInfo, SymbolicExecutor &symbex,
+                                        const std::filesystem::path &testPath,
+                                        std::optional<uint32_t> seed) const override;
 
-    EBPFCmdStepper *getCmdStepper_impl(ExecutionState &state, AbstractSolver &solver,
-                                       const ProgramInfo &programInfo) const override;
+    EBPFCmdStepper *getCmdStepperImpl(ExecutionState &state, AbstractSolver &solver,
+                                      const ProgramInfo &programInfo) const override;
 
-    EBPFExprStepper *getExprStepper_impl(ExecutionState &state, AbstractSolver &solver,
-                                         const ProgramInfo &programInfo) const override;
+    EBPFExprStepper *getExprStepperImpl(ExecutionState &state, AbstractSolver &solver,
+                                        const ProgramInfo &programInfo) const override;
 
     const ArchSpec *getArchSpecImpl() const override;
 
@@ -53,10 +49,6 @@ class EBPFTestgenTarget : public TestgenTarget {
     static const ArchSpec archSpec;
 };
 
-}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen::EBPF
 
 #endif /* TESTGEN_TARGETS_EBPF_TARGET_H_ */

--- a/backends/p4tools/modules/testgen/targets/ebpf/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test_spec.cpp
@@ -1,11 +1,3 @@
 #include "backends/p4tools/modules/testgen/targets/ebpf/test_spec.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+namespace P4Tools::P4Testgen::EBPF {}

--- a/backends/p4tools/modules/testgen/targets/ebpf/test_spec.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test_spec.h
@@ -1,14 +1,6 @@
 #ifndef TESTGEN_TARGETS_EBPF_TEST_SPEC_H_
 #define TESTGEN_TARGETS_EBPF_TEST_SPEC_H_
 
-namespace P4Tools {
-
-namespace P4Testgen {
-
-namespace EBPF {}  // namespace EBPF
-
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+namespace P4Tools::P4Testgen::EBPF {}
 
 #endif /* TESTGEN_TARGETS_EBPF_TEST_SPEC_H_ */

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/cmd_stepper.cpp
@@ -8,13 +8,13 @@
 #include <boost/multiprecision/cpp_int.hpp>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/formulae.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"
 #include "lib/cstring.h"
 #include "lib/ordered_map.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
@@ -66,7 +66,7 @@ void PnaDpdkCmdStepper::initializeTargetEnvironment(ExecutionState &nextState) c
         &PnaZombies::DIRECTION);
 }
 
-std::optional<const Constraint *> PnaDpdkCmdStepper::startParser_impl(
+std::optional<const Constraint *> PnaDpdkCmdStepper::startParserImpl(
     const IR::P4Parser * /*parser*/, ExecutionState &nextState) const {
     // We need to explicitly map the parser error
     nextState.setParserErrorLabel(&PnaConstants::PARSER_ERROR);

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/cmd_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/cmd_stepper.h
@@ -25,8 +25,8 @@ class PnaDpdkCmdStepper : public SharedPnaCmdStepper {
 
     void initializeTargetEnvironment(ExecutionState &nextState) const override;
 
-    std::optional<const Constraint *> startParser_impl(const IR::P4Parser *parser,
-                                                       ExecutionState &state) const override;
+    std::optional<const Constraint *> startParserImpl(const IR::P4Parser *parser,
+                                                      ExecutionState &state) const override;
 
     std::map<Continuation::Exception, Continuation> getExceptionHandlers(
         const IR::P4Parser *parser, Continuation::Body normalContinuation,

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
@@ -5,13 +5,13 @@
 #include <variant>
 #include <vector>
 
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"

--- a/backends/p4tools/modules/testgen/targets/pna/pna.h
+++ b/backends/p4tools/modules/testgen/targets/pna/pna.h
@@ -5,9 +5,7 @@
 #include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 namespace Pna {
 
@@ -24,8 +22,6 @@ class PnaDpdkCompilerTarget : public CompilerTarget {
 
 }  // namespace Pna
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_PNA_PNA_H_ */

--- a/backends/p4tools/modules/testgen/targets/pna/register.h
+++ b/backends/p4tools/modules/testgen/targets/pna/register.h
@@ -8,9 +8,7 @@
 #include "backends/p4tools/modules/testgen/targets/pna/target.h"
 #include "backends/p4tools/modules/testgen/testgen.h"
 
-namespace P4Tools {
-
-namespace P4Testgen {
+namespace P4Tools::P4Testgen {
 
 /// Register the PNA compiler target with the tools framework.
 inline void pna_registerCompilerTarget() { Pna::PnaDpdkCompilerTarget::make(); }
@@ -18,8 +16,6 @@ inline void pna_registerCompilerTarget() { Pna::PnaDpdkCompilerTarget::make(); }
 /// Register the PNA testgen target with the testgen framework.
 inline void pna_registerTestgenTarget() { Pna::PnaDpdkTestgenTarget::make(); }
 
-}  // namespace P4Testgen
-
-}  // namespace P4Tools
+}  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_PNA_REGISTER_H_ */

--- a/backends/p4tools/modules/testgen/targets/pna/shared_program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_program_info.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
 #include "ir/ir.h"
@@ -9,7 +10,6 @@
 #include "lib/cstring.h"
 #include "lib/null.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
@@ -32,7 +32,7 @@ const ordered_map<cstring, const IR::Type_Declaration *>
 }
 
 const IR::Member *SharedPnaProgramInfo::getTargetInputPortVar() const {
-    return new IR::Member(IR::getBitType(TestgenTarget::getPortNumWidth_bits()),
+    return new IR::Member(IR::getBitType(TestgenTarget::getPortNumWidthBits()),
                           new IR::PathExpression("*parser_istd"), "input_port");
 }
 
@@ -66,7 +66,7 @@ const IR::PathExpression *SharedPnaProgramInfo::getBlockParam(cstring blockLabel
     const auto *paramType = param->type;
     // For convenience, resolve type names.
     if (const auto *tn = paramType->to<IR::Type_Name>()) {
-        paramType = resolveProgramType(tn);
+        paramType = resolveProgramType(program, tn);
     }
 
     const auto *archSpec = TestgenTarget::getArchSpec();

--- a/backends/p4tools/modules/testgen/targets/pna/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/target.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
@@ -13,7 +14,6 @@
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 #include "backends/p4tools/modules/testgen/targets/pna/dpdk/cmd_stepper.h"
 #include "backends/p4tools/modules/testgen/targets/pna/dpdk/expr_stepper.h"
 #include "backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.h"

--- a/backends/p4tools/modules/testgen/targets/pna/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/target.cpp
@@ -34,14 +34,13 @@ void PnaDpdkTestgenTarget::make() {
     }
 }
 
-const PnaDpdkProgramInfo *PnaDpdkTestgenTarget::initProgram_impl(
+const PnaDpdkProgramInfo *PnaDpdkTestgenTarget::initProgramImpl(
     const IR::P4Program *program, const IR::Declaration_Instance *mainDecl) const {
     // The blocks in the main declaration are just the arguments in the constructor call.
     // Convert mainDecl->arguments into a vector of blocks, represented as constructor-call
     // expressions.
-    const auto *ns = NamespaceContext::Empty->push(program);
     std::vector<const IR::Type_Declaration *> blocks;
-    argumentsToTypeDeclarations(ns, mainDecl->arguments, blocks);
+    argumentsToTypeDeclarations(program, mainDecl->arguments, blocks);
 
     // We should have six arguments.
     BUG_CHECK(blocks.size() == 4, "%1%: The PNA architecture requires 4 pipes. Received %2%.",
@@ -59,23 +58,24 @@ const PnaDpdkProgramInfo *PnaDpdkTestgenTarget::initProgram_impl(
     return new PnaDpdkProgramInfo(program, programmableBlocks);
 }
 
-PnaTestBackend *PnaDpdkTestgenTarget::getTestBackend_impl(const ProgramInfo &programInfo,
-                                                          SymbolicExecutor &symbex,
-                                                          const std::filesystem::path &testPath,
-                                                          std::optional<uint32_t> seed) const {
+PnaTestBackend *PnaDpdkTestgenTarget::getTestBackendImpl(const ProgramInfo &programInfo,
+                                                         SymbolicExecutor &symbex,
+                                                         const std::filesystem::path &testPath,
+                                                         std::optional<uint32_t> seed) const {
     return new PnaTestBackend(programInfo, symbex, testPath, seed);
 }
 
-int PnaDpdkTestgenTarget::getPortNumWidth_bits_impl() const { return 9; }
+int PnaDpdkTestgenTarget::getPortNumWidthBitsImpl() const { return 9; }
 
-PnaDpdkCmdStepper *PnaDpdkTestgenTarget::getCmdStepper_impl(ExecutionState &state,
-                                                            AbstractSolver &solver,
-                                                            const ProgramInfo &programInfo) const {
+PnaDpdkCmdStepper *PnaDpdkTestgenTarget::getCmdStepperImpl(ExecutionState &state,
+                                                           AbstractSolver &solver,
+                                                           const ProgramInfo &programInfo) const {
     return new PnaDpdkCmdStepper(state, solver, programInfo);
 }
 
-PnaDpdkExprStepper *PnaDpdkTestgenTarget::getExprStepper_impl(
-    ExecutionState &state, AbstractSolver &solver, const ProgramInfo &programInfo) const {
+PnaDpdkExprStepper *PnaDpdkTestgenTarget::getExprStepperImpl(ExecutionState &state,
+                                                             AbstractSolver &solver,
+                                                             const ProgramInfo &programInfo) const {
     return new PnaDpdkExprStepper(state, solver, programInfo);
 }
 

--- a/backends/p4tools/modules/testgen/targets/pna/target.h
+++ b/backends/p4tools/modules/testgen/targets/pna/target.h
@@ -6,9 +6,9 @@
 #include <optional>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/arch_spec.h"
 #include "ir/ir.h"
 
-#include "backends/p4tools/modules/testgen/core/arch_spec.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
@@ -26,20 +26,20 @@ class PnaDpdkTestgenTarget : public TestgenTarget {
     static void make();
 
  protected:
-    const PnaDpdkProgramInfo *initProgram_impl(
+    const PnaDpdkProgramInfo *initProgramImpl(
         const IR::P4Program *program, const IR::Declaration_Instance *mainDecl) const override;
 
-    [[nodiscard]] int getPortNumWidth_bits_impl() const override;
+    [[nodiscard]] int getPortNumWidthBitsImpl() const override;
 
-    PnaTestBackend *getTestBackend_impl(const ProgramInfo &programInfo, SymbolicExecutor &symbex,
-                                        const std::filesystem::path &testPath,
-                                        std::optional<uint32_t> seed) const override;
+    PnaTestBackend *getTestBackendImpl(const ProgramInfo &programInfo, SymbolicExecutor &symbex,
+                                       const std::filesystem::path &testPath,
+                                       std::optional<uint32_t> seed) const override;
 
-    PnaDpdkCmdStepper *getCmdStepper_impl(ExecutionState &state, AbstractSolver &solver,
-                                          const ProgramInfo &programInfo) const override;
+    PnaDpdkCmdStepper *getCmdStepperImpl(ExecutionState &state, AbstractSolver &solver,
+                                         const ProgramInfo &programInfo) const override;
 
-    PnaDpdkExprStepper *getExprStepper_impl(ExecutionState &state, AbstractSolver &solver,
-                                            const ProgramInfo &programInfo) const override;
+    PnaDpdkExprStepper *getExprStepperImpl(ExecutionState &state, AbstractSolver &solver,
+                                           const ProgramInfo &programInfo) const override;
 
     [[nodiscard]] const ArchSpec *getArchSpecImpl() const override;
 

--- a/backends/p4tools/modules/testgen/test/small-step/util.h
+++ b/backends/p4tools/modules/testgen/test/small-step/util.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "backends/p4tools/common/core/z3_solver.h"
+#include "backends/p4tools/common/lib/namespace_context.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "ir/declaration.h"
 #include "ir/indexed_vector.h"
@@ -24,7 +25,6 @@
 #include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
-#include "backends/p4tools/modules/testgen/lib/namespace_context.h"
 #include "backends/p4tools/modules/testgen/test/gtest_utils.h"
 
 namespace Test {
@@ -32,7 +32,7 @@ namespace Test {
 using Body = P4Tools::P4Testgen::Continuation::Body;
 using Continuation = P4Tools::P4Testgen::Continuation;
 using ExecutionState = P4Tools::P4Testgen::ExecutionState;
-using NamespaceContext = P4Tools::P4Testgen::NamespaceContext;
+using NamespaceContext = P4Tools::NamespaceContext;
 using Return = P4Tools::P4Testgen::Continuation::Return;
 using SmallStepEvaluator = P4Tools::P4Testgen::SmallStepEvaluator;
 using TestgenTarget = P4Tools::P4Testgen::TestgenTarget;

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -73,9 +73,8 @@ int Testgen::mainImpl(const IR::P4Program *program) {
     // Print basic information for each test.
     enableInformationLogging();
 
-    auto const inputFile = P4CContext::get().options().file;
+    // Get the options and the seed.
     const auto &testgenOptions = TestgenOptions::get();
-    cstring testDirStr = testgenOptions.outputDir;
     auto seed = Utils::getCurrentSeed();
     if (seed) {
         printFeature("test_info", 4, "============ Program seed %1% =============\n", *seed);
@@ -83,8 +82,10 @@ int Testgen::mainImpl(const IR::P4Program *program) {
 
     // Get the filename of the input file and remove the extension
     // This assumes that inputFile is not null.
+    auto const inputFile = P4CContext::get().options().file;
     auto testPath = std::filesystem::path(inputFile.c_str()).stem();
     // Create the directory, if the directory string is valid and if it does not exist.
+    cstring testDirStr = testgenOptions.outputDir;
     if (!testDirStr.isNullOrEmpty()) {
         auto testDir = std::filesystem::path(testDirStr.c_str());
         std::filesystem::create_directories(testDir);

--- a/test/gtest/helpers.cpp
+++ b/test/gtest/helpers.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
@@ -137,11 +138,15 @@ std::string P4CTestEnvironment::readHeader(const char* filename, bool preprocess
 }
 
 P4CTestEnvironment::P4CTestEnvironment() {
-    // XXX(seth): We should find a more robust way to locate these headers.
-    _coreP4 = readHeader("p4include/core.p4");
-    _v1Model = readHeader("p4include/v1model.p4", true,
-                          "V1MODEL_VERSION", 20200408);
-    _psaP4 = readHeader("p4include/bmv2/psa.p4", true);
+    // Locate the headers based on the relative path of the file.
+    std::filesystem::path srcFilePath{__FILE__};
+    auto srcFileDir = srcFilePath.parent_path();
+    auto corePath = srcFileDir / "../../p4include/core.p4";
+    auto v1modelPath = srcFileDir / "../../p4include/v1model.p4";
+    auto psaPath = srcFileDir / "../../p4include/bmv2/psa.p4";
+    _coreP4 = readHeader(corePath.c_str());
+    _v1Model = readHeader(v1modelPath.c_str(), true, "V1MODEL_VERSION", 20200408);
+    _psaP4 = readHeader(psaPath.c_str(), true);
 }
 
 namespace Test {


### PR DESCRIPTION
Some issues that came up while implementing a new module for P4Testgen. 

- The arch spec file is quite general, move it to the common folder.  The same applies to the namespace context.
- Naming was quite inconsistent. Try to remove all instances of snake case within camel case.
- Try to use concatenated namespaces as much as possible.
- Program info does not really need the namespace context. Everything can be derived from the program object.
- `Bmv2V1Model` should be the name for the BMv2 extension, not `BMv2V1Model` or `BMv2_V1Model` or `BMv2Model`.
- The gtest helpers had a hardcoded path to the P4 source file. Make them relative to the file instead. 