### PR TITLE
Use libbacktrace for stack dumps if available

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,7 +17,8 @@ genrule(
     outs = ["config.h"],
     cmd = " | ".join([
         "sed 's|cmakedefine|define|g' < $(SRCS)",
-        "sed 's|define HAVE_LIBGC 1|undef HAVE_LIBGC|g' > $(OUTS)",
+        "sed 's|define HAVE_LIBGC 1|undef HAVE_LIBGC|g'",
+        "sed 's|define HAVE_LIBBACKTRACE 1|undef HAVE_LIBBACKTRACE|g' > $(OUTS)",
     ]),
     visibility = ["//visibility:private"],
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,8 +176,13 @@ p4c_add_library (rt clock_gettime HAVE_CLOCK_GETTIME)
 include (CheckIncludeFile)
 check_include_file (execinfo.h HAVE_EXECINFO_H)
 check_include_file (ucontext.h HAVE_UCONTEXT_H)
+check_include_file (backtrace-supported.h HAVE_LIBBACKTRACE)
 include (CheckIncludeFileCXX)
 check_include_file_cxx (cxxabi.h HAVE_CXXABI_H)
+
+if (HAVE_LIBBACKTRACE)
+set (P4C_LIB_DEPS "${P4C_LIB_DEPS};-lbacktrace")
+endif ()
 
 # check functions
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,13 @@ may become impractical for compiling large programs.  **Do not disable
 the GC**, unless you really have to.  We have noticed that this may be
 a problem on MacOS.
 
+## Crash dumps
+
+P4c will use [libbacktrace](https://github.com/ianlancetaylor/libbacktrace.git)
+to produce readable crash dumps if it is available.  This is an optional
+dependency; if it is not available everything should build just fine, but
+crash dumps will not be very readable.
+
 # Development tools
 
 There is a variety of design and development documentation [here](docs/README.md).

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -7,6 +7,9 @@
 /* Define to 1 if you have the execinfo.h header */
 #cmakedefine HAVE_EXECINFO_H 1
 
+/* Define to 1 if you have libbacktrace */
+#cmakedefine HAVE_LIBBACKTRACE 1
+
 /* Define to 1 if you have the LIBGC library. */
 #cmakedefine HAVE_LIBGC 1
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 set (LIBP4CTOOLKIT_SRCS
-    backtrace.cpp
+    alloc_trace.cpp
+    backtrace_exception.cpp
     bitvec.cpp
     compile_context.cpp
     crash.cpp
@@ -39,6 +40,8 @@ set (LIBP4CTOOLKIT_SRCS
 
 set (LIBP4CTOOLKIT_HDRS
     algorithm.h
+    alloc_trace.h
+    backtrace_exception.h
     bitops.h
     bitrange.h
     bitvec.h

--- a/lib/alloc_trace.cpp
+++ b/lib/alloc_trace.cpp
@@ -1,0 +1,112 @@
+#include "alloc_trace.h"
+
+#include "hex.h"
+#include "log.h"
+#include "n4.h"
+
+#if HAVE_EXECINFO_H
+#include <execinfo.h>
+#endif
+#if HAVE_LIBBACKTRACE
+#include <backtrace.h>
+
+#include "exename.h"
+#endif
+#if HAVE_CXXABI_H
+#include <cxxabi.h>
+#endif
+
+extern const char *addr2line(void *addr, const char *text);
+
+#if HAVE_LIBBACKTRACE
+extern struct backtrace_state *global_backtrace_state;
+
+void bt_error(void *, const char *msg, int) { BUG("%s", msg); }
+
+int bt_print_callback(void *out_, uintptr_t pc, const char *file, int line, const char *func) {
+    std::ostream &out = *static_cast<std::ostream *>(out_);
+    if (file) {
+        if (const char *p = strstr(file, "/frontends/")) {
+            file = p + 1;
+        } else if (const char *p = strstr(file, "/backends/")) {
+            file = p + 1;
+        } else if (const char *p = strstr(file, "/extensions/")) {
+            file = p + 1;
+        } else if (const char *p = strstr(file, "/lib/")) {
+            file = p + 1;
+        } else if (const char *p = strstr(file, "/ir/")) {
+            file = p + 1;
+        } else if (const char *p = strstr(file, "/include/")) {
+            file = p + 9;
+        }
+    } else {
+        file = "??";
+    }
+    out << Log::endl << file << ":" << line;
+    if (func) {
+#if HAVE_CXXABI_H
+        int status;
+        if (char *fn = abi::__cxa_demangle(func, 0, 0, &status)) {
+            if (strlen(fn) < 100) out << " (" << fn << ")";
+            free(fn);
+        } else
+#endif
+            out << " (" << func << ")";
+    }
+    out << " [" << hex(pc) << "]";
+    return 0;
+}
+#endif
+
+void AllocTrace::count(void **bt, size_t sz) {
+    backtrace tr(bt);
+    data[tr][sz]++;
+}
+
+std::ostream &operator<<(std::ostream &out, const AllocTrace &at) {
+#if HAVE_LIBGC
+    PauseTrace temp_pause;
+#endif
+    typedef decltype(at.data)::value_type data_t;
+    std::vector<std::pair<size_t, const data_t *>> sorted;
+    size_t total_total = 0;
+    for (auto &e : at.data) {
+        size_t total = 0;
+        for (auto &al : e.second) total += al.first * al.second;
+        sorted.emplace_back(total, &e);
+        total_total += total;
+    }
+    std::sort(sorted.begin(), sorted.end(), [](auto &a, auto &b) { return a.first > b.first; });
+#if HAVE_LIBBACKTRACE
+    if (!global_backtrace_state)
+        global_backtrace_state = backtrace_create_state(exename(), 1, bt_error, &out);
+#endif
+    out << "Allocated a total of " << n4(total_total) << "B memory";
+    for (auto &s : sorted) {
+        if (s.first < 1000000) break;  // ignore little  stuff
+        size_t count = 0;
+        for (auto &al : s.second->second) count += al.second;
+        out << Log::endl << "allocated " << n4(s.first) << "B in " << count << " calls";
+#if HAVE_EXECINFO_H
+        out << " from:" << Log::indent;
+#if HAVE_LIBBACKTRACE
+        for (int i = 1; i < ALLOC_TRACE_DEPTH; ++i) {
+            /* due to calling the callback multiple times for inlined functions, we need to
+             * do this in ascending order or it makes no sense */
+            backtrace_pcinfo(global_backtrace_state,
+                             reinterpret_cast<uintptr_t>(s.second->first.trace[i]),
+                             bt_print_callback, bt_error, &out);
+        }
+#else
+        char **syms = backtrace_symbols(s.second->first.trace, ALLOC_TRACE_DEPTH);
+        for (int i = ALLOC_TRACE_DEPTH - 1; i >= 1; --i) {
+            const char *alt = addr2line(s.second->first.trace[i], syms[i]);
+            out << Log::endl << (alt ? alt : syms[i]) << ' ' << s.second->first.trace[i];
+        }
+        free(syms);
+#endif
+        out << Log::unindent;
+#endif
+    }
+    return out;
+}

--- a/lib/alloc_trace.h
+++ b/lib/alloc_trace.h
@@ -1,0 +1,78 @@
+/*
+Copyright 2023-present Intel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef LIB_ALLOC_TRACE_H_
+#define LIB_ALLOC_TRACE_H_
+
+#include <map>
+#include <ostream>
+
+#include "exceptions.h"
+#include "gc.h"
+
+class AllocTrace {
+    struct backtrace {
+        void *trace[ALLOC_TRACE_DEPTH];
+
+        backtrace(const backtrace &) = default;
+        explicit backtrace(void **bt) { memcpy(trace, bt, sizeof(trace)); }
+        bool operator<(const backtrace &a) const {
+            for (int i = 0; i < ALLOC_TRACE_DEPTH; ++i)
+                if (trace[i] != a.trace[i]) return trace[i] < a.trace[i];
+            return false;
+        }
+        bool operator==(const backtrace &a) const {
+            for (int i = 0; i < ALLOC_TRACE_DEPTH; ++i)
+                if (trace[i] != a.trace[i]) return false;
+            return true;
+        }
+    };
+    std::map<backtrace, std::map<size_t, int>> data;
+    void count(void **, size_t);
+    static void callback(void *t, void **bt, size_t sz) {
+        static_cast<AllocTrace *>(t)->count(bt, sz);
+    }
+
+ public:
+    void clear() { data.clear(); }
+#if HAVE_LIBGC
+    alloc_trace_cb_t start() { return set_alloc_trace(callback, this); }
+    void stop(alloc_trace_cb_t old) {
+        auto tmp = set_alloc_trace(old);
+        BUG_CHECK(tmp.fn == callback && tmp.arg == this, "AllocTrace stopped when not running");
+    }
+#else
+    alloc_trace_cb_t start() {
+        BUG("Can't trace allocations without garbage collection");
+        return alloc_trace_cb_t{};
+    }
+    void stop(alloc_trace_cb_t) {}
+#endif
+    friend std::ostream &operator<<(std::ostream &, const AllocTrace &);
+};
+
+class PauseTrace {
+#if HAVE_LIBGC
+    alloc_trace_cb_t hold;
+    PauseTrace(const PauseTrace &) = delete;
+
+ public:
+    PauseTrace() { hold = set_alloc_trace(nullptr, nullptr); }
+    ~PauseTrace() { set_alloc_trace(hold); }
+#endif
+};
+
+#endif /* LIB_ALLOC_TRACE_H_ */

--- a/lib/backtrace_exception.h
+++ b/lib/backtrace_exception.h
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef LIB_BACKTRACE_H_
-#define LIB_BACKTRACE_H_
+#ifndef LIB_BACKTRACE_EXCEPTION_H_
+#define LIB_BACKTRACE_EXCEPTION_H_
 
 #include <exception>
 #include <string>
@@ -57,4 +57,4 @@ class backtrace_exception : public E {
     }
 };
 
-#endif /* LIB_BACKTRACE_H_ */
+#endif /* LIB_BACKTRACE_EXCEPTION_H_ */

--- a/lib/gc.h
+++ b/lib/gc.h
@@ -22,4 +22,12 @@ limitations under the License.
 void setup_gc_logging();
 size_t gc_mem_inuse(size_t *max = 0);  // trigger GC, return inuse after
 
+#define ALLOC_TRACE_DEPTH 5
+struct alloc_trace_cb_t {
+    void (*fn)(void *, void **, size_t);
+    void *arg;
+};
+alloc_trace_cb_t set_alloc_trace(alloc_trace_cb_t cb);
+alloc_trace_cb_t set_alloc_trace(void (*fn)(void *, void **, size_t), void *arg);
+
 #endif /* LIB_GC_H_ */


### PR DESCRIPTION
- Memory allocation tracing hooks to track where memory is being allocated and print summary with stack trace of each allocation site.  Used when logging in ComputeWriteSet to understand how/why it is using so much memory.