### PR TITLE
[P4Testgen] Do not use Equ for mandating a minimum size.

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -318,11 +318,11 @@ bool CmdStepper::preorder(const IR::P4Program * /*program*/) {
         }
     }
 
-    // If this option is active, mandate that all packets conform to a fixed size.
+    // If this option is active, mandate that all packets must be larger than a minimum size.
     auto pktSize = TestgenOptions::get().minPktSize;
     if (pktSize != 0) {
         const auto *fixedSizeEqu =
-            new IR::Equ(ExecutionState::getInputPacketSizeVar(),
+            new IR::Geq(ExecutionState::getInputPacketSizeVar(),
                         IR::getConstant(&PacketVars::PACKET_SIZE_VAR_TYPE, pktSize));
         if (cond == std::nullopt) {
             cond = fixedSizeEqu;


### PR DESCRIPTION
Fixes #4151. This was a silly bug. Earlier, P4Testgen only had to option to fix packet size to a particular value. After transitioning to ranges, the equality was not converted into a greater-equals relation. 