### PR TITLE
[P4Testgen] Fix small issues with metadata test backend. Add more functions to IR utilities. Merge default value function.

### DIFF
--- a/backends/p4tools/CMakeLists.txt
+++ b/backends/p4tools/CMakeLists.txt
@@ -47,19 +47,6 @@ if (${Z3_VERSION_STRING} VERSION_GREATER_EQUAL ${Z3_MAX_VERSION_EXCL})
   message(FATAL_ERROR "The Z3 version has to be lower than ${Z3_MAX_VERSION_EXCL} (the latter currently does no work with libGC). Has ${Z3_VERSION_STRING}.")
 endif()
 
-# Inja is needed to produce test templates.
-set(INJA_BUILD_TESTS OFF CACHE BOOL "Build unit tests when BUILD_TESTING is enabled.")
-set(BUILD_BENCHMARK OFF CACHE BOOL "Build benchmark.")
-FetchContent_Declare(
-  inja
-  GIT_REPOSITORY https://github.com/pantor/inja.git
-  GIT_TAG        3741c73ba78babd2ed88f2acf2fcd6dafdb878e8
-  GIT_PROGRESS TRUE
-)
-FetchContent_MakeAvailable(inja)
-include_directories(SYSTEM ${inja_SOURCE_DIR}/include)
-
-
 # Import common definitions.
 include(common)
 

--- a/backends/p4tools/common/lib/model.cpp
+++ b/backends/p4tools/common/lib/model.cpp
@@ -30,7 +30,7 @@ const IR::Literal *Model::SubstVisitor::preorder(IR::SymbolicVariable *var) {
 }
 
 const IR::Literal *Model::SubstVisitor::preorder(IR::TaintExpression *var) {
-    return IR::getDefaultValue(var->type);
+    return IR::getDefaultValue(var->type, var->getSourceInfo())->checkedTo<IR::Literal>();
 }
 
 Model::CompleteVisitor::CompleteVisitor(Model &model) : self(model) {}
@@ -40,7 +40,7 @@ bool Model::CompleteVisitor::preorder(const IR::SymbolicVariable *var) {
         LOG_FEATURE("common", 5,
                     "***** Did not find a binding for " << var << ". Autocompleting." << std::endl);
         const auto *type = var->type;
-        self.symbolicMap.emplace(var, IR::getDefaultValue(type));
+        self.symbolicMap.emplace(var, IR::getDefaultValue(type, var->getSourceInfo()));
     }
     return false;
 }

