### PR TITLE
Remove P4Testgen codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# The P4Tools repository is owned by the following maintainers.
-backends/p4tools @fruffy @pkotikal @jnfoster
-


### PR DESCRIPTION
The way code owners is currently implemented generates a lot of unnecessary spam. Also, we do not have the resources to review all PRs, so instead we delegate to general approval. 