### PR TITLE
[clang-format] Enforce on the entire codebase.

### DIFF
--- a/backends/p4tools/common/lib/util.h
+++ b/backends/p4tools/common/lib/util.h
@@ -25,7 +25,7 @@ inline std::string logHelper(boost::format &f) { return f.str(); }
 
 /// Helper function for @printFeature
 template <class T, class... Args>
-std::string logHelper(boost::format &f, T &&t, Args &&...args) {
+std::string logHelper(boost::format &f, T &&t, Args &&... args) {
     return logHelper(f % std::forward<T>(t), std::forward<Args>(args)...);
 }
 
@@ -34,7 +34,7 @@ std::string logHelper(boost::format &f, T &&t, Args &&...args) {
 // https://stackoverflow.com/a/25859856
 template <typename... Arguments>
 void printFeature(const std::string &label, int level, const std::string &fmt,
-                  Arguments &&...args) {
+                  Arguments &&... args) {
     boost::format f(fmt);
 
     auto result = logHelper(f, std::forward<Arguments>(args)...);

--- a/backends/p4tools/modules/testgen/lib/logging.h
+++ b/backends/p4tools/modules/testgen/lib/logging.h
@@ -11,14 +11,14 @@ namespace P4Tools::P4Testgen {
 /// Helper functions that prints strings associated with verbose test information, for example
 /// traces, or the test values themselves.
 template <typename... Arguments>
-void printTraces(const std::string &fmt, Arguments &&...args) {
+void printTraces(const std::string &fmt, Arguments &&... args) {
     printFeature("test_traces", 4, fmt, std::forward<Arguments>(args)...);
 }
 
 /// Helper functions that prints strings associated with basic test generation information., for
 /// example the covered statements or tests number.
 template <typename... Arguments>
-void printInfo(const std::string &fmt, Arguments &&...args) {
+void printInfo(const std::string &fmt, Arguments &&... args) {
     printFeature("test_info", 4, fmt, std::forward<Arguments>(args)...);
 }
 

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -135,7 +135,7 @@ class IndexedVector : public Vector<T> {
         return Vector<T>::insert(i, v);
     }
     template <class... Args>
-    void emplace_back(Args &&...args) {
+    void emplace_back(Args &&... args) {
         auto el = new T(std::forward<Args>(args)...);
         push_back(el);
     }

--- a/ir/pattern.h
+++ b/ir/pattern.h
@@ -29,7 +29,7 @@ class Pattern {
     class Base {
      public:
         virtual bool match(const IR::Node *) = 0;
-    } *pattern;
+    } * pattern;
     Pattern(Base *p) : pattern(p) {}  // NOLINT(runtime/explicit)
 
     template <class T>

--- a/ir/v1.cpp
+++ b/ir/v1.cpp
@@ -136,84 +136,84 @@ void IR::Primitive::typecheck() const {
 }
 
 bool IR::Primitive::isOutput(int operand_index) const {
-        if (prim_info.count(name)) return (prim_info.at(name).out_operands >> operand_index) & 1;
-        return false;
+    if (prim_info.count(name)) return (prim_info.at(name).out_operands >> operand_index) & 1;
+    return false;
 }
 
 unsigned IR::Primitive::inferOperandTypes() const {
-        if (prim_info.count(name)) return prim_info.at(name).type_match_operands;
-        return 0;
+    if (prim_info.count(name)) return prim_info.at(name).type_match_operands;
+    return 0;
 }
 
 // infer the index width of a meter/counter/register based on the instance count
 // default to 32 bits if we can't figure it out
 int IR::Stateful::index_width() const {
-        return instance_count > 1 ? ceil_log2(instance_count) : 32;
+    return instance_count > 1 ? ceil_log2(instance_count) : 32;
 }
 
 static int inferIndexWidth(const IR::Expression *obj) {
-        if (auto *glob = obj->to<IR::GlobalRef>())
-            if (auto *sful = glob->obj->to<IR::Stateful>()) return sful->index_width();
-        return 32;
+    if (auto *glob = obj->to<IR::GlobalRef>())
+        if (auto *sful = glob->obj->to<IR::Stateful>()) return sful->index_width();
+    return 32;
 }
 
 const IR::Type *IR::Primitive::inferOperandType(int operand) const {
-        const IR::Type *rv = IR::Type::Unknown::get();
-        unsigned infer = 0;
+    const IR::Type *rv = IR::Type::Unknown::get();
+    unsigned infer = 0;
 
-        if (prim_info.count(name)) infer = prim_info.at(name).type_match_operands;
+    if (prim_info.count(name)) infer = prim_info.at(name).type_match_operands;
 
-        if ((infer >> operand) & 1) {
-            for (auto o : operands) {
-                if ((infer & 1) && o->type != rv) {
-                    rv = o->type;
-                    break;
-                }
-                infer >>= 1;
+    if ((infer >> operand) & 1) {
+        for (auto o : operands) {
+            if ((infer & 1) && o->type != rv) {
+                rv = o->type;
+                break;
             }
-            return rv;
-        }
-        if (name == "truncate") return IR::Type::Bits::get(32);
-        if ((name == "count" || name == "execute_meter") && operand == 1)
-            return IR::Type::Bits::get(inferIndexWidth(operands.at(0)));
-        if (name.startsWith("execute_stateful") && operand == 1) return IR::Type::Bits::get(32);
-        if ((name == "clone_ingress_pkt_to_egress" || name == "clone_i2e" ||
-             name == "clone_egress_pkt_to_egress" || name == "clone_e2e") &&
-            operand == 0) {
-            return IR::Type::Bits::get(32);
-        }
-        if ((name == "execute") && operand == 2)
-            return IR::Type::Bits::get(inferIndexWidth(operands.at(0)));
-        if (name == "modify_field_conditionally" && operand == 1) return IR::Type::Bits::get(1);
-        if (name == "register_read" && operand == 2)
-            return IR::Type::Bits::get(inferIndexWidth(operands.at(1)));
-        if (name == "register_write" && operand == 1)
-            return IR::Type::Bits::get(inferIndexWidth(operands.at(0)));
-        if (name == "shift_left" && operand == 1) {
-            if (operands.at(0)->type->width_bits() > operands.at(1)->type->width_bits())
-                return operands.at(0)->type;
-            return IR::Type::Unknown::get();
-        }
-        if (name == "shift_right" && operand == 1) {
-            if (operands.at(0)->type->width_bits() > operands.at(1)->type->width_bits())
-                return operands.at(0)->type;
-            return IR::Type::Unknown::get();
+            infer >>= 1;
         }
         return rv;
+    }
+    if (name == "truncate") return IR::Type::Bits::get(32);
+    if ((name == "count" || name == "execute_meter") && operand == 1)
+        return IR::Type::Bits::get(inferIndexWidth(operands.at(0)));
+    if (name.startsWith("execute_stateful") && operand == 1) return IR::Type::Bits::get(32);
+    if ((name == "clone_ingress_pkt_to_egress" || name == "clone_i2e" ||
+         name == "clone_egress_pkt_to_egress" || name == "clone_e2e") &&
+        operand == 0) {
+        return IR::Type::Bits::get(32);
+    }
+    if ((name == "execute") && operand == 2)
+        return IR::Type::Bits::get(inferIndexWidth(operands.at(0)));
+    if (name == "modify_field_conditionally" && operand == 1) return IR::Type::Bits::get(1);
+    if (name == "register_read" && operand == 2)
+        return IR::Type::Bits::get(inferIndexWidth(operands.at(1)));
+    if (name == "register_write" && operand == 1)
+        return IR::Type::Bits::get(inferIndexWidth(operands.at(0)));
+    if (name == "shift_left" && operand == 1) {
+        if (operands.at(0)->type->width_bits() > operands.at(1)->type->width_bits())
+            return operands.at(0)->type;
+        return IR::Type::Unknown::get();
+    }
+    if (name == "shift_right" && operand == 1) {
+        if (operands.at(0)->type->width_bits() > operands.at(1)->type->width_bits())
+            return operands.at(0)->type;
+        return IR::Type::Unknown::get();
+    }
+    return rv;
 }
 
 IR::V1Program::V1Program() {
-        // This is used to typecheck P4-14 programs
-        auto *standard_metadata_t = new IR::Type_Struct(
-            "standard_metadata_t",
-            {new IR::StructField("ingress_port", IR::Type::Bits::get(9)),
-             new IR::StructField("packet_length", IR::Type::Bits::get(32)),
-             new IR::StructField("egress_spec", IR::Type::Bits::get(9)),
-             new IR::StructField("egress_port", IR::Type::Bits::get(9)),
-             new IR::StructField("egress_instance", IR::Type::Bits::get(16)),
-             new IR::StructField("instance_type", IR::Type::Bits::get(32)),
-             new IR::StructField("parser_status", IR::Type::Bits::get(8)),
-             new IR::StructField("parser_error_location", IR::Type::Bits::get(8))});
-        scope.add("standard_metadata_t", new IR::v1HeaderType(standard_metadata_t));
-        scope.add("standard_metadata", new IR::Metadata("standard_metadata", standard_metadata_t));
+    // This is used to typecheck P4-14 programs
+    auto *standard_metadata_t =
+        new IR::Type_Struct("standard_metadata_t",
+                            {new IR::StructField("ingress_port", IR::Type::Bits::get(9)),
+                             new IR::StructField("packet_length", IR::Type::Bits::get(32)),
+                             new IR::StructField("egress_spec", IR::Type::Bits::get(9)),
+                             new IR::StructField("egress_port", IR::Type::Bits::get(9)),
+                             new IR::StructField("egress_instance", IR::Type::Bits::get(16)),
+                             new IR::StructField("instance_type", IR::Type::Bits::get(32)),
+                             new IR::StructField("parser_status", IR::Type::Bits::get(8)),
+                             new IR::StructField("parser_error_location", IR::Type::Bits::get(8))});
+    scope.add("standard_metadata_t", new IR::v1HeaderType(standard_metadata_t));
+    scope.add("standard_metadata", new IR::Metadata("standard_metadata", standard_metadata_t));
 }

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -147,7 +147,7 @@ class Vector : public VectorBase {
     const T *const &at(size_t idx) const { return vec.at(idx); }
     const T *&at(size_t idx) { return vec.at(idx); }
     template <class... Args>
-    void emplace_back(Args &&...args) {
+    void emplace_back(Args &&... args) {
         vec.emplace_back(new T(std::forward<Args>(args)...));
     }
     void push_back(T *a) { vec.push_back(a); }

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -620,12 +620,12 @@ class SplitFlowVisit : public SplitFlowVisit_base {
         const_nodes.emplace_back(&node);
     }
     template <class T1, class T2, class... Args>
-    void addNode(T1 &&t1, T2 &&t2, Args &&...args) {
+    void addNode(T1 &&t1, T2 &&t2, Args &&... args) {
         addNode(std::forward<T1>(t1));
         addNode(std::forward<T2>(t2), std::forward<Args>(args)...);
     }
     template <class... Args>
-    explicit SplitFlowVisit(Visitor &v, Args &&...args) : SplitFlowVisit(v) {
+    explicit SplitFlowVisit(Visitor &v, Args &&... args) : SplitFlowVisit(v) {
         addNode(std::forward<Args>(args)...);
     }
     void do_visit() override {

--- a/lib/hvec_map.h
+++ b/lib/hvec_map.h
@@ -190,7 +190,7 @@ class hvec_map : hash_vector_base {
 
     // FIXME -- how to do this without duplicating the code for lvalue/rvalue?
     template <typename... VV>
-    std::pair<iterator, bool> emplace(const KEY &k, VV &&...v) {
+    std::pair<iterator, bool> emplace(const KEY &k, VV &&... v) {
         bool new_key = false;
         size_t idx = hv_insert(&k);
         if (idx >= data.size()) {
@@ -210,7 +210,7 @@ class hvec_map : hash_vector_base {
         return std::make_pair(iterator(*this, idx), new_key);
     }
     template <typename... VV>
-    std::pair<iterator, bool> emplace(KEY &&k, VV &&...v) {
+    std::pair<iterator, bool> emplace(KEY &&k, VV &&... v) {
         bool new_key = false;
         size_t idx = hv_insert(&k);
         if (idx >= data.size()) {

--- a/lib/ordered_map.h
+++ b/lib/ordered_map.h
@@ -172,7 +172,7 @@ class ordered_map {
     const V &at(const K &x) const { return data_map.at(&x)->second; }
 
     template <typename KK, typename... VV>
-    std::pair<iterator, bool> emplace(KK &&k, VV &&...v) {
+    std::pair<iterator, bool> emplace(KK &&k, VV &&... v) {
         auto it = find(k);
         if (it == data.end()) {
             it = data.emplace(data.end(), std::piecewise_construct_t(), std::forward_as_tuple(k),
@@ -183,7 +183,7 @@ class ordered_map {
         return std::make_pair(it, false);
     }
     template <typename KK, typename... VV>
-    std::pair<iterator, bool> emplace_hint(iterator pos, KK &&k, VV &&...v) {
+    std::pair<iterator, bool> emplace_hint(iterator pos, KK &&k, VV &&... v) {
         /* should be const_iterator pos, but glibc++ std::list is broken */
         auto it = find(k);
         if (it == data.end()) {

--- a/lib/ordered_set.h
+++ b/lib/ordered_set.h
@@ -234,7 +234,7 @@ class ordered_set {
     }
 
     template <class... Args>
-    std::pair<iterator, bool> emplace(Args &&...args) {
+    std::pair<iterator, bool> emplace(Args &&... args) {
         auto it = data.emplace(data.end(), std::forward<Args>(args)...);
         auto old = find(*it);
         if (old == data.end()) {
@@ -247,7 +247,7 @@ class ordered_set {
     }
 
     template <class... Args>
-    std::pair<iterator, bool> emplace_back(Args &&...args) {
+    std::pair<iterator, bool> emplace_back(Args &&... args) {
         auto it = data.emplace(data.end(), std::forward<Args>(args)...);
         auto old = find(*it);
         if (old != data.end()) {


### PR DESCRIPTION
This is simply the result of running 'make clang-format-fix-errors' on the top of the main branch.