### PR TITLE
[P4Testgen] Remove complete from the model, make it part of the evaluation step instead. 

### DIFF
--- a/backends/p4tools/common/lib/model.cpp
+++ b/backends/p4tools/common/lib/model.cpp
@@ -16,65 +16,40 @@
 
 namespace P4Tools {
 
-Model::SubstVisitor::SubstVisitor(const Model &model) : self(model) {}
+Model::SubstVisitor::SubstVisitor(const Model &model, bool doComplete)
+    : self(model), doComplete(doComplete) {}
 
 const IR::Literal *Model::SubstVisitor::preorder(IR::StateVariable *var) {
     BUG("At this point all state variables should have been resolved. Encountered %1%.", var);
 }
 
 const IR::Literal *Model::SubstVisitor::preorder(IR::SymbolicVariable *var) {
-    BUG_CHECK(self.symbolicMap.find(var) != self.symbolicMap.end(),
-              "Variable not bound in model: %1%", var);
+    auto varIt = self.symbolicMap.find(var);
+    if (varIt == self.symbolicMap.end()) {
+        if (doComplete) {
+            return IR::getDefaultValue(var->type, var->srcInfo, true)->checkedTo<IR::Literal>();
+        }
+        BUG("Variable not bound in model: %1%", var);
+    }
     prune();
-    return self.symbolicMap.at(var)->checkedTo<IR::Literal>();
+    return varIt->second->checkedTo<IR::Literal>();
 }
 
 const IR::Literal *Model::SubstVisitor::preorder(IR::TaintExpression *var) {
     return IR::getDefaultValue(var->type, var->getSourceInfo())->checkedTo<IR::Literal>();
 }
 
-Model::CompleteVisitor::CompleteVisitor(Model &model) : self(model) {}
-
-bool Model::CompleteVisitor::preorder(const IR::SymbolicVariable *var) {
-    if (self.symbolicMap.find(var) == self.symbolicMap.end()) {
-        LOG_FEATURE("common", 5,
-                    "***** Did not find a binding for " << var << ". Autocompleting." << std::endl);
-        const auto *type = var->type;
-        self.symbolicMap.emplace(var, IR::getDefaultValue(type, var->getSourceInfo()));
-    }
-    return false;
-}
-
-bool Model::CompleteVisitor::preorder(const IR::StateVariable *var) {
-    BUG("At this point all state variables should have been resolved. Encountered %1%.", var);
-}
-
-void Model::complete(const IR::Expression *expr) { expr->apply(CompleteVisitor(*this)); }
-
-void Model::complete(const SymbolicSet &inputSet) {
-    auto completionVisitor = CompleteVisitor(*this);
-    for (const auto &var : inputSet) {
-        var->apply(completionVisitor);
-    }
-}
-
-void Model::complete(const SymbolicMapType &inputMap) {
-    for (const auto &inputTuple : inputMap) {
-        const auto *expr = inputTuple.second;
-        expr->apply(CompleteVisitor(*this));
-    }
-}
-
 const IR::StructExpression *Model::evaluateStructExpr(const IR::StructExpression *structExpr,
+                                                      bool doComplete,
                                                       ExpressionMap *resolvedExpressions) const {
     auto *resolvedStructExpr =
         new IR::StructExpression(structExpr->srcInfo, structExpr->type, structExpr->structType, {});
     for (const auto *namedExpr : structExpr->components) {
         const IR::Expression *resolvedExpr = nullptr;
         if (const auto *subStructExpr = namedExpr->expression->to<IR::StructExpression>()) {
-            resolvedExpr = evaluateStructExpr(subStructExpr, resolvedExpressions);
+            resolvedExpr = evaluateStructExpr(subStructExpr, doComplete, resolvedExpressions);
         } else {
-            resolvedExpr = evaluate(namedExpr->expression, resolvedExpressions);
+            resolvedExpr = evaluate(namedExpr->expression, doComplete, resolvedExpressions);
         }
         resolvedStructExpr->components.push_back(
             new IR::NamedExpression(namedExpr->srcInfo, namedExpr->name, resolvedExpr));
@@ -83,23 +58,24 @@ const IR::StructExpression *Model::evaluateStructExpr(const IR::StructExpression
 }
 
 const IR::ListExpression *Model::evaluateListExpr(const IR::ListExpression *listExpr,
+                                                  bool doComplete,
                                                   ExpressionMap *resolvedExpressions) const {
     auto *resolvedListExpr = new IR::ListExpression(listExpr->srcInfo, listExpr->type, {});
     for (const auto *expr : listExpr->components) {
         const IR::Expression *resolvedExpr = nullptr;
         if (const auto *subStructExpr = expr->to<IR::ListExpression>()) {
-            resolvedExpr = evaluateListExpr(subStructExpr, resolvedExpressions);
+            resolvedExpr = evaluateListExpr(subStructExpr, doComplete, resolvedExpressions);
         } else {
-            resolvedExpr = evaluate(expr, resolvedExpressions);
+            resolvedExpr = evaluate(expr, doComplete, resolvedExpressions);
         }
         resolvedListExpr->components.push_back(resolvedExpr);
     }
     return resolvedListExpr;
 }
 
-const IR::Literal *Model::evaluate(const IR::Expression *expr,
+const IR::Literal *Model::evaluate(const IR::Expression *expr, bool doComplete,
                                    ExpressionMap *resolvedExpressions) const {
-    const auto *substituted = expr->apply(SubstVisitor(*this));
+    const auto *substituted = expr->apply(SubstVisitor(*this, doComplete));
     const auto *evaluated = P4::optimizeExpression(substituted);
     const auto *literal = evaluated->checkedTo<IR::Literal>();
     // Add the variable to the resolvedExpressions list, if the list is not null.
@@ -109,12 +85,13 @@ const IR::Literal *Model::evaluate(const IR::Expression *expr,
     return literal;
 }
 
-Model *Model::evaluate(const SymbolicMapType &inputMap, ExpressionMap *resolvedExpressions) const {
+Model *Model::evaluate(const SymbolicMapType &inputMap, bool doComplete,
+                       ExpressionMap *resolvedExpressions) const {
     auto *result = new Model(*this);
     for (const auto &inputTuple : inputMap) {
         const auto &name = inputTuple.first;
         const auto *expr = inputTuple.second;
-        (*result)[name] = evaluate(expr, resolvedExpressions);
+        (*result)[name] = evaluate(expr, doComplete, resolvedExpressions);
     }
     return result;
 }

--- a/backends/p4tools/common/lib/symbolic_env.cpp
+++ b/backends/p4tools/common/lib/symbolic_env.cpp
@@ -31,17 +31,9 @@ void SymbolicEnv::set(const IR::StateVariable &var, const IR::Expression *value)
     map[var] = P4::optimizeExpression(value);
 }
 
-Model *SymbolicEnv::complete(const Model &model) const {
-    // Produce a new model based on the input model
-    // Add the variables contained in this environment and try to complete them.
-    auto *newModel = new Model(model);
-    newModel->complete(map);
-    return newModel;
-}
-
 Model *SymbolicEnv::evaluate(const Model &model) const {
     // Produce a new model based on the input model
-    return model.evaluate(map);
+    return model.evaluate(map, true);
 }
 
 const IR::Expression *SymbolicEnv::subst(const IR::Expression *expr) const {

--- a/backends/p4tools/common/lib/symbolic_env.h
+++ b/backends/p4tools/common/lib/symbolic_env.h
@@ -26,9 +26,6 @@ class SymbolicEnv {
     /// done on the given value before updating the symbolic state.
     void set(const IR::StateVariable &var, const IR::Expression *value);
 
-    /// Completes the model with all variables referenced in the symbolic environment.
-    [[nodiscard]] Model *complete(const Model &model) const;
-
     /// Evaluates this symbolic environment in the context of the given model.
     ///
     /// A BUG occurs if any symbolic value in this environment refers to a variable that is not

--- a/backends/p4tools/common/lib/taint.cpp
+++ b/backends/p4tools/common/lib/taint.cpp
@@ -274,14 +274,14 @@ class MaskBuilder : public Transform {
     MaskBuilder() { visitDagOnce = false; }
 };
 
-const IR::Literal *Taint::buildTaintMask(const SymbolicMapType &varMap, const Model *completedModel,
+const IR::Literal *Taint::buildTaintMask(const SymbolicMapType &varMap, const Model *evaluatedModel,
                                          const IR::Expression *programPacket) {
     // First propagate taint and simplify the packet.
     const auto *taintedPacket = programPacket->apply(TaintPropagator(varMap));
     // Then create the mask based on the remaining expressions.
     const auto *mask = taintedPacket->apply(MaskBuilder());
     // Produce the evaluated literal. The hex expression should only have 0 or f.
-    return completedModel->evaluate(mask);
+    return evaluatedModel->evaluate(mask, false);
 }
 
 const IR::Expression *Taint::propagateTaint(const SymbolicMapType &varMap,

--- a/backends/p4tools/common/lib/taint.h
+++ b/backends/p4tools/common/lib/taint.h
@@ -24,7 +24,7 @@ class Taint {
     /// @returns the mask for the corresponding program packet, indicating bits of the expression
     /// which are not tainted.
     static const IR::Literal *buildTaintMask(const SymbolicMapType &varMap,
-                                             const Model *completedModel,
+                                             const Model *evaluatedModel,
                                              const IR::Expression *programPacket);
 };
 

--- a/backends/p4tools/common/lib/trace_event.cpp
+++ b/backends/p4tools/common/lib/trace_event.cpp
@@ -11,10 +11,10 @@ TraceEvent::TraceEvent() = default;
 
 const TraceEvent *TraceEvent::subst(const SymbolicEnv & /*env*/) const { return this; }
 
-void TraceEvent::complete(Model * /*model*/) const {}
-
 const TraceEvent *TraceEvent::apply(Transform & /*visitor*/) const { return this; }
 
-const TraceEvent *TraceEvent::evaluate(const Model & /*model*/) const { return this; }
+const TraceEvent *TraceEvent::evaluate(const Model & /*model*/, bool /*doComplete*/) const {
+    return this;
+}
 
 }  // namespace P4Tools

--- a/backends/p4tools/common/lib/trace_event.h
+++ b/backends/p4tools/common/lib/trace_event.h
@@ -27,12 +27,9 @@ class TraceEvent : public ICastable {
     /// Applies the given IR transform to the expressions in this trace event.
     virtual const TraceEvent *apply(Transform &visitor) const;
 
-    /// Completes a model with the variables used in this trace event.
-    virtual void complete(Model *model) const;
-
     /// Evaluates expressions in the body of this trace event for their concrete value in the given
     /// model. A BUG occurs if there are any variables that are unbound by the given model.
-    [[nodiscard]] virtual const TraceEvent *evaluate(const Model &model) const;
+    [[nodiscard]] virtual const TraceEvent *evaluate(const Model &model, bool doComplete) const;
 
  protected:
     /// Prints this trace event to the given ostream.

--- a/backends/p4tools/common/lib/trace_event_types.h
+++ b/backends/p4tools/common/lib/trace_event_types.h
@@ -47,8 +47,7 @@ class Expression : public Generic {
  public:
     [[nodiscard]] const Expression *subst(const SymbolicEnv &env) const override;
     const Expression *apply(Transform &visitor) const override;
-    void complete(Model *model) const override;
-    [[nodiscard]] const Expression *evaluate(const Model &model) const override;
+    [[nodiscard]] const Expression *evaluate(const Model &model, bool doComplete) const override;
 
     explicit Expression(const IR::Expression *value, cstring label);
     ~Expression() override = default;
@@ -76,8 +75,8 @@ class IfStatementCondition : public TraceEvent {
  public:
     [[nodiscard]] const IfStatementCondition *subst(const SymbolicEnv &env) const override;
     const IfStatementCondition *apply(Transform &visitor) const override;
-    void complete(Model *model) const override;
-    [[nodiscard]] const IfStatementCondition *evaluate(const Model &model) const override;
+    [[nodiscard]] const IfStatementCondition *evaluate(const Model &model,
+                                                       bool doComplete) const override;
 
     explicit IfStatementCondition(const IR::Expression *cond);
 
@@ -109,8 +108,8 @@ class ExtractSuccess : public TraceEvent {
  public:
     [[nodiscard]] const ExtractSuccess *subst(const SymbolicEnv &env) const override;
     const ExtractSuccess *apply(Transform &visitor) const override;
-    void complete(Model *model) const override;
-    [[nodiscard]] const ExtractSuccess *evaluate(const Model &model) const override;
+    [[nodiscard]] const ExtractSuccess *evaluate(const Model &model,
+                                                 bool doComplete) const override;
 
     /// @returns the extracted header label stored in this class.
     [[nodiscard]] const IR::Expression *getExtractedHeader() const;
@@ -179,8 +178,7 @@ class Emit : public TraceEvent {
  public:
     [[nodiscard]] const Emit *subst(const SymbolicEnv &env) const override;
     const Emit *apply(Transform &visitor) const override;
-    void complete(Model *model) const override;
-    [[nodiscard]] const Emit *evaluate(const Model &model) const override;
+    [[nodiscard]] const Emit *evaluate(const Model &model, bool doComplete) const override;
 
     Emit(const IR::Expression *emitHeader,
          std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields);
@@ -211,9 +209,7 @@ class Packet : public TraceEvent {
 
     const Packet *apply(Transform &visitor) const override;
 
-    void complete(Model *model) const override;
-
-    [[nodiscard]] const Packet *evaluate(const Model &model) const override;
+    [[nodiscard]] const Packet *evaluate(const Model &model, bool doComplete) const override;
 
     [[nodiscard]] const Packet *subst(const SymbolicEnv &env) const override;
 

--- a/backends/p4tools/common/lib/variables.cpp
+++ b/backends/p4tools/common/lib/variables.cpp
@@ -18,11 +18,9 @@ const IR::StateVariable &getStateVariable(const IR::Type *type, cstring name) {
     return *new IR::StateVariable(new IR::Member(type, &VAR_PREFIX, name));
 }
 
-const IR::SymbolicVariable *getSymbolicVariable(const IR::Type *type, int incarnation,
-                                                cstring name) {
+const IR::SymbolicVariable *getSymbolicVariable(const IR::Type *type, cstring name) {
     // TODO: Is caching worth it here?
-    auto symbolicName = name + "_" + std::to_string(incarnation);
-    return new IR::SymbolicVariable(type, symbolicName);
+    return new IR::SymbolicVariable(type, name);
 }
 
 IR::StateVariable getHeaderValidity(const IR::Expression *headerRef) {

--- a/backends/p4tools/common/lib/variables.h
+++ b/backends/p4tools/common/lib/variables.h
@@ -24,8 +24,7 @@ const IR::StateVariable &getStateVariable(const IR::Type *type, cstring name);
 ///
 /// A BUG occurs if this was previously called with the same @name and @incarnation, but with a
 /// different @type.
-const IR::SymbolicVariable *getSymbolicVariable(const IR::Type *type, int incarnation,
-                                                cstring name);
+const IR::SymbolicVariable *getSymbolicVariable(const IR::Type *type, cstring name);
 
 /// @see ToolsVariables::getSymbolicVariable.
 /// This function is used to generated variables caused by undefined behavior. This is merely a

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
@@ -341,8 +341,7 @@ const IR::Literal *AbstractStepper::evaluateExpression(
     const IR::Literal *result = nullptr;
     if (solverResult != std::nullopt && *solverResult) {
         auto model = Model(solver.getSymbolicMapping());
-        model.complete(expr);
-        result = model.evaluate(expr);
+        result = model.evaluate(expr, true);
     }
     return result;
 }

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
@@ -91,14 +91,14 @@ class TableStepper {
     /// these do not match it steps through the default implementation. If it does not match either,
     /// a P4C_UNIMPLEMENTED is thrown.
     virtual const IR::Expression *computeTargetMatchType(
-        ExecutionState &nextState, const TableUtils::KeyProperties &keyProperties,
-        TableMatchMap *matches, const IR::Expression *hitCondition);
+        const TableUtils::KeyProperties &keyProperties, TableMatchMap *matches,
+        const IR::Expression *hitCondition);
 
     /// A helper function that computes whether a control-plane/table-key hits or not. This does not
     /// handle constant entries, it is specialized for control plane entries.
     /// The function also tracks the list of field matches created to achieve a  hit. We later use
     /// this to insert table entries using the STF/PTF framework.
-    const IR::Expression *computeHit(ExecutionState &nextState, TableMatchMap *matches);
+    const IR::Expression *computeHit(TableMatchMap *matches);
 
     /// Collects properties that may be set per table. Target back end may have different semantics
     /// for table execution that need to be collect before evaluation the table.

--- a/backends/p4tools/modules/testgen/lib/concolic.cpp
+++ b/backends/p4tools/modules/testgen/lib/concolic.cpp
@@ -38,7 +38,7 @@ bool ConcolicMethodImpls::matches(const std::vector<cstring> &paramNames,
 }
 
 bool ConcolicMethodImpls::exec(cstring concolicMethodName, const IR::ConcolicVariable *var,
-                               const ExecutionState &state, const Model &completedModel,
+                               const ExecutionState &state, const Model &evaluatedModel,
                                ConcolicVariableMap *resolvedConcolicVariables) const {
     if (impls.count(concolicMethodName) == 0) {
         return false;
@@ -66,7 +66,7 @@ bool ConcolicMethodImpls::exec(cstring concolicMethodName, const IR::ConcolicVar
     if (!matchingImpl) {
         return false;
     }
-    (*matchingImpl)(concolicMethodName, var, state, completedModel, resolvedConcolicVariables);
+    (*matchingImpl)(concolicMethodName, var, state, evaluatedModel, resolvedConcolicVariables);
     return true;
 }
 
@@ -98,7 +98,7 @@ bool ConcolicResolver::preorder(const IR::ConcolicVariable *var) {
     // Convert the concolic member variable to a state variable.
     auto concolicReplacment = resolvedConcolicVariables.find(*var);
     if (concolicReplacment == resolvedConcolicVariables.end()) {
-        bool found = concolicMethodImpls.exec(concolicMethodName, var, state, completedModel,
+        bool found = concolicMethodImpls.exec(concolicMethodName, var, state, evaluatedModel,
                                               &resolvedConcolicVariables);
         BUG_CHECK(found, "Unknown or unimplemented concolic method: %1%", concolicMethodName);
     }
@@ -109,17 +109,17 @@ const ConcolicVariableMap *ConcolicResolver::getResolvedConcolicVariables() cons
     return &resolvedConcolicVariables;
 }
 
-ConcolicResolver::ConcolicResolver(const Model &completedModel, const ExecutionState &state,
+ConcolicResolver::ConcolicResolver(const Model &evaluatedModel, const ExecutionState &state,
                                    const ConcolicMethodImpls &concolicMethodImpls)
-    : state(state), completedModel(completedModel), concolicMethodImpls(concolicMethodImpls) {
+    : state(state), evaluatedModel(evaluatedModel), concolicMethodImpls(concolicMethodImpls) {
     visitDagOnce = false;
 }
 
-ConcolicResolver::ConcolicResolver(const Model &completedModel, const ExecutionState &state,
+ConcolicResolver::ConcolicResolver(const Model &evaluatedModel, const ExecutionState &state,
                                    const ConcolicMethodImpls &concolicMethodImpls,
                                    ConcolicVariableMap resolvedConcolicVariables)
     : state(state),
-      completedModel(completedModel),
+      evaluatedModel(evaluatedModel),
       resolvedConcolicVariables(std::move(resolvedConcolicVariables)),
       concolicMethodImpls(concolicMethodImpls) {
     visitDagOnce = false;

--- a/backends/p4tools/modules/testgen/lib/concolic.h
+++ b/backends/p4tools/modules/testgen/lib/concolic.h
@@ -34,7 +34,7 @@ class ConcolicMethodImpls {
  private:
     using MethodImpl = std::function<void(
         cstring concolicMethodName, const IR::ConcolicVariable *var, const ExecutionState &state,
-        const Model &completedModel, ConcolicVariableMap *resolvedConcolicVariables)>;
+        const Model &evaluatedModel, ConcolicVariableMap *resolvedConcolicVariables)>;
 
     ordered_map<cstring, ordered_map<uint, std::list<std::pair<std::vector<cstring>, MethodImpl>>>>
         impls;
@@ -48,7 +48,7 @@ class ConcolicMethodImpls {
     explicit ConcolicMethodImpls(const ImplList &implList);
 
     bool exec(cstring concolicMethodName, const IR::ConcolicVariable *var,
-              const ExecutionState &state, const Model &completedModel,
+              const ExecutionState &state, const Model &evaluatedModel,
               ConcolicVariableMap *resolvedConcolicVariables) const;
 
     void add(const ImplList &implList);
@@ -56,10 +56,10 @@ class ConcolicMethodImpls {
 
 class ConcolicResolver : public Inspector {
  public:
-    explicit ConcolicResolver(const Model &completedModel, const ExecutionState &state,
+    explicit ConcolicResolver(const Model &evaluatedModel, const ExecutionState &state,
                               const ConcolicMethodImpls &concolicMethodImpls);
 
-    ConcolicResolver(const Model &completedModel, const ExecutionState &state,
+    ConcolicResolver(const Model &evaluatedModel, const ExecutionState &state,
                      const ConcolicMethodImpls &concolicMethodImpls,
                      ConcolicVariableMap resolvedConcolicVariables);
 
@@ -71,8 +71,8 @@ class ConcolicResolver : public Inspector {
     /// Execution state may be used by concolic implementations to access specific state.
     const ExecutionState &state;
 
-    /// The completed model is queried to produce a (random) assignment for concolic inputs.
-    const Model &completedModel;
+    /// The evaluated model is queried to produce a (random) assignment for concolic inputs.
+    const Model &evaluatedModel;
 
     /// A map of the concolic variables and the assertion associated with the variable. These
     /// assertions are used to add constraints to the solver.

--- a/backends/p4tools/modules/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/execution_state.cpp
@@ -385,8 +385,7 @@ const IR::Expression *ExecutionState::peekPacketBuffer(int amount) {
     if (diff > 0) {
         // We need to enlarge the input packet by the amount we are exceeding the buffer.
         // TODO: How should we perform accounting here?
-        const IR::Expression *newVar =
-            createSymbolicVariable(IR::getBitType(diff), "pktVar", numAllocatedSymbolicVariables);
+        const IR::Expression *newVar = createPacketVariable(IR::getBitType(diff));
         appendToInputPacket(newVar);
         // If the buffer was not empty, append the data we have consumed to the newly generated
         // content and reset the buffer.
@@ -428,8 +427,7 @@ const IR::Expression *ExecutionState::slicePacketBuffer(int amount) {
     if (diff > 0) {
         // We need to enlarge the input packet by the amount we are exceeding the buffer.
         // TODO: How should we perform accounting here?
-        const IR::Expression *newVar =
-            createSymbolicVariable(IR::getBitType(diff), "pktVar", numAllocatedSymbolicVariables);
+        const IR::Expression *newVar = createPacketVariable(IR::getBitType(diff));
         appendToInputPacket(newVar);
         // If the buffer was not empty, append the data we have consumed to the newly generated
         // content and reset the buffer.
@@ -505,15 +503,15 @@ const IR::StateVariable &ExecutionState::getCurrentParserErrorLabel() const {
  *  Variables and symbolic constants
  * ============================================================================================= */
 
-const IR::SymbolicVariable *ExecutionState::createSymbolicVariable(const IR::Type *type,
-                                                                   cstring name,
-                                                                   std::optional<int> instanceID) {
-    if (instanceID.has_value()) {
-        name = name + "_" + std::to_string(instanceID.value());
-    }
-    const auto *variables = ToolsVariables::getSymbolicVariable(type, name);
-    numAllocatedSymbolicVariables++;
-    return variables;
+const IR::SymbolicVariable *ExecutionState::createPacketVariable(const IR::Type *type) {
+    const auto *variable = ToolsVariables::getSymbolicVariable(
+        type, "pktvar_" + std::to_string(numAllocatedPacketVariables));
+    numAllocatedPacketVariables++;
+    BUG_CHECK(numAllocatedPacketVariables < UINT16_MAX,
+              "Allocating too many symbolic packet variables. The symbolic variable counter with "
+              "maximum size %1% counter will overflow.",
+              UINT16_MAX);
+    return variable;
 }
 
 }  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/execution_state.h
+++ b/backends/p4tools/modules/testgen/lib/execution_state.h
@@ -59,9 +59,9 @@ class ExecutionState : public AbstractExecutionState {
     ~ExecutionState() override = default;
 
  private:
-    /// The list of variables that have been created in this state.
-    /// These variables are later fed to the model for completion.
-    SymbolicSet allocatedSymbolicVariables;
+    /// The number of variables that have been created in this state.
+    /// Used to create unique symbolic variables in some cases.
+    int numAllocatedSymbolicVariables = 0;
 
     /// The program trace for the current program point (i.e., how we got to the current state).
     std::vector<std::reference_wrapper<const TraceEvent>> trace;
@@ -369,18 +369,12 @@ class ExecutionState : public AbstractExecutionState {
     /* =========================================================================================
      *  Variables and symbolic constants.
      * =========================================================================================
-     *  These mirror what's available in IRUtils, but automatically fill in the incarnation number,
-     *  based on how many times newParser() has been called.
      */
-    /// @returns the symbolic variables that were allocated in this state
-    [[nodiscard]] const SymbolicSet &getSymbolicVariables() const;
-
     /// @see ToolsVariables::getSymbolicVariable.
     /// We also place the symbolic variables in the set of allocated symbolic variables of this
     /// state.
-    [[nodiscard]] const IR::SymbolicVariable *createSymbolicVariable(const IR::Type *type,
-                                                                     cstring name,
-                                                                     uint64_t instanceID = 0);
+    [[nodiscard]] const IR::SymbolicVariable *createSymbolicVariable(
+        const IR::Type *type, cstring name, std::optional<int> instanceID = std::nullopt);
 
     /* =========================================================================================
      *  Constructors

--- a/backends/p4tools/modules/testgen/lib/execution_state.h
+++ b/backends/p4tools/modules/testgen/lib/execution_state.h
@@ -39,18 +39,31 @@ class ExecutionState : public AbstractExecutionState {
      public:
         using ExceptionHandlers = std::map<Continuation::Exception, Continuation>;
 
+     private:
         Continuation normalContinuation;
         ExceptionHandlers exceptionHandlers;
         const NamespaceContext *namespaces = nullptr;
 
-        StackFrame(Continuation normalContinuation, const NamespaceContext *namespaces)
-            : StackFrame(normalContinuation, {}, namespaces) {}
+     public:
+        StackFrame(Continuation normalContinuation, const NamespaceContext *namespaces);
 
         StackFrame(Continuation normalContinuation, ExceptionHandlers exceptionHandlers,
-                   const NamespaceContext *namespaces)
-            : normalContinuation(normalContinuation),
-              exceptionHandlers(exceptionHandlers),
-              namespaces(namespaces) {}
+                   const NamespaceContext *namespaces);
+
+        StackFrame(const StackFrame &) = default;
+        StackFrame(StackFrame &&) noexcept = default;
+        StackFrame &operator=(const StackFrame &) = default;
+        StackFrame &operator=(StackFrame &&) = default;
+        ~StackFrame() = default;
+
+        /// @returns the top-level continuation of this particular stack frame.
+        [[nodiscard]] const Continuation &getContinuation() const;
+
+        /// @returns the exception handlers contained within this stack frame.
+        [[nodiscard]] const ExceptionHandlers &getExceptionHandlers() const;
+
+        /// @returns the namespaces contained within this stack frame.
+        [[nodiscard]] const NamespaceContext *getNameSpaces() const;
     };
 
     /// No move semantics because of constant members. We always need to clone a state.
@@ -61,7 +74,7 @@ class ExecutionState : public AbstractExecutionState {
  private:
     /// The number of variables that have been created in this state.
     /// Used to create unique symbolic variables in some cases.
-    int numAllocatedSymbolicVariables = 0;
+    uint32_t numAllocatedSymbolicVariables = 0;
 
     /// The program trace for the current program point (i.e., how we got to the current state).
     std::vector<std::reference_wrapper<const TraceEvent>> trace;

--- a/backends/p4tools/modules/testgen/lib/execution_state.h
+++ b/backends/p4tools/modules/testgen/lib/execution_state.h
@@ -72,10 +72,6 @@ class ExecutionState : public AbstractExecutionState {
     ~ExecutionState() override = default;
 
  private:
-    /// The number of variables that have been created in this state.
-    /// Used to create unique symbolic variables in some cases.
-    uint32_t numAllocatedSymbolicVariables = 0;
-
     /// The program trace for the current program point (i.e., how we got to the current state).
     std::vector<std::reference_wrapper<const TraceEvent>> trace;
 
@@ -131,6 +127,16 @@ class ExecutionState : public AbstractExecutionState {
 
     /// State that is needed to track reachability of statements given a query.
     ReachabilityEngineState *reachabilityEngineState = nullptr;
+
+    /// The number of individual packet variables that have been created in this state.
+    /// Used to create unique symbolic variables in some cases.
+    uint16_t numAllocatedPacketVariables = 0;
+
+    /// Helper function to create a new, unique symbolic packet variable.
+    /// Keeps track of the allocated packet variables by incrementing @ref
+    /// numAllocatedPacketVariables.
+    /// @returns a fresh symbolic variable.
+    [[nodiscard]] const IR::SymbolicVariable *createPacketVariable(const IR::Type *type);
 
     /* =========================================================================================
      *  Accessors
@@ -378,16 +384,6 @@ class ExecutionState : public AbstractExecutionState {
 
     /// @returns the current parser error label. Throws a BUG if the label is a nullptr.
     [[nodiscard]] const IR::StateVariable &getCurrentParserErrorLabel() const;
-
-    /* =========================================================================================
-     *  Variables and symbolic constants.
-     * =========================================================================================
-     */
-    /// @see ToolsVariables::getSymbolicVariable.
-    /// We also place the symbolic variables in the set of allocated symbolic variables of this
-    /// state.
-    [[nodiscard]] const IR::SymbolicVariable *createSymbolicVariable(
-        const IR::Type *type, cstring name, std::optional<int> instanceID = std::nullopt);
 
     /* =========================================================================================
      *  Constructors

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -144,8 +144,8 @@ TestBackEnd::TestInfo TestBackEnd::produceTestInfo(
     const std::vector<std::reference_wrapper<const TraceEvent>> *programTraces) {
     // Evaluate all the important expressions necessary for program execution by using the
     // completed model.
-    int calculatedPacketSize =
-        IR::getIntFromLiteral(completedModel->evaluate(ExecutionState::getInputPacketSizeVar()));
+    int calculatedPacketSize = IR::getIntFromLiteral(
+        completedModel->evaluate(ExecutionState::getInputPacketSizeVar(), true));
     const auto *inputPacketExpr = executionState->getInputPacket();
     // The payload fills the space between the minimum input size needed and the symbolically
     // calculated packet size.
@@ -157,12 +157,12 @@ TestBackEnd::TestInfo TestBackEnd::produceTestInfo(
             IR::getBitType(outputPacketExpr->type->width_bits() + payloadExpr->type->width_bits()),
             outputPacketExpr, payloadExpr);
     }
-    const auto *inputPacket = completedModel->evaluate(inputPacketExpr);
-    const auto *outputPacket = completedModel->evaluate(outputPacketExpr);
+    const auto *inputPacket = completedModel->evaluate(inputPacketExpr, true);
+    const auto *outputPacket = completedModel->evaluate(outputPacketExpr, true);
     const auto *inputPort =
-        completedModel->evaluate(executionState->get(programInfo.getTargetInputPortVar()));
+        completedModel->evaluate(executionState->get(programInfo.getTargetInputPortVar()), true);
 
-    const auto *outputPortVar = completedModel->evaluate(outputPortExpr);
+    const auto *outputPortVar = completedModel->evaluate(outputPortExpr, true);
     // Build the taint mask by dissecting the program packet variable
     const auto *evalMask = Taint::buildTaintMask(executionState->getSymbolicEnv().getInternalMap(),
                                                  completedModel, outputPacketExpr);

--- a/backends/p4tools/modules/testgen/lib/test_object.h
+++ b/backends/p4tools/modules/testgen/lib/test_object.h
@@ -26,7 +26,7 @@ class TestObject : public ICastable {
 
     /// @returns a version of the test object where all expressions are resolved and symbolic
     /// variables are substituted according to the mapping present in the @param model.
-    [[nodiscard]] virtual const TestObject *evaluate(const Model &model) const = 0;
+    [[nodiscard]] virtual const TestObject *evaluate(const Model &model, bool doComplete) const = 0;
 };
 
 /// A map of test objects.

--- a/backends/p4tools/modules/testgen/lib/test_spec.h
+++ b/backends/p4tools/modules/testgen/lib/test_spec.h
@@ -38,7 +38,7 @@ class Packet : public TestObject {
  public:
     Packet(int port, const IR::Expression *payload, const IR::Expression *payloadIgnoreMask);
 
-    [[nodiscard]] const Packet *evaluate(const Model &model) const override;
+    [[nodiscard]] const Packet *evaluate(const Model &model, bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 
@@ -71,7 +71,7 @@ class ActionArg : public TestObject {
  public:
     ActionArg(const IR::Parameter *param, const IR::Expression *value);
 
-    [[nodiscard]] const ActionArg *evaluate(const Model &model) const override;
+    [[nodiscard]] const ActionArg *evaluate(const Model &model, bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 
@@ -102,7 +102,7 @@ class ActionCall : public TestObject {
 
     ActionCall(const IR::P4Action *action, std::vector<ActionArg> args);
 
-    [[nodiscard]] const ActionCall *evaluate(const Model &model) const override;
+    [[nodiscard]] const ActionCall *evaluate(const Model &model, bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 
@@ -143,7 +143,7 @@ class Ternary : public TableMatch {
     explicit Ternary(const IR::KeyElement *key, const IR::Expression *value,
                      const IR::Expression *mask);
 
-    [[nodiscard]] const Ternary *evaluate(const Model &model) const override;
+    [[nodiscard]] const Ternary *evaluate(const Model &model, bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 
@@ -170,7 +170,7 @@ class LPM : public TableMatch {
     explicit LPM(const IR::KeyElement *key, const IR::Expression *value,
                  const IR::Expression *prefixLength);
 
-    [[nodiscard]] const LPM *evaluate(const Model &model) const override;
+    [[nodiscard]] const LPM *evaluate(const Model &model, bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 
@@ -193,7 +193,7 @@ class Exact : public TableMatch {
  public:
     explicit Exact(const IR::KeyElement *key, const IR::Expression *value);
 
-    [[nodiscard]] const Exact *evaluate(const Model &model) const override;
+    [[nodiscard]] const Exact *evaluate(const Model &model, bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 
@@ -217,7 +217,7 @@ class TableRule : public TestObject {
  public:
     TableRule(TableMatchMap matches, int priority, ActionCall action, int ttl);
 
-    [[nodiscard]] const TableRule *evaluate(const Model &model) const override;
+    [[nodiscard]] const TableRule *evaluate(const Model &model, bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 
@@ -255,7 +255,7 @@ class TableConfig : public TestObject {
 
     [[nodiscard]] cstring getObjectName() const override;
 
-    [[nodiscard]] const TableConfig *evaluate(const Model &model) const override;
+    [[nodiscard]] const TableConfig *evaluate(const Model &model, bool doComplete) const override;
 
     /// @returns the table rules of this table.
     [[nodiscard]] const std::vector<TableRule> *getRules() const;

--- a/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
@@ -11,6 +11,7 @@
 #include "backends/p4tools/common/core/solver.h"
 #include "backends/p4tools/common/lib/arch_spec.h"
 #include "backends/p4tools/common/lib/constants.h"
+#include "backends/p4tools/common/lib/variables.h"
 #include "ir/id.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"
@@ -80,7 +81,7 @@ void Bmv2V1ModelCmdStepper::initializeTargetEnvironment(ExecutionState &nextStat
     const auto *nineBitType = IR::getBitType(9);
     const auto *oneBitType = IR::getBitType(1);
     nextState.set(programInfo.getTargetInputPortVar(),
-                  nextState.createSymbolicVariable(nineBitType, "bmv2_ingress_port"));
+                  ToolsVariables::getSymbolicVariable(nineBitType, "bmv2_ingress_port"));
     // BMv2 implicitly sets the output port to 0.
     nextState.set(programInfo.getTargetOutputPortVar(), IR::getConstant(nineBitType, 0));
     // Initialize parser_err with no error.

--- a/backends/p4tools/modules/testgen/targets/bmv2/concolic.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/concolic.cpp
@@ -100,8 +100,8 @@ big_int Bmv2Concolic::computeChecksum(const std::vector<const IR::Expression *> 
             const auto *remainderExpr = IR::getConstant(IR::getBitType(fillWidth), 0);
             concatExpr = new IR::Concat(IR::getBitType(concatWidth), concatExpr, remainderExpr);
         }
-        auto dataInt =
-            IR::getBigIntFromLiteral(completedModel.evaluate(concatExpr, resolvedExpressions));
+        auto dataInt = IR::getBigIntFromLiteral(
+            completedModel.evaluate(concatExpr, true, resolvedExpressions));
         bytes = convertBigIntToBytes(dataInt, concatWidth);
     }
     return checksumFun(bytes.data(), bytes.size());
@@ -137,11 +137,12 @@ const ConcolicMethodImpls::ImplList Bmv2Concolic::BMV2_CONCOLIC_METHOD_IMPLS{
          // Assign arguments to concrete variables and perform type checking.
          auto algo = args->at(1)->expression->checkedTo<IR::Constant>()->asInt();
          Model::ExpressionMap resolvedExpressions;
-         const auto *base = completedModel.evaluate(args->at(2)->expression, &resolvedExpressions);
+         const auto *base =
+             completedModel.evaluate(args->at(2)->expression, true, &resolvedExpressions);
          auto baseInt = IR::getBigIntFromLiteral(base);
          const auto *dataExpr = args->at(3)->expression;
          const auto *maxHash =
-             completedModel.evaluate(args->at(4)->expression, &resolvedExpressions);
+             completedModel.evaluate(args->at(4)->expression, true, &resolvedExpressions);
          auto maxHashInt = IR::getBigIntFromLiteral(maxHash);
 
          /// Flatten the data input and compute the byte array that will be used for

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -92,7 +92,7 @@ void Bmv2V1ModelExprStepper::processClone(const ExecutionState &state,
     const auto &preserveIndex = cloneInfo->getPreserveIndex();
     const auto &egressPortVar = programInfo.getTargetOutputPortVar();
     const auto &clonePortVar =
-        ToolsVariables::getSymbolicVariable(egressPortVar->type, 0, "clone_port_var");
+        ToolsVariables::getSymbolicVariable(egressPortVar->type, "clone_port_var");
 
     uint64_t recirculateCount = 0;
     if (state.hasProperty("recirculate_count")) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -912,7 +912,7 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
              const auto *meterState =
                  state.getTestObject("meter_values", externInstance->controlPlaneName(), false);
              Bmv2V1ModelMeterValue *meterValue = nullptr;
-             const auto &inputValue = nextState.createSymbolicVariable(
+             const auto &inputValue = ToolsVariables::getSymbolicVariable(
                  meterResult->type, "meter_value" + std::to_string(call->clone_id));
              // Make sure we do not accidentally get "3" as enum assignment...
              auto *cond = new IR::Lss(inputValue, IR::getConstant(meterResult->type, 3));
@@ -1013,7 +1013,7 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
              const auto *meterState =
                  state.getTestObject("meter_values", externInstance->controlPlaneName(), false);
              Bmv2V1ModelMeterValue *meterValue = nullptr;
-             const auto &inputValue = nextState.createSymbolicVariable(
+             const auto &inputValue = ToolsVariables::getSymbolicVariable(
                  meterResult->type, "meter_value" + std::to_string(call->clone_id));
              // Make sure we do not accidentally get "3" as enum assignment...
              auto *cond = new IR::Lss(inputValue, IR::getConstant(meterResult->type, 3));

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
@@ -151,7 +151,7 @@ const IR::Expression *makeConstant(Token input, const IR::Vector<IR::KeyElement>
             } else {
                 BUG("Unexpected key type %s.", keyType->node_type_name());
             }
-            return ToolsVariables::getSymbolicVariable(type, 0, std::string(inputStr));
+            return ToolsVariables::getSymbolicVariable(type, std::string(inputStr));
         }
     }
     if (input.is(Token::Kind::Number)) {
@@ -162,8 +162,7 @@ const IR::Expression *makeConstant(Token input, const IR::Vector<IR::KeyElement>
     }
     // TODO: Is this the right solution for priorities?
     if (input.is(Token::Kind::Priority)) {
-        return ToolsVariables::getSymbolicVariable(IR::Type_Bits::get(32), 0,
-                                                   std::string(inputStr));
+        return ToolsVariables::getSymbolicVariable(IR::Type_Bits::get(32), std::string(inputStr));
     }
     BUG_CHECK(result != nullptr,
               "Could not match restriction key label %s was not found in key list.",

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.cpp
@@ -34,7 +34,7 @@ void RefersToParser::createConstraint(bool table, cstring currentName, cstring c
     } else {
         tmp = currentName + currentKeyName;
     }
-    auto left = ToolsVariables::getSymbolicVariable(type, 0, tmp);
+    auto left = ToolsVariables::getSymbolicVariable(type, tmp);
     std::string str = currentName.c_str();
     std::vector<std::string> elems;
     std::stringstream ss(str);
@@ -47,7 +47,7 @@ void RefersToParser::createConstraint(bool table, cstring currentName, cstring c
         str += elems[i] + ".";
     }
     tmp = str + destTableName + "_key_" + destKeyName;
-    auto right = ToolsVariables::getSymbolicVariable(type, 0, tmp);
+    auto right = ToolsVariables::getSymbolicVariable(type, tmp);
     auto *expr = new IR::Equ(left, right);
     std::vector<const IR::Expression *> constraint;
     constraint.push_back(expr);

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -9,6 +9,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 
 #include "backends/p4tools/common/lib/trace_event_types.h"
+#include "backends/p4tools/common/lib/variables.h"
 #include "ir/declaration.h"
 #include "ir/id.h"
 #include "ir/irutils.h"
@@ -36,8 +37,8 @@
 namespace P4Tools::P4Testgen::Bmv2 {
 
 const IR::Expression *Bmv2V1ModelTableStepper::computeTargetMatchType(
-    ExecutionState &nextState, const TableUtils::KeyProperties &keyProperties,
-    TableMatchMap *matches, const IR::Expression *hitCondition) {
+    const TableUtils::KeyProperties &keyProperties, TableMatchMap *matches,
+    const IR::Expression *hitCondition) {
     const IR::Expression *keyExpr = keyProperties.key->expression;
 
     // TODO: We consider optional match types to be a no-op, but we could make them exact matches.
@@ -45,7 +46,7 @@ const IR::Expression *Bmv2V1ModelTableStepper::computeTargetMatchType(
         // We can recover from taint by simply not adding the optional match.
         // Create a new symbolic variable that corresponds to the key expression.
         cstring keyName = properties.tableName + "_key_" + keyProperties.name;
-        const auto ctrlPlaneKey = nextState.createSymbolicVariable(keyExpr->type, keyName);
+        const auto *ctrlPlaneKey = ToolsVariables::getSymbolicVariable(keyExpr->type, keyName);
         if (keyProperties.isTainted) {
             matches->emplace(keyProperties.name,
                              new Optional(keyProperties.key, ctrlPlaneKey, false));
@@ -75,8 +76,8 @@ const IR::Expression *Bmv2V1ModelTableStepper::computeTargetMatchType(
             maxKey = IR::getConstant(keyExpr->type, IR::getMaxBvVal(keyExpr->type));
             keyExpr = minKey;
         } else {
-            minKey = nextState.createSymbolicVariable(keyExpr->type, minName);
-            maxKey = nextState.createSymbolicVariable(keyExpr->type, maxName);
+            minKey = ToolsVariables::getSymbolicVariable(keyExpr->type, minName);
+            maxKey = ToolsVariables::getSymbolicVariable(keyExpr->type, maxName);
         }
         matches->emplace(keyProperties.name, new Range(keyProperties.key, minKey, maxKey));
         return new IR::LAnd(hitCondition, new IR::LAnd(new IR::LAnd(new IR::Lss(minKey, maxKey),
@@ -84,13 +85,18 @@ const IR::Expression *Bmv2V1ModelTableStepper::computeTargetMatchType(
                                                        new IR::Leq(keyExpr, maxKey)));
     }
     // If the custom match type does not match, delete to the core match types.
-    return TableStepper::computeTargetMatchType(nextState, keyProperties, matches, hitCondition);
+    return TableStepper::computeTargetMatchType(keyProperties, matches, hitCondition);
 }
 
 void Bmv2V1ModelTableStepper::evalTableActionProfile(
     const std::vector<const IR::ActionListElement *> &tableActionList) {
     const auto *state = getExecutionState();
 
+    // First, we compute the hit condition to trigger this particular action call.
+    TableMatchMap matches;
+    const auto *hitCondition = computeHit(&matches);
+
+    // Now we iterate over all table actions and create a path per table action.
     for (const auto *action : tableActionList) {
         // Grab the path from the method call.
         const auto *tableAction = action->expression->checkedTo<IR::MethodCallExpression>();
@@ -113,7 +119,7 @@ void Bmv2V1ModelTableStepper::evalTableActionProfile(
             // Getting the unique name is needed to avoid generating duplicate arguments.
             cstring keyName =
                 properties.tableName + "_param_" + actionName + std::to_string(argIdx);
-            const auto &actionArg = nextState.createSymbolicVariable(parameter->type, keyName);
+            const auto &actionArg = ToolsVariables::getSymbolicVariable(parameter->type, keyName);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.
@@ -128,10 +134,6 @@ void Bmv2V1ModelTableStepper::evalTableActionProfile(
         // We add the arguments to our action call, effectively creating a const entry call.
         auto *synthesizedAction = tableAction->clone();
         synthesizedAction->arguments = arguments;
-
-        // Now we compute the hit condition to trigger this particular action call.
-        TableMatchMap matches;
-        const auto *hitCondition = computeHit(nextState, &matches);
 
         // We need to set the table action in the state for eventual switch action_run hits.
         // We also will need it for control plane table entries.
@@ -175,6 +177,11 @@ void Bmv2V1ModelTableStepper::evalTableActionSelector(
     const std::vector<const IR::ActionListElement *> &tableActionList) {
     const auto *state = getExecutionState();
 
+    // First, we compute the hit condition to trigger this particular action call.
+    TableMatchMap matches;
+    const auto *hitCondition = computeHit(&matches);
+
+    // Now we iterate over all table actions and create a path per table action.
     for (const auto *action : tableActionList) {
         // Grab the path from the method call.
         const auto *tableAction = action->expression->checkedTo<IR::MethodCallExpression>();
@@ -199,7 +206,7 @@ void Bmv2V1ModelTableStepper::evalTableActionSelector(
             // Getting the unique name is needed to avoid generating duplicate arguments.
             cstring keyName =
                 properties.tableName + "_param_" + actionName + std::to_string(argIdx);
-            const auto &actionArg = nextState.createSymbolicVariable(parameter->type, keyName);
+            const auto &actionArg = ToolsVariables::getSymbolicVariable(parameter->type, keyName);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.
@@ -220,10 +227,6 @@ void Bmv2V1ModelTableStepper::evalTableActionSelector(
         // We add the arguments to our action call, effectively creating a const entry call.
         auto *synthesizedAction = tableAction->clone();
         synthesizedAction->arguments = arguments;
-
-        // Now we compute the hit condition to trigger this particular action call.
-        TableMatchMap matches;
-        const auto *hitCondition = computeHit(nextState, &matches);
 
         // We need to set the table action in the state for eventual switch action_run hits.
         // We also will need it for control plane table entries.

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.h
@@ -56,8 +56,7 @@ class Bmv2V1ModelTableStepper : public TableStepper {
     void evalTableActionSelector(const std::vector<const IR::ActionListElement *> &tableActionList);
 
  protected:
-    const IR::Expression *computeTargetMatchType(ExecutionState &nextState,
-                                                 const TableUtils::KeyProperties &keyProperties,
+    const IR::Expression *computeTargetMatchType(const TableUtils::KeyProperties &keyProperties,
                                                  TableMatchMap *matches,
                                                  const IR::Expression *hitCondition) override;
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
@@ -66,10 +66,10 @@ Bmv2TestBackend::Bmv2TestBackend(const ProgramInfo &programInfo, SymbolicExecuto
 }
 
 TestBackEnd::TestInfo Bmv2TestBackend::produceTestInfo(
-    const ExecutionState *executionState, const Model *completedModel,
+    const ExecutionState *executionState, const Model *finalModel,
     const IR::Expression *outputPacketExpr, const IR::Expression *outputPortExpr,
     const std::vector<std::reference_wrapper<const TraceEvent>> *programTraces) {
-    auto testInfo = TestBackEnd::produceTestInfo(executionState, completedModel, outputPacketExpr,
+    auto testInfo = TestBackEnd::produceTestInfo(executionState, finalModel, outputPacketExpr,
                                                  outputPortExpr, programTraces);
     // This is a hack to deal with a behavioral model quirk.
     // Packets that are too small are truncated to 02000000 (in hex) with width 32 bit.
@@ -84,8 +84,7 @@ TestBackEnd::TestInfo Bmv2TestBackend::produceTestInfo(
 }
 
 const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionState,
-                                                const Model *completedModel,
-                                                const TestInfo &testInfo) {
+                                                const Model *finalModel, const TestInfo &testInfo) {
     // Create a testSpec.
     TestSpec *testSpec = nullptr;
 
@@ -109,7 +108,7 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
         const auto &flatFields = executionState->getFlatFields(
             localMetadataVar, localMetadataType->checkedTo<IR::Type_Struct>(), {});
         for (const auto &fieldRef : flatFields) {
-            const auto *fieldVal = completedModel->evaluate(executionState->get(fieldRef));
+            const auto *fieldVal = finalModel->evaluate(executionState->get(fieldRef), true);
             // Try to remove the leading internal name for the metadata field.
             // Thankfully, this string manipulation is safe if we are out of range.
             auto fieldString = fieldRef->toString();
@@ -127,7 +126,7 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
     for (const auto &tablePair : uninterpretedTableConfigs) {
         const auto tableName = tablePair.first;
         const auto *uninterpretedTableConfig = tablePair.second->checkedTo<TableConfig>();
-        const auto *const tableConfig = uninterpretedTableConfig->evaluate(*completedModel);
+        const auto *tableConfig = uninterpretedTableConfig->evaluate(*finalModel, true);
         testSpec->addTestObject("tables", tableName, tableConfig);
     }
 
@@ -135,7 +134,7 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
     for (const auto &testObject : actionProfiles) {
         const auto profileName = testObject.first;
         const auto *actionProfile = testObject.second->checkedTo<Bmv2V1ModelActionProfile>();
-        const auto *evaluatedProfile = actionProfile->evaluate(*completedModel);
+        const auto *evaluatedProfile = actionProfile->evaluate(*finalModel, true);
         testSpec->addTestObject("action_profiles", profileName, evaluatedProfile);
     }
 
@@ -143,7 +142,7 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
     for (const auto &testObject : actionSelectors) {
         const auto selectorName = testObject.first;
         const auto *actionSelector = testObject.second->checkedTo<Bmv2V1ModelActionSelector>();
-        const auto *evaluatedSelector = actionSelector->evaluate(*completedModel);
+        const auto *evaluatedSelector = actionSelector->evaluate(*finalModel, true);
         testSpec->addTestObject("action_selectors", selectorName, evaluatedSelector);
     }
 
@@ -151,7 +150,7 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
     for (const auto &testObject : cloneSpecs) {
         const auto sessionId = testObject.first;
         const auto *cloneSpec = testObject.second->checkedTo<Bmv2V1ModelCloneSpec>();
-        const auto *evaluatedInfo = cloneSpec->evaluate(*completedModel);
+        const auto *evaluatedInfo = cloneSpec->evaluate(*finalModel, true);
         testSpec->addTestObject("clone_specs", sessionId, evaluatedInfo);
     }
 
@@ -159,7 +158,7 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
     for (const auto &testObject : meterInfos) {
         const auto meterName = testObject.first;
         const auto *meterInfo = testObject.second->checkedTo<Bmv2V1ModelMeterValue>();
-        const auto *evaluateMeterValue = meterInfo->evaluate(*completedModel);
+        const auto *evaluateMeterValue = meterInfo->evaluate(*finalModel, true);
         testSpec->addTestObject("meter_values", meterName, evaluateMeterValue);
     }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.h
@@ -51,7 +51,8 @@ class IndexExpression : public TestObject {
     /// @returns the value stored in the index expression.
     [[nodiscard]] const IR::Expression *getValue() const;
 
-    [[nodiscard]] const IndexExpression *evaluate(const Model &model) const override;
+    [[nodiscard]] const IndexExpression *evaluate(const Model &model,
+                                                  bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 };
@@ -106,7 +107,8 @@ class Bmv2V1ModelRegisterValue : public IndexMap {
 
     [[nodiscard]] cstring getObjectName() const override;
 
-    [[nodiscard]] const Bmv2V1ModelRegisterValue *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2V1ModelRegisterValue *evaluate(const Model &model,
+                                                           bool doComplete) const override;
 };
 
 /* =========================================================================================
@@ -123,7 +125,8 @@ class Bmv2V1ModelMeterValue : public IndexMap {
 
     [[nodiscard]] cstring getObjectName() const override;
 
-    [[nodiscard]] const Bmv2V1ModelMeterValue *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2V1ModelMeterValue *evaluate(const Model &model,
+                                                        bool doComplete) const override;
 
     /// @returns whether the meter associated with this meter value object is a direct meter.
     [[nodiscard]] bool isDirectMeter() const;
@@ -157,7 +160,8 @@ class Bmv2V1ModelActionProfile : public TestObject {
     /// Add an action (its name) and the arguments to the action map of this profile.
     void addToActionMap(cstring actionName, std::vector<ActionArg> actionArgs);
 
-    [[nodiscard]] const Bmv2V1ModelActionProfile *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2V1ModelActionProfile *evaluate(const Model &model,
+                                                           bool doComplete) const override;
 };
 
 /* =========================================================================================
@@ -183,7 +187,8 @@ class Bmv2V1ModelActionSelector : public TestObject {
     /// @returns the associated action profile.
     [[nodiscard]] const Bmv2V1ModelActionProfile *getActionProfile() const;
 
-    [[nodiscard]] const Bmv2V1ModelActionSelector *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2V1ModelActionSelector *evaluate(const Model &model,
+                                                            bool doComplete) const override;
 };
 
 /* =========================================================================================
@@ -211,7 +216,8 @@ class Bmv2V1ModelCloneInfo : public TestObject {
 
     [[nodiscard]] cstring getObjectName() const override;
 
-    [[nodiscard]] const Bmv2V1ModelCloneInfo *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2V1ModelCloneInfo *evaluate(const Model &model,
+                                                       bool doComplete) const override;
 
     /// @returns the associated session ID with this cloned packet.
     [[nodiscard]] const IR::Expression *getSessionId() const;
@@ -247,7 +253,8 @@ class Bmv2V1ModelCloneSpec : public TestObject {
 
     [[nodiscard]] cstring getObjectName() const override;
 
-    [[nodiscard]] const Bmv2V1ModelCloneSpec *evaluate(const Model &model) const override;
+    [[nodiscard]] const Bmv2V1ModelCloneSpec *evaluate(const Model &model,
+                                                       bool doComplete) const override;
 
     /// @returns the associated session ID with this cloned packet.
     [[nodiscard]] const IR::Expression *getSessionId() const;
@@ -281,7 +288,8 @@ class MetadataCollection : public TestObject {
 
     [[nodiscard]] cstring getObjectName() const override;
 
-    [[nodiscard]] const MetadataCollection *evaluate(const Model & /*model*/) const override;
+    [[nodiscard]] const MetadataCollection *evaluate(const Model & /*model*/,
+                                                     bool doComplete) const override;
 
     /// @returns the list of metadata fields.
     [[nodiscard]] const std::map<cstring, const IR::Literal *> &getMetadataFields() const;
@@ -308,7 +316,7 @@ class Optional : public TableMatch {
  public:
     explicit Optional(const IR::KeyElement *key, const IR::Expression *value, bool addMatch);
 
-    [[nodiscard]] const Optional *evaluate(const Model &model) const override;
+    [[nodiscard]] const Optional *evaluate(const Model &model, bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 
@@ -332,7 +340,7 @@ class Range : public TableMatch {
     explicit Range(const IR::KeyElement *key, const IR::Expression *low,
                    const IR::Expression *high);
 
-    [[nodiscard]] const Range *evaluate(const Model &model) const override;
+    [[nodiscard]] const Range *evaluate(const Model &model, bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 

--- a/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.cpp
@@ -13,13 +13,6 @@
 
 namespace P4Tools::P4Testgen::EBPF {
 
-const IR::Expression *EBPFTableStepper::computeTargetMatchType(
-    ExecutionState &nextState, const TableUtils::KeyProperties &keyProperties,
-    TableMatchMap *matches, const IR::Expression *hitCondition) {
-    // If the custom match type does not match, delete to the core match types.
-    return TableStepper::computeTargetMatchType(nextState, keyProperties, matches, hitCondition);
-}
-
 void EBPFTableStepper::checkTargetProperties(
     const std::vector<const IR::ActionListElement *> & /*tableActionList*/) {
     // Iterate over the table keys and check whether we can mitigate taint.

--- a/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/table_stepper.h
@@ -28,11 +28,6 @@ class EBPFTableStepper : public TableStepper {
     } EBPFProperties;
 
  protected:
-    const IR::Expression *computeTargetMatchType(ExecutionState &nextState,
-                                                 const TableUtils::KeyProperties &keyProperties,
-                                                 TableMatchMap *matches,
-                                                 const IR::Expression *hitCondition) override;
-
     void checkTargetProperties(
         const std::vector<const IR::ActionListElement *> &tableActionList) override;
 

--- a/backends/p4tools/modules/testgen/targets/ebpf/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test/P4Tests.cmake
@@ -6,7 +6,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/TestTemplate.cmake)
 # ##################################################################################################
 # TEST PROGRAMS
 # ##################################################################################################
-set(P4TESTGEN_EBPF_EXCLUDES "ebpf_checksum_extern\\.p4" "ebpf_conntrack_extern\\.p4")
 
 set(EBPF_SEARCH_PATTERNS "include.*ebpf_model.p4")
 set(P4TESTS_FOR_EBPF "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*.p4")

--- a/backends/p4tools/modules/testgen/targets/ebpf/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test_backend.cpp
@@ -55,10 +55,10 @@ EBPFTestBackend::EBPFTestBackend(const ProgramInfo &programInfo, SymbolicExecuto
 }
 
 TestBackEnd::TestInfo EBPFTestBackend::produceTestInfo(
-    const ExecutionState *executionState, const Model *completedModel,
+    const ExecutionState *executionState, const Model *finalModel,
     const IR::Expression *outputPacketExpr, const IR::Expression *outputPortExpr,
     const std::vector<std::reference_wrapper<const TraceEvent>> *programTraces) {
-    auto testInfo = TestBackEnd::produceTestInfo(executionState, completedModel, outputPacketExpr,
+    auto testInfo = TestBackEnd::produceTestInfo(executionState, finalModel, outputPacketExpr,
                                                  outputPortExpr, programTraces);
     // This is a hack to deal with an virtual kernel interface quirk.
     // Packets that are too small are truncated to 02000000 (in hex) with width 32 bit.
@@ -78,8 +78,7 @@ TestBackEnd::TestInfo EBPFTestBackend::produceTestInfo(
 }
 
 const TestSpec *EBPFTestBackend::createTestSpec(const ExecutionState *executionState,
-                                                const Model *completedModel,
-                                                const TestInfo &testInfo) {
+                                                const Model *finalModel, const TestInfo &testInfo) {
     // Create a testSpec.
     TestSpec *testSpec = nullptr;
 
@@ -99,7 +98,7 @@ const TestSpec *EBPFTestBackend::createTestSpec(const ExecutionState *executionS
     for (const auto &tablePair : uninterpretedTableConfigs) {
         const auto tableName = tablePair.first;
         const auto *uninterpretedTableConfig = tablePair.second->checkedTo<TableConfig>();
-        const auto *const tableConfig = uninterpretedTableConfig->evaluate(*completedModel);
+        const auto *const tableConfig = uninterpretedTableConfig->evaluate(*finalModel, true);
         testSpec->addTestObject("tables", tableName, tableConfig);
     }
     return testSpec;

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/table_stepper.cpp
@@ -6,14 +6,6 @@
 
 namespace P4Tools::P4Testgen::Pna {
 
-const IR::Expression *PnaDpdkTableStepper::computeTargetMatchType(
-    ExecutionState &nextState, const TableUtils::KeyProperties &keyProperties,
-    TableMatchMap *matches, const IR::Expression *hitCondition) {
-    // If the custom match type does not match, delete to the core match types.
-    return SharedPnaTableStepper::computeTargetMatchType(nextState, keyProperties, matches,
-                                                         hitCondition);
-}
-
 PnaDpdkTableStepper::PnaDpdkTableStepper(PnaDpdkExprStepper *stepper, const IR::P4Table *table)
     : SharedPnaTableStepper(stepper, table) {}
 

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/table_stepper.h
@@ -11,12 +11,6 @@
 namespace P4Tools::P4Testgen::Pna {
 
 class PnaDpdkTableStepper : public SharedPnaTableStepper {
- protected:
-    const IR::Expression *computeTargetMatchType(ExecutionState &nextState,
-                                                 const TableUtils::KeyProperties &keyProperties,
-                                                 TableMatchMap *matches,
-                                                 const IR::Expression *hitCondition) override;
-
  public:
     explicit PnaDpdkTableStepper(PnaDpdkExprStepper *stepper, const IR::P4Table *table);
 };

--- a/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
@@ -9,6 +9,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 
 #include "backends/p4tools/common/lib/trace_event_types.h"
+#include "backends/p4tools/common/lib/variables.h"
 #include "ir/declaration.h"
 #include "ir/id.h"
 #include "ir/irutils.h"
@@ -36,8 +37,8 @@
 namespace P4Tools::P4Testgen::Pna {
 
 const IR::Expression *SharedPnaTableStepper::computeTargetMatchType(
-    ExecutionState &nextState, const TableUtils::KeyProperties &keyProperties,
-    TableMatchMap *matches, const IR::Expression *hitCondition) {
+    const TableUtils::KeyProperties &keyProperties, TableMatchMap *matches,
+    const IR::Expression *hitCondition) {
     const IR::Expression *keyExpr = keyProperties.key->expression;
 
     // TODO: We consider optional match types to be a no-op, but we could make them exact matches.
@@ -45,7 +46,7 @@ const IR::Expression *SharedPnaTableStepper::computeTargetMatchType(
         // We can recover from taint by simply not adding the optional match.
         // Create a new symbolic variable that corresponds to the key expression.
         cstring keyName = properties.tableName + "_key_" + keyProperties.name;
-        const auto *ctrlPlaneKey = nextState.createSymbolicVariable(keyExpr->type, keyName);
+        const auto *ctrlPlaneKey = ToolsVariables::getSymbolicVariable(keyExpr->type, keyName);
         if (keyProperties.isTainted) {
             matches->emplace(keyProperties.name,
                              new Optional(keyProperties.key, ctrlPlaneKey, false));
@@ -75,8 +76,8 @@ const IR::Expression *SharedPnaTableStepper::computeTargetMatchType(
             maxKey = IR::getConstant(keyExpr->type, IR::getMaxBvVal(keyExpr->type));
             keyExpr = minKey;
         } else {
-            minKey = nextState.createSymbolicVariable(keyExpr->type, minName);
-            maxKey = nextState.createSymbolicVariable(keyExpr->type, maxName);
+            minKey = ToolsVariables::getSymbolicVariable(keyExpr->type, minName);
+            maxKey = ToolsVariables::getSymbolicVariable(keyExpr->type, maxName);
         }
         matches->emplace(keyProperties.name, new Range(keyProperties.key, minKey, maxKey));
         return new IR::LAnd(hitCondition, new IR::LAnd(new IR::LAnd(new IR::Lss(minKey, maxKey),
@@ -84,13 +85,18 @@ const IR::Expression *SharedPnaTableStepper::computeTargetMatchType(
                                                        new IR::Leq(keyExpr, maxKey)));
     }
     // If the custom match type does not match, delete to the core match types.
-    return TableStepper::computeTargetMatchType(nextState, keyProperties, matches, hitCondition);
+    return TableStepper::computeTargetMatchType(keyProperties, matches, hitCondition);
 }
 
 void SharedPnaTableStepper::evalTableActionProfile(
     const std::vector<const IR::ActionListElement *> &tableActionList) {
     const auto *state = getExecutionState();
 
+    // First, we compute the hit condition to trigger this particular action call.
+    TableMatchMap matches;
+    const auto *hitCondition = computeHit(&matches);
+
+    // Now we iterate over all table actions and create a path per table action.
     for (const auto *action : tableActionList) {
         // Grab the path from the method call.
         const auto *tableAction = action->expression->checkedTo<IR::MethodCallExpression>();
@@ -113,7 +119,7 @@ void SharedPnaTableStepper::evalTableActionProfile(
             // Getting the unique name is needed to avoid generating duplicate arguments.
             cstring keyName =
                 properties.tableName + "_param_" + actionName + std::to_string(argIdx);
-            const auto &actionArg = nextState.createSymbolicVariable(parameter->type, keyName);
+            const auto &actionArg = ToolsVariables::getSymbolicVariable(parameter->type, keyName);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.
@@ -128,10 +134,6 @@ void SharedPnaTableStepper::evalTableActionProfile(
         // We add the arguments to our action call, effectively creating a const entry call.
         auto *synthesizedAction = tableAction->clone();
         synthesizedAction->arguments = arguments;
-
-        // Now we compute the hit condition to trigger this particular action call.
-        TableMatchMap matches;
-        const auto *hitCondition = computeHit(nextState, &matches);
 
         // We need to set the table action in the state for eventual switch action_run hits.
         // We also will need it for control plane table entries.
@@ -175,6 +177,11 @@ void SharedPnaTableStepper::evalTableActionSelector(
     const std::vector<const IR::ActionListElement *> &tableActionList) {
     const auto *state = getExecutionState();
 
+    // First, we compute the hit condition to trigger this particular action call.
+    TableMatchMap matches;
+    const auto *hitCondition = computeHit(&matches);
+
+    // Now we iterate over all table actions and create a path per table action.
     for (const auto *action : tableActionList) {
         // Grab the path from the method call.
         const auto *tableAction = action->expression->checkedTo<IR::MethodCallExpression>();
@@ -199,7 +206,7 @@ void SharedPnaTableStepper::evalTableActionSelector(
             // Getting the unique name is needed to avoid generating duplicate arguments.
             cstring keyName =
                 properties.tableName + "_param_" + actionName + std::to_string(argIdx);
-            const auto &actionArg = nextState.createSymbolicVariable(parameter->type, keyName);
+            const auto &actionArg = ToolsVariables::getSymbolicVariable(parameter->type, keyName);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.
@@ -220,10 +227,6 @@ void SharedPnaTableStepper::evalTableActionSelector(
         // We add the arguments to our action call, effectively creating a const entry call.
         auto *synthesizedAction = tableAction->clone();
         synthesizedAction->arguments = arguments;
-
-        // Now we compute the hit condition to trigger this particular action call.
-        TableMatchMap matches;
-        const auto *hitCondition = computeHit(nextState, &matches);
 
         // We need to set the table action in the state for eventual switch action_run hits.
         // We also will need it for control plane table entries.

--- a/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.h
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.h
@@ -55,8 +55,7 @@ class SharedPnaTableStepper : public TableStepper {
         TableImplementation implementaton = TableImplementation::standard;
     } SharedPnaProperties;
 
-    const IR::Expression *computeTargetMatchType(ExecutionState &nextState,
-                                                 const TableUtils::KeyProperties &keyProperties,
+    const IR::Expression *computeTargetMatchType(const TableUtils::KeyProperties &keyProperties,
                                                  TableMatchMap *matches,
                                                  const IR::Expression *hitCondition) override;
 

--- a/backends/p4tools/modules/testgen/targets/pna/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/test_backend.cpp
@@ -52,17 +52,16 @@ PnaTestBackend::PnaTestBackend(const ProgramInfo &programInfo, SymbolicExecutor 
 }
 
 TestBackEnd::TestInfo PnaTestBackend::produceTestInfo(
-    const ExecutionState *executionState, const Model *completedModel,
+    const ExecutionState *executionState, const Model *finalModel,
     const IR::Expression *outputPacketExpr, const IR::Expression *outputPortExpr,
     const std::vector<std::reference_wrapper<const TraceEvent>> *programTraces) {
-    auto testInfo = TestBackEnd::produceTestInfo(executionState, completedModel, outputPacketExpr,
+    auto testInfo = TestBackEnd::produceTestInfo(executionState, finalModel, outputPacketExpr,
                                                  outputPortExpr, programTraces);
     return testInfo;
 }
 
 const TestSpec *PnaTestBackend::createTestSpec(const ExecutionState *executionState,
-                                               const Model *completedModel,
-                                               const TestInfo &testInfo) {
+                                               const Model *finalModel, const TestInfo &testInfo) {
     // Create a testSpec.
     TestSpec *testSpec = nullptr;
 
@@ -86,7 +85,7 @@ const TestSpec *PnaTestBackend::createTestSpec(const ExecutionState *executionSt
         const auto &flatFields = executionState->getFlatFields(
             localMetadataVar, localMetadataType->checkedTo<IR::Type_Struct>(), {});
         for (const auto &fieldRef : flatFields) {
-            const auto *fieldVal = completedModel->evaluate(executionState->get(fieldRef));
+            const auto *fieldVal = finalModel->evaluate(executionState->get(fieldRef), true);
             // Try to remove the leading internal name for the metadata field.
             // Thankfully, this string manipulation is safe if we are out of range.
             auto fieldString = fieldRef->toString();
@@ -104,7 +103,7 @@ const TestSpec *PnaTestBackend::createTestSpec(const ExecutionState *executionSt
     for (const auto &tablePair : uninterpretedTableConfigs) {
         const auto tableName = tablePair.first;
         const auto *uninterpretedTableConfig = tablePair.second->checkedTo<TableConfig>();
-        const auto *const tableConfig = uninterpretedTableConfig->evaluate(*completedModel);
+        const auto *const tableConfig = uninterpretedTableConfig->evaluate(*finalModel, true);
         testSpec->addTestObject("tables", tableName, tableConfig);
     }
 
@@ -112,7 +111,7 @@ const TestSpec *PnaTestBackend::createTestSpec(const ExecutionState *executionSt
     for (const auto &testObject : actionProfiles) {
         const auto profileName = testObject.first;
         const auto *actionProfile = testObject.second->checkedTo<PnaDpdkActionProfile>();
-        const auto *evaluatedProfile = actionProfile->evaluate(*completedModel);
+        const auto *evaluatedProfile = actionProfile->evaluate(*finalModel, true);
         testSpec->addTestObject("action_profiles", profileName, evaluatedProfile);
     }
 
@@ -120,7 +119,7 @@ const TestSpec *PnaTestBackend::createTestSpec(const ExecutionState *executionSt
     for (const auto &testObject : actionSelectors) {
         const auto selectorName = testObject.first;
         const auto *actionSelector = testObject.second->checkedTo<PnaDpdkActionSelector>();
-        const auto *evaluatedSelector = actionSelector->evaluate(*completedModel);
+        const auto *evaluatedSelector = actionSelector->evaluate(*finalModel, true);
         testSpec->addTestObject("action_selectors", selectorName, evaluatedSelector);
     }
 

--- a/backends/p4tools/modules/testgen/targets/pna/test_spec.h
+++ b/backends/p4tools/modules/testgen/targets/pna/test_spec.h
@@ -38,7 +38,8 @@ class PnaDpdkRegisterCondition : public TestObject {
     /// The function will throw a bug if this is not the case.
     [[nodiscard]] const IR::Constant *getEvaluatedValue() const;
 
-    [[nodiscard]] const PnaDpdkRegisterCondition *evaluate(const Model &model) const override;
+    [[nodiscard]] const PnaDpdkRegisterCondition *evaluate(const Model &model,
+                                                           bool doComplete) const override;
 
     [[nodiscard]] cstring getObjectName() const override;
 };
@@ -79,7 +80,8 @@ class PnaDpdkRegisterValue : public TestObject {
     /// The function will throw a bug if this is not the case.
     [[nodiscard]] const IR::Constant *getEvaluatedValue() const;
 
-    [[nodiscard]] const PnaDpdkRegisterValue *evaluate(const Model &model) const override;
+    [[nodiscard]] const PnaDpdkRegisterValue *evaluate(const Model &model,
+                                                       bool doComplete) const override;
 };
 
 /* =========================================================================================
@@ -110,7 +112,8 @@ class PnaDpdkActionProfile : public TestObject {
     /// Add an action (its name) and the arguments to the action map of this profile.
     void addToActionMap(cstring actionName, std::vector<ActionArg> actionArgs);
 
-    [[nodiscard]] const PnaDpdkActionProfile *evaluate(const Model &model) const override;
+    [[nodiscard]] const PnaDpdkActionProfile *evaluate(const Model &model,
+                                                       bool doComplete) const override;
 };
 
 /* =========================================================================================
@@ -136,7 +139,8 @@ class PnaDpdkActionSelector : public TestObject {
     /// @returns the associated action profile.
     [[nodiscard]] const PnaDpdkActionProfile *getActionProfile() const;
 
-    [[nodiscard]] const PnaDpdkActionSelector *evaluate(const Model &model) const override;
+    [[nodiscard]] const PnaDpdkActionSelector *evaluate(const Model &model,
+                                                        bool doComplete) const override;
 };
 
 /* =========================================================================================
@@ -151,7 +155,8 @@ class MetadataCollection : public TestObject {
 
     [[nodiscard]] cstring getObjectName() const override;
 
-    [[nodiscard]] const MetadataCollection *evaluate(const Model & /*model*/) const override;
+    [[nodiscard]] const MetadataCollection *evaluate(const Model & /*model*/,
+                                                     bool doComplete) const override;
 
     /// @returns the clone port expression.
     [[nodiscard]] const std::map<cstring, const IR::Literal *> &getMetadataFields() const;
@@ -176,7 +181,7 @@ class Optional : public TableMatch {
  public:
     explicit Optional(const IR::KeyElement *key, const IR::Expression *value, bool addMatch);
 
-    const Optional *evaluate(const Model &model) const override;
+    const Optional *evaluate(const Model &model, bool doComplete) const override;
 
     cstring getObjectName() const override;
 
@@ -200,7 +205,7 @@ class Range : public TableMatch {
     explicit Range(const IR::KeyElement *key, const IR::Expression *low,
                    const IR::Expression *high);
 
-    const Range *evaluate(const Model &model) const override;
+    const Range *evaluate(const Model &model, bool doComplete) const override;
 
     cstring getObjectName() const override;
 

--- a/backends/p4tools/modules/testgen/test/gtest_utils.cpp
+++ b/backends/p4tools/modules/testgen/test/gtest_utils.cpp
@@ -59,7 +59,7 @@ void P4ToolsTestCase::ensureInit() {
 }
 
 const IR::SymbolicVariable *SymbolicConverter::preorder(IR::Member *member) {
-    return P4Tools::ToolsVariables::getSymbolicVariable(member->type, 0, member->toString());
+    return P4Tools::ToolsVariables::getSymbolicVariable(member->type, member->toString());
 }
 
 }  // namespace Test

--- a/backends/p4tools/modules/testgen/test/small-step/p4_asserts_parser_test.cpp
+++ b/backends/p4tools/modules/testgen/test/small-step/p4_asserts_parser_test.cpp
@@ -101,9 +101,9 @@ TEST_F(P4AssertsParserTest, Restrictions) {
     ASSERT_EQ(parsingResult.size(), (unsigned long)1);
     {
         const auto &expr1 = P4Tools::ToolsVariables::getSymbolicVariable(
-            IR::Type_Bits::get(8), 0, "ingress.ternary_table_mask_h.h.a1");
+            IR::Type_Bits::get(8), "ingress.ternary_table_mask_h.h.a1");
         const auto &expr2 = P4Tools::ToolsVariables::getSymbolicVariable(
-            IR::Type_Bits::get(8), 0, "ingress.ternary_table_lpm_prefix_h.h.a1");
+            IR::Type_Bits::get(8), "ingress.ternary_table_lpm_prefix_h.h.a1");
         const auto *const1 = IR::getConstant(IR::Type_Bits::get(8), 0);
         const auto *const2 = IR::getConstant(IR::Type_Bits::get(8), 64);
         const auto *operation =
@@ -112,14 +112,14 @@ TEST_F(P4AssertsParserTest, Restrictions) {
     }
     {
         const auto &expr1 = P4Tools::ToolsVariables::getSymbolicVariable(
-            IR::Type_Bits::get(8), 0, "ingress.ternary_table_key_h.h.a1");
+            IR::Type_Bits::get(8), "ingress.ternary_table_key_h.h.a1");
         const auto *const1 = IR::getConstant(IR::Type_Bits::get(8), 0);
         const auto *operation1 = new IR::Neq(expr1, const1);
         ASSERT_TRUE(parsingResult[0][1]->equiv(*operation1));
     }
     {
         const auto &expr1 = P4Tools::ToolsVariables::getSymbolicVariable(
-            IR::Type_Bits::get(8), 0, "ingress.ternary_table_key_h.h.a");
+            IR::Type_Bits::get(8), "ingress.ternary_table_key_h.h.a");
         const auto *const2 = IR::getConstant(IR::Type_Bits::get(8), 255);
         const auto *operation2 = new IR::Neq(expr1, const2);
         ASSERT_TRUE(parsingResult[0][2]->equiv(*operation2));
@@ -131,9 +131,9 @@ TEST_F(P4AssertsParserTest, RestrictionMiddleblockReferToInTable) {
         "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_restrictions_2.p4",
         false);
     ASSERT_EQ(parsingResult.size(), (unsigned long)3);
-    const auto &expr1 = P4Tools::ToolsVariables::getSymbolicVariable(IR::Type_Bits::get(8), 0,
+    const auto &expr1 = P4Tools::ToolsVariables::getSymbolicVariable(IR::Type_Bits::get(8),
                                                                      "ingress.table_1_key_h.h.a");
-    const auto &expr2 = P4Tools::ToolsVariables::getSymbolicVariable(IR::Type_Bits::get(8), 0,
+    const auto &expr2 = P4Tools::ToolsVariables::getSymbolicVariable(IR::Type_Bits::get(8),
                                                                      "ingress.table_2_key_h.h.b");
     const auto *operation = new IR::Equ(expr1, expr2);
     ASSERT_TRUE(parsingResult[0][0]->equiv(*operation));
@@ -144,11 +144,11 @@ TEST_F(P4AssertsParserTest, RestrictionMiddleblockReferToInAction) {
         "backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_restrictions_2.p4",
         false);
     ASSERT_EQ(parsingResult.size(), (unsigned long)3);
-    auto expr1 = P4Tools::ToolsVariables::getSymbolicVariable(
-        IR::Type_Bits::get(8), 0, "ingress.table_1_arg_ingress.MyAction10");
-    auto expr2 = P4Tools::ToolsVariables::getSymbolicVariable(IR::Type_Bits::get(8), 0,
-                                                              "ingress.table_1_key_h.h.a");
-    auto operation = new IR::Equ(expr1, expr2);
+    const auto *expr1 = P4Tools::ToolsVariables::getSymbolicVariable(
+        IR::Type_Bits::get(8), "ingress.table_1_arg_ingress.MyAction10");
+    const auto *expr2 = P4Tools::ToolsVariables::getSymbolicVariable(IR::Type_Bits::get(8),
+                                                                     "ingress.table_1_key_h.h.a");
+    auto *operation = new IR::Equ(expr1, expr2);
     ASSERT_TRUE(parsingResult[1][0]->equiv(*operation));
 }
 

--- a/backends/p4tools/modules/testgen/test/small-step/util.h
+++ b/backends/p4tools/modules/testgen/test/small-step/util.h
@@ -156,11 +156,11 @@ void stepAndExamineOp(
     // Examine the resulting stack.
     ASSERT_EQ(executionState.get().getStack().size(), 1u);
     const auto stackFrame = executionState.get().getStack().top();
-    ASSERT_TRUE(stackFrame.get().exceptionHandlers.empty());
-    ASSERT_EQ(stackFrame.get().namespaces, NamespaceContext::Empty);
+    ASSERT_TRUE(stackFrame.get().getExceptionHandlers().empty());
+    ASSERT_EQ(stackFrame.get().getNameSpaces(), NamespaceContext::Empty);
 
     // Examine the pushed continuation.
-    Continuation pushedContinuation = stackFrame.get().normalContinuation;
+    Continuation pushedContinuation = stackFrame.get().getContinuation();
     ASSERT_TRUE(pushedContinuation.parameterOpt);
     Body pushedBody = pushedContinuation.body;
     ASSERT_EQ(pushedBody, Body({Return(rebuildNode(*pushedContinuation.parameterOpt))}));


### PR DESCRIPTION
The `complete` step, which assigns default variables to symbolic variables that are not present in the Z3 model, is redundant. It requires us to keep track of symbolic variables in the execution state, which cost additional memory. Instead, we can just lazily complete a variable at the moment we evaluate it. We simply add a parameter to the evaluate function.

With these changes we can both simplify the model and the execution state. For example, since we do not need to track variable creation any more we will not need the call `ExecutionState::createSymbolicVariable` and can directly call `ToolsVariables::getSymbolicVariable`. This means we do not always need an execution state to create a new symbolic variable. 

@vlstill With this change, use `ToolsVariables::getSymbolicVariable` instead of `nextState.createSymbolicVariable`. Now there will not be an error anymore if one uses the wrong call to create a symbolic variable.
