### PR TITLE
[P4Testgen] Reduce overtainting by short-circuiting some expressions and extern invocations

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -1489,6 +1489,17 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
              const auto *algo = args->at(3)->expression;
              const auto *oneBitType = IR::getBitType(1);
 
+             // In some cases the condition is false already. No need to do complex processing then.
+             if (const auto *boolVal = verifyCond->to<IR::BoolLiteral>()) {
+                 if (!boolVal->value) {
+                     auto &taintedState = state.clone();
+                     taintedState.popBody();
+                     result->emplace_back(taintedState);
+                     return;
+                 }
+             }
+
+             // Handle the case where the condition might be true.
              // If the condition is tainted or the input data is tainted, the checksum error
              // will not be reliable.
              if (argsAreTainted) {
@@ -1501,8 +1512,6 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
                  result->emplace_back(taintedState);
                  return;
              }
-
-             // Handle the case where the condition is true.
 
              // Generate the checksum arguments.
              auto *checksumArgs = new IR::Vector<IR::Argument>();
@@ -1603,6 +1612,20 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
              const auto *checksumVarType = checksumVar->type;
              const auto *data = args->at(1)->expression;
              const auto *algo = args->at(3)->expression;
+
+             // In some cases the condition is false already. No need to do complex processing then.
+             if (const auto *boolVal = updateCond->to<IR::BoolLiteral>()) {
+                 if (!boolVal->value) {
+                     auto &taintedState = state.clone();
+                     taintedState.popBody();
+                     result->emplace_back(taintedState);
+                     return;
+                 }
+             }
+
+             // Handle the case where the condition might be true.
+             // If the condition is tainted or the input data is tainted, the checksum error
+             // will not be reliable.
              // If the condition is tainted or the input data is tainted.
              // The checksum will also be tainted.
              if (argsAreTainted) {


### PR DESCRIPTION
Sometimes we can overtaint because an expression that technically short-circuits is treated as taint. Implement an optimization for this behavior in the taint checker. Also try to eliminate sources of taint in some externs by exiting early (verify and update checksum).

Fixes #3887.
