### PR TITLE
cmake: Fix include search for Z3 in testgen library

### DIFF
--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -114,7 +114,7 @@ configure_file(register.h.in register.h)
 
 # The library.
 add_p4tools_library(testgen ${TESTGEN_SOURCES})
-# make sure the testgen library sees both Z3 and Inja includes and anything that links to testgen
+# Make sure the testgen library and anything that links to it see both the Z3 and Inja includes.
 # also links to Z3 and inja
 target_link_libraries(testgen PUBLIC p4tools-common inja)
 

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -114,16 +114,15 @@ configure_file(register.h.in register.h)
 
 # The library.
 add_p4tools_library(testgen ${TESTGEN_SOURCES})
-add_dependencies(testgen p4tools-common inja)
-target_include_directories(testgen SYSTEM PUBLIC ${inja_SOURCE_DIR}/include)
-target_include_directories(testgen SYSTEM PUBLIC ${inja_SOURCE_DIR}/third_party/include)
+# make sure the testgen library sees both Z3 and Inja includes and anything that links to testgen
+# also links to Z3 and inja
+target_link_libraries(testgen PUBLIC ${TESTGEN_LIBS})
 
 # The executable.
 add_p4tools_executable(p4testgen main.cpp)
 target_link_libraries(
   p4testgen
   testgen
-  ${TESTGEN_LIBS}
 )
 
 add_custom_target(
@@ -148,7 +147,6 @@ if(ENABLE_GTESTS)
     testgen-gtest
     PRIVATE testgen
     PRIVATE gtest
-    ${TESTGEN_LIBS}
   )
 
   if(ENABLE_TESTING)

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -116,13 +116,14 @@ configure_file(register.h.in register.h)
 add_p4tools_library(testgen ${TESTGEN_SOURCES})
 # make sure the testgen library sees both Z3 and Inja includes and anything that links to testgen
 # also links to Z3 and inja
-target_link_libraries(testgen PUBLIC ${TESTGEN_LIBS})
+target_link_libraries(testgen PUBLIC p4tools-common inja)
 
 # The executable.
 add_p4tools_executable(p4testgen main.cpp)
 target_link_libraries(
   p4testgen
   testgen
+  ${TESTGEN_LIBS}
 )
 
 add_custom_target(
@@ -147,6 +148,7 @@ if(ENABLE_GTESTS)
     testgen-gtest
     PRIVATE testgen
     PRIVATE gtest
+    ${TESTGEN_LIBS}
   )
 
   if(ENABLE_TESTING)


### PR DESCRIPTION
@fruffy The change in https://github.com/p4lang/p4c/commit/38ba8dfd57d23aec71931b663f84d4eb86b0380a#diff-b2d8f4059a838269ba2d86ef0f39a84301da327327cd0415e56e7e6d68507e92R117 broke build of testgen on systems where Z3 does not have includes in the default system directory. The reason is that `add_dependencies` only affects ordering, not include-/link- search paths. Instead if I set the (static) `testgen` library to be linked to Z3 and `inja` with the `PUBLIC` option it will mean that both the library itself, and anything that it is linked to will see the include paths for both Z3 and inja and any resulting binaries will be linked to both. This not only fixes the problem, but it is also cleaner (except for the cmake weirdness that `target_link_libraries` affects both include- and link-search, but that it a feature of cmake itself).