### PR TITLE
Allow unknown fields when parsing P4Info files

### DIFF
--- a/backends/bmv2/base_test.py
+++ b/backends/bmv2/base_test.py
@@ -219,8 +219,7 @@ class P4RuntimeTest(BaseTest):
         testutils.log.info(f"Reading p4info from {proto_txt_path}")
         self.p4info = p4info_pb2.P4Info()
         with open(proto_txt_path, "rb") as fin:
-            google.protobuf.text_format.Merge(fin.read(), self.p4info,
-                                              allow_unknown_field=True)
+            google.protobuf.text_format.Merge(fin.read(), self.p4info, allow_unknown_field=True)
 
         self.import_p4info_names()
 
@@ -248,8 +247,7 @@ class P4RuntimeTest(BaseTest):
         # config.p4info = self.p4info
         proto_txt_path = ptfutils.test_param_get("p4info")
         with open(proto_txt_path, "r", encoding="utf-8") as fin:
-            google.protobuf.text_format.Merge(fin.read(), config.p4info,
-                                              allow_unknown_field=True)
+            google.protobuf.text_format.Merge(fin.read(), config.p4info, allow_unknown_field=True)
         config_path = ptfutils.test_param_get("config")
         testutils.log.info(f"Reading config (compiled P4 program) from {config_path}")
         with open(config_path, "rb") as config_f:
@@ -1121,8 +1119,7 @@ def update_config(config_path, p4info_path, grpc_addr, device_id):
     request.device_id = device_id
     config = request.config
     with open(p4info_path, "r", encoding="utf-8") as p4info_f:
-        google.protobuf.text_format.Merge(p4info_f.read(), config.p4info,
-                                          allow_unknown_field=True)
+        google.protobuf.text_format.Merge(p4info_f.read(), config.p4info, allow_unknown_field=True)
     with open(config_path, "rb") as config_f:
         config.p4_device_config = config_f.read()
     request.action = p4runtime_pb2.SetForwardingPipelineConfigRequest.VERIFY_AND_COMMIT

--- a/backends/bmv2/base_test.py
+++ b/backends/bmv2/base_test.py
@@ -219,7 +219,8 @@ class P4RuntimeTest(BaseTest):
         testutils.log.info(f"Reading p4info from {proto_txt_path}")
         self.p4info = p4info_pb2.P4Info()
         with open(proto_txt_path, "rb") as fin:
-            google.protobuf.text_format.Merge(fin.read(), self.p4info)
+            google.protobuf.text_format.Merge(fin.read(), self.p4info,
+                                              allow_unknown_field=True)
 
         self.import_p4info_names()
 
@@ -247,7 +248,8 @@ class P4RuntimeTest(BaseTest):
         # config.p4info = self.p4info
         proto_txt_path = ptfutils.test_param_get("p4info")
         with open(proto_txt_path, "r", encoding="utf-8") as fin:
-            google.protobuf.text_format.Merge(fin.read(), config.p4info)
+            google.protobuf.text_format.Merge(fin.read(), config.p4info,
+                                              allow_unknown_field=True)
         config_path = ptfutils.test_param_get("config")
         testutils.log.info(f"Reading config (compiled P4 program) from {config_path}")
         with open(config_path, "rb") as config_f:
@@ -1119,7 +1121,8 @@ def update_config(config_path, p4info_path, grpc_addr, device_id):
     request.device_id = device_id
     config = request.config
     with open(p4info_path, "r", encoding="utf-8") as p4info_f:
-        google.protobuf.text_format.Merge(p4info_f.read(), config.p4info)
+        google.protobuf.text_format.Merge(p4info_f.read(), config.p4info,
+                                          allow_unknown_field=True)
     with open(config_path, "rb") as config_f:
         config.p4_device_config = config_f.read()
     request.action = p4runtime_pb2.SetForwardingPipelineConfigRequest.VERIFY_AND_COMMIT


### PR DESCRIPTION
For example, recently the field has_initial_entries was added to P4Info messages in the p4c implementation of generating P4Info files. However, if someone is testing with a version of behavioral-model built from a p4lang/PI version that has not been updated yet, then without the changes in this PR, the Merge() calls will fail if they see such an unknown message field.  With these changes, they will silently allow such unknown fields.