### PR TITLE
Try to fix Opensuse certificate errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ A p4c package is available in the following repositories for Ubuntu 20.04 and ne
 
 ```bash
 . /etc/os-release
-echo "deb https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/home:p4lang.list
-curl -L "https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
+echo "deb http://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/ /" | sudo tee /etc/apt/sources.list.d/home:p4lang.list
+curl -fsSL https://download.opensuse.org/repositories/home:p4lang/xUbuntu_${DISTRIB_RELEASE}/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_p4lang.gpg > /dev/null
 sudo apt-get update
 sudo apt install p4lang-p4c
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ p4c has package support for several Ubuntu and Debian distributions.
 A p4c package is available in the following repositories for Ubuntu 20.04 and newer.
 
 ```bash
-. /etc/os-release
+source /etc/lsb-release
 echo "deb http://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/ /" | sudo tee /etc/apt/sources.list.d/home:p4lang.list
 curl -fsSL https://download.opensuse.org/repositories/home:p4lang/xUbuntu_${DISTRIB_RELEASE}/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_p4lang.gpg > /dev/null
 sudo apt-get update

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -100,11 +100,11 @@ if [[ "${DISTRIB_RELEASE}" == "18.04" ]] || [[ "$(which simple_switch 2> /dev/nu
   export CC=gcc-9
   export CXX=g++-9
 else
-  sudo apt-get update && sudo apt-get install -y curl gnupg
-  echo "deb https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/ /" | sudo tee /etc/apt/sources.list.d/home:p4lang.list
-  curl -L "https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/Release.key" | sudo apt-key add -
-  # Try to avoid certificate errors.
-  sudo apt install ca-certificates
+  sudo apt-get update && sudo apt-get install -y wget ca-certificates
+  # Add the p4lang opensuse repository in a secure fashion.
+  sudo mkdir -p /etc/apt/keyrings/p4lang
+  wget -O- https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/Release.gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/p4lang/p4lang-release-keyring.gpg > /dev/null
+  echo "deb [signed-by=/etc/apt/keyrings/p4lang/p4lang-release-keyring.gpg] https://download.opensuse.org/repositories/home:/p4lang/ ../xUbuntu_${DISTRIB_RELEASE} main" | sudo tee /etc/apt/sources.list.d/home:p4lang.list
   P4C_DEPS+=" p4lang-bmv2"
 fi
 

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -101,10 +101,9 @@ if [[ "${DISTRIB_RELEASE}" == "18.04" ]] || [[ "$(which simple_switch 2> /dev/nu
   export CXX=g++-9
 else
   sudo apt-get update && sudo apt-get install -y wget ca-certificates
-  # Add the p4lang opensuse repository in a secure fashion.
-  sudo mkdir -p /etc/apt/keyrings/p4lang
-  wget -O- https://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/Release.gpg | gpg --dearmor | sudo tee /etc/apt/keyrings/p4lang/p4lang-release-keyring.gpg > /dev/null
-  echo "deb [signed-by=/etc/apt/keyrings/p4lang/p4lang-release-keyring.gpg] https://download.opensuse.org/repositories/home:/p4lang/ ../xUbuntu_${DISTRIB_RELEASE} main" | sudo tee /etc/apt/sources.list.d/home:p4lang.list
+  # Add the p4lang opensuse repository.
+  echo "deb http://download.opensuse.org/repositories/home:/p4lang/xUbuntu_${DISTRIB_RELEASE}/ /" | sudo tee /etc/apt/sources.list.d/home:p4lang.list
+  curl -fsSL https://download.opensuse.org/repositories/home:p4lang/xUbuntu_${DISTRIB_RELEASE}/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_p4lang.gpg > /dev/null
   P4C_DEPS+=" p4lang-bmv2"
 fi
 


### PR DESCRIPTION
The OpenSuse repository keeps failing to download the p4lang debian packages. Maybe updating the deprecated key installation technique can help?

@rst0git I can not quite figure out how to fix this. Do maybe know how to fix the key installation issue? 

I believe the OpenSuse repository is malformed? It does not have a `dists` folder. I managed to work around that, but I still run into key issues. 
