### PR TITLE
Ensured that error messages cannot be demoted to info messages

### DIFF
--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -206,6 +206,10 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
         "--Winfo", "diagnostic",
         [](const char *diagnostic) {
             if (diagnostic) {
+                if (ErrorCatalog::getCatalog().isError(diagnostic)) {
+                    ::error(ErrorType::ERR_INVALID, "Error %1% cannot be demoted", diagnostic);
+                    return false;
+                }
                 P4CContext::get().setDiagnosticAction(diagnostic, DiagnosticAction::Info);
             }
             return true;

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -112,6 +112,23 @@ class ErrorCatalog {
         return "--unknown--";
     }
 
+    /// retrieve the code for name
+    int getCode(cstring name) {
+        auto it =
+            std::find_if(errorCatalog.begin(), errorCatalog.end(),
+                         [name](const std::pair<int, cstring> &p) { return p.second == name; });
+        if (it != errorCatalog.end()) return it->first;
+        return -1;
+    }
+
+    /// return true if the name is an error; false otherwise
+    bool isError(cstring name) {
+        int code = getCode(name);
+        if (code == -1) return false;
+        if (code >= ErrorType::ERR_MAX_ERRORS) return false;
+        return true;
+    }
+
  private:
     ErrorCatalog() {}
 


### PR DESCRIPTION
The PR ensures that error messages cannot be demoted to info messages.

With `p4c --Winfo=invalid ...`, the following error is printed out:

`[--Werror=invalid] error: Error invalid cannot be demoted`