### PR TITLE
Fix incorrect learn action in case of learner table invoked from nested controls

### DIFF
--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -1264,7 +1264,10 @@ bool ConvertStatementToDpdk::preorder(const IR::MethodCallStatement *s) {
             }
             auto action = a->expr->arguments->at(0)->expression;
             auto action_name = action->to<IR::StringLiteral>()->value;
-            action_name = ::get(structure->learner_action_map, action_name);
+            auto act = parent->to<IR::P4Action>();
+            cstring parent_act = act->name.name;
+            action_name =
+                ::get(structure->learner_action_map, std::make_pair(action_name, parent_act));
             auto param = a->expr->arguments->at(1)->expression;
             auto timeout_id = a->expr->arguments->at(2)->expression;
             if (timeout_id->is<IR::Constant>()) {

--- a/backends/dpdk/dpdkHelpers.h
+++ b/backends/dpdk/dpdkHelpers.h
@@ -150,6 +150,7 @@ class ConvertStatementToDpdk : public Inspector {
     P4::ReferenceMap *refmap;
     DpdkProgramStructure *structure;
     const IR::P4Parser *parser = nullptr;
+    const IR::Node *parent = nullptr;
     IR::Type_Struct *metadataStruct = nullptr;
 
  private:
@@ -184,6 +185,7 @@ class ConvertStatementToDpdk : public Inspector {
     void process_relation_operation(const IR::Expression *, const IR::Operation_Relation *);
     cstring append_parser_name(const IR::P4Parser *p, cstring);
     void set_parser(const IR::P4Parser *p) { parser = p; }
+    void set_parent(const IR::Node *p) { parent = p; }
     bool handleConstSwitch(const IR::SwitchStatement *a);
 };
 

--- a/backends/dpdk/dpdkProgram.cpp
+++ b/backends/dpdk/dpdkProgram.cpp
@@ -495,6 +495,7 @@ bool ConvertToDpdkParser::preorder(const IR::ParserState *) { return false; }
 bool ConvertToDpdkControl::preorder(const IR::P4Action *a) {
     auto helper = new DPDK::ConvertStatementToDpdk(refmap, typemap, structure, metadataStruct);
     helper->setCalledBy(this);
+    helper->set_parent(a);
     a->body->apply(*helper);
     auto stmt_list = new IR::IndexedVector<IR::DpdkAsmStatement>();
     for (auto i : helper->get_instr()) stmt_list->push_back(i);

--- a/backends/dpdk/dpdkProgramStructure.h
+++ b/backends/dpdk/dpdkProgramStructure.h
@@ -29,7 +29,7 @@ struct DpdkProgramStructure {
     // table and action info for learner tables
     ordered_set<cstring> learner_tables;
     ordered_set<cstring> learner_actions;
-    ordered_map<cstring, cstring> learner_action_map;
+    ordered_map<std::pair<cstring, cstring>, cstring> learner_action_map;
     ordered_map<cstring, std::vector<cstring>> learner_action_params;
     ordered_map<cstring, const IR::P4Table *> learner_action_table;
     ordered_map<cstring, enum InternalTableType> table_type_map;

--- a/backends/dpdk/dpdkUtils.cpp
+++ b/backends/dpdk/dpdkUtils.cpp
@@ -135,8 +135,9 @@ bool reservedNames(P4::ReferenceMap *refMap, std::vector<cstring> names, cstring
 
 // Update bitwidth of Metadata fields to 32 or 64 bits if it 8-bit aligned.
 int getMetadataFieldWidth(int width) {
-    BUG_CHECK(width <= 64, "Metadata bit-width expected to be within 64-bits");
     if (width % 8 != 0) {
+        BUG_CHECK(width <= 64, "Metadata bit-width expected to be within 64-bits, found %1%",
+                  width);
         if (width < 32)
             return 32;
         else

--- a/testdata/p4_16_samples/pna-dpdk-add_on_miss1.p4
+++ b/testdata/p4_16_samples/pna-dpdk-add_on_miss1.p4
@@ -1,0 +1,341 @@
+/* -*- P4_16 -*- */
+
+#include <core.p4>
+#include <pna.p4>
+
+/*************************************************************************
+ ************* C O N S T A N T S    A N D   T Y P E S  *******************
+ *************************************************************************/
+const int IPV4_HOST_SIZE = 65536;
+
+/*************************************************************************
+ ***********************  H E A D E R S  *********************************
+ *************************************************************************/
+
+/*  Define all the headers the program will recognize             */
+/*  The actual sets of headers processed by each gress can differ */
+
+typedef bit<48>  EthernetAddress;
+typedef bit<32>  IPv4Address;
+typedef bit<128> IPv6Address;
+
+typedef bit<16> etype_t;
+const etype_t ETYPE_IPV4      = 0x0800; /* IPv4 */
+
+typedef bit<8> ipproto_t;
+const ipproto_t IPPROTO_TCP = 6;       /* Transmission Control Protocol */
+const ipproto_t IPPROTO_UDP = 17;      /* User Datagram Protocol */
+
+// https://en.wikipedia.org/wiki/Ethernet_frame
+header ethernet_h {
+    EthernetAddress dst_addr;
+    EthernetAddress src_addr;
+    etype_t ether_type;
+}
+
+// RFC 791
+// https://en.wikipedia.org/wiki/IPv4
+// https://tools.ietf.org/html/rfc791
+header ipv4_h {
+    bit<8>  version_ihl;        // version always 4 for IPv4, ihl=header length
+    bit<8>  diffserv;           // 6 bits of DSCP followed by 2-bit ECN
+    bit<16> total_len;          // in bytes, including IPv4 header
+    bit<16> identification;
+    bit<16> flags_frag_offset;
+    bit<8>  ttl;                // time to live
+    ipproto_t protocol;
+    bit<16> hdr_checksum;
+    IPv4Address src_addr;
+    IPv4Address dst_addr;
+}
+
+// RFC 793 and several later RFCs that update it
+// https://en.wikipedia.org/wiki/Transmission_Control_Protocol
+// https://tools.ietf.org/html/rfc793
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<4>  res;
+    bit<8>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+// Masks of the bit positions of some bit flags within the TCP flags
+// field.
+const bit<8> TCP_URG_MASK = 0x20;
+const bit<8> TCP_ACK_MASK = 0x10;
+const bit<8> TCP_PSH_MASK = 0x08;
+const bit<8> TCP_RST_MASK = 0x04;
+const bit<8> TCP_SYN_MASK = 0x02;
+const bit<8> TCP_FIN_MASK = 0x01;
+
+// RFC 768
+// https://en.wikipedia.org/wiki/User_Datagram_Protocol
+// https://tools.ietf.org/html/rfc768
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> length;
+    bit<16> checksum;
+}
+
+// Define names for different expire time profile id values.
+
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NOW    = (ExpireTimeProfileId_t) 0;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEW    = (ExpireTimeProfileId_t) 1;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_ESTABLISHED = (ExpireTimeProfileId_t) 2;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEVER  = (ExpireTimeProfileId_t) 3;
+
+/*************************************************************************
+ **************  I N G R E S S   P R O C E S S I N G   *******************
+ *************************************************************************/
+
+    /***********************  H E A D E R S  ************************/
+
+struct headers_t {
+    ethernet_h   ethernet;
+    ipv4_h       ipv4;
+    tcp_h        tcp;
+    udp_h        udp;
+}
+
+    /******  G L O B A L   I N G R E S S   M E T A D A T A  *********/
+enum bit<16> direction_t {
+    INVALID = 0,
+    OUTBOUND = 1,
+    INBOUND = 2
+}
+
+struct metadata_t {
+    direction_t direction;
+}
+
+    /***********************  P A R S E R  **************************/
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t  hdr,
+    inout metadata_t meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+     state start {
+        transition parse_ethernet;
+    }
+
+    state parse_ethernet {
+        pkt.extract(hdr.ethernet);
+        transition select (hdr.ethernet.ether_type) {
+            ETYPE_IPV4:  parse_ipv4;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select (hdr.ipv4.protocol) {
+            IPPROTO_TCP: parse_tcp;
+            IPPROTO_UDP: parse_udp;
+            default: accept;
+        }
+    }
+
+    state parse_tcp {
+        pkt.extract(hdr.tcp);
+        transition accept;
+    }
+
+    state parse_udp {
+        pkt.extract(hdr.udp);
+        transition accept;
+    }
+}
+
+// As of 2023-Mar-14, p4c-dpdk implementation of PNA architecture
+// still requires PreControl.
+
+control PreControlImpl(
+    in    headers_t hdr,
+    inout metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+    /***************** M A T C H - A C T I O N  *********************/
+
+
+IPv4Address directionNeutralAddr (
+    in direction_t direction,
+    in IPv4Address outbound_address,
+    in IPv4Address inbound_address)
+{
+    if (direction == direction_t.OUTBOUND) {
+        return outbound_address;
+    } else {
+        return inbound_address;
+    }
+}
+
+bit<16> directionNeutralPort (
+    in direction_t direction,
+    in bit<16> outbound_port,
+    in bit<16> inbound_port)
+{
+    if (direction == direction_t.OUTBOUND) {
+        return outbound_port;
+    } else {
+        return inbound_port;
+    }
+}
+
+struct ct_tcp_table_hit_params_t {
+}
+
+control conntrack(inout headers_t  hdr, inout metadata_t meta) {
+// Inputs from previous tables (or actions, or in general other P4
+    // code) that can modify the behavior of actions of ct_tcp_table.
+    ExpireTimeProfileId_t new_expire_time_profile_id;
+
+    action ct_tcp_table_hit () {
+        // Make a change to the packet that is visible in the packet
+        // output by the device, for debug purposes only.  I cannot
+        // imagine any reason why someone would want to make a change
+        // like this to a packet in a production P4 program.
+        hdr.ethernet.src_addr[7:0] = 0xf1;
+    }
+
+    action ct_tcp_table_miss() {
+        // Make a change to the packet that is visible in the packet
+        // output by the device, for debug purposes only.  I cannot
+        // imagine any reason why someone would want to make a change
+        // like this to a packet in a production P4 program.
+        hdr.ethernet.src_addr[7:0] = 0xa5;
+        add_entry(action_name = "ct_tcp_table_hit",  // name of action
+            action_params = (ct_tcp_table_hit_params_t) {},
+            expire_time_profile_id = new_expire_time_profile_id);
+    }
+
+    table ct_tcp_table {
+        key = {
+          directionNeutralAddr(meta.direction, hdr.ipv4.src_addr, hdr.ipv4.dst_addr):
+              exact @name("ipv4_addr1");
+          directionNeutralAddr(meta.direction, hdr.ipv4.dst_addr, hdr.ipv4.src_addr):
+              exact @name("ipv4_addr2");
+          hdr.ipv4.protocol : exact;
+          directionNeutralPort(meta.direction, hdr.tcp.src_port, hdr.tcp.dst_port):
+              exact @name("tcp_port1");
+          directionNeutralPort(meta.direction, hdr.tcp.dst_port, hdr.tcp.src_port):
+              exact @name("tcp_port2");
+       }
+        actions = {
+            @tableonly   ct_tcp_table_hit;
+            @defaultonly ct_tcp_table_miss;
+        }
+
+        // New PNA table property 'add_on_miss = true' indicates that
+        // this table can use extern function add_entry() in its
+        // default (i.e. miss) action to add a new entry to the table
+        // from the data plane.
+        add_on_miss = true;
+
+        // As of 2023-Mar-14, p4c-dpdk implementation of PNA
+        // architecture does not implement value AUTO_DELETE yet.
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = ct_tcp_table_miss;
+    }
+   apply {
+       new_expire_time_profile_id = EXPIRE_TIME_PROFILE_TCP_NEW;
+       ct_tcp_table.apply();
+   }
+}
+
+control inbound(
+    inout headers_t  hdr,
+    inout metadata_t meta)
+{
+    apply {
+      meta.direction = direction_t.INBOUND; 
+      conntrack.apply(hdr, meta);
+    }
+}
+
+control outbound(
+    inout headers_t  hdr,
+    inout metadata_t meta)
+{
+    apply {
+      meta.direction = direction_t.OUTBOUND; 
+      conntrack.apply(hdr, meta);
+    }
+}
+
+control MainControlImpl(
+    inout headers_t  hdr,
+    inout metadata_t meta,
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    action drop () {
+        drop_packet();
+    }
+
+    
+    action send(PortId_t port) {
+        send_to_port(port);
+    }
+
+
+    table ipv4_host {
+        key = {
+            hdr.ipv4.dst_addr : exact;
+        }
+        actions = {
+            send;
+            drop;
+            @defaultonly NoAction;
+        }
+        const default_action = drop();
+        size = IPV4_HOST_SIZE;
+    }
+
+    apply {
+        if (hdr.ipv4.isValid() && hdr.tcp.isValid()) {
+           if (istd.direction == PNA_Direction_t.HOST_TO_NET)
+               outbound.apply(hdr, meta); 
+           else              
+               inbound.apply(hdr, meta); 
+            //ct_tcp_table.apply();
+        }
+        if (hdr.ipv4.isValid()) {
+            ipv4_host.apply();
+        }
+    }
+}
+
+    /*********************  D E P A R S E R  ************************/
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,
+    in    metadata_t meta,
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr);
+    }
+}
+
+/************ F I N A L   P A C K A G E ******************************/
+
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    ) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1-first.p4
@@ -1,0 +1,218 @@
+#include <core.p4>
+#include <pna.p4>
+
+const int IPV4_HOST_SIZE = 65536;
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+typedef bit<128> IPv6Address;
+typedef bit<16> etype_t;
+const etype_t ETYPE_IPV4 = 16w0x800;
+typedef bit<8> ipproto_t;
+const ipproto_t IPPROTO_TCP = 8w6;
+const ipproto_t IPPROTO_UDP = 8w17;
+header ethernet_h {
+    EthernetAddress dst_addr;
+    EthernetAddress src_addr;
+    etype_t         ether_type;
+}
+
+header ipv4_h {
+    bit<8>      version_ihl;
+    bit<8>      diffserv;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<16>     flags_frag_offset;
+    bit<8>      ttl;
+    ipproto_t   protocol;
+    bit<16>     hdr_checksum;
+    IPv4Address src_addr;
+    IPv4Address dst_addr;
+}
+
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<4>  res;
+    bit<8>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+const bit<8> TCP_URG_MASK = 8w0x20;
+const bit<8> TCP_ACK_MASK = 8w0x10;
+const bit<8> TCP_PSH_MASK = 8w0x8;
+const bit<8> TCP_RST_MASK = 8w0x4;
+const bit<8> TCP_SYN_MASK = 8w0x2;
+const bit<8> TCP_FIN_MASK = 8w0x1;
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> length;
+    bit<16> checksum;
+}
+
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NOW = (ExpireTimeProfileId_t)8w0;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEW = (ExpireTimeProfileId_t)8w1;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_ESTABLISHED = (ExpireTimeProfileId_t)8w2;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEVER = (ExpireTimeProfileId_t)8w3;
+struct headers_t {
+    ethernet_h ethernet;
+    ipv4_h     ipv4;
+    tcp_h      tcp;
+    udp_h      udp;
+}
+
+enum bit<16> direction_t {
+    INVALID = 16w0,
+    OUTBOUND = 16w1,
+    INBOUND = 16w2
+}
+
+struct metadata_t {
+    direction_t direction;
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_h>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            8w17: parse_udp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract<tcp_h>(hdr.tcp);
+        transition accept;
+    }
+    state parse_udp {
+        pkt.extract<udp_h>(hdr.udp);
+        transition accept;
+    }
+}
+
+control PreControlImpl(in headers_t hdr, inout metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+IPv4Address directionNeutralAddr(in direction_t direction, in IPv4Address outbound_address, in IPv4Address inbound_address) {
+    if (direction == direction_t.OUTBOUND) {
+        return outbound_address;
+    } else {
+        return inbound_address;
+    }
+}
+bit<16> directionNeutralPort(in direction_t direction, in bit<16> outbound_port, in bit<16> inbound_port) {
+    if (direction == direction_t.OUTBOUND) {
+        return outbound_port;
+    } else {
+        return inbound_port;
+    }
+}
+struct ct_tcp_table_hit_params_t {
+}
+
+control conntrack(inout headers_t hdr, inout metadata_t meta) {
+    ExpireTimeProfileId_t new_expire_time_profile_id;
+    action ct_tcp_table_hit() {
+        hdr.ethernet.src_addr[7:0] = 8w0xf1;
+    }
+    action ct_tcp_table_miss() {
+        hdr.ethernet.src_addr[7:0] = 8w0xa5;
+        add_entry<ct_tcp_table_hit_params_t>(action_name = "ct_tcp_table_hit", action_params = (ct_tcp_table_hit_params_t){}, expire_time_profile_id = new_expire_time_profile_id);
+    }
+    table ct_tcp_table {
+        key = {
+            directionNeutralAddr(meta.direction, hdr.ipv4.src_addr, hdr.ipv4.dst_addr): exact @name("ipv4_addr1");
+            directionNeutralAddr(meta.direction, hdr.ipv4.dst_addr, hdr.ipv4.src_addr): exact @name("ipv4_addr2");
+            hdr.ipv4.protocol                                                         : exact @name("hdr.ipv4.protocol");
+            directionNeutralPort(meta.direction, hdr.tcp.src_port, hdr.tcp.dst_port)  : exact @name("tcp_port1");
+            directionNeutralPort(meta.direction, hdr.tcp.dst_port, hdr.tcp.src_port)  : exact @name("tcp_port2");
+        }
+        actions = {
+            @tableonly ct_tcp_table_hit();
+            @defaultonly ct_tcp_table_miss();
+        }
+        add_on_miss = true;
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = ct_tcp_table_miss();
+    }
+    apply {
+        new_expire_time_profile_id = (ExpireTimeProfileId_t)8w1;
+        ct_tcp_table.apply();
+    }
+}
+
+control inbound(inout headers_t hdr, inout metadata_t meta) {
+    @name("conntrack") conntrack() conntrack_inst;
+    apply {
+        meta.direction = direction_t.INBOUND;
+        conntrack_inst.apply(hdr, meta);
+    }
+}
+
+control outbound(inout headers_t hdr, inout metadata_t meta) {
+    @name("conntrack") conntrack() conntrack_inst_0;
+    apply {
+        meta.direction = direction_t.OUTBOUND;
+        conntrack_inst_0.apply(hdr, meta);
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action drop() {
+        drop_packet();
+    }
+    action send(PortId_t port) {
+        send_to_port(port);
+    }
+    table ipv4_host {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("hdr.ipv4.dst_addr");
+        }
+        actions = {
+            send();
+            drop();
+            @defaultonly NoAction();
+        }
+        const default_action = drop();
+        size = 65536;
+    }
+    @name("outbound") outbound() outbound_inst;
+    @name("inbound") inbound() inbound_inst;
+    apply {
+        if (hdr.ipv4.isValid() && hdr.tcp.isValid()) {
+            if (istd.direction == PNA_Direction_t.HOST_TO_NET) {
+                outbound_inst.apply(hdr, meta);
+            } else {
+                inbound_inst.apply(hdr, meta);
+            }
+        }
+        if (hdr.ipv4.isValid()) {
+            ipv4_host.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in metadata_t meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<headers_t>(hdr);
+    }
+}
+
+PNA_NIC<headers_t, metadata_t, headers_t, metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1-frontend.p4
@@ -1,0 +1,307 @@
+#include <core.p4>
+#include <pna.p4>
+
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+typedef bit<16> etype_t;
+typedef bit<8> ipproto_t;
+header ethernet_h {
+    EthernetAddress dst_addr;
+    EthernetAddress src_addr;
+    etype_t         ether_type;
+}
+
+header ipv4_h {
+    bit<8>      version_ihl;
+    bit<8>      diffserv;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<16>     flags_frag_offset;
+    bit<8>      ttl;
+    ipproto_t   protocol;
+    bit<16>     hdr_checksum;
+    IPv4Address src_addr;
+    IPv4Address dst_addr;
+}
+
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<4>  res;
+    bit<8>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> length;
+    bit<16> checksum;
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    ipv4_h     ipv4;
+    tcp_h      tcp;
+    udp_h      udp;
+}
+
+enum bit<16> direction_t {
+    INVALID = 16w0,
+    OUTBOUND = 16w1,
+    INBOUND = 16w2
+}
+
+struct metadata_t {
+    direction_t direction;
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_h>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            8w17: parse_udp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract<tcp_h>(hdr.tcp);
+        transition accept;
+    }
+    state parse_udp {
+        pkt.extract<udp_h>(hdr.udp);
+        transition accept;
+    }
+}
+
+control PreControlImpl(in headers_t hdr, inout metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+struct ct_tcp_table_hit_params_t {
+}
+
+control MainControlImpl(inout headers_t hdr, inout metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.outbound.conntrack.new_expire_time_profile_id") ExpireTimeProfileId_t outbound_conntrack_new_expire_time_profile_id;
+    @name("MainControlImpl.outbound.conntrack.key_0") bit<32> outbound_conntrack_key;
+    @name("MainControlImpl.outbound.conntrack.key_1") bit<32> outbound_conntrack_key_0;
+    @name("MainControlImpl.outbound.conntrack.key_2") bit<8> outbound_conntrack_key_1;
+    @name("MainControlImpl.outbound.conntrack.key_3") bit<16> outbound_conntrack_key_2;
+    @name("MainControlImpl.outbound.conntrack.key_4") bit<16> outbound_conntrack_key_3;
+    @name("MainControlImpl.inbound.conntrack.new_expire_time_profile_id") ExpireTimeProfileId_t inbound_conntrack_new_expire_time_profile_id;
+    @name("MainControlImpl.inbound.conntrack.key_0") bit<32> inbound_conntrack_key;
+    @name("MainControlImpl.inbound.conntrack.key_1") bit<32> inbound_conntrack_key_0;
+    @name("MainControlImpl.inbound.conntrack.key_2") bit<8> inbound_conntrack_key_1;
+    @name("MainControlImpl.inbound.conntrack.key_3") bit<16> inbound_conntrack_key_2;
+    @name("MainControlImpl.inbound.conntrack.key_4") bit<16> inbound_conntrack_key_3;
+    @name("MainControlImpl.direction_0") direction_t direction_8;
+    @name("MainControlImpl.outbound_address_0") IPv4Address outbound_address;
+    @name("MainControlImpl.inbound_address_0") IPv4Address inbound_address;
+    @name("MainControlImpl.retval") IPv4Address retval;
+    @name("MainControlImpl.direction_1") direction_t direction_9;
+    @name("MainControlImpl.outbound_address_1") IPv4Address outbound_address_4;
+    @name("MainControlImpl.inbound_address_1") IPv4Address inbound_address_4;
+    @name("MainControlImpl.retval") IPv4Address retval_0;
+    @name("MainControlImpl.direction_2") direction_t direction_10;
+    @name("MainControlImpl.outbound_port_0") bit<16> outbound_port;
+    @name("MainControlImpl.inbound_port_0") bit<16> inbound_port;
+    @name("MainControlImpl.retval_0") bit<16> retval_3;
+    @name("MainControlImpl.direction_3") direction_t direction_11;
+    @name("MainControlImpl.outbound_port_1") bit<16> outbound_port_4;
+    @name("MainControlImpl.inbound_port_1") bit<16> inbound_port_4;
+    @name("MainControlImpl.retval_0") bit<16> retval_4;
+    @name("MainControlImpl.direction_4") direction_t direction_12;
+    @name("MainControlImpl.outbound_address_2") IPv4Address outbound_address_5;
+    @name("MainControlImpl.inbound_address_2") IPv4Address inbound_address_5;
+    @name("MainControlImpl.retval") IPv4Address retval_5;
+    @name("MainControlImpl.direction_5") direction_t direction_13;
+    @name("MainControlImpl.outbound_address_3") IPv4Address outbound_address_6;
+    @name("MainControlImpl.inbound_address_3") IPv4Address inbound_address_6;
+    @name("MainControlImpl.retval") IPv4Address retval_6;
+    @name("MainControlImpl.direction_6") direction_t direction_14;
+    @name("MainControlImpl.outbound_port_2") bit<16> outbound_port_5;
+    @name("MainControlImpl.inbound_port_2") bit<16> inbound_port_5;
+    @name("MainControlImpl.retval_0") bit<16> retval_7;
+    @name("MainControlImpl.direction_7") direction_t direction_15;
+    @name("MainControlImpl.outbound_port_3") bit<16> outbound_port_6;
+    @name("MainControlImpl.inbound_port_3") bit<16> inbound_port_6;
+    @name("MainControlImpl.retval_0") bit<16> retval_8;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.drop") action drop() {
+        drop_packet();
+    }
+    @name("MainControlImpl.send") action send(@name("port") PortId_t port) {
+        send_to_port(port);
+    }
+    @name("MainControlImpl.ipv4_host") table ipv4_host_0 {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("hdr.ipv4.dst_addr");
+        }
+        actions = {
+            send();
+            drop();
+            @defaultonly NoAction_1();
+        }
+        const default_action = drop();
+        size = 65536;
+    }
+    @name("MainControlImpl.outbound.conntrack.ct_tcp_table_hit") action outbound_conntrack_ct_tcp_table_hit_0() {
+        hdr.ethernet.src_addr[7:0] = 8w0xf1;
+    }
+    @name("MainControlImpl.outbound.conntrack.ct_tcp_table_miss") action outbound_conntrack_ct_tcp_table_miss_0() {
+        hdr.ethernet.src_addr[7:0] = 8w0xa5;
+        add_entry<ct_tcp_table_hit_params_t>(action_name = "ct_tcp_table_hit", action_params = (ct_tcp_table_hit_params_t){}, expire_time_profile_id = outbound_conntrack_new_expire_time_profile_id);
+    }
+    @name("MainControlImpl.outbound.conntrack.ct_tcp_table") table outbound_conntrack_ct_tcp_table {
+        key = {
+            outbound_conntrack_key  : exact @name("ipv4_addr1");
+            outbound_conntrack_key_0: exact @name("ipv4_addr2");
+            outbound_conntrack_key_1: exact @name("hdr.ipv4.protocol");
+            outbound_conntrack_key_2: exact @name("tcp_port1");
+            outbound_conntrack_key_3: exact @name("tcp_port2");
+        }
+        actions = {
+            @tableonly outbound_conntrack_ct_tcp_table_hit_0();
+            @defaultonly outbound_conntrack_ct_tcp_table_miss_0();
+        }
+        add_on_miss = true;
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = outbound_conntrack_ct_tcp_table_miss_0();
+    }
+    @name("MainControlImpl.inbound.conntrack.ct_tcp_table_hit") action inbound_conntrack_ct_tcp_table_hit_0() {
+        hdr.ethernet.src_addr[7:0] = 8w0xf1;
+    }
+    @name("MainControlImpl.inbound.conntrack.ct_tcp_table_miss") action inbound_conntrack_ct_tcp_table_miss_0() {
+        hdr.ethernet.src_addr[7:0] = 8w0xa5;
+        add_entry<ct_tcp_table_hit_params_t>(action_name = "ct_tcp_table_hit", action_params = (ct_tcp_table_hit_params_t){}, expire_time_profile_id = inbound_conntrack_new_expire_time_profile_id);
+    }
+    @name("MainControlImpl.inbound.conntrack.ct_tcp_table") table inbound_conntrack_ct_tcp_table {
+        key = {
+            inbound_conntrack_key  : exact @name("ipv4_addr1");
+            inbound_conntrack_key_0: exact @name("ipv4_addr2");
+            inbound_conntrack_key_1: exact @name("hdr.ipv4.protocol");
+            inbound_conntrack_key_2: exact @name("tcp_port1");
+            inbound_conntrack_key_3: exact @name("tcp_port2");
+        }
+        actions = {
+            @tableonly inbound_conntrack_ct_tcp_table_hit_0();
+            @defaultonly inbound_conntrack_ct_tcp_table_miss_0();
+        }
+        add_on_miss = true;
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = inbound_conntrack_ct_tcp_table_miss_0();
+    }
+    apply {
+        if (hdr.ipv4.isValid() && hdr.tcp.isValid()) {
+            if (istd.direction == PNA_Direction_t.HOST_TO_NET) {
+                meta.direction = direction_t.OUTBOUND;
+                outbound_conntrack_new_expire_time_profile_id = (ExpireTimeProfileId_t)8w1;
+                direction_8 = meta.direction;
+                outbound_address = hdr.ipv4.src_addr;
+                inbound_address = hdr.ipv4.dst_addr;
+                if (direction_8 == direction_t.OUTBOUND) {
+                    retval = outbound_address;
+                } else {
+                    retval = inbound_address;
+                }
+                outbound_conntrack_key = retval;
+                direction_9 = meta.direction;
+                outbound_address_4 = hdr.ipv4.dst_addr;
+                inbound_address_4 = hdr.ipv4.src_addr;
+                if (direction_9 == direction_t.OUTBOUND) {
+                    retval_0 = outbound_address_4;
+                } else {
+                    retval_0 = inbound_address_4;
+                }
+                outbound_conntrack_key_0 = retval_0;
+                outbound_conntrack_key_1 = hdr.ipv4.protocol;
+                direction_10 = meta.direction;
+                outbound_port = hdr.tcp.src_port;
+                inbound_port = hdr.tcp.dst_port;
+                if (direction_10 == direction_t.OUTBOUND) {
+                    retval_3 = outbound_port;
+                } else {
+                    retval_3 = inbound_port;
+                }
+                outbound_conntrack_key_2 = retval_3;
+                direction_11 = meta.direction;
+                outbound_port_4 = hdr.tcp.dst_port;
+                inbound_port_4 = hdr.tcp.src_port;
+                if (direction_11 == direction_t.OUTBOUND) {
+                    retval_4 = outbound_port_4;
+                } else {
+                    retval_4 = inbound_port_4;
+                }
+                outbound_conntrack_key_3 = retval_4;
+                outbound_conntrack_ct_tcp_table.apply();
+            } else {
+                meta.direction = direction_t.INBOUND;
+                inbound_conntrack_new_expire_time_profile_id = (ExpireTimeProfileId_t)8w1;
+                direction_12 = meta.direction;
+                outbound_address_5 = hdr.ipv4.src_addr;
+                inbound_address_5 = hdr.ipv4.dst_addr;
+                if (direction_12 == direction_t.OUTBOUND) {
+                    retval_5 = outbound_address_5;
+                } else {
+                    retval_5 = inbound_address_5;
+                }
+                inbound_conntrack_key = retval_5;
+                direction_13 = meta.direction;
+                outbound_address_6 = hdr.ipv4.dst_addr;
+                inbound_address_6 = hdr.ipv4.src_addr;
+                if (direction_13 == direction_t.OUTBOUND) {
+                    retval_6 = outbound_address_6;
+                } else {
+                    retval_6 = inbound_address_6;
+                }
+                inbound_conntrack_key_0 = retval_6;
+                inbound_conntrack_key_1 = hdr.ipv4.protocol;
+                direction_14 = meta.direction;
+                outbound_port_5 = hdr.tcp.src_port;
+                inbound_port_5 = hdr.tcp.dst_port;
+                if (direction_14 == direction_t.OUTBOUND) {
+                    retval_7 = outbound_port_5;
+                } else {
+                    retval_7 = inbound_port_5;
+                }
+                inbound_conntrack_key_2 = retval_7;
+                direction_15 = meta.direction;
+                outbound_port_6 = hdr.tcp.dst_port;
+                inbound_port_6 = hdr.tcp.src_port;
+                if (direction_15 == direction_t.OUTBOUND) {
+                    retval_8 = outbound_port_6;
+                } else {
+                    retval_8 = inbound_port_6;
+                }
+                inbound_conntrack_key_3 = retval_8;
+                inbound_conntrack_ct_tcp_table.apply();
+            }
+        }
+        if (hdr.ipv4.isValid()) {
+            ipv4_host_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in metadata_t meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<headers_t>(hdr);
+    }
+}
+
+PNA_NIC<headers_t, metadata_t, headers_t, metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1-midend.p4
@@ -1,0 +1,211 @@
+#include <core.p4>
+#include <pna.p4>
+
+header ethernet_h {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> ether_type;
+}
+
+header ipv4_h {
+    bit<8>  version_ihl;
+    bit<8>  diffserv;
+    bit<16> total_len;
+    bit<16> identification;
+    bit<16> flags_frag_offset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdr_checksum;
+    bit<32> src_addr;
+    bit<32> dst_addr;
+}
+
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<4>  res;
+    bit<8>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> length;
+    bit<16> checksum;
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    ipv4_h     ipv4;
+    tcp_h      tcp;
+    udp_h      udp;
+}
+
+struct metadata_t {
+    bit<16> direction;
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract<ipv4_h>(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            8w6: parse_tcp;
+            8w17: parse_udp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract<tcp_h>(hdr.tcp);
+        transition accept;
+    }
+    state parse_udp {
+        pkt.extract<udp_h>(hdr.udp);
+        transition accept;
+    }
+}
+
+control PreControlImpl(in headers_t hdr, inout metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+struct ct_tcp_table_hit_params_t {
+}
+
+control MainControlImpl(inout headers_t hdr, inout metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.outbound.conntrack.new_expire_time_profile_id") bit<8> outbound_conntrack_new_expire_time_profile_id;
+    @name("MainControlImpl.inbound.conntrack.new_expire_time_profile_id") bit<8> inbound_conntrack_new_expire_time_profile_id;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.drop") action drop() {
+        drop_packet();
+    }
+    @name("MainControlImpl.send") action send(@name("port") bit<32> port) {
+        send_to_port(port);
+    }
+    @name("MainControlImpl.ipv4_host") table ipv4_host_0 {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("hdr.ipv4.dst_addr");
+        }
+        actions = {
+            send();
+            drop();
+            @defaultonly NoAction_1();
+        }
+        const default_action = drop();
+        size = 65536;
+    }
+    @name("MainControlImpl.outbound.conntrack.ct_tcp_table_hit") action outbound_conntrack_ct_tcp_table_hit_0() {
+        hdr.ethernet.src_addr[7:0] = 8w0xf1;
+    }
+    @name("MainControlImpl.outbound.conntrack.ct_tcp_table_miss") action outbound_conntrack_ct_tcp_table_miss_0() {
+        hdr.ethernet.src_addr[7:0] = 8w0xa5;
+        add_entry<ct_tcp_table_hit_params_t>(action_name = "ct_tcp_table_hit", action_params = (ct_tcp_table_hit_params_t){}, expire_time_profile_id = outbound_conntrack_new_expire_time_profile_id);
+    }
+    @name("MainControlImpl.outbound.conntrack.ct_tcp_table") table outbound_conntrack_ct_tcp_table {
+        key = {
+            hdr.ipv4.src_addr: exact @name("ipv4_addr1");
+            hdr.ipv4.dst_addr: exact @name("ipv4_addr2");
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol");
+            hdr.tcp.src_port : exact @name("tcp_port1");
+            hdr.tcp.dst_port : exact @name("tcp_port2");
+        }
+        actions = {
+            @tableonly outbound_conntrack_ct_tcp_table_hit_0();
+            @defaultonly outbound_conntrack_ct_tcp_table_miss_0();
+        }
+        add_on_miss = true;
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = outbound_conntrack_ct_tcp_table_miss_0();
+    }
+    @name("MainControlImpl.inbound.conntrack.ct_tcp_table_hit") action inbound_conntrack_ct_tcp_table_hit_0() {
+        hdr.ethernet.src_addr[7:0] = 8w0xf1;
+    }
+    @name("MainControlImpl.inbound.conntrack.ct_tcp_table_miss") action inbound_conntrack_ct_tcp_table_miss_0() {
+        hdr.ethernet.src_addr[7:0] = 8w0xa5;
+        add_entry<ct_tcp_table_hit_params_t>(action_name = "ct_tcp_table_hit", action_params = (ct_tcp_table_hit_params_t){}, expire_time_profile_id = inbound_conntrack_new_expire_time_profile_id);
+    }
+    @name("MainControlImpl.inbound.conntrack.ct_tcp_table") table inbound_conntrack_ct_tcp_table {
+        key = {
+            hdr.ipv4.dst_addr: exact @name("ipv4_addr1");
+            hdr.ipv4.src_addr: exact @name("ipv4_addr2");
+            hdr.ipv4.protocol: exact @name("hdr.ipv4.protocol");
+            hdr.tcp.dst_port : exact @name("tcp_port1");
+            hdr.tcp.src_port : exact @name("tcp_port2");
+        }
+        actions = {
+            @tableonly inbound_conntrack_ct_tcp_table_hit_0();
+            @defaultonly inbound_conntrack_ct_tcp_table_miss_0();
+        }
+        add_on_miss = true;
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = inbound_conntrack_ct_tcp_table_miss_0();
+    }
+    @hidden action pnadpdkadd_on_miss1l253() {
+        meta.direction = 16w1;
+        outbound_conntrack_new_expire_time_profile_id = 8w1;
+    }
+    @hidden action pnadpdkadd_on_miss1l253_0() {
+        meta.direction = 16w2;
+        inbound_conntrack_new_expire_time_profile_id = 8w1;
+    }
+    @hidden table tbl_pnadpdkadd_on_miss1l253 {
+        actions = {
+            pnadpdkadd_on_miss1l253();
+        }
+        const default_action = pnadpdkadd_on_miss1l253();
+    }
+    @hidden table tbl_pnadpdkadd_on_miss1l253_0 {
+        actions = {
+            pnadpdkadd_on_miss1l253_0();
+        }
+        const default_action = pnadpdkadd_on_miss1l253_0();
+    }
+    apply {
+        if (hdr.ipv4.isValid() && hdr.tcp.isValid()) {
+            if (istd.direction == PNA_Direction_t.HOST_TO_NET) {
+                tbl_pnadpdkadd_on_miss1l253.apply();
+                outbound_conntrack_ct_tcp_table.apply();
+            } else {
+                tbl_pnadpdkadd_on_miss1l253_0.apply();
+                inbound_conntrack_ct_tcp_table.apply();
+            }
+        }
+        if (hdr.ipv4.isValid()) {
+            ipv4_host_0.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in metadata_t meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdkadd_on_miss1l330() {
+        pkt.emit<ethernet_h>(hdr.ethernet);
+        pkt.emit<ipv4_h>(hdr.ipv4);
+        pkt.emit<tcp_h>(hdr.tcp);
+        pkt.emit<udp_h>(hdr.udp);
+    }
+    @hidden table tbl_pnadpdkadd_on_miss1l330 {
+        actions = {
+            pnadpdkadd_on_miss1l330();
+        }
+        const default_action = pnadpdkadd_on_miss1l330();
+    }
+    apply {
+        tbl_pnadpdkadd_on_miss1l330.apply();
+    }
+}
+
+PNA_NIC<headers_t, metadata_t, headers_t, metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1.p4
@@ -1,0 +1,214 @@
+#include <core.p4>
+#include <pna.p4>
+
+const int IPV4_HOST_SIZE = 65536;
+typedef bit<48> EthernetAddress;
+typedef bit<32> IPv4Address;
+typedef bit<128> IPv6Address;
+typedef bit<16> etype_t;
+const etype_t ETYPE_IPV4 = 0x800;
+typedef bit<8> ipproto_t;
+const ipproto_t IPPROTO_TCP = 6;
+const ipproto_t IPPROTO_UDP = 17;
+header ethernet_h {
+    EthernetAddress dst_addr;
+    EthernetAddress src_addr;
+    etype_t         ether_type;
+}
+
+header ipv4_h {
+    bit<8>      version_ihl;
+    bit<8>      diffserv;
+    bit<16>     total_len;
+    bit<16>     identification;
+    bit<16>     flags_frag_offset;
+    bit<8>      ttl;
+    ipproto_t   protocol;
+    bit<16>     hdr_checksum;
+    IPv4Address src_addr;
+    IPv4Address dst_addr;
+}
+
+header tcp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<32> seq_no;
+    bit<32> ack_no;
+    bit<4>  data_offset;
+    bit<4>  res;
+    bit<8>  flags;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgent_ptr;
+}
+
+const bit<8> TCP_URG_MASK = 0x20;
+const bit<8> TCP_ACK_MASK = 0x10;
+const bit<8> TCP_PSH_MASK = 0x8;
+const bit<8> TCP_RST_MASK = 0x4;
+const bit<8> TCP_SYN_MASK = 0x2;
+const bit<8> TCP_FIN_MASK = 0x1;
+header udp_h {
+    bit<16> src_port;
+    bit<16> dst_port;
+    bit<16> length;
+    bit<16> checksum;
+}
+
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NOW = (ExpireTimeProfileId_t)0;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEW = (ExpireTimeProfileId_t)1;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_ESTABLISHED = (ExpireTimeProfileId_t)2;
+const ExpireTimeProfileId_t EXPIRE_TIME_PROFILE_TCP_NEVER = (ExpireTimeProfileId_t)3;
+struct headers_t {
+    ethernet_h ethernet;
+    ipv4_h     ipv4;
+    tcp_h      tcp;
+    udp_h      udp;
+}
+
+enum bit<16> direction_t {
+    INVALID = 0,
+    OUTBOUND = 1,
+    INBOUND = 2
+}
+
+struct metadata_t {
+    direction_t direction;
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout metadata_t meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.ether_type) {
+            ETYPE_IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        pkt.extract(hdr.ipv4);
+        transition select(hdr.ipv4.protocol) {
+            IPPROTO_TCP: parse_tcp;
+            IPPROTO_UDP: parse_udp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        pkt.extract(hdr.tcp);
+        transition accept;
+    }
+    state parse_udp {
+        pkt.extract(hdr.udp);
+        transition accept;
+    }
+}
+
+control PreControlImpl(in headers_t hdr, inout metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+IPv4Address directionNeutralAddr(in direction_t direction, in IPv4Address outbound_address, in IPv4Address inbound_address) {
+    if (direction == direction_t.OUTBOUND) {
+        return outbound_address;
+    } else {
+        return inbound_address;
+    }
+}
+bit<16> directionNeutralPort(in direction_t direction, in bit<16> outbound_port, in bit<16> inbound_port) {
+    if (direction == direction_t.OUTBOUND) {
+        return outbound_port;
+    } else {
+        return inbound_port;
+    }
+}
+struct ct_tcp_table_hit_params_t {
+}
+
+control conntrack(inout headers_t hdr, inout metadata_t meta) {
+    ExpireTimeProfileId_t new_expire_time_profile_id;
+    action ct_tcp_table_hit() {
+        hdr.ethernet.src_addr[7:0] = 0xf1;
+    }
+    action ct_tcp_table_miss() {
+        hdr.ethernet.src_addr[7:0] = 0xa5;
+        add_entry(action_name = "ct_tcp_table_hit", action_params = (ct_tcp_table_hit_params_t){  }, expire_time_profile_id = new_expire_time_profile_id);
+    }
+    table ct_tcp_table {
+        key = {
+            directionNeutralAddr(meta.direction, hdr.ipv4.src_addr, hdr.ipv4.dst_addr): exact @name("ipv4_addr1");
+            directionNeutralAddr(meta.direction, hdr.ipv4.dst_addr, hdr.ipv4.src_addr): exact @name("ipv4_addr2");
+            hdr.ipv4.protocol                                                         : exact;
+            directionNeutralPort(meta.direction, hdr.tcp.src_port, hdr.tcp.dst_port)  : exact @name("tcp_port1");
+            directionNeutralPort(meta.direction, hdr.tcp.dst_port, hdr.tcp.src_port)  : exact @name("tcp_port2");
+        }
+        actions = {
+            @tableonly ct_tcp_table_hit;
+            @defaultonly ct_tcp_table_miss;
+        }
+        add_on_miss = true;
+        pna_idle_timeout = PNA_IdleTimeout_t.NOTIFY_CONTROL;
+        const default_action = ct_tcp_table_miss;
+    }
+    apply {
+        new_expire_time_profile_id = EXPIRE_TIME_PROFILE_TCP_NEW;
+        ct_tcp_table.apply();
+    }
+}
+
+control inbound(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+        meta.direction = direction_t.INBOUND;
+        conntrack.apply(hdr, meta);
+    }
+}
+
+control outbound(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+        meta.direction = direction_t.OUTBOUND;
+        conntrack.apply(hdr, meta);
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout metadata_t meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action drop() {
+        drop_packet();
+    }
+    action send(PortId_t port) {
+        send_to_port(port);
+    }
+    table ipv4_host {
+        key = {
+            hdr.ipv4.dst_addr: exact;
+        }
+        actions = {
+            send;
+            drop;
+            @defaultonly NoAction;
+        }
+        const default_action = drop();
+        size = IPV4_HOST_SIZE;
+    }
+    apply {
+        if (hdr.ipv4.isValid() && hdr.tcp.isValid()) {
+            if (istd.direction == PNA_Direction_t.HOST_TO_NET) {
+                outbound.apply(hdr, meta);
+            } else {
+                inbound.apply(hdr, meta);
+            }
+        }
+        if (hdr.ipv4.isValid()) {
+            ipv4_host.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in metadata_t meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1.p4-error
@@ -1,0 +1,2 @@
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table outbound_conntrack_ct_tcp_table. Copying all match fields to metadata
+[--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table inbound_conntrack_ct_tcp_table. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1.p4.bfrt.json
@@ -1,0 +1,268 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [
+    {
+      "name" : "pipe.MainControlImpl.ipv4_host",
+      "id" : 47903772,
+      "table_type" : "MatchAction_Direct",
+      "size" : 65536,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "hdr.ipv4.dst_addr",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 22742608,
+          "name" : "MainControlImpl.send",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : [
+            {
+              "id" : 1,
+              "name" : "port",
+              "repeated" : false,
+              "mandatory" : true,
+              "read_only" : false,
+              "annotations" : [],
+              "type" : {
+                "type" : "bytes",
+                "width" : 32
+              }
+            }
+          ]
+        },
+        {
+          "id" : 24740121,
+          "name" : "MainControlImpl.drop",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "data" : []
+        },
+        {
+          "id" : 21257015,
+          "name" : "NoAction",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.MainControlImpl.outbound.conntrack.ct_tcp_table",
+      "id" : 45603629,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "ipv4_addr1",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "ipv4_addr2",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.ipv4.protocol",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 8
+          }
+        },
+        {
+          "id" : 4,
+          "name" : "tcp_port1",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 5,
+          "name" : "tcp_port2",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 33141335,
+          "name" : "MainControlImpl.outbound.conntrack.ct_tcp_table_hit",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : []
+        },
+        {
+          "id" : 32676708,
+          "name" : "MainControlImpl.outbound.conntrack.ct_tcp_table_miss",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    },
+    {
+      "name" : "pipe.MainControlImpl.inbound.conntrack.ct_tcp_table",
+      "id" : 38252535,
+      "table_type" : "MatchAction_Direct",
+      "size" : 1024,
+      "annotations" : [],
+      "depends_on" : [],
+      "has_const_default_action" : true,
+      "key" : [
+        {
+          "id" : 1,
+          "name" : "ipv4_addr1",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 2,
+          "name" : "ipv4_addr2",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 32
+          }
+        },
+        {
+          "id" : 3,
+          "name" : "hdr.ipv4.protocol",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 8
+          }
+        },
+        {
+          "id" : 4,
+          "name" : "tcp_port1",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        },
+        {
+          "id" : 5,
+          "name" : "tcp_port2",
+          "repeated" : false,
+          "annotations" : [],
+          "mandatory" : false,
+          "match_type" : "Exact",
+          "type" : {
+            "type" : "bytes",
+            "width" : 16
+          }
+        }
+      ],
+      "action_specs" : [
+        {
+          "id" : 25275198,
+          "name" : "MainControlImpl.inbound.conntrack.ct_tcp_table_hit",
+          "action_scope" : "TableOnly",
+          "annotations" : [
+            {
+              "name" : "@tableonly"
+            }
+          ],
+          "data" : []
+        },
+        {
+          "id" : 28147341,
+          "name" : "MainControlImpl.inbound.conntrack.ct_tcp_table_miss",
+          "action_scope" : "DefaultOnly",
+          "annotations" : [
+            {
+              "name" : "@defaultonly"
+            }
+          ],
+          "data" : []
+        }
+      ],
+      "data" : [],
+      "supported_operations" : [],
+      "attributes" : ["EntryScope"]
+    }
+  ],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-add_on_miss1.p4.spec
@@ -1,0 +1,233 @@
+
+struct ethernet_h {
+	bit<48> dst_addr
+	bit<48> src_addr
+	bit<16> ether_type
+}
+
+struct ipv4_h {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> total_len
+	bit<16> identification
+	bit<16> flags_frag_offset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdr_checksum
+	bit<32> src_addr
+	bit<32> dst_addr
+}
+
+struct tcp_h {
+	bit<16> src_port
+	bit<16> dst_port
+	bit<32> seq_no
+	bit<32> ack_no
+	bit<8> data_offset_res
+	bit<8> flags
+	bit<16> window
+	bit<16> checksum
+	bit<16> urgent_ptr
+}
+
+struct udp_h {
+	bit<16> src_port
+	bit<16> dst_port
+	bit<16> length
+	bit<16> checksum
+}
+
+struct send_arg_t {
+	bit<32> port
+}
+
+header ethernet instanceof ethernet_h
+header ipv4 instanceof ipv4_h
+header tcp instanceof tcp_h
+header udp instanceof udp_h
+
+struct metadata_t {
+	bit<32> pna_main_input_metadata_direction
+	bit<32> pna_main_input_metadata_input_port
+	bit<16> local_metadata_direction
+	bit<32> pna_main_output_metadata_output_port
+	bit<32> MainControlImpl_outbound_conntrack_ct_tcp_table_retval
+	bit<32> MainControlImpl_outbound_conntrack_ct_tcp_table_retval_0
+	;oldname:MainControlImpl_outbound_conntrack_ct_tcp_table_ipv4_protocol
+	bit<8> MainControlImpl_outbound_conntrack_ct_tcp_table_ipv4_protoc0
+	bit<16> MainControlImpl_outbound_conntrack_ct_tcp_table_retval_1
+	bit<16> MainControlImpl_outbound_conntrack_ct_tcp_table_retval_2
+	bit<32> MainControlImpl_inbound_conntrack_ct_tcp_table_retval
+	bit<32> MainControlImpl_inbound_conntrack_ct_tcp_table_retval_0
+	bit<8> MainControlImpl_inbound_conntrack_ct_tcp_table_ipv4_protocol
+	bit<16> MainControlImpl_inbound_conntrack_ct_tcp_table_retval_1
+	bit<16> MainControlImpl_inbound_conntrack_ct_tcp_table_retval_2
+	bit<48> MainControlT_tmp
+	bit<48> MainControlT_tmp_0
+	bit<48> MainControlT_tmp_1
+	bit<48> MainControlT_tmp_2
+	bit<8> MainControlT_outbound_conntrack_new_expire_time_profile_id
+	bit<8> MainControlT_inbound_conntrack_new_expire_time_profile_id
+}
+metadata instanceof metadata_t
+
+regarray direction size 0x100 initval 0
+action NoAction args none {
+	return
+}
+
+action drop args none {
+	drop
+	return
+}
+
+action send args instanceof send_arg_t {
+	mov m.pna_main_output_metadata_output_port t.port
+	return
+}
+
+action outbound_conntrack_ct_tcp_table_hit_0 args none {
+	mov m.MainControlT_tmp h.ethernet.src_addr
+	and m.MainControlT_tmp 0xFFFFFFFFFF00
+	mov h.ethernet.src_addr m.MainControlT_tmp
+	or h.ethernet.src_addr 0xF1
+	return
+}
+
+action outbound_conntrack_ct_tcp_table_miss_0 args none {
+	mov m.MainControlT_tmp_0 h.ethernet.src_addr
+	and m.MainControlT_tmp_0 0xFFFFFFFFFF00
+	mov h.ethernet.src_addr m.MainControlT_tmp_0
+	or h.ethernet.src_addr 0xA5
+	learn outbound_conntrack_ct_tcp_table_hit_0 m.MainControlT_outbound_conntrack_new_expire_time_profile_id
+	return
+}
+
+action inbound_conntrack_ct_tcp_table_hit_0 args none {
+	mov m.MainControlT_tmp_1 h.ethernet.src_addr
+	and m.MainControlT_tmp_1 0xFFFFFFFFFF00
+	mov h.ethernet.src_addr m.MainControlT_tmp_1
+	or h.ethernet.src_addr 0xF1
+	return
+}
+
+action inbound_conntrack_ct_tcp_table_miss_0 args none {
+	mov m.MainControlT_tmp_2 h.ethernet.src_addr
+	and m.MainControlT_tmp_2 0xFFFFFFFFFF00
+	mov h.ethernet.src_addr m.MainControlT_tmp_2
+	or h.ethernet.src_addr 0xA5
+	learn inbound_conntrack_ct_tcp_table_hit_0 m.MainControlT_inbound_conntrack_new_expire_time_profile_id
+	return
+}
+
+table ipv4_host {
+	key {
+		h.ipv4.dst_addr exact
+	}
+	actions {
+		send
+		drop
+		NoAction
+	}
+	default_action drop args none const
+	size 0x10000
+}
+
+
+learner outbound_conntrack_ct_tcp_table {
+	key {
+		m.MainControlImpl_outbound_conntrack_ct_tcp_table_retval
+		m.MainControlImpl_outbound_conntrack_ct_tcp_table_retval_0
+		m.MainControlImpl_outbound_conntrack_ct_tcp_table_ipv4_protoc0
+		m.MainControlImpl_outbound_conntrack_ct_tcp_table_retval_1
+		m.MainControlImpl_outbound_conntrack_ct_tcp_table_retval_2
+	}
+	actions {
+		outbound_conntrack_ct_tcp_table_hit_0 @tableonly
+		outbound_conntrack_ct_tcp_table_miss_0 @defaultonly
+	}
+	default_action outbound_conntrack_ct_tcp_table_miss_0 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+learner inbound_conntrack_ct_tcp_table {
+	key {
+		m.MainControlImpl_inbound_conntrack_ct_tcp_table_retval
+		m.MainControlImpl_inbound_conntrack_ct_tcp_table_retval_0
+		m.MainControlImpl_inbound_conntrack_ct_tcp_table_ipv4_protocol
+		m.MainControlImpl_inbound_conntrack_ct_tcp_table_retval_1
+		m.MainControlImpl_inbound_conntrack_ct_tcp_table_retval_2
+	}
+	actions {
+		inbound_conntrack_ct_tcp_table_hit_0 @tableonly
+		inbound_conntrack_ct_tcp_table_miss_0 @defaultonly
+	}
+	default_action inbound_conntrack_ct_tcp_table_miss_0 args none 
+	size 0x10000
+	timeout {
+		10
+		30
+		60
+		120
+		300
+		43200
+		120
+		120
+
+		}
+}
+
+apply {
+	rx m.pna_main_input_metadata_input_port
+	regrd m.pna_main_input_metadata_direction direction m.pna_main_input_metadata_input_port
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.ether_type 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
+	jmpeq MAINPARSERIMPL_PARSE_TCP h.ipv4.protocol 0x6
+	jmpeq MAINPARSERIMPL_PARSE_UDP h.ipv4.protocol 0x11
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_UDP :	extract h.udp
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_TCP :	extract h.tcp
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ipv4
+	jmpnv LABEL_END h.tcp
+	jmpneq LABEL_FALSE_0 m.pna_main_input_metadata_direction 0x1
+	mov m.local_metadata_direction 0x1
+	mov m.MainControlT_outbound_conntrack_new_expire_time_profile_id 0x1
+	mov m.MainControlImpl_outbound_conntrack_ct_tcp_table_retval h.ipv4.src_addr
+	mov m.MainControlImpl_outbound_conntrack_ct_tcp_table_retval_0 h.ipv4.dst_addr
+	mov m.MainControlImpl_outbound_conntrack_ct_tcp_table_ipv4_protoc0 h.ipv4.protocol
+	mov m.MainControlImpl_outbound_conntrack_ct_tcp_table_retval_1 h.tcp.src_port
+	mov m.MainControlImpl_outbound_conntrack_ct_tcp_table_retval_2 h.tcp.dst_port
+	table outbound_conntrack_ct_tcp_table
+	jmp LABEL_END
+	LABEL_FALSE_0 :	mov m.local_metadata_direction 0x2
+	mov m.MainControlT_inbound_conntrack_new_expire_time_profile_id 0x1
+	mov m.MainControlImpl_inbound_conntrack_ct_tcp_table_retval h.ipv4.dst_addr
+	mov m.MainControlImpl_inbound_conntrack_ct_tcp_table_retval_0 h.ipv4.src_addr
+	mov m.MainControlImpl_inbound_conntrack_ct_tcp_table_ipv4_protocol h.ipv4.protocol
+	mov m.MainControlImpl_inbound_conntrack_ct_tcp_table_retval_1 h.tcp.dst_port
+	mov m.MainControlImpl_inbound_conntrack_ct_tcp_table_retval_2 h.tcp.src_port
+	table inbound_conntrack_ct_tcp_table
+	LABEL_END :	jmpnv LABEL_END_1 h.ipv4
+	table ipv4_host
+	LABEL_END_1 :	emit h.ethernet
+	emit h.ipv4
+	emit h.tcp
+	emit h.udp
+	tx m.pna_main_output_metadata_output_port
+}
+
+


### PR DESCRIPTION
The mapping of add_entry action specified by user and its corresponding compiler generated internal name was not handling the add_on_miss table to be applied from multiple control paths including nested controls.

To fix this, added the miss(default) action in the map for fetching internal action name for the action name provided in add_entry.

Fixes https://github.com/p4lang/p4c/issues/3966