### PR TITLE
Update BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,11 +10,11 @@ package(
 license(
     name = "license",
     package_name = "com_github_p4lang_p4c",
-    license_kinds = [
-        "@rules_license//licenses/spdx:Apache-2.0",
-    ],
+    license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
     license_text = "LICENSE",
 )
+
+exports_files(["LICENSE"])
 
 filegroup(
     name = "p4include",


### PR DESCRIPTION
Clean up license declarations to conform with best practices.