### PR TITLE
Fix missing header for intmax_t typedef

### DIFF
--- a/lib/hex.h
+++ b/lib/hex.h
@@ -17,12 +17,13 @@ limitations under the License.
 #ifndef LIB_HEX_H_
 #define LIB_HEX_H_
 
+#include <cstdint>
 #include <iomanip>
 #include <iostream>
 #include <vector>
 
 class hex {
-    intmax_t val;
+    std::intmax_t val;
     int width;
     char fill;
 


### PR DESCRIPTION
Add include directive for cstdint which is necessary to use std::intmax_t, also qualify intmax_t with std namespace because of the use of C++ header instead of C.