### PR TITLE
[P4Testgen] Miscellaneous fixes for P4testgen

### DIFF
--- a/backends/p4tools/README.md
+++ b/backends/p4tools/README.md
@@ -30,6 +30,7 @@ make
 ## Dependencies
 * [inja](https://github.com/pantor/inja) template engine for testcase generation.
 * [z3](https://github.com/Z3Prover/z3) SMT solver to compute path constraints.
+    * Important: We currently only support Z3 versions 4.8.14 to 4.12.0.
 
 
 ## Development Style

--- a/backends/p4tools/common/lib/variables.cpp
+++ b/backends/p4tools/common/lib/variables.cpp
@@ -54,6 +54,9 @@ IR::StateVariable convertReference(const IR::Expression *ref) {
     if (const auto *member = ref->to<IR::Member>()) {
         return member;
     }
+    if (const auto *arrIndex = ref->to<IR::ArrayIndex>()) {
+        return arrIndex;
+    }
     // Local variable.
     const auto *path = ref->checkedTo<IR::PathExpression>();
     return path;

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.cpp
@@ -147,7 +147,7 @@ void Metadata::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, 
         dataJson["seed"] = *seed;
     }
     dataJson["test_name"] = basePath.stem();
-    dataJson["test_id"] = testId + 1;
+    dataJson["test_id"] = testId;
     computeTraceData(testSpec, dataJson);
 
     dataJson["send"] = getSend(testSpec);
@@ -177,14 +177,14 @@ void Metadata::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, 
     metadataFile.flush();
 }
 
-void Metadata::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+void Metadata::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                           float currentCoverage) {
     auto incrementedbasePath = basePath;
-    incrementedbasePath.concat("_" + std::to_string(testIdx));
+    incrementedbasePath.concat("_" + std::to_string(testId));
     incrementedbasePath.replace_extension(".yml");
     metadataFile = std::ofstream(incrementedbasePath);
     std::string testCase = getTestCaseTemplate();
-    emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);
+    emitTestcase(testSpec, selectedBranches, testId, testCase, currentCoverage);
 }
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/metadata/metadata.h
@@ -38,7 +38,7 @@ class Metadata : public TF {
     Metadata(std::filesystem::path basePath, std::optional<unsigned int> seed);
 
     /// Produce a Metadata test.
-    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testIdx,
+    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testId,
                     float currentCoverage) override;
 
  private:

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
@@ -378,7 +378,7 @@ entities : [
     return TEST_CASE;
 }
 
-void Protobuf::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+void Protobuf::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                             const std::string &testCase, float currentCoverage) {
     inja::json dataJson;
     if (selectedBranches != nullptr) {
@@ -388,7 +388,7 @@ void Protobuf::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, 
         dataJson["seed"] = *seed;
     }
     dataJson["test_name"] = basePath.stem();
-    dataJson["test_id"] = testIdx + 1;
+    dataJson["test_id"] = testId;
     // TODO: Traces are disabled until we are able to escape illegal characters (e.g., '"').
     // dataJson["trace"] = getTrace(testSpec);
     dataJson["trace"] = inja::json::array();
@@ -401,17 +401,18 @@ void Protobuf::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, 
     dataJson["coverage"] = coverageStr.str();
 
     LOG5("Protobuf test back end: emitting testcase:" << std::setw(4) << dataJson);
-    auto protobufFile = basePath;
-    protobufFile.replace_extension("_" + std::to_string(testIdx) + ".proto");
-    auto protobufFileStream = std::ofstream(protobufFile);
+    auto incrementedbasePath = basePath;
+    incrementedbasePath.concat("_" + std::to_string(testId));
+    incrementedbasePath.replace_extension(".stf");
+    auto protobufFileStream = std::ofstream(incrementedbasePath);
     inja::render_to(protobufFileStream, testCase, dataJson);
     protobufFileStream.flush();
 }
 
-void Protobuf::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+void Protobuf::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                           float currentCoverage) {
     std::string testCase = getTestCaseTemplate();
-    emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);
+    emitTestcase(testSpec, selectedBranches, testId, testCase, currentCoverage);
 }
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.h
@@ -40,7 +40,7 @@ class Protobuf : public TF {
     Protobuf(std::filesystem::path basePath, std::optional<unsigned int> seed);
 
     /// Produce a Protobuf test.
-    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testIdx,
+    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testId,
                     float currentCoverage) override;
 
  private:
@@ -53,7 +53,7 @@ class Protobuf : public TF {
     /// @param selectedBranches enumerates the choices the interpreter made for this path.
     /// @param currentCoverage contains statistics  about the current coverage of this test and its
     /// preceding tests.
-    void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+    void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                       const std::string &testCase, float currentCoverage);
 
     /// @returns the inja test case template as a string.

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
@@ -244,7 +244,6 @@ import base_test as bt
 class AbstractTest(bt.P4RuntimeTest):
     EnumColor = Enum("EnumColor", ["GREEN", "YELLOW", "RED"], start=0)
 
-    @bt.autocleanup
     def setUp(self):
         bt.P4RuntimeTest.setUp(self)
         success = bt.P4RuntimeTest.updateConfig(self)
@@ -262,6 +261,7 @@ class AbstractTest(bt.P4RuntimeTest):
     def verifyPackets(self):
         pass
 
+    @bt.autocleanup
     def runTestImpl(self):
         self.setupCtrlPlane()
         bt.testutils.log.info("Sending Packet ...")
@@ -407,7 +407,7 @@ class Test{{test_id}}(AbstractTest):
         ptfutils.verify_no_other_packets(self, self.device_id, timeout=2)
 ## endif
 ## else
-        pass
+        ptfutils.verify_no_other_packets(self, self.device_id, timeout=2)
 ## endif
 
     def runTest(self):
@@ -417,14 +417,14 @@ class Test{{test_id}}(AbstractTest):
     return TEST_CASE;
 }
 
-void PTF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+void PTF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                        const std::string &testCase, float currentCoverage) {
     inja::json dataJson;
     if (selectedBranches != nullptr) {
         dataJson["selected_branches"] = selectedBranches.c_str();
     }
 
-    dataJson["test_id"] = testIdx + 1;
+    dataJson["test_id"] = testId + 1;
     dataJson["trace"] = getTrace(testSpec);
     dataJson["control_plane"] = getControlPlane(testSpec);
     dataJson["send"] = getSend(testSpec);
@@ -450,7 +450,7 @@ void PTF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_
     ptfFileStream.flush();
 }
 
-void PTF::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+void PTF::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                      float currentCoverage) {
     if (!preambleEmitted) {
         auto ptfFile = basePath;
@@ -460,7 +460,7 @@ void PTF::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t 
         preambleEmitted = true;
     }
     std::string testCase = getTestCaseTemplate();
-    emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);
+    emitTestcase(testSpec, selectedBranches, testId, testCase, currentCoverage);
 }
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
@@ -424,7 +424,7 @@ void PTF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_
         dataJson["selected_branches"] = selectedBranches.c_str();
     }
 
-    dataJson["test_id"] = testId + 1;
+    dataJson["test_id"] = testId;
     dataJson["trace"] = getTrace(testSpec);
     dataJson["control_plane"] = getControlPlane(testSpec);
     dataJson["send"] = getSend(testSpec);

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.h
@@ -43,7 +43,7 @@ class PTF : public TF {
     PTF(std::filesystem::path basePath, std::optional<unsigned int> seed);
 
     /// Produce a PTF test.
-    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testIdx,
+    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testId,
                     float currentCoverage) override;
 
  private:
@@ -52,11 +52,11 @@ class PTF : public TF {
     void emitPreamble();
 
     /// Emits a test case.
-    /// @param testIdx specifies the test name.
+    /// @param testId specifies the test name.
     /// @param selectedBranches enumerates the choices the interpreter made for this path.
     /// @param currentCoverage contains statistics  about the current coverage of this test and its
     /// preceding tests.
-    void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+    void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                       const std::string &testCase, float currentCoverage);
 
     /// @returns the inja test case template as a string.

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.cpp
@@ -263,7 +263,7 @@ expect {{verify.eg_port}} {{verify.exp_pkt}}$
     return TEST_CASE;
 }
 
-void STF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+void STF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                        const std::string &testCase, float currentCoverage) {
     inja::json dataJson;
     if (selectedBranches != nullptr) {
@@ -273,7 +273,7 @@ void STF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_
         dataJson["seed"] = *seed;
     }
 
-    dataJson["test_id"] = testIdx + 1;
+    dataJson["test_id"] = testId;
     dataJson["trace"] = getTrace(testSpec);
     dataJson["control_plane"] = getControlPlane(testSpec);
     dataJson["send"] = getSend(testSpec);
@@ -293,17 +293,17 @@ void STF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_
 
     LOG5("STF test back end: emitting testcase:" << std::setw(4) << dataJson);
     auto incrementedbasePath = basePath;
-    incrementedbasePath.concat("_" + std::to_string(testIdx));
+    incrementedbasePath.concat("_" + std::to_string(testId));
     incrementedbasePath.replace_extension(".stf");
     auto stfFileStream = std::ofstream(incrementedbasePath);
     inja::render_to(stfFileStream, testCase, dataJson);
     stfFileStream.flush();
 }
 