--- a/backends/p4tools/common/lib/taint.cpp
+++ b/backends/p4tools/common/lib/taint.cpp
@@ -167,11 +167,11 @@ class TaintPropagator : public Transform {
     const IR::Node *postorder(IR::TaintExpression *expr) override { return expr; }
 
     const IR::Node *postorder(IR::SymbolicVariable *var) override {
-        return new IR::Constant(var->type, IR::getMaxBvVal(var->type));
+        return IR::getMaxValueConstant(var->type);
     }
 
     const IR::Node *postorder(IR::ConcolicVariable *var) override {
-        return new IR::Constant(var->type, IR::getMaxBvVal(var->type));
+        return IR::getMaxValueConstant(var->type);
     }
     const IR::Node *postorder(IR::Operation_Unary *unary_op) override { return unary_op->expr; }
 
@@ -228,7 +228,7 @@ class MaskBuilder : public Transform {
  private:
     const IR::Node *preorder(IR::Member *member) override {
         // Non-tainted members just return the max value, which corresponds to a mask of all zeroes.
-        return IR::getConstant(member->type, IR::getMaxBvVal(member->type));
+        return IR::getMaxValueConstant(member->type);
     }
 
     const IR::Node *preorder(IR::PathExpression *path) override {
@@ -244,7 +244,7 @@ class MaskBuilder : public Transform {
 
     const IR::Node *preorder(IR::Literal *lit) override {
         // Fill out a literal with zeroes.
-        const auto *maxConst = IR::getConstant(lit->type, IR::getMaxBvVal(lit->type));
+        const auto *maxConst = IR::getMaxValueConstant(lit->type);
         // If the literal would have been zero anyway, just return it.
         if (lit->equiv(*maxConst)) {
             return lit;

--- a/backends/p4tools/common/lib/trace_event_types.cpp
+++ b/backends/p4tools/common/lib/trace_event_types.cpp
@@ -299,4 +299,6 @@ ParserState::ParserState(const IR::ParserState *state) : state(state) {}
 
 void ParserState::print(std::ostream &os) const { os << "[State] " << state->controlPlaneName(); }
 
+const IR::ParserState *ParserState::getParserState() const { return state; }
+
 }  // namespace P4Tools::TraceEvents

--- a/backends/p4tools/common/lib/trace_event_types.h
+++ b/backends/p4tools/common/lib/trace_event_types.h
@@ -272,6 +272,9 @@ class ParserState : public TraceEvent {
     ParserState &operator=(const ParserState &) = default;
     ParserState &operator=(ParserState &&) = default;
 
+    /// @returns the parser state associated with this event.
+    const IR::ParserState *getParserState() const;
+
  protected:
     void print(std::ostream &os) const override;
 };

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -4,6 +4,10 @@ include(common)
 
 project(p4testgen)
 
+# Declare common P4Testgen variables.
+set(P4TESTGEN_DIR ${P4C_BINARY_DIR}/testgen)
+set(P4TESTGEN_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/p4testgen")
+
 # Source files for p4testgen.
 set(
   TESTGEN_SOURCES

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -30,7 +30,7 @@ set(
   core/symbolic_executor/symbolic_executor.cpp
   core/target.cpp
 
-  lib/collect_coverable_statements.cpp
+  lib/collect_coverable_nodes.cpp
   lib/concolic.cpp
   lib/continuation.cpp
   lib/execution_state.cpp

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -60,6 +60,17 @@ set(
   test/z3-solver/expressions.cpp
 )
 
+# Inja is needed to produce test templates.
+set(INJA_BUILD_TESTS OFF CACHE BOOL "Build unit tests when BUILD_TESTING is enabled.")
+set(BUILD_BENCHMARK OFF CACHE BOOL "Build benchmark.")
+FetchContent_Declare(
+  inja
+  GIT_REPOSITORY https://github.com/pantor/inja.git
+  GIT_TAG        3741c73ba78babd2ed88f2acf2fcd6dafdb878e8
+  GIT_PROGRESS TRUE
+)
+FetchContent_MakeAvailable(inja)
+
 # Testgen libraries.
 set(
   TESTGEN_LIBS
@@ -97,15 +108,14 @@ endforeach()
 # Fill the template
 configure_file(register.h.in register.h)
 
+# The library.
 add_p4tools_library(testgen ${TESTGEN_SOURCES})
+add_dependencies(testgen p4tools-common inja)
+target_include_directories(testgen SYSTEM PUBLIC ${inja_SOURCE_DIR}/include)
+target_include_directories(testgen SYSTEM PUBLIC ${inja_SOURCE_DIR}/third_party/include)
 
-target_link_libraries(
-  testgen
-  ${TESTGEN_LIBS}
-)
-
+# The executable.
 add_p4tools_executable(p4testgen main.cpp)
-
 target_link_libraries(
   p4testgen
   testgen
@@ -134,6 +144,7 @@ if(ENABLE_GTESTS)
     testgen-gtest
     PRIVATE testgen
     PRIVATE gtest
+    ${TESTGEN_LIBS}
   )
 
   if(ENABLE_TESTING)

--- a/backends/p4tools/modules/testgen/core/program_info.cpp
+++ b/backends/p4tools/modules/testgen/core/program_info.cpp
@@ -68,7 +68,7 @@ const IR::Expression *ProgramInfo::createTargetUninitialized(const IR::Type *typ
     if (forceTaint) {
         return ToolsVariables::getTaintExpression(type);
     }
-    return IR::getDefaultValue(type);
+    return IR::getDefaultValue(type, {}, true);
 }
 
 /* =============================================================================================

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -397,12 +397,12 @@ bool ExprStepper::preorder(const IR::SelectExpression *selectExpression) {
                 selectExpression);
         }
 
-        nextState.replaceTopBody(Continuation::Return(selectCase->state));
+        const auto *decl = state.findDecl(selectCase->state)->getNode();
+        nextState.replaceTopBody(Continuation::Return(decl));
         // Some path selection strategies depend on looking ahead and collecting potential
         // statements. If that is the case, apply the CoverableNodesScanner visitor.
         P4::Coverage::CoverageSet coveredStmts;
         if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
-            const auto *decl = state.findDecl(selectCase->state)->getNode();
             auto collector = CoverableNodesScanner(state);
             collector.updateNodeCoverage(decl, coveredStmts);
         }

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -23,7 +23,7 @@
 #include "backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h"
 #include "backends/p4tools/modules/testgen/core/small_step/table_stepper.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/path_selection.h"
-#include "backends/p4tools/modules/testgen/lib/collect_coverable_statements.h"
+#include "backends/p4tools/modules/testgen/lib/collect_coverable_nodes.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
@@ -235,13 +235,13 @@ bool ExprStepper::preorder(const IR::Mux *mux) {
         auto &nextState = state.clone();
         // Some path selection strategies depend on looking ahead and collecting potential
         // statements. If that is the case, apply the CoverableNodesScanner visitor.
-        P4::Coverage::CoverageSet coveredStmts;
+        P4::Coverage::CoverageSet coveredNodes;
         if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
             auto collector = CoverableNodesScanner(state);
-            collector.updateNodeCoverage(expr, coveredStmts);
+            collector.updateNodeCoverage(expr, coveredNodes);
         }
         nextState.replaceTopBody(Continuation::Return(expr));
-        result->emplace_back(cond, state, nextState, coveredStmts);
+        result->emplace_back(cond, state, nextState, coveredNodes);
     }
 
     return false;
@@ -401,13 +401,13 @@ bool ExprStepper::preorder(const IR::SelectExpression *selectExpression) {
         nextState.replaceTopBody(Continuation::Return(decl));
         // Some path selection strategies depend on looking ahead and collecting potential
         // statements. If that is the case, apply the CoverableNodesScanner visitor.
-        P4::Coverage::CoverageSet coveredStmts;
+        P4::Coverage::CoverageSet coveredNodes;
         if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
             auto collector = CoverableNodesScanner(state);
-            collector.updateNodeCoverage(decl, coveredStmts);
+            collector.updateNodeCoverage(decl, coveredNodes);
         }
         result->emplace_back(new IR::LAnd(missCondition, matchCondition), state, nextState,
-                             coveredStmts);
+                             coveredNodes);
         missCondition = new IR::LAnd(new IR::LNot(matchCondition), missCondition);
     }
 

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -200,7 +200,7 @@ const IR::Expression *TableStepper::evalTableConstEntries() {
         }
     }
 
-    for (const auto &entry : entryVector) {
+    for (const auto *entry : entryVector) {
         const auto *action = entry->getAction();
         const auto *tableAction = action->checkedTo<IR::MethodCallExpression>();
         const auto *actionType = stepper->state.getActionDecl(tableAction);

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -27,7 +27,7 @@
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/small_step/expr_stepper.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/path_selection.h"
-#include "backends/p4tools/modules/testgen/lib/collect_coverable_statements.h"
+#include "backends/p4tools/modules/testgen/lib/collect_coverable_nodes.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
@@ -245,10 +245,10 @@ const IR::Expression *TableStepper::evalTableConstEntries() {
         nextState.set(getTableReachedVar(table), IR::getBoolLiteral(true));
         // Some path selection strategies depend on looking ahead and collecting potential
         // statements. If that is the case, apply the CoverableNodesScanner visitor.
-        P4::Coverage::CoverageSet coveredStmts;
+        P4::Coverage::CoverageSet coveredNodes;
         if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
             auto collector = CoverableNodesScanner(stepper->state);
-            collector.updateNodeCoverage(actionType, coveredStmts);
+            collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
         // Add some tracing information.
@@ -284,7 +284,7 @@ const IR::Expression *TableStepper::evalTableConstEntries() {
         // The default condition can only be triggered, if we do not hit this match.
         // We encode this constraint in this expression.
         stepper->result->emplace_back(new IR::LAnd(tableMissCondition, hitCondition),
-                                      stepper->state, nextState, coveredStmts);
+                                      stepper->state, nextState, coveredNodes);
         tableMissCondition = new IR::LAnd(new IR::LNot(hitCondition), tableMissCondition);
     }
     return tableMissCondition;
@@ -339,10 +339,10 @@ void TableStepper::setTableDefaultEntries(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
         // Some path selection strategies depend on looking ahead and collecting potential
         // statements. If that is the case, apply the CoverableNodesScanner visitor.
-        P4::Coverage::CoverageSet coveredStmts;
+        P4::Coverage::CoverageSet coveredNodes;
         if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
             auto collector = CoverableNodesScanner(stepper->state);
-            collector.updateNodeCoverage(actionType, coveredStmts);
+            collector.updateNodeCoverage(actionType, coveredNodes);
         }
         nextState.set(getTableHitVar(table), IR::getBoolLiteral(false));
         nextState.set(getTableReachedVar(table), IR::getBoolLiteral(true));
@@ -351,7 +351,7 @@ void TableStepper::setTableDefaultEntries(
         tableStream << "| Overriding default action: " << actionName;
         nextState.add(*new TraceEvents::Generic(tableStream.str()));
         nextState.replaceTopBody(&replacements);
-        stepper->result->emplace_back(std::nullopt, stepper->state, nextState, coveredStmts);
+        stepper->result->emplace_back(std::nullopt, stepper->state, nextState, coveredNodes);
     }
 }
 
@@ -413,10 +413,10 @@ void TableStepper::evalTableControlEntries(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
         // Some path selection strategies depend on looking ahead and collecting potential
         // statements. If that is the case, apply the CoverableNodesScanner visitor.
-        P4::Coverage::CoverageSet coveredStmts;
+        P4::Coverage::CoverageSet coveredNodes;
         if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
             auto collector = CoverableNodesScanner(stepper->state);
-            collector.updateNodeCoverage(actionType, coveredStmts);
+            collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
         nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
@@ -438,7 +438,7 @@ void TableStepper::evalTableControlEntries(
         tableStream << "| Chosen action: " << actionName;
         nextState.add(*new TraceEvents::Generic(tableStream.str()));
         nextState.replaceTopBody(&replacements);
-        stepper->result->emplace_back(hitCondition, stepper->state, nextState, coveredStmts);
+        stepper->result->emplace_back(hitCondition, stepper->state, nextState, coveredNodes);
     }
 }
 
@@ -594,15 +594,15 @@ void TableStepper::addDefaultAction(std::optional<const IR::Expression *> tableM
     replacements.emplace_back(new IR::MethodCallStatement(Util::SourceInfo(), tableAction));
     // Some path selection strategies depend on looking ahead and collecting potential
     // statements.
-    P4::Coverage::CoverageSet coveredStmts;
+    P4::Coverage::CoverageSet coveredNodes;
     if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
         auto collector = CoverableNodesScanner(stepper->state);
-        collector.updateNodeCoverage(actionType, coveredStmts);
+        collector.updateNodeCoverage(actionType, coveredNodes);
     }
     nextState.set(getTableHitVar(table), IR::getBoolLiteral(false));
     nextState.set(getTableReachedVar(table), IR::getBoolLiteral(true));
     nextState.replaceTopBody(&replacements);
-    stepper->result->emplace_back(tableMissCondition, stepper->state, nextState, coveredStmts);
+    stepper->result->emplace_back(tableMissCondition, stepper->state, nextState, coveredNodes);
 }
 
 void TableStepper::checkTargetProperties(

--- a/backends/p4tools/modules/testgen/core/symbolic_executor/greedy_stmt_cov.cpp
+++ b/backends/p4tools/modules/testgen/core/symbolic_executor/greedy_stmt_cov.cpp
@@ -121,7 +121,7 @@ void GreedyStmtSelection::run(const Callback &callback) {
         Util::ScopedTimer chooseBranchtimer("branch_selection");
         auto branch = popPotentialBranch(getVisitedNodes(), potentialBranches);
         if (branch.has_value()) {
-            executionState = branch->nextState;
+            executionState = branch.value().nextState;
             continue;
         }
         // We did not find a single branch that could cover new state.

--- a/backends/p4tools/modules/testgen/lib/collect_coverable_nodes.h
+++ b/backends/p4tools/modules/testgen/lib/collect_coverable_nodes.h
@@ -1,5 +1,5 @@
-#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_COLLECT_COVERABLE_STATEMENTS_H_
-#define BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_COLLECT_COVERABLE_STATEMENTS_H_
+#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_COLLECT_COVERABLE_NODES_H_
+#define BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_COLLECT_COVERABLE_NODES_H_
 
 #include <set>
 
@@ -10,6 +10,10 @@
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 
 namespace P4Tools::P4Testgen {
+
+/// A cache of already computed nodes to avoid superfluous computation.
+using NodeCache = std::map<const IR::Node *, P4::Coverage::CoverageSet>;
+static NodeCache cachedNodes;
 
 /// CoverableNodesScanner is similar to @ref CollectNodes. It collects all the nodes
 /// present in a particular node. However, compared to CollectNodes, it traverses the entire
@@ -34,6 +38,7 @@ class CoverableNodesScanner : public Inspector {
     bool preorder(const IR::AssignmentStatement *stmt) override;
     bool preorder(const IR::MethodCallStatement *stmt) override;
     bool preorder(const IR::ExitStatement *stmt) override;
+    bool preorder(const IR::MethodCallExpression *call) override;
 
  public:
     explicit CoverableNodesScanner(const ExecutionState &state);
@@ -48,4 +53,4 @@ class CoverableNodesScanner : public Inspector {
 
 }  // namespace P4Tools::P4Testgen
 
-#endif /*BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_COLLECT_COVERABLE_STATEMENTS_H_*/
+#endif /*BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_COLLECT_COVERABLE_NODES_H_*/

--- a/backends/p4tools/modules/testgen/lib/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_spec.cpp
@@ -64,7 +64,7 @@ cstring ActionArg::getActionParamName() const { return param->controlPlaneName()
 
 const IR::Constant *ActionArg::getEvaluatedValue() const {
     if (const auto *boolVal = value->to<IR::BoolLiteral>()) {
-        return IR::getConstant(IR::getBitType(1), boolVal->value ? 1 : 0);
+        return IR::convertBoolLiteral(boolVal);
     }
     const auto *constant = value->to<IR::Constant>();
     BUG_CHECK(constant,

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.cpp
@@ -102,6 +102,9 @@ header_offsets:
   {{offset.label}}: {{offset.offset}}
 ## endfor
 
+# The in-order list of parser states which were traversed for this test.
+parser_states: {% for s in parser_states %}{{s}}{% if not loop.is_last %}, {% endif %}{% endfor %}
+
 # Metadata results after this test has completed.
 metadata:
 ## for metadata_field in metadata_fields
@@ -114,6 +117,7 @@ metadata:
 void Metadata::computeTraceData(const TestSpec *testSpec, inja::json &dataJson) {
     dataJson["trace"] = inja::json::array();
     dataJson["offsets"] = inja::json::array();
+    dataJson["parser_states"] = inja::json::array();
     const auto *traces = testSpec->getTraces();
     if (traces != nullptr) {
         for (const auto &trace : *traces) {
@@ -122,6 +126,9 @@ void Metadata::computeTraceData(const TestSpec *testSpec, inja::json &dataJson) 
                 j["label"] = successfulExtract->getExtractedHeader()->toString();
                 j["offset"] = successfulExtract->getOffset();
                 dataJson["offsets"].push_back(j);
+            }
+            if (const auto *parserState = trace.get().to<TraceEvents::ParserState>()) {
+                dataJson["parser_states"].push_back(parserState->getParserState()->getName().name);
             }
             std::stringstream ss;
             ss << trace;

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.cpp
@@ -173,7 +173,8 @@ void Metadata::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, 
 void Metadata::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
                           float currentCoverage) {
     auto incrementedbasePath = basePath;
-    incrementedbasePath.replace_extension("_" + std::to_string(testIdx) + ".yml");
+    incrementedbasePath.concat("_" + std::to_string(testIdx));
+    incrementedbasePath.replace_extension(".yml");
     metadataFile = std::ofstream(incrementedbasePath);
     std::string testCase = getTestCaseTemplate();
     emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -22,7 +22,7 @@
 
 #include "backends/p4tools/modules/testgen/core/small_step/table_stepper.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/path_selection.h"
-#include "backends/p4tools/modules/testgen/lib/collect_coverable_statements.h"
+#include "backends/p4tools/modules/testgen/lib/collect_coverable_nodes.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
@@ -154,10 +154,10 @@ void Bmv2V1ModelTableStepper::evalTableActionProfile(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
         // Some path selection strategies depend on looking ahead and collecting potential
         // statements. If that is the case, apply the CoverableNodesScanner visitor.
-        P4::Coverage::CoverageSet coveredStmts;
+        P4::Coverage::CoverageSet coveredNodes;
         if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
             auto collector = CoverableNodesScanner(*state);
-            collector.updateNodeCoverage(actionType, coveredStmts);
+            collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
         nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
@@ -167,7 +167,7 @@ void Bmv2V1ModelTableStepper::evalTableActionProfile(
         tableStream << " Chosen action: " << actionName;
         nextState.add(*new TraceEvents::Generic(tableStream.str()));
         nextState.replaceTopBody(&replacements);
-        getResult()->emplace_back(hitCondition, *state, nextState, coveredStmts);
+        getResult()->emplace_back(hitCondition, *state, nextState, coveredNodes);
     }
 }
 
@@ -248,10 +248,10 @@ void Bmv2V1ModelTableStepper::evalTableActionSelector(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
         // Some path selection strategies depend on looking ahead and collecting potential
         // statements. If that is the case, apply the CoverableNodesScanner visitor.
-        P4::Coverage::CoverageSet coveredStmts;
+        P4::Coverage::CoverageSet coveredNodes;
         if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
             auto collector = CoverableNodesScanner(*state);
-            collector.updateNodeCoverage(actionType, coveredStmts);
+            collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
         nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
@@ -261,7 +261,7 @@ void Bmv2V1ModelTableStepper::evalTableActionSelector(
         tableStream << " Chosen action: " << actionName;
         nextState.add(*new TraceEvents::Generic(tableStream.str()));
         nextState.replaceTopBody(&replacements);
-        getResult()->emplace_back(hitCondition, *state, nextState, coveredStmts);
+        getResult()->emplace_back(hitCondition, *state, nextState, coveredNodes);
     }
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
@@ -36,7 +36,6 @@ option(P4TOOLS_TESTGEN_BMV2_TEST_PTF "Run tests on the PTF test back end" ON)
 option(P4TOOLS_TESTGEN_BMV2_TEST_STF "Run tests on the STF test back end" ON)
 # Test settings.
 set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10 ")
-set(P4TESTGEN_DRIVER "${P4TOOLS_BINARY_DIR}/p4testgen")
 
 # ASSERT_ASSUME TESTS
 include(${CMAKE_CURRENT_LIST_DIR}/AssumeAssertTests.cmake)

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
@@ -1,8 +1,5 @@
 # This file defines how a test should be written for a particular target. This is used by testutils
 
-set(P4TOOLS_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
-set(P4TESTGEN_DIR ${CMAKE_SOURCE_DIR}/build/testgen)
-
 # Write the script to check BMv2 STF tests to the designated test file.
 # Arguments:
 #   - testfile is the testing script that this script is written to.
@@ -108,7 +105,7 @@ function(p4tools_add_test_with_args)
   file(WRITE ${__testfile} "#! /usr/bin/env bash\n")
   file(APPEND ${__testfile} "# Generated file, modify with care\n\n")
   file(APPEND ${__testfile} "set -e\n")
-  file(APPEND ${__testfile} "cd ${P4TOOLS_BINARY_DIR}\n")
+  file(APPEND ${__testfile} "cd ${P4C_BINARY_DIR}\n")
 
   if(${TOOLS_BMV2_TESTS_USE_ASSERT_MODE})
     set(test_args "${test_args} --assertion-mode")

--- a/backends/p4tools/modules/testgen/targets/ebpf/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test/P4Tests.cmake
@@ -25,7 +25,6 @@ set(P4C_EBPF_TEST_SUITES_P416 ${ebpftests})
 option(P4TOOLS_TESTGEN_EBPF_TEST_STF "Run tests on the STF test back end" ON)
 # Test settings.
 set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10")
-set(P4TESTGEN_DRIVER "${P4TOOLS_BINARY_DIR}/p4testgen")
 
 if(P4TOOLS_TESTGEN_EBPF_TEST_STF)
   p4tools_add_tests(

--- a/backends/p4tools/modules/testgen/targets/ebpf/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test/TestTemplate.cmake
@@ -1,8 +1,5 @@
 # This file defines how a test should be written for a particular target. This is used by testutils
 
-set(P4TOOLS_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
-set(P4TESTGEN_DIR ${CMAKE_SOURCE_DIR}/build/testgen)
-
 # Write the script to check eBPF Kernel STF tests to the designated test file.
 # Arguments:
 #   - testfile is the testing script that this script is written to.
@@ -66,7 +63,7 @@ macro(p4tools_add_test_with_args)
   file(WRITE ${__testfile} "#! /usr/bin/env bash\n")
   file(APPEND ${__testfile} "# Generated file, modify with care\n\n")
   file(APPEND ${__testfile} "set -e\n")
-  file(APPEND ${__testfile} "cd ${P4TOOLS_BINARY_DIR}\n")
+  file(APPEND ${__testfile} "cd ${P4C_BINARY_DIR}\n")
   file(
     APPEND ${__testfile} "${driver} --target ${target} --arch ${arch} "
     "${test_args} --out-dir ${__testfolder} \"$@\" ${P4C_SOURCE_DIR}/${p4test}\n"

--- a/backends/p4tools/modules/testgen/targets/pna/backend/metadata/metadata.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/backend/metadata/metadata.cpp
@@ -102,6 +102,9 @@ header_offsets:
   {{offset.label}}: {{offset.offset}}
 ## endfor
 
+# The in-order list of parser states which were traversed for this test.
+parser_states: {% for s in parser_states %}{{s}}{% if not loop.is_last %}, {% endif %}{% endfor %}
+
 # Metadata results after this test has completed.
 metadata:
 ## for metadata_field in metadata_fields
@@ -114,6 +117,7 @@ metadata:
 void Metadata::computeTraceData(const TestSpec *testSpec, inja::json &dataJson) {
     dataJson["trace"] = inja::json::array();
     dataJson["offsets"] = inja::json::array();
+    dataJson["parser_states"] = inja::json::array();
     const auto *traces = testSpec->getTraces();
     if (traces != nullptr) {
         for (const auto &trace : *traces) {
@@ -122,6 +126,9 @@ void Metadata::computeTraceData(const TestSpec *testSpec, inja::json &dataJson) 
                 j["label"] = successfulExtract->getExtractedHeader()->toString();
                 j["offset"] = successfulExtract->getOffset();
                 dataJson["offsets"].push_back(j);
+            }
+            if (const auto *parserState = trace.get().to<TraceEvents::ParserState>()) {
+                dataJson["parser_states"].push_back(parserState->getParserState()->getName().name);
             }
             std::stringstream ss;
             ss << trace;

--- a/backends/p4tools/modules/testgen/targets/pna/backend/metadata/metadata.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/backend/metadata/metadata.cpp
@@ -173,7 +173,8 @@ void Metadata::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, 
 void Metadata::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
                           float currentCoverage) {
     auto incrementedbasePath = basePath;
-    incrementedbasePath.replace_extension("_" + std::to_string(testIdx) + ".yml");
+    incrementedbasePath.concat("_" + std::to_string(testIdx));
+    incrementedbasePath.replace_extension(".yml");
     metadataFile = std::ofstream(incrementedbasePath);
     std::string testCase = getTestCaseTemplate();
     emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);

--- a/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
@@ -22,7 +22,7 @@
 
 #include "backends/p4tools/modules/testgen/core/small_step/table_stepper.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/path_selection.h"
-#include "backends/p4tools/modules/testgen/lib/collect_coverable_statements.h"
+#include "backends/p4tools/modules/testgen/lib/collect_coverable_nodes.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
@@ -154,10 +154,10 @@ void SharedPnaTableStepper::evalTableActionProfile(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
         // Some path selection strategies depend on looking ahead and collecting potential
         // statements. If that is the case, apply the CoverableNodesScanner visitor.
-        P4::Coverage::CoverageSet coveredStmts;
+        P4::Coverage::CoverageSet coveredNodes;
         if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
             auto collector = CoverableNodesScanner(*state);
-            collector.updateNodeCoverage(actionType, coveredStmts);
+            collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
         nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
@@ -167,7 +167,7 @@ void SharedPnaTableStepper::evalTableActionProfile(
         tableStream << " Chosen action: " << actionName;
         nextState.add(*new TraceEvents::Generic(tableStream.str()));
         nextState.replaceTopBody(&replacements);
-        getResult()->emplace_back(hitCondition, *state, nextState, coveredStmts);
+        getResult()->emplace_back(hitCondition, *state, nextState, coveredNodes);
     }
 }
 
@@ -248,10 +248,10 @@ void SharedPnaTableStepper::evalTableActionSelector(
             new IR::MethodCallStatement(Util::SourceInfo(), synthesizedAction));
         // Some path selection strategies depend on looking ahead and collecting potential
         // statements. If that is the case, apply the CoverableNodesScanner visitor.
-        P4::Coverage::CoverageSet coveredStmts;
+        P4::Coverage::CoverageSet coveredNodes;
         if (requiresLookahead(TestgenOptions::get().pathSelectionPolicy)) {
             auto collector = CoverableNodesScanner(*state);
-            collector.updateNodeCoverage(actionType, coveredStmts);
+            collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
         nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
@@ -261,7 +261,7 @@ void SharedPnaTableStepper::evalTableActionSelector(
         tableStream << " Chosen action: " << actionName;
         nextState.add(*new TraceEvents::Generic(tableStream.str()));
         nextState.replaceTopBody(&replacements);
-        getResult()->emplace_back(hitCondition, *state, nextState, coveredStmts);
+        getResult()->emplace_back(hitCondition, *state, nextState, coveredNodes);
     }
 }
 

--- a/backends/p4tools/modules/testgen/targets/pna/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/pna/test/P4Tests.cmake
@@ -29,7 +29,6 @@ set(P4C_V1_TEST_SUITES_P416 ${v1tests} ${pna_tests})
 option(P4TOOLS_TESTGEN_PNA_TEST_METADATA "Run tests on the Metadata test back end" ON)
 # Test settings.
 set(EXTRA_OPTS "--strict --print-traces --seed 1000 --max-tests 10 ")
-set(P4TESTGEN_DRIVER "${P4TOOLS_BINARY_DIR}/p4testgen")
 
 # Metadata
 if(P4TOOLS_TESTGEN_PNA_TEST_METADATA)

--- a/backends/p4tools/modules/testgen/targets/pna/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/pna/test/TestTemplate.cmake
@@ -1,8 +1,5 @@
 # This file defines how a test should be written for a particular target. This is used by testutils
 
-set(P4TOOLS_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
-set(P4TESTGEN_DIR ${CMAKE_SOURCE_DIR}/build/testgen)
-
 # Write the script to validate whether a given protobuf file has a valid format.
 # Arguments:
 #   - testfile is the testing script that this script is written to.
@@ -57,7 +54,7 @@ function(p4tools_add_test_with_args)
   file(WRITE ${__testfile} "#! /usr/bin/env bash\n")
   file(APPEND ${__testfile} "# Generated file, modify with care\n\n")
   file(APPEND ${__testfile} "set -e\n")
-  file(APPEND ${__testfile} "cd ${P4TOOLS_BINARY_DIR}\n")
+  file(APPEND ${__testfile} "cd ${P4C_BINARY_DIR}\n")
 
   file(
     APPEND ${__testfile} "${driver} --target ${target} --arch ${arch} "

--- a/frontends/p4/defaultValues.h
+++ b/frontends/p4/defaultValues.h
@@ -33,17 +33,11 @@ class DoDefaultValues final : public Transform {
     const IR::Expression *defaultValue(const IR::Expression *expression, const IR::Type *type);
 
  public:
-    DoDefaultValues(TypeMap *typeMap) : typeMap(typeMap) { CHECK_NULL(typeMap); }
+    explicit DoDefaultValues(TypeMap *typeMap) : typeMap(typeMap) { CHECK_NULL(typeMap); }
     const IR::Node *postorder(IR::Dots *dots) override;
     const IR::Node *postorder(IR::StructExpression *expression) override;
     const IR::Node *postorder(IR::ListExpression *expression) override;
     const IR::Node *postorder(IR::HeaderStackExpression *expression) override;
-
-    /**
-     * Generate a default value for the specified type.
-     * The resulting expression will have the specified srcInfo position
-     */
-    static const IR::Expression *defaultValue(Util::SourceInfo srcInfo, const IR::Type *type);
 };
 
 class DefaultValues : public PassManager {

--- a/ir/irutils.cpp
+++ b/ir/irutils.cpp
@@ -73,15 +73,95 @@ const IR::Constant *convertBoolLiteral(const IR::BoolLiteral *lit) {
     return IR::getConstant(IR::getBitType(1), lit->value ? 1 : 0);
 }
 
-const Literal *getDefaultValue(const Type *type) {
-    if (type->is<Type_Bits>()) {
-        return getConstant(type, 0);
+const IR::Expression *getDefaultValue(const IR::Type *type, const Util::SourceInfo &srcInfo,
+                                      bool valueRequired) {
+    if (const auto *tb = type->to<IR::Type_Bits>()) {
+        // TODO: Use getConstant.
+        return new IR::Constant(srcInfo, tb, 0);
     }
-    if (type->is<Type_Boolean>()) {
-        return getBoolLiteral(false);
+    if (type->is<IR::Type_Boolean>()) {
+        // TODO: Use getBoolLiteral.
+        return new BoolLiteral(Type::Boolean::get(), false);
     }
-    P4C_UNIMPLEMENTED("Default value for type %s of type %s not implemented.", type,
-                      type->node_type_name());
+    if (type->is<IR::Type_InfInt>()) {
+        return new IR::Constant(srcInfo, 0);
+    }
+    if (const auto *te = type->to<IR::Type_Enum>()) {
+        return new IR::Member(srcInfo, new IR::TypeNameExpression(te->name),
+                              te->members.at(0)->getName());
+    }
+    if (const auto *te = type->to<IR::Type_SerEnum>()) {
+        return new IR::Cast(srcInfo, type->getP4Type(), new IR::Constant(srcInfo, te->type, 0));
+    }
+    if (const auto *te = type->to<IR::Type_Error>()) {
+        return new IR::Member(srcInfo, new IR::TypeNameExpression(te->name), "NoError");
+    }
+    if (type->is<IR::Type_String>()) {
+        return new IR::StringLiteral(srcInfo, cstring(""));
+    }
+    if (type->is<IR::Type_Varbits>()) {
+        if (valueRequired) {
+            P4C_UNIMPLEMENTED("%1%: No default value for varbit types.", srcInfo);
+        }
+        ::error(ErrorType::ERR_UNSUPPORTED, "%1% default values for varbit types", srcInfo);
+        return nullptr;
+    }
+    if (const auto *ht = type->to<IR::Type_Header>()) {
+        return new IR::InvalidHeader(ht->getP4Type());
+    }
+    if (const auto *hu = type->to<IR::Type_HeaderUnion>()) {
+        return new IR::InvalidHeaderUnion(hu->getP4Type());
+    }
+    if (const auto *st = type->to<IR::Type_StructLike>()) {
+        auto *vec = new IR::IndexedVector<IR::NamedExpression>();
+        for (const auto *field : st->fields) {
+            const auto *value = getDefaultValue(field->type, srcInfo);
+            if (value == nullptr) {
+                return nullptr;
+            }
+            vec->push_back(new IR::NamedExpression(field->name, value));
+        }
+        const auto *resultType = st->getP4Type();
+        return new IR::StructExpression(srcInfo, resultType, resultType, *vec);
+    }
+    if (const auto *tf = type->to<IR::Type_Fragment>()) {
+        return getDefaultValue(tf->type, srcInfo);
+    }
+    if (const auto *tt = type->to<IR::Type_BaseList>()) {
+        auto *vec = new IR::Vector<IR::Expression>();
+        for (const auto *field : tt->components) {
+            const auto *value = getDefaultValue(field, srcInfo);
+            if (value == nullptr) {
+                return nullptr;
+            }
+            vec->push_back(value);
+        }
+        return new IR::ListExpression(srcInfo, *vec);
+    }
+    if (const auto *ts = type->to<IR::Type_Stack>()) {
+        auto *vec = new IR::Vector<IR::Expression>();
+        const auto *elementType = ts->elementType;
+        for (size_t i = 0; i < ts->getSize(); i++) {
+            const IR::Expression *invalid = nullptr;
+            if (elementType->is<IR::Type_Header>()) {
+                invalid = new IR::InvalidHeader(elementType->getP4Type());
+            } else {
+                BUG_CHECK(elementType->is<IR::Type_HeaderUnion>(),
+                          "%1%: expected a header or header union stack", elementType);
+                invalid = new IR::InvalidHeaderUnion(srcInfo, elementType->getP4Type());
+            }
+            vec->push_back(invalid);
+        }
+        const auto *resultType = ts->getP4Type();
+        return new IR::HeaderStackExpression(srcInfo, resultType, *vec, resultType);
+    }
+    if (valueRequired) {
+        P4C_UNIMPLEMENTED("%1%: No default value for type %2% (%3%).", srcInfo, type,
+                          type->node_type_name());
+    }
+    ::error(ErrorType::ERR_INVALID, "%1%: No default value for type %2% (%3%)", srcInfo, type,
+            type->node_type_name());
+    return nullptr;
 }
 
 const IR::Constant *getMaxValueConstant(const Type *t) {

--- a/ir/irutils.h
+++ b/ir/irutils.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "lib/big_int_util.h"
+#include "lib/source_file.h"
 
 namespace IR {
 
@@ -42,10 +43,25 @@ const Constant *getConstant(const Type *type, big_int v);
 /// @returns a bool literal. The value is cached.
 const BoolLiteral *getBoolLiteral(bool value);
 
-/// @returns the "default" value for a given type. The current mapping is
-/// Type_Bits       0
-/// Type_Boolean    false
-const Literal *getDefaultValue(const Type *type);
+/// @returns the "default" value for a given type.
+/// The resulting expression will have the specified srcInfo position.
+/// The current mapping as defined in the P4 specification is:
+/// Type_Bits           0
+/// Type_Boolean        false
+/// Type_InfInt         0
+/// Type_Enum           first member
+/// Type_SerEnum        first member
+/// Type_Error          NoError
+/// Type_String         ""
+/// Type_Header         InvalidHeader
+/// Type_HeaderUnion    InvalidHeaderUnion
+/// Type_StructLike     StructExpression (fields filled with getDefaultValue)
+/// Type_Fragment       recurses into getDefaultValue
+/// Type_BaseList       ListExpression (fields filled with getDefaultValue)
+/// Type_Stack          HeaderStackExpression (fields filled with getDefaultValue)
+/// Definition: https://p4.org/p4-spec/docs/P4-16-working-spec.html#sec-default-values
+const IR::Expression *getDefaultValue(const Type *type, const Util::SourceInfo &srcInfo = {},
+                                      bool valueRequired = false);
 
 /// Converts a bool literal into a constant of type Type_Bits and width 1.
 /// The value is 1, if the bool literal is true, 0 otherwise.

--- a/ir/irutils.h
+++ b/ir/irutils.h
@@ -35,6 +35,7 @@ const Type_Bits *getBitTypeToFit(int value);
 /* =========================================================================================
  *  Expressions
  * ========================================================================================= */
+
 /// @returns a constant. The value is cached.
 const Constant *getConstant(const Type *type, big_int v);
 
@@ -46,9 +47,27 @@ const BoolLiteral *getBoolLiteral(bool value);
 /// Type_Boolean    false
 const Literal *getDefaultValue(const Type *type);
 
+/// Converts a bool literal into a constant of type Type_Bits and width 1.
+/// The value is 1, if the bool literal is true, 0 otherwise.
+const IR::Constant *convertBoolLiteral(const IR::BoolLiteral *lit);
+
+/// @returns a constant with the maximum big_int value that can fit into this bit width.
+/// Implicitly converts boolean types to a bit vector of width one with value 1.
+const IR::Constant *getMaxValueConstant(const Type *t);
+
+/// Given an StructExpression, returns a flat vector of the expressions contained in that
+/// struct. Unfortunately, list and struct expressions are similar but have no common ancestors.
+/// This is why we require two separate methods.
+std::vector<const Expression *> flattenStructExpression(const StructExpression *structExpr);
+
+/// Given an ListExpression, returns a flat vector of the expressions contained in that
+/// list.
+std::vector<const Expression *> flattenListExpression(const ListExpression *listExpr);
+
 /* =========================================================================================
  *  Other helper functions
  * ========================================================================================= */
+
 /// @returns the big int value stored in a literal.
 big_int getBigIntFromLiteral(const Literal *);
 
@@ -66,15 +85,6 @@ big_int getMaxBvVal(int bitWidth);
 /// @returns the minimum value that can fit into this type.
 // This is 0 for unsigned and -(2^(t->size - 1)) for signed.
 big_int getMinBvVal(const Type *t);
-
-/// Given an StructExpression, returns a flat vector of the expressions contained in that
-/// struct. Unfortunately, list and struct expressions are similar but have no common ancestors.
-/// This is why we require two separate methods.
-std::vector<const Expression *> flattenStructExpression(const StructExpression *structExpr);
-
-/// Given an ListExpression, returns a flat vector of the expressions contained in that
-/// list.
-std::vector<const Expression *> flattenListExpression(const ListExpression *listExpr);
 
 }  // namespace IR
 

--- a/midend/coverage.cpp
+++ b/midend/coverage.cpp
@@ -6,6 +6,10 @@
 
 namespace P4::Coverage {
 
+bool SourceIdCmp::operator()(const IR::Node *s1, const IR::Node *s2) const {
+    return s1->clone_id < s2->clone_id;
+}
+
 CollectNodes::CollectNodes(CoverageOptions coverageOptions) : coverageOptions(coverageOptions) {}
 
 bool CollectNodes::preorder(const IR::AssignmentStatement *stmt) {
@@ -47,8 +51,10 @@ void printCoverageReport(const CoverageSet &all, const CoverageSet &visited) {
     LOG_FEATURE("coverage", 4, "Not covered program nodes:");
     for (const auto *node : all) {
         if (visited.count(node) == 0) {
-            auto sourceLine = node->getSourceInfo().toPosition().sourceLine;
-            LOG_FEATURE("coverage", 4, '\t' << sourceLine << ": " << *node);
+            const auto &srcInfo = node->getSourceInfo();
+            auto sourceLine = srcInfo.toPosition().sourceLine;
+            LOG_FEATURE("coverage", 4,
+                        '\t' << srcInfo.getSourceFile() << "\\" << sourceLine << ": " << *node);
         }
     }
     // Do not really need to know which program nodes we have covered. Increase the log level here.

--- a/midend/coverage.h
+++ b/midend/coverage.h
@@ -18,9 +18,7 @@ namespace P4::Coverage {
 
 /// Utility function to compare IR nodes in a set. We use their source info.
 struct SourceIdCmp {
-    bool operator()(const IR::Node *s1, const IR::Node *s2) const {
-        return s1->srcInfo < s2->srcInfo;
-    }
+    bool operator()(const IR::Node *s1, const IR::Node *s2) const;
 };
 
 /// Specifies, which IR nodes to track with this particular visitor.


### PR DESCRIPTION
- Merge the `defaultValue` from `defaultValues.h` with `getDefaultValue` from `irutils.h`
- Fix up small issues with the metadata collection test back ends. Also collect the parser states that were traversed.
- Clean up some incorrect naming after the expanding coverage from IR statements to IR nodes.
- Do not use source info for coverage sets, instead use the clone id.
- Move the inja submodule initialization into the testgen extension. 
- Fix incorrect variable setting in the CMake test backend files. 