### PR TITLE
Add a PTF test CI pipeline for p4c-dpdk on the DPDK SoftNIC

### DIFF
--- a/.github/workflows/ci-dpdk-ptf-tests.yml
+++ b/.github/workflows/ci-dpdk-ptf-tests.yml
@@ -1,0 +1,97 @@
+name: "p4c-dpdk-ptf-tests"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      
+concurrency:
+  # if workflow for PR or push is already running stop it, and start new one
+  group: p4c_dpdk_ptf_ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Envs for infrap4d and dpdk libs
+# DEPEND_INSTALL is put to a default searching directory for 
+#   visibility of different libs like libprotobuf
+env:
+    SDE: ${{ github.workspace }}
+    P4C_DIR: ${{ github.workspace }}/p4c
+    SDE_INSTALL: ${{ github.workspace }}/sde_install
+    IPDK_RECIPE: ${{ github.workspace }}/ipdk.recipe
+    DEPEND_INSTALL: /usr/local
+
+jobs:
+  build_p4dpdk_ubuntu:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 'ccache'
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ptf-${{ runner.os }}-test
+          max-size: 1000M
+
+      - name: 'Checkout DPDK-target'
+        uses: actions/checkout@v3
+        with:
+             repository: p4lang/p4-dpdk-target
+             path: p4sde
+             submodules: 'recursive'
+             
+      - name: 'Checkout ipdk-recipe'
+        uses: actions/checkout@v3
+        with:
+             repository: ipdk-io/networking-recipe
+             path: ipdk.recipe
+             submodules: 'recursive'
+
+      - name: checkout P4C
+        uses: actions/checkout@v3
+        with:
+             path: p4c
+             submodules: recursive
+
+      - name: 'Install DPDK dependencies'
+        working-directory: p4sde/tools/setup
+        run: |
+              sudo apt update -y
+              python install_dep.py
+
+      - name: 'Compile p4sde dpdk target'
+        working-directory: p4sde
+        run: |
+             mkdir ${GITHUB_WORKSPACE}/install
+             ./autogen.sh
+             ./configure --prefix=$SDE_INSTALL
+             make 
+             make install
+
+      - name: 'Build infrap4d dependencies'
+        working-directory: ipdk.recipe
+        run: |
+             echo "Install infrap4d dependencies"
+             sudo apt install libatomic1 libnl-route-3-dev openssl
+             sudo pip3 install -r requirements.txt
+             cd $IPDK_RECIPE/setup
+             echo "Build infrap4d dependencies"
+             cmake -B build -DCMAKE_INSTALL_PREFIX="$DEPEND_INSTALL" -DUSE_SUDO=ON
+             cmake --build build 
+
+      - name: 'Build infrap4d'
+        working-directory: ipdk.recipe
+        run: |       
+             sudo ./make-all.sh --target=dpdk --no-krnlmon --no-ovs -S $SDE_INSTALL -D $DEPEND_INSTALL
+
+      - name: Build p4c with only the DPDK backend
+        working-directory: p4c
+        run: |
+          sudo -E tools/dpdk-ci-build.sh $P4C_DIR $IPDK_RECIPE $SDE_INSTALL $DEPEND_INSTALL
+
+      - name: 'Run DPDK PTF tests'
+        working-directory: p4c/build
+        run: |
+             sudo $IPDK_RECIPE/install/sbin/copy_config_files.sh $IPDK_RECIPE/install $SDE_INSTALL
+             sudo $IPDK_RECIPE/install/sbin/set_hugepages.sh
+             sudo -E ctest --output-on-failure --schedule-random -R dpdk-ptf*

