### PR TITLE
Get host architecture dynamically while downloading `protoc` binary

### DIFF
--- a/cmake/Protobuf.cmake
+++ b/cmake/Protobuf.cmake
@@ -44,10 +44,13 @@ macro(p4c_obtain_protobuf)
       USES_TERMINAL_DOWNLOAD TRUE
       GIT_PROGRESS TRUE
     )
+
     # Derive the target architecture in order to download the right zip.
     set(protobuf_ARCH "x86_64")
-    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
       set(protobuf_ARCH "aarch_64")
+    else()
+      MESSAGE(FATAL_ERROR "Unsupported host architecture `${CMAKE_HOST_SYSTEM_PROCESSOR}`")
     endif()
 
     # Pull a different protoc binary for MacOS.

--- a/cmake/Protobuf.cmake
+++ b/cmake/Protobuf.cmake
@@ -44,20 +44,25 @@ macro(p4c_obtain_protobuf)
       USES_TERMINAL_DOWNLOAD TRUE
       GIT_PROGRESS TRUE
     )
+    # Derive the target architecture in order to download the right zip.
+    set(protobuf_ARCH "x86_64")
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+      set(protobuf_ARCH "aarch_64")
+    endif()
+
     # Pull a different protoc binary for MacOS.
     # TODO: Should we build from scratch?
     if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
       fetchcontent_declare(
         protoc
-        URL https://github.com/protocolbuffers/protobuf/releases/download/v${P4C_PROTOBUF_VERSION}/protoc-${P4C_PROTOBUF_VERSION}-osx-x86_64.zip
+        URL https://github.com/protocolbuffers/protobuf/releases/download/v${P4C_PROTOBUF_VERSION}/protoc-${P4C_PROTOBUF_VERSION}-osx-${protobuf_ARCH}.zip
         USES_TERMINAL_DOWNLOAD TRUE
         GIT_PROGRESS TRUE
       )
     else()
       fetchcontent_declare(
         protoc
-        URL https://github.com/protocolbuffers/protobuf/releases/download/v${P4C_PROTOBUF_VERSION}/protoc-${P4C_PROTOBUF_VERSION}-linux-x86_64.zip
-        URL_HASH SHA256=3a4c1e5f2516c639d3079b1586e703fc7bcfa2136d58bda24d1d54f949c315e8
+        URL https://github.com/protocolbuffers/protobuf/releases/download/v${P4C_PROTOBUF_VERSION}/protoc-${P4C_PROTOBUF_VERSION}-linux-${protobuf_ARCH}.zip
         USES_TERMINAL_DOWNLOAD TRUE
         GIT_PROGRESS TRUE
       )

--- a/cmake/Protobuf.cmake
+++ b/cmake/Protobuf.cmake
@@ -46,9 +46,10 @@ macro(p4c_obtain_protobuf)
     )
 
     # Derive the target architecture in order to download the right zip.
-    set(protobuf_ARCH "x86_64")
     if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")
       set(protobuf_ARCH "aarch_64")
+    elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64")
+      set(protobuf_ARCH "x86_64")
     else()
       MESSAGE(FATAL_ERROR "Unsupported host architecture `${CMAKE_HOST_SYSTEM_PROCESSOR}`")
     endif()


### PR DESCRIPTION
In `cmake/Protobuf.cmake`, when `P4C_USE_PREINSTALLED_PROTOBUF` is enabled (which is the default case), the `protoc` binary is directly fetched from GitHub releases. However, there was an issue with the hardcoded assumption that the downloaded `.zip` archive is for the `x86_64` architecture, which resulted in compilation errors on `arm64` systems such as Apple M1/M2 silicons or when building multi-platform Docker containers.

This pull request addresses the problem by dynamically selecting the appropriate `.zip` archive based on the host architecture. It achieves this by utilizing the `CMAKE_HOST_SYSTEM_PROCESSOR` variable in CMake, which leverages `uname -r` to identify the target architecture.

Currently, this selection logic has been implemented for the `arm64` architecture, but it can be easily extended to support other architectures as needed.

Furthermore, in order to accommodate this dynamic selection, the `URL_HASH` directive in the `fetchcontent_declare` has been removed since it was not feasible to compute the SHA1 hash of the file dynamically.