### PR TITLE
Allowing local_copyprop to propagate MethodCallExpression into table …

### DIFF
--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -93,6 +93,7 @@ class DoLocalCopyPropagation : public ControlFlowVisitor, Transform, P4WriteCont
     bool hasSideEffects(const IR::Expression *e) {
         return bool(::hasSideEffects(refMap, typeMap, e));
     }
+    bool isHeaderUnionIsValid(const IR::Expression *e);
 
     void visit_local_decl(const IR::Declaration_Variable *);
     const IR::Node *postorder(IR::Declaration_Variable *) override;

--- a/testdata/p4_16_samples/copyprop2.p4
+++ b/testdata/p4_16_samples/copyprop2.p4
@@ -1,0 +1,37 @@
+#include <core.p4>
+
+header Foo {
+    bit<32> data;
+}
+
+struct H {
+    Foo h;
+}
+
+parser P(packet_in pkt, out H hdr) {
+    state start {
+	pkt.extract(hdr.h);
+        transition accept;
+    }
+}
+
+control C(inout H hdr) {
+    bool h_is_valid;
+    table t {
+	key = {
+            h_is_valid: exact;
+        }
+        actions = {
+            NoAction;
+        }
+    }
+    apply {
+        h_is_valid = hdr.h.isValid();
+        t.apply();
+    }
+}
+
+parser PARSER(packet_in pkt, out H hdr);
+control CTRL(inout H hdr);
+package top(PARSER _p, CTRL _c);
+top(P(), C()) main;

--- a/testdata/p4_16_samples_outputs/copyprop2-first.p4
+++ b/testdata/p4_16_samples_outputs/copyprop2-first.p4
@@ -1,0 +1,38 @@
+#include <core.p4>
+
+header Foo {
+    bit<32> data;
+}
+
+struct H {
+    Foo h;
+}
+
+parser P(packet_in pkt, out H hdr) {
+    state start {
+        pkt.extract<Foo>(hdr.h);
+        transition accept;
+    }
+}
+
+control C(inout H hdr) {
+    bool h_is_valid;
+    table t {
+        key = {
+            h_is_valid: exact @name("h_is_valid");
+        }
+        actions = {
+            NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        h_is_valid = hdr.h.isValid();
+        t.apply();
+    }
+}
+
+parser PARSER(packet_in pkt, out H hdr);
+control CTRL(inout H hdr);
+package top(PARSER _p, CTRL _c);
+top(P(), C()) main;

--- a/testdata/p4_16_samples_outputs/copyprop2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/copyprop2-frontend.p4
@@ -1,0 +1,40 @@
+#include <core.p4>
+
+header Foo {
+    bit<32> data;
+}
+
+struct H {
+    Foo h;
+}
+
+parser P(packet_in pkt, out H hdr) {
+    state start {
+        pkt.extract<Foo>(hdr.h);
+        transition accept;
+    }
+}
+
+control C(inout H hdr) {
+    @name("C.h_is_valid") bool h_is_valid_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("C.t") table t_0 {
+        key = {
+            h_is_valid_0: exact @name("h_is_valid");
+        }
+        actions = {
+            NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        h_is_valid_0 = hdr.h.isValid();
+        t_0.apply();
+    }
+}
+
+parser PARSER(packet_in pkt, out H hdr);
+control CTRL(inout H hdr);
+package top(PARSER _p, CTRL _c);
+top(P(), C()) main;

--- a/testdata/p4_16_samples_outputs/copyprop2-midend.p4
+++ b/testdata/p4_16_samples_outputs/copyprop2-midend.p4
@@ -1,0 +1,38 @@
+#include <core.p4>
+
+header Foo {
+    bit<32> data;
+}
+
+struct H {
+    Foo h;
+}
+
+parser P(packet_in pkt, out H hdr) {
+    state start {
+        pkt.extract<Foo>(hdr.h);
+        transition accept;
+    }
+}
+
+control C(inout H hdr) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("C.t") table t_0 {
+        key = {
+            hdr.h.isValid(): exact @name("h_is_valid");
+        }
+        actions = {
+            NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+parser PARSER(packet_in pkt, out H hdr);
+control CTRL(inout H hdr);
+package top(PARSER _p, CTRL _c);
+top(P(), C()) main;

--- a/testdata/p4_16_samples_outputs/copyprop2.p4
+++ b/testdata/p4_16_samples_outputs/copyprop2.p4
@@ -1,0 +1,37 @@
+#include <core.p4>
+
+header Foo {
+    bit<32> data;
+}
+
+struct H {
+    Foo h;
+}
+
+parser P(packet_in pkt, out H hdr) {
+    state start {
+        pkt.extract(hdr.h);
+        transition accept;
+    }
+}
+
+control C(inout H hdr) {
+    bool h_is_valid;
+    table t {
+        key = {
+            h_is_valid: exact;
+        }
+        actions = {
+            NoAction;
+        }
+    }
+    apply {
+        h_is_valid = hdr.h.isValid();
+        t.apply();
+    }
+}
+
+parser PARSER(packet_in pkt, out H hdr);
+control CTRL(inout H hdr);
+package top(PARSER _p, CTRL _c);
+top(P(), C()) main;


### PR DESCRIPTION
…key, for example:
```
bool is_valid = hdr.ethernet.isValid();
table t {
   key = { is_valid : exact };
   ...
}
```
is transformed to 
```
table t {
    keys = { hdr.ethernet.isValid() : exact };
    ...
}
```
which saves resource reserved for the boolean variable.