### PR TITLE
README: add a couple packages required for passing tests on Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Most dependencies can be installed using `apt-get install`:
 sudo apt-get install cmake g++ git automake libtool libgc-dev bison flex \
 libfl-dev libboost-dev libboost-iostreams-dev \
 libboost-graph-dev llvm pkg-config python3 python3-pip \
-tcpdump
+tcpdump libpcap-dev gcc-multilib
 
 pip3 install --user -r requirements.txt
 ```


### PR DESCRIPTION
Although compilation succeeds without these packages, some of the ebpf/ubpf tests run by `make check` will non-obviously fail due to missing C header files. Installing these 2 packages fixes that. Tested on a fresh Ubuntu 20.04 installation.