### PR TITLE
Set up P4C for IWYU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,33 +342,10 @@ set (IR_DEF_FILES)           # list to collect all .def files
 # Other configuration files that need to be generated
 configure_file ("${P4C_SOURCE_DIR}/cmake/config.h.cmake" "${P4C_BINARY_DIR}/config.h")
 
-set (IR_GENERATED_SRCS
-  ${P4C_BINARY_DIR}/ir/ir-generated.h
-  ${P4C_BINARY_DIR}/ir/ir-generated.cpp
-  ${P4C_BINARY_DIR}/ir/gen-tree-macro.h)
 # IR_GENERATOR_DIRECTORY is used to set the RUNTIME_OUTPUT_DIRECTORY property
 # of the irgenerator target to the matching path
 set (IR_GENERATOR_DIRECTORY ${P4C_BINARY_DIR}/tools/ir-generator)
 set (IR_GENERATOR ${IR_GENERATOR_DIRECTORY}/irgenerator)
-
-# Set up IWYU for P4C. Each CMake target needs to manually add IWYU to its checks.
-if(ENABLE_IWYU)
-  message("Enabling IWYU checks.")
-  find_program(iwyu_path NAMES include-what-you-use iwyu REQUIRED)
-  set(
-    iwyu_path
-    ${iwyu_path}
-    -Xiwyu
-    --max_line_length=100
-    -Xiwyu
-    --no_fwd_decls
-    -Xiwyu
-    --cxx17ns
-    -Xiwyu
-    --mapping_file=${P4C_SOURCE_DIR}/tools/iwyu_mappings/p4c.imp
-  )
-  message("IWYU command: ${iwyu_path}")
-endif()
 
 # the order of adding subdirectories matters because of target dependencies
 add_subdirectory (tools/driver)
@@ -439,8 +416,13 @@ if (ENABLE_GTESTS)
   add_subdirectory (test)
 endif ()
 
-# IR Generation
-set_source_files_properties(${IR_GENERATOR} PROPERTIES GENERATED TRUE)
+################################ IR Generation Begin ################################
+
+set (IR_GENERATED_SRCS
+  ${P4C_BINARY_DIR}/ir/ir-generated.h
+  ${P4C_BINARY_DIR}/ir/ir-generated.cpp
+  ${P4C_BINARY_DIR}/ir/gen-tree-macro.h)
+set_source_files_properties(${IR_GENERATED_SRCS} PROPERTIES GENERATED TRUE)
 
 # Fixup #line directives in the generated IR files
 # This is a vestige of automake. CMake handles dependencies correctly,
@@ -450,8 +432,8 @@ set_source_files_properties(${IR_GENERATOR} PROPERTIES GENERATED TRUE)
 # build files only if they have changed. This avoids rebuilding the whole
 # tree when small changes to the .def files affect only the .cpp file and
 # not the headers.
