### PR TITLE
Allow building testgen without P4TEST enabled

### DIFF
--- a/backends/p4tools/modules/testgen/test/small-step/p4_asserts_parser_test.cpp
+++ b/backends/p4tools/modules/testgen/test/small-step/p4_asserts_parser_test.cpp
@@ -10,7 +10,6 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
-#include "backends/p4test/version.h"
 #include "backends/p4tools/common/compiler/midend.h"
 #include "backends/p4tools/common/lib/variables.h"
 #include "frontends/common/options.h"
@@ -55,7 +54,6 @@ Restrictions loadExample(const char *curFile, bool flag) {
     std::string includeDir = std::string(buildPath) + std::string("p4include");
     auto *originalEnv = getenv("P4C_16_INCLUDE_PATH");
     setenv("P4C_16_INCLUDE_PATH", includeDir.c_str(), 1);
-    options.compilerVersion = P4TEST_VERSION_STRING;
     const IR::P4Program *program = nullptr;
     options.file = sourcePath;
     options.file += curFile;

--- a/backends/p4tools/modules/testgen/test/small-step/reachability.cpp
+++ b/backends/p4tools/modules/testgen/test/small-step/reachability.cpp
@@ -7,7 +7,6 @@
 #include <fstream>
 #include <functional>
 
-#include "backends/p4test/version.h"
 #include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
 #include "frontends/common/parseInput.h"
@@ -61,7 +60,6 @@ ReturnedInfo loadExampleForReachability(const char *curFile) {
     std::string includeDir = std::string(buildPath) + std::string("p4include");
     auto *originalEnv = getenv("P4C_16_INCLUDE_PATH");
     setenv("P4C_16_INCLUDE_PATH", includeDir.c_str(), 1);
-    options.compilerVersion = P4TEST_VERSION_STRING;
     const IR::P4Program *program = nullptr;
     options.file = sourcePath;
     options.file += curFile;


### PR DESCRIPTION
This follows on #4065 where I already fixed build of the compiler without p4test, but I had accidentally disabled testgen when testing the build. Apparently the exact same pattern is repeated in testgen tests, so I propose the same solution.
