### PR TITLE
backends/ebpf: Change packet length calc to pass kernel verifier (#4158)

### DIFF
--- a/backends/ebpf/ebpfProgram.cpp
+++ b/backends/ebpf/ebpfProgram.cpp
@@ -242,8 +242,8 @@ void EBPFProgram::emitLocalVariables(CodeBuilder *builder) {
     builder->newline();
 
     builder->emitIndent();
-    builder->appendFormat("u32 %s = %s - %s", lengthVar.c_str(), packetEndVar.c_str(),
-                          packetStartVar.c_str());
+    builder->appendFormat("u32 %s = %s", lengthVar.c_str(),
+                          builder->target->dataLength(model.CPacketName.str()).c_str());
     builder->endOfStatement(true);
 }
 

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -96,6 +96,7 @@ class Target {
                           cstring argName) const = 0;
     virtual cstring dataOffset(cstring base) const = 0;
     virtual cstring dataEnd(cstring base) const = 0;
+    virtual cstring dataLength(cstring base) const = 0;
     virtual cstring forwardReturnCode() const = 0;
     virtual cstring dropReturnCode() const = 0;
     virtual cstring abortReturnCode() const = 0;
@@ -183,6 +184,7 @@ class KernelSamplesTarget : public Target {
     cstring dataEnd(cstring base) const override {
         return cstring("((void*)(long)") + base + "->data_end)";
     }
+    cstring dataLength(cstring base) const override { return cstring(base) + "->len"; }
     cstring forwardReturnCode() const override { return "TC_ACT_OK"; }
     cstring dropReturnCode() const override { return "TC_ACT_SHOT"; }
     cstring abortReturnCode() const override { return "TC_ACT_SHOT"; }
@@ -206,6 +208,9 @@ class XdpTarget : public KernelSamplesTarget {
     cstring sysMapPath() const override { return "/sys/fs/bpf/xdp/globals"; }
     cstring packetDescriptorType() const override { return "struct xdp_md"; }
 
+    cstring dataLength(cstring base) const override {
+        return cstring("(") + base + "->data_end - " + base + "->data)";
+    }
     void emitResizeBuffer(Util::SourceCodeBuilder *builder, cstring buffer,
                           cstring offsetVar) const override;
     void emitMain(Util::SourceCodeBuilder *builder, cstring functionName,
@@ -237,6 +242,7 @@ class BccTarget : public Target {
     cstring dataEnd(cstring base) const override {
         return cstring("(") + base + " + " + base + "->len)";
     }
+    cstring dataLength(cstring base) const override { return cstring(base) + "->len"; }
     cstring forwardReturnCode() const override { return "0"; }
     cstring dropReturnCode() const override { return "1"; }
     cstring abortReturnCode() const override { return "1"; }

--- a/backends/ubpf/target.h
+++ b/backends/ubpf/target.h
@@ -54,6 +54,7 @@ class UbpfTarget : public EBPF::Target {
 
     cstring dataOffset(UNUSED cstring base) const override { return cstring(""); }
     cstring dataEnd(UNUSED cstring base) const override { return cstring(""); }
+    cstring dataLength(UNUSED cstring base) const override { return cstring(""); }
     cstring dropReturnCode() const override { return "0"; }
     cstring abortReturnCode() const override { return "1"; }
     cstring forwardReturnCode() const override { return "1"; }


### PR DESCRIPTION
This basically copies the strategy used in the PSA sub-backend.

Edit: as discovered in a comment below, this PR is only needed for passing the verifier in kernel versions prior to 5.9.