### PR TITLE
Open up ResolutionContext interface a bit

### DIFF
--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -53,6 +53,7 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
     /// We are resolving a method call.  Find the arguments from the context.
     const IR::Vector<IR::Argument> *methodArguments(cstring name) const;
 
+ public:
     /// Resolve references for @p name, restricted to @p type declarations.
     const std::vector<const IR::IDeclaration *> *resolve(IR::ID name, ResolutionType type) const;
 
@@ -60,7 +61,9 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
     const IR::IDeclaration *resolveUnique(IR::ID name, ResolutionType type,
                                           const IR::INamespace * = nullptr) const;
 
-    const IR::IDeclaration *resolvePath(const IR::Path *path, bool isType) const;
+    /// Resolve @p path; if @p isType is `true` then resolution will
+    /// only return type nodes.
+    virtual const IR::IDeclaration *resolvePath(const IR::Path *path, bool isType) const;
 
     // Resolve a refrence to a type @p type.
     const IR::Type *resolveType(const IR::Type *type) const;
@@ -86,7 +89,7 @@ class ResolveReferences : public Inspector, private ResolutionContext {
  private:
     /// Resolve @p path; if @p isType is `true` then resolution will
     /// only return type nodes.
-    void resolvePath(const IR::Path *path, bool isType) const;
+    const IR::IDeclaration *resolvePath(const IR::Path *path, bool isType) const override;
 
  public:
     explicit ResolveReferences(/* out */ P4::ReferenceMap *refMap, bool checkShadow = false);

--- a/frontends/p4/methodInstance.cpp
+++ b/frontends/p4/methodInstance.cpp
@@ -150,17 +150,13 @@ ConstructorCall *ConstructorCall::resolve(const IR::ConstructorCallExpression *c
     if (auto tsc = ct->to<IR::Type_SpecializedCanonical>())
         ct = typeMap ? typeMap->getTypeType(tsc->baseType, true) : tsc;
 
-    if (ct->is<IR::Type_Extern>()) {
-        auto decl = refMap->getDeclaration(type->path, true);
-        auto ext = decl->to<IR::Type_Extern>();
-        BUG_CHECK(ext, "%1%: expected an extern type", dbp(decl));
+    auto decl = refMap->getDeclaration(type->path, true);
+    if (auto ext = decl ? decl->to<IR::Type_Extern>() : nullptr) {
         auto constr = ext->lookupConstructor(cce->arguments);
         result = new ExternConstructorCall(cce, ext->to<IR::Type_Extern>(), constr);
         BUG_CHECK(constr, "%1%: constructor not found", ext);
         constructorParameters = constr->type->parameters;
-    } else if (ct->is<IR::IContainer>()) {
-        auto decl = refMap->getDeclaration(type->path, true);
-        auto cont = decl->to<IR::IContainer>();
+    } else if (auto cont = decl ? decl->to<IR::IContainer>() : nullptr) {
         BUG_CHECK(cont, "%1%: expected a container", dbp(decl));
         result = new ContainerConstructorCall(cce, cont);
         constructorParameters = cont->getConstructorParameters();


### PR DESCRIPTION
- fix ConstructorCall::resolve to work without typeMap when just a ResolutionContext is available