### PR TITLE
Add an option to the DPDK P4C back end to generate TDI builder configurations.

### DIFF
--- a/backends/dpdk/CMakeLists.txt
+++ b/backends/dpdk/CMakeLists.txt
@@ -62,6 +62,7 @@ set(P4C_DPDK_SOURCES
     dpdkUtils.cpp
     options.cpp
     control-plane/bfruntime_ext.cpp
+    tdiConf.cpp
     )
 
 set(P4C_DPDK_HEADERS
@@ -82,6 +83,7 @@ set(P4C_DPDK_HEADERS
     options.h
     control-plane/bfruntime_ext.h
     control-plane/bfruntime_arch_handler.h
+    tdiConf.h
     )
 
 set (IR_DEF_FILES ${IR_DEF_FILES} ${CMAKE_CURRENT_SOURCE_DIR}/dpdk.def PARENT_SCOPE)

--- a/backends/dpdk/main.cpp
+++ b/backends/dpdk/main.cpp
@@ -114,7 +114,7 @@ int main(int argc, char *const argv[]) {
     if (::errorCount() > 0) return 1;
 
     if (!options.tdiBuilderConf.isNullOrEmpty()) {
-        DPDK::TdiBfrtConf::generate(options);
+        DPDK::TdiBfrtConf::generate(program, options);
     }
 
     if (!options.bfRtSchema.isNullOrEmpty()) {

--- a/backends/dpdk/main.cpp
+++ b/backends/dpdk/main.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "backends/dpdk/control-plane/bfruntime_arch_handler.h"
 #include "backends/dpdk/midend.h"
 #include "backends/dpdk/options.h"
+#include "backends/dpdk/tdiConf.h"
 #include "backends/dpdk/version.h"
 #include "control-plane/bfruntime_ext.h"
 #include "control-plane/p4RuntimeSerializer.h"
@@ -111,6 +112,10 @@ int main(int argc, char *const argv[]) {
 
     P4::serializeP4RuntimeIfRequired(program, options);
     if (::errorCount() > 0) return 1;
+
+    if (!options.tdiBuilderConf.isNullOrEmpty()) {
+        DPDK::TdiBfrtConf::generate(options);
+    }
 
     if (!options.bfRtSchema.isNullOrEmpty()) {
         generateTDIBfrtJson(false, program, options);

--- a/backends/dpdk/options.h
+++ b/backends/dpdk/options.h
@@ -24,15 +24,17 @@ namespace DPDK {
 class DpdkOptions : public CompilerOptions {
  public:
     cstring bfRtSchema = "";
-    // file to output to
+    // File to output to.
     cstring outputFile = nullptr;
-    // file to ouput TDI Json to
+    // File to output TDI JSON to.
     cstring tdiFile = "";
-    // file to ouput context Json to
+    // File to output context JSON to.
     cstring ctxtFile = "";
-    // read from json
+    // File to output the TDI builder configuration to.
+    cstring tdiBuilderConf = "";
+    // Read from JSON.
     bool loadIRFromJson = false;
-    // Enable/Disable Egress pipeline in psa
+    // Enable/disable Egress pipeline in PSA.
     bool enableEgress = false;
 
     DpdkOptions() {
@@ -67,6 +69,13 @@ class DpdkOptions : public CompilerOptions {
                 return true;
             },
             "Write output to outfile");
+        registerOption(
+            "--tdi-builder-conf", "file",
+            [this](const char *arg) {
+                tdiBuilderConf = arg;
+                return true;
+            },
+            "Generate and write the TDI builder configuration to the specified file");
         registerOption(
             "--tdi", "file",
             [this](const char *arg) {

--- a/backends/dpdk/tdiConf.cpp
+++ b/backends/dpdk/tdiConf.cpp
@@ -1,0 +1,98 @@
+/* Copyright 2023 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "backends/dpdk/tdiConf.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+namespace DPDK {
+
+void TdiBfrtConf::generate(DPDK::DpdkOptions &options) {
+    auto outFile = std::filesystem::path(options.outputFile.c_str());
+    auto tdiFile = std::filesystem::path(options.tdiFile.c_str());
+    auto programName = outFile.stem();
+    auto outDir = outFile.parent_path();
+    auto configFile = outFile.replace_filename("spec");
+
+    if (options.bfRtSchema == nullptr) {
+        options.bfRtSchema = (outDir / programName).replace_filename("json").c_str();
+        ::warning(
+            "BF-Runtime Schema file name not provided, but is required for the TDI builder "
+            "configuration. Generating file %1%",
+            options.bfRtSchema);
+    }
+    if (options.ctxtFile == nullptr) {
+        options.ctxtFile = (outDir / "context.json").c_str();
+        ::warning(
+            "DPDK context file name not provided, but is required for the TDI builder "
+            "configuration. Generating file %1%",
+            options.ctxtFile);
+    }
+
+    auto contextFile = options.ctxtFile;
+    auto bfRtSchema = options.bfRtSchema;
+    // TODO: Ideally, this should be a template. We could use Inja, but this adds another
+    // dependency.
+    std::stringstream ss;
+    ss << R"""(
+{
+    "chip_list": [
+        {
+            "chip_family": "dpdk"
+        }
+    ],
+    "instance": 0,
+    "p4_devices": [
+        {
+            "device-id": 0,
+            "p4_programs": [
+                {
+)""";
+    ss << R"""(                    "program-name" : )""";
+    ss << "\"" << programName << "\",";
+    ss << R"""(                    "bfrt-config" : )""";
+    ss << "\"" << bfRtSchema << "\",";
+    ss << R"""(                    "p4_pipelines": [
+                        {)""";
+    ss << R"""(                            "p4_pipeline_name": "pipe",
+                            "context": )""";
+    ss << "\"" << contextFile << "\",";
+    ss << R"""(                            "config": )""";
+    ss << "\"" << configFile << "\",";
+    ss << R"""(
+                            "pipe_scope": [
+                                0,
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+)""";
+    std::ofstream out;
+    out.open(tdiFile);
+    if (out.is_open()) {
+        out << ss;
+    } else {
+        ::error(ErrorType::ERR_IO, "Could not open file: %1%", tdiFile.c_str());
+        return;
+    }
+    out.close();
+}
+}  // namespace DPDK

--- a/backends/dpdk/tdiConf.cpp
+++ b/backends/dpdk/tdiConf.cpp
@@ -27,10 +27,10 @@ void TdiBfrtConf::generate(DPDK::DpdkOptions &options) {
                 "No output file provided. Unable to generate correct TDI builder config file.");
         return;
     }
-    auto inputFile = std::filesystem::path(options.file.c_str());
-    auto outFile = std::filesystem::path(options.outputFile.c_str());
+    auto inputFile = std::filesystem::absolute(options.file.c_str());
+    auto outFile = std::filesystem::absolute(options.outputFile.c_str());
     auto outDir = outFile.parent_path();
-    auto tdiFile = std::filesystem::path(options.tdiBuilderConf.c_str());
+    auto tdiFile = std::filesystem::absolute(options.tdiBuilderConf.c_str());
     auto programName = inputFile.stem();
 
     if (options.bfRtSchema.isNullOrEmpty()) {
@@ -48,8 +48,8 @@ void TdiBfrtConf::generate(DPDK::DpdkOptions &options) {
             options.ctxtFile);
     }
 
-    auto contextFile = options.ctxtFile;
-    auto bfRtSchema = options.bfRtSchema;
+    auto contextFile = std::filesystem::absolute(options.ctxtFile.c_str());
+    auto bfRtSchema = std::filesystem::absolute(options.bfRtSchema.c_str());
     // TODO: Ideally, this should be a template. We could use Inja, but this adds another
     // dependency.
     std::stringstream ss;
@@ -67,18 +67,18 @@ void TdiBfrtConf::generate(DPDK::DpdkOptions &options) {
                 {
 )""";
     ss << R"""(                    "program-name" : )""";
-    ss << "" << programName << ",\n";
+    ss << programName << ",\n";
     ss << R"""(                    "bfrt-config" : )""";
-    ss << "\"" << bfRtSchema << "\",\n";
+    ss << bfRtSchema << ",\n";
     ss << R"""(                    "p4_pipelines": [
                         {
 )""";
     ss << R"""(                            "p4_pipeline_name": "pipe",
                             "context": )""";
-    ss << "\"" << contextFile << "\",";
+    ss << contextFile << ",";
     ss << R"""(
                             "config": )""";
-    ss << "" << outFile << ",";
+    ss << outFile << ",";
     ss << R"""(
                             "pipe_scope": [
                                 0,

--- a/backends/dpdk/tdiConf.cpp
+++ b/backends/dpdk/tdiConf.cpp
@@ -81,7 +81,7 @@ void TdiBfrtConf::generate(DPDK::DpdkOptions &options) {
     ss << outFile << ",";
     ss << R"""(
                             "pipe_scope": [
-                                0,
+                                0
                             ]
                         }
                     ]

--- a/backends/dpdk/tdiConf.cpp
+++ b/backends/dpdk/tdiConf.cpp
@@ -21,7 +21,51 @@ limitations under the License.
 
 namespace DPDK {
 
-void TdiBfrtConf::generate(DPDK::DpdkOptions &options) {
+std::vector<cstring> TdiBfrtConf::getPipeNames(const IR::Declaration_Instance *main) {
+    std::vector<cstring> pipeNames;
+    for (const auto *arg : *main->arguments) {
+        const auto *expr = arg->expression;
+
+        if (const auto *ctorCall = expr->to<IR::ConstructorCallExpression>()) {
+            const auto *constructedTypeName = ctorCall->constructedType->checkedTo<IR::Type_Name>();
+            pipeNames.emplace_back(constructedTypeName->path->name.name);
+        } else if (const auto *pathExpr = expr->to<IR::PathExpression>()) {
+            pipeNames.emplace_back(pathExpr->path->name.name);
+        } else {
+            BUG("Unexpected main-declaration argument node type: %1%", expr->node_type_name());
+        }
+    }
+    return pipeNames;
+}
+
+std::optional<cstring> TdiBfrtConf::findPipeName(const IR::P4Program *prog,
+                                                 DPDK::DpdkOptions &options) {
+    if (options.arch == "pna") {
+        // The PNA pipename is currently fixed to "pipe".
+        return "pipe";
+    }
+    if (options.arch == "psa") {
+        // We try to infer the pipename by looking up the "main" declaration.
+        auto *decls = prog->getDeclsByName("main");
+        const IR::Declaration_Instance *main = nullptr;
+        for (const auto *decl : *decls) {
+            main = decl->checkedTo<IR::Declaration_Instance>();
+        }
+        if (main == nullptr) {
+            ::error(ErrorType::ERR_NOT_FOUND, "Program does not contain a `main` module");
+            return std::nullopt;
+        }
+        // We then get the list of constructor and type names in this call and return the first.
+        // TODO: Do we want to return all pipe names and their respective configurations?
+        auto pipeNames = getPipeNames(main);
+        BUG_CHECK(!pipeNames.empty(), "Program main does not have any pipe arguments.");
+        return pipeNames.at(0);
+    }
+    ::error("Unsupported target %1% for TDI Builder config generation.", options.arch);
+    return std::nullopt;
+}
+
+void TdiBfrtConf::generate(const IR::P4Program *prog, DPDK::DpdkOptions &options) {
     if (options.outputFile.isNullOrEmpty()) {
         ::error(ErrorType::ERR_UNEXPECTED,
                 "No output file provided. Unable to generate correct TDI builder config file.");
@@ -50,6 +94,11 @@ void TdiBfrtConf::generate(DPDK::DpdkOptions &options) {
 
     auto contextFile = std::filesystem::absolute(options.ctxtFile.c_str());
     auto bfRtSchema = std::filesystem::absolute(options.bfRtSchema.c_str());
+
+    auto pipeName = findPipeName(prog, options);
+    if (!pipeName.has_value()) {
+        return;
+    }
     // TODO: Ideally, this should be a template. We could use Inja, but this adds another
     // dependency.
     std::stringstream ss;
@@ -71,9 +120,11 @@ void TdiBfrtConf::generate(DPDK::DpdkOptions &options) {
     ss << R"""(                    "bfrt-config" : )""";
     ss << bfRtSchema << ",\n";
     ss << R"""(                    "p4_pipelines": [
-                        {
-)""";
-    ss << R"""(                            "p4_pipeline_name": "pipe",
+                        {)""";
+    ss << R"""(
+                            "p4_pipeline_name": )""";
+    ss << "\"" << pipeName.value() << "\",";
+    ss << R"""(
                             "context": )""";
     ss << contextFile << ",";
     ss << R"""(

--- a/backends/dpdk/tdiConf.h
+++ b/backends/dpdk/tdiConf.h
@@ -22,9 +22,18 @@ limitations under the License.
 namespace DPDK {
 
 class TdiBfrtConf {
+ private:
+    /// Iterates over the arguments of the main declaration instance and returns the callee names as
+    /// a vector of cstrings.
+    static std::vector<cstring> getPipeNames(const IR::Declaration_Instance *main);
+
+    /// @returns the canonical pipe name for the respective architecture.
+    static std::optional<cstring> findPipeName(const IR::P4Program *prog,
+                                               DPDK::DpdkOptions &options);
+
  public:
     /// Generate the TDI configuration file required by the tdi-pipeline-builder.
-    static void generate(DPDK::DpdkOptions &options);
+    static void generate(const IR::P4Program *prog, DPDK::DpdkOptions &options);
 };
 
 }  // namespace DPDK

--- a/backends/dpdk/tdiConf.h
+++ b/backends/dpdk/tdiConf.h
@@ -1,0 +1,32 @@
+/* Copyright 2023 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef BACKENDS_DPDK_TDICONF_H_
+#define BACKENDS_DPDK_TDICONF_H_
+
+#include <string>
+
+#include "backends/dpdk/options.h"
+namespace DPDK {
+
+class TdiBfrtConf {
+ public:
+    /// Generate the TDI configuration file required by the tdi-pipeline-builder.
+    static void generate(DPDK::DpdkOptions &options);
+};
+
+}  // namespace DPDK
+
+#endif /* BACKENDS_DPDK_TDICONF_H_ */


### PR DESCRIPTION
This PR adds the parameter `--tdi-builder-conf` to the p4c-dpdk compiler. This parameter emits the configuration necessary for the `tdi-pipeline_builder`. I am not a direct user, so I simply guessed the parameters necessary. Please let me know if there is anything else to add or remove.

Sidenote:

The `p4c-dpdk` compiler now has about four to five different parameters to create a configuration and output file.
```
--bf-rt-schema file        Generate and write BF-RT JSON schema to the specified file
-o outfile                 Write output to outfile
--tdi file                 Generate and write TDI JSON to the specified file
--context file             Generate and write context JSON to the specified file
--tdi-builder-conf file    Generate and write the TDI builder configuration to the specified file
```

 It might make sense to consolidate some of these? 