### PR TITLE
[P4Testgen] Move some table code into helper functions, move gen_eq to "common" folder

### DIFF
--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -36,6 +36,7 @@ set(
 
   lib/arch_spec.cpp
   lib/format_int.cpp
+  lib/gen_eq.cpp
   lib/model.cpp
   lib/namespace_context.cpp
   lib/symbolic_env.cpp

--- a/backends/p4tools/common/lib/gen_eq.cpp
+++ b/backends/p4tools/common/lib/gen_eq.cpp
@@ -1,4 +1,4 @@
-#include "backends/p4tools/modules/testgen/lib/gen_eq.h"
+#include "backends/p4tools/common/lib/gen_eq.h"
 
 #include <cstddef>
 #include <string>
@@ -8,7 +8,7 @@
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 
-namespace P4Tools::P4Testgen {
+namespace P4Tools {
 
 const IR::Expression *GenEq::equate(const IR::Expression *target, const IR::Expression *keyset) {
     if (const auto *defaultKey = keyset->to<IR::DefaultExpression>()) {
@@ -113,4 +113,4 @@ const IR::Equ *GenEq::mkEq(const IR::Expression *e1, const IR::Expression *e2) {
     return new IR::Equ(IR::Type::Boolean::get(), e1, e2);
 }
 
-}  // namespace P4Tools::P4Testgen
+}  // namespace P4Tools

--- a/backends/p4tools/common/lib/gen_eq.h
+++ b/backends/p4tools/common/lib/gen_eq.h
@@ -1,9 +1,9 @@
-#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_GEN_EQ_H_
-#define BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_GEN_EQ_H_
+#ifndef BACKENDS_P4TOOLS_COMMON_LIB_GEN_EQ_H_
+#define BACKENDS_P4TOOLS_COMMON_LIB_GEN_EQ_H_
 
 #include "ir/ir.h"
 
-namespace P4Tools::P4Testgen {
+namespace P4Tools {
 
 /// Generates an equality on a target expression and a keyset expression, recursing into lists.
 /// This supports fuzzy matching on singleton lists: singleton lists are considered the same as
@@ -13,6 +13,7 @@ class GenEq {
  public:
     static const IR::Expression *equate(const IR::Expression *target, const IR::Expression *keyset);
 
+ private:
     static const IR::Expression *equate(const IR::Expression *target,
                                         const IR::DefaultExpression *keyset);
 
@@ -26,11 +27,10 @@ class GenEq {
     static const IR::Expression *equate(const IR::ListExpression *target,
                                         const IR::ListExpression *keyset);
 
- private:
     /// Convenience method for producing a typed Eq node on the given expressions.
     static const IR::Equ *mkEq(const IR::Expression *e1, const IR::Expression *e2);
 };
 
-}  // namespace P4Tools::P4Testgen
+}  // namespace P4Tools
 
-#endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_GEN_EQ_H_ */
+#endif /* BACKENDS_P4TOOLS_COMMON_LIB_GEN_EQ_H_ */

--- a/backends/p4tools/common/lib/table_utils.h
+++ b/backends/p4tools/common/lib/table_utils.h
@@ -64,6 +64,15 @@ std::vector<const IR::ActionListElement *> buildTableActionList(const IR::P4Tabl
 /// It is used for comparison.
 bool compareLPMEntries(const IR::Entry *leftIn, const IR::Entry *rightIn, size_t lpmIndex);
 
+/// @returns the name of the default action of the table as path expression.
+const IR::PathExpression *getDefaultActionName(const IR::P4Table &table);
+
+/// Matches the match values of an entry with the values and variables of the key.
+/// @returns a boolean expression describing the match.
+/// Returns a false IR::BoolLiteral if there are no keys.
+const IR::Expression *computeEntryMatch(const IR::P4Table &table, const IR::Entry &entry,
+                                        const IR::Key &key);
+
 }  // namespace P4Tools::TableUtils
 
 #endif /* BACKENDS_P4TOOLS_COMMON_LIB_TABLE_UTILS_H_ */

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -35,7 +35,6 @@ set(
   lib/continuation.cpp
   lib/execution_state.cpp
   lib/final_state.cpp
-  lib/gen_eq.cpp
   lib/logging.cpp
   lib/packet_vars.cpp
   lib/test_backend.cpp

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "backends/p4tools/common/core/solver.h"
+#include "backends/p4tools/common/lib/gen_eq.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/variables.h"
 #include "ir/declaration.h"
@@ -27,7 +28,6 @@
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
-#include "backends/p4tools/modules/testgen/lib/gen_eq.h"
 #include "backends/p4tools/modules/testgen/options.h"
 
 namespace P4Tools::P4Testgen {

--- a/frontends/p4/optimizeExpressions.h
+++ b/frontends/p4/optimizeExpressions.h
@@ -8,8 +8,7 @@ namespace P4 {
 
 /// Applies expression optimizations to the input node.
 /// Currently, performs constant folding and strength reduction.
-template <class T>
-const T *optimizeExpression(const T *node) {
+inline const IR::Expression *optimizeExpression(const IR::Expression *node) {
     auto pass = PassRepeated({
         new P4::StrengthReduction(nullptr, nullptr, nullptr),
         new P4::ConstantFolding(nullptr, nullptr, false),


### PR DESCRIPTION
Also simplify `optimizeExpressions.h`. The function does not need to be a template.