### PR TITLE
Show annotations in actions' dbprint

### DIFF
--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -145,7 +145,7 @@ void IR::ActionFunction::dbprint(std::ostream &out) const {
 }
 
 void IR::P4Action::dbprint(std::ostream &out) const {
-    out << "action " << name << "(";
+    out << annotations << "action " << name << "(";
     const char *sep = "";
     for (auto arg : parameters->parameters) {
         out << sep << arg->direction << ' ' << arg->type << ' ' << arg->name;


### PR DESCRIPTION
This shall change allows seeing annotations in action's dbprint output where it was missing previously

e.g.
```
@hidden @Foo(1) action action_1() {...
```
