### PR TITLE
[P4Testgen] Fix an infinite loop in the coverable nodes scanner.

### DIFF
--- a/backends/p4tools/modules/testgen/lib/collect_coverable_nodes.cpp
+++ b/backends/p4tools/modules/testgen/lib/collect_coverable_nodes.cpp
@@ -28,6 +28,7 @@ bool CoverableNodesScanner::preorder(const IR::ParserState *parserState) {
         parserState->name == IR::ParserState::reject) {
         return true;
     }
+    seenParserIds.emplace(parserState->clone_id);
 
     CHECK_NULL(parserState->selectExpression);
     const auto &executionState = state.get();
@@ -44,7 +45,6 @@ bool CoverableNodesScanner::preorder(const IR::ParserState *parserState) {
         const auto *decl = executionState.findDecl(pathExpression)->getNode();
         decl->apply_visitor_preorder(*this);
     }
-    seenParserIds.emplace(parserState->clone_id);
     return true;
 }
 


### PR DESCRIPTION
The parser ID was added too late. If a parser state references itself, the scanner will loop infinitely. 