### PR TITLE
[P4Testgen] Make the ranges of supported ports a command line parameter for P4Testgen

### DIFF
--- a/backends/bmv2/run-bmv2-ptf-test.py
+++ b/backends/bmv2/run-bmv2-ptf-test.py
@@ -181,7 +181,7 @@ class NNEnv(PTFTestEnv):
         )
         # TODO: There is currently a bug where we can not support more than 344 ports at once.
         # The nanomsg test back end simply hangs, the reason is unclear.
-        port_range = "0-50"
+        port_range = "0-8"
         run_ptf_cmd = (
             f"ptf --platform nn --device-socket 0-{{{port_range}}}@ipc://{self.options.testdir}/"
             f"bmv2_packets_1.ipc --pypath {pypath} "

--- a/backends/p4tools/common/options.h
+++ b/backends/p4tools/common/options.h
@@ -18,13 +18,6 @@ namespace P4Tools {
 /// instance.
 class AbstractP4cToolOptions : protected Util::Options {
  public:
-    /// The maximum permitted packet size, in bits.
-    // The default is the jumbo frame packet size, 9000 bytes.
-    int maxPktSize = 72000;
-
-    /// The minimum permitted packet size, in bits.
-    int minPktSize = 0;
-
     /// A seed for the PRNG.
     std::optional<uint32_t> seed = std::nullopt;
 

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -286,25 +286,11 @@ bool CmdStepper::preorder(const IR::MethodCallStatement *methodCallStatement) {
 bool CmdStepper::preorder(const IR::P4Program * /*program*/) {
     // Don't invoke logStep for the top-level program, as that would be overly verbose.
 
-    const auto &options = TestgenOptions::get();
     // Get the initial constraints of the target. These constraints influence branch selection.
     std::optional<const Constraint *> cond = programInfo.getTargetConstraints();
 
     // Initialize all relevant environment variables for the respective target.
     initializeTargetEnvironment(state);
-
-    if (!options.permittedPortRanges.empty()) {
-        if (cond == std::nullopt) {
-            cond = new IR::BoolLiteral(true);
-        }
-        const auto &inputPortVar = programInfo.getTargetInputPortVar();
-        for (auto portRange : options.permittedPortRanges) {
-            const auto *loVarIn = IR::getConstant(inputPortVar->type, portRange.first);
-            const auto *hiVarIn = IR::getConstant(inputPortVar->type, portRange.second);
-            cond = new IR::LAnd(new IR::LAnd(cond.value(), new IR::Leq(loVarIn, inputPortVar)),
-                                new IR::Leq(inputPortVar, hiVarIn));
-        }
-    }
 
     // If this option is active, mandate that all packets conform to a fixed size.
     auto pktSize = TestgenOptions::get().minPktSize;
@@ -315,7 +301,7 @@ bool CmdStepper::preorder(const IR::P4Program * /*program*/) {
         if (cond == std::nullopt) {
             cond = fixedSizeEqu;
         } else {
-            cond = new IR::LAnd(*cond, fixedSizeEqu);
+            cond = new IR::LAnd(cond.value(), fixedSizeEqu);
         }
     }
 

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -63,6 +63,17 @@ class TestgenOptions : public AbstractP4cToolOptions {
     /// for statement reachability analysis.
     bool dcg = false;
 
+    /// The maximum permitted packet size, in bits.
+    // The default is the jumbo frame packet size, 9000 bytes.
+    int maxPktSize = 72000;
+
+    /// The minimum permitted packet size, in bits.
+    int minPktSize = 0;
+
+    /// The list of permitted port ranges.
+    /// TestGen will consider these when choosing input and output ports.
+    std::vector<std::pair<int, int>> permittedPortRanges;
+
     /// Enforces the test generation of tests with mandatory output packet.
     bool withOutputPacket = false;
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
@@ -109,12 +109,6 @@ std::optional<const Constraint *> Bmv2V1ModelCmdStepper::startParserImpl(
         parser, programInfo.getParserErrorType(), 3, "parser_error");
     nextState.setParserErrorLabel(errVar);
 
-    /// Set the restriction on the input port for PTF tests.
-    /// This is necessary since the PTF framework only allows a specific port range.
-    if (TestgenOptions::get().testBackend == "PTF") {
-        const auto &portVar = programInfo.getTargetInputPortVar();
-        return new IR::Lss(portVar, new IR::Constant(portVar->type, 8));
-    }
     return std::nullopt;
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -98,6 +98,12 @@ Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(
     auto mappedDirectExterns = directExternMapper.getdirectExternMap();
     directExternMap.insert(mappedDirectExterns.begin(), mappedDirectExterns.end());
 
+    /// If permittedPortRanges is not empty, set the restrictions on the output port.
+    if (!options.permittedPortRanges.empty()) {
+        constraint = new IR::LAnd(
+            constraint, getPortConstraint(getTargetOutputPortVar(), options.permittedPortRanges));
+    }
+
     /// Finally, set the target constraints.
     targetConstraints = constraint;
 }
@@ -158,17 +164,10 @@ std::vector<Continuation::Command> Bmv2V1ModelProgramInfo::processDeclaration(
         auto *portStmt = new IR::AssignmentStatement(egressPortVar, getTargetOutputPortVar());
         cmds.emplace_back(portStmt);
 
-        /// If the option is not empty, set the restrictions on the output port.
+        /// If permittedPortRanges is not empty, set the restrictions on the output port.
         if (!options.permittedPortRanges.empty()) {
-            const IR::Expression *cond = new IR::BoolLiteral(true);
-            const auto &outPortVar = getTargetOutputPortVar();
-            for (auto portRange : options.permittedPortRanges) {
-                const auto *loVarOut = IR::getConstant(outPortVar->type, portRange.first);
-                const auto *hiVarOut = IR::getConstant(outPortVar->type, portRange.second);
-                cond = new IR::LAnd(new IR::LAnd(cond, new IR::Leq(loVarOut, outPortVar)),
-                                    new IR::Leq(outPortVar, hiVarOut));
-            }
-            cmds.emplace_back(Continuation::Guard(cond));
+            cmds.emplace_back(Continuation::Guard(
+                getPortConstraint(getTargetOutputPortVar(), options.permittedPortRanges)));
         }
         // TODO: We have not implemented multi cast yet.
         // Drop the packet if the multicast group is set.
@@ -200,6 +199,19 @@ const IR::StateVariable &Bmv2V1ModelProgramInfo::getTargetInputPortVar() const {
                                                  "ingress_port"));
 }
 
+const IR::Expression *Bmv2V1ModelProgramInfo::getPortConstraint(
+    const IR::StateVariable &portVar, const std::vector<std::pair<int, int>> &permittedPortRanges) {
+    /// The drop port is also a valid port. Initialize the condition with it.
+    const IR::Expression *portConstraint =
+        new IR::Equ(portVar, new IR::Constant(portVar->type, BMv2Constants::DROP_PORT));
+    for (auto portRange : permittedPortRanges) {
+        const auto *loVarOut = IR::getConstant(portVar->type, portRange.first);
+        const auto *hiVarOut = IR::getConstant(portVar->type, portRange.second);
+        portConstraint = new IR::LOr(portConstraint, new IR::LAnd(new IR::Leq(loVarOut, portVar),
+                                                                  new IR::Leq(portVar, hiVarOut)));
+    }
+    return portConstraint;
+}
 const IR::StateVariable &Bmv2V1ModelProgramInfo::getTargetOutputPortVar() const {
     return *new IR::StateVariable(new IR::Member(IR::getBitType(BMv2Constants::PORT_BIT_WIDTH),
                                                  new IR::PathExpression("*standard_metadata"),

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
@@ -55,6 +55,11 @@ class Bmv2V1ModelProgramInfo : public ProgramInfo {
 
     [[nodiscard]] const IR::StateVariable &getTargetInputPortVar() const override;
 
+    /// @returns the constraint expression for a given port variable.
+    static const IR::Expression *getPortConstraint(
+        const IR::StateVariable &portVar,
+        const std::vector<std::pair<int, int>> &permittedPortRanges);
+
     [[nodiscard]] const IR::StateVariable &getTargetOutputPortVar() const override;
 
     [[nodiscard]] const IR::Expression *dropIsActive() const override;

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
@@ -55,9 +55,6 @@ class Bmv2V1ModelProgramInfo : public ProgramInfo {
 
     [[nodiscard]] const IR::StateVariable &getTargetInputPortVar() const override;
 
-    /// @returns the constraint expression for a given port variable.
-    static const IR::Expression *getPortConstraint(const IR::StateVariable &portVar);
-
     [[nodiscard]] const IR::StateVariable &getTargetOutputPortVar() const override;
 
     [[nodiscard]] const IR::Expression *dropIsActive() const override;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -278,7 +278,6 @@ p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
   "Expected packet was not received on device"
   # The packet has a zero width and is dropped by PTF.
-  issue281.p4
   parser-unroll-issue3537-1.p4
   parser-unroll-issue3537.p4
   parser-unroll-test2.p4

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
@@ -74,10 +74,12 @@ if(P4TOOLS_TESTGEN_BMV2_TEST_PTF)
        # A particular test (or packet?) combination leads to an infinite loop in the simple switch.
        "${P4C_SOURCE_DIR}/testdata/p4_16_samples/v1model-special-ops-bmv2.p4"
   )
+  # Currently, the test back end only support ports 0-8.
+  # TODO: Support the full range of ports.
   p4tools_add_tests(
     TESTS "${P4C_V1_TEST_SUITES_P416_PTF}"
     TAG "testgen-p4c-bmv2-ptf" DRIVER ${P4TESTGEN_DRIVER}
-    TARGET "bmv2" ARCH "v1model" P416_PTF TEST_ARGS "--test-backend PTF --packet-size-range 0:12000 ${EXTRA_OPTS} "
+    TARGET "bmv2" ARCH "v1model" P416_PTF TEST_ARGS "--test-backend PTF --packet-size-range 0:12000 --port-ranges 0:8 ${EXTRA_OPTS} "
   )
   include(${CMAKE_CURRENT_LIST_DIR}/BMV2PTFXfail.cmake)
 endif()


### PR DESCRIPTION
Previously, we hard-coded the range of supported ports in the target code. Different testing setups may have different levels of port support, so make this setting configurable. Since ports are a top-level primitive in P4Testgen, we can make this a top-level option. 

Fixes #4035.