### PR TITLE
Migrate Automatic Exec Groups by adding a toolchain parameter to the affected actions

### DIFF
--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -1,6 +1,6 @@
 """P4 compilation rule."""
 
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "CPP_TOOLCHAIN_TYPE", "find_cpp_toolchain", "use_cpp_toolchain")
 
 def _extract_common_p4c_args(ctx):
     """Extract common arguments for p4c build rules."""
@@ -54,6 +54,7 @@ def _run_shell_cmd_with_p4c(ctx, command, **run_shell_kwargs):
             transitive = [cpp_toolchain.all_files],
         ),
         use_default_shell_env = True,
+        toolchain = CPP_TOOLCHAIN_TYPE,
         **run_shell_kwargs
     )
 


### PR DESCRIPTION
This is a step forward for the full migration of Automatic Exec Groups (AEGs). This change will be effective once AEGs are enabled.

Goal of this migration:
* Each toolchain type should have its own execution platform. Before this change, the execution platform was selected on a rule base, not on a toolchain type base.
* Each action which uses a tool coming from a toolchain should specify the toolchain type inside ctx.action.{run, run_shell} toolchain attribute.

The affected action uses tools from cpp toolchain. Hence, cpp toolchain is added to the `toolchain` param.