### PR TITLE
[P4Testgen] Change Protobuf backend test case file extension to `.txtpb`

### DIFF
--- a/backends/p4tools/modules/testgen/benchmarks/test_coverage.py
+++ b/backends/p4tools/modules/testgen/benchmarks/test_coverage.py
@@ -200,7 +200,7 @@ def collect_data_from_folder(input_dir, parse_type):
     if parse_type == "PTF":
         files = get_test_files(input_dir, "*.py")
     elif parse_type == "PROTOBUF":
-        files = get_test_files(input_dir, "*.proto")
+        files = get_test_files(input_dir, "*.txtpb")
     else:
         files = get_test_files(input_dir, "*.stf")
     return parse_coverage_and_timestamps(files, parse_type)

--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
@@ -403,7 +403,7 @@ void Protobuf::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, 
     LOG5("Protobuf test back end: emitting testcase:" << std::setw(4) << dataJson);
     auto incrementedbasePath = basePath;
     incrementedbasePath.concat("_" + std::to_string(testId));
-    incrementedbasePath.replace_extension(".proto");
+    incrementedbasePath.replace_extension(".txtpb");
     auto protobufFileStream = std::ofstream(incrementedbasePath);
     inja::render_to(protobufFileStream, testCase, dataJson);
     protobufFileStream.flush();

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
@@ -36,14 +36,14 @@ macro(check_bmv2_with_ptf testfile testfolder p4test)
   file(APPEND ${testfile} "done\n")
 endmacro(check_bmv2_with_ptf)
 
-# Write the script to validate whether a given protobuf file has a valid format.
+# Write the script to validate whether a given protobuf text format file has a valid format.
 # Arguments:
 #   - testfile is the testing script that this script is written to.
 #   - testfolder is target folder of the test.
 function(validate_protobuf testfile testfolder)
   # Find all the proto tests generated for this P4 file and validate their correctness.
-  file(APPEND ${testfile} "stffiles=($(find ${testfolder} -name \"*.proto\"  | sort -n ))\n")
-  file(APPEND ${testfile} "for item in \${stffiles[@]}\n")
+  file(APPEND ${testfile} "txtpbfiles=($(find ${testfolder} -name \"*.txtpb\"  | sort -n ))\n")
+  file(APPEND ${testfile} "for item in \${txtpbfiles[@]}\n")
   file(APPEND ${testfile} "do\n")
   file(APPEND ${testfile} "\techo \"Found \${item}\"\n")
   file(APPEND ${testfile} "\tprotoc --proto_path=${CMAKE_CURRENT_LIST_DIR}/../proto --proto_path=${P4C_SOURCE_DIR}/control-plane/p4runtime/proto --proto_path=${P4C_SOURCE_DIR}/control-plane --encode=p4testgen.TestCase p4testgen.proto < \${item}\n")


### PR DESCRIPTION
With the same reasoning as #4066. `.proto` is usually used for the schema definition file, while `.txtpb` is the current recommendation for the [text format file](https://protobuf.dev/reference/protobuf/textformat-spec/#text-format-files).