### PR TITLE
Hashvec-based maps to save memory

### DIFF
--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -23,7 +23,7 @@ limitations under the License.
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
 #include "lib/alloc_trace.h"
-#include "lib/ordered_map.h"
+#include "lib/hvec_map.h"
 #include "lib/ordered_set.h"
 
 namespace P4 {
@@ -93,7 +93,7 @@ class BaseLocation : public StorageLocation {
 /// Base class for location sets that contain fields
 class WithFieldsLocation : public StorageLocation {
  protected:
-    ordered_map<cstring, const StorageLocation *> fieldLocations;
+    hvec_map<cstring, const StorageLocation *> fieldLocations;
     friend class StorageFactory;
     WithFieldsLocation(const IR::Type *type, cstring name) : StorageLocation(type, name) {}
 
@@ -105,7 +105,7 @@ class WithFieldsLocation : public StorageLocation {
     void replaceField(cstring field, StorageLocation *replacement) {
         fieldLocations[field] = replacement;
     }
-    IterValues<ordered_map<cstring, const StorageLocation *>::const_iterator> fields() const {
+    IterValues<hvec_map<cstring, const StorageLocation *>::const_iterator> fields() const {
         return Values(fieldLocations);
     }
     void dbprint(std::ostream &out) const override {
@@ -232,7 +232,7 @@ class LocationSet : public IHasDbPrint {
 /// Maps a declaration to its associated storage.
 class StorageMap : public IHasDbPrint {
     /// Storage location for each declaration.
-    ordered_map<const IR::IDeclaration *, StorageLocation *> storage;
+    hvec_map<const IR::IDeclaration *, StorageLocation *> storage;
     StorageFactory factory;
 
  public:
@@ -357,7 +357,7 @@ class ProgramPoints : public IHasDbPrint {
 class Definitions : public IHasDbPrint {
     /// Set of program points that have written last to each location
     /// (conservative approximation).
-    ordered_map<const BaseLocation *, const ProgramPoints *> definitions;
+    hvec_map<const BaseLocation *, const ProgramPoints *> definitions;
     /// If true the current program point is actually unreachable.
     bool unreachable = false;
 
@@ -413,7 +413,7 @@ class AllDefinitions : public IHasDbPrint {
     /// However, for ProgramPoints representing P4Control, P4Action,
     /// P4Table, P4Function -- the definitions are BEFORE the
     /// ProgramPoint.
-    std::unordered_map<ProgramPoint, Definitions *> atPoint;
+    hvec_map<ProgramPoint, Definitions *> atPoint;
 
  public:
     StorageMap *storageMap;
@@ -469,7 +469,7 @@ class ComputeWriteSet : public Inspector, public IHasDbPrint {
     /// if true we are processing an expression on the lhs of an assignment
     bool lhs;
     /// For each expression the location set it writes
-    ordered_map<const IR::Expression *, const LocationSet *> writes;
+    hvec_map<const IR::Expression *, const LocationSet *> writes;
     bool virtualMethod;  /// True if we are analyzing a virtual method
     AllocTrace memuse;
     alloc_trace_cb_t nested_trace;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -25,6 +25,7 @@ set (LIBP4CTOOLKIT_SRCS
     gc.cpp
     big_int_util.cpp
     hash.cpp
+    hashvec.cpp
     hex.cpp
     indent.cpp
     json.cpp
@@ -59,7 +60,9 @@ set (LIBP4CTOOLKIT_HDRS
     gc.h
     big_int_util.h
     hash.h
+    hashvec.h
     hex.h
+    hvec_map.h
     indent.h
     json.h
     log.h

--- a/lib/hashvec.cpp
+++ b/lib/hashvec.cpp
@@ -1,0 +1,484 @@
+/*
+Copyright 2023-present Intel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "hashvec.h"
+
+#include "exceptions.h"
+
+/* FIXME -- there are almost certainly problems when the hashtable size
+ * FIXME -- exceeds INT_MAX elements.  That requires 16GB+ memory... */
+
+struct hash_vector_base::internal {
+    uint32_t (*gethash)(const hash_vector_base *, size_t);
+    void (*sethash)(hash_vector_base *, size_t, uint32_t);
+    size_t maxset;
+    char ismap, ismulti, hashelsize;
+};
+
+uint32_t hash_vector_base::gethash_s1(const hash_vector_base *ht, size_t i) {
+    return ht->hash.s1[i];
+}
+uint32_t hash_vector_base::gethash_s2(const hash_vector_base *ht, size_t i) {
+    return ht->hash.s2[i];
+}
+uint32_t hash_vector_base::gethash_s3(const hash_vector_base *ht, size_t i) {
+    return ht->hash.s3[i];
+}
+void hash_vector_base::sethash_s1(hash_vector_base *ht, size_t i, uint32_t v) {
+    ht->hash.s1[i] = v;
+}
+void hash_vector_base::sethash_s2(hash_vector_base *ht, size_t i, uint32_t v) {
+    ht->hash.s2[i] = v;
+}
+void hash_vector_base::sethash_s3(hash_vector_base *ht, size_t i, uint32_t v) {
+    ht->hash.s3[i] = v;
+}
+
+static size_t mod_f(size_t x) { return x % 0xf; }
+static size_t mod_1f(size_t x) { return x % 0x1f; }
+static size_t mod_3f(size_t x) { return x % 0x3f; }
+static size_t mod_7f(size_t x) { return x % 0x7f; }
+static size_t mod_ff(size_t x) { return x % 0xff; }
+static size_t mod_1ff(size_t x) { return x % 0x1ff; }
+static size_t mod_3ff(size_t x) { return x % 0x3ff; }
+static size_t mod_7ff(size_t x) { return x % 0x7ff; }
+static size_t mod_fff(size_t x) { return x % 0xfff; }
+static size_t mod_1fff(size_t x) { return x % 0x1fff; }
+static size_t mod_3fff(size_t x) { return x % 0x3fff; }
+static size_t mod_7fff(size_t x) { return x % 0x7fff; }
+static size_t mod_ffff(size_t x) { return x % 0xffff; }
+static size_t mod_1ffff(size_t x) { return x % 0x1ffff; }
+static size_t mod_3ffff(size_t x) { return x % 0x3ffff; }
+static size_t mod_7ffff(size_t x) { return x % 0x7ffff; }
+static size_t mod_fffff(size_t x) { return x % 0xfffff; }
+static size_t mod_1fffff(size_t x) { return x % 0x1fffff; }
+static size_t mod_3fffff(size_t x) { return x % 0x3fffff; }
+static size_t mod_7fffff(size_t x) { return x % 0x7fffff; }
+static size_t mod_ffffff(size_t x) { return x % 0xffffff; }
+static size_t mod_1ffffff(size_t x) { return x % 0x1ffffff; }
+static size_t mod_3ffffff(size_t x) { return x % 0x3ffffff; }
+static size_t mod_7ffffff(size_t x) { return x % 0x7ffffff; }
+static size_t mod_fffffff(size_t x) { return x % 0xfffffff; }
+static size_t mod_1fffffff(size_t x) { return x % 0x1fffffff; }
+static size_t mod_3fffffff(size_t x) { return x % 0x3fffffff; }
+static size_t mod_7fffffff(size_t x) { return x % 0x7fffffff; }
+static size_t mod_ffffffff(size_t x) { return x % 0xffffffff; }
+
+static size_t (*mod_hashsize[])(size_t x) = {
+    0,
+    0,
+    0,
+    0,
+    mod_f,
+    mod_1f,
+    mod_3f,
+    mod_7f,
+    mod_ff,
+    mod_1ff,
+    mod_3ff,
+    mod_7ff,
+    mod_fff,
+    mod_1fff,
+    mod_3fff,
+    mod_7fff,
+    mod_ffff,
+    mod_1ffff,
+    mod_3ffff,
+    mod_7ffff,
+    mod_fffff,
+    mod_1fffff,
+    mod_3fffff,
+    mod_7fffff,
+    mod_ffffff,
+    mod_1ffffff,
+    mod_3ffffff,
+    mod_7ffffff,
+    mod_fffffff,
+    mod_1fffffff,
+    mod_3fffffff,
+    mod_7fffffff,
+    mod_ffffffff,
+};
+
+void hash_vector_base::allochash() {
+    // FIXME -- all switch cases are doing the same thing (just with different types) so
+    // it should be possible to simplify this
+    switch (info->hashelsize) {
+        case sizeof(uint8_t):
+            hash.s1 = new uint8_t[hashsize];
+            memset(hash.s1, 0, hashsize * info->hashelsize);
+            break;
+        case sizeof(uint16_t):
+            hash.s2 = new uint16_t[hashsize];
+            memset(hash.s2, 0, hashsize * info->hashelsize);
+            break;
+        case sizeof(uint32_t):
+            hash.s3 = new uint32_t[hashsize];
+            memset(hash.s3, 0, hashsize * info->hashelsize);
+            break;
+    }
+}
+
+void hash_vector_base::freehash() {
+    // FIXME -- all switch cases are doing the same thing (just with different types) so
+    // it should be possible to simplify this
+    switch (info->hashelsize) {
+        case sizeof(uint8_t):
+            delete[] hash.s1;
+            break;
+        case sizeof(uint16_t):
+            delete[] hash.s2;
+            break;
+        case sizeof(uint32_t):
+            delete[] hash.s2;
+            break;
+    }
+    hash.s1 = nullptr;
+}
+
+hash_vector_base::hash_vector_base(bool ismap, bool ismulti, size_t capacity) {
+    static internal formats[] = {{hash_vector_base::gethash_s1, hash_vector_base::sethash_s1,
+                                  UINT8_MAX, 0, 0, sizeof(uint8_t)},
+                                 {hash_vector_base::gethash_s2, hash_vector_base::sethash_s2,
+                                  UINT16_MAX, 0, 0, sizeof(uint16_t)},
+                                 {hash_vector_base::gethash_s3, hash_vector_base::sethash_s3,
+                                  UINT32_MAX, 0, 0, sizeof(uint32_t)},
+                                 {hash_vector_base::gethash_s1, hash_vector_base::sethash_s1,
+                                  UINT8_MAX, 1, 0, sizeof(uint8_t)},
+                                 {hash_vector_base::gethash_s2, hash_vector_base::sethash_s2,
+                                  UINT16_MAX, 1, 0, sizeof(uint16_t)},
+                                 {hash_vector_base::gethash_s3, hash_vector_base::sethash_s3,
+                                  UINT32_MAX, 1, 0, sizeof(uint32_t)},
+                                 {hash_vector_base::gethash_s1, hash_vector_base::sethash_s1,
+                                  UINT8_MAX, 0, 1, sizeof(uint8_t)},
+                                 {hash_vector_base::gethash_s2, hash_vector_base::sethash_s2,
+                                  UINT16_MAX, 0, 1, sizeof(uint16_t)},
+                                 {hash_vector_base::gethash_s3, hash_vector_base::sethash_s3,
+                                  UINT32_MAX, 0, 1, sizeof(uint32_t)},
+                                 {hash_vector_base::gethash_s1, hash_vector_base::sethash_s1,
+                                  UINT8_MAX, 1, 1, sizeof(uint8_t)},
+                                 {hash_vector_base::gethash_s2, hash_vector_base::sethash_s2,
+                                  UINT16_MAX, 1, 1, sizeof(uint16_t)},
+                                 {hash_vector_base::gethash_s3, hash_vector_base::sethash_s3,
+                                  UINT32_MAX, 1, 1, sizeof(uint32_t)},
+                                 {0, 0, 0, 0, 0, 0}};
+
+    hashsize = 15;
+    log_hashsize = 4;
+    while (hashsize / 2 < capacity) {
+        hashsize += hashsize + 1;
+        log_hashsize++;
+    }
+    BUG_CHECK(hashsize + 1 == (1UL << log_hashsize), "hash corrupt");
+    info = formats + (ismap ? 3 : 0) + (ismulti ? 6 : 0);
+    BUG_CHECK(info->ismap == ismap, "corrupt");
+    while (capacity > info->maxset) {
+        info++;
+        BUG_CHECK(info->ismap == ismap, "capacity %d exceeds max", capacity);
+    }
+    allochash();
+    inuse = collisions = 0;
+}
+
+hash_vector_base::hash_vector_base(const hash_vector_base &a)
+    : info(a.info),
+      hashsize(a.hashsize),
+      collisions(a.collisions),
+      log_hashsize(a.log_hashsize),
+      inuse(a.inuse),
+      erased(a.erased) {
+    allochash();
+    memcpy(hash.s1, a.hash.s1, hashsize * info->hashelsize);
+}
+
+hash_vector_base::hash_vector_base(hash_vector_base &&a)
+    : info(a.info),
+      hashsize(a.hashsize),
+      collisions(a.collisions),
+      log_hashsize(a.log_hashsize),
+      inuse(a.inuse),
+      erased(a.erased) {
+    hash.s1 = a.hash.s1;
+    a.hash.s1 = nullptr;
+}
+
+hash_vector_base &hash_vector_base::operator=(const hash_vector_base &a) {
+    freehash();
+    info = a.info;
+    hashsize = a.hashsize;
+    inuse = a.inuse;
+    collisions = a.collisions;
+    log_hashsize = a.log_hashsize;
+    erased = a.erased;
+    allochash();
+    memcpy(hash.s1, a.hash.s1, hashsize * info->hashelsize);
+    return *this;
+}
+
+hash_vector_base &hash_vector_base::operator=(hash_vector_base &&a) {
+    freehash();
+    info = a.info;
+    hashsize = a.hashsize;
+    inuse = a.inuse;
+    collisions = a.collisions;
+    log_hashsize = a.log_hashsize;
+    erased = a.erased;
+    hash.s1 = a.hash.s1;
+    a.hash.s1 = nullptr;
+    return *this;
+}
+
+void hash_vector_base::clear() {
+    freehash();
+    while (info->hashelsize > 1) --info;
+    hashsize = 15;
+    collisions = 0;
+    log_hashsize = 4;
+    inuse = 0;
+    erased.clear();
+    allochash();
+}
+
+size_t hash_vector_base::find(const void *key, lookup_cache *cache) const {
+    size_t hash = mod_hashsize[log_hashsize](hashfn(key));
+    size_t idx, collisions = 0;
+    while ((idx = info->gethash(this, hash)) && (erased[idx - 1] || !cmpfn(key, idx - 1))) {
+        if (++collisions >= hashsize) {
+            idx = 0;
+            break;
+        }
+        if (++hash == hashsize) hash = 0;
+    }
+    cache->slot = hash;
+    cache->collisions = collisions;
+    return idx;
+}
+
+size_t hash_vector_base::find_next(const void *key, lookup_cache *cache) const {
+    size_t hash = cache->slot;
+    size_t idx, collisions = cache->collisions;
+    if (!(idx = info->gethash(this, hash))) return idx;
+    if (++hash == hashsize) hash = 0;
+    while ((idx = info->gethash(this, hash)) && (erased[idx - 1] || !cmpfn(key, idx - 1))) {
+        if (++collisions >= hashsize) {
+            idx = 0;
+            break;
+        }
+        if (++hash == hashsize) hash = 0;
+    }
+    cache->slot = hash;
+    cache->collisions = collisions;
+    return idx;
+}
+
+void *hash_vector_base::lookup(const void *key, lookup_cache *cache) {
+    size_t idx;
+    lookup_cache local;
+    if (!cache) cache = &local;
+    idx = find(key, cache);
+    return idx ? getval(idx - 1) : 0;
+}
+
+void *hash_vector_base::lookup_next(const void *key, lookup_cache *cache) {
+    size_t idx = 0;
+    if (info->ismulti) idx = find_next(key, cache);
+    return idx ? getval(idx - 1) : 0;
+}
+
+void hash_vector_base::redo_hash() {
+    size_t i, j;
+    lookup_cache cache;
+    memset(hash.s1, 0, hashsize * info->hashelsize);
+    collisions = 0;
+    size_t limit = this->limit();
+    auto erased = this->erased;
+    this->erased.clear();
+    for (i = j = 0; i < limit; i++) {
+        if (erased[i]) continue;
+        const void *k = getkey(i);
+        if (find(k, &cache)) {
+            if (info->ismulti)
+                while (find_next(k, &cache))
+                    ;
+            else
+                BUG("dupliacte keys in hash_vector_base::redo_hash");
+        }
+        if (j != i) {
+            moveentry(j, i);
+        }
+        info->sethash(this, cache.slot, ++j);
+        collisions += cache.collisions;
+    }
+    resizedata(j);
+    inuse = j;
+}
+
+size_t hash_vector_base::hv_insert(const void *key, lookup_cache *cache) {
+    lookup_cache local;
+    size_t idx;
+    if (cache) {
+#ifndef NDEBUG
+        if (find(key, &local) && info->ismulti)
+            while (find_next(key, &local))
+                ;
+        BUG_CHECK(local.slot == cache->slot && local.collisions == cache->collisions,
+                  "invalid cache in hash_vector_base::hv_insert");
+#endif
+    } else {
+        cache = &local;
+        if (find(key, cache) && info->ismulti)
+            while (find_next(key, cache))
+                ;
+    }
+    if ((collisions += cache->collisions) > hashsize / 2) {
+        /* Too many collisions -- redo hash table */
+        if (inuse * 3 < limit() * 2) {
+            /* Many empty slots from removals, so don't expand anything */
+        } else if (/* !ht->hashfn[1] && */ hashsize > inuse * 10) {
+            /* Hashtable 90% empty and no alternate hash function.   Hash
+             * function isn't working but expanding further will likely
+             * make things worse, not better.
+             * Nothing we can do, so punt */
+        } else /* if (!ht->hashfn[1] || ht->hashsize < ht->limit*3) */ {
+            /* No alternate hashfn, or hashtable pretty full, expand hash */
+            hashsize += hashsize + 1;
+            log_hashsize++;
+            BUG_CHECK((hashsize & (hashsize + 1)) == 0, "hash corruption");
+            BUG_CHECK(hashsize + 1 == (1UL << log_hashsize), "hash corruption");
+            freehash();
+            allochash();
+#if 0
+        } else {
+            // FIXME -- figure out a way to allow changing the hash function in this case
+            ht->hashfn++;
+#endif
+        }
+        redo_hash();
+        if (find(key, cache) && info->ismulti)
+            while (find_next(key, cache))
+                ;
+    }
+    if ((idx = info->gethash(this, cache->slot)) == 0) {
+        bool need_redo = false;
+        if (limit() >= hashsize) {
+            hashsize += hashsize + 1;
+            log_hashsize++;
+            BUG_CHECK((hashsize & (hashsize + 1)) == 0, "hash corruption");
+            BUG_CHECK(hashsize + 1 == (1UL << log_hashsize), "hash corruption");
+            freehash();
+            need_redo = true;
+        }
+        if (limit() >= info->maxset) {
+            BUG_CHECK(info->ismap == info[1].ismap, "hash_vector overflow %d entries", limit() + 1);
+            freehash();
+            info++;
+            need_redo = true;
+        }
+        if (need_redo) {
+            allochash();
+            redo_hash();
+            if (find(key, cache) && info->ismulti)
+                while (find_next(key, cache))
+                    ;
+        }
+        info->sethash(this, cache->slot, limit() + 1);
+        inuse++;
+        return -1;
+    } else if (erased[idx - 1]) {
+        inuse++;
+    }
+    return idx - 1;
+}
+
+size_t hash_vector_base::remove(const void *key, lookup_cache *cache) {
+    lookup_cache local;
+    size_t idx;
+    if (cache) {
+#ifndef NDEBUG
+        if (find(key, &local) && info->ismulti)
+            while (local.slot != cache->slot && find_next(key, cache))
+                ;
+        BUG_CHECK(local.slot == cache->slot && local.collisions == cache->collisions,
+                  "invalid cache in hash_vector_base::remove");
+#endif
+    } else {
+        cache = &local;
+        find(key, cache);
+    }
+    if ((idx = info->gethash(this, cache->slot)) != 0) {
+        if (!erased[idx - 1]) inuse--;
+        if (idx == limit()) {
+            resizedata(idx - 1);
+            info->sethash(this, cache->slot, 0);
+            collisions -= cache->collisions;
+        } else {
+            erased[idx - 1] = 1;
+        }
+    }
+    return idx - 1;
+}
+
+uint32_t hash_vector_base::lookup_cache::getidx(const hash_vector_base *ht) {
+    BUG_CHECK(slot < ht->hashsize, "invalid cache");
+    return ht->info->gethash(ht, slot) - 1;
+}
+
+const void *hash_vector_base::lookup_cache::getkey(const hash_vector_base *ht) {
+    size_t idx;
+    BUG_CHECK(slot < ht->hashsize, "invalid cache");
+    idx = ht->info->gethash(ht, slot);
+    if (idx > 0) return ht->getkey(idx - 1);
+    return 0;
+}
+
+void *hash_vector_base::lookup_cache::getval(hash_vector_base *ht) {
+    size_t idx;
+    BUG_CHECK(slot < ht->hashsize, "invalid cache");
+    idx = ht->info->gethash(ht, slot);
+    if (idx > 0) return ht->getval(idx - 1);
+    return 0;
+}
+
+#ifdef DEBUG
+#include <iomanip>
+
+void hash_vector_base::dump(std::ostream &out) {
+    int fs = 4, ls = 18;
+    out << "hash_vector " << (void *)this << ": " << (info->ismap ? "map" : "set")
+        << static_cast<int>(info->hashelsize) << "\n";
+    out << "hashsize=" << hashsize << ", limit=" << limit() << ", inuse=" << inuse
+        << ", collisions=" << collisions;
+    size_t limit = this->limit();
+    if (limit > 999999) {
+        fs = 8;
+        ls = 9;
+    } else if (limit > 99999) {
+        fs = 7;
+        ls = 10;
+    } else if (limit > 9999) {
+        fs = 6;
+        ls = 12;
+    } else if (limit > 999) {
+        fs = 5;
+        ls = 15;
+    }
+    for (size_t i = 0; i < hashsize; i++) {
+        if (i % ls == 0) out << "\n";
+        out << std::setw(fs) << info->gethash(this, i);
+    }
+    out << "\nerased=" << erased << std::endl;
+}
+#endif /* DEBUG */

--- a/lib/hashvec.h
+++ b/lib/hashvec.h
@@ -1,0 +1,91 @@
+/*
+Copyright 2023-present Intel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef LIB_HASHVEC_H_
+#define LIB_HASHVEC_H_
+
+#include <cstdint>
+
+#include "bitvec.h"
+#ifdef DEBUG
+#include <iostream>
+#endif
+
+class hash_vector_base {
+    struct internal;
+    internal *info;
+    union {
+        uint8_t *s1;
+        uint16_t *s2;
+        uint32_t *s3;
+        // FIXME -- add uint64_t for vectors of more than 2**32 elements?
+    } hash;
+    static uint32_t gethash_s1(const hash_vector_base *, size_t);
+    static uint32_t gethash_s2(const hash_vector_base *, size_t);
+    static uint32_t gethash_s3(const hash_vector_base *, size_t);
+    static void sethash_s1(hash_vector_base *, size_t, uint32_t);
+    static void sethash_s2(hash_vector_base *, size_t, uint32_t);
+    static void sethash_s3(hash_vector_base *, size_t, uint32_t);
+    void allochash();
+    void freehash();
+
+    size_t hashsize;                 /* size of the hash array - always a power-of-2-minus-1 */
+    size_t collisions, log_hashsize; /* log(base 2) of hashsize+1 */
+
+ public:
+    struct lookup_cache {
+        size_t slot;
+        size_t collisions;
+        uint32_t getidx(const hash_vector_base *);
+        const void *getkey(const hash_vector_base *);
+        void *getval(hash_vector_base *);
+    };
+#ifdef DEBUG
+    void dump(std::ostream &);
+#endif
+
+ protected:
+    size_t inuse;  /* number of elements in use in the table */
+    bitvec erased; /* elements that have been erased */
+    hash_vector_base(bool ismap, bool ismulti, size_t capacity);
+    hash_vector_base(const hash_vector_base &);
+    hash_vector_base(hash_vector_base &&);
+    hash_vector_base &operator=(const hash_vector_base &);
+    hash_vector_base &operator=(hash_vector_base &&);
+    virtual ~hash_vector_base() { freehash(); }
+    virtual size_t hashfn(const void *) const = 0;
+    virtual bool cmpfn(const void *, const void *) const = 0;
+    virtual bool cmpfn(const void *, size_t) const = 0;
+    virtual const void *getkey(uint32_t) const = 0;
+    virtual void *getval(uint32_t) = 0;
+    virtual uint32_t limit() = 0;
+    virtual void resizedata(size_t) = 0;
+    virtual void moveentry(size_t, size_t) = 0;
+
+    void clear();
+    size_t find(const void *key, lookup_cache *cache) const;
+    size_t find_next(const void *key, lookup_cache *cache) const;
+    void *lookup(const void *key, lookup_cache *cache = nullptr);
+    void *lookup_next(const void *key, lookup_cache *cache = nullptr);
+    size_t hv_insert(const void *key, lookup_cache *cache = nullptr);
+    // returns data index caller needs to store value in; if == data.size(), need emplace_back
+    // also need to clear erased[index]
+    size_t remove(const void *key, lookup_cache *cache = nullptr);
+    // returns data index caller needs to clear (if < data.size()) or -1 if nothing removed
+    void redo_hash();
+};
+
+#endif /* LIB_HASHVEC_H_ */

--- a/lib/hvec_map.h
+++ b/lib/hvec_map.h
@@ -1,0 +1,342 @@
+/*
+Copyright 2023-present Intel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef LIB_HVEC_MAP_H_
+#define LIB_HVEC_MAP_H_
+
+#include <tuple>
+#include <vector>
+
+#include "exceptions.h"
+#include "hashvec.h"
+
+template <class KEY, class VAL, class HASH = std::hash<KEY>, class PRED = std::equal_to<KEY>,
+          class ALLOC = std::allocator<std::pair<const KEY, VAL>>>
+class hvec_map : hash_vector_base {
+    HASH hf;  // FIXME -- use empty base optimization for these?
+    PRED eql;
+
+ public:
+    typedef KEY key_type;
+    typedef std::pair<const KEY, VAL> value_type;
+    typedef VAL mapped_type;
+    typedef HASH hasher;
+    typedef PRED key_equal;
+    typedef ALLOC allocator_type;
+
+    typedef typename std::vector<value_type>::pointer pointer;
+    typedef typename std::vector<value_type>::const_pointer const_pointer;
+    typedef typename std::vector<value_type>::reference reference;
+    typedef typename std::vector<value_type>::const_reference const_reference;
+
+    typedef hash_vector_base::lookup_cache lookup_cache;
+
+    explicit hvec_map(size_t icap = 0, const hasher &hf = hasher(),
+                      const key_equal &eql = key_equal(),
+                      const allocator_type &a = allocator_type())
+        : hash_vector_base(true, false, icap), hf(hf), eql(eql), data(a) {
+        data.reserve(icap);
+    }
+    hvec_map(const hvec_map &) = default;
+    hvec_map(hvec_map &&) = default;
+    hvec_map &operator=(const hvec_map &) = default;
+    hvec_map &operator=(hvec_map &&) = default;
+    ~hvec_map() = default;
+    template <class ITER>
+    hvec_map(ITER begin, ITER end, const hasher &hf = hasher(), const key_equal &eql = key_equal(),
+             const allocator_type &a = allocator_type())
+        : hash_vector_base(true, false, end - begin), hf(hf), eql(eql), data(a) {
+        data.reserve(end - begin);
+        for (auto it = begin; it != end; ++it) insert(*it);
+    }
+    hvec_map(std::initializer_list<value_type> il, const hasher &hf = hasher(),
+             const key_equal &eql = key_equal(), const allocator_type &a = allocator_type())
+        : hash_vector_base(true, false, il.size()), hf(hf), eql(eql), data(a) {
+        data.reserve(il.size());
+        for (auto &i : il) insert(i);
+    }
+
+ private:
+    template <class HVM, class VT>
+    class _iter {
+        HVM *self;
+        size_t idx;
+
+        friend class hvec_map;
+        _iter(HVM &s, size_t i) : self(&s), idx(i) {}
+
+     public:
+        using value_type = VT;
+        using difference_type = ssize_t;
+        using pointer = typename HVM::pointer;
+        using reference = typename HVM::reference;
+        using iterator_category = std::bidirectional_iterator_tag;
+        _iter(const _iter &) = default;
+        _iter &operator=(const _iter &a) {
+            self = a.self;
+            idx = a.idx;
+            return *this;
+        }
+        value_type &operator*() const { return self->data[idx]; }
+        value_type *operator->() const { return &self->data[idx]; }
+        _iter &operator++() {
+            do {
+                ++idx;
+            } while (self->erased[idx]);
+            return *this;
+        }
+        _iter &operator--() {
+            do {
+                --idx;
+            } while (self->erased[idx]);
+            return *this;
+        }
+        _iter operator++(int) {
+            auto copy = *this;
+            ++*this;
+            return copy;
+        }
+        _iter operator--(int) {
+            auto copy = *this;
+            --*this;
+            return copy;
+        }
+        bool operator==(const _iter &a) const { return self == a.self && idx == a.idx; }
+        bool operator!=(const _iter &a) const { return self != a.self || idx != a.idx; }
+        operator _iter<const HVM, const VT>() const {
+            return _iter<const HVM, const VT>(*self, idx);
+        }
+    };
+
+ public:
+    typedef _iter<hvec_map, value_type> iterator;
+    typedef _iter<const hvec_map, const value_type> const_iterator;
+    iterator begin() { return iterator(*this, erased.ffz()); }
+    iterator end() { return iterator(*this, data.size()); }
+    const_iterator begin() const { return const_iterator(*this, erased.ffz()); }
+    const_iterator end() const { return const_iterator(*this, data.size()); }
+    const_iterator cbegin() const { return const_iterator(*this, erased.ffz()); }
+    const_iterator cend() const { return const_iterator(*this, data.size()); }
+
+    bool empty() const { return inuse == 0; }
+    size_t size() const { return inuse; }
+    size_t max_size() const { return UINT32_MAX; }
+    bool operator==(const hvec_map &a) {
+        if (inuse != a.inuse) return false;
+        auto it = begin();
+        for (auto &el : a)
+            if (el != *it++) return false;
+        return true;
+    }
+    bool operator!=(const hvec_map &a) { return !(*this == a); }
+    void clear() {
+        hash_vector_base::clear();
+        data.clear();
+    }
+
+    iterator find(const KEY &k) {
+        hash_vector_base::lookup_cache cache;
+        size_t idx = hash_vector_base::find(&k, &cache);
+        return idx ? iterator(*this, idx - 1) : end();
+    }
+    const_iterator find(const KEY &k) const {
+        hash_vector_base::lookup_cache cache;
+        size_t idx = hash_vector_base::find(&k, &cache);
+        return idx ? const_iterator(*this, idx - 1) : end();
+    }
+
+    // FIXME -- how to do this without duplicating the code for lvalue/rvalue?
+    VAL &operator[](const KEY &k) {
+        size_t idx = hv_insert(&k);
+        if (idx >= data.size()) {
+            data.emplace_back(k, VAL());
+            return data.back().second;
+        } else {
+            if (erased[idx]) {
+                erased[idx] = 0;
+                const_cast<KEY &>(data[idx].first) = k;
+                data[idx].second = VAL();
+            }
+            return data[idx].second;
+        }
+    }
+    VAL &operator[](KEY &&k) {
+        size_t idx = hv_insert(&k);
+        if (idx >= data.size()) {
+            data.emplace_back(std::move(k), VAL());
+            return data.back().second;
+        } else {
+            if (erased[idx]) {
+                erased[idx] = 0;
+                const_cast<KEY &>(data[idx].first) = std::move(k);
+                data[idx].second = VAL();
+            }
+            return data[idx].second;
+        }
+    }
+
+    // FIXME -- how to do this without duplicating the code for lvalue/rvalue?
+    template <typename... VV>
+    std::pair<iterator, bool> emplace(const KEY &k, VV &&...v) {
+        bool new_key = false;
+        size_t idx = hv_insert(&k);
+        if (idx >= data.size()) {
+            idx = data.size();
+            data.emplace_back(std::piecewise_construct_t(), std::forward_as_tuple(k),
+                              std::forward_as_tuple(std::forward<VV>(v)...));
+            new_key = true;
+        } else {
+            if ((new_key = erased[idx])) {
+                erased[idx] = 0;
+                const_cast<KEY &>(data[idx].first) = k;
+                data[idx].second = VAL(std::forward<VV>(v)...);
+            } else {
+                data[idx].second = VAL(std::forward<VV>(v)...);
+            }
+        }
+        return std::make_pair(iterator(*this, idx), new_key);
+    }
+    template <typename... VV>
+    std::pair<iterator, bool> emplace(KEY &&k, VV &&...v) {
+        bool new_key = false;
+        size_t idx = hv_insert(&k);
+        if (idx >= data.size()) {
+            idx = data.size();
+            data.emplace_back(std::piecewise_construct_t(), std::forward_as_tuple(std::move(k)),
+                              std::forward_as_tuple(std::forward<VV>(v)...));
+            new_key = true;
+        } else {
+            if ((new_key = erased[idx])) {
+                erased[idx] = 0;
+                const_cast<KEY &>(data[idx].first) = std::move(k);
+                data[idx].second = VAL(std::forward<VV>(v)...);
+            } else {
+                data[idx].second = VAL(std::forward<VV>(v)...);
+            }
+        }
+        return std::make_pair(iterator(*this, idx), new_key);
+    }
+    std::pair<iterator, bool> insert(const value_type &v) {
+        bool new_key = false;
+        size_t idx = hv_insert(&v.first);
+        if (idx >= data.size()) {
+            idx = data.size();
+            data.push_back(v);
+            new_key = true;
+        } else {
+            if ((new_key = erased[idx])) {
+                erased[idx] = 0;
+                const_cast<KEY &>(data[idx].first) = v.first;
+                data[idx].second = v.second;
+            } else {
+                data[idx].second = v.second;
+            }
+        }
+        return std::make_pair(iterator(*this, idx), new_key);
+    }
+    template <class HVM, class VT>
+    _iter<HVM, VT> erase(_iter<HVM, VT> it) {
+        BUG_CHECK(this == it.self, "incorrect iterator for hvec_map::erase");
+        erased[it.idx] = 1;
+        // FIXME -- would be better to call dtor here, but that will cause
+        // problems with the vector when it resized or is destroyed.  Could
+        // use raw memory and manual construct instead.
+        const_cast<KEY &>(data[it.idx].first) = KEY();
+        data[it.idx].second = VAL();
+        ++it;
+        --inuse;
+        return it;
+    }
+    size_t erase(const KEY &k) {
+        size_t idx = remove(&k);
+        if (idx + 1 == 0) return 0;
+        if (idx < data.size()) {
+            const_cast<KEY &>(data[idx].first) = KEY();
+            data[idx].second = VAL();
+        }
+        return 1;
+    }
+#ifdef DEBUG
+    using hash_vector_base::dump;
+#endif
+
+ private:
+    std::vector<value_type, ALLOC> data;
+    size_t hashfn(const void *a) const override { return hf(*static_cast<const KEY *>(a)); }
+    bool cmpfn(const void *a, const void *b) const override {
+        return eql(*static_cast<const KEY *>(a), *static_cast<const KEY *>(b));
+    }
+    bool cmpfn(const void *a, size_t b) const override {
+        return eql(*static_cast<const KEY *>(a), data[b].first);
+    }
+    const void *getkey(uint32_t i) const override { return &data[i].first; }
+    void *getval(uint32_t i) override { return &data[i].second; }
+    uint32_t limit() override { return data.size(); }
+    void resizedata(size_t sz) override { data.resize(sz); }
+    void moveentry(size_t to, size_t from) override {
+        // can't just assign, as the keys are const -- need to destruct & construct
+        data[to].~value_type();
+        new (&data[to]) value_type(std::move(data[from]));
+    }
+};
+
+// XXX(seth): We use this namespace to hide our get() overloads from ADL. GCC
+// 4.8 has a bug which causes these overloads to be considered when get() is
+// called on a type in the global namespace, even if the number of arguments
+// doesn't match up, which can trigger template instantiations that cause
+// errors.
+namespace GetImpl {
+
+template <class K, class T, class V, class Comp, class Alloc>
+inline V get(const hvec_map<K, V, Comp, Alloc> &m, T key, V def = V()) {
+    auto it = m.find(key);
+    if (it != m.end()) return it->second;
+    return def;
+}
+
+template <class K, class T, class V, class Comp, class Alloc>
+inline V *getref(hvec_map<K, V, Comp, Alloc> &m, T key) {
+    auto it = m.find(key);
+    if (it != m.end()) return &it->second;
+    return 0;
+}
+
+template <class K, class T, class V, class Comp, class Alloc>
+inline const V *getref(const hvec_map<K, V, Comp, Alloc> &m, T key) {
+    auto it = m.find(key);
+    if (it != m.end()) return &it->second;
+    return 0;
+}
+
+template <class K, class T, class V, class Comp, class Alloc>
+inline V get(const hvec_map<K, V, Comp, Alloc> *m, T key, V def = V()) {
+    return m ? get(*m, key, def) : def;
+}
+
+template <class K, class T, class V, class Comp, class Alloc>
+inline V *getref(hvec_map<K, V, Comp, Alloc> *m, T key) {
+    return m ? getref(*m, key) : 0;
+}
+
+template <class K, class T, class V, class Comp, class Alloc>
+inline const V *getref(const hvec_map<K, V, Comp, Alloc> *m, T key) {
+    return m ? getref(*m, key) : 0;
+}
+
+}  // namespace GetImpl
+using namespace GetImpl;  // NOLINT(build/namespaces)
+
+#endif /* LIB_HVEC_MAP_H_ */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/expr_uses_test.cpp
   gtest/format_test.cpp
   gtest/helpers.cpp
+  gtest/hvec_map.cpp
   gtest/indexed_vector.cpp
   gtest/json_test.cpp
   gtest/midend_test.cpp

--- a/test/gtest/hvec_map.cpp
+++ b/test/gtest/hvec_map.cpp
@@ -1,0 +1,176 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "lib/hvec_map.h"
+
+#include "gtest/gtest.h"
+
+namespace Test {
+
+TEST(hvec_map, map_equal) {
+    hvec_map<unsigned, unsigned> a;
+    hvec_map<unsigned, unsigned> b;
+
+    EXPECT_TRUE(a == b);
+
+    a[1] = 111;
+    a[2] = 222;
+    a[3] = 333;
+    a[4] = 444;
+
+    b[1] = 111;
+    b[2] = 222;
+    b[3] = 333;
+    b[4] = 444;
+
+    EXPECT_TRUE(a == b);
+
+    a.erase(2);
+    b.erase(2);
+
+    EXPECT_TRUE(a == b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_TRUE(a == b);
+}
+
+TEST(hvec_map, map_not_equal) {
+    hvec_map<unsigned, unsigned> a;
+    hvec_map<unsigned, unsigned> b;
+
+    EXPECT_TRUE(a == b);
+
+    a[1] = 111;
+    a[2] = 222;
+    a[3] = 333;
+    a[4] = 444;
+
+    b[4] = 444;
+    b[3] = 333;
+    b[2] = 222;
+    b[1] = 111;
+
+    EXPECT_TRUE(a != b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_TRUE(a == b);
+
+    a[1] = 111;
+    a[2] = 222;
+
+    b[1] = 111;
+    b[2] = 222;
+    b[3] = 333;
+
+    EXPECT_TRUE(a != b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_TRUE(a == b);
+
+    a[1] = 111;
+    a[2] = 222;
+    a[3] = 333;
+    a[4] = 444;
+
+    b[4] = 111;
+    b[3] = 222;
+    b[2] = 333;
+    b[1] = 444;
+
+    EXPECT_TRUE(a != b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_TRUE(a == b);
+
+    a[1] = 111;
+    a[2] = 222;
+    a[3] = 333;
+    a[4] = 444;
+
+    b[1] = 111;
+    b[2] = 111;
+    b[3] = 111;
+    b[4] = 111;
+
+    EXPECT_TRUE(a != b);
+}
+
+TEST(hvec_map, insert_emplace_erase) {
+    hvec_map<unsigned, unsigned> om;
+    std::map<unsigned, unsigned> sm;
+
+    typename hvec_map<unsigned, unsigned>::const_iterator it = om.end();
+    for (auto v : {0, 1, 2, 3, 4, 5, 6, 7, 8}) {
+        sm.emplace(v, 2 * v);
+        std::pair<unsigned, unsigned> pair{v, 2 * v};
+        if (v % 2 == 0) {
+            if ((v / 2) % 2 == 0) {
+                it = om.insert(pair).first;
+            } else {
+                it = om.emplace(v, pair.second).first;
+            }
+        } else {
+            if ((v / 2) % 2 == 0) {
+                it = om.insert(std::move(pair)).first;
+            } else {
+                it = om.emplace(std::move(v), v * 2).first;
+            }
+        }
+    }
+
+    EXPECT_TRUE(std::equal(om.begin(), om.end(), sm.begin(), sm.end()));
+
+    it = std::next(om.begin(), 2);
+    om.erase(it);
+    sm.erase(std::next(sm.begin(), 2));
+
+    EXPECT_TRUE(om.size() == sm.size());
+    EXPECT_TRUE(std::equal(om.begin(), om.end(), sm.begin(), sm.end()));
+}
+
+TEST(hvec_map, string_map) {
+    hvec_map<std::string, std::string> m;
+
+    for (int i = 1; i <= 100; ++i) {
+        m[std::to_string(i)] = "test";
+        m[std::to_string(i)] += std::to_string(i);
+    }
+    EXPECT_EQ(m.size(), 100);
+    for (int i = 1; i <= 100; i += 2) m.erase(std::to_string(i));
+    EXPECT_EQ(m.size(), 50);
+    for (int i = 102; i <= 200; i += 2) m[std::to_string(i)] = "foobar";
+    EXPECT_EQ(m.size(), 100);
+
+    int idx = 2;
+    for (auto &el : m) {
+        EXPECT_TRUE(el.first == std::to_string(idx));
+        if (idx <= 100)
+            EXPECT_TRUE(el.second.c_str() + 4 == std::to_string(idx));
+        else
+            EXPECT_EQ(el.second, "foobar");
+        idx += 2;
+    }
+}
+
+}  // namespace Test


### PR DESCRIPTION
The impetus for this comes from a customer case that is blowing up (memory-use-wise) in the frontend ComputeWriteSets code -- it turns out that the overhead for an ordered_map where both the key and value are just pointers is quite extreme.

This code is old C code that I've repurposed to be the base class of an improve C++ map class -- it keeps the map elements in a simple `vector<pair<KEY, VALUE>>` and has a separate hash table of indexes into the vector for fast lookup.  So the overhead is just a few bytes per entry, compared to the ~48 bytes (6 pointers) per entry used by ordered_map.  This reduces the peak memory use for our case from 12GB to 5.1GB.  Speed is pretty much unchanged.

This could trivially be extended to support more efficient ordered_sets as well (and multimaps and multisets)