### PR TITLE
Fix #4067: Add static casts required by newer versions of G++

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -880,7 +880,7 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
                      testBackend);
                  auto &nextState = state.clone();
                  nextState.set(meterResult, IR::getConstant(meterResult->type,
-                                                            BMv2Constants::METER_COLOR::GREEN));
+                                                            static_cast<big_int>(BMv2Constants::METER_COLOR::GREEN)));
                  nextState.popBody();
                  result->emplace_back(nextState);
                  return;
@@ -1002,7 +1002,7 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
                      "(GREEN).",
                      testBackend);
                  nextState.set(meterResult, IR::getConstant(meterResult->type,
-                                                            BMv2Constants::METER_COLOR::GREEN));
+                                                            static_cast<big_int>(BMv2Constants::METER_COLOR::GREEN)));
                  nextState.popBody();
                  result->emplace_back(nextState);
                  return;

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -879,8 +879,10 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
                      "meter.execute_meter not implemented for %1%. Choosing default value (GREEN).",
                      testBackend);
                  auto &nextState = state.clone();
-                 nextState.set(meterResult, IR::getConstant(meterResult->type,
-                                                            static_cast<big_int>(BMv2Constants::METER_COLOR::GREEN)));
+                 nextState.set(
+                     meterResult,
+                     IR::getConstant(meterResult->type,
+                                     static_cast<big_int>(BMv2Constants::METER_COLOR::GREEN)));
                  nextState.popBody();
                  result->emplace_back(nextState);
                  return;
@@ -1001,8 +1003,10 @@ void Bmv2V1ModelExprStepper::evalExternMethodCall(const IR::MethodCallExpression
                      "direct_meter.read configuration not possible for %1%. Choosing default value "
                      "(GREEN).",
                      testBackend);
-                 nextState.set(meterResult, IR::getConstant(meterResult->type,
-                                                            static_cast<big_int>(BMv2Constants::METER_COLOR::GREEN)));
+                 nextState.set(
+                     meterResult,
+                     IR::getConstant(meterResult->type,
+                                     static_cast<big_int>(BMv2Constants::METER_COLOR::GREEN)));
                  nextState.popBody();
                  result->emplace_back(nextState);
                  return;


### PR DESCRIPTION
Code updates suggested by Fabian Ruffy, and verified by building with these changes on a Fedora 37 Linux system running G++ 12.3.1.