### PR TITLE
Dpdk Backend: Fix whole header move instructions for DPDK

### DIFF
--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -66,7 +66,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
                                          new DPDK::ProcessControls(&structure.pipeline_controls)),
         new DismantleMuxExpressions(typeMap, refMap),
         new P4::ConstantFolding(refMap, typeMap, false),
-        new ElimHeaderCopy(typeMap),
+        new EliminateHeaderCopy(refMap, typeMap),
         new P4::TypeChecking(refMap, typeMap),
         new P4::RemoveAllUnusedDeclarations(refMap),
         new ConvertActionSelectorAndProfile(refMap, typeMap, &structure),

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -1142,6 +1142,17 @@ class ElimHeaderCopy : public Transform {
     const IR::Node *postorder(IR::Member *m) override;
 };
 
+class EliminateHeaderCopy : public PassManager {
+ public:
+    EliminateHeaderCopy(P4::ReferenceMap *refMap, P4::TypeMap *typeMap) {
+        passes.push_back(new P4::ClearTypeMap(typeMap));
+        passes.push_back(new P4::ResolveReferences(refMap));
+        passes.push_back(new P4::TypeInference(refMap, typeMap, false));
+        passes.push_back(new P4::TypeChecking(refMap, typeMap, true));
+        passes.push_back(new ElimHeaderCopy(typeMap));
+    }
+};
+
 /// This pass checks whether an assignment statement has large operands (>64-bit).
 // If one operand is >64-bit and other is <= 64-bit, the smaller operand should be a header field
 // to maintain the endianness for copy. This pass detects if these conditions are satisfied or not.

--- a/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment.p4.spec
@@ -74,9 +74,48 @@ action NoAction args none {
 }
 
 action encap_one_tunnel_layer_ipv4 args instanceof encap_one_tunnel_layer_ipv4_arg_t {
-	mov h.ipv4_3 h.ipv4_2
-	mov h.ipv4_2 h.ipv4_1
-	mov h.ipv4_1 h.ipv4_0
+	jmpnv LABEL_FALSE_0 h.ipv4_2
+	validate h.ipv4_3
+	jmp LABEL_END_0
+	LABEL_FALSE_0 :	invalidate h.ipv4_3
+	LABEL_END_0 :	mov h.ipv4_3.version_ihl h.ipv4_2.version_ihl
+	mov h.ipv4_3.dscp_ecn h.ipv4_2.dscp_ecn
+	mov h.ipv4_3.length h.ipv4_2.length
+	mov h.ipv4_3.identification h.ipv4_2.identification
+	mov h.ipv4_3.rsvd_df_mf_frag_off h.ipv4_2.rsvd_df_mf_frag_off
+	mov h.ipv4_3.ttl h.ipv4_2.ttl
+	mov h.ipv4_3.protocol h.ipv4_2.protocol
+	mov h.ipv4_3.csum h.ipv4_2.csum
+	mov h.ipv4_3.src_ip h.ipv4_2.src_ip
+	mov h.ipv4_3.dst_ip h.ipv4_2.dst_ip
+	jmpnv LABEL_FALSE_1 h.ipv4_1
+	validate h.ipv4_2
+	jmp LABEL_END_1
+	LABEL_FALSE_1 :	invalidate h.ipv4_2
+	LABEL_END_1 :	mov h.ipv4_2.version_ihl h.ipv4_1.version_ihl
+	mov h.ipv4_2.dscp_ecn h.ipv4_1.dscp_ecn
+	mov h.ipv4_2.length h.ipv4_1.length
+	mov h.ipv4_2.identification h.ipv4_1.identification
+	mov h.ipv4_2.rsvd_df_mf_frag_off h.ipv4_1.rsvd_df_mf_frag_off
+	mov h.ipv4_2.ttl h.ipv4_1.ttl
+	mov h.ipv4_2.protocol h.ipv4_1.protocol
+	mov h.ipv4_2.csum h.ipv4_1.csum
+	mov h.ipv4_2.src_ip h.ipv4_1.src_ip
+	mov h.ipv4_2.dst_ip h.ipv4_1.dst_ip
+	jmpnv LABEL_FALSE_2 h.ipv4_0
+	validate h.ipv4_1
+	jmp LABEL_END_2
+	LABEL_FALSE_2 :	invalidate h.ipv4_1
+	LABEL_END_2 :	mov h.ipv4_1.version_ihl h.ipv4_0.version_ihl
+	mov h.ipv4_1.dscp_ecn h.ipv4_0.dscp_ecn
+	mov h.ipv4_1.length h.ipv4_0.length
+	mov h.ipv4_1.identification h.ipv4_0.identification
+	mov h.ipv4_1.rsvd_df_mf_frag_off h.ipv4_0.rsvd_df_mf_frag_off
+	mov h.ipv4_1.ttl h.ipv4_0.ttl
+	mov h.ipv4_1.protocol h.ipv4_0.protocol
+	mov h.ipv4_1.csum h.ipv4_0.csum
+	mov h.ipv4_1.src_ip h.ipv4_0.src_ip
+	mov h.ipv4_1.dst_ip h.ipv4_0.dst_ip
 	invalidate h.ipv4_0
 	mov h.mac.da t.mac_da
 	mov h.mac.sa t.mac_sa


### PR DESCRIPTION
Due to missing type information, header copy elimination was not expanding whole header copy to member-wise copy in some cases. Added passes to update refmap and typemap before the header copy elimination pass.

Fixes #3965 #4114 