### PR TITLE
[P4Testgen] Match switch labels directly using string literal expressions

### DIFF
--- a/backends/p4tools/common/lib/symbolic_env.cpp
+++ b/backends/p4tools/common/lib/symbolic_env.cpp
@@ -87,11 +87,14 @@ bool SymbolicEnv::isSymbolicValue(const IR::Node *node) {
 
     // Concrete constants and symbolic constants form the basis of symbolic values.
     //
-    // Constants and BoolLiterals are concrete constants.
+    // Constants, StringLiterals, and BoolLiterals are concrete constants.
     if (expr->is<IR::Constant>()) {
         return true;
     }
     if (expr->is<IR::BoolLiteral>()) {
+        return true;
+    }
+    if (expr->is<IR::StringLiteral>()) {
         return true;
     }
     // Tainted expressions are symbolic values.

--- a/backends/p4tools/common/lib/table_utils.h
+++ b/backends/p4tools/common/lib/table_utils.h
@@ -45,6 +45,10 @@ struct TableProperties {
 
     /// Ordered list of key fields with useful properties.
     std::vector<KeyProperties> resolvedKeys;
+
+    /// Maps an action in the action list to a numerical identifier.
+    /// We do not use IR::MethodCallExpression here because we also look up switch labels.
+    std::map<cstring, int> actionIdMap;
 };
 
 /// Checks whether certain table properties are immutable and sets the properties param

--- a/backends/p4tools/modules/testgen/benchmarks/plots.py
+++ b/backends/p4tools/modules/testgen/benchmarks/plots.py
@@ -42,10 +42,10 @@ def plot_preconditions(args, extra_args):
     preconditions = [
         "None",
         "1500B pkt",
-        "P4-constraints",
-        "P4-constraints + 1500B pkt",
-        "P4-constraints + 1500B IPv4 pkt",
-        "P4-constraints + 1500B IPv4-TCP pkt",
+        "P4Constraints",
+        "P4Constraints + 1500B pkt",
+        "P4Constraints + 1500B IPv4 pkt",
+        "P4Constraints + 1500B IPv4-TCP pkt",
     ]
     data = [146784, 83784, 74472, 42486, 28216, 7054]
     target_frame = pd.DataFrame({"Precondition": preconditions, "Number of tests": data})

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.h
@@ -34,10 +34,6 @@ class CmdStepper : public AbstractStepper {
     bool preorder(const IR::SwitchStatement *switchStatement) override;
 
  protected:
-    /// This call replaces the action labels of cases in a switch statement with the corresponding
-    /// indices. We need this to match the executed action with the appropriate label.
-    IR::SwitchStatement *replaceSwitchLabels(const IR::SwitchStatement *switchStatement);
-
     /// Initializes the given state for entry into the given parser.
     ///
     /// @returns constraints for associating packet data with symbolic state.

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
@@ -40,13 +40,6 @@ class TableStepper {
         const IR::Type *type, const IR::P4Table *table, cstring name,
         std::optional<int> idx1_opt = std::nullopt, std::optional<int> idx2_opt = std::nullopt);
 
-    /// @returns the boolean-typed state variable that tracks whether given table is reached.
-    static const IR::StateVariable &getTableReachedVar(const IR::P4Table *table);
-
-    /// @returns the state variable that tracks the value read by the key at the given index in the
-    /// given the table.
-    static const IR::StateVariable &getTableKeyReadVar(const IR::P4Table *table, int keyIdx);
-
     /// @returns the boolean-typed state variable that tracks whether a table has resulted in a hit.
     /// The value of this variable is false if the table misses or is not reached.
     static const IR::StateVariable &getTableHitVar(const IR::P4Table *table);
@@ -56,6 +49,8 @@ class TableStepper {
     /// This variable is initially set to the number of actions in the table, indicating that no
     /// action has been selected. It is set by setTableAction and read by getTableAction.
     static const IR::StateVariable &getTableActionVar(const IR::P4Table *table);
+
+    static const IR::StateVariable &getTableResultVar(const IR::P4Table *table);
 
  protected:
     /* =========================================================================================
@@ -78,7 +73,7 @@ class TableStepper {
 
     /// Sets the action taken by the given table. The arguments in the given MethodCallExpression
     /// are assumed to be symbolic values.
-    void setTableAction(ExecutionState &nextState, const IR::MethodCallExpression *actionCall);
+    const IR::StringLiteral *getTableActionString(const IR::MethodCallExpression *actionCall);
 
     /// A helper function to iteratively resolve table keys into symbolic values.
     /// This function returns false, if no key needs to be resolved.

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -153,10 +153,6 @@ void Bmv2V1ModelTableStepper::evalTableActionProfile(
         auto *synthesizedAction = tableAction->clone();
         synthesizedAction->arguments = arguments;
 
-        // We need to set the table action in the state for eventual switch action_run hits.
-        // We also will need it for control plane table entries.
-        setTableAction(nextState, tableAction);
-
         // Finally, add all the new rules to the execution state.
         const ActionCall ctrlPlaneActionCall(actionName, actionType, ctrlPlaneArgs);
         auto tableRule =
@@ -181,7 +177,7 @@ void Bmv2V1ModelTableStepper::evalTableActionProfile(
         }
 
         nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
-        nextState.set(getTableReachedVar(table), IR::getBoolLiteral(true));
+        nextState.set(getTableActionVar(table), getTableActionString(tableAction));
         std::stringstream tableStream;
         tableStream << "Table Branch: " << properties.tableName;
         tableStream << " Chosen action: " << actionName;
@@ -245,10 +241,6 @@ void Bmv2V1ModelTableStepper::evalTableActionSelector(
         auto *synthesizedAction = tableAction->clone();
         synthesizedAction->arguments = arguments;
 
-        // We need to set the table action in the state for eventual switch action_run hits.
-        // We also will need it for control plane table entries.
-        setTableAction(nextState, tableAction);
-
         // Finally, add all the new rules to the execution state.
         ActionCall ctrlPlaneActionCall(actionName, actionType, ctrlPlaneArgs);
         auto tableRule =
@@ -275,7 +267,7 @@ void Bmv2V1ModelTableStepper::evalTableActionSelector(
         }
 
         nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
-        nextState.set(getTableReachedVar(table), IR::getBoolLiteral(true));
+        nextState.set(getTableActionVar(table), getTableActionString(tableAction));
         std::stringstream tableStream;
         tableStream << "Table Branch: " << properties.tableName;
         tableStream << " Chosen action: " << actionName;

--- a/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
@@ -134,10 +134,6 @@ void SharedPnaTableStepper::evalTableActionProfile(
         auto *synthesizedAction = tableAction->clone();
         synthesizedAction->arguments = arguments;
 
-        // We need to set the table action in the state for eventual switch action_run hits.
-        // We also will need it for control plane table entries.
-        setTableAction(nextState, tableAction);
-
         // Finally, add all the new rules to the execution state.
         const ActionCall ctrlPlaneActionCall(actionName, actionType, ctrlPlaneArgs);
         auto tableRule =
@@ -162,7 +158,7 @@ void SharedPnaTableStepper::evalTableActionProfile(
         }
 
         nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
-        nextState.set(getTableReachedVar(table), IR::getBoolLiteral(true));
+        nextState.set(getTableActionVar(table), getTableActionString(tableAction));
         std::stringstream tableStream;
         tableStream << "Table Branch: " << properties.tableName;
         tableStream << " Chosen action: " << actionName;
@@ -226,10 +222,6 @@ void SharedPnaTableStepper::evalTableActionSelector(
         auto *synthesizedAction = tableAction->clone();
         synthesizedAction->arguments = arguments;
 
-        // We need to set the table action in the state for eventual switch action_run hits.
-        // We also will need it for control plane table entries.
-        setTableAction(nextState, tableAction);
-
         // Finally, add all the new rules to the execution state.
         ActionCall ctrlPlaneActionCall(actionName, actionType, ctrlPlaneArgs);
         auto tableRule =
@@ -256,7 +248,8 @@ void SharedPnaTableStepper::evalTableActionSelector(
         }
 
         nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
-        nextState.set(getTableReachedVar(table), IR::getBoolLiteral(true));
+        nextState.set(getTableActionVar(table), getTableActionString(tableAction));
+
         std::stringstream tableStream;
         tableStream << "Table Branch: " << properties.tableName;
         tableStream << " Chosen action: " << actionName;


### PR DESCRIPTION
This PR simplifies the way we handle `action_return`. Instead of returning an index and then trying to reconstruction the action from the index and the table, we simply return a string expression. This string expression contains the action name, which we can directly match.
