### PR TITLE
[P4Testgen] Add more trace information to P4Testgen

### DIFF
--- a/backends/p4tools/common/lib/trace_event_types.cpp
+++ b/backends/p4tools/common/lib/trace_event_types.cpp
@@ -69,10 +69,15 @@ MethodCall::MethodCall(const IR::MethodCallExpression *call) : call(call) {}
 
 void MethodCall::print(std::ostream &os) const {
     const auto &srcInfo = call->getSourceInfo();
+    // Convert the method call to a string and strip any new lines.
+    std::stringstream callStream;
+    call->dbprint(callStream);
+    auto callString = callStream.str();
+    callString.erase(std::remove(callString.begin(), callString.end(), '\n'), callString.cend());
     if (srcInfo.isValid()) {
-        os << "[MethodCall]: " << call;
+        os << "[MethodCall]: " << callString;
     } else {
-        os << "[P4Testgen MethodCall]: " << call;
+        os << "[P4Testgen MethodCall]: " << callString;
     }
 }
 

--- a/backends/p4tools/common/lib/trace_event_types.cpp
+++ b/backends/p4tools/common/lib/trace_event_types.cpp
@@ -168,8 +168,7 @@ const AssignmentStatement *AssignmentStatement::evaluate(const Model &model,
 void AssignmentStatement::print(std::ostream &os) const {
     const auto &srcInfo = stmt.getSourceInfo();
     if (srcInfo.isValid()) {
-        auto fragment = srcInfo.toSourceFragment();
-        fragment = fragment.exceptLast(2);
+        auto fragment = srcInfo.toSourceFragment(false);
         fragment = fragment.trim();
         os << "[AssignmentStatement]: " << fragment << "| Computed: " << stmt;
     } else {

--- a/backends/p4tools/common/lib/trace_event_types.cpp
+++ b/backends/p4tools/common/lib/trace_event_types.cpp
@@ -25,6 +25,17 @@ Generic::Generic(cstring label) : label(label) {}
 void Generic::print(std::ostream &os) const { os << "[" << label << "]"; }
 
 /* =============================================================================================
+ *   GenericDescription
+ * ============================================================================================= */
+
+GenericDescription::GenericDescription(cstring label, cstring description)
+    : Generic(label), description(description) {}
+
+void GenericDescription::print(std::ostream &os) const {
+    Generic::print(os);
+    os << ": " << description;
+}
+/* =============================================================================================
  *   Expression
  * ============================================================================================= */
 
@@ -47,7 +58,7 @@ const Expression *Expression::evaluate(const Model &model, bool doComplete) cons
 
 void Expression::print(std::ostream &os) const {
     Generic::print(os);
-    os << " = " << formatHexExpr(value, true);
+    os << ": " << formatHexExpr(value, true);
 }
 
 /* =============================================================================================

--- a/backends/p4tools/common/lib/trace_event_types.h
+++ b/backends/p4tools/common/lib/trace_event_types.h
@@ -19,11 +19,12 @@ namespace P4Tools::TraceEvents {
  *   Generic
  * ============================================================================================= */
 
-/// A generic event that only takes in a string.
+/// A generic event that only takes in a string as label.
 class Generic : public TraceEvent {
  protected:
     // A label that specifies the type of this generic trace event.
     cstring label;
+
     void print(std::ostream &os) const override;
 
  public:
@@ -33,6 +34,22 @@ class Generic : public TraceEvent {
     Generic(Generic &&) = default;
     Generic &operator=(const Generic &) = default;
     Generic &operator=(Generic &&) = default;
+};
+
+/* =============================================================================================
+ *   GenericDescription
+ * ============================================================================================= */
+
+/// A generic event that takes in two strings, the first is the label, the second a description of
+/// the label.
+class GenericDescription : public Generic {
+ protected:
+    cstring description;
+
+    void print(std::ostream &os) const override;
+
+ public:
+    explicit GenericDescription(cstring description, cstring label);
 };
 
 /* =============================================================================================

--- a/backends/p4tools/common/lib/trace_event_types.h
+++ b/backends/p4tools/common/lib/trace_event_types.h
@@ -61,6 +61,27 @@ class Expression : public Generic {
 };
 
 /* =============================================================================================
+ *   MethodCallExpression
+ * ============================================================================================= */
+
+/// Label dedicated to method call expression.
+class MethodCall : public TraceEvent {
+ private:
+    const IR::MethodCallExpression *call;
+
+ public:
+    explicit MethodCall(const IR::MethodCallExpression *call);
+    ~MethodCall() override = default;
+    MethodCall(const MethodCall &) = default;
+    MethodCall(MethodCall &&) = default;
+    MethodCall &operator=(const MethodCall &) = default;
+    MethodCall &operator=(MethodCall &&) = default;
+
+ protected:
+    void print(std::ostream &os) const override;
+};
+
+/* =============================================================================================
  *   IfStatementCondition
  * ============================================================================================= */
 
@@ -79,6 +100,27 @@ class IfStatementCondition : public TraceEvent {
                                                        bool doComplete) const override;
 
     explicit IfStatementCondition(const IR::Expression *cond);
+
+ protected:
+    void print(std::ostream &os) const override;
+};
+
+/* =============================================================================================
+ *   AssignmentStatement
+ * ============================================================================================= */
+
+/// Represents an assignment statement.
+class AssignmentStatement : public TraceEvent {
+ private:
+    const IR::AssignmentStatement &stmt;
+
+ public:
+    [[nodiscard]] const AssignmentStatement *subst(const SymbolicEnv &env) const override;
+    const AssignmentStatement *apply(Transform &visitor) const override;
+    [[nodiscard]] const AssignmentStatement *evaluate(const Model &model,
+                                                      bool doComplete) const override;
+
+    explicit AssignmentStatement(const IR::AssignmentStatement &stmt);
 
  protected:
     void print(std::ostream &os) const override;

--- a/backends/p4tools/modules/testgen/benchmarks/test_coverage.py
+++ b/backends/p4tools/modules/testgen/benchmarks/test_coverage.py
@@ -176,6 +176,9 @@ def parse_coverage_and_timestamps(test_files, parse_type):
                     if parse_type == "PROTOBUF":
                         datestr = line.replace('metadata: "Date generated: ', "")
                         datestr = datestr.replace('"\n', "")
+                    elif parse_type == "PTF":
+                        datestr = line.replace("Date generated: ", "")
+                        datestr = datestr.replace("\n", "")
                     else:
                         datestr = line.replace("# Date generated: ", "")
                         datestr = datestr.replace("\n", "")
@@ -185,6 +188,8 @@ def parse_coverage_and_timestamps(test_files, parse_type):
                     if parse_type == "PROTOBUF":
                         covstr = line.replace('metadata: "Current node coverage: ', "")
                         covstr = covstr.replace('"\n', "")
+                    elif parse_type == "PTF":
+                        covstr = line.replace("Current statement coverage: ", "")
                     else:
                         covstr = line.replace("# Current node coverage: ", "")
                     covstr = covstr.replace("\n", "")

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -507,7 +507,8 @@ IR::SwitchStatement *CmdStepper::replaceSwitchLabels(const IR::SwitchStatement *
         // Do not replace default expression labels.
         if (!newSwitchCase->label->is<IR::DefaultExpression>()) {
             newSwitchCase->label =
-                IR::getConstant(actionVar->type, actionsIds[switchCase->label->toString()]);
+                IR::getConstant(actionVar->type, actionsIds[switchCase->label->toString()],
+                                switchCase->label->getSourceInfo());
         }
         newCases.push_back(newSwitchCase);
     }
@@ -548,6 +549,7 @@ bool CmdStepper::preorder(const IR::SwitchStatement *switchStatement) {
                 cmds.emplace_back(switchCase->statement);
             }
         }
+        nextState.add(*new TraceEvents::Generic("TaintedSwitchCase"));
         cmds.emplace_back(Continuation::PropertyUpdate("inUndefinedState", currentTaint));
     } else {
         // Otherwise, we pick the switch statement case in a normal fashion.
@@ -567,6 +569,8 @@ bool CmdStepper::preorder(const IR::SwitchStatement *switchStatement) {
             }
             // If any of the values in the match list hits, execute the switch case block.
             if (hasMatched) {
+                nextState.add(*new TraceEvents::GenericDescription(
+                    "SwitchCase", switchCase->label->getSourceInfo().toBriefSourceFragment()));
                 cmds.emplace_back(switchCase->statement);
                 // If the statement is a block, we do not fall through and terminate execution.
                 if (switchCase->statement->is<IR::BlockStatement>()) {
@@ -575,6 +579,7 @@ bool CmdStepper::preorder(const IR::SwitchStatement *switchStatement) {
             }
             // The default label must be last. Always break here.
             if (switchCase->label->is<IR::DefaultExpression>()) {
+                nextState.add(*new TraceEvents::GenericDescription("SwitchCase", "default"));
                 cmds.emplace_back(switchCase->statement);
                 break;
             }

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -89,7 +89,7 @@ bool CmdStepper::preorder(const IR::AssignmentStatement *assign) {
         TESTGEN_UNIMPLEMENTED("Unsupported assign type %1% node: %2%", leftType,
                               leftType->node_type_name());
     }
-
+    state.add(*new TraceEvents::AssignmentStatement(*assign));
     state.popBody();
     result->emplace_back(state);
     return false;
@@ -279,6 +279,7 @@ bool CmdStepper::preorder(const IR::MethodCallStatement *methodCallStatement) {
     }
     state.pushCurrentContinuation(type);
     state.replaceBody(Continuation::Body({Continuation::Return(methodCallStatement->methodCall)}));
+    state.add(*new TraceEvents::MethodCall(methodCallStatement->methodCall));
     result->emplace_back(state);
     return false;
 }

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -9,6 +9,7 @@
 #include "backends/p4tools/common/lib/gen_eq.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/taint.h"
+#include "backends/p4tools/common/lib/trace_event_types.h"
 #include "backends/p4tools/common/lib/variables.h"
 #include "ir/declaration.h"
 #include "ir/irutils.h"

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/ptf/ptf.cpp
@@ -324,12 +324,13 @@ std::string PTF::getTestCaseTemplate() {
     static std::string TEST_CASE(
         R"""(
 class Test{{test_id}}(AbstractTest):
-    # Date generated: {{timestamp}}
-## if length(selected_branches) > 0
-    # {{selected_branches}}
-## endif
     '''
-    # Current node coverage: {{coverage}}
+    Date generated: {{timestamp}}
+    Current node coverage: {{coverage}}
+## if length(selected_branches) > 0
+    Selected branches: {{selected_branches}}
+## endif
+    Trace:
 ## for trace_item in trace
     {{trace_item}}
 ##endfor

--- a/ir/irutils.h
+++ b/ir/irutils.h
@@ -38,10 +38,14 @@ const Type_Bits *getBitTypeToFit(int value);
  * ========================================================================================= */
 
 /// @returns a constant. The value is cached.
-const Constant *getConstant(const Type *type, big_int v);
+const Constant *getConstant(const Type *type, big_int v, const Util::SourceInfo &srcInfo = {});
 
 /// @returns a bool literal. The value is cached.
-const BoolLiteral *getBoolLiteral(bool value);
+const BoolLiteral *getBoolLiteral(bool value, const Util::SourceInfo &srcInfo = {});
+
+/// @returns a constant with the maximum big_int value that can fit into this bit width.
+/// Implicitly converts boolean types to a bit vector of width one with value 1.
+const IR::Constant *getMaxValueConstant(const Type *t, const Util::SourceInfo &srcInfo = {});
 
 /// @returns the "default" value for a given type.
 /// The resulting expression will have the specified srcInfo position.
@@ -66,10 +70,6 @@ const IR::Expression *getDefaultValue(const Type *type, const Util::SourceInfo &
 /// Converts a bool literal into a constant of type Type_Bits and width 1.
 /// The value is 1, if the bool literal is true, 0 otherwise.
 const IR::Constant *convertBoolLiteral(const IR::BoolLiteral *lit);
-
-/// @returns a constant with the maximum big_int value that can fit into this bit width.
-/// Implicitly converts boolean types to a bit vector of width one with value 1.
-const IR::Constant *getMaxValueConstant(const Type *t);
 
 /// Given an StructExpression, returns a flat vector of the expressions contained in that
 /// struct. Unfortunately, list and struct expressions are similar but have no common ancestors.

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -179,9 +179,9 @@ SourcePosition InputSources::getCurrentPosition() const {
     return SourcePosition(line, column);
 }
 
-cstring InputSources::getSourceFragment(const SourcePosition &position) const {
+cstring InputSources::getSourceFragment(const SourcePosition &position, bool useMarker) const {
     SourceInfo info(this, position, position);
-    return getSourceFragment(info);
+    return getSourceFragment(info, useMarker);
 }
 
 cstring carets(cstring source, unsigned start, unsigned end) {
@@ -202,12 +202,12 @@ cstring carets(cstring source, unsigned start, unsigned end) {
     return builder.str();
 }
 
-cstring InputSources::getSourceFragment(const SourceInfo &position) const {
+cstring InputSources::getSourceFragment(const SourceInfo &position, bool useMarker) const {
     if (!position.isValid()) return "";
 
     // If the position spans multiple lines, truncate to just the first line
     if (position.getEnd().getLineNumber() > position.getStart().getLineNumber())
-        return getSourceFragment(position.getStart());
+        return getSourceFragment(position.getStart(), useMarker);
 
     cstring result = getLine(position.getStart().getLineNumber());
     // Normally result has a newline, but if not
@@ -216,7 +216,11 @@ cstring InputSources::getSourceFragment(const SourceInfo &position) const {
     if (result.find('\n') == nullptr) toadd = cstring::newline;
     cstring marker =
         carets(result, position.getStart().getColumnNumber(), position.getEnd().getColumnNumber());
-    return result + toadd + marker + cstring::newline;
+    if (useMarker) {
+        return result + toadd + marker + cstring::newline;
+    } else {
+        return result + toadd + cstring::newline;
+    }
 }
 
 cstring InputSources::getBriefSourceFragment(const SourceInfo &position) const {
@@ -259,9 +263,9 @@ cstring InputSources::toDebugString() const {
 
 ///////////////////////////////////////////////////
 
-cstring SourceInfo::toSourceFragment() const {
+cstring SourceInfo::toSourceFragment(bool useMarker) const {
     if (!isValid()) return "";
-    return sources->getSourceFragment(*this);
+    return sources->getSourceFragment(*this, useMarker);
 }
 
 cstring SourceInfo::toBriefSourceFragment() const {

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -176,7 +176,7 @@ class SourceInfo final {
 
     void dbprint(std::ostream &out) const { out << this->toDebugString(); }
 
-    cstring toSourceFragment() const;
+    cstring toSourceFragment(bool useMarker = true) const;
     cstring toBriefSourceFragment() const;
     cstring toPositionString() const;
     cstring toSourcePositionData(unsigned *outLineNumber, unsigned *outColumnNumber) const;
@@ -294,8 +294,8 @@ class InputSources final {
        string describing a position in the sources, e.g.:
        int<32> variable;
                ^^^^^^^^ */
-    cstring getSourceFragment(const SourcePosition &position) const;
-    cstring getSourceFragment(const SourceInfo &position) const;
+    cstring getSourceFragment(const SourcePosition &position, bool useMarker) const;
+    cstring getSourceFragment(const SourceInfo &position, bool useMarker) const;
     cstring getBriefSourceFragment(const SourceInfo &position) const;
 
     cstring toDebugString() const;


### PR DESCRIPTION
Add some more tracing information to P4Testgen:
- Assignment statements
- Method calls
- Switch cases

Also augment the IR utility functions with SourceInfo as parameter so that we can trace back certain literals to their original expression. 