### PR TITLE
Change Dockerfile to build p4tools by default.

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -129,7 +129,8 @@ jobs:
 
     - name: Build (Ubuntu 18.04, GCC)
       run: |
-        docker build -t p4c --build-arg BASE_IMAGE=ubuntu:18.04 --build-arg IMAGE_TYPE=test .
+        docker build -t p4c --build-arg BASE_IMAGE=ubuntu:18.04 --build-arg IMAGE_TYPE=test \
+        --build-arg ENABLE_TEST_TOOLS=OFF .
         ./tools/export_ccache.sh
 
       # run with sudo (...) --privileged

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Whether to install dependencies required to run PTF-ebpf tests
 ARG INSTALL_PTF_EBPF_DEPENDENCIES=OFF
 # Whether to build the P4Tools back end and platform.
-ARG ENABLE_TEST_TOOLS=OFF
+ARG ENABLE_TEST_TOOLS=ON
 # Whether to treat warnings as errors.
 ARG ENABLE_WERROR=ON
 # Compile with Clang compiler


### PR DESCRIPTION
Build p4tools into p4c docker image by default. In particular, this will make p4testgen easily available in the prebuilt docker image on dockerhub/p4lang/p4c.

Impact:
* On my x86 platform, the p4c docker image build time increased from 29 min to 37 min. Since the main intent is to simplify developers' lives by using a prebuilt image, this seems like a good tradeoff. Building is done in the background in a CI pipeline.
* The docker p4c image size increased from 1.59GB to 1.70GB.