### PR TITLE
[P4Testgen] Remove execution state from the symbolic executor, make it a parameter.

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/small_step.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/small_step.cpp
@@ -112,7 +112,7 @@ SmallStepEvaluator::REngineType SmallStepEvaluator::renginePreprocessing(
 class CommandVisitor {
  private:
     std::reference_wrapper<SmallStepEvaluator> self;
-    std::reference_wrapper<ExecutionState> state;
+    ExecutionStateReference state;
     using Branch = SmallStepEvaluator::Branch;
     using Result = SmallStepEvaluator::Result;
 

--- a/backends/p4tools/modules/testgen/core/small_step/small_step.h
+++ b/backends/p4tools/modules/testgen/core/small_step/small_step.h
@@ -28,7 +28,7 @@ class SmallStepEvaluator {
     struct Branch {
         const Constraint *constraint;
 
-        std::reference_wrapper<ExecutionState> nextState;
+        ExecutionStateReference nextState;
 
         P4::Coverage::CoverageSet potentialStatements;
 

--- a/backends/p4tools/modules/testgen/core/symbolic_executor/depth_first.h
+++ b/backends/p4tools/modules/testgen/core/symbolic_executor/depth_first.h
@@ -19,7 +19,7 @@ class DepthFirstSearch : public SymbolicExecutor {
     /// Executes the P4 program along a randomly chosen path. When the program terminates, the
     /// given callback is invoked. If the callback returns true, then the executor terminates.
     /// Otherwise, execution of the P4 program continues on a different random path.
-    void run(const Callback &callBack) override;
+    void runImpl(const Callback &callBack, ExecutionStateReference executionState) override;
 
     /// Constructor for this strategy, considering inheritance
     DepthFirstSearch(AbstractSolver &solver, const ProgramInfo &programInfo);
@@ -42,7 +42,7 @@ class DepthFirstSearch : public SymbolicExecutor {
     /// 2. If there are successors left, try to find a successor that covers new statements. Set the
     /// nextState as this successors state.
     /// 3. If no successor with new statements was found set a random successor.
-    [[nodiscard]] bool pickSuccessor(StepResult successors);
+    [[nodiscard]] std::optional<ExecutionStateReference> pickSuccessor(StepResult successors);
 };
 
 }  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/symbolic_executor/greedy_stmt_cov.h
+++ b/backends/p4tools/modules/testgen/core/symbolic_executor/greedy_stmt_cov.h
@@ -26,7 +26,7 @@ class GreedyStmtSelection : public SymbolicExecutor {
     /// Executes the P4 program along a randomly chosen path. When the program terminates, the
     /// given callback is invoked. If the callback returns true, then the executor terminates.
     /// Otherwise, execution of the P4 program continues on a different random path.
-    void run(const Callback &callBack) override;
+    void runImpl(const Callback &callBack, ExecutionStateReference state) override;
 
     /// Constructor for this strategy, considering inheritance
     GreedyStmtSelection(AbstractSolver &solver, const ProgramInfo &programInfo);
@@ -74,7 +74,7 @@ class GreedyStmtSelection : public SymbolicExecutor {
     /// 2. If there are successors left, try to find a successor that covers new statements. Set the
     /// nextState as this successors state.
     /// 3. If no successor with new statements was found set a random successor.
-    [[nodiscard]] bool pickSuccessor(StepResult successors);
+    [[nodiscard]] std::optional<ExecutionStateReference> pickSuccessor(StepResult successors);
 };
 
 }  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/symbolic_executor/max_stmt_cov.cpp
+++ b/backends/p4tools/modules/testgen/core/symbolic_executor/max_stmt_cov.cpp
@@ -20,14 +20,15 @@
 
 namespace P4Tools::P4Testgen {
 
-void RandomMaxStmtCoverage::run(const Callback &callback) {
+void RandomMaxStmtCoverage::runImpl(const Callback &callBack,
+                                    ExecutionStateReference executionState) {
     // Loop until we reach terminate, or until there are no more
     // branches to produce tests.
     while (true) {
         try {
             if (executionState.get().isTerminal()) {
                 // We've reached the end of the program. Call back and (if desired) end execution.
-                bool terminate = handleTerminalState(callback, executionState);
+                bool terminate = handleTerminalState(callBack, executionState);
                 uint64_t coverage = visitedNodes.size();
                 // We set the coverage saddle track accordingly.
                 if (coverage == coverageSaddleTrack.first) {

--- a/backends/p4tools/modules/testgen/core/symbolic_executor/max_stmt_cov.h
+++ b/backends/p4tools/modules/testgen/core/symbolic_executor/max_stmt_cov.h
@@ -26,7 +26,7 @@ class RandomMaxStmtCoverage : public SymbolicExecutor {
     /// Executes the P4 program along a randomly chosen path. When the program terminates, the
     /// given callback is invoked. If the callback returns true, then the executor terminates.
     /// Otherwise, execution of the P4 program continues on a different random path.
-    void run(const Callback &callBack) override;
+    void runImpl(const Callback &callBack, ExecutionStateReference executionState) override;
 
     /// Constructor for this strategy, considering inheritance.
     RandomMaxStmtCoverage(AbstractSolver &solver, const ProgramInfo &programInfo,

--- a/backends/p4tools/modules/testgen/core/symbolic_executor/random_backtrack.h
+++ b/backends/p4tools/modules/testgen/core/symbolic_executor/random_backtrack.h
@@ -19,7 +19,7 @@ class RandomBacktrack : public SymbolicExecutor {
     /// Executes the P4 program along a randomly chosen path. When the program terminates, the
     /// given callback is invoked. If the callback returns true, then the executor terminates.
     /// Otherwise, execution of the P4 program continues on a different random path.
-    void run(const Callback &callBack) override;
+    void runImpl(const Callback &callBack, ExecutionStateReference executionState) override;
 
     /// Constructor for this strategy, considering inheritance
     RandomBacktrack(AbstractSolver &solver, const ProgramInfo &programInfo);
@@ -42,7 +42,7 @@ class RandomBacktrack : public SymbolicExecutor {
     /// 2. If there are successors left, try to find a successor that covers new statements. Set the
     /// nextState as this successors state.
     /// 3. If no successor with new statements was found set a random successor.
-    [[nodiscard]] bool pickSuccessor(StepResult successors);
+    [[nodiscard]] std::optional<ExecutionStateReference> pickSuccessor(StepResult successors);
 };
 
 }  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/symbolic_executor/selected_branches.h
+++ b/backends/p4tools/modules/testgen/core/symbolic_executor/selected_branches.h
@@ -20,7 +20,7 @@ class SelectedBranches : public SymbolicExecutor {
     /// Executes the P4 program along a randomly chosen path. When the program terminates, the
     /// given callback is invoked. If the callback returns true, then the executor terminates.
     /// Otherwise, execution of the P4 program continues on a different random path.
-    void run(const Callback &callBack) override;
+    void runImpl(const Callback &callBack, ExecutionStateReference executionState) override;
 
     /// Constructor for this strategy, considering inheritance
     SelectedBranches(AbstractSolver &solver, const ProgramInfo &programInfo,

--- a/backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.cpp
+++ b/backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.cpp
@@ -33,6 +33,10 @@ SymbolicExecutor::StepResult SymbolicExecutor::step(ExecutionState &state) {
     return successors;
 }
 
+void SymbolicExecutor::run(const Callback &callBack) {
+    runImpl(callBack, ExecutionState::create(programInfo.program));
+}
+
 bool SymbolicExecutor::handleTerminalState(const Callback &callback,
                                            const ExecutionState &terminalState) {
     // Check the solver for satisfiability. If it times out or reports non-satisfiability, issue
@@ -84,7 +88,6 @@ SymbolicExecutor::Branch SymbolicExecutor::popRandomBranch(
 SymbolicExecutor::SymbolicExecutor(AbstractSolver &solver, const ProgramInfo &programInfo)
     : programInfo(programInfo),
       solver(solver),
-      executionState(ExecutionState::create(programInfo.program)),
       coverableNodes(programInfo.getCoverableNodes()),
       evaluator(solver, programInfo) {
     // If there is no seed provided, do not randomize the solver.
@@ -100,8 +103,9 @@ void SymbolicExecutor::updateVisitedNodes(const P4::Coverage::CoverageSet &newNo
 
 const P4::Coverage::CoverageSet &SymbolicExecutor::getVisitedNodes() { return visitedNodes; }
 
-void SymbolicExecutor::printCurrentTraceAndBranches(std::ostream &out) {
-    const auto &branchesList = executionState.get().getSelectedBranches();
+void SymbolicExecutor::printCurrentTraceAndBranches(std::ostream &out,
+                                                    const ExecutionState &executionState) {
+    const auto &branchesList = executionState.getSelectedBranches();
     printTraces("Track branches:");
     out << "Selected " << branchesList.size() << " branches : (";
     printTraces("Selected %1% branches : (", branchesList.size());

--- a/backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h
+++ b/backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h
@@ -42,13 +42,14 @@ class SymbolicExecutor {
     /// Executes the P4 program along a randomly chosen path. When the program terminates, the
     /// given callback is invoked. If the callback returns true, then the executor terminates.
     /// Otherwise, execution of the P4 program continues on a different random path.
-    /// TODO there is a lot of code repetition in subclasses. Refactor and extract duplicates.
-    virtual void run(const Callback &callBack) = 0;
+    virtual void run(const Callback &callBack);
+
+    virtual void runImpl(const Callback &callBack, ExecutionStateReference executionState) = 0;
 
     explicit SymbolicExecutor(AbstractSolver &solver, const ProgramInfo &programInfo);
 
     /// Writes a list of the selected branches into @param out.
-    void printCurrentTraceAndBranches(std::ostream &out);
+    void printCurrentTraceAndBranches(std::ostream &out, const ExecutionState &executionState);
 
     /// Getter to access visitedNodes.
     const P4::Coverage::CoverageSet &getVisitedNodes();
@@ -62,9 +63,6 @@ class SymbolicExecutor {
 
     /// The SMT solver backing this executor.
     AbstractSolver &solver;
-
-    /// The current execution state.
-    std::reference_wrapper<ExecutionState> executionState;
 
     /// Set of all statements, to be retrieved from programInfo.
     const P4::Coverage::CoverageSet &coverableNodes;

--- a/backends/p4tools/modules/testgen/lib/execution_state.h
+++ b/backends/p4tools/modules/testgen/lib/execution_state.h
@@ -406,6 +406,8 @@ class ExecutionState : public AbstractExecutionState {
     ExecutionState &operator=(const ExecutionState &) = default;
 };
 
+using ExecutionStateReference = std::reference_wrapper<ExecutionState>;
+
 }  // namespace P4Tools::P4Testgen
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_EXECUTION_STATE_H_ */

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -5,14 +5,12 @@
 
 #include "backends/p4tools/common/lib/format_int.h"
 #include "backends/p4tools/common/lib/model.h"
-#include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/taint.h"
 #include "backends/p4tools/common/lib/trace_event.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/irutils.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
-#include "lib/log.h"
 #include "lib/null.h"
 #include "lib/timer.h"
 #include "midend/coverage.h"
@@ -24,7 +22,6 @@
 #include "backends/p4tools/modules/testgen/lib/final_state.h"
 #include "backends/p4tools/modules/testgen/lib/logging.h"
 #include "backends/p4tools/modules/testgen/lib/packet_vars.h"
-#include "backends/p4tools/modules/testgen/lib/test_spec.h"
 #include "backends/p4tools/modules/testgen/lib/tf.h"
 #include "backends/p4tools/modules/testgen/options.h"
 
@@ -93,7 +90,7 @@ bool TestBackEnd::run(const FinalState &state) {
         // Add a list of tracked branches to the test output, too.
         std::stringstream selectedBranches;
         if (TestgenOptions::get().trackBranches) {
-            symbex.printCurrentTraceAndBranches(selectedBranches);
+            symbex.printCurrentTraceAndBranches(selectedBranches, *executionState);
         }
 
         abort = printTestInfo(executionState, testInfo, outputPortExpr);

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -76,19 +76,8 @@ int generateAbstractTests(const TestgenOptions &testgenOptions, const ProgramInf
         return testBackend->run(std::forward<decltype(finalState)>(finalState));
     };
 
-    try {
-        // Run the symbolic executor with given exploration strategy.
-        symbex.run(callBack);
-    } catch (...) {
-        if (testgenOptions.trackBranches) {
-            // Print list of the selected branches and store all information into
-            // dumpFolder/selectedBranches.txt file.
-            // This printed list could be used for repeat this bug in arguments of --input-branches
-            // command line. For example, --input-branches "1,1".
-            symbex.printCurrentTraceAndBranches(std::cerr);
-        }
-        throw;
-    }
+    symbex.run(callBack);
+
     // Emit a performance report, if desired.
     testBackend->printPerformanceReport(true);
 


### PR DESCRIPTION
Execution state should only live as long as the `run` function of the symbolic executor is active. This also makes sure we do not access some stale execution state via the symbolic executor. 

This impacts the SelectedBranches implementation, which is now simplified.