-set (fixup_file "${CMAKE_CURRENT_BINARY_DIR}/irgen-fixup.awk")
-file(WRITE "${fixup_file}" "/^#\$/ { printf \"#line %d \\\"${CMAKE_CURRENT_BINARY_DIR}/ir/%s\\\"\\n\", NR+1, name; next; } 1\n")
+set (fixup_file "${P4C_BINARY_DIR}/irgen-fixup.awk")
+file(WRITE "${fixup_file}" "/^#\$/ { printf \"#line %d \\\"${P4C_BINARY_DIR}/ir/%s\\\"\\n\", NR+1, name; next; } 1\n")
 set(temp_ir_genfiles
   ir/ir-generated.cpp.tmp ir/ir-generated.cpp.fixup
   ir/ir-generated.h.tmp   ir/ir-generated.h.fixup
@@ -471,6 +453,11 @@ add_custom_command (OUTPUT ${IR_GENERATED_SRCS}
   COMMENT "Generating IR class files")
 
 add_custom_target(genIR DEPENDS ${IR_GENERATED_SRCS})
+set_source_files_properties(${IR_GENERATOR} PROPERTIES GENERATED TRUE)
+add_library(ir-generated OBJECT ${IR_GENERATED_SRCS})
+
+################################ IR Generation End ################################
+
 
 # Header files
 # p4test needs all the backend include files, whether the backend is enabled or not
@@ -577,3 +564,53 @@ SET(CPACK_SOURCE_IGNORE_FILES
 INCLUDE(CPack)
 
 ADD_CUSTOM_TARGET(dist COMMAND ${CMAKE_MAKE_PROGRAM} clean package_source)
+
+#################### IWYU
+# Needs to be part of the top-level to be able to find all targets in the compiler framework.
+if(ENABLE_IWYU)
+  # Set up IWYU for P4C.
+  message("Enabling IWYU checks.")
+  find_program(iwyu_path NAMES include-what-you-use iwyu REQUIRED)
+  set(iwyu_path
+      ${iwyu_path}
+      -Xiwyu
+      --max_line_length=100
+      -Xiwyu
+      --no_fwd_decls
+      -Xiwyu
+      --cxx17ns
+      -Xiwyu
+      --mapping_file=${P4C_SOURCE_DIR}/tools/iwyu_mappings/p4c.imp
+  )
+  message("IWYU command: ${iwyu_path}")
+  function(get_all_targets var)
+    set(targets)
+    get_all_targets_recursive(targets ${CMAKE_CURRENT_SOURCE_DIR})
+    set(${var} ${targets} PARENT_SCOPE)
+  endfunction()
+
+  macro(get_all_targets_recursive targets dir)
+    get_property(subdirectories DIRECTORY ${dir} PROPERTY SUBDIRECTORIES)
+    foreach(subdir ${subdirectories})
+      get_all_targets_recursive(${targets} ${subdir})
+    endforeach()
+
+    get_property(current_targets DIRECTORY ${dir} PROPERTY BUILDSYSTEM_TARGETS)
+    list(APPEND ${targets} ${current_targets})
+  endmacro()
+
+  # Apply IWYU to all targets.
+  get_all_targets(all_targets)
+  # Remove generated files from IWYU.
+  list(FILTER all_targets EXCLUDE REGEX "controlplane-gen")
+  list(FILTER all_targets EXCLUDE REGEX "dpdk_runtime")
+  list(FILTER all_targets EXCLUDE REGEX "ir-generated")
+  list(FILTER all_targets EXCLUDE REGEX "genIR")
+  list(FILTER all_targets EXCLUDE REGEX "parser-gen")
+  list(FILTER all_targets EXCLUDE REGEX "gtest")
+  message("Applying IWYU to targets: ${all_targets}")
+  foreach(target ${all_targets})
+    set_property(TARGET ${target} PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${iwyu_path})
+  endforeach()
+
+endif()

--- a/backends/dpdk/CMakeLists.txt
+++ b/backends/dpdk/CMakeLists.txt
@@ -21,8 +21,8 @@ include_directories(${P4C_BINARY_DIR}/control-plane)
 ################ Proto
 set (DPDK_P4RUNTIME_DIR ${CMAKE_CURRENT_SOURCE_DIR}/control-plane/proto)
 set (DPDK_P4RUNTIME_INFO_PROTO ${DPDK_P4RUNTIME_DIR}/p4info.proto)
-set (DPDK_P4RUNTIME_INFO_GEN_SRCS ${P4C_BINARY_DIR}/control-plane/p4/config/dpdk/p4info.pb.cc)
-set (DPDK_P4RUNTIME_INFO_GEN_HDRS ${P4C_BINARY_DIR}/control-plane/p4/config/dpdk/p4info.pb.h)
+set (DPDK_P4RUNTIME_INFO_GEN_SRCS ${P4C_BINARY_DIR}/p4/config/dpdk/p4info.pb.cc)
+set (DPDK_P4RUNTIME_INFO_GEN_HDRS ${P4C_BINARY_DIR}/p4/config/dpdk/p4info.pb.h)
 # The generated code for protobuf has an excessive number of warnings
 # Silence -Warray-bounds as the root issue is out of our control: https://github.com/protocolbuffers/protobuf/issues/7140
 set_source_files_properties(${DPDK_P4RUNTIME_INFO_GEN_SRCS} PROPERTIES
@@ -30,7 +30,7 @@ set_source_files_properties(${DPDK_P4RUNTIME_INFO_GEN_SRCS} PROPERTIES
 
 add_custom_target (dpdk_runtime_dir
   ${CMAKE_COMMAND} -E make_directory
-  ${P4C_BINARY_DIR}/control-plane/p4/config/dpdk)
+  ${P4C_BINARY_DIR}/p4/config/dpdk)
 # Generate source code from .proto using protoc. The output is
 # placed in the build directory inside `control-plane` directory
 add_custom_command(
@@ -38,8 +38,8 @@ add_custom_command(
   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
     --proto_path ${DPDK_P4RUNTIME_DIR}
     --proto_path ${P4C_SOURCE_DIR}/control-plane/p4runtime/proto
-    --cpp_out ${P4C_BINARY_DIR}/control-plane/p4/config/dpdk
-    --python_out ${P4C_BINARY_DIR}/control-plane/p4/config/dpdk
+    --cpp_out ${P4C_BINARY_DIR}/p4/config/dpdk
+    --python_out ${P4C_BINARY_DIR}/p4/config/dpdk
           ${DPDK_P4RUNTIME_INFO_PROTO}
   DEPENDS ${DPDK_P4RUNTIME_INFO_PROTO} dpdk_runtime_dir
   COMMENT "Generating protobuf files for p4info on target DPDK."

--- a/backends/dpdk/main.cpp
+++ b/backends/dpdk/main.cpp
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 #include <cstdio>
-#include <fstream>
+#include <fstream>  // IWYU pragma: keep
 #include <iostream>
 #include <string>
 

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <fstream>
+#include <fstream>  // IWYU pragma: keep
 #include <iostream>
 
 #include "backends/p4test/version.h"

--- a/backends/p4tools/CMakeLists.txt
+++ b/backends/p4tools/CMakeLists.txt
@@ -72,7 +72,6 @@ set(ENABLE_TESTING ON)
 # Include sub projects.
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/common)
 
-
 # Custom IR constructs for P4Tools.
 set(IR_DEF_FILES ${IR_DEF_FILES} ${CMAKE_CURRENT_SOURCE_DIR}/common/testgen.def)
 

--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -63,6 +63,3 @@ target_include_directories(
 )
 
 add_dependencies(p4tools-common genIR frontend)
-if(ENABLE_IWYU)
-  set_property(TARGET p4tools-common PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${iwyu_path})
-endif()

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -138,11 +138,4 @@ if(ENABLE_GTESTS)
     set_tests_properties(testgen-gtest PROPERTIES LABELS "gtest-testgen")
   endif()
 
-  if(ENABLE_IWYU)
-    set_property(TARGET testgen-gtest PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${iwyu_path})
-  endif()
-endif()
-
-if(ENABLE_IWYU)
-  set_property(TARGET testgen PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${iwyu_path})
 endif()

--- a/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
@@ -24,7 +24,7 @@
 #include "backends/p4tools/modules/testgen//lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/core/externs.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
-#include "backends/p4tools/modules/testgen/core/small_step/expr_stepper.h"
+#include "backends/p4tools/modules/testgen/core/small_step/expr_stepper.h"  // IWYU pragma: associated
 #include "backends/p4tools/modules/testgen/core/small_step/small_step.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"

--- a/cmake/Linters.cmake
+++ b/cmake/Linters.cmake
@@ -20,6 +20,7 @@ list(FILTER P4C_LINT_LIST EXCLUDE REGEX "backends/p4tools/submodules")
 list(FILTER P4C_LINT_LIST EXCLUDE REGEX "backends/ebpf/runtime")
 list(FILTER P4C_LINT_LIST EXCLUDE REGEX "backends/ubpf/runtime")
 list(FILTER P4C_LINT_LIST EXCLUDE REGEX "control-plane/p4runtime")
+list(FILTER P4C_LINT_LIST EXCLUDE REGEX "test/frameworks")
 
 #################### CPPLINT
 add_cpplint_files(${P4C_SOURCE_DIR} "${P4C_LINT_LIST}")

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -81,10 +81,6 @@ set (CONTROLPLANE_SRCS
   typeSpecConverter.cpp
   bfruntime.cpp
   )
-set (CONTROLPLANE_SOURCES
-  ${P4RUNTIME_GEN_SRCS}
-  ${CONTROLPLANE_SRCS}
-  )
 
 set (CONTROLPLANE_HDRS
   addMissingIds.h
@@ -98,10 +94,12 @@ set (CONTROLPLANE_HDRS
   bfruntime.h
   )
 
+add_library(controlplane-gen OBJECT ${P4RUNTIME_GEN_SRCS})
+
 include_directories (${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 # Silence -Warray-bounds as the root issue is out of our control: https://github.com/protocolbuffers/protobuf/issues/7140
 set_source_files_properties (${P4RUNTIME_GEN_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds")
 
-add_library (controlplane STATIC ${CONTROLPLANE_SOURCES} )
-target_link_libraries (controlplane ${PROTOBUF_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+add_library (controlplane STATIC ${CONTROLPLANE_SRCS} )
+target_link_libraries (controlplane ${PROTOBUF_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} controlplane-gen)
 add_dependencies (controlplane mkP4configdir genIR frontend)

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -52,7 +52,7 @@ set (P4RUNTIME_GEN_PYTHON "control-plane")
 #   control-plane/p4/config/p4info.pb.h
 #   control-plane/p4/config/p4info.pb.cc
 add_custom_target (mkP4configdir
-  ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/p4/config)
+  ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/p4/config)
 add_custom_command(OUTPUT ${P4RUNTIME_GEN_SRCS} ${P4RUNTIME_GEN_HDRS}
   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
           -I ${P4RUNTIME_STD_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -335,7 +335,7 @@ int64_t getTableSize(const IR::P4Table *table);
 
 /// A traits class describing the properties of "counterlike" things.
 template <typename Kind>
-struct CounterlikeTraits;
+struct CounterlikeTraits;  // IWYU pragma: keep
 
 /// The information about a counter or meter instance which is necessary to
 /// serialize it. @Kind must be a class with a CounterlikeTraits<>

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -38,16 +38,16 @@ limitations under the License.
 #include <boost/algorithm/string.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 
+// TODO(antonin): this include should go away when we cleanup getMatchFields
+// and tableNeedsPriority implementations.
+#include "control-plane/bytestrings.h"
+#include "control-plane/flattenHeader.h"
 #include "frontends/common/options.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/coreLibrary.h"
 #include "frontends/p4/enumInstance.h"
 #include "frontends/p4/evaluator/evaluator.h"
 #include "frontends/p4/externInstance.h"
-// TODO(antonin): this include should go away when we cleanup getMatchFields
-// and tableNeedsPriority implementations.
-#include "bytestrings.h"
-#include "flattenHeader.h"
 #include "frontends/p4/fromv1.0/v1model.h"
 #include "frontends/p4/methodInstance.h"
 #include "frontends/p4/parseAnnotations.h"

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -236,17 +236,15 @@ endmacro(add_parser)
 add_parser(v1)
 add_parser(p4)
 
+add_library (parser-gen OBJECT ${p4PARSER_GEN_SRCS} ${v1PARSER_GEN_SRCS})
+add_dependencies (parser-gen mkp4dirs mkv1dirs ir-generated)
+
 set (FRONTEND_SOURCES
-  ${IR_GENERATED_SRCS}
   ${COMMON_FRONTEND_SRCS}
   ${PARSERS_SRCS}
   ${P4_FRONTEND_SRCS}
   ${V1_FRONTEND_SRCS}
-  ${p4PARSER_GEN_SRCS}
-  ${v1PARSER_GEN_SRCS}
   )
-
-set_source_files_properties(${IR_GENERATED_SRCS} PROPERTIES GENERATED TRUE)
 
 set (FRONTEND_CPPLINT_FILES
   ${P4_FRONTEND_SRCS} ${P4_FRONTEND_HDRS}
@@ -255,8 +253,8 @@ set (FRONTEND_CPPLINT_FILES
   ${PARSERS_SRCS} ${PARSERS_HDRS})
 
 if (FLEX_INCLUDE_DIRS)
-  include_directories(${FLEX_INCLUDE_DIRS})
+  include_directories (${FLEX_INCLUDE_DIRS})
 endif ()
 add_library (frontend STATIC ${FRONTEND_SOURCES} ${EXTENSION_FRONTEND_SOURCES})
-add_dependencies (frontend genIR)
-add_dependencies (frontend mkp4dirs mkv1dirs)
+add_dependencies (frontend genIR parser-gen)
+target_link_libraries (frontend parser-gen)

--- a/frontends/p4/callGraph.h
+++ b/frontends/p4/callGraph.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include "ir/ir.h"
 #include "lib/exceptions.h"
 #include "lib/log.h"
-#include "lib/map.h"
+#include "lib/map.h"  // IWYU pragma: keep
 #include "lib/null.h"
 #include "lib/ordered_map.h"
 #include "lib/ordered_set.h"

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -17,6 +17,7 @@ limitations under the License.
 #ifndef _FRONTENDS_P4_DEF_USE_H_
 #define _FRONTENDS_P4_DEF_USE_H_
 
+#include <typeindex>  // IWYU pragma: keep
 #include <unordered_set>
 
 #include "frontends/p4/typeChecking/typeChecker.h"

--- a/ir/CMakeLists.txt
+++ b/ir/CMakeLists.txt
@@ -64,4 +64,7 @@ set (BASE_IR_DEF_FILES
 set (IR_DEF_FILES ${IR_DEF_FILES} ${BASE_IR_DEF_FILES} PARENT_SCOPE)
 
 add_library (ir STATIC ${IR_SRCS})
-add_dependencies(ir genIR)
+add_dependencies(ir genIR ir-generated)
+target_link_libraries (ir ir-generated)
+
+

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -18,7 +18,7 @@ limitations under the License.
 #define _IR_IR_H_
 
 // generated ir file
-#include "ir/ir-generated.h"  // IWYU pragma: keep
-#include "ir/ir-inline.h"     // IWYU pragma: keep
+#include "ir/ir-generated.h"  // IWYU pragma: export
+#include "ir/ir-inline.h"     // IWYU pragma: export
 
 #endif /* _IR_IR_H_*/

--- a/lib/log.cpp
+++ b/lib/log.cpp
@@ -22,9 +22,8 @@ limitations under the License.
 #define NOGC_ARGS
 #endif /* HAVE_LIBGC */
 
-#include <string.h>
-
-#include <fstream>
+#include <cstring>
+#include <fstream>  // IWYU pragma: keep
 #include <iomanip>
 #include <iostream>
 #include <memory>

--- a/lib/nullstream.cpp
+++ b/lib/nullstream.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "nullstream.h"
 
-#include <fstream>
+#include <fstream>  // IWYU pragma: keep
 
 std::ostream *openFile(cstring name, bool nullOnError) {
     if (name.isNullOrEmpty()) {

--- a/test/gtest/helpers.cpp
+++ b/test/gtest/helpers.cpp
@@ -16,8 +16,8 @@ limitations under the License.
 
 #include <cstdio>
 #include <filesystem>
-#include <fstream>
 #include <sstream>
+#include <fstream>  // IWYU pragma: keep
 #include <stdexcept>
 
 #include "helpers.h"


### PR DESCRIPTION
Factoring some changes out of #3767 to make reviewing easier. 

These changes make it possible to run IWYU across the compiler. The main change necessary was to factor out generated files such that IWYU does not try to fix includes for them. This mostly concerns protobuf files. 

With this PR, it is now possible to run IWYU across the entire compiler. 

https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhyIWYU.md#why-include-what-you-use

