### PR TITLE
eBPF backend: generate P4Runtime files if required

### DIFF
--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -73,8 +73,10 @@ void compile(EbpfOptions &options) {
         if (::errorCount() > 0) return;
     }
 
-    P4::serializeP4RuntimeIfRequired(program, options);
-    if (::errorCount() > 0) return;
+    if (!options.arch.isNullOrEmpty() && options.arch != "filter") {
+        P4::serializeP4RuntimeIfRequired(program, options);
+        if (::errorCount() > 0) return;
+    }
 
     EBPF::MidEnd midend;
     midend.addDebugHook(hook);

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include <string>
 
 #include "backends/ebpf/version.h"
+#include "control-plane/p4RuntimeSerializer.h"
 #include "ebpfBackend.h"
 #include "ebpfOptions.h"
 #include "frontends/common/applyOptionsPragmas.h"
@@ -71,6 +72,10 @@ void compile(EbpfOptions &options) {
         program = frontend.run(options, program);
         if (::errorCount() > 0) return;
     }
+
+    P4::serializeP4RuntimeIfRequired(program, options);
+    if (::errorCount() > 0) return;
+
     EBPF::MidEnd midend;
     midend.addDebugHook(hook);
     auto toplevel = midend.run(options, program);

--- a/backends/ebpf/psa/examples/bng.p4info.txt
+++ b/backends/ebpf/psa/examples/bng.p4info.txt
@@ -1,0 +1,634 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44961932
+    name: "ingress.ingress_port_vlan"
+    alias: "ingress_port_vlan"
+  }
+  match_fields {
+    id: 1
+    name: "ig_port"
+    bitwidth: 32
+    match_type: EXACT
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  match_fields {
+    id: 2
+    name: "vlan_id"
+    bitwidth: 12
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 3
+    name: "inner_vlan_id"
+    bitwidth: 12
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 4
+    name: "vlan_is_valid"
+    bitwidth: 1
+    match_type: EXACT
+  }
+  action_refs {
+    id: 28724955
+  }
+  action_refs {
+    id: 22692352
+  }
+  action_refs {
+    id: 17049673
+  }
+  const_default_action_id: 28724955
+  size: 8192
+}
+tables {
+  preamble {
+    id: 48128582
+    name: "ingress.fwd_classifier"
+    alias: "fwd_classifier"
+  }
+  match_fields {
+    id: 1
+    name: "eth_dst"
+    bitwidth: 48
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 2
+    name: "ig_port"
+    bitwidth: 32
+    match_type: EXACT
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  match_fields {
+    id: 3
+    name: "eth_type"
+    bitwidth: 16
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 4
+    name: "ip_eth_type"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  action_refs {
+    id: 17126659
+  }
+  const_default_action_id: 17126659
+  size: 1024
+}
+tables {
+  preamble {
+    id: 39559972
+    name: "ingress.routing_v4"
+    alias: "routing_v4"
+  }
+  match_fields {
+    id: 1
+    name: "ipv4_dst"
+    bitwidth: 32
+    match_type: LPM
+  }
+  action_refs {
+    id: 23773064
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1024
+}
+tables {
+  preamble {
+    id: 46108324
+    name: "ingress.next_vlan"
+    alias: "next_vlan"
+  }
+  match_fields {
+    id: 1
+    name: "egress_port"
+    bitwidth: 32
+    match_type: EXACT
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  action_refs {
+    id: 24264530
+  }
+  action_refs {
+    id: 25482061
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
+    id: 39700076
+    name: "ingress.t_line_map"
+    alias: "t_line_map"
+  }
+  match_fields {
+    id: 1
+    name: "s_tag"
+    bitwidth: 12
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "c_tag"
+    bitwidth: 12
+    match_type: EXACT
+  }
+  action_refs {
+    id: 27019812
+  }
+  const_default_action_id: 27019812
+  size: 8192
+}
+tables {
+  preamble {
+    id: 44043720
+    name: "ingress.t_pppoe_cp"
+    alias: "t_pppoe_cp"
+  }
+  match_fields {
+    id: 1
+    name: "pppoe_code"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  action_refs {
+    id: 24273938
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21257015
+  size: 16
+}
+tables {
+  preamble {
+    id: 44640033
+    name: "ingress.t_pppoe_term_v4"
+    alias: "t_pppoe_term_v4"
+  }
+  match_fields {
+    id: 1
+    name: "line_id"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "ipv4_src"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  match_fields {
+    id: 3
+    name: "pppoe_session_id"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  action_refs {
+    id: 27546548
+  }
+  action_refs {
+    id: 21552277
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 21552277
+  size: 32768
+}
+tables {
+  preamble {
+    id: 35352298
+    name: "ingress.t_line_session_map"
+    alias: "t_line_session_map"
+  }
+  match_fields {
+    id: 1
+    name: "line_id"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  action_refs {
+    id: 23290668
+  }
+  action_refs {
+    id: 33281717
+  }
+  const_default_action_id: 21257015
+  size: 8192
+}
+tables {
+  preamble {
+    id: 43257449
+    name: "ingress.t_qos_v4"
+    alias: "t_qos_v4"
+  }
+  match_fields {
+    id: 1
+    name: "line_id"
+    bitwidth: 32
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 2
+    name: "ipv4_src"
+    bitwidth: 32
+    match_type: LPM
+  }
+  match_fields {
+    id: 3
+    name: "ipv4_dscp"
+    bitwidth: 6
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 4
+    name: "ipv4_ecn"
+    bitwidth: 2
+    match_type: TERNARY
+  }
+  action_refs {
+    id: 25481605
+  }
+  action_refs {
+    id: 23799701
+  }
+  const_default_action_id: 23799701
+  size: 256
+}
+tables {
+  preamble {
+    id: 40343816
+    name: "egress.egress_vlan"
+    alias: "egress_vlan"
+  }
+  match_fields {
+    id: 1
+    name: "vlan_id"
+    bitwidth: 12
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "eg_port"
+    bitwidth: 32
+    match_type: EXACT
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  action_refs {
+    id: 18121475
+  }
+  action_refs {
+    id: 27953516
+  }
+  action_refs {
+    id: 20119496
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 20119496
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 28724955
+    name: "ingress.deny"
+    alias: "deny"
+  }
+}
+actions {
+  preamble {
+    id: 22692352
+    name: "ingress.permit"
+    alias: "permit"
+  }
+  params {
+    id: 1
+    name: "port_type"
+    bitwidth: 2
+  }
+}
+actions {
+  preamble {
+    id: 17049673
+    name: "ingress.permit_with_internal_vlan"
+    alias: "permit_with_internal_vlan"
+  }
+  params {
+    id: 1
+    name: "vlan_id"
+    bitwidth: 12
+  }
+  params {
+    id: 2
+    name: "port_type"
+    bitwidth: 2
+  }
+}
+actions {
+  preamble {
+    id: 17126659
+    name: "ingress.set_forwarding_type"
+    alias: "set_forwarding_type"
+  }
+  params {
+    id: 1
+    name: "fwd_type"
+    bitwidth: 3
+  }
+}
+actions {
+  preamble {
+    id: 23773064
+    name: "ingress.route"
+    alias: "route"
+  }
+  params {
+    id: 1
+    name: "port_num"
+    bitwidth: 32
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  params {
+    id: 2
+    name: "smac"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "dmac"
+    bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 24264530
+    name: "ingress.set_vlan"
+    alias: "set_vlan"
+  }
+  params {
+    id: 1
+    name: "vlan_id"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 25482061
+    name: "ingress.set_double_vlan"
+    alias: "set_double_vlan"
+  }
+  params {
+    id: 1
+    name: "outer_vlan_id"
+    bitwidth: 12
+  }
+  params {
+    id: 2
+    name: "inner_vlan_id"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 27019812
+    name: "ingress.set_line"
+    alias: "set_line"
+  }
+  params {
+    id: 1
+    name: "line_id"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 24273938
+    name: "ingress.punt_to_cpu"
+    alias: "punt_to_cpu"
+  }
+}
+actions {
+  preamble {
+    id: 21552277
+    name: "ingress.term_disabled"
+    alias: "term_disabled"
+  }
+}
+actions {
+  preamble {
+    id: 27546548
+    name: "ingress.term_enabled_v4"
+    alias: "term_enabled_v4"
+  }
+}
+actions {
+  preamble {
+    id: 23290668
+    name: "ingress.set_session"
+    alias: "set_session"
+  }
+  params {
+    id: 1
+    name: "pppoe_session_id"
+    bitwidth: 16
+  }
+}
+actions {
+  preamble {
+    id: 33281717
+    name: "ingress.drop"
+    alias: "ingress.drop"
+  }
+}
+actions {
+  preamble {
+    id: 25481605
+    name: "ingress.qos_prio"
+    alias: "qos_prio"
+  }
+}
+actions {
+  preamble {
+    id: 23799701
+    name: "ingress.qos_besteff"
+    alias: "qos_besteff"
+  }
+}
+actions {
+  preamble {
+    id: 21538986
+    name: "egress_drop"
+    alias: "egress_drop"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 25379917
+    name: "egress.push_outer_vlan"
+    alias: "push_outer_vlan"
+  }
+}
+actions {
+  preamble {
+    id: 31322955
+    name: "egress.push_inner_vlan"
+    alias: "push_inner_vlan"
+  }
+}
+actions {
+  preamble {
+    id: 18121475
+    name: "egress.push_vlan"
+    alias: "push_vlan"
+  }
+}
+actions {
+  preamble {
+    id: 27953516
+    name: "egress.pop_vlan"
+    alias: "pop_vlan"
+  }
+}
+actions {
+  preamble {
+    id: 20119496
+    name: "egress.drop"
+    alias: "egress.drop"
+  }
+}
+actions {
+  preamble {
+    id: 22074232
+    name: "egress.encap_v4"
+    alias: "encap_v4"
+  }
+}
+counters {
+  preamble {
+    id: 311360029
+    name: "ingress.c_line_rx"
+    alias: "c_line_rx"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 8192
+}
+counters {
+  preamble {
+    id: 310227288
+    name: "ingress.c_terminated"
+    alias: "c_terminated"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 8192
+}
+counters {
+  preamble {
+    id: 304818642
+    name: "ingress.c_dropped"
+    alias: "c_dropped"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 8192
+}
+counters {
+  preamble {
+    id: 303724639
+    name: "ingress.c_control"
+    alias: "c_control"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 8192
+}
+counters {
+  preamble {
+    id: 304907518
+    name: "egress.c_line_tx"
+    alias: "c_line_tx"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 8192
+}
+meters {
+  preamble {
+    id: 339043923
+    name: "ingress.m_besteff"
+    alias: "m_besteff"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 8192
+}
+meters {
+  preamble {
+    id: 349736854
+    name: "ingress.m_prio"
+    alias: "m_prio"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 8192
+}
+type_info {
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/backends/ebpf/psa/examples/l2l3-acl.p4
+++ b/backends/ebpf/psa/examples/l2l3-acl.p4
@@ -350,7 +350,7 @@ control egress(inout headers_t headers, inout local_metadata_t local_metadata, i
             mod_vlan;
         }
 
-        psa_direct_counter = { out_pkts };
+        psa_direct_counter = out_pkts;
     }
 
     apply {

--- a/backends/ebpf/psa/examples/l2l3-acl.p4info.txt
+++ b/backends/ebpf/psa/examples/l2l3-acl.p4info.txt
@@ -1,0 +1,409 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 44402382
+    name: "ingress.tbl_ingress_vlan"
+    alias: "tbl_ingress_vlan"
+  }
+  match_fields {
+    id: 1
+    name: "standard_metadata.ingress_port"
+    bitwidth: 32
+    match_type: EXACT
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  match_fields {
+    id: 2
+    name: "headers.vlan_tag.$valid$"
+    bitwidth: 1
+    match_type: EXACT
+  }
+  action_refs {
+    id: 26602363
+  }
+  action_refs {
+    id: 21257015
+  }
+  size: 1024
+}
+tables {
+  preamble {
+    id: 36329505
+    name: "ingress.tbl_mac_learning"
+    alias: "tbl_mac_learning"
+  }
+  match_fields {
+    id: 1
+    name: "headers.ethernet.src_addr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 24963522
+  }
+  action_refs {
+    id: 21257015
+  }
+  const_default_action_id: 24963522
+  size: 1024
+}
+tables {
+  preamble {
+    id: 47124605
+    name: "ingress.tbl_routable"
+    alias: "tbl_routable"
+  }
+  match_fields {
+    id: 1
+    name: "headers.ethernet.dst_addr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "headers.vlan_tag.vlan_id"
+    bitwidth: 12
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  size: 1024
+}
+tables {
+  preamble {
+    id: 36764017
+    name: "ingress.tbl_routing"
+    alias: "tbl_routing"
+  }
+  match_fields {
+    id: 1
+    name: "headers.ipv4.dst_addr"
+    bitwidth: 32
+    match_type: LPM
+  }
+  action_refs {
+    id: 32416464
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  implementation_id: 286177969
+  size: 1024
+}
+tables {
+  preamble {
+    id: 49220983
+    name: "ingress.tbl_switching"
+    alias: "tbl_switching"
+  }
+  match_fields {
+    id: 1
+    name: "headers.ethernet.dst_addr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "headers.vlan_tag.vlan_id"
+    bitwidth: 12
+    match_type: EXACT
+  }
+  action_refs {
+    id: 26512162
+  }
+  action_refs {
+    id: 33500236
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1024
+}
+tables {
+  preamble {
+    id: 41681420
+    name: "ingress.tbl_acl"
+    alias: "tbl_acl"
+  }
+  match_fields {
+    id: 1
+    name: "headers.ipv4.src_addr"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "headers.ipv4.dst_addr"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  match_fields {
+    id: 3
+    name: "headers.ipv4.protocol"
+    bitwidth: 8
+    match_type: EXACT
+  }
+  match_fields {
+    id: 4
+    name: "local_metadata.l4_sport"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  match_fields {
+    id: 5
+    name: "local_metadata.l4_dport"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  action_refs {
+    id: 33281717
+  }
+  action_refs {
+    id: 21257015
+  }
+  const_default_action_id: 21257015
+  size: 1024
+}
+tables {
+  preamble {
+    id: 39854909
+    name: "egress.tbl_vlan_egress"
+    alias: "tbl_vlan_egress"
+  }
+  match_fields {
+    id: 1
+    name: "istd.egress_port"
+    bitwidth: 32
+    match_type: EXACT
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  action_refs {
+    id: 17271484
+  }
+  action_refs {
+    id: 23028825
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  direct_resource_ids: 330499363
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 26602363
+    name: "ingress.push_vlan"
+    alias: "push_vlan"
+  }
+}
+actions {
+  preamble {
+    id: 24963522
+    name: "ingress.mac_learn"
+    alias: "mac_learn"
+  }
+}
+actions {
+  preamble {
+    id: 33281717
+    name: "ingress.drop"
+    alias: "drop"
+  }
+}
+actions {
+  preamble {
+    id: 32416464
+    name: "ingress.set_nexthop"
+    alias: "set_nexthop"
+  }
+  params {
+    id: 1
+    name: "smac"
+    bitwidth: 48
+  }
+  params {
+    id: 2
+    name: "dmac"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "vlan_id"
+    bitwidth: 12
+  }
+}
+actions {
+  preamble {
+    id: 26512162
+    name: "ingress.forward"
+    alias: "forward"
+  }
+  params {
+    id: 1
+    name: "output_port"
+    bitwidth: 32
+    type_name {
+      name: "PortId_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 33500236
+    name: "ingress.broadcast"
+    alias: "broadcast"
+  }
+  params {
+    id: 1
+    name: "grp_id"
+    bitwidth: 32
+    type_name {
+      name: "MulticastGroup_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 21538986
+    name: "egress_drop"
+    alias: "egress_drop"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 17271484
+    name: "egress.strip_vlan"
+    alias: "strip_vlan"
+  }
+}
+actions {
+  preamble {
+    id: 23028825
+    name: "egress.mod_vlan"
+    alias: "mod_vlan"
+  }
+  params {
+    id: 1
+    name: "vlan_id"
+    bitwidth: 12
+  }
+}
+action_profiles {
+  preamble {
+    id: 286177969
+    name: "ingress.as"
+    alias: "as"
+  }
+  table_ids: 36764017
+  with_selector: true
+  size: 1024
+}
+counters {
+  preamble {
+    id: 302795906
+    name: "ingress.in_pkts"
+    alias: "in_pkts"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 100
+}
+direct_counters {
+  preamble {
+    id: 330499363
+    name: "egress.out_pkts"
+    alias: "out_pkts"
+  }
+  spec {
+    unit: BOTH
+  }
+  direct_table_id: 39854909
+}
+digests {
+  preamble {
+    id: 393026453
+    name: "packet_deparser.mac_learn_digest"
+    alias: "mac_learn_digest"
+  }
+  type_spec {
+    struct {
+      name: "mac_learn_digest_t"
+    }
+  }
+}
+type_info {
+  structs {
+    key: "mac_learn_digest_t"
+    value {
+      members {
+        name: "mac_addr"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 48
+            }
+          }
+        }
+      }
+      members {
+        name: "port"
+        type_spec {
+          new_type {
+            name: "PortId_t"
+          }
+        }
+      }
+      members {
+        name: "vlan_id"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 12
+            }
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "MulticastGroup_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/MulticastGroup_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/backends/ebpf/psa/examples/upf.p4info.txt
+++ b/backends/ebpf/psa/examples/upf.p4info.txt
@@ -1,0 +1,441 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 48051950
+    name: "ingress.upf_process_ingress_l4port.ingress_l4_dst_port"
+    alias: "ingress_l4_dst_port"
+  }
+  match_fields {
+    id: 1
+    name: "meta.upf.l4_dport"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  action_refs {
+    id: 28485346
+  }
+  action_refs {
+    id: 19834885
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 512
+}
+tables {
+  preamble {
+    id: 44346287
+    name: "ingress.upf_process_ingress_l4port.ingress_l4_src_port"
+    alias: "ingress_l4_src_port"
+  }
+  match_fields {
+    id: 1
+    name: "meta.upf.l4_sport"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  action_refs {
+    id: 28485346
+  }
+  action_refs {
+    id: 23129627
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 512
+}
+tables {
+  preamble {
+    id: 41287617
+    name: "ingress.upf_process_ingress_l4port.ingress_l4port_fields"
+    alias: "ingress_l4port_fields"
+  }
+  match_fields {
+    id: 1
+    name: "hdr.tcp.$valid$"
+    bitwidth: 1
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "hdr.udp.$valid$"
+    bitwidth: 1
+    match_type: EXACT
+  }
+  action_refs {
+    id: 28485346
+  }
+  action_refs {
+    id: 29310518
+  }
+  action_refs {
+    id: 29396459
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  size: 1024
+  is_const_table: true
+  has_initial_entries: true
+}
+tables {
+  preamble {
+    id: 34340350
+    name: "ingress.upf_ingress.source_interface_lookup_by_port"
+    alias: "source_interface_lookup_by_port"
+  }
+  match_fields {
+    id: 1
+    name: "istd.ingress_port"
+    bitwidth: 32
+    match_type: EXACT
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  action_refs {
+    id: 25125189
+  }
+  action_refs {
+    id: 28485346
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 28485346
+  size: 1024
+}
+tables {
+  preamble {
+    id: 42859075
+    name: "ingress.upf_ingress.session_lookup_by_ue_ip"
+    alias: "session_lookup_by_ue_ip"
+  }
+  match_fields {
+    id: 1
+    name: "ipv4_dst"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21356685
+  }
+  action_refs {
+    id: 28485346
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 28485346
+  size: 1024
+}
+tables {
+  preamble {
+    id: 44952065
+    name: "ingress.upf_ingress.session_lookup_by_teid"
+    alias: "session_lookup_by_teid"
+  }
+  match_fields {
+    id: 1
+    name: "gtpu.teid"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21356685
+  }
+  action_refs {
+    id: 28485346
+  }
+  const_default_action_id: 28485346
+  size: 1024
+}
+tables {
+  preamble {
+    id: 44930716
+    name: "ingress.upf_ingress.pdr_lookup"
+    alias: "pdr_lookup"
+  }
+  match_fields {
+    id: 1
+    name: "meta.upf.seid"
+    bitwidth: 64
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "ipv4.srcAddr"
+    bitwidth: 32
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 3
+    name: "ipv4.dstAddr"
+    bitwidth: 32
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 4
+    name: "ipv4.protocol"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 5
+    name: "meta.upf.src_port_range_id"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 6
+    name: "meta.upf.dst_port_range_id"
+    bitwidth: 8
+    match_type: TERNARY
+  }
+  match_fields {
+    id: 7
+    name: "meta.upf.src"
+    bitwidth: 4
+    match_type: EXACT
+  }
+  action_refs {
+    id: 27855505
+  }
+  action_refs {
+    id: 19604500
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  const_default_action_id: 19604500
+  size: 1024
+}
+tables {
+  preamble {
+    id: 49311877
+    name: "ingress.upf_ingress.far_lookup"
+    alias: "far_lookup"
+  }
+  match_fields {
+    id: 1
+    name: "meta.upf.far_id"
+    bitwidth: 32
+    match_type: EXACT
+  }
+  action_refs {
+    id: 22392182
+  }
+  action_refs {
+    id: 21059050
+  }
+  action_refs {
+    id: 19604500
+  }
+  const_default_action_id: 19604500
+  size: 1024
+}
+tables {
+  preamble {
+    id: 50204833
+    name: "ingress.ip_forward.ipv4_lpm"
+    alias: "ipv4_lpm"
+  }
+  match_fields {
+    id: 1
+    name: "meta.upf.dest"
+    bitwidth: 4
+    match_type: EXACT
+  }
+  match_fields {
+    id: 2
+    name: "meta.upf.outer_dst_addr"
+    bitwidth: 32
+    match_type: LPM
+  }
+  action_refs {
+    id: 29826784
+  }
+  action_refs {
+    id: 23916784
+  }
+  const_default_action_id: 23916784
+  size: 1024
+}
+actions {
+  preamble {
+    id: 28485346
+    name: "nop"
+    alias: "nop"
+  }
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 30788783
+    name: "ingress_drop"
+    alias: "ingress_drop"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 19834885
+    name: "ingress.upf_process_ingress_l4port.set_ingress_dst_port_range_id"
+    alias: "set_ingress_dst_port_range_id"
+  }
+  params {
+    id: 1
+    name: "range_id"
+    bitwidth: 8
+  }
+}
+actions {
+  preamble {
+    id: 23129627
+    name: "ingress.upf_process_ingress_l4port.set_ingress_src_port_range_id"
+    alias: "set_ingress_src_port_range_id"
+  }
+  params {
+    id: 1
+    name: "range_id"
+    bitwidth: 8
+  }
+}
+actions {
+  preamble {
+    id: 19604500
+    name: "ingress.upf_ingress.drop"
+    alias: "upf_ingress.drop"
+  }
+}
+actions {
+  preamble {
+    id: 21356685
+    name: "ingress.upf_ingress.set_seid"
+    alias: "set_seid"
+  }
+  params {
+    id: 1
+    name: "seid"
+    bitwidth: 64
+  }
+}
+actions {
+  preamble {
+    id: 27855505
+    name: "ingress.upf_ingress.set_far_id"
+    alias: "set_far_id"
+  }
+  params {
+    id: 1
+    name: "far_id"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 21059050
+    name: "ingress.upf_ingress.far_encap_forward"
+    alias: "far_encap_forward"
+  }
+  params {
+    id: 1
+    name: "dest"
+    bitwidth: 4
+  }
+  params {
+    id: 2
+    name: "teid"
+    bitwidth: 32
+  }
+  params {
+    id: 3
+    name: "gtpu_remote_ip"
+    bitwidth: 32
+  }
+  params {
+    id: 4
+    name: "gtpu_local_ip"
+    bitwidth: 32
+  }
+}
+actions {
+  preamble {
+    id: 22392182
+    name: "ingress.upf_ingress.far_forward"
+    alias: "far_forward"
+  }
+  params {
+    id: 1
+    name: "dest"
+    bitwidth: 4
+  }
+}
+actions {
+  preamble {
+    id: 25125189
+    name: "ingress.upf_ingress.set_source_interface"
+    alias: "set_source_interface"
+  }
+  params {
+    id: 1
+    name: "src"
+    bitwidth: 4
+  }
+}
+actions {
+  preamble {
+    id: 23916784
+    name: "ingress.ip_forward.drop"
+    alias: "ip_forward.drop"
+  }
+}
+actions {
+  preamble {
+    id: 29826784
+    name: "ingress.ip_forward.forward"
+    alias: "forward"
+  }
+  params {
+    id: 1
+    name: "srcAddr"
+    bitwidth: 48
+  }
+  params {
+    id: 2
+    name: "dstAddr"
+    bitwidth: 48
+  }
+  params {
+    id: 3
+    name: "port"
+    bitwidth: 32
+    type_name {
+      name: "PortId_t"
+    }
+  }
+}
+type_info {
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/backends/ebpf/tests/p4testdata/action-profile2.p4info.txt
+++ b/backends/ebpf/tests/p4testdata/action-profile2.p4info.txt
@@ -1,0 +1,103 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 39967501
+    name: "MyIC.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "a.eth.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 21832421
+  }
+  action_refs {
+    id: 23466264
+  }
+  implementation_id: 298015716
+  size: 1024
+}
+tables {
+  preamble {
+    id: 47318070
+    name: "MyIC.tbl2"
+    alias: "tbl2"
+  }
+  match_fields {
+    id: 1
+    name: "a.eth.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 21832421
+  }
+  action_refs {
+    id: 23466264
+  }
+  implementation_id: 298015716
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 27646489
+    name: "send_to_port"
+    alias: "send_to_port"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 21832421
+    name: "MyIC.a1"
+    alias: "a1"
+  }
+  params {
+    id: 1
+    name: "param"
+    bitwidth: 48
+  }
+}
+actions {
+  preamble {
+    id: 23466264
+    name: "MyIC.a2"
+    alias: "a2"
+  }
+  params {
+    id: 1
+    name: "param"
+    bitwidth: 16
+  }
+}
+action_profiles {
+  preamble {
+    id: 298015716
+    name: "MyIC.ap"
+    alias: "ap"
+  }
+  table_ids: 39967501
+  table_ids: 47318070
+  size: 1024
+}
+type_info {
+}

--- a/backends/ebpf/tests/p4testdata/action-selector2.p4info.txt
+++ b/backends/ebpf/tests/p4testdata/action-selector2.p4info.txt
@@ -1,0 +1,90 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 39967501
+    name: "MyIC.tbl"
+    alias: "tbl"
+  }
+  match_fields {
+    id: 1
+    name: "a.eth.srcAddr"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 30183046
+  }
+  implementation_id: 294316857
+  size: 1024
+}
+tables {
+  preamble {
+    id: 47318070
+    name: "MyIC.tbl2"
+    alias: "tbl2"
+  }
+  match_fields {
+    id: 1
+    name: "a.eth.etherType"
+    bitwidth: 16
+    match_type: EXACT
+  }
+  action_refs {
+    id: 21257015
+  }
+  action_refs {
+    id: 30183046
+  }
+  implementation_id: 294316857
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 30183046
+    name: "MyIC.fwd"
+    alias: "fwd"
+  }
+  params {
+    id: 1
+    name: "port"
+    bitwidth: 32
+    type_name {
+      name: "PortId_t"
+    }
+  }
+}
+action_profiles {
+  preamble {
+    id: 294316857
+    name: "MyIC.as"
+    alias: "as"
+  }
+  table_ids: 39967501
+  table_ids: 47318070
+  with_selector: true
+  size: 1024
+}
+type_info {
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/backends/ebpf/tests/p4testdata/counters.p4info.txt
+++ b/backends/ebpf/tests/p4testdata/counters.p4info.txt
@@ -1,0 +1,122 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 37391034
+    name: "ingress.tbl_fwd"
+    alias: "tbl_fwd"
+  }
+  match_fields {
+    id: 1
+    name: "istd.ingress_port"
+    bitwidth: 32
+    match_type: EXACT
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  action_refs {
+    id: 30696436
+  }
+  action_refs {
+    id: 17328525
+  }
+  action_refs {
+    id: 21257015
+  }
+  size: 100
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 30696436
+    name: "ingress.do_forward"
+    alias: "do_forward"
+  }
+  params {
+    id: 1
+    name: "egress_port"
+    bitwidth: 32
+    type_name {
+      name: "PortId_t"
+    }
+  }
+}
+actions {
+  preamble {
+    id: 17328525
+    name: "ingress.do_forward_2"
+    alias: "do_forward_2"
+  }
+  params {
+    id: 1
+    name: "egress_port"
+    bitwidth: 32
+    type_name {
+      name: "PortId_t"
+    }
+  }
+}
+counters {
+  preamble {
+    id: 302841553
+    name: "ingress.test1_cnt"
+    alias: "test1_cnt"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 308452316
+    name: "ingress.test2_cnt"
+    alias: "test2_cnt"
+  }
+  spec {
+    unit: PACKETS
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 310846522
+    name: "ingress.test3_cnt"
+    alias: "test3_cnt"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+counters {
+  preamble {
+    id: 304574509
+    name: "ingress.action_cnt"
+    alias: "action_cnt"
+  }
+  spec {
+    unit: BOTH
+  }
+  size: 1024
+}
+type_info {
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/backends/ebpf/tests/p4testdata/digest.p4info.txt
+++ b/backends/ebpf/tests/p4testdata/digest.p4info.txt
@@ -1,0 +1,49 @@
+pkg_info {
+  arch: "psa"
+}
+digests {
+  preamble {
+    id: 401112174
+    name: "IngressDeparserImpl.mac_learn_digest"
+    alias: "mac_learn_digest"
+  }
+  type_spec {
+    struct {
+      name: "mac_learn_digest_t"
+    }
+  }
+}
+type_info {
+  structs {
+    key: "mac_learn_digest_t"
+    value {
+      members {
+        name: "srcAddr"
+        type_spec {
+          bitstring {
+            bit {
+              bitwidth: 48
+            }
+          }
+        }
+      }
+      members {
+        name: "ingress_port"
+        type_spec {
+          new_type {
+            name: "PortId_t"
+          }
+        }
+      }
+    }
+  }
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/backends/ebpf/tests/p4testdata/meters-direct.p4info.txt
+++ b/backends/ebpf/tests/p4testdata/meters-direct.p4info.txt
@@ -1,0 +1,72 @@
+pkg_info {
+  arch: "psa"
+}
+tables {
+  preamble {
+    id: 37391034
+    name: "ingress.tbl_fwd"
+    alias: "tbl_fwd"
+  }
+  match_fields {
+    id: 1
+    name: "istd.ingress_port"
+    bitwidth: 32
+    match_type: EXACT
+    type_name {
+      name: "PortId_t"
+    }
+  }
+  action_refs {
+    id: 30696436
+  }
+  action_refs {
+    id: 21257015
+  }
+  direct_resource_ids: 358755246
+  size: 100
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 30696436
+    name: "ingress.do_forward"
+    alias: "do_forward"
+  }
+  params {
+    id: 1
+    name: "egress_port"
+    bitwidth: 32
+    type_name {
+      name: "PortId_t"
+    }
+  }
+}
+direct_meters {
+  preamble {
+    id: 358755246
+    name: "ingress.meter1"
+    alias: "meter1"
+  }
+  spec {
+    unit: BYTES
+  }
+  direct_table_id: 37391034
+}
+type_info {
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/backends/ebpf/tests/p4testdata/meters.p4info.txt
+++ b/backends/ebpf/tests/p4testdata/meters.p4info.txt
@@ -1,0 +1,32 @@
+pkg_info {
+  arch: "psa"
+}
+actions {
+  preamble {
+    id: 27646489
+    name: "send_to_port"
+    alias: "send_to_port"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 30788783
+    name: "ingress_drop"
+    alias: "ingress_drop"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+meters {
+  preamble {
+    id: 341978030
+    name: "ingress.meter1"
+    alias: "meter1"
+  }
+  spec {
+    unit: BYTES
+  }
+  size: 1
+}
+type_info {
+}

--- a/backends/ebpf/tests/p4testdata/pvs.p4info.txt
+++ b/backends/ebpf/tests/p4testdata/pvs.p4info.txt
@@ -1,0 +1,16 @@
+pkg_info {
+  arch: "psa"
+}
+value_sets {
+  preamble {
+    id: 54519382
+    name: "IngressParserImpl.pvs"
+    alias: "pvs"
+  }
+  match {
+    id: 1
+    bitwidth: 32
+    match_type: EXACT
+  }
+  size: 4
+}

--- a/backends/ebpf/tests/p4testdata/register-apply.p4info.txt
+++ b/backends/ebpf/tests/p4testdata/register-apply.p4info.txt
@@ -1,0 +1,32 @@
+pkg_info {
+  arch: "psa"
+}
+registers {
+  preamble {
+    id: 382856063
+    name: "ingress.reg"
+    alias: "reg"
+  }
+  type_spec {
+    bitstring {
+      bit {
+        bitwidth: 32
+      }
+    }
+  }
+  size: 10
+  index_type_name {
+    name: "PortId_t"
+  }
+}
+type_info {
+  new_types {
+    key: "PortId_t"
+    value {
+      translated_type {
+        uri: "p4.org/psa/v1/PortId_t"
+        sdn_bitwidth: 32
+      }
+    }
+  }
+}

--- a/backends/ebpf/tests/ptf/bng.py
+++ b/backends/ebpf/tests/ptf/bng.py
@@ -118,6 +118,7 @@ def pkt_decrement_ttl(pkt):
 
 class BNGTest(P4EbpfTest):
     p4_file_path = "../psa/examples/bng.p4"
+    p4info_reference_file_path = "../psa/examples/bng.p4info.txt"
     session_installed = False
 
     def setUp(self):

--- a/backends/ebpf/tests/ptf/common.py
+++ b/backends/ebpf/tests/ptf/common.py
@@ -80,6 +80,7 @@ class P4EbpfTest(BaseTest):
     switch_ns = "test"
     p4_file_path = ""
     p4c_additional_args = ""
+    p4info_reference_file_path = ""
 
     def setUp(self):
         super(P4EbpfTest, self).setUp()
@@ -128,6 +129,10 @@ class P4EbpfTest(BaseTest):
         if self.is_xdp_test():
             p4args += " --xdp"
 
+        if self.p4info_reference_file_path:
+            self.p4info_p4c_generated = os.path.join("ptf_out", filename + ".p4info.txt")
+            p4args += " --p4runtime-files {}".format(self.p4info_p4c_generated)
+
         p4args = p4args + " " + self.p4c_additional_args
 
         logger.info("P4ARGS=" + p4args)
@@ -143,6 +148,16 @@ class P4EbpfTest(BaseTest):
             ),
             "Compilation error",
         )
+
+        if self.p4info_reference_file_path:
+            self.exec_cmd(
+                "diff -B -u -w {expected} {produced}".format(
+                    expected=self.p4info_reference_file_path,
+                    produced=self.p4info_p4c_generated,
+                ),
+                "Compiler produced incorrect P4info file",
+            )
+            logger.info("Generated P4info file is correct")
 
         self.dataplane = ptf.dataplane_instance
         self.dataplane.flush()

--- a/backends/ebpf/tests/ptf/l2l3_acl.py
+++ b/backends/ebpf/tests/ptf/l2l3_acl.py
@@ -38,6 +38,7 @@ def pkt_add_vlan(pkt, vlan_vid=10, vlan_pcp=0, dl_vlan_cfi=0):
 
 class L2L3SwitchTest(P4EbpfTest):
     p4_file_path = "../psa/examples/l2l3-acl.p4"
+    p4info_reference_file_path = "../psa/examples/l2l3-acl.p4info.txt"
 
     def configure_port(self, port_id, vlan_id=None):
         if vlan_id is None:

--- a/backends/ebpf/tests/ptf/meters.py
+++ b/backends/ebpf/tests/ptf/meters.py
@@ -123,6 +123,7 @@ class MeterPSATest(P4EbpfTest):
     """
 
     p4_file_path = "p4testdata/meters.p4"
+    p4info_reference_file_path = "p4testdata/meters.p4info.txt"
 
     def runTest(self):
         pkt = testutils.simple_ip_packet()
@@ -236,6 +237,7 @@ class DirectMeterPSATest(P4EbpfTest):
     """
 
     p4_file_path = "p4testdata/meters-direct.p4"
+    p4info_reference_file_path = "p4testdata/meters-direct.p4info.txt"
 
     def runTest(self):
         pkt = testutils.simple_ip_packet()

--- a/backends/ebpf/tests/ptf/register.py
+++ b/backends/ebpf/tests/ptf/register.py
@@ -66,6 +66,7 @@ class RegisterApplyPSATest(P4EbpfTest):
     """
 
     p4_file_path = "p4testdata/register-apply.p4"
+    p4info_reference_file_path = "p4testdata/register-apply.p4info.txt"
 
     def runTest(self):
         pkt = testutils.simple_ip_packet()

--- a/backends/ebpf/tests/ptf/table_implementation.py
+++ b/backends/ebpf/tests/ptf/table_implementation.py
@@ -54,6 +54,7 @@ class ActionProfileTwoTablesSameInstancePSATest(P4EbpfTest):
     """
 
     p4_file_path = "p4testdata/action-profile2.p4"
+    p4info_reference_file_path = "p4testdata/action-profile2.p4info.txt"
 
     def runTest(self):
         ref = self.action_profile_add_action(ap="MyIC_ap", action=2, data=[0x1122])
@@ -235,6 +236,7 @@ class ActionSelectorTwoTablesSameInstancePSATest(ActionSelectorTest):
     """
 
     p4_file_path = "p4testdata/action-selector2.p4"
+    p4info_reference_file_path = "p4testdata/action-selector2.p4info.txt"
 
     def runTest(self):
         self.create_default_rule_set(table="MyIC_tbl", selector="MyIC_as")

--- a/backends/ebpf/tests/ptf/test.py
+++ b/backends/ebpf/tests/ptf/test.py
@@ -366,6 +366,7 @@ class PacketInAdvancePSATest(P4EbpfTest):
 
 class DigestPSATest(P4EbpfTest):
     p4_file_path = "p4testdata/digest.p4"
+    p4info_reference_file_path = "p4testdata/digest.p4info.txt"
 
     def runTest(self):
         pkt = testutils.simple_ip_packet(eth_src="fa:fb:fc:fd:fe:f0")
@@ -408,6 +409,7 @@ class WideFieldDigest(P4EbpfTest):
 
 class CountersPSATest(P4EbpfTest):
     p4_file_path = "p4testdata/counters.p4"
+    p4info_reference_file_path = "p4testdata/counters.p4info.txt"
 
     def runTest(self):
         pkt = testutils.simple_ip_packet(
@@ -479,6 +481,7 @@ class ParserValueSetPSATest(P4EbpfTest):
     """
 
     p4_file_path = "p4testdata/pvs.p4"
+    p4info_reference_file_path = "p4testdata/pvs.p4info.txt"
 
     def runTest(self):
         pkt = testutils.simple_udp_packet(ip_dst="10.0.0.1", udp_dport=80)

--- a/backends/ebpf/tests/ptf/upf.py
+++ b/backends/ebpf/tests/ptf/upf.py
@@ -79,6 +79,7 @@ def pkt_route(pkt, mac_src, mac_dst):
 
 class UPFTest(P4EbpfTest):
     p4_file_path = "../psa/examples/upf.p4"
+    p4info_reference_file_path = "../psa/examples/upf.p4info.txt"
 
     def setup_pfcp_session(self, seid, teid, ue_ip):
         self.table_add(


### PR DESCRIPTION
Allow to generate P4Runtime files by ebpf backend, because options related to them are ignored.

Supports only PSA architecture. For ebpf filer model options for generating P4info files are (still) ignored.