### PR TITLE
Avoid using reserved identifiers as include guards

### DIFF
--- a/backends/ebpf/codeGen.h
+++ b/backends/ebpf/codeGen.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_CODEGEN_H_
-#define _BACKENDS_EBPF_CODEGEN_H_
+#ifndef BACKENDS_EBPF_CODEGEN_H_
+#define BACKENDS_EBPF_CODEGEN_H_
 
 #include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
@@ -139,4 +139,4 @@ class EBPFInitializerUtils {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_CODEGEN_H_ */
+#endif /* BACKENDS_EBPF_CODEGEN_H_ */

--- a/backends/ebpf/ebpfBackend.h
+++ b/backends/ebpf/ebpfBackend.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_EBPFBACKEND_H_
-#define _BACKENDS_EBPF_EBPFBACKEND_H_
+#ifndef BACKENDS_EBPF_EBPFBACKEND_H_
+#define BACKENDS_EBPF_EBPFBACKEND_H_
 
 #include "ebpfObject.h"
 #include "ebpfOptions.h"
@@ -29,4 +29,4 @@ void run_ebpf_backend(const EbpfOptions &options, const IR::ToplevelBlock *tople
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_EBPFBACKEND_H_ */
+#endif /* BACKENDS_EBPF_EBPFBACKEND_H_ */

--- a/backends/ebpf/ebpfControl.h
+++ b/backends/ebpf/ebpfControl.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_EBPFCONTROL_H_
-#define _BACKENDS_EBPF_EBPFCONTROL_H_
+#ifndef BACKENDS_EBPF_EBPFCONTROL_H_
+#define BACKENDS_EBPF_EBPFCONTROL_H_
 
 #include "ebpfObject.h"
 #include "ebpfTable.h"
@@ -95,4 +95,4 @@ class EBPFControl : public EBPFObject {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_EBPFCONTROL_H_ */
+#endif /* BACKENDS_EBPF_EBPFCONTROL_H_ */

--- a/backends/ebpf/ebpfDeparser.h
+++ b/backends/ebpf/ebpfDeparser.h
@@ -14,8 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#ifndef _BACKENDS_EBPF_EBPFDEPARSER_H_
-#define _BACKENDS_EBPF_EBPFDEPARSER_H_
+#ifndef BACKENDS_EBPF_EBPFDEPARSER_H_
+#define BACKENDS_EBPF_EBPFDEPARSER_H_
 
 #include "ebpfControl.h"
 
@@ -93,4 +93,4 @@ class EBPFDeparser : public EBPFControl {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_EBPFDEPARSER_H_ */
+#endif /* BACKENDS_EBPF_EBPFDEPARSER_H_ */

--- a/backends/ebpf/ebpfModel.h
+++ b/backends/ebpf/ebpfModel.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_EBPFMODEL_H_
-#define _BACKENDS_EBPF_EBPFMODEL_H_
+#ifndef BACKENDS_EBPF_EBPFMODEL_H_
+#define BACKENDS_EBPF_EBPFMODEL_H_
 
 #include "frontends/common/model.h"
 #include "frontends/p4/coreLibrary.h"
@@ -82,4 +82,4 @@ class EBPFModel : public ::Model::Model {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_EBPFMODEL_H_ */
+#endif /* BACKENDS_EBPF_EBPFMODEL_H_ */

--- a/backends/ebpf/ebpfObject.h
+++ b/backends/ebpf/ebpfObject.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_EBPFOBJECT_H_
-#define _BACKENDS_EBPF_EBPFOBJECT_H_
+#ifndef BACKENDS_EBPF_EBPFOBJECT_H_
+#define BACKENDS_EBPF_EBPFOBJECT_H_
 
 #include "codeGen.h"
 #include "ebpfModel.h"
@@ -58,4 +58,4 @@ class EBPFObject : public ICastable {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_EBPFOBJECT_H_ */
+#endif /* BACKENDS_EBPF_EBPFOBJECT_H_ */

--- a/backends/ebpf/ebpfOptions.h
+++ b/backends/ebpf/ebpfOptions.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_EBPFOPTIONS_H_
-#define _BACKENDS_EBPF_EBPFOPTIONS_H_
+#ifndef BACKENDS_EBPF_EBPFOPTIONS_H_
+#define BACKENDS_EBPF_EBPFOPTIONS_H_
 
 #include <getopt.h>
 
@@ -71,4 +71,4 @@ class EbpfOptions : public CompilerOptions {
 
 using EbpfContext = P4CContextWithOptions<EbpfOptions>;
 
-#endif /* _BACKENDS_EBPF_EBPFOPTIONS_H_ */
+#endif /* BACKENDS_EBPF_EBPFOPTIONS_H_ */

--- a/backends/ebpf/ebpfParser.h
+++ b/backends/ebpf/ebpfParser.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_EBPFPARSER_H_
-#define _BACKENDS_EBPF_EBPFPARSER_H_
+#ifndef BACKENDS_EBPF_EBPFPARSER_H_
+#define BACKENDS_EBPF_EBPFPARSER_H_
 
 #include "ebpfObject.h"
 #include "ebpfProgram.h"
@@ -104,4 +104,4 @@ class EBPFParser : public EBPFObject {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_EBPFPARSER_H_ */
+#endif /* BACKENDS_EBPF_EBPFPARSER_H_ */

--- a/backends/ebpf/ebpfProgram.h
+++ b/backends/ebpf/ebpfProgram.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_EBPFPROGRAM_H_
-#define _BACKENDS_EBPF_EBPFPROGRAM_H_
+#ifndef BACKENDS_EBPF_EBPFPROGRAM_H_
+#define BACKENDS_EBPF_EBPFPROGRAM_H_
 
 #include "codeGen.h"
 #include "ebpfModel.h"
@@ -97,4 +97,4 @@ class EBPFProgram : public EBPFObject {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_EBPFPROGRAM_H_ */
+#endif /* BACKENDS_EBPF_EBPFPROGRAM_H_ */

--- a/backends/ebpf/ebpfTable.h
+++ b/backends/ebpf/ebpfTable.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_EBPFTABLE_H_
-#define _BACKENDS_EBPF_EBPFTABLE_H_
+#ifndef BACKENDS_EBPF_EBPFTABLE_H_
+#define BACKENDS_EBPF_EBPFTABLE_H_
 
 #include "ebpfObject.h"
 #include "ebpfProgram.h"
@@ -182,4 +182,4 @@ class EBPFValueSet : public EBPFTableBase {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_EBPFTABLE_H_ */
+#endif /* BACKENDS_EBPF_EBPFTABLE_H_ */

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_EBPFTYPE_H_
-#define _BACKENDS_EBPF_EBPFTYPE_H_
+#ifndef BACKENDS_EBPF_EBPFTYPE_H_
+#define BACKENDS_EBPF_EBPFTYPE_H_
 
 #include "ebpfObject.h"
 #include "ir/ir.h"
@@ -184,4 +184,4 @@ class EBPFEnumType : public EBPFType, public EBPF::IHasWidth {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_EBPFTYPE_H_ */
+#endif /* BACKENDS_EBPF_EBPFTYPE_H_ */

--- a/backends/ebpf/lower.h
+++ b/backends/ebpf/lower.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_LOWER_H_
-#define _BACKENDS_EBPF_LOWER_H_
+#ifndef BACKENDS_EBPF_LOWER_H_
+#define BACKENDS_EBPF_LOWER_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -57,4 +57,4 @@ class Lower : public PassManager {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_LOWER_H_ */
+#endif /* BACKENDS_EBPF_LOWER_H_ */

--- a/backends/ebpf/midend.h
+++ b/backends/ebpf/midend.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_MIDEND_H_
-#define _BACKENDS_EBPF_MIDEND_H_
+#ifndef BACKENDS_EBPF_MIDEND_H_
+#define BACKENDS_EBPF_MIDEND_H_
 
 #include "ebpfOptions.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
@@ -38,4 +38,4 @@ class MidEnd {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_MIDEND_H_ */
+#endif /* BACKENDS_EBPF_MIDEND_H_ */

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_EBPF_TARGET_H_
-#define _BACKENDS_EBPF_TARGET_H_
+#ifndef BACKENDS_EBPF_TARGET_H_
+#define BACKENDS_EBPF_TARGET_H_
 
 #include "lib/cstring.h"
 #include "lib/error.h"
@@ -269,4 +269,4 @@ class TestTarget : public EBPF::KernelSamplesTarget {
 
 }  // namespace EBPF
 
-#endif /* _BACKENDS_EBPF_TARGET_H_ */
+#endif /* BACKENDS_EBPF_TARGET_H_ */

--- a/backends/graphs/controls.h
+++ b/backends/graphs/controls.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_GRAPHS_CONTROLS_H_
-#define _BACKENDS_GRAPHS_CONTROLS_H_
+#ifndef BACKENDS_GRAPHS_CONTROLS_H_
+#define BACKENDS_GRAPHS_CONTROLS_H_
 
 #include "graphs.h"
 
@@ -68,4 +68,4 @@ class ControlGraphs : public Graphs {
 
 }  // namespace graphs
 
-#endif /* _BACKENDS_GRAPHS_CONTROLS_H_ */
+#endif /* BACKENDS_GRAPHS_CONTROLS_H_ */

--- a/backends/graphs/graph_visitor.h
+++ b/backends/graphs/graph_visitor.h
@@ -20,8 +20,8 @@
 #include "graphs.h"
 #include "lib/json.h"
 
-#ifndef _BACKENDS_GRAPHS_GRAPH_VISITOR_H_
-#define _BACKENDS_GRAPHS_GRAPH_VISITOR_H_
+#ifndef BACKENDS_GRAPHS_GRAPH_VISITOR_H_
+#define BACKENDS_GRAPHS_GRAPH_VISITOR_H_
 
 namespace graphs {
 
@@ -137,4 +137,4 @@ class Graph_visitor : public Graphs {
 
 }  // namespace graphs
 
-#endif /* _BACKENDS_GRAPHS_GRAPH_VISITOR_H_ */
+#endif /* BACKENDS_GRAPHS_GRAPH_VISITOR_H_ */

--- a/backends/graphs/graphs.h
+++ b/backends/graphs/graphs.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_GRAPHS_GRAPHS_H_
-#define _BACKENDS_GRAPHS_GRAPHS_H_
+#ifndef BACKENDS_GRAPHS_GRAPHS_H_
+#define BACKENDS_GRAPHS_GRAPHS_H_
 
 #include "config.h"
 
@@ -225,4 +225,4 @@ class Graphs : public Inspector {
 
 }  // namespace graphs
 
-#endif  // _BACKENDS_GRAPHS_GRAPHS_H_
+#endif  /* BACKENDS_GRAPHS_GRAPHS_H_ */

--- a/backends/graphs/graphs.h
+++ b/backends/graphs/graphs.h
@@ -225,4 +225,4 @@ class Graphs : public Inspector {
 
 }  // namespace graphs
 
-#endif  /* BACKENDS_GRAPHS_GRAPHS_H_ */
+#endif /* BACKENDS_GRAPHS_GRAPHS_H_ */

--- a/backends/graphs/parsers.h
+++ b/backends/graphs/parsers.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _BACKENDS_GRAPHS_PARSERS_H_
-#define _BACKENDS_GRAPHS_PARSERS_H_
+#ifndef BACKENDS_GRAPHS_PARSERS_H_
+#define BACKENDS_GRAPHS_PARSERS_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "graphs.h"
@@ -61,4 +61,4 @@ class ParserGraphs : public Graphs {
 
 }  // namespace graphs
 
-#endif /* _BACKENDS_GRAPHS_PARSERS_H_ */
+#endif /* BACKENDS_GRAPHS_PARSERS_H_ */

--- a/backends/p4test/midend.h
+++ b/backends/p4test/midend.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_P4TEST_MIDEND_H_
-#define _BACKENDS_P4TEST_MIDEND_H_
+#ifndef BACKENDS_P4TEST_MIDEND_H_
+#define BACKENDS_P4TEST_MIDEND_H_
 
 #include "frontends/common/options.h"
 #include "frontends/p4/evaluator/evaluator.h"
@@ -42,4 +42,4 @@ class MidEnd : public PassManager {
 
 }  // namespace P4Test
 
-#endif /* _BACKENDS_P4TEST_MIDEND_H_ */
+#endif /* BACKENDS_P4TEST_MIDEND_H_ */

--- a/backends/ubpf/midend.h
+++ b/backends/ubpf/midend.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _BACKENDS_UBPF_MIDEND_H_
-#define _BACKENDS_UBPF_MIDEND_H_
+#ifndef BACKENDS_UBPF_MIDEND_H_
+#define BACKENDS_UBPF_MIDEND_H_
 
 #include "backends/ebpf/ebpfOptions.h"
 #include "backends/ebpf/midend.h"
@@ -32,4 +32,4 @@ class MidEnd : public EBPF::MidEnd {
 
 }  // namespace UBPF
 
-#endif /* _BACKENDS_UBPF_MIDEND_H_ */
+#endif /* BACKENDS_UBPF_MIDEND_H_ */

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _COMMON_CONSTANTFOLDING_H_
-#define _COMMON_CONSTANTFOLDING_H_
+#ifndef COMMON_CONSTANTFOLDING_H_
+#define COMMON_CONSTANTFOLDING_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -167,4 +167,4 @@ class ConstantFolding : public PassManager {
 
 }  // namespace P4
 
-#endif /* _COMMON_CONSTANTFOLDING_H_ */
+#endif /* COMMON_CONSTANTFOLDING_H_ */

--- a/frontends/common/constantParsing.h
+++ b/frontends/common/constantParsing.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_COMMON_CONSTANTPARSING_H_
-#define _FRONTENDS_COMMON_CONSTANTPARSING_H_
+#ifndef FRONTENDS_COMMON_CONSTANTPARSING_H_
+#define FRONTENDS_COMMON_CONSTANTPARSING_H_
 
 #include "lib/cstring.h"
 
@@ -86,4 +86,4 @@ IR::Constant *parseConstant(const Util::SourceInfo &srcInfo, const UnparsedConst
  */
 int parseConstantChecked(const Util::SourceInfo &srcInfo, const UnparsedConstant &constant);
 
-#endif /* _FRONTENDS_COMMON_CONSTANTPARSING_H_ */
+#endif /* FRONTENDS_COMMON_CONSTANTPARSING_H_ */

--- a/frontends/common/model.h
+++ b/frontends/common/model.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_COMMON_MODEL_H_
-#define _FRONTENDS_COMMON_MODEL_H_
+#ifndef FRONTENDS_COMMON_MODEL_H_
+#define FRONTENDS_COMMON_MODEL_H_
 
 #include "ir/id.h"
 #include "lib/cstring.h"
@@ -65,4 +65,4 @@ class Model {};
 
 }  // namespace Model
 
-#endif /* _FRONTENDS_COMMON_MODEL_H_ */
+#endif /* FRONTENDS_COMMON_MODEL_H_ */

--- a/frontends/common/parseInput.h
+++ b/frontends/common/parseInput.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_COMMON_PARSEINPUT_H_
-#define _FRONTENDS_COMMON_PARSEINPUT_H_
+#ifndef FRONTENDS_COMMON_PARSEINPUT_H_
+#define FRONTENDS_COMMON_PARSEINPUT_H_
 
 #include "frontends/common/options.h"
 #include "frontends/p4/fromv1.0/converters.h"
@@ -109,4 +109,4 @@ const IR::P4Program *parseP4String(const std::string &input,
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_COMMON_PARSEINPUT_H_ */
+#endif /* FRONTENDS_COMMON_PARSEINPUT_H_ */

--- a/frontends/common/programMap.h
+++ b/frontends/common/programMap.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_COMMON_PROGRAMMAP_H_
-#define _FRONTENDS_COMMON_PROGRAMMAP_H_
+#ifndef FRONTENDS_COMMON_PROGRAMMAP_H_
+#define FRONTENDS_COMMON_PROGRAMMAP_H_
 
 #include "ir/ir.h"
 #include "lib/log.h"
@@ -65,4 +65,4 @@ class ProgramMap : public IHasDbPrint {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_COMMON_PROGRAMMAP_H_ */
+#endif /* FRONTENDS_COMMON_PROGRAMMAP_H_ */

--- a/frontends/common/resolveReferences/referenceMap.h
+++ b/frontends/common/resolveReferences/referenceMap.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _COMMON_RESOLVEREFERENCES_REFERENCEMAP_H_
-#define _COMMON_RESOLVEREFERENCES_REFERENCEMAP_H_
+#ifndef COMMON_RESOLVEREFERENCES_REFERENCEMAP_H_
+#define COMMON_RESOLVEREFERENCES_REFERENCEMAP_H_
 
 #include "frontends/common/programMap.h"
 #include "ir/ir.h"
@@ -121,4 +121,4 @@ class ReferenceMap final : public ProgramMap, public NameGenerator, public Decla
 
 }  // namespace P4
 
-#endif /* _COMMON_RESOLVEREFERENCES_REFERENCEMAP_H_ */
+#endif /* COMMON_RESOLVEREFERENCES_REFERENCEMAP_H_ */

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _COMMON_RESOLVEREFERENCES_RESOLVEREFERENCES_H_
-#define _COMMON_RESOLVEREFERENCES_RESOLVEREFERENCES_H_
+#ifndef COMMON_RESOLVEREFERENCES_RESOLVEREFERENCES_H_
+#define COMMON_RESOLVEREFERENCES_RESOLVEREFERENCES_H_
 
 #include "ir/ir.h"
 #include "lib/cstring.h"
@@ -133,4 +133,4 @@ class ResolveReferences : public Inspector, private ResolutionContext {
 
 }  // namespace P4
 
-#endif /* _COMMON_RESOLVEREFERENCES_RESOLVEREFERENCES_H_ */
+#endif /* COMMON_RESOLVEREFERENCES_RESOLVEREFERENCES_H_ */

--- a/frontends/p4-14/typecheck.h
+++ b/frontends/p4-14/typecheck.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_14_TYPECHECK_H_
-#define _FRONTENDS_P4_14_TYPECHECK_H_
+#ifndef FRONTENDS_P4_14_TYPECHECK_H_
+#define FRONTENDS_P4_14_TYPECHECK_H_
 
 #include "ir/ir.h"
 #include "ir/pass_manager.h"
@@ -37,4 +37,4 @@ class TypeCheck : public PassManager {
     const IR::Node *apply_visitor(const IR::Node *, const char *) override;
 };
 
-#endif /* _FRONTENDS_P4_14_TYPECHECK_H_ */
+#endif /* FRONTENDS_P4_14_TYPECHECK_H_ */

--- a/frontends/p4/actionsInlining.h
+++ b/frontends/p4/actionsInlining.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_ACTIONSINLINING_H_
-#define _FRONTENDS_P4_ACTIONSINLINING_H_
+#ifndef FRONTENDS_P4_ACTIONSINLINING_H_
+#define FRONTENDS_P4_ACTIONSINLINING_H_
 
 #include "commonInlining.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -114,4 +114,4 @@ class InlineActions : public Transform {
 
 }  // namespace P4_14
 
-#endif /* _FRONTENDS_P4_ACTIONSINLINING_H_ */
+#endif /* FRONTENDS_P4_ACTIONSINLINING_H_ */

--- a/frontends/p4/alias.h
+++ b/frontends/p4/alias.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_ALIAS_H_
-#define _FRONTENDS_P4_ALIAS_H_
+#ifndef FRONTENDS_P4_ALIAS_H_
+#define FRONTENDS_P4_ALIAS_H_
 
 /*
  * A simple conservative syntactic alias analysis.  Two things may
@@ -244,4 +244,4 @@ class ReadsWrites : public Inspector {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_ALIAS_H_ */
+#endif /* FRONTENDS_P4_ALIAS_H_ */

--- a/frontends/p4/callGraph.h
+++ b/frontends/p4/callGraph.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_CALLGRAPH_H_
-#define _FRONTENDS_P4_CALLGRAPH_H_
+#ifndef FRONTENDS_P4_CALLGRAPH_H_
+#define FRONTENDS_P4_CALLGRAPH_H_
 
 #include <algorithm>
 #include <unordered_set>
@@ -357,4 +357,4 @@ class CallGraph {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_CALLGRAPH_H_ */
+#endif /* FRONTENDS_P4_CALLGRAPH_H_ */

--- a/frontends/p4/checkConstants.h
+++ b/frontends/p4/checkConstants.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_CHECKCONSTANTS_H_
-#define _FRONTENDS_P4_CHECKCONSTANTS_H_
+#ifndef FRONTENDS_P4_CHECKCONSTANTS_H_
+#define FRONTENDS_P4_CHECKCONSTANTS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -52,4 +52,4 @@ class CheckConstants : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_CHECKCONSTANTS_H_ */
+#endif /* FRONTENDS_P4_CHECKCONSTANTS_H_ */

--- a/frontends/p4/checkCoreMethods.h
+++ b/frontends/p4/checkCoreMethods.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_CHECKCOREMETHODS_H_
-#define _FRONTENDS_P4_CHECKCOREMETHODS_H_
+#ifndef FRONTENDS_P4_CHECKCOREMETHODS_H_
+#define FRONTENDS_P4_CHECKCOREMETHODS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -51,4 +51,4 @@ class CheckCoreMethods : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_CHECKCOREMETHODS_H_ */
+#endif /* FRONTENDS_P4_CHECKCOREMETHODS_H_ */

--- a/frontends/p4/checkNamedArgs.h
+++ b/frontends/p4/checkNamedArgs.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_CHECKNAMEDARGS_H_
-#define _FRONTENDS_P4_CHECKNAMEDARGS_H_
+#ifndef FRONTENDS_P4_CHECKNAMEDARGS_H_
+#define FRONTENDS_P4_CHECKNAMEDARGS_H_
 
 #include "ir/ir.h"
 #include "ir/visitor.h"
@@ -53,4 +53,4 @@ class CheckNamedArgs : public Inspector {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_CHECKNAMEDARGS_H_ */
+#endif /* FRONTENDS_P4_CHECKNAMEDARGS_H_ */

--- a/frontends/p4/cloner.h
+++ b/frontends/p4/cloner.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_CLONER_H_
-#define _FRONTENDS_P4_CLONER_H_
+#ifndef FRONTENDS_P4_CLONER_H_
+#define FRONTENDS_P4_CLONER_H_
 
 #include "ir/ir.h"
 
@@ -42,4 +42,4 @@ class ClonePathExpressions : public Transform {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_CLONER_H_ */
+#endif /* FRONTENDS_P4_CLONER_H_ */

--- a/frontends/p4/commonInlining.h
+++ b/frontends/p4/commonInlining.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_COMMONINLINING_H_
-#define _FRONTENDS_P4_COMMONINLINING_H_
+#ifndef FRONTENDS_P4_COMMONINLINING_H_
+#define FRONTENDS_P4_COMMONINLINING_H_
 
 #define DEBUG_INLINER 0
 
@@ -189,4 +189,4 @@ class InlineDriver : public Visitor {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_COMMONINLINING_H_ */
+#endif /* FRONTENDS_P4_COMMONINLINING_H_ */

--- a/frontends/p4/coreLibrary.h
+++ b/frontends/p4/coreLibrary.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_CORELIBRARY_H_
-#define _FRONTENDS_P4_CORELIBRARY_H_
+#ifndef FRONTENDS_P4_CORELIBRARY_H_
+#define FRONTENDS_P4_CORELIBRARY_H_
 
 #include "frontends/common/model.h"
 #include "ir/ir.h"
@@ -137,4 +137,4 @@ class P4CoreLibrary : public ::Model::Model {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_CORELIBRARY_H_ */
+#endif /* FRONTENDS_P4_CORELIBRARY_H_ */

--- a/frontends/p4/createBuiltins.h
+++ b/frontends/p4/createBuiltins.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_CREATEBUILTINS_H_
-#define _P4_CREATEBUILTINS_H_
+#ifndef P4_CREATEBUILTINS_H_
+#define P4_CREATEBUILTINS_H_
 
 #include "ir/ir.h"
 #include "ir/visitor.h"
@@ -53,4 +53,4 @@ class CreateBuiltins final : public Transform {
 };
 }  // namespace P4
 
-#endif /* _P4_CREATEBUILTINS_H_ */
+#endif /* P4_CREATEBUILTINS_H_ */

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_DEF_USE_H_
-#define _FRONTENDS_P4_DEF_USE_H_
+#ifndef FRONTENDS_P4_DEF_USE_H_
+#define FRONTENDS_P4_DEF_USE_H_
 
 #include <typeindex>  // IWYU pragma: keep
 #include <unordered_set>
@@ -566,4 +566,4 @@ class ComputeWriteSet : public Inspector, public IHasDbPrint {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_DEF_USE_H_ */
+#endif /* FRONTENDS_P4_DEF_USE_H_ */

--- a/frontends/p4/defaultArguments.h
+++ b/frontends/p4/defaultArguments.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_DEFAULTARGUMENTS_H_
-#define _FRONTENDS_P4_DEFAULTARGUMENTS_H_
+#ifndef FRONTENDS_P4_DEFAULTARGUMENTS_H_
+#define FRONTENDS_P4_DEFAULTARGUMENTS_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
@@ -64,4 +64,4 @@ class DefaultArguments : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_DEFAULTARGUMENTS_H_ */
+#endif /* FRONTENDS_P4_DEFAULTARGUMENTS_H_ */

--- a/frontends/p4/defaultValues.h
+++ b/frontends/p4/defaultValues.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_DEFAULTVALUES_H_
-#define _P4_DEFAULTVALUES_H_
+#ifndef P4_DEFAULTVALUES_H_
+#define P4_DEFAULTVALUES_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -53,4 +53,4 @@ class DefaultValues : public PassManager {
 
 }  // namespace P4
 
-#endif /* _P4_DEFAULTVALUES_H_ */
+#endif /* P4_DEFAULTVALUES_H_ */

--- a/frontends/p4/deprecated.h
+++ b/frontends/p4/deprecated.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_DEPRECATED_H_
-#define _FRONTENDS_P4_DEPRECATED_H_
+#ifndef FRONTENDS_P4_DEPRECATED_H_
+#define FRONTENDS_P4_DEPRECATED_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "ir/ir.h"
@@ -53,4 +53,4 @@ class Deprecated : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_DEPRECATED_H_ */
+#endif /* FRONTENDS_P4_DEPRECATED_H_ */

--- a/frontends/p4/directCalls.h
+++ b/frontends/p4/directCalls.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_DIRECTCALLS_H_
-#define _FRONTENDS_P4_DIRECTCALLS_H_
+#ifndef FRONTENDS_P4_DIRECTCALLS_H_
+#define FRONTENDS_P4_DIRECTCALLS_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "ir/ir.h"
@@ -61,4 +61,4 @@ class InstantiateDirectCalls : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_DIRECTCALLS_H_ */
+#endif /* FRONTENDS_P4_DIRECTCALLS_H_ */

--- a/frontends/p4/dontcareArgs.h
+++ b/frontends/p4/dontcareArgs.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_DONTCAREARGS_H_
-#define _FRONTENDS_P4_DONTCAREARGS_H_
+#ifndef FRONTENDS_P4_DONTCAREARGS_H_
+#define FRONTENDS_P4_DONTCAREARGS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -70,4 +70,4 @@ class RemoveDontcareArgs : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_DONTCAREARGS_H_ */
+#endif /* FRONTENDS_P4_DONTCAREARGS_H_ */

--- a/frontends/p4/entryPriorities.h
+++ b/frontends/p4/entryPriorities.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_ENTRYPRIORITIES_H_
-#define _FRONTENDS_P4_ENTRYPRIORITIES_H_
+#ifndef FRONTENDS_P4_ENTRYPRIORITIES_H_
+#define FRONTENDS_P4_ENTRYPRIORITIES_H_
 
 #include "coreLibrary.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
@@ -51,4 +51,4 @@ class EntryPriorities : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_ENTRYPRIORITIES_H_ */
+#endif /* FRONTENDS_P4_ENTRYPRIORITIES_H_ */

--- a/frontends/p4/enumInstance.h
+++ b/frontends/p4/enumInstance.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_ENUMINSTANCE_H_
-#define _FRONTENDS_P4_ENUMINSTANCE_H_
+#ifndef FRONTENDS_P4_ENUMINSTANCE_H_
+#define FRONTENDS_P4_ENUMINSTANCE_H_
 
 #include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
@@ -61,4 +61,4 @@ class SerEnumInstance : public EnumInstance {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_ENUMINSTANCE_H_ */
+#endif /* FRONTENDS_P4_ENUMINSTANCE_H_ */

--- a/frontends/p4/evaluator/evaluator.h
+++ b/frontends/p4/evaluator/evaluator.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _EVALUATOR_EVALUATOR_H_
-#define _EVALUATOR_EVALUATOR_H_
+#ifndef EVALUATOR_EVALUATOR_H_
+#define EVALUATOR_EVALUATOR_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeMap.h"
@@ -121,4 +121,4 @@ class EvaluatorPass final : public PassManager, public IHasBlock {
 
 }  // namespace P4
 
-#endif /* _EVALUATOR_EVALUATOR_H_ */
+#endif /* EVALUATOR_EVALUATOR_H_ */

--- a/frontends/p4/evaluator/substituteParameters.h
+++ b/frontends/p4/evaluator/substituteParameters.h
@@ -16,8 +16,8 @@ limitations under the License.
 
 /* -*-C++-*- */
 
-#ifndef _EVALUATOR_SUBSTITUTEPARAMETERS_H_
-#define _EVALUATOR_SUBSTITUTEPARAMETERS_H_
+#ifndef EVALUATOR_SUBSTITUTEPARAMETERS_H_
+#define EVALUATOR_SUBSTITUTEPARAMETERS_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/parameterSubstitution.h"
@@ -53,4 +53,4 @@ class SubstituteParameters : public TypeVariableSubstitutionVisitor {
 
 }  // namespace P4
 
-#endif /* _EVALUATOR_SUBSTITUTEPARAMETERS_H_ */
+#endif /* EVALUATOR_SUBSTITUTEPARAMETERS_H_ */

--- a/frontends/p4/externInstance.h
+++ b/frontends/p4/externInstance.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_EXTERNINSTANCE_H_
-#define _FRONTENDS_P4_EXTERNINSTANCE_H_
+#ifndef FRONTENDS_P4_EXTERNINSTANCE_H_
+#define FRONTENDS_P4_EXTERNINSTANCE_H_
 
 #include <optional>
 
@@ -92,4 +92,4 @@ struct ExternInstance final {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_EXTERNINSTANCE_H_ */
+#endif /* FRONTENDS_P4_EXTERNINSTANCE_H_ */

--- a/frontends/p4/fromv1.0/converters.h
+++ b/frontends/p4/fromv1.0/converters.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_FROMV1_0_CONVERTERS_H_
-#define _FRONTENDS_P4_FROMV1_0_CONVERTERS_H_
+#ifndef FRONTENDS_P4_FROMV1_0_CONVERTERS_H_
+#define FRONTENDS_P4_FROMV1_0_CONVERTERS_H_
 
 #include <typeindex>
 #include <typeinfo>
@@ -1048,4 +1048,4 @@ class Converter : public PassManager {
 
 }  // namespace P4V1
 
-#endif /* _FRONTENDS_P4_FROMV1_0_CONVERTERS_H_ */
+#endif /* FRONTENDS_P4_FROMV1_0_CONVERTERS_H_ */

--- a/frontends/p4/fromv1.0/programStructure.h
+++ b/frontends/p4/fromv1.0/programStructure.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_FROMV1_0_PROGRAMSTRUCTURE_H_
-#define _FRONTENDS_P4_FROMV1_0_PROGRAMSTRUCTURE_H_
+#ifndef FRONTENDS_P4_FROMV1_0_PROGRAMSTRUCTURE_H_
+#define FRONTENDS_P4_FROMV1_0_PROGRAMSTRUCTURE_H_
 
 #include <set>
 #include <vector>
@@ -329,4 +329,4 @@ class ProgramStructure {
 
 }  // namespace P4V1
 
-#endif /* _FRONTENDS_P4_FROMV1_0_PROGRAMSTRUCTURE_H_ */
+#endif /* FRONTENDS_P4_FROMV1_0_PROGRAMSTRUCTURE_H_ */

--- a/frontends/p4/fromv1.0/v1model.h
+++ b/frontends/p4/fromv1.0/v1model.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_FROMV1_0_V1MODEL_H_
-#define _FRONTENDS_P4_FROMV1_0_V1MODEL_H_
+#ifndef FRONTENDS_P4_FROMV1_0_V1MODEL_H_
+#define FRONTENDS_P4_FROMV1_0_V1MODEL_H_
 
 #include "frontends/common/model.h"
 #include "frontends/p4/coreLibrary.h"
@@ -367,4 +367,4 @@ class getV1ModelVersion : public Inspector {
 
 }  // namespace P4V1
 
-#endif /* _FRONTENDS_P4_FROMV1_0_V1MODEL_H_ */
+#endif /* FRONTENDS_P4_FROMV1_0_V1MODEL_H_ */

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_FRONTEND_H_
-#define _P4_FRONTEND_H_
+#ifndef P4_FRONTEND_H_
+#define P4_FRONTEND_H_
 
 #include "../common/options.h"
 #include "ir/ir.h"
@@ -46,4 +46,4 @@ class FrontEnd {
 
 }  // namespace P4
 
-#endif /* _P4_FRONTEND_H_ */
+#endif /* P4_FRONTEND_H_ */

--- a/frontends/p4/functionsInlining.h
+++ b/frontends/p4/functionsInlining.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_FUNCTIONSINLINING_H_
-#define _FRONTENDS_P4_FUNCTIONSINLINING_H_
+#ifndef FRONTENDS_P4_FUNCTIONSINLINING_H_
+#define FRONTENDS_P4_FUNCTIONSINLINING_H_
 
 #include "commonInlining.h"
 #include "frontends/p4/cloner.h"
@@ -120,4 +120,4 @@ class InlineFunctions : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_FUNCTIONSINLINING_H_ */
+#endif /* FRONTENDS_P4_FUNCTIONSINLINING_H_ */

--- a/frontends/p4/hierarchicalNames.h
+++ b/frontends/p4/hierarchicalNames.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_HIERARCHICALNAMES_H_
-#define _FRONTENDS_P4_HIERARCHICALNAMES_H_
+#ifndef FRONTENDS_P4_HIERARCHICALNAMES_H_
+#define FRONTENDS_P4_HIERARCHICALNAMES_H_
 
 #include "ir/ir.h"
 #include "ir/visitor.h"
@@ -99,4 +99,4 @@ class HierarchicalNames : public Transform {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_HIERARCHICALNAMES_H_ */
+#endif /* FRONTENDS_P4_HIERARCHICALNAMES_H_ */

--- a/frontends/p4/inlining.h
+++ b/frontends/p4/inlining.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_INLINING_H_
-#define _FRONTENDS_P4_INLINING_H_
+#ifndef FRONTENDS_P4_INLINING_H_
+#define FRONTENDS_P4_INLINING_H_
 
 #include "commonInlining.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
@@ -469,4 +469,4 @@ class Inline : public PassRepeated {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_INLINING_H_ */
+#endif /* FRONTENDS_P4_INLINING_H_ */

--- a/frontends/p4/localizeActions.h
+++ b/frontends/p4/localizeActions.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_LOCALIZEACTIONS_H_
-#define _FRONTENDS_P4_LOCALIZEACTIONS_H_
+#ifndef FRONTENDS_P4_LOCALIZEACTIONS_H_
+#define FRONTENDS_P4_LOCALIZEACTIONS_H_
 
 #include "frontends/p4/callGraph.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -188,4 +188,4 @@ class LocalizeAllActions : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_LOCALIZEACTIONS_H_ */
+#endif /* FRONTENDS_P4_LOCALIZEACTIONS_H_ */

--- a/frontends/p4/methodInstance.h
+++ b/frontends/p4/methodInstance.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_METHODINSTANCE_H_
-#define _FRONTENDS_P4_METHODINSTANCE_H_
+#ifndef FRONTENDS_P4_METHODINSTANCE_H_
+#define FRONTENDS_P4_METHODINSTANCE_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/parameterSubstitution.h"
@@ -378,4 +378,4 @@ class ControlInstantiation : public Instantiation {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_METHODINSTANCE_H_ */
+#endif /* FRONTENDS_P4_METHODINSTANCE_H_ */

--- a/frontends/p4/moveConstructors.h
+++ b/frontends/p4/moveConstructors.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_MOVECONSTRUCTORS_H_
-#define _FRONTENDS_P4_MOVECONSTRUCTORS_H_
+#ifndef FRONTENDS_P4_MOVECONSTRUCTORS_H_
+#define FRONTENDS_P4_MOVECONSTRUCTORS_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "ir/pass_manager.h"
@@ -57,4 +57,4 @@ class MoveConstructors : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_MOVECONSTRUCTORS_H_ */
+#endif /* FRONTENDS_P4_MOVECONSTRUCTORS_H_ */

--- a/frontends/p4/moveDeclarations.h
+++ b/frontends/p4/moveDeclarations.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_MOVEDECLARATIONS_H_
-#define _FRONTENDS_P4_MOVEDECLARATIONS_H_
+#ifndef FRONTENDS_P4_MOVEDECLARATIONS_H_
+#define FRONTENDS_P4_MOVEDECLARATIONS_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "ir/ir.h"
@@ -121,4 +121,4 @@ class MoveInitializers : public Transform {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_MOVEDECLARATIONS_H_ */
+#endif /* FRONTENDS_P4_MOVEDECLARATIONS_H_ */

--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_PARSEANNOTATIONS_H_
-#define _P4_PARSEANNOTATIONS_H_
+#ifndef P4_PARSEANNOTATIONS_H_
+#define P4_PARSEANNOTATIONS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/parsers/parserDriver.h"
@@ -178,4 +178,4 @@ class ParseAnnotationBodies final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _P4_PARSEANNOTATIONS_H_ */
+#endif /* P4_PARSEANNOTATIONS_H_ */

--- a/frontends/p4/parserCallGraph.h
+++ b/frontends/p4/parserCallGraph.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_PARSERCALLGRAPH_H_
-#define _FRONTENDS_P4_PARSERCALLGRAPH_H_
+#ifndef FRONTENDS_P4_PARSERCALLGRAPH_H_
+#define FRONTENDS_P4_PARSERCALLGRAPH_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/callGraph.h"
@@ -44,4 +44,4 @@ class ComputeParserCG : public Inspector {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_PARSERCALLGRAPH_H_ */
+#endif /* FRONTENDS_P4_PARSERCALLGRAPH_H_ */

--- a/frontends/p4/parserControlFlow.h
+++ b/frontends/p4/parserControlFlow.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_PARSERCONTROLFLOW_H_
-#define _FRONTENDS_P4_PARSERCONTROLFLOW_H_
+#ifndef FRONTENDS_P4_PARSERCONTROLFLOW_H_
+#define FRONTENDS_P4_PARSERCONTROLFLOW_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/moveDeclarations.h"
@@ -133,4 +133,4 @@ class RemoveParserIfs : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_PARSERCONTROLFLOW_H_ */
+#endif /* FRONTENDS_P4_PARSERCONTROLFLOW_H_ */

--- a/frontends/p4/reassociation.h
+++ b/frontends/p4/reassociation.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_REASSOCIATION_H_
-#define _P4_REASSOCIATION_H_
+#ifndef P4_REASSOCIATION_H_
+#define P4_REASSOCIATION_H_
 
 #include "ir/ir.h"
 #include "ir/visitor.h"
@@ -48,4 +48,4 @@ class Reassociation final : public Transform {
 
 }  // namespace P4
 
-#endif /* _P4_REASSOCIATION_H_ */
+#endif /* P4_REASSOCIATION_H_ */

--- a/frontends/p4/removeParameters.h
+++ b/frontends/p4/removeParameters.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_REMOVEPARAMETERS_H_
-#define _FRONTENDS_P4_REMOVEPARAMETERS_H_
+#ifndef FRONTENDS_P4_REMOVEPARAMETERS_H_
+#define FRONTENDS_P4_REMOVEPARAMETERS_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -137,4 +137,4 @@ class RemoveActionParameters : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_REMOVEPARAMETERS_H_ */
+#endif /* FRONTENDS_P4_REMOVEPARAMETERS_H_ */

--- a/frontends/p4/removeReturns.h
+++ b/frontends/p4/removeReturns.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_REMOVERETURNS_H_
-#define _FRONTENDS_P4_REMOVERETURNS_H_
+#ifndef FRONTENDS_P4_REMOVERETURNS_H_
+#define FRONTENDS_P4_REMOVERETURNS_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/ternaryBool.h"
@@ -111,4 +111,4 @@ class RemoveReturns : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_REMOVERETURNS_H_ */
+#endif /* FRONTENDS_P4_REMOVERETURNS_H_ */

--- a/frontends/p4/reservedWords.h
+++ b/frontends/p4/reservedWords.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_RESERVEDWORDS_H_
-#define _P4_RESERVEDWORDS_H_
+#ifndef P4_RESERVEDWORDS_H_
+#define P4_RESERVEDWORDS_H_
 
 #include <set>
 
@@ -27,4 +27,4 @@ extern std::set<cstring> reservedWords;
 
 }  // namespace P4
 
-#endif /* _P4_RESERVEDWORDS_H_ */
+#endif /* P4_RESERVEDWORDS_H_ */

--- a/frontends/p4/resetHeaders.h
+++ b/frontends/p4/resetHeaders.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_RESETHEADERS_H_
-#define _FRONTENDS_P4_RESETHEADERS_H_
+#ifndef FRONTENDS_P4_RESETHEADERS_H_
+#define FRONTENDS_P4_RESETHEADERS_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -81,4 +81,4 @@ class ResetHeaders : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_RESETHEADERS_H_ */
+#endif /* FRONTENDS_P4_RESETHEADERS_H_ */

--- a/frontends/p4/setHeaders.h
+++ b/frontends/p4/setHeaders.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_SETHEADERS_H_
-#define _FRONTENDS_P4_SETHEADERS_H_
+#ifndef FRONTENDS_P4_SETHEADERS_H_
+#define FRONTENDS_P4_SETHEADERS_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -73,4 +73,4 @@ class SetHeaders final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_SETHEADERS_H_ */
+#endif /* FRONTENDS_P4_SETHEADERS_H_ */

--- a/frontends/p4/sideEffects.h
+++ b/frontends/p4/sideEffects.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_SIDEEFFECTS_H_
-#define _FRONTENDS_P4_SIDEEFFECTS_H_
+#ifndef FRONTENDS_P4_SIDEEFFECTS_H_
+#define FRONTENDS_P4_SIDEEFFECTS_H_
 
 /* makes explicit side effect ordering */
 
@@ -415,4 +415,4 @@ class SideEffectOrdering : public PassRepeated {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_SIDEEFFECTS_H_ */
+#endif /* FRONTENDS_P4_SIDEEFFECTS_H_ */

--- a/frontends/p4/simplify.h
+++ b/frontends/p4/simplify.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_SIMPLIFY_H_
-#define _FRONTENDS_P4_SIMPLIFY_H_
+#ifndef FRONTENDS_P4_SIMPLIFY_H_
+#define FRONTENDS_P4_SIMPLIFY_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/methodInstance.h"
@@ -83,4 +83,4 @@ class SimplifyControlFlow : public PassRepeated {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_SIMPLIFY_H_ */
+#endif /* FRONTENDS_P4_SIMPLIFY_H_ */

--- a/frontends/p4/simplifyDefUse.h
+++ b/frontends/p4/simplifyDefUse.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_SIMPLIFYDEFUSE_H_
-#define _FRONTENDS_P4_SIMPLIFYDEFUSE_H_
+#ifndef FRONTENDS_P4_SIMPLIFYDEFUSE_H_
+#define FRONTENDS_P4_SIMPLIFYDEFUSE_H_
 
 #include "frontends/p4/cloner.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -109,4 +109,4 @@ class SimplifyDefUse : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_SIMPLIFYDEFUSE_H_ */
+#endif /* FRONTENDS_P4_SIMPLIFYDEFUSE_H_ */

--- a/frontends/p4/simplifyParsers.h
+++ b/frontends/p4/simplifyParsers.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_SIMPLIFYPARSERS_H_
-#define _FRONTENDS_P4_SIMPLIFYPARSERS_H_
+#ifndef FRONTENDS_P4_SIMPLIFYPARSERS_H_
+#define FRONTENDS_P4_SIMPLIFYPARSERS_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/parserCallGraph.h"
@@ -60,4 +60,4 @@ class SimplifyParsers : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_SIMPLIFYPARSERS_H_ */
+#endif /* FRONTENDS_P4_SIMPLIFYPARSERS_H_ */

--- a/frontends/p4/simplifySwitch.h
+++ b/frontends/p4/simplifySwitch.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_SIMPLIFYSWITCH_H_
-#define _FRONTENDS_P4_SIMPLIFYSWITCH_H_
+#ifndef FRONTENDS_P4_SIMPLIFYSWITCH_H_
+#define FRONTENDS_P4_SIMPLIFYSWITCH_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -50,4 +50,4 @@ class SimplifySwitch : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_SIMPLIFYSWITCH_H_ */
+#endif /* FRONTENDS_P4_SIMPLIFYSWITCH_H_ */

--- a/frontends/p4/specialize.h
+++ b/frontends/p4/specialize.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_SPECIALIZE_H_
-#define _FRONTENDS_P4_SPECIALIZE_H_
+#ifndef FRONTENDS_P4_SPECIALIZE_H_
+#define FRONTENDS_P4_SPECIALIZE_H_
 
 #include "frontends/common/constantFolding.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
@@ -215,4 +215,4 @@ class SpecializeAll : public PassRepeated {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_SPECIALIZE_H_ */
+#endif /* FRONTENDS_P4_SPECIALIZE_H_ */

--- a/frontends/p4/specializeGenericFunctions.h
+++ b/frontends/p4/specializeGenericFunctions.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_SPECIALIZEGENERICFUNCTIONS_H_
-#define _FRONTENDS_P4_SPECIALIZEGENERICFUNCTIONS_H_
+#ifndef FRONTENDS_P4_SPECIALIZEGENERICFUNCTIONS_H_
+#define FRONTENDS_P4_SPECIALIZEGENERICFUNCTIONS_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -148,4 +148,4 @@ class SpecializeGenericFunctions : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_SPECIALIZEGENERICFUNCTIONS_H_ */
+#endif /* FRONTENDS_P4_SPECIALIZEGENERICFUNCTIONS_H_ */

--- a/frontends/p4/specializeGenericTypes.h
+++ b/frontends/p4/specializeGenericTypes.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_SPECIALIZEGENERICTYPES_H_
-#define _FRONTENDS_P4_SPECIALIZEGENERICTYPES_H_
+#ifndef FRONTENDS_P4_SPECIALIZEGENERICTYPES_H_
+#define FRONTENDS_P4_SPECIALIZEGENERICTYPES_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -197,4 +197,4 @@ class RemoveGenericTypes : public Transform {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_SPECIALIZEGENERICTYPES_H_ */
+#endif /* FRONTENDS_P4_SPECIALIZEGENERICTYPES_H_ */

--- a/frontends/p4/staticAssert.h
+++ b/frontends/p4/staticAssert.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_STATICASSERT_H_
-#define _FRONTENDS_P4_STATICASSERT_H_
+#ifndef FRONTENDS_P4_STATICASSERT_H_
+#define FRONTENDS_P4_STATICASSERT_H_
 
 #include "frontends/p4/methodInstance.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -104,4 +104,4 @@ class StaticAssert : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_STATICASSERT_H_ */
+#endif /* FRONTENDS_P4_STATICASSERT_H_ */

--- a/frontends/p4/strengthReduction.h
+++ b/frontends/p4/strengthReduction.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_STRENGTHREDUCTION_H_
-#define _P4_STRENGTHREDUCTION_H_
+#ifndef P4_STRENGTHREDUCTION_H_
+#define P4_STRENGTHREDUCTION_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/sideEffects.h"
@@ -116,4 +116,4 @@ class StrengthReduction : public PassManager {
 
 }  // namespace P4
 
-#endif /* _P4_STRENGTHREDUCTION_H_ */
+#endif /* P4_STRENGTHREDUCTION_H_ */

--- a/frontends/p4/structInitializers.h
+++ b/frontends/p4/structInitializers.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_STRUCTINITIALIZERS_H_
-#define _FRONTENDS_P4_STRUCTINITIALIZERS_H_
+#ifndef FRONTENDS_P4_STRUCTINITIALIZERS_H_
+#define FRONTENDS_P4_STRUCTINITIALIZERS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -54,4 +54,4 @@ class StructInitializers : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_STRUCTINITIALIZERS_H_ */
+#endif /* FRONTENDS_P4_STRUCTINITIALIZERS_H_ */

--- a/frontends/p4/symbol_table.h
+++ b/frontends/p4/symbol_table.h
@@ -16,8 +16,8 @@ limitations under the License.
 
 /* -*-C++-*- */
 
-#ifndef _P4_SYMBOL_TABLE_H_
-#define _P4_SYMBOL_TABLE_H_
+#ifndef P4_SYMBOL_TABLE_H_
+#define P4_SYMBOL_TABLE_H_
 
 /* A very simple symbol table that recognizes types; necessary because
    the v1.2 grammar is ambiguous without type information */
@@ -88,4 +88,4 @@ class ProgramStructure final {
 };
 
 }  // namespace Util
-#endif /* _P4_SYMBOL_TABLE_H_ */
+#endif /* P4_SYMBOL_TABLE_H_ */

--- a/frontends/p4/tableApply.h
+++ b/frontends/p4/tableApply.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_TABLEAPPLY_H_
-#define _FRONTENDS_P4_TABLEAPPLY_H_
+#ifndef FRONTENDS_P4_TABLEAPPLY_H_
+#define FRONTENDS_P4_TABLEAPPLY_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeMap.h"
@@ -44,4 +44,4 @@ class TableApplySolver {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_TABLEAPPLY_H_ */
+#endif /* FRONTENDS_P4_TABLEAPPLY_H_ */

--- a/frontends/p4/tableKeyNames.h
+++ b/frontends/p4/tableKeyNames.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_TABLEKEYNAMES_H_
-#define _FRONTENDS_P4_TABLEKEYNAMES_H_
+#ifndef FRONTENDS_P4_TABLEKEYNAMES_H_
+#define FRONTENDS_P4_TABLEKEYNAMES_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/p4/typeMap.h"
@@ -98,4 +98,4 @@ class TableKeyNames final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_TABLEKEYNAMES_H_ */
+#endif /* FRONTENDS_P4_TABLEKEYNAMES_H_ */

--- a/frontends/p4/ternaryBool.h
+++ b/frontends/p4/ternaryBool.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_TERNARYBOOL_H_
-#define _FRONTENDS_P4_TERNARYBOOL_H_
+#ifndef FRONTENDS_P4_TERNARYBOOL_H_
+#define FRONTENDS_P4_TERNARYBOOL_H_
 
 #include "lib/cstring.h"
 
@@ -26,4 +26,4 @@ cstring toString(const TernaryBool &c);
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_TERNARYBOOL_H_ */
+#endif /* FRONTENDS_P4_TERNARYBOOL_H_ */

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_TOP4_TOP4_H_
-#define _P4_TOP4_TOP4_H_
+#ifndef P4_TOP4_TOP4_H_
+#define P4_TOP4_TOP4_H_
 
 #include "ir/ir.h"
 #include "ir/visitor.h"
@@ -272,4 +272,4 @@ void dumpP4(const IR::INode *node);
 
 }  // namespace P4
 
-#endif /* _P4_TOP4_TOP4_H_ */
+#endif /* P4_TOP4_TOP4_H_ */

--- a/frontends/p4/typeChecking/bindVariables.h
+++ b/frontends/p4/typeChecking/bindVariables.h
@@ -1,5 +1,5 @@
-#ifndef _FRONTENDS_P4_TYPECHECKING_BINDVARIABLES_H_
-#define _FRONTENDS_P4_TYPECHECKING_BINDVARIABLES_H_
+#ifndef FRONTENDS_P4_TYPECHECKING_BINDVARIABLES_H_
+#define FRONTENDS_P4_TYPECHECKING_BINDVARIABLES_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -45,4 +45,4 @@ class BindTypeVariables : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_TYPECHECKING_BINDVARIABLES_H_ */
+#endif /* FRONTENDS_P4_TYPECHECKING_BINDVARIABLES_H_ */

--- a/frontends/p4/typeChecking/syntacticEquivalence.h
+++ b/frontends/p4/typeChecking/syntacticEquivalence.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _TYPECHECKING_SYNTACTICEQUIVALENCE_H_
-#define _TYPECHECKING_SYNTACTICEQUIVALENCE_H_
+#ifndef TYPECHECKING_SYNTACTICEQUIVALENCE_H_
+#define TYPECHECKING_SYNTACTICEQUIVALENCE_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeMap.h"
@@ -44,4 +44,4 @@ class SameExpression {
 
 }  // namespace P4
 
-#endif /* _TYPECHECKING_SYNTACTICEQUIVALENCE_H_ */
+#endif /* TYPECHECKING_SYNTACTICEQUIVALENCE_H_ */

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _TYPECHECKING_TYPECHECKER_H_
-#define _TYPECHECKING_TYPECHECKER_H_
+#ifndef TYPECHECKING_TYPECHECKER_H_
+#define TYPECHECKING_TYPECHECKER_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/methodInstance.h"
@@ -371,4 +371,4 @@ class ApplyTypesToExpressions : public Transform {
 
 }  // namespace P4
 
-#endif /* _TYPECHECKING_TYPECHECKER_H_ */
+#endif /* TYPECHECKING_TYPECHECKER_H_ */

--- a/frontends/p4/typeChecking/typeConstraints.h
+++ b/frontends/p4/typeChecking/typeConstraints.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _TYPECHECKING_TYPECONSTRAINTS_H_
-#define _TYPECHECKING_TYPECONSTRAINTS_H_
+#ifndef TYPECHECKING_TYPECONSTRAINTS_H_
+#define TYPECHECKING_TYPECONSTRAINTS_H_
 
 #include <optional>
 #include <sstream>
@@ -293,4 +293,4 @@ class TypeConstraints final : public IHasDbPrint {
 };
 }  // namespace P4
 
-#endif /* _TYPECHECKING_TYPECONSTRAINTS_H_ */
+#endif /* TYPECHECKING_TYPECONSTRAINTS_H_ */

--- a/frontends/p4/typeChecking/typeSubstitution.h
+++ b/frontends/p4/typeChecking/typeSubstitution.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _TYPECHECKING_TYPESUBSTITUTION_H_
-#define _TYPECHECKING_TYPESUBSTITUTION_H_
+#ifndef TYPECHECKING_TYPESUBSTITUTION_H_
+#define TYPECHECKING_TYPESUBSTITUTION_H_
 
 #include <map>
 #include <sstream>
@@ -92,4 +92,4 @@ class TypeVariableSubstitution final : public TypeSubstitution<const IR::ITypeVa
 
 }  // namespace P4
 
-#endif /* _TYPECHECKING_TYPESUBSTITUTION_H_ */
+#endif /* TYPECHECKING_TYPESUBSTITUTION_H_ */

--- a/frontends/p4/typeChecking/typeSubstitutionVisitor.h
+++ b/frontends/p4/typeChecking/typeSubstitutionVisitor.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _TYPECHECKING_TYPESUBSTITUTIONVISITOR_H_
-#define _TYPECHECKING_TYPESUBSTITUTIONVISITOR_H_
+#ifndef TYPECHECKING_TYPESUBSTITUTIONVISITOR_H_
+#define TYPECHECKING_TYPESUBSTITUTIONVISITOR_H_
 
 #include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
@@ -93,4 +93,4 @@ class TypeSubstitutionVisitor : public TypeVariableSubstitutionVisitor {
 };
 
 }  // namespace P4
-#endif /* _TYPECHECKING_TYPESUBSTITUTIONVISITOR_H_ */
+#endif /* TYPECHECKING_TYPESUBSTITUTIONVISITOR_H_ */

--- a/frontends/p4/typeChecking/typeUnification.h
+++ b/frontends/p4/typeChecking/typeUnification.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _TYPECHECKING_TYPEUNIFICATION_H_
-#define _TYPECHECKING_TYPEUNIFICATION_H_
+#ifndef TYPECHECKING_TYPEUNIFICATION_H_
+#define TYPECHECKING_TYPEUNIFICATION_H_
 
 #include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
@@ -60,4 +60,4 @@ class TypeUnification final {
 
 }  // namespace P4
 
-#endif /* _TYPECHECKING_TYPEUNIFICATION_H_ */
+#endif /* TYPECHECKING_TYPEUNIFICATION_H_ */

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_TYPEMAP_H_
-#define _FRONTENDS_P4_TYPEMAP_H_
+#ifndef FRONTENDS_P4_TYPEMAP_H_
+#define FRONTENDS_P4_TYPEMAP_H_
 
 #include "frontends/common/programMap.h"
 #include "frontends/p4/typeChecking/typeSubstitution.h"
@@ -111,4 +111,4 @@ class TypeMap final : public ProgramMap {
 };
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_TYPEMAP_H_ */
+#endif /* FRONTENDS_P4_TYPEMAP_H_ */

--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_UNIQUENAMES_H_
-#define _FRONTENDS_P4_UNIQUENAMES_H_
+#ifndef FRONTENDS_P4_UNIQUENAMES_H_
+#define FRONTENDS_P4_UNIQUENAMES_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeMap.h"
@@ -156,4 +156,4 @@ class UniqueParameters : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_UNIQUENAMES_H_ */
+#endif /* FRONTENDS_P4_UNIQUENAMES_H_ */

--- a/frontends/p4/unusedDeclarations.h
+++ b/frontends/p4/unusedDeclarations.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_UNUSEDDECLARATIONS_H_
-#define _P4_UNUSEDDECLARATIONS_H_
+#ifndef P4_UNUSEDDECLARATIONS_H_
+#define P4_UNUSEDDECLARATIONS_H_
 
 #include "../common/resolveReferences/resolveReferences.h"
 #include "ir/ir.h"
@@ -155,4 +155,4 @@ class RemoveAllUnusedDeclarations : public PassManager {
 
 }  // namespace P4
 
-#endif /* _P4_UNUSEDDECLARATIONS_H_ */
+#endif /* P4_UNUSEDDECLARATIONS_H_ */

--- a/frontends/p4/uselessCasts.h
+++ b/frontends/p4/uselessCasts.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_P4_USELESSCASTS_H_
-#define _FRONTENDS_P4_USELESSCASTS_H_
+#ifndef FRONTENDS_P4_USELESSCASTS_H_
+#define FRONTENDS_P4_USELESSCASTS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -48,4 +48,4 @@ class UselessCasts : public PassManager {
 
 }  // namespace P4
 
-#endif /* _FRONTENDS_P4_USELESSCASTS_H_ */
+#endif /* FRONTENDS_P4_USELESSCASTS_H_ */

--- a/frontends/p4/validateMatchAnnotations.h
+++ b/frontends/p4/validateMatchAnnotations.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_VALIDATEMATCHANNOTATIONS_H_
-#define _P4_VALIDATEMATCHANNOTATIONS_H_
+#ifndef P4_VALIDATEMATCHANNOTATIONS_H_
+#define P4_VALIDATEMATCHANNOTATIONS_H_
 
 #include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
@@ -49,4 +49,4 @@ class ValidateMatchAnnotations final : public Inspector {
 
 }  // namespace P4
 
-#endif /* _P4_VALIDATEMATCHANNOTATIONS_H_ */
+#endif /* P4_VALIDATEMATCHANNOTATIONS_H_ */

--- a/frontends/p4/validateParsedProgram.h
+++ b/frontends/p4/validateParsedProgram.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_VALIDATEPARSEDPROGRAM_H_
-#define _P4_VALIDATEPARSEDPROGRAM_H_
+#ifndef P4_VALIDATEPARSEDPROGRAM_H_
+#define P4_VALIDATEPARSEDPROGRAM_H_
 
 #include "ir/ir.h"
 #include "ir/visitor.h"
@@ -93,4 +93,4 @@ class ValidateParsedProgram final : public Inspector {
 
 }  // namespace P4
 
-#endif /* _P4_VALIDATEPARSEDPROGRAM_H_ */
+#endif /* P4_VALIDATEPARSEDPROGRAM_H_ */

--- a/frontends/p4/validateValueSets.h
+++ b/frontends/p4/validateValueSets.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _P4_VALIDATEVALUESETS_H_
-#define _P4_VALIDATEVALUESETS_H_
+#ifndef P4_VALIDATEVALUESETS_H_
+#define P4_VALIDATEVALUESETS_H_
 
 #include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
@@ -39,4 +39,4 @@ class ValidateValueSets final : public Inspector {
 
 }  // namespace P4
 
-#endif /* _P4_VALIDATEVALUESETS_H_ */
+#endif /* P4_VALIDATEVALUESETS_H_ */

--- a/frontends/parsers/parserDriver.h
+++ b/frontends/parsers/parserDriver.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _FRONTENDS_PARSERS_PARSERDRIVER_H_
-#define _FRONTENDS_PARSERS_PARSERDRIVER_H_
+#ifndef FRONTENDS_PARSERS_PARSERDRIVER_H_
+#define FRONTENDS_PARSERS_PARSERDRIVER_H_
 
 #include <cstdio>
 #include <iostream>
@@ -289,4 +289,4 @@ class V1ParserDriver final : public P4::AbstractParserDriver {
 
 }  // namespace V1
 
-#endif /* _FRONTENDS_PARSERS_PARSERDRIVER_H_ */
+#endif /* FRONTENDS_PARSERS_PARSERDRIVER_H_ */

--- a/ir/dbprint.h
+++ b/ir/dbprint.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_DBPRINT_H_
-#define _IR_DBPRINT_H_
+#ifndef IR_DBPRINT_H_
+#define IR_DBPRINT_H_
 
 #include <cassert>
 #include <iosfwd>
@@ -94,4 +94,4 @@ inline std::ostream &operator<<(std::ostream &out, const DBPrint::dbprint_flags 
 
 }  // end namespace DBPrint
 
-#endif /* _IR_DBPRINT_H_ */
+#endif /* IR_DBPRINT_H_ */

--- a/ir/declaration.h
+++ b/ir/declaration.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_DECLARATION_H_
-#define _IR_DECLARATION_H_
+#ifndef IR_DECLARATION_H_
+#define IR_DECLARATION_H_
 
 #include "ir/id.h"
 #include "ir/node.h"
@@ -51,4 +51,4 @@ class IDeclaration : public virtual INode {
 
 }  // namespace IR
 
-#endif /* _IR_DECLARATION_H_ */
+#endif /* IR_DECLARATION_H_ */

--- a/ir/dump.h
+++ b/ir/dump.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_DUMP_H_
-#define _IR_DUMP_H_
+#ifndef IR_DUMP_H_
+#define IR_DUMP_H_
 
 #include <cstdint>
 #include <iostream>
@@ -63,4 +63,4 @@ inline std::ostream &operator<<(std::ostream &out, const Dump &d) {
     return out;
 }
 
-#endif /* _IR_DUMP_H_ */
+#endif /* IR_DUMP_H_ */

--- a/ir/id.h
+++ b/ir/id.h
@@ -55,4 +55,4 @@ struct ID : Util::IHasSourceInfo {
 };
 
 }  // namespace IR
-#endif  /* IR_ID_H_ */
+#endif /* IR_ID_H_ */

--- a/ir/id.h
+++ b/ir/id.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_ID_H_
-#define _IR_ID_H_
+#ifndef IR_ID_H_
+#define IR_ID_H_
 
 #include "lib/cstring.h"
 #include "lib/error.h"
@@ -55,4 +55,4 @@ struct ID : Util::IHasSourceInfo {
 };
 
 }  // namespace IR
-#endif  // _IR_ID_H_
+#endif  /* IR_ID_H_ */

--- a/ir/ir-inline.h
+++ b/ir/ir-inline.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_IR_INLINE_H_
-#define _IR_IR_INLINE_H_
+#ifndef IR_IR_INLINE_H_
+#define IR_IR_INLINE_H_
 
 #include "ir/id.h"
 #include "ir/indexed_vector.h"
@@ -325,4 +325,4 @@ void IR::NodeMap<KEY, VALUE, MAP, COMP, ALLOC>::visit_children(Visitor &v) const
         v.visit(k.second);
     }
 }
-#endif /* _IR_IR_INLINE_H_ */
+#endif /* IR_IR_INLINE_H_ */

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_IR_H_
-#define _IR_IR_H_
+#ifndef IR_IR_H_
+#define IR_IR_H_
 
 // generated ir file
 #include "ir/ir-generated.h"  // IWYU pragma: export

--- a/ir/ir.h
+++ b/ir/ir.h
@@ -21,4 +21,4 @@ limitations under the License.
 #include "ir/ir-generated.h"  // IWYU pragma: export
 #include "ir/ir-inline.h"     // IWYU pragma: export
 
-#endif /* _IR_IR_H_*/
+#endif /* IR_IR_H_ */

--- a/ir/json_generator.h
+++ b/ir/json_generator.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_JSON_GENERATOR_H_
-#define _IR_JSON_GENERATOR_H_
+#ifndef IR_JSON_GENERATOR_H_
+#define IR_JSON_GENERATOR_H_
 
 #include <cassert>
 #include <optional>
@@ -309,4 +309,4 @@ class JSONGenerator {
     }
 };
 
-#endif /* _IR_JSON_GENERATOR_H_ */
+#endif /* IR_JSON_GENERATOR_H_ */

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_JSON_LOADER_H_
-#define _IR_JSON_LOADER_H_
+#ifndef IR_JSON_LOADER_H_
+#define IR_JSON_LOADER_H_
 
 #include <assert.h>
 
@@ -377,4 +377,4 @@ IR::NameMap<T, MAP, COMP, ALLOC> *IR::NameMap<T, MAP, COMP, ALLOC>::fromJSON(JSO
     return new IR::NameMap<T, MAP, COMP, ALLOC>(json);
 }
 
-#endif /* _IR_JSON_LOADER_H_ */
+#endif /* IR_JSON_LOADER_H_ */

--- a/ir/namemap.h
+++ b/ir/namemap.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_NAMEMAP_H_
-#define _IR_NAMEMAP_H_
+#ifndef IR_NAMEMAP_H_
+#define IR_NAMEMAP_H_
 
 #include <map>
 
@@ -161,4 +161,4 @@ class NameMap : public Node {
 
 }  // namespace IR
 
-#endif /* _IR_NAMEMAP_H_ */
+#endif /* IR_NAMEMAP_H_ */

--- a/ir/node.h
+++ b/ir/node.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_NODE_H_
-#define _IR_NODE_H_
+#ifndef IR_NODE_H_
+#define IR_NODE_H_
 
 #include <iosfwd>
 #include <typeinfo>
@@ -205,4 +205,4 @@ inline bool equiv(const INode *a, const INode *b) {
 
 }  // namespace IR
 
-#endif /* _IR_NODE_H_ */
+#endif /* IR_NODE_H_ */

--- a/ir/nodemap.h
+++ b/ir/nodemap.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_NODEMAP_H_
-#define _IR_NODEMAP_H_
+#ifndef IR_NODEMAP_H_
+#define IR_NODEMAP_H_
 
 #include "ir/node.h"
 #include "lib/cstring.h"
@@ -97,4 +97,4 @@ class NodeMap : public Node {
 
 }  // namespace IR
 
-#endif /* _IR_NODEMAP_H_ */
+#endif /* IR_NODEMAP_H_ */

--- a/ir/pass_manager.h
+++ b/ir/pass_manager.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_PASS_MANAGER_H_
-#define _IR_PASS_MANAGER_H_
+#ifndef IR_PASS_MANAGER_H_
+#define IR_PASS_MANAGER_H_
 
 #include <functional>
 #include <initializer_list>
@@ -214,4 +214,4 @@ class DynamicVisitor : virtual public Visitor {
     DynamicVisitor *clone() const override { return new DynamicVisitor(*this); }
 };
 
-#endif /* _IR_PASS_MANAGER_H_ */
+#endif /* IR_PASS_MANAGER_H_ */

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_VECTOR_H_
-#define _IR_VECTOR_H_
+#ifndef IR_VECTOR_H_
+#define IR_VECTOR_H_
 
 #include "ir/dbprint.h"
 #include "ir/node.h"
@@ -234,4 +234,4 @@ const T *get(const IR::Vector<T> *vec, U name) {
 }  // namespace GetImpl
 using namespace GetImpl;  // NOLINT(build/namespaces)
 
-#endif /* _IR_VECTOR_H_ */
+#endif /* IR_VECTOR_H_ */

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _IR_VISITOR_H_
-#define _IR_VISITOR_H_
+#ifndef IR_VISITOR_H_
+#define IR_VISITOR_H_
 
 #include <cassert>
 #include <cstddef>
@@ -786,4 +786,4 @@ const IR::Node *transformAllMatching(const IR::Node *root, Func &&function) {
     return root->apply(NodeVisitor(std::forward<Func>(function)));
 }
 
-#endif /* _IR_VISITOR_H_ */
+#endif /* IR_VISITOR_H_ */

--- a/lib/algorithm.h
+++ b/lib/algorithm.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_ALGORITHM_H_
-#define _LIB_ALGORITHM_H_
+#ifndef LIB_ALGORITHM_H_
+#define LIB_ALGORITHM_H_
 
 #include <algorithm>
 #include <set>
@@ -92,4 +92,4 @@ Iter end(std::pair<Iter, Iter> pr) {
     return pr.second;
 }
 
-#endif /* _LIB_ALGORITHM_H_ */
+#endif /* LIB_ALGORITHM_H_ */

--- a/lib/backtrace.h
+++ b/lib/backtrace.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_BACKTRACE_H_
-#define _LIB_BACKTRACE_H_
+#ifndef LIB_BACKTRACE_H_
+#define LIB_BACKTRACE_H_
 
 #include <exception>
 #include <string>
@@ -57,4 +57,4 @@ class backtrace_exception : public E {
     }
 };
 
-#endif /* _LIB_BACKTRACE_H_ */
+#endif /* LIB_BACKTRACE_H_ */

--- a/lib/bitops.h
+++ b/lib/bitops.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_BITOPS_H_
-#define _LIB_BITOPS_H_
+#ifndef LIB_BITOPS_H_
+#define LIB_BITOPS_H_
 
 #include <limits.h>
 
@@ -58,4 +58,4 @@ static inline unsigned bitmask2bytemask(const bitvec &a) {
     return rv;
 }
 
-#endif /* _LIB_BITOPS_H_ */
+#endif /* LIB_BITOPS_H_ */

--- a/lib/bitrange.h
+++ b/lib/bitrange.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_BITRANGE_H_
-#define _LIB_BITRANGE_H_
+#ifndef LIB_BITRANGE_H_
+#define LIB_BITRANGE_H_
 
 #include "bitvec.h"
 
@@ -51,4 +51,4 @@ class bitranges {
     iter end() const { return iter(bits.end()); }
 };
 
-#endif /* _LIB_BITRANGE_H_ */
+#endif /* LIB_BITRANGE_H_ */

--- a/lib/bitvec.h
+++ b/lib/bitvec.h
@@ -681,4 +681,4 @@ inline bitvec operator-(bitvec &&a, const bitvec &b) {
     return rv;
 }
 
-#endif  /* LIB_BITVEC_H_ */
+#endif /* LIB_BITVEC_H_ */

--- a/lib/bitvec.h
+++ b/lib/bitvec.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_BITVEC_H_
-#define _LIB_BITVEC_H_
+#ifndef LIB_BITVEC_H_
+#define LIB_BITVEC_H_
 
 #include <assert.h>
 #include <limits.h>
@@ -681,4 +681,4 @@ inline bitvec operator-(bitvec &&a, const bitvec &b) {
     return rv;
 }
 
-#endif  // _LIB_BITVEC_H_
+#endif  /* LIB_BITVEC_H_ */

--- a/lib/castable.h
+++ b/lib/castable.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_CASTABLE_H_
-#define _LIB_CASTABLE_H_
+#ifndef LIB_CASTABLE_H_
+#define LIB_CASTABLE_H_
 
 #include <typeinfo>
 
@@ -59,4 +59,4 @@ class ICastable {
     }
 };
 
-#endif /* _LIB_CASTABLE_H_ */
+#endif /* LIB_CASTABLE_H_ */

--- a/lib/compile_context.h
+++ b/lib/compile_context.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_COMPILE_CONTEXT_H_
-#define _LIB_COMPILE_CONTEXT_H_
+#ifndef LIB_COMPILE_CONTEXT_H_
+#define LIB_COMPILE_CONTEXT_H_
 
 #include <typeinfo>
 #include <vector>
@@ -109,4 +109,4 @@ class BaseCompileContext : public ICompileContext {
     ErrorReporter errorReporterInstance;
 };
 
-#endif /* _LIB_COMPILE_CONTEXT_H_ */
+#endif /* LIB_COMPILE_CONTEXT_H_ */

--- a/lib/crash.h
+++ b/lib/crash.h
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_CRASH_H_
-#define _LIB_CRASH_H_
+#ifndef LIB_CRASH_H_
+#define LIB_CRASH_H_
 
 void setup_signals();
 const char *addr2line(void *addr, const char *text);
 
-#endif /* _LIB_CRASH_H_ */
+#endif /* LIB_CRASH_H_ */

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_CSTRING_H_
-#define _LIB_CSTRING_H_
+#ifndef LIB_CSTRING_H_
+#define LIB_CSTRING_H_
 
 #include <cstddef>
 #include <cstring>
@@ -366,4 +366,4 @@ struct hash<cstring> {
 };
 }  // namespace std
 
-#endif /* _LIB_CSTRING_H_ */
+#endif /* LIB_CSTRING_H_ */

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -17,8 +17,8 @@ limitations under the License.
 /* -*-c++-*-
    C#-like enumerator interface */
 
-#ifndef _LIB_ENUMERATOR_H_
-#define _LIB_ENUMERATOR_H_
+#ifndef LIB_ENUMERATOR_H_
+#define LIB_ENUMERATOR_H_
 
 #include <cstdint>
 #include <functional>
@@ -561,4 +561,4 @@ bool EnumeratorHandle<T>::operator!=(const EnumeratorHandle<T> &other) const {
 }
 
 }  // namespace Util
-#endif /* _LIB_ENUMERATOR_H_ */
+#endif /* LIB_ENUMERATOR_H_ */

--- a/lib/error.h
+++ b/lib/error.h
@@ -16,8 +16,8 @@ limitations under the License.
 
 /* -*-C++-*- */
 
-#ifndef _LIB_ERROR_H_
-#define _LIB_ERROR_H_
+#ifndef LIB_ERROR_H_
+#define LIB_ERROR_H_
 
 #include "lib/compile_context.h"
 #include "lib/cstring.h"
@@ -170,4 +170,4 @@ inline void diagnose(DiagnosticAction defaultAction, const char *diagnosticName,
     context.errorReporter().diagnose(action, diagnosticName, format, suffix, args...);
 }
 
-#endif /* _LIB_ERROR_H_ */
+#endif /* LIB_ERROR_H_ */

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_ERROR_CATALOG_H_
-#define _LIB_ERROR_CATALOG_H_
+#ifndef LIB_ERROR_CATALOG_H_
+#define LIB_ERROR_CATALOG_H_
 
 #include <map>
 #include <string>
@@ -113,4 +113,4 @@ class ErrorCatalog {
     static std::map<int, cstring> errorCatalog;
 };
 
-#endif  // _LIB_ERROR_CATALOG_H_
+#endif  /* LIB_ERROR_CATALOG_H_ */

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -113,4 +113,4 @@ class ErrorCatalog {
     static std::map<int, cstring> errorCatalog;
 };
 
-#endif  /* LIB_ERROR_CATALOG_H_ */
+#endif /* LIB_ERROR_CATALOG_H_ */

--- a/lib/error_helper.h
+++ b/lib/error_helper.h
@@ -323,4 +323,4 @@ auto bug_helper(boost::format &f, std::string message, std::string position, std
                       std::forward<Args>(args)...);
 }
 
-#endif  /* LIB_ERROR_HELPER_H_ */
+#endif /* LIB_ERROR_HELPER_H_ */

--- a/lib/error_helper.h
+++ b/lib/error_helper.h
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#ifndef _LIB_ERROR_HELPER_H_
-#define _LIB_ERROR_HELPER_H_
+#ifndef LIB_ERROR_HELPER_H_
+#define LIB_ERROR_HELPER_H_
 
 #include <stdarg.h>
 
@@ -323,4 +323,4 @@ auto bug_helper(boost::format &f, std::string message, std::string position, std
                       std::forward<Args>(args)...);
 }
 
-#endif  // _LIB_ERROR_HELPER_H_
+#endif  /* LIB_ERROR_HELPER_H_ */

--- a/lib/error_message.h
+++ b/lib/error_message.h
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#ifndef _LIB_ERROR_MESSAGE_H_
-#define _LIB_ERROR_MESSAGE_H_
+#ifndef LIB_ERROR_MESSAGE_H_
+#define LIB_ERROR_MESSAGE_H_
 
 #include <cstring>
 #include <vector>
@@ -71,4 +71,4 @@ struct ParserErrorMessage {
     std::string toString() const;
 };
 
-#endif /* _LIB_ERROR_MESSAGE_H_ */
+#endif /* LIB_ERROR_MESSAGE_H_ */

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_ERROR_REPORTER_H_
-#define _LIB_ERROR_REPORTER_H_
+#ifndef LIB_ERROR_REPORTER_H_
+#define LIB_ERROR_REPORTER_H_
 
 #include "error_catalog.h"
 #include "error_helper.h"
@@ -249,4 +249,4 @@ class ErrorReporter {
     std::unordered_map<cstring, DiagnosticAction> diagnosticActions;
 };
 
-#endif /* _LIB_ERROR_REPORTER_H_ */
+#endif /* LIB_ERROR_REPORTER_H_ */

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -16,8 +16,8 @@ limitations under the License.
 
 /* -*-c++-*- */
 
-#ifndef _LIB_EXCEPTIONS_H_
-#define _LIB_EXCEPTIONS_H_
+#ifndef LIB_EXCEPTIONS_H_
+#define LIB_EXCEPTIONS_H_
 
 #include <unistd.h>
 
@@ -147,4 +147,4 @@ class CompilationError : public P4CExceptionBase {
         throw Util::CompilationError(__VA_ARGS__); \
     } while (0)
 
-#endif /* _LIB_EXCEPTIONS_H_ */
+#endif /* LIB_EXCEPTIONS_H_ */

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -1,5 +1,5 @@
-#ifndef _LIB_HASH_H_
-#define _LIB_HASH_H_
+#ifndef LIB_HASH_H_
+#define LIB_HASH_H_
 
 #include <cstddef>
 #include <type_traits>
@@ -40,4 +40,4 @@ auto murmur(const T &obj, typename std::enable_if<std::is_standard_layout<T>::va
 }  // namespace Hash
 }  // namespace Util
 
-#endif /* _LIB_HASH_H_ */
+#endif /* LIB_HASH_H_ */

--- a/lib/hex.h
+++ b/lib/hex.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_HEX_H_
-#define _LIB_HEX_H_
+#ifndef LIB_HEX_H_
+#define LIB_HEX_H_
 
 #include <iomanip>
 #include <iostream>
@@ -59,4 +59,4 @@ class hexvec {
 
 std::ostream &operator<<(std::ostream &os, const hexvec &h);
 
-#endif /* _LIB_HEX_H_ */
+#endif /* LIB_HEX_H_ */

--- a/lib/indent.h
+++ b/lib/indent.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_INDENT_H_
-#define _LIB_INDENT_H_
+#ifndef LIB_INDENT_H_
+#define LIB_INDENT_H_
 
 #include <iomanip>
 #include <iostream>
@@ -120,4 +120,4 @@ class TempIndent {
 
 }  // end namespace IndentCtl
 
-#endif /* _LIB_INDENT_H_ */
+#endif /* LIB_INDENT_H_ */

--- a/lib/json.h
+++ b/lib/json.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_JSON_H_
-#define _LIB_JSON_H_
+#ifndef LIB_JSON_H_
+#define LIB_JSON_H_
 
 #include <iostream>
 #include <stdexcept>
@@ -185,4 +185,4 @@ class JsonObject final : public IJson, public ordered_map<cstring, IJson *> {
 
 }  // namespace Util
 
-#endif /* _LIB_JSON_H_ */
+#endif /* LIB_JSON_H_ */

--- a/lib/log.h
+++ b/lib/log.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_LOG_H_
-#define _LIB_LOG_H_
+#ifndef LIB_LOG_H_
+#define LIB_LOG_H_
 
 #include <functional>
 #include <iostream>
@@ -212,4 +212,4 @@ std::ostream &operator<<(std::ostream &out, const std::set<T> &set) {
     return format_container(out, set, '(', ')');
 }
 
-#endif /* _LIB_LOG_H_ */
+#endif /* LIB_LOG_H_ */

--- a/lib/ltbitmatrix.h
+++ b/lib/ltbitmatrix.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_LTBITMATRIX_H_
-#define _LIB_LTBITMATRIX_H_
+#ifndef LIB_LTBITMATRIX_H_
+#define LIB_LTBITMATRIX_H_
 
 #include "bitvec.h"
 
@@ -112,4 +112,4 @@ inline bool operator>>(const char *p, LTBitMatrix &bm) {
     return true;
 }
 
-#endif /* _LIB_LTBITMATRIX_H_ */
+#endif /* LIB_LTBITMATRIX_H_ */

--- a/lib/map.h
+++ b/lib/map.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_MAP_H_
-#define _LIB_MAP_H_
+#ifndef LIB_MAP_H_
+#define LIB_MAP_H_
 
 #include <map>
 
@@ -222,4 +222,4 @@ MapForKey<M> ValuesForKey(M &m, typename M::key_type k) {
     return MapForKey<M>(m, k);
 }
 
-#endif /* _LIB_MAP_H_ */
+#endif /* LIB_MAP_H_ */

--- a/lib/match.h
+++ b/lib/match.h
@@ -58,4 +58,4 @@ struct match_t {
 std::ostream &operator<<(std::ostream &, const match_t &);
 bool operator>>(const char *, match_t &);
 
-#endif /*_LIB_MATCH_H_ */
+#endif /* LIB_MATCH_H_ */

--- a/lib/match.h
+++ b/lib/match.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_MATCH_H_
-#define _LIB_MATCH_H_
+#ifndef LIB_MATCH_H_
+#define LIB_MATCH_H_
 
 #include <stdint.h>
 

--- a/lib/null.h
+++ b/lib/null.h
@@ -16,8 +16,8 @@ limitations under the License.
 
 /* -*-C++-*- */
 
-#ifndef _LIB_NULL_H_
-#define _LIB_NULL_H_
+#ifndef LIB_NULL_H_
+#define LIB_NULL_H_
 
 #include "error.h"  // for BUG macro
 
@@ -30,4 +30,4 @@ limitations under the License.
         if ((a) == nullptr) BUG(__FILE__ ":" LIB_TOSTRING(__LINE__) ": Null " #a); \
     } while (0)
 
-#endif /* _LIB_NULL_H_ */
+#endif /* LIB_NULL_H_ */

--- a/lib/nullstream.h
+++ b/lib/nullstream.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_NULLSTREAM_H_
-#define _LIB_NULLSTREAM_H_
+#ifndef LIB_NULLSTREAM_H_
+#define LIB_NULLSTREAM_H_
 
 #include <iostream>
 #include <ostream>
@@ -48,4 +48,4 @@ typedef onullstream<char> nullstream;
 // otherwise a nullptr is returned
 std::ostream *openFile(cstring name, bool nullOnError);
 
-#endif /* _LIB_NULLSTREAM_H_ */
+#endif /* LIB_NULLSTREAM_H_ */

--- a/lib/options.h
+++ b/lib/options.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_OPTIONS_H_
-#define _LIB_OPTIONS_H_
+#ifndef LIB_OPTIONS_H_
+#define LIB_OPTIONS_H_
 
 #include <functional>
 #include <ostream>
@@ -103,4 +103,4 @@ class Options {
 
 }  // namespace Util
 
-#endif /* _LIB_OPTIONS_H_ */
+#endif /* LIB_OPTIONS_H_ */

--- a/lib/ordered_set.h
+++ b/lib/ordered_set.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_ORDERED_SET_H_
-#define _LIB_ORDERED_SET_H_
+#ifndef LIB_ORDERED_SET_H_
+#define LIB_ORDERED_SET_H_
 
 #include <cassert>
 #include <functional>
@@ -311,4 +311,4 @@ inline auto intersects(const ordered_set<T, C1, A1> &a, const U &b) -> decltype(
     return false;
 }
 
-#endif /* _LIB_ORDERED_SET_H_ */
+#endif /* LIB_ORDERED_SET_H_ */

--- a/lib/path.h
+++ b/lib/path.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_PATH_H_
-#define _LIB_PATH_H_
+#ifndef LIB_PATH_H_
+#define LIB_PATH_H_
 
 /*
   It's 2015 and C++ still does not have a portable way to manipulate pathnames.
@@ -67,4 +67,4 @@ class PathName final {
 };
 }  // namespace Util
 
-#endif /* _LIB_PATH_H_ */
+#endif /* LIB_PATH_H_ */

--- a/lib/range.h
+++ b/lib/range.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_RANGE_H_
-#define _LIB_RANGE_H_
+#ifndef LIB_RANGE_H_
+#define LIB_RANGE_H_
 
 #include <iostream>
 
@@ -61,4 +61,4 @@ std::ostream &operator<<(std::ostream &out, const RangeIter<T> &r) {
     return out;
 }
 
-#endif /* _LIB_RANGE_H_ */
+#endif /* LIB_RANGE_H_ */

--- a/lib/safe_vector.h
+++ b/lib/safe_vector.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_SAFE_VECTOR_H_
-#define _LIB_SAFE_VECTOR_H_
+#ifndef LIB_SAFE_VECTOR_H_
+#define LIB_SAFE_VECTOR_H_
 
 #include <vector>
 
@@ -33,4 +33,4 @@ class safe_vector : public std::vector<T, _Alloc> {
     const_reference operator[](size_type n) const { return this->at(n); }
 };
 
-#endif /* _LIB_SAFE_VECTOR_H_ */
+#endif /* LIB_SAFE_VECTOR_H_ */

--- a/lib/sourceCodeBuilder.h
+++ b/lib/sourceCodeBuilder.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_SOURCECODEBUILDER_H_
-#define _LIB_SOURCECODEBUILDER_H_
+#ifndef LIB_SOURCECODEBUILDER_H_
+#define LIB_SOURCECODEBUILDER_H_
 
 #include <ctype.h>
 
@@ -111,4 +111,4 @@ class SourceCodeBuilder {
 };
 }  // namespace Util
 
-#endif /* _LIB_SOURCECODEBUILDER_H_ */
+#endif /* LIB_SOURCECODEBUILDER_H_ */

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -18,8 +18,8 @@ limitations under the License.
 
 /* Source-level information for a P4 program */
 
-#ifndef _LIB_SOURCE_FILE_H_
-#define _LIB_SOURCE_FILE_H_
+#ifndef LIB_SOURCE_FILE_H_
+#define LIB_SOURCE_FILE_H_
 
 #include <vector>
 
@@ -318,4 +318,4 @@ class InputSources final {
 
 inline void dbprint(const IHasDbPrint *o) { o->dbprint(std::cout); }
 
-#endif /* _LIB_SOURCE_FILE_H_ */
+#endif /* LIB_SOURCE_FILE_H_ */

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -16,8 +16,8 @@ limitations under the License.
 
 /* -*-c++-*- */
 
-#ifndef _LIB_STRINGIFY_H_
-#define _LIB_STRINGIFY_H_
+#ifndef LIB_STRINGIFY_H_
+#define LIB_STRINGIFY_H_
 
 #include <stdint.h>
 
@@ -84,4 +84,4 @@ cstring printf_format(const char *fmt_str, ...);
 // vprintf into a string
 cstring vprintf_format(const char *fmt_str, va_list ap);
 }  // namespace Util
-#endif /* _LIB_STRINGIFY_H_ */
+#endif /* LIB_STRINGIFY_H_ */

--- a/lib/stringref.h
+++ b/lib/stringref.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_STRINGREF_H_
-#define _LIB_STRINGREF_H_
+#ifndef LIB_STRINGREF_H_
+#define LIB_STRINGREF_H_
 
 #include <cstdlib>
 #include <cstring>
@@ -308,4 +308,4 @@ class StringRef::Split {
 inline StringRef::Split StringRef::split(char ch) const { return Split(*this, nullptr, find(ch)); }
 inline StringRef::Split StringRef::split(const char *s) const { return Split(*this, s, find(s)); }
 
-#endif /* _LIB_STRINGREF_H_ */
+#endif /* LIB_STRINGREF_H_ */

--- a/lib/symbitmatrix.h
+++ b/lib/symbitmatrix.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _LIB_SYMBITMATRIX_H_
-#define _LIB_SYMBITMATRIX_H_
+#ifndef LIB_SYMBITMATRIX_H_
+#define LIB_SYMBITMATRIX_H_
 
 #include "bitvec.h"
 
@@ -101,4 +101,4 @@ class SymBitMatrix : private bitvec {
     bool operator|=(const SymBitMatrix &a) { return bitvec::operator|=(a); }
 };
 
-#endif /* _LIB_SYMBITMATRIX_H_ */
+#endif /* LIB_SYMBITMATRIX_H_ */

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -1,5 +1,5 @@
-#ifndef _LIB_TIMER_H_
-#define _LIB_TIMER_H_
+#ifndef LIB_TIMER_H_
+#define LIB_TIMER_H_
 
 #include <cstddef>
 #include <functional>
@@ -53,4 +53,4 @@ class ScopedTimer {
 
 }  // namespace Util
 
-#endif /* _LIB_TIMER_H_ */
+#endif /* LIB_TIMER_H_ */

--- a/midend/actionSynthesis.h
+++ b/midend/actionSynthesis.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_ACTIONSYNTHESIS_H_
-#define _MIDEND_ACTIONSYNTHESIS_H_
+#ifndef MIDEND_ACTIONSYNTHESIS_H_
+#define MIDEND_ACTIONSYNTHESIS_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -185,4 +185,4 @@ class MoveActionsToTables : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_ACTIONSYNTHESIS_H_ */
+#endif /* MIDEND_ACTIONSYNTHESIS_H_ */

--- a/midend/checkSize.h
+++ b/midend/checkSize.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_CHECKSIZE_H_
-#define _MIDEND_CHECKSIZE_H_
+#ifndef MIDEND_CHECKSIZE_H_
+#define MIDEND_CHECKSIZE_H_
 
 #include "ir/ir.h"
 
@@ -55,4 +55,4 @@ class CheckTableSize : public Modifier {
 
 }  // namespace P4
 
-#endif /* _MIDEND_CHECKSIZE_H_ */
+#endif /* MIDEND_CHECKSIZE_H_ */

--- a/midend/compileTimeOps.h
+++ b/midend/compileTimeOps.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_COMPILETIMEOPS_H_
-#define _MIDEND_COMPILETIMEOPS_H_
+#ifndef MIDEND_COMPILETIMEOPS_H_
+#define MIDEND_COMPILETIMEOPS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -42,4 +42,4 @@ class CompileTimeOperations : public Inspector {
 
 }  // namespace P4
 
-#endif /* _MIDEND_COMPILETIMEOPS_H_ */
+#endif /* MIDEND_COMPILETIMEOPS_H_ */

--- a/midend/complexComparison.h
+++ b/midend/complexComparison.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_COMPLEXCOMPARISON_H_
-#define _MIDEND_COMPLEXCOMPARISON_H_
+#ifndef MIDEND_COMPLEXCOMPARISON_H_
+#define MIDEND_COMPLEXCOMPARISON_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -59,4 +59,4 @@ class SimplifyComparisons final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_COMPLEXCOMPARISON_H_ */
+#endif /* MIDEND_COMPLEXCOMPARISON_H_ */

--- a/midend/convertEnums.h
+++ b/midend/convertEnums.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_CONVERTENUMS_H_
-#define _MIDEND_CONVERTENUMS_H_
+#ifndef MIDEND_CONVERTENUMS_H_
+#define MIDEND_CONVERTENUMS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -146,4 +146,4 @@ class EnumOn32Bits : public P4::ChooseEnumRepresentation {
 
 }  // namespace P4
 
-#endif /* _MIDEND_CONVERTENUMS_H_ */
+#endif /* MIDEND_CONVERTENUMS_H_ */

--- a/midend/convertErrors.h
+++ b/midend/convertErrors.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_CONVERTERRORS_H_
-#define _MIDEND_CONVERTERRORS_H_
+#ifndef MIDEND_CONVERTERRORS_H_
+#define MIDEND_CONVERTERRORS_H_
 
 #include <map>
 
@@ -96,4 +96,4 @@ class ConvertErrors : public PassManager {
 };
 }  // namespace P4
 
-#endif /* _MIDEND_CONVERTERRORS_H_ */
+#endif /* MIDEND_CONVERTERRORS_H_ */

--- a/midend/copyStructures.h
+++ b/midend/copyStructures.h
@@ -129,4 +129,4 @@ class CopyStructures : public PassRepeated {
 
 }  // namespace P4
 
-#endif /* _MIDEND_COPYSTRUCTURES_H__ */
+#endif /* MIDEND_COPYSTRUCTURES_H_ */

--- a/midend/copyStructures.h
+++ b/midend/copyStructures.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_COPYSTRUCTURES_H_
-#define _MIDEND_COPYSTRUCTURES_H_
+#ifndef MIDEND_COPYSTRUCTURES_H_
+#define MIDEND_COPYSTRUCTURES_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"

--- a/midend/eliminateInvalidHeaders.h
+++ b/midend/eliminateInvalidHeaders.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_ELIMINATEINVALIDHEADERS_H_
-#define _MIDEND_ELIMINATEINVALIDHEADERS_H_
+#ifndef MIDEND_ELIMINATEINVALIDHEADERS_H_
+#define MIDEND_ELIMINATEINVALIDHEADERS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -58,4 +58,4 @@ class EliminateInvalidHeaders final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_ELIMINATEINVALIDHEADERS_H_ */
+#endif /* MIDEND_ELIMINATEINVALIDHEADERS_H_ */

--- a/midend/eliminateNewtype.h
+++ b/midend/eliminateNewtype.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_ELIMINATENEWTYPE_H_
-#define _MIDEND_ELIMINATENEWTYPE_H_
+#ifndef MIDEND_ELIMINATENEWTYPE_H_
+#define MIDEND_ELIMINATENEWTYPE_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -54,4 +54,4 @@ class EliminateNewtype final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_ELIMINATENEWTYPE_H_ */
+#endif /* MIDEND_ELIMINATENEWTYPE_H_ */

--- a/midend/eliminateSerEnums.h
+++ b/midend/eliminateSerEnums.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_ELIMINATESERENUMS_H_
-#define _MIDEND_ELIMINATESERENUMS_H_
+#ifndef MIDEND_ELIMINATESERENUMS_H_
+#define MIDEND_ELIMINATESERENUMS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -52,4 +52,4 @@ class EliminateSerEnums final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_ELIMINATESERENUMS_H_ */
+#endif /* MIDEND_ELIMINATESERENUMS_H_ */

--- a/midend/eliminateSwitch.h
+++ b/midend/eliminateSwitch.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_ELIMINATESWITCH_H_
-#define _MIDEND_ELIMINATESWITCH_H_
+#ifndef MIDEND_ELIMINATESWITCH_H_
+#define MIDEND_ELIMINATESWITCH_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -106,4 +106,4 @@ class EliminateSwitch final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_ELIMINATESWITCH_H_ */
+#endif /* MIDEND_ELIMINATESWITCH_H_ */

--- a/midend/eliminateTuples.h
+++ b/midend/eliminateTuples.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_ELIMINATETUPLES_H_
-#define _MIDEND_ELIMINATETUPLES_H_
+#ifndef MIDEND_ELIMINATETUPLES_H_
+#define MIDEND_ELIMINATETUPLES_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -132,4 +132,4 @@ class EliminateTuples final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_ELIMINATETUPLES_H_ */
+#endif /* MIDEND_ELIMINATETUPLES_H_ */

--- a/midend/expandEmit.h
+++ b/midend/expandEmit.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_EXPANDEMIT_H_
-#define _MIDEND_EXPANDEMIT_H_
+#ifndef MIDEND_EXPANDEMIT_H_
+#define MIDEND_EXPANDEMIT_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -70,4 +70,4 @@ class ExpandEmit : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_EXPANDEMIT_H_ */
+#endif /* MIDEND_EXPANDEMIT_H_ */

--- a/midend/expandLookahead.h
+++ b/midend/expandLookahead.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_EXPANDLOOKAHEAD_H_
-#define _MIDEND_EXPANDLOOKAHEAD_H_
+#ifndef MIDEND_EXPANDLOOKAHEAD_H_
+#define MIDEND_EXPANDLOOKAHEAD_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -98,4 +98,4 @@ class ExpandLookahead : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_EXPANDLOOKAHEAD_H_ */
+#endif /* MIDEND_EXPANDLOOKAHEAD_H_ */

--- a/midend/fillEnumMap.h
+++ b/midend/fillEnumMap.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_FILLENUMMAP_H_
-#define _MIDEND_FILLENUMMAP_H_
+#ifndef MIDEND_FILLENUMMAP_H_
+#define MIDEND_FILLENUMMAP_H_
 
 #include "convertEnums.h"
 
@@ -37,4 +37,4 @@ class FillEnumMap : public Transform {
 
 }  // namespace P4
 
-#endif /* _MIDEND_FILLENUMMAP_H_ */
+#endif /* MIDEND_FILLENUMMAP_H_ */

--- a/midend/flattenHeaders.h
+++ b/midend/flattenHeaders.h
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_FLATTENHEADERS_H_
-#define _MIDEND_FLATTENHEADERS_H_
+#ifndef MIDEND_FLATTENHEADERS_H_
+#define MIDEND_FLATTENHEADERS_H_
 
 #include "flattenInterfaceStructs.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -151,4 +151,4 @@ class FlattenHeaders final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_FLATTENHEADERS_H_ */
+#endif /* MIDEND_FLATTENHEADERS_H_ */

--- a/midend/flattenInterfaceStructs.h
+++ b/midend/flattenInterfaceStructs.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_FLATTENINTERFACESTRUCTS_H_
-#define _MIDEND_FLATTENINTERFACESTRUCTS_H_
+#ifndef MIDEND_FLATTENINTERFACESTRUCTS_H_
+#define MIDEND_FLATTENINTERFACESTRUCTS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -267,4 +267,4 @@ class FlattenInterfaceStructs final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_FLATTENINTERFACESTRUCTS_H_ */
+#endif /* MIDEND_FLATTENINTERFACESTRUCTS_H_ */

--- a/midend/flattenUnions.h
+++ b/midend/flattenUnions.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_FLATTENUNIONS_H_
-#define _MIDEND_FLATTENUNIONS_H_
+#ifndef MIDEND_FLATTENUNIONS_H_
+#define MIDEND_FLATTENUNIONS_H_
 
 #include "./frontends/p4/parserControlFlow.h"
 #include "./frontends/p4/simplifyDefUse.h"
@@ -209,4 +209,4 @@ class FlattenHeaderUnion : public PassManager {
 };
 }  // namespace P4
 
-#endif /* _MIDEND_FLATTENUNIONS_H_ */
+#endif /* MIDEND_FLATTENUNIONS_H_ */

--- a/midend/hsIndexSimplify.h
+++ b/midend/hsIndexSimplify.h
@@ -1,5 +1,5 @@
-#ifndef _MIDEND_HSINDEXSIMPLIFY_H_
-#define _MIDEND_HSINDEXSIMPLIFY_H_
+#ifndef MIDEND_HSINDEXSIMPLIFY_H_
+#define MIDEND_HSINDEXSIMPLIFY_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -104,4 +104,4 @@ class HSIndexSimplifier : public PassManager {
 
 }  // namespace P4
 
-#endif /*  _MIDEND_HSINDEXSIMPLIFY_H_ */
+#endif /* MIDEND_HSINDEXSIMPLIFY_H_ */

--- a/midend/interpreter.h
+++ b/midend/interpreter.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_INTERPRETER_H_
-#define _MIDEND_INTERPRETER_H_
+#ifndef MIDEND_INTERPRETER_H_
+#define MIDEND_INTERPRETER_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/coreLibrary.h"
@@ -580,4 +580,4 @@ class SymbolicPacketIn final : public SymbolicExtern {
 
 }  // namespace P4
 
-#endif /* _MIDEND_INTERPRETER_H_ */
+#endif /* MIDEND_INTERPRETER_H_ */

--- a/midend/midEndLast.h
+++ b/midend/midEndLast.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_MIDENDLAST_H_
-#define _MIDEND_MIDENDLAST_H_
+#ifndef MIDEND_MIDENDLAST_H_
+#define MIDEND_MIDENDLAST_H_
 
 #include "ir/ir.h"
 
@@ -29,4 +29,4 @@ class MidEndLast : public Inspector {
 
 }  // namespace P4
 
-#endif /* _MIDEND_MIDENDLAST_H_ */
+#endif /* MIDEND_MIDENDLAST_H_ */

--- a/midend/nestedStructs.h
+++ b/midend/nestedStructs.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_NESTEDSTRUCTS_H_
-#define _MIDEND_NESTEDSTRUCTS_H_
+#ifndef MIDEND_NESTEDSTRUCTS_H_
+#define MIDEND_NESTEDSTRUCTS_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -159,4 +159,4 @@ class NestedStructs final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_NESTEDSTRUCTS_H_ */
+#endif /* MIDEND_NESTEDSTRUCTS_H_ */

--- a/midend/noMatch.h
+++ b/midend/noMatch.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_NOMATCH_H_
-#define _MIDEND_NOMATCH_H_
+#ifndef MIDEND_NOMATCH_H_
+#define MIDEND_NOMATCH_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "ir/ir.h"
@@ -53,4 +53,4 @@ class HandleNoMatch : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_NOMATCH_H_ */
+#endif /* MIDEND_NOMATCH_H_ */

--- a/midend/orderArguments.h
+++ b/midend/orderArguments.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_ORDERARGUMENTS_H_
-#define _MIDEND_ORDERARGUMENTS_H_
+#ifndef MIDEND_ORDERARGUMENTS_H_
+#define MIDEND_ORDERARGUMENTS_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -56,4 +56,4 @@ class OrderArguments : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_ORDERARGUMENTS_H_ */
+#endif /* MIDEND_ORDERARGUMENTS_H_ */

--- a/midend/parserUnroll.h
+++ b/midend/parserUnroll.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_PARSERUNROLL_H_
-#define _MIDEND_PARSERUNROLL_H_
+#ifndef MIDEND_PARSERUNROLL_H_
+#define MIDEND_PARSERUNROLL_H_
 
 #include <unordered_map>
 
@@ -308,4 +308,4 @@ class ParsersUnroll : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_PARSERUNROLL_H_ */
+#endif /* MIDEND_PARSERUNROLL_H_ */

--- a/midend/predication.h
+++ b/midend/predication.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_PREDICATION_H_
-#define _MIDEND_PREDICATION_H_
+#ifndef MIDEND_PREDICATION_H_
+#define MIDEND_PREDICATION_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -145,4 +145,4 @@ class Predication final : public Transform {
 
 }  // namespace P4
 
-#endif /* _MIDEND_PREDICATION_H_ */
+#endif /* MIDEND_PREDICATION_H_ */

--- a/midend/removeAssertAssume.h
+++ b/midend/removeAssertAssume.h
@@ -1,5 +1,5 @@
-#ifndef _MIDEND_REMOVEASSERTASSUME_H_
-#define _MIDEND_REMOVEASSERTASSUME_H_
+#ifndef MIDEND_REMOVEASSERTASSUME_H_
+#define MIDEND_REMOVEASSERTASSUME_H_
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeChecking/typeChecker.h"

--- a/midend/removeAssertAssume.h
+++ b/midend/removeAssertAssume.h
@@ -36,4 +36,4 @@ class RemoveAssertAssume final : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_REMOVEASSERTASSUME_H_*/
+#endif /* MIDEND_REMOVEASSERTASSUME_H_ */

--- a/midend/removeExits.h
+++ b/midend/removeExits.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_REMOVEEXITS_H_
-#define _MIDEND_REMOVEEXITS_H_
+#ifndef MIDEND_REMOVEEXITS_H_
+#define MIDEND_REMOVEEXITS_H_
 
 #include "frontends/p4/removeReturns.h"
 
@@ -70,4 +70,4 @@ class RemoveExits : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_REMOVEEXITS_H_ */
+#endif /* MIDEND_REMOVEEXITS_H_ */

--- a/midend/removeLeftSlices.h
+++ b/midend/removeLeftSlices.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_REMOVELEFTSLICES_H_
-#define _MIDEND_REMOVELEFTSLICES_H_
+#ifndef MIDEND_REMOVELEFTSLICES_H_
+#define MIDEND_REMOVELEFTSLICES_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -54,4 +54,4 @@ class RemoveLeftSlices : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_REMOVELEFTSLICES_H_ */
+#endif /* MIDEND_REMOVELEFTSLICES_H_ */

--- a/midend/removeMiss.h
+++ b/midend/removeMiss.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_REMOVEMISS_H_
-#define _MIDEND_REMOVEMISS_H_
+#ifndef MIDEND_REMOVEMISS_H_
+#define MIDEND_REMOVEMISS_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -54,4 +54,4 @@ class RemoveMiss : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_REMOVEMISS_H_ */
+#endif /* MIDEND_REMOVEMISS_H_ */

--- a/midend/removeSelectBooleans.h
+++ b/midend/removeSelectBooleans.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_REMOVESELECTBOOLEANS_H_
-#define _MIDEND_REMOVESELECTBOOLEANS_H_
+#ifndef MIDEND_REMOVESELECTBOOLEANS_H_
+#define MIDEND_REMOVESELECTBOOLEANS_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -60,4 +60,4 @@ class RemoveSelectBooleans : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_REMOVESELECTBOOLEANS_H_ */
+#endif /* MIDEND_REMOVESELECTBOOLEANS_H_ */

--- a/midend/removeUnusedParameters.h
+++ b/midend/removeUnusedParameters.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_REMOVEUNUSEDPARAMETERS_H_
-#define _MIDEND_REMOVEUNUSEDPARAMETERS_H_
+#ifndef MIDEND_REMOVEUNUSEDPARAMETERS_H_
+#define MIDEND_REMOVEUNUSEDPARAMETERS_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "ir/ir.h"
@@ -61,4 +61,4 @@ class RemoveUnusedActionParameters : public Transform {
 
 }  // namespace P4
 
-#endif /* _MIDEND_REMOVEUNUSEDPARAMETERS_H_ */
+#endif /* MIDEND_REMOVEUNUSEDPARAMETERS_H_ */

--- a/midend/replaceSelectRange.h
+++ b/midend/replaceSelectRange.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  *
  */
-#ifndef _MIDEND_REPLACESELECTRANGE_H_
-#define _MIDEND_REPLACESELECTRANGE_H_
+#ifndef MIDEND_REPLACESELECTRANGE_H_
+#define MIDEND_REPLACESELECTRANGE_H_
 
 #include <iomanip>
 #include <iostream>
@@ -68,4 +68,4 @@ class ReplaceSelectRange final : public PassManager {
 };
 
 }  // namespace P4
-#endif /* _MIDEND_REPLACESELECTRANGE_H_ */
+#endif /* MIDEND_REPLACESELECTRANGE_H_ */

--- a/midend/simplifyKey.h
+++ b/midend/simplifyKey.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_SIMPLIFYKEY_H_
-#define _MIDEND_SIMPLIFYKEY_H_
+#ifndef MIDEND_SIMPLIFYKEY_H_
+#define MIDEND_SIMPLIFYKEY_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/sideEffects.h"
@@ -194,4 +194,4 @@ class SimplifyKey : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_SIMPLIFYKEY_H_ */
+#endif /* MIDEND_SIMPLIFYKEY_H_ */

--- a/midend/simplifySelectCases.h
+++ b/midend/simplifySelectCases.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_SIMPLIFYSELECTCASES_H_
-#define _MIDEND_SIMPLIFYSELECTCASES_H_
+#ifndef MIDEND_SIMPLIFYSELECTCASES_H_
+#define MIDEND_SIMPLIFYSELECTCASES_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -62,4 +62,4 @@ class SimplifySelectCases : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_SIMPLIFYSELECTCASES_H_ */
+#endif /* MIDEND_SIMPLIFYSELECTCASES_H_ */

--- a/midend/simplifySelectList.h
+++ b/midend/simplifySelectList.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_SIMPLIFYSELECTLIST_H_
-#define _MIDEND_SIMPLIFYSELECTLIST_H_
+#ifndef MIDEND_SIMPLIFYSELECTLIST_H_
+#define MIDEND_SIMPLIFYSELECTLIST_H_
 
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
@@ -95,4 +95,4 @@ class SimplifySelectList : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_SIMPLIFYSELECTLIST_H_ */
+#endif /* MIDEND_SIMPLIFYSELECTLIST_H_ */

--- a/midend/singleArgumentSelect.h
+++ b/midend/singleArgumentSelect.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_SINGLEARGUMENTSELECT_H_
-#define _MIDEND_SINGLEARGUMENTSELECT_H_
+#ifndef MIDEND_SINGLEARGUMENTSELECT_H_
+#define MIDEND_SINGLEARGUMENTSELECT_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -68,4 +68,4 @@ class SingleArgumentSelect : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_SINGLEARGUMENTSELECT_H_ */
+#endif /* MIDEND_SINGLEARGUMENTSELECT_H_ */

--- a/midend/tableHit.h
+++ b/midend/tableHit.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_TABLEHIT_H_
-#define _MIDEND_TABLEHIT_H_
+#ifndef MIDEND_TABLEHIT_H_
+#define MIDEND_TABLEHIT_H_
 
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
@@ -57,4 +57,4 @@ class TableHit : public PassManager {
 
 }  // namespace P4
 
-#endif /* _MIDEND_TABLEHIT_H_ */
+#endif /* MIDEND_TABLEHIT_H_ */

--- a/midend/validateProperties.h
+++ b/midend/validateProperties.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _MIDEND_VALIDATEPROPERTIES_H_
-#define _MIDEND_VALIDATEPROPERTIES_H_
+#ifndef MIDEND_VALIDATEPROPERTIES_H_
+#define MIDEND_VALIDATEPROPERTIES_H_
 
 #include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
@@ -50,4 +50,4 @@ class ValidateTableProperties : public Inspector {
 
 }  // namespace P4
 
-#endif /* _MIDEND_VALIDATEPROPERTIES_H_ */
+#endif /* MIDEND_VALIDATEPROPERTIES_H_ */

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -104,7 +104,7 @@ Util::Enumerator<IrClass *> *IrDefinitions::getClasses() const {
 }
 
 void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &impl) const {
-    std::string macroname = "_IR_GENERATED_H_";
+    std::string macroname = "IR_GENERATED_H_";
     out << "#ifndef " << macroname << "\n"
         << "#define " << macroname << "\n"
         << std::endl;

--- a/tools/ir-generator/irclass.h
+++ b/tools/ir-generator/irclass.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _TOOLS_IR_GENERATOR_IRCLASS_H_
-#define _TOOLS_IR_GENERATOR_IRCLASS_H_
+#ifndef TOOLS_IR_GENERATOR_IRCLASS_H_
+#define TOOLS_IR_GENERATOR_IRCLASS_H_
 
 #include <map>
 #include <stdexcept>
@@ -386,4 +386,4 @@ inline std::ostream &operator<<(std::ostream &out, const LineDirective &l) {
     return out;
 }
 
-#endif /* _TOOLS_IR_GENERATOR_IRCLASS_H_ */
+#endif /* TOOLS_IR_GENERATOR_IRCLASS_H_ */

--- a/tools/ir-generator/type.h
+++ b/tools/ir-generator/type.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef _TOOLS_IR_GENERATOR_TYPE_H_
-#define _TOOLS_IR_GENERATOR_TYPE_H_
+#ifndef TOOLS_IR_GENERATOR_TYPE_H_
+#define TOOLS_IR_GENERATOR_TYPE_H_
 
 #include <vector>
 
@@ -217,4 +217,4 @@ class FunctionType : public Type {
     }
 };
 
-#endif /* _TOOLS_IR_GENERATOR_TYPE_H_ */
+#endif /* TOOLS_IR_GENERATOR_TYPE_H_ */


### PR DESCRIPTION
Batch-processed by

```bash
$ git ls-tree --full-tree --name-only -r HEAD | grep '[.]h$' | while read filename; do  sed -Ei -e 's/^(#(define|ifndef)\s+)_([A-Z0-9_]+_H_)$/\1\3/' -e 's,^(#endif\s+)(/\*\s+_([A-Z0-9_]+_H_)\s+\*/|//\s+_([A-Z0-9_]+_H_))\s*$,\1/* \3\4 */,' $filename; done
```

Identifiers of the following forms are reserved:

- identifiers with a double underscore anywhere;
- identifiers that begin with an underscore followed by an uppercase letter;
- in the global namespace, identifiers that begin with an underscore.

We should not use reserved identifiers. More e.g. at https://en.cppreference.com/w/cpp/language/identifiers