--- a/backends/dpdk/CMakeLists.txt
+++ b/backends/dpdk/CMakeLists.txt
@@ -114,6 +114,9 @@ add_custom_target(linkp4cdpdk
 
 add_dependencies(p4c_driver linkp4cdpdk)
 
+
+# Tests
+set(DPDK_PTF_DRIVER "${CMAKE_CURRENT_SOURCE_DIR}/run-dpdk-ptf-test.py")
 set(DPDK_COMPILER_DRIVER "${CMAKE_CURRENT_SOURCE_DIR}/run-dpdk-test.py")
 
 set (P4_16_SUITES
@@ -122,6 +125,27 @@ set (P4_16_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_16_psa_errors/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_dpdk_errors/*.p4"
   "${P4C_SOURCE_DIR}/testdata/p4_16_pna_errors/*.p4")
-p4c_add_tests("dpdk" ${DPDK_COMPILER_DRIVER} "${P4_16_SUITES}" "" "--bfrt")
+ p4c_add_tests("dpdk" ${DPDK_COMPILER_DRIVER} "${P4_16_SUITES}" "" "--bfrt") 
+
+
+# PTF tests for DPDK is only enabled if infrap4d and dpdk-target are installed.
+# Add PTF tests for these files.
+set (DPDK_PTF_TEST_SUITES
+  "${P4C_SOURCE_DIR}/testdata/p4_16_samples/pna-dpdk-add_on_miss0.p4"
+)
+
+# check for infrap4d
+find_program (INFRAP4D infrap4d
+  PATHS $ENV{IPDK_RECIPE} )
+# SDE_INSTALL is the path to the dpdk-target install directory
+if (INFRAP4D AND DEFINED ENV{SDE_INSTALL})
+   p4c_add_tests("dpdk-ptf" ${DPDK_PTF_DRIVER} "${DPDK_PTF_TEST_SUITES}" "" "--ipdk-recipe=$ENV{IPDK_RECIPE}  \
+      --sde-install=$ENV{SDE_INSTALL} \
+      --ld-library-path=$ENV{LD_LIBRARY_PATH} \
+      -ll=DEBUG ")
+else()
+  MESSAGE(WARNING "Infrap4d or dpdk-target is not available(Or required Env Vars Not Defined), not adding DPDK PTF tests")
+endif()
+
 
 include(DpdkXfail.cmake)

--- a/backends/dpdk/run-dpdk-ptf-test.py
+++ b/backends/dpdk/run-dpdk-ptf-test.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+import os
+import random
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+# Append tools to the import path.
+FILE_DIR = Path(__file__).resolve().parent
+TOOLS_PATH = FILE_DIR.joinpath("../../tools")
+sys.path.append(str(TOOLS_PATH))
+import testutils
+
+PARSER = argparse.ArgumentParser()
+PARSER.add_argument("p4c_dir", help="The location of the the compiler source directory")
+PARSER.add_argument("p4_file", help="the p4 file to process")
+PARSER.add_argument(
+    "-tf",
+    "--testfile",
+    dest="testfile",
+    help="The path for the ptf py file for this test.",
+)
+PARSER.add_argument(
+    "-td",
+    "--testdir",
+    dest="testdir",
+    help="The location of the test directory.",
+)
+PARSER.add_argument(
+    "--ipdk-recipe",
+    dest="ipdk_recipe",
+    help="The location of the IPDK_RECIPE folder for infrap4d-related executables.",
+)
+PARSER.add_argument(
+    "--sde-install",
+    dest="sde_install",
+    help="The location of the SDE_INSTALL folder, which is used for locating the dpdk libs.",
+)
+
+PARSER.add_argument(
+    "--ld-library-path",
+    dest="ld_library_path",
+    help="The location of the shared libs for ipdk and dpdk",
+)
+
+PARSER.add_argument(
+    "-b",
+    "--nocleanup",
+    action="store_true",
+    dest="nocleanup",
+    help="Do not remove temporary results for failing tests.",
+)
+PARSER.add_argument(
+    "-n",
+    "--num-taps",
+    default=2,
+    dest="num_taps",
+    help="How many TAPs to create.",
+)
+PARSER.add_argument(
+    "-ll",
+    "--log_level",
+    dest="log_level",
+    default="WARNING",
+    choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"],
+    help="The log level to choose.",
+)
+
+# 9559 is the default P4Runtime API server port
+GRPC_PORT: int = 9559
+PTF_ADDR: str = "0.0.0.0"
+
+
+# Check if target ports are ready to be connected (make sure infrap4d is on)
+def is_port_alive(host, port) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=5) as conn:
+            return True
+    except (socket.timeout, ConnectionRefusedError):
+        return False
+
+
+# We want to disable IPv6 to avoid ICMPv6 spam
+def diable_IPv6():
+    testutils.exec_process("sysctl -w net.ipv6.conf.all.disable_ipv6=1")
+    testutils.exec_process("sysctl -w net.ipv6.conf.default.disable_ipv6=1")
+    # Also filter igmp packets, -w is necessary because of a race condition
+    testutils.exec_process("iptables -w -A OUTPUT -p 2 -j DROP")
+    return testutils.SUCCESS
+
+
+class Options:
+    """Options for this testing script. Usually correspond to command line inputs."""
+
+    # File that is being compiled.
+    p4_file: Path = Path(".")
+    # Path to ptf test file that is used.
+    testfile: Path = Path(".")
+    # Actual location of the test framework.
+    testdir: Path = Path(".")
+    # The base directory where tests are executed.
+    p4c_dir: Path = Path(".")
+    # IPDK Recipe folder
+    ipdk_recipe: Path = Path(".")
+    # SDE_INSTALL folder
+    sde_install: Path = Path(".")
+    # LD_LIBRARY_PATH
+    ld_library_path: Path = Path(".")
+    # Number of TAPs to create
+    num_taps: int = 2
+
+
+class PTFTestEnv:
+    options: Options = Options()
+    switch_proc: testutils.subprocess.Popen = None
+    proc_env_vars: dict = None
+
+    def __init__(self, options):
+        self.options = options
+        # Configure IPv6
+        diable_IPv6()
+
+    def __del__(self):
+        if self.switch_proc:
+            # Terminate the switch process and emit its output in case of failure.
+            testutils.kill_proc_group(self.switch_proc)
+
+    def create_TAPs(self, proc_env_vars: dict, insecure_mode: bool = True) -> int:
+        """Create TAPs with gNMI"""
+        testutils.log.info(
+            "---------------------- Creating TAPs ----------------------",
+        )
+        for index in range(self.options.num_taps):
+            tap_name = f"TAP{index}"
+            cmd = (
+                f"{self.options.ipdk_recipe}/install/bin/gnmi-ctl set "
+                f"device:virtual-device,name:{tap_name},pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:1500,port-type:TAP "
+                f"-grpc_use_insecure_mode={insecure_mode}"
+            )
+            _, returncode = testutils.exec_process(cmd, env=proc_env_vars)
+            if returncode != testutils.SUCCESS:
+                testutils.log.error("Failed to create TAP")
+                return returncode
+            _, returncode = testutils.exec_process(f"ifconfig {tap_name} up")
+            if returncode != testutils.SUCCESS:
+                testutils.log.error("Failed to activate TAP interface")
+                return returncode
+        return returncode
+
+    def compile_program(
+        self, info_name: Path, bf_rt_schema: Path, context: Path, dpdk_spec: Path
+    ) -> int:
+        """Create /pipe directory"""
+        _, returncode = testutils.exec_process(
+            f"mkdir {self.options.testdir.joinpath('pipe')}", timeout=30
+        )
+        if returncode != testutils.SUCCESS:
+            testutils.log.error("Failed to create /pipe directory")
+            return returncode
+
+        """Compile the input P4 program using p4c-dpdk."""
+        testutils.log.info("---------------------- Compile with p4c-dpdk ----------------------")
+        compilation_cmd = f"{self.options.p4c_dir}/build/p4c-dpdk --arch pna --target dpdk \
+            --p4runtime-files {info_name} \
+            --bf-rt-schema {bf_rt_schema} \
+            --context {context} \
+            --tdi-builder-conf {self.options.testdir.joinpath(Path(self.options.p4_file.name).with_suffix('.conf'))}\
+            -o {dpdk_spec} {self.options.p4_file}"
+        _, returncode = testutils.exec_process(compilation_cmd, timeout=30)
+        if returncode != testutils.SUCCESS:
+            testutils.log.error("Failed to compile the P4 program %s.", self.options.p4_file)
+        return returncode
+
+    def run_infrap4d(
+        self, proc_env_vars: dict, insecure_mode: bool = True
+    ) -> testutils.subprocess.Popen:
+        """Start infrap4d and return the process handle."""
+        testutils.log.info(
+            "---------------------- Start infrap4d ----------------------",
+        )
+        run_infrap4d_cmd = (
+            f"{self.options.ipdk_recipe}/install/sbin/infrap4d "
+            f"-grpc_open_insecure_mode={insecure_mode}"
+        )
+        self.switch_proc = testutils.open_process(run_infrap4d_cmd, env=proc_env_vars)
+        cnt = 1
+        while not is_port_alive(PTF_ADDR, GRPC_PORT) and cnt != 5:
+            time.sleep(2)
+            cnt += 1
+            testutils.log.info("Cannot connect to Infrap4d: " + str(cnt) + " try")
+        return self.switch_proc
+
+    def build_and_load_pipeline(
+        self, p4c_conf: Path, conf_bin: Path, info_name: Path, proc_env_vars: dict
+    ) -> int:
+        testutils.log.info("---------------------- Build and Load Pipleline ----------------------")
+        command = (
+            f"{self.options.ipdk_recipe}/install/bin/tdi_pipeline_builder "
+            f"--p4c_conf_file={p4c_conf} "
+            f"--bf_pipeline_config_binary_file={conf_bin}"
+        )
+
+        _, returncode = testutils.exec_process(command, timeout=30, env=proc_env_vars)
+        if returncode != testutils.SUCCESS:
+            testutils.log.error("Failed to build pipeline")
+            return returncode
+
+        # load pipeline
+        command = (
+            f"{self.options.ipdk_recipe}/install/bin/p4rt-ctl "
+            "set-pipe br0 "
+            f"{conf_bin} "
+            f"{info_name} "
+        )
+        _, returncode = testutils.exec_process(command, timeout=30)
+        if returncode != testutils.SUCCESS:
+            testutils.log.error("Failed to load pipeline")
+            return returncode
+        return testutils.SUCCESS
+
+    def run_ptf(self, grpc_port: int) -> int:
+        """Run the PTF test."""
+        testutils.log.info("---------------------- Run PTF test ----------------------")
+        # Add the file location to the python path.
+        pypath = FILE_DIR
+        # Show list of the tests
+        testListCmd = f"ptf --pypath {pypath} --test-dir {self.options.testdir} --list"
+        _, returncode = testutils.exec_process(testListCmd)
+        if returncode != testutils.SUCCESS:
+            return returncode
+        taps: str = ""
+        for index in range(self.options.num_taps):
+            taps += f" -i {index}@TAP{index}"
+        test_params = f"grpcaddr='{PTF_ADDR}:{grpc_port}'"
+        run_ptf_cmd = (
+            f"ptf --pypath {pypath} {taps} --log-file {self.options.testdir.joinpath('ptf.log')} "
+            f"--test-params={test_params} --test-dir {self.options.testdir}"
+        )
+        _, returncode = testutils.exec_process(run_ptf_cmd)
+        return returncode
+
+
+def run_test(options: Options) -> int:
+    """Add necessary environment variables for libs and executables"""
+    proc_env_vars: dict = os.environ.copy()
+    proc_env_vars["LD_LIBRARY_PATH"] = f"{options.ld_library_path}"
+    proc_env_vars["SDE_INSTALL"] = f"{options.sde_install}"
+
+    """Define the test environment and compile the P4 target"""
+    test_name = Path(options.p4_file.name)
+    info_name = options.testdir.joinpath("p4Info.txt")
+    bf_rt_schema = options.testdir.joinpath("bf-rt.json")
+    conf_bin = options.testdir.joinpath(test_name.with_suffix(".pb.bin"))
+    """ Files needed by the pipeline"""
+    context = options.testdir.joinpath("pipe/context.json")
+    p4c_conf = options.testdir.joinpath(test_name.with_suffix(".conf"))
+    dpdk_spec = options.testdir.joinpath(f"pipe/{test_name.with_suffix('.spec')}")
+
+    # Copy the test file into the test folder so that it can be picked up by PTF.
+    testutils.copy_file(options.testfile, options.testdir)
+
+    # Create the test environment
+    testenv = PTFTestEnv(options)
+
+    # Compile the P4 program.
+    returncode = testenv.compile_program(info_name, bf_rt_schema, context, dpdk_spec)
+    if returncode != testutils.SUCCESS:
+        return returncode
+
+    # Run the switch.
+    switch_proc = testenv.run_infrap4d(proc_env_vars)
+    if switch_proc is None:
+        return testutils.FAILURE
+
+    # Create the TAP interfaces.
+    returncode = testenv.create_TAPs(proc_env_vars)
+    if returncode != testutils.SUCCESS:
+        return returncode
+
+    # Build and load the pipeline
+    returncode = testenv.build_and_load_pipeline(p4c_conf, conf_bin, info_name, proc_env_vars)
+    if returncode != testutils.SUCCESS:
+        return returncode
+
+    # Run the PTF test and retrieve the result.
+    result = testenv.run_ptf(GRPC_PORT)
+    # Delete the test environment and trigger a clean up.
+    del testenv
+    # Print switch log if the results were not successful.
+    if result != testutils.SUCCESS:
+        if switch_proc.stdout:
+            out = switch_proc.stdout.read()
+            # Do not bother to print whitespace.
+            if out.strip():
+                testutils.log.error("######## Switch output ######## \n%s", out)
+        if switch_proc.stderr:
+            err = switch_proc.stderr.read()
+            # Do not bother to print whitespace.
+            if err.strip():
+                testutils.log.error("######## Switch errors ######## \n%s", err)
+    return result
+
+
+def create_options(test_args) -> testutils.Optional[Options]:
+    """Parse the input arguments and create a processed options object."""
+    options = Options()
+    options.p4_file = Path(testutils.check_if_file(test_args.p4_file))
+    testfile = test_args.testfile
+    if not testfile:
+        testutils.log.info("No test file provided. Checking for file in folder.")
+        testfile = options.p4_file.with_suffix(".py")
+    result = testutils.check_if_file(testfile)
+    if not result:
+        return None
+    options.testfile = Path(result)
+    testdir = test_args.testdir
+    if not testdir:
+        testutils.log.info("No test directory provided. Generating temporary folder.")
+        testdir = tempfile.mkdtemp(dir=Path(".").absolute())
+        # Generous permissions because the program is usually edited by sudo.
+        os.chmod(testdir, 0o755)
+    options.testdir = Path(testdir)
+    options.p4c_dir = Path(test_args.p4c_dir)
+    options.ipdk_recipe = Path(test_args.ipdk_recipe)
+    options.sde_install = Path(test_args.sde_install)
+    options.ld_library_path = Path(test_args.ld_library_path)
+    options.num_taps = test_args.num_taps
+
+    # Configure logging.
+    logging.basicConfig(
+        filename=options.testdir.joinpath("test.log"),
+        format="%(levelname)s: %(message)s",
+        level=getattr(logging, test_args.log_level),
+        filemode="w",
+    )
+    stderr_log = logging.StreamHandler()
+    stderr_log.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    logging.getLogger().addHandler(stderr_log)
+    return options
+
+
+if __name__ == "__main__":
+    # Parse options and process argv
+    args, argv = PARSER.parse_known_args()
+
+    test_options = create_options(args)
+    if not test_options:
+        sys.exit(testutils.FAILURE)
+
+    if not testutils.check_root():
+        testutils.log.error("This script requires root privileges; Exiting.")
+        sys.exit(1)
+
+    # Run the test with the extracted options
+    test_result = run_test(test_options)
+    if not (args.nocleanup or test_result != testutils.SUCCESS):
+        testutils.log.info("Removing temporary test directory.")
+        testutils.del_dir(test_options.testdir)
+    sys.exit(test_result)

--- a/testdata/p4_16_samples/pna-dpdk-add_on_miss0.p4
+++ b/testdata/p4_16_samples/pna-dpdk-add_on_miss0.p4
@@ -1,0 +1,275 @@
+/* -*- P4_16 -*- */
+
+#include <core.p4>
+#include <pna.p4>
+
+/*************************************************************************
+ ************* C O N S T A N T S    A N D   T Y P E S  *******************
+ *************************************************************************/
+const int IPV4_HOST_SIZE = 65536;
+
+/*************************************************************************
+ ***********************  H E A D E R S  *********************************
+ *************************************************************************/
+
+/*  Define all the headers the program will recognize             */
+/*  The actual sets of headers processed by each gress can differ */
+
+typedef bit<48>  EthernetAddress;
+typedef bit<32>  IPv4Address;
+typedef bit<128> IPv6Address;
+
+typedef bit<16> etype_t;
+const etype_t ETYPE_IPV4      = 0x0800; /* IPv4 */
+
+typedef bit<8> ipproto_t;
+const ipproto_t IPPROTO_TCP = 6;       /* Transmission Control Protocol */
+const ipproto_t IPPROTO_UDP = 17;      /* User Datagram Protocol */
+
+// https://en.wikipedia.org/wiki/Ethernet_frame
+header ethernet_h {
+    EthernetAddress dst_addr;
+    EthernetAddress src_addr;
+    etype_t ether_type;
+}
+
+// RFC 791
+// https://en.wikipedia.org/wiki/IPv4
+// https://tools.ietf.org/html/rfc791
+header ipv4_h {
+    bit<8>  version_ihl;        // version always 4 for IPv4, ihl=header length
+    bit<8>  diffserv;           // 6 bits of DSCP followed by 2-bit ECN
+    bit<16> total_len;          // in bytes, including IPv4 header
+    bit<16> identification;
+    bit<16> flags_frag_offset;
+    bit<8>  ttl;                // time to live
+    ipproto_t protocol;
+    bit<16> hdr_checksum;
+    IPv4Address src_addr;
+    IPv4Address dst_addr;
+}
+
+// RFC 793 and several later RFCs that update it
+// https://en.wikipedia.org/wiki/Transmission_Control_Protocol
+// https://tools.ietf.org/html/rfc793
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<4>  res;
+    bit<8>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+// Masks of the bit positions of some bit flags within the TCP flags
+// field.
+const bit<8> TCP_URG_MASK = 0x20;
+const bit<8> TCP_ACK_MASK = 0x10;
+const bit<8> TCP_PSH_MASK = 0x08;
+const bit<8> TCP_RST_MASK = 0x04;
+const bit<8> TCP_SYN_MASK = 0x02;
+const bit<8> TCP_FIN_MASK = 0x01;
+
+// RFC 768
+// https://en.wikipedia.org/wiki/User_Datagram_Protocol
+// https://tools.ietf.org/html/rfc768
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> length;
+    bit<16> checksum;
+}
+
+// Define names for different expire time profile id values.
+
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NOW    = (ExpireTimeProfileId_t) 0;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEW    = (ExpireTimeProfileId_t) 1;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_ESTABLISHED = (ExpireTimeProfileId_t) 2;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEVER  = (ExpireTimeProfileId_t) 3;
+
+/*************************************************************************
+ **************  I N G R E S S   P R O C E S S I N G   *******************
+ *************************************************************************/
+
+    /***********************  H E A D E R S  ************************/
+
+struct headers_t {
+    ethernet_h   ethernet;
+    ipv4_h       ipv4;
+    tcp_h        tcp;
+    udp_h        udp;
+}
+
+    /******  G L O B A L   I N G R E S S   M E T A D A T A  *********/
+
+struct metadata_t {
+}
+
+    /***********************  P A R S E R  **************************/
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t  hdr,
+    inout metadata_t meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+     state start {
+        transition parse_ethernet;
+    }
+
+    state parse_ethernet {
+        pkt.extract(hdr.ethernet);
+        transition select (hdr.ethernet.ether_type) {
+            ETYPE_IPV4:  parse_ipv4;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select (hdr.ipv4.protocol) {
+            IPPROTO_TCP: parse_tcp;
+            IPPROTO_UDP: parse_udp;
+            default: accept;
+        }
+    }
+
+    state parse_tcp {
+        pkt.extract(hdr.tcp);
+        transition accept;
+    }
+
+    state parse_udp {
+        pkt.extract(hdr.udp);
+        transition accept;
+    }
+}
+
+// As of 2023-Mar-14, p4c-dpdk implementation of PNA architecture
+// still requires PreControl.
+
+control PreControlImpl(
+    in    headers_t hdr,
+    inout metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+    /***************** M A T C H - A C T I O N  *********************/
+
+struct ct_tcp_table_hit_params_t {
+}
+
+control MainControlImpl(
+    inout headers_t  hdr,
+    inout metadata_t meta,
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action drop () {
+        drop_packet();
+    }
+
+    // Inputs from previous tables (or actions, or in general other P4
+    // code) that can modify the behavior of actions of ct_tcp_table.
+    ExpireTimeProfileId_t new_expire_time_profile_id;
+
+    action ct_tcp_table_hit () {
+        // Make a change to the packet that is visible in the packet
+        // output by the device, for debug purposes only.  I cannot
+        // imagine any reason why someone would want to make a change
+        // like this to a packet in a production P4 program.
+        hdr.ethernet.src_addr[7:0] = 0xf1;
+    }
+
+    action ct_tcp_table_miss() {
+        // Make a change to the packet that is visible in the packet
+        // output by the device, for debug purposes only.  I cannot
+        // imagine any reason why someone would want to make a change
+        // like this to a packet in a production P4 program.
+        hdr.ethernet.src_addr[7:0] = 0xa5;
+        add_entry(action_name = "ct_tcp_table_hit",  // name of action
+            action_params = (ct_tcp_table_hit_params_t) {},
+            expire_time_profile_id = new_expire_time_profile_id);
+    }
+
+    table ct_tcp_table {
+        key = {
+            hdr.ipv4.src_addr: exact;
+            hdr.ipv4.dst_addr: exact;
+            hdr.ipv4.protocol: exact;
+            hdr.tcp.src_port:  exact;
+            hdr.tcp.dst_port:  exact;
+        }
+        actions = {
+            @tableonly   ct_tcp_table_hit;
+            @defaultonly ct_tcp_table_miss;
+        }
+
+        // New PNA table property 'add_on_miss = true' indicates that
+        // this table can use extern function add_entry() in its
+        // default (i.e. miss) action to add a new entry to the table
+        // from the data plane.
+        add_on_miss = true;
+
+        // As of 2023-Mar-14, p4c-dpdk implementation of PNA
+        // architecture does not implement value AUTO_DELETE yet.
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = ct_tcp_table_miss;
+    }
+
+    action send(PortId_t port) {
+        send_to_port(port);
+    }
+
+    table ipv4_host {
+        key = {
+            hdr.ipv4.dst_addr : exact;
+        }
+        actions = {
+            send;
+            drop;
+            @defaultonly NoAction;
+        }
+        const default_action = drop();
+        size = IPV4_HOST_SIZE;
+    }
+
+    apply {
+        new_expire_time_profile_id = EXPIRE_TIME_PROFILE_TCP_NEW;
+        if (hdr.ipv4.isValid() && hdr.tcp.isValid()) {
+            ct_tcp_table.apply();
+        }
+        if (hdr.ipv4.isValid()) {
+            ipv4_host.apply();
+        }
+    }
+}
+
+    /*********************  D E P A R S E R  ************************/
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,
+    in    metadata_t meta,
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr);
+    }
+}
+
+/************ F I N A L   P A C K A G E ******************************/
+
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    ) main;

