### PR TITLE
Make P4-16 the default parser option.

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
@@ -119,7 +119,7 @@ function(p4tools_add_test_with_args)
 
   file(
     APPEND ${__testfile} "${driver} --target ${target} --arch ${arch} "
-    "--std p4-16 ${test_args} --out-dir ${__testfolder} \"$@\" ${P4C_SOURCE_DIR}/${p4test}\n"
+    "${test_args} --out-dir ${__testfolder} \"$@\" ${P4C_SOURCE_DIR}/${p4test}\n"
   )
 
   if(${TOOLS_BMV2_TESTS_USE_ASSERT_MODE} OR ${TOOLS_BMV2_TESTS_DISABLE_ASSUME_MODE})

--- a/backends/p4tools/modules/testgen/targets/ebpf/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test/TestTemplate.cmake
@@ -69,7 +69,7 @@ macro(p4tools_add_test_with_args)
   file(APPEND ${__testfile} "cd ${P4TOOLS_BINARY_DIR}\n")
   file(
     APPEND ${__testfile} "${driver} --target ${target} --arch ${arch} "
-    "--std p4-16 ${test_args} --out-dir ${__testfolder} \"$@\" ${P4C_SOURCE_DIR}/${p4test}\n"
+    "${test_args} --out-dir ${__testfolder} \"$@\" ${P4C_SOURCE_DIR}/${p4test}\n"
   )
   # If ENABLE_RUNNER is active, run the generated tests on the eBPF kernek.
   if(${TOOLS_EBPF_TESTS_ENABLE_RUNNER})

--- a/backends/p4tools/modules/testgen/targets/pna/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/pna/test/TestTemplate.cmake
@@ -61,7 +61,7 @@ function(p4tools_add_test_with_args)
 
   file(
     APPEND ${__testfile} "${driver} --target ${target} --arch ${arch} "
-    "--std p4-16 ${test_args} --out-dir ${__testfolder} \"$@\" ${P4C_SOURCE_DIR}/${p4test}\n"
+    "${test_args} --out-dir ${__testfolder} \"$@\" ${P4C_SOURCE_DIR}/${p4test}\n"
   )
 
   execute_process(COMMAND chmod +x ${__testfile})

--- a/frontends/common/parser_options.h
+++ b/frontends/common/parser_options.h
@@ -56,7 +56,7 @@ class ParserOptions : public Util::Options {
     // Name of executable that is being run.
     cstring exe_name;
     // Which language to compile
-    FrontendVersion langVersion = FrontendVersion::P4_14;
+    FrontendVersion langVersion = FrontendVersion::P4_16;
     // options to pass to preprocessor
     cstring preprocessor_options = "";
     // file to compile (- for stdin)


### PR DESCRIPTION
P4-14 is effectively deprecated. Reflect this in the default settings for the options parser. 