### PR TITLE
Don't omit the apply block label in P4Control::dbprint

### DIFF
--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -224,8 +224,9 @@ void IR::P4Control::dbprint(std::ostream &out) const {
     if (constructorParams) out << '(' << constructorParams << ')';
     out << " " << type->annotations << "{" << indent;
     for (auto d : controlLocals) out << Log::endl << d;
+    out << Log::endl << "apply {" << indent;
     for (auto s : body->components) out << Log::endl << s;
-    out << " }" << unindent;
+    out << " } }" << unindent << unindent;
 }
 
 void IR::V1Program::dbprint(std::ostream &out) const {


### PR DESCRIPTION
Before this change, the statements of the `P4Control`'s "body"/`apply` block were printed directly after the variables and tables declared in the control. With this change, the dbprint more closely resembles the original P4 code and is more readable.
