### PR TITLE
[P4Testgen] More StateVariable refactoring. Allow PathExpression to be state variables. 

### DIFF
--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -39,6 +39,7 @@ set(
   lib/model.cpp
   lib/namespace_context.cpp
   lib/symbolic_env.cpp
+  lib/table_utils.cpp
   lib/taint.cpp
   lib/trace_event.cpp
   lib/trace_event_types.cpp

--- a/backends/p4tools/common/compiler/midend.cpp
+++ b/backends/p4tools/common/compiler/midend.cpp
@@ -61,7 +61,7 @@ P4::ChooseEnumRepresentation *MidEnd::mkConvertEnumsPolicy() {
     class EnumOn32Bits : public P4::ChooseEnumRepresentation {
         bool convert(const IR::Type_Enum * /*type*/) const override { return true; }
 
-        unsigned enumSize(unsigned) const override { return 32; }
+        [[nodiscard]] unsigned enumSize(unsigned /*enumCount*/) const override { return 32; }
     };
 
     return new EnumOn32Bits();
@@ -72,7 +72,7 @@ P4::ChooseErrorRepresentation *MidEnd::mkConvertErrorPolicy() {
     class ErrorOn32Bits : public P4::ChooseErrorRepresentation {
         bool convert(const IR::Type_Error * /*type*/) const override { return true; }
 
-        unsigned errorSize(unsigned) const override { return 32; }
+        [[nodiscard]] unsigned errorSize(unsigned /*errorCount*/) const override { return 32; }
     };
 
     return new ErrorOn32Bits();
@@ -89,8 +89,6 @@ P4::TypeMap *MidEnd::getTypeMap() { return &typeMap; }
 
 void MidEnd::addDefaultPasses() {
     addPasses({
-        // Convert t.apply().miss to !t.apply().hit.
-        new P4::RemoveMiss(&refMap, &typeMap),
         // Replaces switch statements that operate on arbitrary scalars with switch statements
         // that
         // operate on actions by introducing a new table.

--- a/backends/p4tools/common/lib/constants.h
+++ b/backends/p4tools/common/lib/constants.h
@@ -1,9 +1,9 @@
-#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_CONSTANTS_H_
-#define BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_CONSTANTS_H_
+#ifndef BACKENDS_P4TOOLS_COMMON_LIB_CONSTANTS_H_
+#define BACKENDS_P4TOOLS_COMMON_LIB_CONSTANTS_H_
 
 #include "ir/ir.h"
 
-namespace P4Tools::P4Testgen {
+namespace P4Tools {
 
 class P4Constants {
  public:
@@ -31,6 +31,6 @@ class P4Constants {
     static constexpr const char *MATCH_KIND_LPM = "lpm";
 };
 
-}  // namespace P4Tools::P4Testgen
+}  // namespace P4Tools
 
-#endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_CONSTANTS_H_ */
+#endif /* BACKENDS_P4TOOLS_COMMON_LIB_CONSTANTS_H_ */

--- a/backends/p4tools/common/lib/model.cpp
+++ b/backends/p4tools/common/lib/model.cpp
@@ -124,7 +124,7 @@ const IR::Expression *Model::get(const IR::StateVariable &var, bool checked) con
     if (it != end()) {
         return it->second;
     }
-    BUG_CHECK(!checked, "Unable to find var %s in the model.", var->toString());
+    BUG_CHECK(!checked, "Unable to find var %s in the model.", var);
     return nullptr;
 }
 

--- a/backends/p4tools/common/lib/symbolic_env.cpp
+++ b/backends/p4tools/common/lib/symbolic_env.cpp
@@ -22,7 +22,7 @@ const IR::Expression *SymbolicEnv::get(const IR::StateVariable &var) const {
     if (it != map.end()) {
         return it->second;
     }
-    BUG("Unable to find var %s in the symbolic environment.", var->toString());
+    BUG("Unable to find var %s in the symbolic environment.", var);
 }
 
 bool SymbolicEnv::exists(const IR::StateVariable &var) const { return map.find(var) != map.end(); }

--- a/backends/p4tools/common/lib/table_utils.cpp
+++ b/backends/p4tools/common/lib/table_utils.cpp
@@ -1,0 +1,82 @@
+#include "backends/p4tools/common/lib/table_utils.h"
+
+namespace P4Tools::TableUtils {
+
+void checkTableImmutability(const IR::P4Table *table, TableProperties &properties) {
+    bool isConstant = false;
+    const auto *entriesAnnotation = table->properties->getProperty("entries");
+    if (entriesAnnotation != nullptr) {
+        isConstant = entriesAnnotation->isConstant;
+    }
+    // Also check if the table is invisible to the control plane.
+    // This also implies that it cannot be modified.
+    properties.tableIsImmutable = isConstant || table->getAnnotation("hidden") != nullptr;
+    const auto *defaultAction = table->properties->getProperty("default_action");
+    CHECK_NULL(defaultAction);
+    properties.defaultIsImmutable = defaultAction->isConstant;
+}
+
+std::vector<const IR::ActionListElement *> buildTableActionList(const IR::P4Table *table) {
+    std::vector<const IR::ActionListElement *> tableActionList;
+    const auto *actionList = table->getActionList();
+    if (actionList == nullptr) {
+        return tableActionList;
+    }
+    for (size_t idx = 0; idx < actionList->size(); idx++) {
+        const auto *action = actionList->actionList.at(idx);
+        if (action->getAnnotation("defaultonly") != nullptr) {
+            continue;
+        }
+        // Check some properties of the list.
+        CHECK_NULL(action->expression);
+        action->expression->checkedTo<IR::MethodCallExpression>();
+        tableActionList.emplace_back(action);
+    }
+    return tableActionList;
+}
+
+bool compareLPMEntries(const IR::Entry *leftIn, const IR::Entry *rightIn, size_t lpmIndex) {
+    // Get the entry key that matches with provided lpm index.
+    // There should only be one and we only need to compare this precision.
+    BUG_CHECK(
+        lpmIndex < leftIn->keys->components.size() && lpmIndex < rightIn->keys->components.size(),
+        "LPM index out of range.");
+    const auto *left = leftIn->keys->components.at(lpmIndex);
+    const auto *right = rightIn->keys->components.at(lpmIndex);
+
+    // The expressions are equivalent, so no need to compare.
+    if (left->equiv(*right)) {
+        return true;
+    }
+
+    // DefaultExpression are least precise.
+    if (left->is<IR::DefaultExpression>()) {
+        return true;
+    }
+    if (right->is<IR::DefaultExpression>()) {
+        return false;
+    }
+    // Constants are implicitly more precise than masks.
+    if (left->is<IR::Constant>() && right->is<IR::Mask>()) {
+        return true;
+    }
+    if (left->is<IR::Mask>() && right->is<IR::Constant>()) {
+        return false;
+    }
+
+    const IR::Constant *leftMaskVal = nullptr;
+    const IR::Constant *rightMaskVal = nullptr;
+    if (const auto *leftMask = left->to<IR::Mask>()) {
+        leftMaskVal = leftMask->right->checkedTo<IR::Constant>();
+        // The other value must be a mask at this point.
+        if (const auto *rightMask = right->checkedTo<IR::Mask>()) {
+            rightMaskVal = rightMask->right->checkedTo<IR::Constant>();
+        }
+        return (leftMaskVal->value) >= (rightMaskVal->value);
+    }
+
+    BUG("Unhandled sort elements type: left: %1% - %2% \n right: %3% - %4% ", left,
+        left->node_type_name(), right, right->node_type_name());
+}
+
+}  // namespace P4Tools::TableUtils

--- a/backends/p4tools/common/lib/table_utils.h
+++ b/backends/p4tools/common/lib/table_utils.h
@@ -1,0 +1,69 @@
+#ifndef BACKENDS_P4TOOLS_COMMON_LIB_TABLE_UTILS_H_
+#define BACKENDS_P4TOOLS_COMMON_LIB_TABLE_UTILS_H_
+
+#include "ir/ir.h"
+#include "lib/cstring.h"
+
+namespace P4Tools::TableUtils {
+
+/// KeyProperties define properties of table keys that are useful for execution.
+struct KeyProperties {
+    /// The original key element
+    IR::KeyElement const *key;
+
+    /// The control plane name of the key.
+    cstring name;
+
+    /// The index of this key within the current table.
+    size_t index;
+
+    /// The match type of this key (exact, ternary, lpm, etc...)
+    cstring matchType;
+
+    /// Whether the key is tainted.
+    /// For matches such as LPM and ternary, we can still generate a match.
+    bool isTainted;
+
+    explicit KeyProperties(IR::KeyElement const *key, cstring name, size_t index, cstring matchType,
+                           bool isTainted)
+        : key(key), name(name), index(index), matchType(matchType), isTainted(isTainted) {}
+};
+
+/// Basic table properties that are set when initializing the TableStepper.
+struct TableProperties {
+    /// Control plane name of the table.
+    cstring tableName;
+
+    /// Whether key expressions of the table contain taint. This makes it difficult to match.
+    bool tableIsTainted = false;
+
+    /// Whether the table is constant and can not accept control plane entries.
+    bool tableIsImmutable = false;
+
+    /// Indicates whether the default action can be overridden.
+    bool defaultIsImmutable = false;
+
+    /// Ordered list of key fields with useful properties.
+    std::vector<KeyProperties> resolvedKeys;
+};
+
+/// Checks whether certain table properties are immutable and sets the properties param
+/// accordingly.
+void checkTableImmutability(const IR::P4Table *table, TableProperties &properties);
+
+/// Collects the list of actions contained in the table and filters out @defaultonly actions.
+std::vector<const IR::ActionListElement *> buildTableActionList(const IR::P4Table *table);
+
+/// The function compares the right and left expression.
+/// Returns true if the values are equal or if the left value is more precise.
+/// If the left value is constant entries and the right value
+/// is Mask/Default then priority is given to constants.
+/// For more detailed information see
+/// https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md#longest-prefix-match-tables
+/// @param lpmIndex indicates the index of the lpm entry in the list of entries.
+/// It is used for comparison.
+bool compareLPMEntries(const IR::Entry *leftIn, const IR::Entry *rightIn, size_t lpmIndex);
+
+}  // namespace P4Tools::TableUtils
+
+#endif /* BACKENDS_P4TOOLS_COMMON_LIB_TABLE_UTILS_H_ */

--- a/backends/p4tools/common/lib/trace_event_types.cpp
+++ b/backends/p4tools/common/lib/trace_event_types.cpp
@@ -109,14 +109,14 @@ void IfStatementCondition::print(std::ostream &os) const {
 
 ExtractSuccess::ExtractSuccess(
     const IR::Expression *extractedHeader, int offset, const IR::Expression *condition,
-    std::vector<std::pair<const IR::Member *, const IR::Expression *>> fields)
+    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields)
     : extractedHeader(extractedHeader),
       offset(offset),
       condition(condition),
       fields(std::move(fields)) {}
 
 const ExtractSuccess *ExtractSuccess::subst(const SymbolicEnv &env) const {
-    std::vector<std::pair<const IR::Member *, const IR::Expression *>> applyFields;
+    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> applyFields;
     applyFields.reserve(fields.size());
     for (const auto &field : fields) {
         applyFields.emplace_back(field.first, env.subst(field.second));
@@ -125,7 +125,7 @@ const ExtractSuccess *ExtractSuccess::subst(const SymbolicEnv &env) const {
 }
 
 const ExtractSuccess *ExtractSuccess::apply(Transform &visitor) const {
-    std::vector<std::pair<const IR::Member *, const IR::Expression *>> applyFields;
+    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> applyFields;
     applyFields.reserve(fields.size());
     for (const auto &field : fields) {
         applyFields.emplace_back(field.first, field.second->apply(visitor));
@@ -140,7 +140,7 @@ void ExtractSuccess::complete(Model *model) const {
 }
 
 const ExtractSuccess *ExtractSuccess::evaluate(const Model &model) const {
-    std::vector<std::pair<const IR::Member *, const IR::Expression *>> applyFields;
+    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> applyFields;
     applyFields.reserve(fields.size());
     for (const auto &field : fields) {
         if (Taint::hasTaint(model, field.second)) {
@@ -189,11 +189,11 @@ void ExtractFailure::print(std::ostream &os) const {
  * ============================================================================================= */
 
 Emit::Emit(const IR::Expression *emitHeader,
-           std::vector<std::pair<const IR::Member *, const IR::Expression *>> fields)
+           std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields)
     : emitHeader(emitHeader), fields(std::move(fields)) {}
 
 const Emit *Emit::subst(const SymbolicEnv &env) const {
-    std::vector<std::pair<const IR::Member *, const IR::Expression *>> applyFields;
+    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> applyFields;
     applyFields.reserve(fields.size());
     for (const auto &field : fields) {
         applyFields.emplace_back(field.first, env.subst(field.second));
@@ -202,7 +202,7 @@ const Emit *Emit::subst(const SymbolicEnv &env) const {
 }
 
 const Emit *Emit::apply(Transform &visitor) const {
-    std::vector<std::pair<const IR::Member *, const IR::Expression *>> applyFields;
+    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> applyFields;
     applyFields.reserve(fields.size());
     for (const auto &field : fields) {
         applyFields.emplace_back(field.first, field.second->apply(visitor));
@@ -217,7 +217,7 @@ void Emit::complete(Model *model) const {
 }
 
 const Emit *Emit::evaluate(const Model &model) const {
-    std::vector<std::pair<const IR::Member *, const IR::Expression *>> applyFields;
+    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> applyFields;
     applyFields.reserve(fields.size());
     for (const auto &field : fields) {
         if (Taint::hasTaint(model, field.second)) {

--- a/backends/p4tools/common/lib/trace_event_types.h
+++ b/backends/p4tools/common/lib/trace_event_types.h
@@ -104,7 +104,7 @@ class ExtractSuccess : public TraceEvent {
     const IR::Expression *condition;
 
     /// The list of fields and their values of the emitted header.
-    std::vector<std::pair<const IR::Member *, const IR::Expression *>> fields;
+    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields;
 
  public:
     [[nodiscard]] const ExtractSuccess *subst(const SymbolicEnv &env) const override;
@@ -120,7 +120,7 @@ class ExtractSuccess : public TraceEvent {
 
     ExtractSuccess(const IR::Expression *extractedHeader, int offset,
                    const IR::Expression *condition,
-                   std::vector<std::pair<const IR::Member *, const IR::Expression *>> fields);
+                   std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields);
     ExtractSuccess(const ExtractSuccess &) = default;
     ExtractSuccess(ExtractSuccess &&) = default;
     ExtractSuccess &operator=(const ExtractSuccess &) = default;
@@ -174,7 +174,7 @@ class Emit : public TraceEvent {
     const IR::Expression *emitHeader;
 
     /// The list of fields and their values of the emitted header.
-    std::vector<std::pair<const IR::Member *, const IR::Expression *>> fields;
+    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields;
 
  public:
     [[nodiscard]] const Emit *subst(const SymbolicEnv &env) const override;
@@ -183,7 +183,7 @@ class Emit : public TraceEvent {
     [[nodiscard]] const Emit *evaluate(const Model &model) const override;
 
     Emit(const IR::Expression *emitHeader,
-         std::vector<std::pair<const IR::Member *, const IR::Expression *>> fields);
+         std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields);
     ~Emit() override = default;
     Emit(const Emit &) = default;
     Emit(Emit &&) = default;

--- a/backends/p4tools/common/lib/variables.cpp
+++ b/backends/p4tools/common/lib/variables.cpp
@@ -30,11 +30,6 @@ IR::StateVariable ToolsVariables::getHeaderValidity(const IR::Expression *header
     return new IR::Member(IR::Type::Boolean::get(), headerRef, VALID);
 }
 
-IR::StateVariable ToolsVariables::addStateVariablePostfix(const IR::Expression *paramPath,
-                                                          const IR::Type_Base *baseType) {
-    return new IR::Member(baseType, paramPath, "*");
-}
-
 const IR::TaintExpression *ToolsVariables::getTaintExpression(const IR::Type *type) {
     // Do not cache varbits.
     if (type->is<IR::Extracted_Varbits>()) {

--- a/backends/p4tools/common/lib/variables.h
+++ b/backends/p4tools/common/lib/variables.h
@@ -43,11 +43,6 @@ class ToolsVariables {
     ///
     /// @param headerRef a header instance. This is either a Member or a PathExpression.
     static IR::StateVariable getHeaderValidity(const IR::Expression *headerRef);
-
-    /// @returns a IR::StateVariable that is postfixed with "*". This is used for PathExpressions
-    /// with are not yet members.
-    static IR::StateVariable addStateVariablePostfix(const IR::Expression *paramPath,
-                                                     const IR::Type_Base *baseType);
 };
 
 }  // namespace P4Tools

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h
@@ -161,7 +161,7 @@ class AbstractStepper : public Inspector {
     /// Type_StructLike, unroll the reference and reset each member.
     /// If forceTaint is active, all references are set tainted. Otherwise a target-specific
     /// mechanism is used.
-    void setTargetUninitialized(ExecutionState &nextState, const IR::Member *ref,
+    void setTargetUninitialized(ExecutionState &nextState, const IR::StateVariable &ref,
                                 bool forceTaint) const;
 
     /// This is a helper function to declare structlike data structures.

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.h
@@ -58,8 +58,8 @@ class ExprStepper : public AbstractStepper {
     /// Iterate over the fields in @param flatFields and set the corresponding values in
     /// @param nextState. If there is a varbit, assign the @param varbitFieldSize as size to
     /// it. @returns the list of members and their assigned values.
-    static std::vector<std::pair<const IR::Member *, const IR::Expression *>> setFields(
-        ExecutionState &nextState, const std::vector<const IR::Member *> &flatFields,
+    static std::vector<std::pair<IR::StateVariable, const IR::Expression *>> setFields(
+        ExecutionState &nextState, const std::vector<IR::StateVariable> &flatFields,
         int varBitFieldSize);
     /// This function call is used in member expressions to cleanly resolve hit, miss, and action
     /// run expressions. These are return values of a table.apply() call, and fairly special in P4.

--- a/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
@@ -9,6 +9,7 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
+#include "backends/p4tools/common/lib/constants.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/trace_event_types.h"
 #include "backends/p4tools/common/lib/variables.h"
@@ -729,7 +730,8 @@ void ExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
                  if (varbit->size < varBitFieldSize) {
                      auto &nextState = state.clone();
                      nextState.set(state.getCurrentParserErrorLabel(),
-                                   IR::getConstant(programInfo.getParserErrorType(), 4));
+                                   IR::getConstant(programInfo.getParserErrorType(),
+                                                   P4Constants::PARSER_ERROR_HEADER_TOO_SHORT));
                      nextState.replaceTopBody(Continuation::Exception::Reject);
                      result->emplace_back(condInfo.advanceCond, state, nextState);
                      return;

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -357,15 +357,12 @@ void TableStepper::setTableDefaultEntries(
         std::vector<ActionArg> ctrlPlaneArgs;
         for (size_t argIdx = 0; argIdx < parameters->size(); ++argIdx) {
             const auto *parameter = parameters->getParameter(argIdx);
-            // Synthesize a variables constant here that corresponds to a control plane argument.
+            // Synthesize a variable constant here that corresponds to a control plane argument.
             // We get the unique name of the table coupled with the unique name of the action.
             // Getting the unique name is needed to avoid generating duplicate arguments.
-            const auto &actionDataVar =
-                getTableStateVariable(parameter->type, table, "*actionData", idx, argIdx);
             cstring paramName =
                 properties.tableName + "_arg_" + actionName + std::to_string(argIdx);
             const auto &actionArg = nextState.createSymbolicVariable(parameter->type, paramName);
-            nextState.set(actionDataVar, actionArg);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.
@@ -414,8 +411,7 @@ void TableStepper::evalTableControlEntries(
     const auto *keys = table->getKey();
     BUG_CHECK(keys != nullptr, "An empty key list should have been handled earlier.");
 
-    for (size_t idx = 0; idx < tableActionList.size(); idx++) {
-        const auto *action = tableActionList.at(idx);
+    for (const auto *action : tableActionList) {
         // Grab the path from the method call.
         const auto *tableAction = action->expression->checkedTo<IR::MethodCallExpression>();
         // Try to find the action declaration corresponding to the path reference in the table.
@@ -436,15 +432,12 @@ void TableStepper::evalTableControlEntries(
         std::vector<ActionArg> ctrlPlaneArgs;
         for (size_t argIdx = 0; argIdx < parameters->size(); ++argIdx) {
             const auto *parameter = parameters->getParameter(argIdx);
-            // Synthesize a variables constant here that corresponds to a control plane argument.
+            // Synthesize a variable constant here that corresponds to a control plane argument.
             // We get the unique name of the table coupled with the unique name of the action.
             // Getting the unique name is needed to avoid generating duplicate arguments.
-            const auto &actionDataVar =
-                getTableStateVariable(parameter->type, table, "*actionData", idx, argIdx);
             cstring paramName =
                 properties.tableName + "_arg_" + actionName + std::to_string(argIdx);
             const auto &actionArg = nextState.createSymbolicVariable(parameter->type, paramName);
-            nextState.set(actionDataVar, actionArg);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -130,9 +130,9 @@ const IR::Expression *TableStepper::computeTargetMatchType(ExecutionState &nextS
                                                            TableMatchMap *matches,
                                                            const IR::Expression *hitCondition) {
     const IR::Expression *keyExpr = keyProperties.key->expression;
-    // Create a new variables constant that corresponds to the key expression.
+    // Create a new variable constant that corresponds to the key expression.
     cstring keyName = properties.tableName + "_key_" + keyProperties.name;
-    const auto ctrlPlaneKey = nextState.createSymbolicVariable(keyExpr->type, keyName);
+    const auto *ctrlPlaneKey = nextState.createSymbolicVariable(keyExpr->type, keyName);
 
     if (keyProperties.matchType == P4Constants::MATCH_KIND_EXACT) {
         hitCondition = new IR::LAnd(hitCondition, new IR::Equ(keyExpr, ctrlPlaneKey));
@@ -217,7 +217,7 @@ void TableStepper::setTableAction(ExecutionState &nextState,
               table);
     // Store the selected action.
     const auto &tableActionVar = getTableActionVar(table);
-    nextState.set(tableActionVar, IR::getConstant(tableActionVar->type, actionIdx));
+    nextState.set(tableActionVar, IR::getConstant(tableActionVar.type, actionIdx));
 }
 
 const IR::Expression *TableStepper::evalTableConstEntries() {

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -10,6 +10,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/multiprecision/number.hpp>
 
+#include "backends/p4tools/common/lib/constants.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/trace_event_types.h"
 #include "backends/p4tools/common/lib/variables.h"
@@ -23,7 +24,6 @@
 #include "lib/source_file.h"
 #include "midend/coverage.h"
 
-#include "backends/p4tools/modules/testgen/core/constants.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/expr_stepper.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/path_selection.h"

--- a/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
@@ -10,6 +10,7 @@
 
 #include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/lib/arch_spec.h"
+#include "backends/p4tools/common/lib/constants.h"
 #include "ir/id.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"
@@ -135,9 +136,11 @@ std::map<Continuation::Exception, Continuation> Bmv2V1ModelCmdStepper::getExcept
 
             ::warning("Ingress parser exception handler not fully implemented");
             result.emplace(Continuation::Exception::Reject, Continuation::Body({}));
-            result.emplace(Continuation::Exception::PacketTooShort,
-                           Continuation::Body({new IR::AssignmentStatement(
-                               errVar, IR::getConstant(errVar->type, 1))}));
+            result.emplace(
+                Continuation::Exception::PacketTooShort,
+                Continuation::Body({new IR::AssignmentStatement(
+                    errVar,
+                    IR::getConstant(errVar->type, P4Constants::PARSER_ERROR_PACKET_TOO_SHORT))}));
             // NoMatch will transition to the next block.
             result.emplace(Continuation::Exception::NoMatch, Continuation::Body({}));
             break;

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -36,8 +36,8 @@
 namespace P4Tools::P4Testgen::Bmv2 {
 
 const IR::Expression *Bmv2V1ModelTableStepper::computeTargetMatchType(
-    ExecutionState &nextState, const KeyProperties &keyProperties, TableMatchMap *matches,
-    const IR::Expression *hitCondition) {
+    ExecutionState &nextState, const TableUtils::KeyProperties &keyProperties,
+    TableMatchMap *matches, const IR::Expression *hitCondition) {
     const IR::Expression *keyExpr = keyProperties.key->expression;
 
     // TODO: We consider optional match types to be a no-op, but we could make them exact matches.

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -113,12 +113,9 @@ void Bmv2V1ModelTableStepper::evalTableActionProfile(
             // Synthesize a symbolic variable here that corresponds to a control plane argument.
             // We get the unique name of the table coupled with the unique name of the action.
             // Getting the unique name is needed to avoid generating duplicate arguments.
-            const auto &actionDataVar =
-                getTableStateVariable(parameter->type, table, "*actionData", idx, argIdx);
             cstring keyName =
                 properties.tableName + "_param_" + actionName + std::to_string(argIdx);
             const auto &actionArg = nextState.createSymbolicVariable(parameter->type, keyName);
-            nextState.set(actionDataVar, actionArg);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.
@@ -204,12 +201,9 @@ void Bmv2V1ModelTableStepper::evalTableActionSelector(
             // Synthesize a symbolic variable here that corresponds to a control plane argument.
             // We get the unique name of the table coupled with the unique name of the action.
             // Getting the unique name is needed to avoid generating duplicate arguments.
-            const auto &actionDataVar =
-                getTableStateVariable(parameter->type, table, "*actionData", idx, argIdx);
             cstring keyName =
                 properties.tableName + "_param_" + actionName + std::to_string(argIdx);
             const auto &actionArg = nextState.createSymbolicVariable(parameter->type, keyName);
-            nextState.set(actionDataVar, actionArg);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.h
@@ -57,7 +57,7 @@ class Bmv2V1ModelTableStepper : public TableStepper {
 
  protected:
     const IR::Expression *computeTargetMatchType(ExecutionState &nextState,
-                                                 const KeyProperties &keyProperties,
+                                                 const TableUtils::KeyProperties &keyProperties,
                                                  TableMatchMap *matches,
                                                  const IR::Expression *hitCondition) override;
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
@@ -106,9 +106,9 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
         const auto *bmv2ProgInfo = programInfo.checkedTo<Bmv2V1ModelProgramInfo>();
         const auto *localMetadataVar = bmv2ProgInfo->getBlockParam("Parser", 2);
         const auto *localMetadataType = executionState->resolveType(localMetadataVar->type);
-        auto flatFields = executionState->getFlatFields(
+        const auto &flatFields = executionState->getFlatFields(
             localMetadataVar, localMetadataType->checkedTo<IR::Type_Struct>(), {});
-        for (const auto *fieldRef : flatFields) {
+        for (const auto &fieldRef : flatFields) {
             const auto *fieldVal = completedModel->evaluate(executionState->get(fieldRef));
             // Try to remove the leading internal name for the metadata field.
             // Thankfully, this string manipulation is safe if we are out of range.

--- a/backends/p4tools/modules/testgen/targets/ebpf/constants.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/constants.cpp
@@ -1,3 +1,8 @@
 #include "backends/p4tools/modules/testgen/targets/ebpf/constants.h"
 
-namespace P4Tools::P4Testgen::EBPF {}  // namespace P4Tools::P4Testgen::EBPF
+namespace P4Tools::P4Testgen::EBPF {
+
+const IR::PathExpression EBPFConstants::ACCEPT_VAR =
+    IR::PathExpression(new IR::Type_Boolean(), new IR::Path("*accept"));
+
+}  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/constants.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/constants.h
@@ -1,10 +1,14 @@
 #ifndef TESTGEN_TARGETS_EBPF_CONSTANTS_H_
 #define TESTGEN_TARGETS_EBPF_CONSTANTS_H_
 
+#include "ir/ir.h"
+
 namespace P4Tools::P4Testgen::EBPF {
 
 class EBPFConstants {
  public:
+    /// eBPF-internal drop variable.
+    static const IR::PathExpression ACCEPT_VAR;
 };
 
 }  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
@@ -10,6 +10,7 @@
 
 #include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/util.h"
+#include "backends/p4tools/common/lib/variables.h"
 #include "ir/id.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"
@@ -24,6 +25,7 @@
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 #include "backends/p4tools/modules/testgen/lib/packet_vars.h"
 #include "backends/p4tools/modules/testgen/targets/ebpf/concolic.h"
+#include "backends/p4tools/modules/testgen/targets/ebpf/constants.h"
 
 namespace P4Tools::P4Testgen::EBPF {
 
@@ -115,8 +117,7 @@ const IR::StateVariable &EBPFProgramInfo::getTargetOutputPortVar() const {
 }
 
 const IR::Expression *EBPFProgramInfo::dropIsActive() const {
-    return new IR::LNot(
-        new IR::Member(IR::Type_Boolean::get(), new IR::PathExpression("*accept"), "*"));
+    return new IR::LNot(ToolsVariables::getStateVariable(IR::Type_Boolean::get(), "*accept"));
 }
 
 const IR::Type_Bits *EBPFProgramInfo::getParserErrorType() const { return &PARSER_ERR_BITS; }

--- a/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.cpp
@@ -13,10 +13,9 @@
 
 namespace P4Tools::P4Testgen::EBPF {
 
-const IR::Expression *EBPFTableStepper::computeTargetMatchType(ExecutionState &nextState,
-                                                               const KeyProperties &keyProperties,
-                                                               TableMatchMap *matches,
-                                                               const IR::Expression *hitCondition) {
+const IR::Expression *EBPFTableStepper::computeTargetMatchType(
+    ExecutionState &nextState, const TableUtils::KeyProperties &keyProperties,
+    TableMatchMap *matches, const IR::Expression *hitCondition) {
     // If the custom match type does not match, delete to the core match types.
     return TableStepper::computeTargetMatchType(nextState, keyProperties, matches, hitCondition);
 }

--- a/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.h
@@ -29,7 +29,7 @@ class EBPFTableStepper : public TableStepper {
 
  protected:
     const IR::Expression *computeTargetMatchType(ExecutionState &nextState,
-                                                 const KeyProperties &keyProperties,
+                                                 const TableUtils::KeyProperties &keyProperties,
                                                  TableMatchMap *matches,
                                                  const IR::Expression *hitCondition) override;
 

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/table_stepper.cpp
@@ -7,8 +7,8 @@
 namespace P4Tools::P4Testgen::Pna {
 
 const IR::Expression *PnaDpdkTableStepper::computeTargetMatchType(
-    ExecutionState &nextState, const KeyProperties &keyProperties, TableMatchMap *matches,
-    const IR::Expression *hitCondition) {
+    ExecutionState &nextState, const TableUtils::KeyProperties &keyProperties,
+    TableMatchMap *matches, const IR::Expression *hitCondition) {
     // If the custom match type does not match, delete to the core match types.
     return SharedPnaTableStepper::computeTargetMatchType(nextState, keyProperties, matches,
                                                          hitCondition);

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/table_stepper.h
@@ -13,7 +13,7 @@ namespace P4Tools::P4Testgen::Pna {
 class PnaDpdkTableStepper : public SharedPnaTableStepper {
  protected:
     const IR::Expression *computeTargetMatchType(ExecutionState &nextState,
-                                                 const KeyProperties &keyProperties,
+                                                 const TableUtils::KeyProperties &keyProperties,
                                                  TableMatchMap *matches,
                                                  const IR::Expression *hitCondition) override;
 

--- a/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
@@ -36,8 +36,8 @@
 namespace P4Tools::P4Testgen::Pna {
 
 const IR::Expression *SharedPnaTableStepper::computeTargetMatchType(
-    ExecutionState &nextState, const KeyProperties &keyProperties, TableMatchMap *matches,
-    const IR::Expression *hitCondition) {
+    ExecutionState &nextState, const TableUtils::KeyProperties &keyProperties,
+    TableMatchMap *matches, const IR::Expression *hitCondition) {
     const IR::Expression *keyExpr = keyProperties.key->expression;
 
     // TODO: We consider optional match types to be a no-op, but we could make them exact matches.

--- a/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
@@ -91,8 +91,7 @@ void SharedPnaTableStepper::evalTableActionProfile(
     const std::vector<const IR::ActionListElement *> &tableActionList) {
     const auto *state = getExecutionState();
 
-    for (size_t idx = 0; idx < tableActionList.size(); idx++) {
-        const auto *action = tableActionList.at(idx);
+    for (const auto *action : tableActionList) {
         // Grab the path from the method call.
         const auto *tableAction = action->expression->checkedTo<IR::MethodCallExpression>();
         // Try to find the action declaration corresponding to the path reference in the table.
@@ -113,12 +112,9 @@ void SharedPnaTableStepper::evalTableActionProfile(
             // Synthesize a symbolic variable here that corresponds to a control plane argument.
             // We get the unique name of the table coupled with the unique name of the action.
             // Getting the unique name is needed to avoid generating duplicate arguments.
-            const auto &actionDataVar =
-                getTableStateVariable(parameter->type, table, "*actionData", idx, argIdx);
             cstring keyName =
                 properties.tableName + "_param_" + actionName + std::to_string(argIdx);
             const auto &actionArg = nextState.createSymbolicVariable(parameter->type, keyName);
-            nextState.set(actionDataVar, actionArg);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.
@@ -180,8 +176,7 @@ void SharedPnaTableStepper::evalTableActionSelector(
     const std::vector<const IR::ActionListElement *> &tableActionList) {
     const auto *state = getExecutionState();
 
-    for (size_t idx = 0; idx < tableActionList.size(); idx++) {
-        const auto *action = tableActionList.at(idx);
+    for (const auto *action : tableActionList) {
         // Grab the path from the method call.
         const auto *tableAction = action->expression->checkedTo<IR::MethodCallExpression>();
         // Try to find the action declaration corresponding to the path reference in the table.
@@ -204,12 +199,9 @@ void SharedPnaTableStepper::evalTableActionSelector(
             // Synthesize a symbolic variable here that corresponds to a control plane argument.
             // We get the unique name of the table coupled with the unique name of the action.
             // Getting the unique name is needed to avoid generating duplicate arguments.
-            const auto &actionDataVar =
-                getTableStateVariable(parameter->type, table, "*actionData", idx, argIdx);
             cstring keyName =
                 properties.tableName + "_param_" + actionName + std::to_string(argIdx);
             const auto &actionArg = nextState.createSymbolicVariable(parameter->type, keyName);
-            nextState.set(actionDataVar, actionArg);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.

--- a/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
@@ -45,7 +45,7 @@ const IR::Expression *SharedPnaTableStepper::computeTargetMatchType(
         // We can recover from taint by simply not adding the optional match.
         // Create a new symbolic variable that corresponds to the key expression.
         cstring keyName = properties.tableName + "_key_" + keyProperties.name;
-        const auto ctrlPlaneKey = nextState.createSymbolicVariable(keyExpr->type, keyName);
+        const auto *ctrlPlaneKey = nextState.createSymbolicVariable(keyExpr->type, keyName);
         if (keyProperties.isTainted) {
             matches->emplace(keyProperties.name,
                              new Optional(keyProperties.key, ctrlPlaneKey, false));

--- a/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.h
@@ -56,7 +56,7 @@ class SharedPnaTableStepper : public TableStepper {
     } SharedPnaProperties;
 
     const IR::Expression *computeTargetMatchType(ExecutionState &nextState,
-                                                 const KeyProperties &keyProperties,
+                                                 const TableUtils::KeyProperties &keyProperties,
                                                  TableMatchMap *matches,
                                                  const IR::Expression *hitCondition) override;
 

--- a/backends/p4tools/modules/testgen/targets/pna/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/test_backend.cpp
@@ -83,9 +83,9 @@ const TestSpec *PnaTestBackend::createTestSpec(const ExecutionState *executionSt
         const auto *pnaProgInfo = programInfo.checkedTo<PnaDpdkProgramInfo>();
         const auto *localMetadataVar = pnaProgInfo->getBlockParam("MainParserT", 2);
         const auto *localMetadataType = executionState->resolveType(localMetadataVar->type);
-        auto flatFields = executionState->getFlatFields(
+        const auto &flatFields = executionState->getFlatFields(
             localMetadataVar, localMetadataType->checkedTo<IR::Type_Struct>(), {});
-        for (const auto *fieldRef : flatFields) {
+        for (const auto &fieldRef : flatFields) {
             const auto *fieldVal = completedModel->evaluate(executionState->get(fieldRef));
             // Try to remove the leading internal name for the metadata field.
             // Thankfully, this string manipulation is safe if we are out of range.

--- a/backends/p4tools/p4tools.def
+++ b/backends/p4tools/p4tools.def
@@ -5,30 +5,32 @@
 class StateVariable : Expression {
     #noconstructor
 
-    /// The wrapped member.
-    const Member *member;
+    /// The wrapped reference.
+    const Expression *ref;
 
     /// The expression type is derived from the member.
-    StateVariable(Member member) : Expression(member->getSourceInfo(), member->type), member(member) {}
-
     /// Implicit conversions to allow implementations to be treated like a Member*.
 #emit
-    operator const Member *() const { return member; }
+    operator const Expression *() const { return ref; }
 #end
-    Member const &operator*() const { return *member; }
-    Member operator->() const { return member; }
+    Expression const &operator*() const { return *ref; }
+    Expression operator->() const { return ref; }
+
+    StateVariable(Member member) : Expression(member->getSourceInfo(), member->type), ref(member) {}
+    /// The expression type is derived from the path.
+    StateVariable(PathExpression path) : Expression(path->getSourceInfo(), path->type), ref(path) {}
 
     /// Implements comparisons so that StateVariables can be used as map keys.
     bool operator==(const StateVariable &other) const override {
         // Delegate to IR's notion of equality.
-        return *member == *other.member;
+        return *ref == *other.ref;
     }
 
     /// Implements comparisons so that StateVariables can be used as map keys.
     bool operator<(const StateVariable &other) const {
         // We use a custom compare function.
         // TODO: Is there a faster way to implement this comparison?
-        return compare(member, other.member) < 0;
+        return compare(ref, other.ref) < 0;
     }
 
     int compare(const Expression *e1, const Expression *e2) const {
@@ -77,9 +79,9 @@ class StateVariable : Expression {
         return 0;
     }
 
-    toString { return member->toString(); }
+    toString { return ref->toString(); }
 
-    dbprint { member->dbprint(out); }
+    dbprint { ref->dbprint(out); }
 }
 
 /// Signifies that a particular expression is tainted.


### PR DESCRIPTION
- StateVariables can now be both PathExpressions or Members. This gets rid of unnecessary conversions we had to do. This change is also a setup for more simplifications to the way we handle references in the interpreter. The goal is to get rid of IR::Member or IR::PathExpression completely. 
- Create a `table_utils` file in `common`. This file contains general utility functions for table processing, which are not tied to the interpreter functionality.
- Move the `constants.h` to `common`. It broadly defines constants from the P4 specification. 
- Remove some unnecessary variable declarations from the table stepper. They were never actually used.