--- a/testdata/p4_16_samples/pna-dpdk-add_on_miss0.py
+++ b/testdata/p4_16_samples/pna-dpdk-add_on_miss0.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Andy Fingerhut, andy.fingerhut@gmail.com
+
+import logging
+import pprint
+import queue
+import time
+
+import ptf
+import ptf.testutils as tu
+from ptf.base_tests import BaseTest
+import p4runtime_sh.shell as sh
+import p4runtime_sh.utils as shutils
+import p4runtime_sh.p4runtime as p4rt
+
+
+# Bsed on https://github.com/jafingerhut/p4-guide/blob/master/ipdk/23.01/add_on_miss0/ptf-tests/ptf-test1.py
+
+
+logger = logging.getLogger(None)
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+# create formatter and add it to the handlers
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+pp = pprint.PrettyPrinter(indent=4)
+
+
+class AbstractIdleTimeoutTest(BaseTest):
+    def setUp(self):
+        # Setting up PTF dataplane
+        self.dataplane = ptf.dataplane_instance
+        self.dataplane.flush()
+
+        logging.info("AbstractIdleTimeoutTest.setUp()")
+        grpc_addr = tu.test_param_get("grpcaddr")
+        if grpc_addr is None:
+            grpc_addr = 'localhost:9559'
+        certs_dir = '/usr/share/stratum/certs'
+        root_certificate = certs_dir + '/ca.crt'
+        private_key = certs_dir + '/client.key'
+        certificate_chain = certs_dir + '/client.crt'
+        # Default to insecure
+        ssl_opts = p4rt.SSLOptions(True, root_certificate, certificate_chain,
+                                   private_key)
+        sh.setup(device_id=1,
+                 grpc_addr=grpc_addr,
+                 election_id=(0, 1),
+                 ssl_options=ssl_opts)
+
+    def tearDown(self):
+        logging.info("IdleTimeoutTest.tearDown()")
+        sh.teardown()
+
+    def runTestImpl(self):
+        self.setupCtrlPlane()
+        logger.info("Sending Packet ...")
+        self.sendPacket()
+        logger.info("Verifying Packet ...")
+        self.verifyPackets()
+
+#############################################################
+# Define a few small helper functions that help construct
+# parameters for the table_add() method.
+#############################################################
+
+def entry_count(table_name):
+    te = sh.TableEntry(table_name)
+    n = 0
+    for x in te.read():
+        n = n + 1
+    return n
+
+def init_key_from_read_tableentry(read_te):
+    new_te = sh.TableEntry(read_te.name)
+    # This is only written to work for tables where all key fields are
+    # match_kind exact.
+    for f in read_te.match._fields:
+        new_te.match[f] = '%d' % (int.from_bytes(read_te.match[f].exact.value, 'big'))
+    return new_te
+
+def delete_all_entries(tname):
+    te = sh.TableEntry(tname)
+    for e in te.read():
+        d = init_key_from_read_tableentry(e)
+        d.delete()
+
+def add_ipv4_host_entry_action_send(ipv4_addr_str, port_int):
+    te = sh.TableEntry('ipv4_host')(action='send')
+    te.match['dst_addr'] = '%s' % (ipv4_addr_str)
+    te.action['port'] = '%d' % (port_int)
+    te.insert()
+
+
+class OneEntryTest(AbstractIdleTimeoutTest):
+
+    def sendPacket(self):
+        in_dmac = 'ee:30:ca:9d:1e:00'
+        in_smac = 'ee:cd:00:7e:70:00'
+        ip_src_addr = '1.1.1.1'
+        ip_dst_addr = '2.2.2.2'
+        ig_port = 0
+        sport = 59597
+        dport = 7503
+        pkt_in = tu.simple_tcp_packet(eth_src=in_smac, eth_dst=in_dmac,
+                                      ip_src=ip_src_addr, ip_dst=ip_dst_addr,
+                                      tcp_sport=sport, tcp_dport=dport)
+        
+        # Send in a first packet that should experience a miss on
+        # table ct_tcp_table, cause a new entry to be added by the
+        # data plane with a 30-second expiration time, and be
+        # forwarded with a change to its source MAC address that the
+        # add_on_miss0.p4 program uses to indicate that a miss
+        # occurred.
+        logging.info("Sending packet #1")
+        tu.send_packet(self, ig_port, pkt_in)
+        first_pkt_time = time.time()
+
+    def verifyPackets(self):
+        in_dmac = 'ee:30:ca:9d:1e:00'
+        in_smac = 'ee:cd:00:7e:70:00'
+        ip_src_addr = '1.1.1.1'
+        ip_dst_addr = '2.2.2.2'
+        sport = 59597
+        dport = 7503
+        # add_on_miss0.p4 replaces least significant 8 bits of source
+        # MAC address with 0xf1 on a hit of table ct_tcp_table, or
+        # 0xa5 on a miss.
+        out_smac_for_miss = in_smac[:-2] + 'a5'
+        eg_port = 1
+        exp_pkt_for_miss = \
+            tu.simple_tcp_packet(eth_src=out_smac_for_miss, eth_dst=in_dmac,
+                                 ip_src=ip_src_addr, ip_dst=ip_dst_addr,
+                                 tcp_sport=sport, tcp_dport=dport)
+
+        # Check hit not tested for now for simplicity
+        # out_smac_for_hit = in_smac[:-2] + 'f1'
+        # exp_pkt_for_hit = \
+        #     tu.simple_tcp_packet(eth_src=out_smac_for_hit, eth_dst=in_dmac,
+        #                          ip_src=ip_src_addr, ip_dst=ip_dst_addr,
+        #                          tcp_sport=sport, tcp_dport=dport)
+
+        
+        tu.verify_packets(self, exp_pkt_for_miss, [eg_port])
+        logging.info("    packet experienced a miss in ct_tcp_table as expected")
+
+    def setupCtrlPlane(self):
+        ig_port = 0
+        eg_port = 1
+
+        ip_src_addr = '1.1.1.1'
+        ip_dst_addr = '2.2.2.2'
+
+        logging.info("Attempting to delete all entries in ipv4_host")
+        delete_all_entries('ipv4_host')
+        logging.info("Attempting to add entries to ipv4_host")
+        add_ipv4_host_entry_action_send(ip_src_addr, ig_port)
+        add_ipv4_host_entry_action_send(ip_dst_addr, eg_port)
+        logging.info("Now ipv4_host contains %d entries"
+                     "" % (entry_count('ipv4_host')))
+
+    def runTest(self):
+        self.runTestImpl()
+        
+
+        
+        
+       

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0-first.p4
@@ -1,0 +1,169 @@
+#include <core.p4>
+#include <pna.p4>
+
+const int IPV4_HOST_SIZE = 65536;
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+typedef bit<128> IPv6Address;
+typedef bit<16> etype_t;
+const etype_t ETYPE_IPV4 = 16w0x800;
+typedef bit<8> ipproto_t;
+const ipproto_t IPPROTO_TCP = 8w6;
+const ipproto_t IPPROTO_UDP = 8w17;
+header ethernet_h {
+    EthernetAddress dst_addr;
+    EthernetAddress src_addr;
+    etype_t         ether_type;
+}
+
+header ipv4_h {
+    bit<8>      version_ihl;
+    bit<8>      diffserv;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<16>     flags_frag_offset;
+    bit<8>      ttl;
+    ipproto_t   protocol;
+    bit<16>     hdr_checksum;
+    IPv4Address src_addr;
+    IPv4Address dst_addr;
+}
+
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<4>  res;
+    bit<8>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+const bit<8> TCP_URG_MASK = 8w0x20;
+const bit<8> TCP_ACK_MASK = 8w0x10;
+const bit<8> TCP_PSH_MASK = 8w0x8;
+const bit<8> TCP_RST_MASK = 8w0x4;
+const bit<8> TCP_SYN_MASK = 8w0x2;
+const bit<8> TCP_FIN_MASK = 8w0x1;
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> length;
+    bit<16> checksum;
+}
+
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NOW = (ExpireTimeProfileId_t)8w0;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEW = (ExpireTimeProfileId_t)8w1;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_ESTABLISHED = (ExpireTimeProfileId_t)8w2;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEVER = (ExpireTimeProfileId_t)8w3;
+struct headers_t {
+    ethernet_h ethernet;
+    ipv4_h     ipv4;
+    tcp_h      tcp;
+    udp_h      udp;
+}
+
+struct metadata_t {
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_h>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            8w17: parse_udp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract<tcp_h>(hdr.tcp);
+        transition accept;
+    }
+    state parse_udp {
+        pkt.extract<udp_h>(hdr.udp);
+        transition accept;
+    }
+}
+
+control PreControlImpl(in headers_t hdr, inout metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+struct ct_tcp_table_hit_params_t {
+}
+
+control MainControlImpl(inout headers_t hdr, inout metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action drop() {
+        drop_packet();
+    }
+    ExpireTimeProfileId_t new_expire_time_profile_id;
+    action ct_tcp_table_hit() {
+        hdr.ethernet.src_addr[7:0] = 8w0xf1;
+    }
+    action ct_tcp_table_miss() {
+        hdr.ethernet.src_addr[7:0] = 8w0xa5;
+        add_entry<ct_tcp_table_hit_params_t>(action_name = "ct_tcp_table_hit", action_params = (ct_tcp_table_hit_params_t){}, expire_time_profile_id = new_expire_time_profile_id);
+    }
+    table ct_tcp_table {
+        key = {
+            hdr.ipv4.src_addr: exact @name("hdr.ipv4.src_addr");
+            hdr.ipv4.dst_addr: exact @name("hdr.ipv4.dst_addr");
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol");
+            hdr.tcp.src_port : exact @name("hdr.tcp.src_port");
+            hdr.tcp.dst_port : exact @name("hdr.tcp.dst_port");
+        }
+        actions = {
+            @tableonly ct_tcp_table_hit();
+            @defaultonly ct_tcp_table_miss();
+        }
+        add_on_miss = true;
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = ct_tcp_table_miss();
+    }
+    action send(PortId_t port) {
+        send_to_port(port);
+    }
+    table ipv4_host {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("hdr.ipv4.dst_addr");
+        }
+        actions = {
+            send();
+            drop();
+            @defaultonly NoAction();
+        }
+        const default_action = drop();
+        size = 65536;
+    }
+    apply {
+        new_expire_time_profile_id = (ExpireTimeProfileId_t)8w1;
+        if (hdr.ipv4.isValid() && hdr.tcp.isValid()) {
+            ct_tcp_table.apply();
+        }
+        if (hdr.ipv4.isValid()) {
+            ipv4_host.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in metadata_t meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<headers_t>(hdr);
+    }
+}
+
+PNA_NIC<headers_t, metadata_t, headers_t, metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0-frontend.p4
@@ -1,0 +1,153 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+typedef bit<16> etype_t;
+typedef bit<8> ipproto_t;
+header ethernet_h {
+    EthernetAddress dst_addr;
+    EthernetAddress src_addr;
+    etype_t         ether_type;
+}
+
+header ipv4_h {
+    bit<8>      version_ihl;
+    bit<8>      diffserv;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<16>     flags_frag_offset;
+    bit<8>      ttl;
+    ipproto_t   protocol;
+    bit<16>     hdr_checksum;
+    IPv4Address src_addr;
+    IPv4Address dst_addr;
+}
+
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<4>  res;
+    bit<8>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> length;
+    bit<16> checksum;
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    ipv4_h     ipv4;
+    tcp_h      tcp;
+    udp_h      udp;
+}
+
+struct metadata_t {
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_h>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            8w17: parse_udp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract<tcp_h>(hdr.tcp);
+        transition accept;
+    }
+    state parse_udp {
+        pkt.extract<udp_h>(hdr.udp);
+        transition accept;
+    }
+}
+
+control PreControlImpl(in headers_t hdr, inout metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+struct ct_tcp_table_hit_params_t {
+}
+
+control MainControlImpl(inout headers_t hdr, inout metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.new_expire_time_profile_id") ExpireTimeProfileId_t new_expire_time_profile_id_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.drop") action drop() {
+        drop_packet();
+    }
+    @name("MainControlImpl.ct_tcp_table_hit") action ct_tcp_table_hit() {
+        hdr.ethernet.src_addr[7:0] = 8w0xf1;
+    }
+    @name("MainControlImpl.ct_tcp_table_miss") action ct_tcp_table_miss() {
+        hdr.ethernet.src_addr[7:0] = 8w0xa5;
+        add_entry<ct_tcp_table_hit_params_t>(action_name = "ct_tcp_table_hit", action_params = (ct_tcp_table_hit_params_t){}, expire_time_profile_id = new_expire_time_profile_id_0);
+    }
+    @name("MainControlImpl.ct_tcp_table") table ct_tcp_table_0 {
+        key = {
+            hdr.ipv4.src_addr: exact @name("hdr.ipv4.src_addr");
+            hdr.ipv4.dst_addr: exact @name("hdr.ipv4.dst_addr");
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol");
+            hdr.tcp.src_port : exact @name("hdr.tcp.src_port");
+            hdr.tcp.dst_port : exact @name("hdr.tcp.dst_port");
+        }
+        actions = {
+            @tableonly ct_tcp_table_hit();
+            @defaultonly ct_tcp_table_miss();
+        }
+        add_on_miss = true;
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = ct_tcp_table_miss();
+    }
+    @name("MainControlImpl.send") action send(@name("port") PortId_t port) {
+        send_to_port(port);
+    }
+    @name("MainControlImpl.ipv4_host") table ipv4_host_0 {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("hdr.ipv4.dst_addr");
+        }
+        actions = {
+            send();
+            drop();
+            @defaultonly NoAction_1();
+        }
+        const default_action = drop();
+        size = 65536;
+    }
+    apply {
+        new_expire_time_profile_id_0 = (ExpireTimeProfileId_t)8w1;
+        if (hdr.ipv4.isValid() && hdr.tcp.isValid()) {
+            ct_tcp_table_0.apply();
+        }
+        if (hdr.ipv4.isValid()) {
+            ipv4_host_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in metadata_t meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<headers_t>(hdr);
+    }
+}
+
+PNA_NIC<headers_t, metadata_t, headers_t, metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0-midend.p4
@@ -1,0 +1,170 @@
+#include <core.p4>
+#include <pna.p4>
+
+header ethernet_h {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> ether_type;
+}
+
+header ipv4_h {
+    bit<8>  version_ihl;
+    bit<8>  diffserv;
+    bit<16> total_len;
+    bit<16> identification;
+    bit<16> flags_frag_offset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdr_checksum;
+    bit<32> src_addr;
+    bit<32> dst_addr;
+}
+
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<4>  res;
+    bit<8>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> length;
+    bit<16> checksum;
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    ipv4_h     ipv4;
+    tcp_h      tcp;
+    udp_h      udp;
+}
+
+struct metadata_t {
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_h>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            8w17: parse_udp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract<tcp_h>(hdr.tcp);
+        transition accept;
+    }
+    state parse_udp {
+        pkt.extract<udp_h>(hdr.udp);
+        transition accept;
+    }
+}
+
+control PreControlImpl(in headers_t hdr, inout metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+struct ct_tcp_table_hit_params_t {
+}
+
+control MainControlImpl(inout headers_t hdr, inout metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.new_expire_time_profile_id") bit<8> new_expire_time_profile_id_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.drop") action drop() {
+        drop_packet();
+    }
+    @name("MainControlImpl.ct_tcp_table_hit") action ct_tcp_table_hit() {
+        hdr.ethernet.src_addr[7:0] = 8w0xf1;
+    }
+    @name("MainControlImpl.ct_tcp_table_miss") action ct_tcp_table_miss() {
+        hdr.ethernet.src_addr[7:0] = 8w0xa5;
+        add_entry<ct_tcp_table_hit_params_t>(action_name = "ct_tcp_table_hit", action_params = (ct_tcp_table_hit_params_t){}, expire_time_profile_id = new_expire_time_profile_id_0);
+    }
+    @name("MainControlImpl.ct_tcp_table") table ct_tcp_table_0 {
+        key = {
+            hdr.ipv4.src_addr: exact @name("hdr.ipv4.src_addr");
+            hdr.ipv4.dst_addr: exact @name("hdr.ipv4.dst_addr");
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol");
+            hdr.tcp.src_port : exact @name("hdr.tcp.src_port");
+            hdr.tcp.dst_port : exact @name("hdr.tcp.dst_port");
+        }
+        actions = {
+            @tableonly ct_tcp_table_hit();
+            @defaultonly ct_tcp_table_miss();
+        }
+        add_on_miss = true;
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = ct_tcp_table_miss();
+    }
+    @name("MainControlImpl.send") action send(@name("port") bit<32> port) {
+        send_to_port(port);
+    }
+    @name("MainControlImpl.ipv4_host") table ipv4_host_0 {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("hdr.ipv4.dst_addr");
+        }
+        actions = {
+            send();
+            drop();
+            @defaultonly NoAction_1();
+        }
+        const default_action = drop();
+        size = 65536;
+    }
+    @hidden action pnadpdkadd_on_miss0l245() {
+        new_expire_time_profile_id_0 = 8w1;
+    }
+    @hidden table tbl_pnadpdkadd_on_miss0l245 {
+        actions = {
+            pnadpdkadd_on_miss0l245();
+        }
+        const default_action = pnadpdkadd_on_miss0l245();
+    }
+    apply {
+        tbl_pnadpdkadd_on_miss0l245.apply();
+        if (hdr.ipv4.isValid() && hdr.tcp.isValid()) {
+            ct_tcp_table_0.apply();
+        }
+        if (hdr.ipv4.isValid()) {
+            ipv4_host_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in metadata_t meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdkadd_on_miss0l264() {
+        pkt.emit<ethernet_h>(hdr.ethernet);
+        pkt.emit<ipv4_h>(hdr.ipv4);
+        pkt.emit<tcp_h>(hdr.tcp);
+        pkt.emit<udp_h>(hdr.udp);
+    }
+    @hidden table tbl_pnadpdkadd_on_miss0l264 {
+        actions = {
+            pnadpdkadd_on_miss0l264();
+        }
+        const default_action = pnadpdkadd_on_miss0l264();
+    }
+    apply {
+        tbl_pnadpdkadd_on_miss0l264.apply();
+    }
+}
+
+PNA_NIC<headers_t, metadata_t, headers_t, metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0.p4
@@ -1,0 +1,169 @@
+#include <core.p4>
+#include <pna.p4>
+
+const int IPV4_HOST_SIZE = 65536;
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+typedef bit<128> IPv6Address;
+typedef bit<16> etype_t;
+const etype_t ETYPE_IPV4 = 0x800;
+typedef bit<8> ipproto_t;
+const ipproto_t IPPROTO_TCP = 6;
+const ipproto_t IPPROTO_UDP = 17;
+header ethernet_h {
+    EthernetAddress dst_addr;
+    EthernetAddress src_addr;
+    etype_t         ether_type;
+}
+
+header ipv4_h {
+    bit<8>      version_ihl;
+    bit<8>      diffserv;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<16>     flags_frag_offset;
+    bit<8>      ttl;
+    ipproto_t   protocol;
+    bit<16>     hdr_checksum;
+    IPv4Address src_addr;
+    IPv4Address dst_addr;
+}
+
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<4>  res;
+    bit<8>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+const bit<8> TCP_URG_MASK = 0x20;
+const bit<8> TCP_ACK_MASK = 0x10;
+const bit<8> TCP_PSH_MASK = 0x8;
+const bit<8> TCP_RST_MASK = 0x4;
+const bit<8> TCP_SYN_MASK = 0x2;
+const bit<8> TCP_FIN_MASK = 0x1;
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> length;
+    bit<16> checksum;
+}
+
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NOW = (ExpireTimeProfileId_t)0;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEW = (ExpireTimeProfileId_t)1;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_ESTABLISHED = (ExpireTimeProfileId_t)2;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEVER = (ExpireTimeProfileId_t)3;
+struct headers_t {
+    ethernet_h ethernet;
+    ipv4_h     ipv4;
+    tcp_h      tcp;
+    udp_h      udp;
+}
+
+struct metadata_t {
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            ETYPE_IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            IPPROTO_TCP: parse_tcp;
+            IPPROTO_UDP: parse_udp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract(hdr.tcp);
+        transition accept;
+    }
+    state parse_udp {
+        pkt.extract(hdr.udp);
+        transition accept;
+    }
+}
+
+control PreControlImpl(in headers_t hdr, inout metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+struct ct_tcp_table_hit_params_t {
+}
+
+control MainControlImpl(inout headers_t hdr, inout metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action drop() {
+        drop_packet();
+    }
+    ExpireTimeProfileId_t new_expire_time_profile_id;
+    action ct_tcp_table_hit() {
+        hdr.ethernet.src_addr[7:0] = 0xf1;
+    }
+    action ct_tcp_table_miss() {
+        hdr.ethernet.src_addr[7:0] = 0xa5;
+        add_entry(action_name = "ct_tcp_table_hit", action_params = (ct_tcp_table_hit_params_t){  }, expire_time_profile_id = new_expire_time_profile_id);
+    }
+    table ct_tcp_table {
+        key = {
+            hdr.ipv4.src_addr: exact;
+            hdr.ipv4.dst_addr: exact;
+            hdr.ipv4.protocol: exact;
+            hdr.tcp.src_port : exact;
+            hdr.tcp.dst_port : exact;
+        }
+        actions = {
+            @tableonly ct_tcp_table_hit;
+            @defaultonly ct_tcp_table_miss;
+        }
+        add_on_miss = true;
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = ct_tcp_table_miss;
+    }
+    action send(PortId_t port) {
+        send_to_port(port);
+    }
+    table ipv4_host {
+        key = {
+            hdr.ipv4.dst_addr: exact;
+        }
+        actions = {
+            send;
+            drop;
+            @defaultonly NoAction;
+        }
+        const default_action = drop();
+        size = IPV4_HOST_SIZE;
+    }
+    apply {
+        new_expire_time_profile_id = EXPIRE_TIME_PROFILE_TCP_NEW;
+        if (hdr.ipv4.isValid() && hdr.tcp.isValid()) {
+            ct_tcp_table.apply();
+        }
+        if (hdr.ipv4.isValid()) {
+            ipv4_host.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in metadata_t meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0.p4-error
@@ -1,0 +1,1 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table ct_tcp_table. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0.p4.bfrt.json
@@ -1,0 +1,170 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.ct_tcp_table",
+      "id" : 35731637,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.src_addr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "hdr.ipv4.dst_addr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.ipv4.protocol",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 8
+          }
+        },
+        {
+          "id" : 4,
+          "name" : "hdr.tcp.src_port",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 5,
+          "name" : "hdr.tcp.dst_port",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 17749373,
+          "name" : "MainControlImpl.ct_tcp_table_hit",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : []
+        },
+        {
+          "id" : 22853387,
+          "name" : "MainControlImpl.ct_tcp_table_miss",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.MainControlImpl.ipv4_host",
+      "id" : 47903772,
+      "table_type" : "MatchAction_Direct",
+      "size" : 65536,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dst_addr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 22742608,
+          "name" : "MainControlImpl.send",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "port",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 24740121,
+          "name" : "MainControlImpl.drop",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss0.p4.spec
@@ -1,0 +1,166 @@
+
+struct ethernet_h {
+	bit<48> dst_addr
+	bit<48> src_addr
+	bit<16> ether_type
+}
+
+struct ipv4_h {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> total_len
+	bit<16> identification
+	bit<16> flags_frag_offset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdr_checksum
+	bit<32> src_addr
+	bit<32> dst_addr
+}
+
+struct tcp_h {
+	bit<16> src_port
+	bit<16> dst_port
+	bit<32> seq_no
+	bit<32> ack_no
+	bit<8> data_offset_res
+	bit<8> flags
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgent_ptr
+}
+
+struct udp_h {
+	bit<16> src_port
+	bit<16> dst_port
+	bit<16> length
+	bit<16> checksum
+}
+
+struct send_arg_t {
+	bit<32> port
+}
+
+header ethernet instanceof ethernet_h
+header ipv4 instanceof ipv4_h
+header tcp instanceof tcp_h
+header udp instanceof udp_h
+
+struct metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlImpl_ct_tcp_table_ipv4_src_addr
+	bit<32> MainControlImpl_ct_tcp_table_ipv4_dst_addr
+	bit<8> MainControlImpl_ct_tcp_table_ipv4_protocol
+	bit<16> MainControlImpl_ct_tcp_table_tcp_src_port
+	bit<16> MainControlImpl_ct_tcp_table_tcp_dst_port
+	bit<48> MainControlT_tmp
+	bit<48> MainControlT_tmp_0
+	bit<8> MainControlT_new_expire_time_profile_id
+}
+metadata instanceof metadata_t
+
+regarray direction size 0x100 initval 0
+action NoAction args none {
+	return
+}
+
+action drop args none {
+	drop
+	return
+}
+
+action ct_tcp_table_hit args none {
+	mov m.MainControlT_tmp h.ethernet.src_addr
+	and m.MainControlT_tmp 0xFFFFFFFFFF00
+	mov h.ethernet.src_addr m.MainControlT_tmp
+	or h.ethernet.src_addr 0xF1
+	return
+}
+
+action ct_tcp_table_miss args none {
+	mov m.MainControlT_tmp_0 h.ethernet.src_addr
+	and m.MainControlT_tmp_0 0xFFFFFFFFFF00
+	mov h.ethernet.src_addr m.MainControlT_tmp_0
+	or h.ethernet.src_addr 0xA5
+	learn ct_tcp_table_hit m.MainControlT_new_expire_time_profile_id
+	return
+}
+
+action send args instanceof send_arg_t {
+	mov m.pna_main_output_metadata_output_port t.port
+	return
+}
+
+table ipv4_host {
+	key {
+		h.ipv4.dst_addr exact
+	}
+	actions {
+		send
+		drop
+		NoAction
+	}
+	default_action drop args none const
+	size 0x10000
+}
+
+
+learner ct_tcp_table {
+	key {
+		m.MainControlImpl_ct_tcp_table_ipv4_src_addr
+		m.MainControlImpl_ct_tcp_table_ipv4_dst_addr
+		m.MainControlImpl_ct_tcp_table_ipv4_protocol
+		m.MainControlImpl_ct_tcp_table_tcp_src_port
+		m.MainControlImpl_ct_tcp_table_tcp_dst_port
+	}
+	actions {
+		ct_tcp_table_hit @tableonly
+		ct_tcp_table_miss @defaultonly
+	}
+	default_action ct_tcp_table_miss args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.ether_type 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	jmpeq MAINPARSERIMPL_PARSE_TCP h.ipv4.protocol 0x6
+	jmpeq MAINPARSERIMPL_PARSE_UDP h.ipv4.protocol 0x11
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_UDP :	extract h.udp
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_TCP :	extract h.tcp
+	MAINPARSERIMPL_ACCEPT :	mov m.MainControlT_new_expire_time_profile_id 0x1
+	jmpnv LABEL_END h.ipv4
+	jmpnv LABEL_END h.tcp
+	mov m.MainControlImpl_ct_tcp_table_ipv4_src_addr h.ipv4.src_addr
+	mov m.MainControlImpl_ct_tcp_table_ipv4_dst_addr h.ipv4.dst_addr
+	mov m.MainControlImpl_ct_tcp_table_ipv4_protocol h.ipv4.protocol
+	mov m.MainControlImpl_ct_tcp_table_tcp_src_port h.tcp.src_port
+	mov m.MainControlImpl_ct_tcp_table_tcp_dst_port h.tcp.dst_port
+	table ct_tcp_table
+	LABEL_END :	jmpnv LABEL_END_0 h.ipv4
+	table ipv4_host
+	LABEL_END_0 :	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	emit h.udp
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/tools/dpdk-ci-build.sh
+++ b/tools/dpdk-ci-build.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+set -e  # Exit on error.
+set -x  # Make command execution verbose
+
+if [ -z "$1" ]; then
+    echo "- Missing mandatory argument: P4C_DIR"
+    echo " - Usage: source dpdk-ci-build.sh <P4C_DIR> <IPDK_RECIPE> <SDE_INSTALL> <DEPEND_INSTALL>"
+    return 0
+fi
+
+if [ -z "$2" ]; then
+    echo "- Missing mandatory argument: IPDK_RECIPE"
+    echo " - Usage: source dpdk-ci-build.sh <P4C_DIR> <IPDK_RECIPE> <SDE_INSTALL> <DEPEND_INSTALL>"
+    return 0
+fi
+
+if [ -z "$3" ]; then
+    echo "- Missing mandatory argument: SDE_INSTALL"
+    echo " - Usage: source dpdk-ci-build.sh <P4C_DIR> <IPDK_RECIPE> <SDE_INSTALL> <DEPEND_INSTALL>"
+    return 0
+fi
+
+if [ -z "$4" ]; then
+    echo "- Missing mandatory argument: DEPEND_INSTALL"
+    echo " - Usage: source dpdk-ci-build.sh <P4C_DIR> <IPDK_RECIPE> <SDE_INSTALL> <DEPEND_INSTALL>"
+    return 0
+fi
+
+export P4C_DIR=$1
+export IPDK_RECIPE=$2
+export SDE_INSTALL=$3
+export DEPEND_INSTALL=$4
+
+
+
+# Update SDE libraries for infrap4d; commands are copied from  ipdk.recipe/scripts/dpdk/dpdk-ci-build.sh
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SDE_INSTALL/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SDE_INSTALL/lib64
+
+
+ #if OS =Fedora:   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SDE_INSTALL/lib64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SDE_INSTALL/lib/x86_64-linux-gnu
+
+
+# Update IPDK RECIPE libraries
+export LD_LIBRARY_PATH=$IPDK_RECIPE/install/lib:$IPDK_RECIPE/install/lib64:$LD_LIBRARY_PATH
+export PATH=$IPDK_RECIPE/install/bin:$IPDK_RECIPE/install/sbin:$PATH
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib64
+
+# Update Dependent libraries
+export LD_LIBRARY_PATH=$DEPEND_INSTALL/lib:$DEPEND_INSTALL/lib64:$LD_LIBRARY_PATH
+export PATH=$DEPEND_INSTALL/bin:$DEPEND_INSTALL/sbin:$PATH
+export LIBRARY_PATH=$DEPEND_INSTALL/lib:$DEPEND_INSTALL/lib64:$LIBRARY_PATH
+
+echo ""
+echo ""
+echo "Updated Environment Variables ..."
+echo "SDE_INSTALL: $SDE_INSTALL"
+echo "LIBRARY_PATH: $LIBRARY_PATH"
+echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+echo "PATH: $PATH"
+echo ""
+
+# Install P4C deps and build p4c-dpdk
+cd $P4C_DIR
+P4C_DEPS="bison \
+          build-essential \
+          ccache \
+          cmake \
+          flex \
+          g++ \
+          git \
+          lld \
+          libboost-dev \
+          libboost-graph-dev \
+          libboost-iostreams-dev \
+          libfl-dev \
+          libgc-dev \
+          pkg-config \
+          python3 \
+          python3-pip \
+          python3-setuptools \
+          tcpdump \
+          tcpreplay \
+          python3-netaddr"
+
+apt-get update
+apt-get install -y --no-install-recommends  ${P4C_DEPS}
+pip3 install --upgrade pip
+pip3 install -r ${P4C_DIR}/requirements.txt
+pip3 install git+https://github.com/p4lang/p4runtime-shell.git
+
+# Build P4C
+CMAKE_FLAGS="-DCMAKE_UNITY_BUILD=ON"
+CMAKE_FLAGS+="
+  -DENABLE_BMV2=OFF \
+  -DENABLE_EBPF=OFF \
+  -DENABLE_UBPF=OFF \
+  -DENABLE_GTESTS=OFF \
+  -DENABLE_P4TEST=OFF \
+  -DENABLE_P4TC=OFF \
+  -DENABLE_P4C_GRAPHS=OFF \
+  -DENABLE_PROTOBUF_STATIC=OFF \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+  -DENABLE_TEST_TOOLS=ON \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+"
+
+mkdir build
+cd build
+cmake .. ${CMAKE_FLAGS}
+make "-j$(nproc)"
+
+set +e
+


### PR DESCRIPTION
# Summary

This PR sets up a PTF test CI pipeline for p4c-dpdk and the dpdk-target. 

- [PTF(Packet Testing Framework)](https://github.com/p4lang/ptf) is a Python based dataplane test framework.
- [p4c-dpdk](https://github.com/p4lang/p4c/blob/main/backends/dpdk) is the p4 dpdk compiler backend that translates the P4-16 programs to DPDK API to configure the DPDK software switch (SWX) pipeline.
- [DPDK-target](https://github.com/p4lang/p4-dpdk-target/tree/main) implements the P4 pipeline,driven by artifacts generated by the P4 compiler.

# Background

A PTF test CI pipeline for p4c-dpdk on the DPDK SWX is currently missing. Adding such tests is beneficial for both the development of the compiler backend and DPDK SWX pipeline.

# Demo

- Make sure `infrap4d` and `p4sde/dpdk-target` are properly [setup](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/dpdk-guide.md). 
- Define `$P4C_DIR` as the root directory for p4c. 
- Run `sudo $P4C_DIR/backends/dpdk/run-dpdk-ptf-test.py $P4C_DIR $P4C_DIR/testdata/p4_16_samples/pna-dpdk-add_on_miss0.p4 --ipdk-recipe $IPDK_RECIPE --sde-install $SDE_INSTALL --ld-library-path $LD_LIBRARY_PATH --testfile $P4C_DIR/testdata/p4_16_samples/pna-dpdk-add_on_miss0.py -ll DEBUG`

Output:
```
Updated Environment Variables ...
// Skip

1024
1024
INFO: ---------------------- Build conf file ----------------------
INFO: Executing command: python3 /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/p4c/backends/dpdk/edit-conf-file.py -i /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/p4c/backends/dpdk/conf_template.conf -o /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/add_on_miss0.conf -s test_dir temp_prog -r  /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst add_on_miss0.p4
INFO: Executing command: mkdir /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/pipe
INFO: ---------------------- Compile with p4c-dpdk ----------------------
INFO: Executing command: p4c-dpdk --arch pna --target dpdk             --p4runtime-files /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/p4Info.txt             --bf-rt-schema /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/bf-rt.json             --context /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/pipe/context.json             -o /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/pipe/add_on_miss0.spec /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/p4c/testdata/p4_16_samples/add_on_miss0.p4
WARNING: [--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table ct_tcp_table. Copying all match fields to metadata
INFO: ---------------------- Start infrap4d ----------------------
INFO: Writing / h o m e / r u n n e r / w o r k / p 4 c - d p d k - c i - p i p e l i n e / p 4 c - d p d k - c i - p i p e l i n e / i p d k . r e c i p e / i n s t a l l / s b i n / i n f r a p 4 d   - g r p c _ o p e n _ i n s e c u r e _ m o d e = T r u e
INFO: ---------------------- Creating TAPs ----------------------
INFO: Executing command: /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/ipdk.recipe/install/bin/gnmi-ctl set device:virtual-device,name:TAP0,pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:1500,port-type:TAP -grpc_use_insecure_mode=True
INFO: setting vhost_dev = true.Set request, successful...!!!
WARNING: I20230714 19:52:04.519886 106752 gnmi_ctl.cc:103] Client context cancelled.
INFO: Executing command: ifconfig TAP0 up
INFO: Executing command: /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/ipdk.recipe/install/bin/gnmi-ctl set device:virtual-device,name:TAP1,pipeline-name:pipe,mempool-name:MEMPOOL0,mtu:1500,port-type:TAP -grpc_use_insecure_mode=True
INFO: setting vhost_dev = true.Set request, successful...!!!
WARNING: I20230714 19:52:04.740332 106773 gnmi_ctl.cc:103] Client context cancelled.
INFO: Executing command: ifconfig TAP1 up
INFO: ---------------------- Build and Load Pipleline ----------------------
INFO: Executing command: /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/ipdk.recipe/install/bin/tdi_pipeline_builder --p4c_conf_file=/home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/add_on_miss0.conf --bf_pipeline_config_binary_file=/home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/add_on_miss0.pb.bin
WARNING: I20230714 19:52:04.801210 106788 tdi_pipeline_builder.cc:116] Found P4 program: add_on_miss0.p4
WARNING: I20230714 19:52:04.80[18](https://github.com/Hoooao/p4c-dpdk-ci-pipeline/actions/runs/5556956035/job/15053507547#step:9:19)88 106788 tdi_pipeline_builder.cc:123] 	Found pipeline: pipe
INFO: Executing command: /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/ipdk.recipe/install/bin/p4rt-ctl set-pipe br0 /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/add_on_miss0.pb.bin /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/p4Info.txt 
INFO: *** Warning: Unable to locate TLS certificates ***
INFO: Attempting P4RT communication over insecure channel on port localhost:9559...
INFO: ---------------------- Run PTF test ----------------------
INFO: Executing command: ptf --pypath /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/p4c/backends/dpdk --test-dir /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst --list
WARNING: /usr/local/bin/ptf:[19](https://github.com/Hoooao/p4c-dpdk-ci-pipeline/actions/runs/5556956035/job/15053507547#step:9:20): DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
WARNING:   import imp
INFO: Using packet manipulation module: ptf.packet_scapy
INFO: Tests are shown grouped by module. If a test is in any groups beyond "standard"
INFO: and its module's group then they are shown in parentheses.
INFO: 
INFO: Tests marked with '!' are disabled because they are experimental, special-purpose,
INFO: or are too long to be run normally. These are not part of the "standard" test
INFO: group or their module's test group.
INFO: 
INFO: Test List:
INFO:   Module add_on_miss0:  No description
INFO:     OneEntryTest:     
INFO: 
INFO: 1 modules shown with a total of 1 tests
INFO: 
INFO: Test groups: add_on_miss0, all, standard
INFO: Executing command: ptf --pypath /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/p4c/backends/dpdk  -i 0@TAP0 -i 1@TAP1 --log-file /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst/ptf.log --test-params=grpcaddr='0.0.0.0:9559' --test-dir /home/runner/work/p4c-dpdk-ci-pipeline/p4c-dpdk-ci-pipeline/tmpjdvgvxst
WARNING: /usr/local/bin/ptf:19: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
WARNING:   import imp
WARNING: 2023-07-14 19:52:08,105 - root - INFO - port map: {(0, 0): 'TAP0', (0, 1): 'TAP1'}
WARNING: 2023-07-14 19:52:08,106 - root - INFO - Autogen random seed: 78534030
WARNING: 2023-07-14 19:52:08,119 - root - INFO - *** TEST RUN START: Fri Jul 14 19:52:08 2023
WARNING: add_on_miss0.OneEntryTest ... 2023-07-14 19:52:08,119 - root - INFO - AbstractIdleTimeoutTest.setUp()
WARNING: 2023-07-14 19:52:08,148 - root - INFO - Attempting to delete all entries in ipv4_host
WARNING: 2023-07-14 19:52:08,152 - root - INFO - Attempting to add entries to ipv4_host
WARNING: 2023-07-14 19:52:08,330 - root - INFO - Now ipv4_host contains 2 entries
WARNING: 2023-07-14 19:52:08,330 - root - INFO - Sending Packet ...
WARNING: 2023-07-14 19:52:08,334 - root - INFO - Sending packet #1
WARNING: 2023-07-14 19:52:08,335 - root - INFO - Verifying Packet ...
WARNING: 2023-07-14 19:52:08,539 - root - INFO -     packet experienced a miss in ct_tcp_table as expected
WARNING: 2023-07-14 19:52:08,539 - root - INFO - IdleTimeoutTest.tearDown()
WARNING: ok
WARNING: 
WARNING: ----------------------------------------------------------------------
WARNING: Ran 1 test in 0.425s
```
# Current status and further plans

- There is only one test added to the PTF test suite, but we will be working on the P4Testgen for it. 
- Currently, the dependency building for `infrap4d` takes too long. We will be working on a Docker image to try to accelerate the building process. 