### PR TITLE
Add the source file to the src info comparison operator.

### DIFF
--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -168,7 +168,9 @@ class SourceInfo final {
         return *this;
     }
 
-    bool operator==(const SourceInfo &rhs) const { return start == rhs.start && end == rhs.end; }
+    bool operator==(const SourceInfo &rhs) const {
+        return start == rhs.start && end == rhs.end && getSourceFile() == rhs.getSourceFile();
+    }
 
     cstring toDebugString() const;
 
@@ -195,10 +197,15 @@ class SourceInfo final {
        'invalid' source positions come first.
        This is true if the start of other is strictly before
        the start of this. */
-    bool operator<(const SourceInfo &rhs) const {
-        if (!rhs.isValid()) return false;
-        if (!isValid()) return true;
-        return this->start < rhs.start;
+    inline bool operator<(const SourceInfo &rhs) const {
+        if (!rhs.isValid()) {
+            return false;
+        }
+        if (!isValid()) {
+            return true;
+        }
+        return this->start < rhs.start ||
+               ((this->start == rhs.start) && this->getSourceFile() < rhs.getSourceFile());
     }
     inline bool operator>(const SourceInfo &rhs) const { return rhs.operator<(*this); }
     inline bool operator<=(const SourceInfo &rhs) const { return !this->operator>(rhs); }

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -168,9 +168,7 @@ class SourceInfo final {
         return *this;
     }
 
-    bool operator==(const SourceInfo &rhs) const {
-        return start == rhs.start && end == rhs.end && getSourceFile() == rhs.getSourceFile();
-    }
+    bool operator==(const SourceInfo &rhs) const { return start == rhs.start && end == rhs.end; }
 
     cstring toDebugString() const;
 
@@ -197,15 +195,10 @@ class SourceInfo final {
        'invalid' source positions come first.
        This is true if the start of other is strictly before
        the start of this. */
-    inline bool operator<(const SourceInfo &rhs) const {
-        if (!rhs.isValid()) {
-            return false;
-        }
-        if (!isValid()) {
-            return true;
-        }
-        return this->start < rhs.start ||
-               ((this->start == rhs.start) && this->getSourceFile() < rhs.getSourceFile());
+    bool operator<(const SourceInfo &rhs) const {
+        if (!rhs.isValid()) return false;
+        if (!isValid()) return true;
+        return this->start < rhs.start;
     }
     inline bool operator>(const SourceInfo &rhs) const { return rhs.operator<(*this); }
     inline bool operator<=(const SourceInfo &rhs) const { return !this->operator>(rhs); }

--- a/midend/coverage.cpp
+++ b/midend/coverage.cpp
@@ -7,7 +7,7 @@
 namespace P4::Coverage {
 
 bool SourceIdCmp::operator()(const IR::Node *s1, const IR::Node *s2) const {
-    return s1->clone_id < s2->clone_id;
+    return s1->srcInfo < s2->srcInfo;
 }
 
 CollectNodes::CollectNodes(CoverageOptions coverageOptions) : coverageOptions(coverageOptions) {}


### PR DESCRIPTION
The `SrcInfo` class was not taking the file name into account for equal or less operators. It can happen that the line and column number for a particular object are the same, but the source file is completely different. 