### PR TITLE
backends/ebpf: Output error if a header is not byte-aligned (#4176).

### DIFF
--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -182,6 +182,9 @@ set (EBPF_TEST_SUITES
 set (EBPF_KERNEL_TEST_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*_ebpf-kernel.p4"
   )
+set (EBPF_ERRORS_SUITES
+  "${P4C_SOURCE_DIR}/testdata/p4_16_ebpf_errors/*.p4"
+  )
 
 # determine the kernel version
 execute_process(COMMAND uname -r
@@ -247,6 +250,7 @@ endif()
 # Ideally, this is done via check for the python package
 p4c_add_tests("ebpf-bcc" ${EBPF_DRIVER_BCC} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_BCC}")
 p4c_add_tests("ebpf" ${EBPF_DRIVER_TEST} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_TEST}")
+p4c_add_tests("ebpf-errors" ${EBPF_DRIVER_TEST} ${EBPF_ERRORS_SUITES} "${XFAIL_TESTS_TEST}")
 
 # These are special tests with args that are not included in the default ebpf tests
 p4c_add_test_with_args("ebpf" ${EBPF_DRIVER_TEST} FALSE "testdata/p4_16_samples/ebpf_checksum_extern.p4" "testdata/p4_16_samples/ebpf_checksum_extern.p4" "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-checksum-ebpf.c" "")

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -407,7 +407,14 @@ void StateTranslationVisitor::compileExtract(const IR::Expression *destination) 
         return;
     }
 
+    // We expect all headers to start on a byte boundary.
     unsigned width = ht->width_bits();
+    if ((width % 8) != 0) {
+        ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET,
+                "Header %1% size %2% is not a multiple of 8 bits.", destination, width);
+        return;
+    }
+
     auto program = state->parser->program;
 
     cstring offsetStr =

--- a/backends/ebpf/targets/target.py
+++ b/backends/ebpf/targets/target.py
@@ -103,7 +103,7 @@ class EBPFTarget:
         if returncode != testutils.SUCCESS:
             testutils.log.error("Failed to compile the P4 program.")
             # If the compiler crashed fail the test
-            if "Compiler Bug" in out:
+            if out is not None and "Compiler Bug" in out:
                 sys.exit(testutils.FAILURE)
 
         # Check if we expect the p4 compilation of the p4 file to fail
@@ -114,7 +114,7 @@ class EBPFTarget:
                 returncode = testutils.FAILURE
             else:
                 returncode = testutils.SUCCESS
-        return returncode, expected_error
+        return returncode, expected_error, out
 
     def _write_pcap_files(self, iface_pkts_map):
         """Writes the collected packets to their respective interfaces.

--- a/testdata/p4_16_ebpf_errors/header_unaligned.p4
+++ b/testdata/p4_16_ebpf_errors/header_unaligned.p4
@@ -1,0 +1,28 @@
+#include <ebpf_model.p4>
+#include <core.p4>
+
+header ThreeBit_h {
+    bit<3> x;
+}
+
+struct Headers_t {
+    ThreeBit_h foo;
+    ThreeBit_h bar;
+}
+
+parser prs(packet_in p, out Headers_t headers) {
+    state start {
+        p.extract(headers.foo);
+        p.extract(headers.bar);
+        transition accept;
+    }
+}
+
+control pipe(inout Headers_t headers, out bool pass) {
+
+    apply {
+        pass = true;
+    }
+}
+
+ebpfFilter(prs(), pipe()) main;

--- a/testdata/p4_16_ebpf_errors_outputs/header_unaligned.p4-stderr
+++ b/testdata/p4_16_ebpf_errors_outputs/header_unaligned.p4-stderr
@@ -1,0 +1,6 @@
+header_unaligned.p4(15): [--Werror=target-error] error: Header headers.foo size 3 is not a multiple of 8 bits.
+        p.extract(headers.foo);
+                  ^^^^^^^^^^^
+header_unaligned.p4(16): [--Werror=target-error] error: Header headers.bar size 3 is not a multiple of 8 bits.
+        p.extract(headers.bar);
+                  ^^^^^^^^^^^


### PR DESCRIPTION
Also adds support for testing error messages in the eBPF backend (separate commit).

Previously, declaring such a header would not have caused any compile-time errors but generated functionally incorrect code. With this patch, the user is made aware and compilation fails.

Fixes #4176 