### PR TITLE
backends/ebpf: Fix #4098 by renaming conflicting write_partial macro.

### DIFF
--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -191,7 +191,7 @@ void ControlBodyTranslator::compileEmitField(const IR::Expression *expr, cstring
             builder->appendFormat("write_byte(%s, BYTES(%s) + %d, (%s) << %d)",
                                   program->packetStartVar.c_str(), program->offsetVar.c_str(), i,
                                   program->byteVar.c_str(), 8 - bitsToWrite);
-        else
+        else  // FIXME change to use write_partial_ex
             builder->appendFormat("write_partial(%s + BYTES(%s) + %d, %d, (%s) << %d)",
                                   program->packetStartVar.c_str(), program->offsetVar.c_str(), i,
                                   alignment, program->byteVar.c_str(), 8 - bitsToWrite);

--- a/backends/ebpf/ebpfDeparser.cpp
+++ b/backends/ebpf/ebpfDeparser.cpp
@@ -247,7 +247,7 @@ void DeparserHdrEmitTranslator::emitField(CodeBuilder *builder, cstring field,
                                   program->byteVar.c_str());
         } else {  // write partial
             shift = (8 - alignment - bitsToWrite);
-            builder->appendFormat("write_partial(%s + BYTES(%s) + %d, %d, %d, (%s >> %d))",
+            builder->appendFormat("write_partial_ex(%s + BYTES(%s) + %d, %d, %d, (%s >> %d))",
                                   program->packetStartVar.c_str(), program->offsetVar.c_str(),
                                   i,  // do not reverse byte order
                                   bitsToWrite, shift, program->byteVar.c_str(),
@@ -266,7 +266,7 @@ void DeparserHdrEmitTranslator::emitField(CodeBuilder *builder, cstring field,
                                       i,  // do not reverse byte order
                                       program->byteVar.c_str(), 8 - alignment % 8);
             } else {
-                builder->appendFormat("write_partial(%s + BYTES(%s) + %d + 1, %d, %d, (%s))",
+                builder->appendFormat("write_partial_ex(%s + BYTES(%s) + %d + 1, %d, %d, (%s))",
                                       program->packetStartVar.c_str(), program->offsetVar.c_str(),
                                       i,  // do not reverse byte order
                                       bitsToWrite, 8 + alignment - bitsToWrite,

--- a/backends/ebpf/ebpfProgram.h
+++ b/backends/ebpf/ebpfProgram.h
@@ -90,6 +90,7 @@ class EBPFProgram : public EBPFObject {
     virtual void emitPipeline(CodeBuilder *builder);
 
  public:
+    virtual void emitCommonPreamble(CodeBuilder *builder);
     virtual void emitGeneratedComment(CodeBuilder *builder);
     virtual void emitH(CodeBuilder *builder, cstring headerFile);  // emits C headers
     virtual void emitC(CodeBuilder *builder, cstring headerFile);  // emits C program

--- a/backends/ebpf/psa/ebpfPsaGen.cpp
+++ b/backends/ebpf/psa/ebpfPsaGen.cpp
@@ -87,16 +87,7 @@ void PSAEbpfGenerator::emitPreamble(CodeBuilder *builder) const {
 }
 
 void PSAEbpfGenerator::emitCommonPreamble(CodeBuilder *builder) const {
-    builder->newline();
-    builder->appendLine("#define EBPF_MASK(t, w) ((((t)(1)) << (w)) - (t)1)");
-    builder->appendLine("#define BYTES(w) ((w) / 8)");
-    builder->appendLine(
-        "#define write_partial(a, w, s, v) do { *((u8*)a) = ((*((u8*)a)) "
-        "& ~(EBPF_MASK(u8, w) << s)) | (v << s) ; } while (0)");
-    builder->appendLine(
-        "#define write_byte(base, offset, v) do { "
-        "*(u8*)((base) + (offset)) = (v); "
-        "} while (0)");
+    ingress->emitCommonPreamble(builder);  // from ebpfProgram
     builder->target->emitPreamble(builder);
 }
 


### PR DESCRIPTION
As mentioned in the issue, we have conflicting versions of this macro. This patch avoids the issue by renaming the second version.

In an ideal world, all call sites would make use of the second, more general version. But that felt like too invasive a change, so instead I went for a minimalist approach.

The issue never arose before, because the only flow which made use of `ebpfDeparser` was within the PSA target.