### PR TITLE
Make sure we ignore warnings in the Protobuf dependency source code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,10 @@ set(EXTENSION_IR_SOURCES)
 # extensions can provide specific conversions (e.g., for externs)
 set(EXTENSION_P4_14_CONV_SOURCES)
 
+########################################## P4Runtime Begin #########################################
+# TODO: Ideally, this code should be part of the control-plane CMakelists.txt file. However, because
+# extensions which may depend on P4Runtime variables are instantiated before the control-plane we
+# need to keep the P4Runtime installation in the top-level CMakelists file.
 # Print download state while setting up P4Runtime.
 set(FETCHCONTENT_QUIET_PREV ${FETCHCONTENT_QUIET})
 set(FETCHCONTENT_QUIET OFF)
@@ -381,6 +385,7 @@ message("Done with setting up P4Runtime for P4C.")
 set(P4RUNTIME_STD_DIR ${p4runtime_SOURCE_DIR}/proto CACHE INTERNAL
                                                           "Path to the P4Runtime directory."
 )
+########################################## P4Runtime End ##########################################
 
 file (GLOB p4c_extensions RELATIVE ${P4C_SOURCE_DIR}/extensions ${P4C_SOURCE_DIR}/extensions/*)
 MESSAGE ("-- Available extensions ${p4c_extensions}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,26 @@ set(EXTENSION_IR_SOURCES)
 # extensions can provide specific conversions (e.g., for externs)
 set(EXTENSION_P4_14_CONV_SOURCES)
 
+# Print download state while setting up P4Runtime.
+set(FETCHCONTENT_QUIET_PREV ${FETCHCONTENT_QUIET})
+set(FETCHCONTENT_QUIET OFF)
+# Fetch and declare the P4Runtime library.
+FetchContent_Declare(
+  p4runtime
+  GIT_REPOSITORY https://github.com/p4lang/p4runtime.git
+  GIT_TAG        d76a3640a223f47a43dc34e5565b72e43796ba57
+  GIT_PROGRESS TRUE
+  GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(p4runtime)
+set(FETCHCONTENT_QUIET ${FETCHCONTENT_QUIET_PREV})
+message("Done with setting up P4Runtime for P4C.")
+# The standard P4Runtime protocol buffers message definitions live in the PI
+# repo, which is included in this repo as a git module.
+set(P4RUNTIME_STD_DIR ${p4runtime_SOURCE_DIR}/proto CACHE INTERNAL
+                                                          "Path to the P4Runtime directory."
+)
+
 file (GLOB p4c_extensions RELATIVE ${P4C_SOURCE_DIR}/extensions ${P4C_SOURCE_DIR}/extensions/*)
 MESSAGE ("-- Available extensions ${p4c_extensions}")
 foreach (ext ${p4c_extensions})

--- a/backends/dpdk/CMakeLists.txt
+++ b/backends/dpdk/CMakeLists.txt
@@ -23,10 +23,6 @@ set (DPDK_P4RUNTIME_DIR ${CMAKE_CURRENT_SOURCE_DIR}/control-plane/proto)
 set (DPDK_P4RUNTIME_INFO_PROTO ${DPDK_P4RUNTIME_DIR}/p4info.proto)
 set (DPDK_P4RUNTIME_INFO_GEN_SRCS ${CMAKE_CURRENT_BINARY_DIR}/p4/config/p4info.pb.cc)
 set (DPDK_P4RUNTIME_INFO_GEN_HDRS ${CMAKE_CURRENT_BINARY_DIR}/p4/config/p4info.pb.h)
-# The generated code for protobuf has an excessive number of warnings
-# Silence -Warray-bounds as the root issue is out of our control: https://github.com/protocolbuffers/protobuf/issues/7140
-set_source_files_properties(${DPDK_P4RUNTIME_INFO_GEN_SRCS} PROPERTIES
-  COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds")
 
 add_custom_target (dpdk_runtime_dir
   ${CMAKE_COMMAND} -E make_directory
@@ -50,6 +46,9 @@ add_library(dpdk_runtime STATIC ${DPDK_P4RUNTIME_INFO_GEN_SRCS})
 target_include_directories(dpdk_runtime
   SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIR}
 )
+
+# Silence various warnings as the root issue is out of our control, example https://github.com/protocolbuffers/protobuf/issues/7140
+set_source_files_properties(${DPDK_P4RUNTIME_INFO_GEN_SRCS} {$DPDK_P4RUNTIME_INFO_GEN_HDRS} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds -Wno-error")
 
 set(P4C_DPDK_SOURCES
     ../bmv2/common/lower.cpp

--- a/backends/dpdk/control-plane/bfruntime_arch_handler.h
+++ b/backends/dpdk/control-plane/bfruntime_arch_handler.h
@@ -21,7 +21,12 @@ limitations under the License.
 #include <unordered_map>
 #include <vector>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "backends/dpdk/p4/config/p4info.pb.h"
+#pragma GCC diagnostic pop
+
 #include "control-plane/bfruntime.h"
 #include "control-plane/p4RuntimeArchHandler.h"
 #include "control-plane/p4RuntimeArchStandard.h"

--- a/cmake/Protobuf.cmake
+++ b/cmake/Protobuf.cmake
@@ -71,6 +71,9 @@ macro(p4c_obtain_protobuf)
     )
     set(Protobuf_INCLUDE_DIR ${protobuf_SOURCE_DIR}/src/ CACHE STRING "Protobuf include directory.")
     set(PROTOBUF_LIBRARY libprotobuf)
+    # Protobuf source code may trigger warnings which we need to ignore.
+    set_target_properties(libprotobuf PROPERTIES COMPILE_FLAGS "-Wno-error")
+
     message("Done with setting up Protobuf for P4C.")
   endif()
 endmacro(p4c_obtain_protobuf)

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -80,7 +80,7 @@ add_custom_command(OUTPUT ${P4RUNTIME_GEN_SRCS} ${P4RUNTIME_GEN_HDRS}
           ${P4RUNTIME_PROTO}
   DEPENDS ${P4RUNTIME_PROTO}
   COMMENT "Generating protobuf files"
-  )
+)
 
 # These macros are much nicer than the custom command, but do not work for generating
 # files in a different directory (e.g. p4/config). If we are ok with just generating
@@ -123,7 +123,7 @@ target_link_libraries (controlplane-gen PUBLIC ${PROTOBUF_LIBRARY})
 include_directories (${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 # Silence various warnings as the root issue is out of our control, example https://github.com/protocolbuffers/protobuf/issues/7140
-set_source_files_properties (${P4RUNTIME_GEN_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds -Wno-pedantic")
+set_source_files_properties (${P4RUNTIME_GEN_SRCS} {$P4RUNTIME_GEN_HDRS} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds -Wno-error")
 
 add_library (controlplane STATIC ${CONTROLPLANE_SRCS} )
 target_link_libraries (controlplane ${CMAKE_THREAD_LIBS_INIT} controlplane-gen)

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -12,27 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# Print download state while setting up P4Runtime.
-set(FETCHCONTENT_QUIET_PREV ${FETCHCONTENT_QUIET})
-set(FETCHCONTENT_QUIET OFF)
-# Fetch and declare the P4Runtime library.
-FetchContent_Declare(
-  p4runtime
-  GIT_REPOSITORY https://github.com/p4lang/p4runtime.git
-  GIT_TAG        d76a3640a223f47a43dc34e5565b72e43796ba57
-  GIT_PROGRESS TRUE
-  GIT_SHALLOW TRUE
-)
-FetchContent_MakeAvailable(p4runtime)
-set(FETCHCONTENT_QUIET ${FETCHCONTENT_QUIET_PREV})
-message("Done with setting up P4Runtime for P4C.")
-
-# The standard P4Runtime protocol buffers message definitions live in the PI
-# repo, which is included in this repo as a git module.
-set(P4RUNTIME_STD_DIR ${p4runtime_SOURCE_DIR}/proto CACHE INTERNAL
-                                                          "Path to the P4Runtime directory."
-)
 set (P4RUNTIME_INFO_PROTO ${P4RUNTIME_STD_DIR}/p4/config/v1/p4info.proto)
 set (P4RUNTIME_INFO_GEN_SRCS ${CMAKE_CURRENT_BINARY_DIR}/p4/config/v1/p4info.pb.cc)
 set (P4RUNTIME_INFO_GEN_HDRS ${CMAKE_CURRENT_BINARY_DIR}/p4/config/v1/p4info.pb.h)

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -122,8 +122,8 @@ target_link_libraries (controlplane-gen PUBLIC ${PROTOBUF_LIBRARY})
 # Needed for the correct import of google/status.pb.cc
 include_directories (${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
-# Silence -Warray-bounds as the root issue is out of our control: https://github.com/protocolbuffers/protobuf/issues/7140
-set_source_files_properties (${P4RUNTIME_GEN_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds")
+# Silence various warnings as the root issue is out of our control, example https://github.com/protocolbuffers/protobuf/issues/7140
+set_source_files_properties (${P4RUNTIME_GEN_SRCS} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds -Wno-pedantic")
 
 add_library (controlplane STATIC ${CONTROLPLANE_SRCS} )
 target_link_libraries (controlplane ${CMAKE_THREAD_LIBS_INIT} controlplane-gen)

--- a/control-plane/bfruntime.h
+++ b/control-plane/bfruntime.h
@@ -32,7 +32,11 @@ limitations under the License.
 #include "lib/json.h"
 #include "lib/log.h"
 #include "lib/null.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "p4/config/v1/p4info.pb.h"
+#pragma GCC diagnostic pop
 
 namespace p4configv1 = ::p4::config::v1;
 

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "p4/config/v1/p4info.pb.h"
 #pragma GCC diagnostic pop
 

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -15,10 +15,12 @@ limitations under the License.
 */
 #include "p4RuntimeSerializer.h"
 
-#include <google/protobuf/text_format.h>
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#include <google/protobuf/text_format.h>
 #include <google/protobuf/util/json_util.h>
+#pragma GCC diagnostic pop
 
 #include <algorithm>
 #include <iostream>
@@ -30,8 +32,9 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-#include "p4/config/v1/p4info.pb.h"
-#include "p4/config/v1/p4types.pb.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "p4/v1/p4runtime.pb.h"
 #pragma GCC diagnostic pop
 

--- a/control-plane/typeSpecConverter.cpp
+++ b/control-plane/typeSpecConverter.cpp
@@ -29,7 +29,6 @@ limitations under the License.
 #include "lib/error.h"
 #include "lib/exceptions.h"
 #include "lib/null.h"
-#include "p4/config/v1/p4types.pb.h"
 #include "p4RuntimeArchHandler.h"
 
 namespace p4configv1 = ::p4::config::v1;

--- a/control-plane/typeSpecConverter.h
+++ b/control-plane/typeSpecConverter.h
@@ -22,7 +22,11 @@ limitations under the License.
 
 #include "ir/ir.h"
 #include "ir/visitor.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include "p4/config/v1/p4info.pb.h"
+#pragma GCC diagnostic pop
 
 namespace p4 {
 


### PR DESCRIPTION
This PR does two things. 
- Depending on the compiler and options enabled (warnings as errors) compilation can fail. Make sure we ignore Protobuf code and warnings since we have not control over it. We do this by both setting the appropriate CMake options and also wrapping `#pragmas` around the relevant Protobuf includes.
- In CMake, the control-plane is instantiated after extensions. If an extension requires P4Runtime, we may grab the dependency too late. Ideally, we would fix initialization order such that extensions are instantiated after we are done with the compiler front end.  Consider cleaning up the initialization order in a separate PR.