### PR TITLE
Add P4Tools to the P4C docker image.

### DIFF
--- a/.github/workflows/ci-container-image.yml
+++ b/.github/workflows/ci-container-image.yml
@@ -20,6 +20,8 @@ jobs:
   build:
     if: ${{ github.repository == 'p4lang/p4c' }}
     runs-on: ubuntu-latest
+    env:
+      ENABLE_TEST_TOOLS: ON
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
There is no P4C container yet which contains P4tools. Enable P4Tools for the container build so that we can easily share P4tools docker images. 