### PR TITLE
Allow building the compiler without P4TEST enabled

### DIFF
--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -1,7 +1,6 @@
 #include <cstdlib>
 #include <fstream>
 
-#include "backends/p4test/version.h"
 #include "frontends/common/constantFolding.h"
 #include "frontends/common/parseInput.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
@@ -219,7 +218,6 @@ const IR::P4Program *load_model(const char *curFile, CompilerOptions &options) {
     auto originalEnv = getenv("P4C_16_INCLUDE_PATH");
     setenv("P4C_16_INCLUDE_PATH", includeDir.c_str(), 1);
     options.loopsUnrolling = true;
-    options.compilerVersion = P4TEST_VERSION_STRING;
     options.file = sourcePath;
     options.file += "testdata/p4_16_samples/";
     options.file += curFile;


### PR DESCRIPTION
The parser unroll gtest was using compiler version macro from P4TEST. As there is no global version macro, I opted for not setting the version at all in the test.