### PR TITLE
[P4Testgen] Support string types in the Z3 solver.

### DIFF
--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -156,7 +156,7 @@ z3::sort Z3Solver::toSort(const IR::Type *type) {
         return ctx().bv_sort(bits->width_bits());
     }
 
-    if (const auto *string = type->to<IR::Type_String>()) {
+    if (type->is<IR::Type_String>()) {
         return ctx().string_sort();
     }
 

--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -156,6 +156,10 @@ z3::sort Z3Solver::toSort(const IR::Type *type) {
         return ctx().bv_sort(bits->width_bits());
     }
 
+    if (const auto *string = type->to<IR::Type_String>()) {
+        return ctx().string_sort();
+    }
+
     BUG("Z3Solver: unimplemented type %1%: %2% ", type->node_type_name(), type);
 }
 


### PR DESCRIPTION
We support string literals already, but not the symbolic string type `string_sort`. Fix that. 