-void STF::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+void STF::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                      float currentCoverage) {
     std::string testCase = getTestCaseTemplate();
-    emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);
+    emitTestcase(testSpec, selectedBranches, testId, testCase, currentCoverage);
 }
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/stf/stf.h
@@ -34,16 +34,16 @@ class STF : public TF {
     STF(std::filesystem::path basePath, std::optional<unsigned int> seed);
 
     /// Produce an STF test.
-    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testIdx,
+    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testId,
                     float currentCoverage) override;
 
  private:
     /// Emits a test case.
-    /// @param testIdx specifies the test name.
+    /// @param testId specifies the test name.
     /// @param selectedBranches enumerates the choices the interpreter made for this path.
     /// @param currentCoverage contains statistics  about the current coverage of this test and its
     /// preceding tests.
-    void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+    void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                       const std::string &testCase, float currentCoverage);
 
     /// @returns the inja test case template as a string.

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -1046,7 +1046,6 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
              result->emplace_back(cond, state, nextState);
              return;
          }},
-
         /* ======================================================================================
          *  digest
          *  Calling digest causes a message containing the values specified in

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
@@ -45,7 +45,8 @@ Bmv2TestBackend::Bmv2TestBackend(const ProgramInfo &programInfo, SymbolicExecuto
     if (testBackendString.isNullOrEmpty()) {
         ::error(
             "No test back end provided. Please provide a test back end using the --test-backend "
-            "parameter.");
+            "parameter. Supported back ends are %1%.",
+            Utils::containerToString(SUPPORTED_BACKENDS));
         exit(EXIT_FAILURE);
     }
 

--- a/backends/p4tools/modules/testgen/targets/ebpf/backend/stf/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/backend/stf/stf.cpp
@@ -222,7 +222,7 @@ expect {{verify.eg_port}} {{verify.exp_pkt}}
     return TEST_CASE;
 }
 
-void STF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+void STF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                        const std::string &testCase, float currentCoverage) {
     inja::json dataJson;
     if (selectedBranches != nullptr) {
@@ -232,7 +232,7 @@ void STF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_
         dataJson["seed"] = *seed;
     }
 
-    dataJson["test_id"] = testIdx + 1;
+    dataJson["test_id"] = testId;
     dataJson["trace"] = getTrace(testSpec);
     dataJson["control_plane"] = getControlPlane(testSpec);
     dataJson["send"] = getSend(testSpec);
@@ -243,17 +243,18 @@ void STF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_
     dataJson["coverage"] = coverageStr.str();
 
     LOG5("STF test back end: emitting testcase:" << std::setw(4) << dataJson);
-    auto stfFile = basePath;
-    stfFile.replace_extension("_" + std::to_string(testIdx) + ".stf");
-    auto stfFileStream = std::ofstream(stfFile);
+    auto incrementedbasePath = basePath;
+    incrementedbasePath.concat("_" + std::to_string(testId));
+    incrementedbasePath.replace_extension(".stf");
+    auto stfFileStream = std::ofstream(incrementedbasePath);
     inja::render_to(stfFileStream, testCase, dataJson);
     stfFileStream.flush();
 }
 
-void STF::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+void STF::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                      float currentCoverage) {
     std::string testCase = getTestCaseTemplate();
-    emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);
+    emitTestcase(testSpec, selectedBranches, testId, testCase, currentCoverage);
 }
 
 }  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/backend/stf/stf.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/backend/stf/stf.h
@@ -32,7 +32,7 @@ class STF : public TF {
     STF(std::filesystem::path basePath, std::optional<unsigned int> seed);
 
     /// Produce an STF test.
-    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testIdx,
+    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testId,
                     float currentCoverage) override;
 
  private:
@@ -41,7 +41,7 @@ class STF : public TF {
     /// @param selectedBranches enumerates the choices the interpreter made for this path.
     /// @param currentCoverage contains statistics  about the current coverage of this test and its
     /// preceding tests.
-    void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+    void emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                       const std::string &testCase, float currentCoverage);
 
     /// @returns the inja test case template as a string.

--- a/backends/p4tools/modules/testgen/targets/ebpf/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test_backend.cpp
@@ -10,6 +10,7 @@
 
 #include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/trace_event.h"
+#include "backends/p4tools/common/lib/util.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"
 #include "lib/cstring.h"
@@ -34,23 +35,20 @@ EBPFTestBackend::EBPFTestBackend(const ProgramInfo &programInfo, SymbolicExecuto
                                  const std::filesystem::path &testPath)
     : TestBackEnd(programInfo, symbex) {
     cstring testBackendString = TestgenOptions::get().testBackend;
+    if (testBackendString.isNullOrEmpty()) {
+        ::error(
+            "No test back end provided. Please provide a test back end using the --test-backend "
+            "parameter. Supported back ends are %1%.",
+            Utils::containerToString(SUPPORTED_BACKENDS));
+        exit(EXIT_FAILURE);
+    }
 
     if (testBackendString == "STF") {
         testWriter = new STF(testPath.c_str(), TestgenOptions::get().seed);
     } else {
-        std::stringstream supportedBackendString;
-        bool isFirst = true;
-        for (const auto &backend : SUPPORTED_BACKENDS) {
-            if (!isFirst) {
-                supportedBackendString << ", ";
-            } else {
-                isFirst = false;
-            }
-            supportedBackendString << backend;
-        }
         P4C_UNIMPLEMENTED(
             "Test back end %1% not implemented for this target. Supported back ends are %2%.",
-            testBackendString, supportedBackendString.str());
+            testBackendString, Utils::containerToString(SUPPORTED_BACKENDS));
     }
 }
 

--- a/backends/p4tools/modules/testgen/targets/pna/backend/metadata/metadata.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/backend/metadata/metadata.cpp
@@ -147,7 +147,7 @@ void Metadata::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, 
         dataJson["seed"] = *seed;
     }
     dataJson["test_name"] = basePath.stem();
-    dataJson["test_id"] = testId + 1;
+    dataJson["test_id"] = testId;
     computeTraceData(testSpec, dataJson);
 
     dataJson["send"] = getSend(testSpec);
@@ -177,14 +177,14 @@ void Metadata::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, 
     metadataFile.flush();
 }
 
-void Metadata::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testIdx,
+void Metadata::outputTest(const TestSpec *testSpec, cstring selectedBranches, size_t testId,
                           float currentCoverage) {
     auto incrementedbasePath = basePath;
-    incrementedbasePath.concat("_" + std::to_string(testIdx));
+    incrementedbasePath.concat("_" + std::to_string(testId));
     incrementedbasePath.replace_extension(".yml");
     metadataFile = std::ofstream(incrementedbasePath);
     std::string testCase = getTestCaseTemplate();
-    emitTestcase(testSpec, selectedBranches, testIdx, testCase, currentCoverage);
+    emitTestcase(testSpec, selectedBranches, testId, testCase, currentCoverage);
 }
 
 }  // namespace P4Tools::P4Testgen::Pna

--- a/backends/p4tools/modules/testgen/targets/pna/backend/metadata/metadata.h
+++ b/backends/p4tools/modules/testgen/targets/pna/backend/metadata/metadata.h
@@ -38,7 +38,7 @@ class Metadata : public TF {
     Metadata(std::filesystem::path basePath, std::optional<unsigned int> seed);
 
     /// Produce a Metadata test.
-    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testIdx,
+    void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testId,
                     float currentCoverage) override;
 
  private:

--- a/backends/p4tools/modules/testgen/targets/pna/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/test_backend.cpp
@@ -38,7 +38,8 @@ PnaTestBackend::PnaTestBackend(const ProgramInfo &programInfo, SymbolicExecutor 
     if (testBackendString.isNullOrEmpty()) {
         ::error(
             "No test back end provided. Please provide a test back end using the --test-backend "
-            "parameter.");
+            "parameter. Supported back ends are %1%.",
+            Utils::containerToString(SUPPORTED_BACKENDS));
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
- Unify test numbering and the name of the variable in the test back ends. They all start from 0 now. Also make sure the test name does not have a duplicate `.`. 
- Provide hints on available test back ends. 
- Verify that no other packets are present if the packet is dropped in PTF.
- Add some hints on the support Z3 versions. #4034 will fix this, too.
- Support array indices when converting references.

Fixes #4033.