### PR TITLE
[P4Testgen] Fix textproto generation and escape traces properly.

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/backend/protobuf/protobuf.cpp
@@ -263,7 +263,7 @@ metadata: "{{selected_branches}}"
 metadata: "Current node coverage: {{coverage}}"
 
 ## for trace_item in trace
-traces: "{{trace_item}}"
+traces: '{{trace_item}}'
 ## endfor
 
 input_packet {
@@ -389,9 +389,7 @@ void Protobuf::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, 
     }
     dataJson["test_name"] = basePath.stem();
     dataJson["test_id"] = testId;
-    // TODO: Traces are disabled until we are able to escape illegal characters (e.g., '"').
-    // dataJson["trace"] = getTrace(testSpec);
-    dataJson["trace"] = inja::json::array();
+    dataJson["trace"] = getTrace(testSpec);
     dataJson["control_plane"] = getControlPlane(testSpec);
     dataJson["send"] = getSend(testSpec);
     dataJson["verify"] = getVerify(testSpec);

--- a/backends/p4tools/modules/testgen/targets/bmv2/proto/p4testgen.proto
+++ b/backends/p4tools/modules/testgen/targets/bmv2/proto/p4testgen.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 
 package p4testgen;
 
-import "p4runtime/proto/p4/v1/p4runtime.proto";
+import "p4/v1/p4runtime.proto";
 
 message InputPacketAtPort {
     // The raw bytes of the test packet.

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
@@ -46,7 +46,7 @@ function(validate_protobuf testfile testfolder)
   file(APPEND ${testfile} "for item in \${txtpbfiles[@]}\n")
   file(APPEND ${testfile} "do\n")
   file(APPEND ${testfile} "\techo \"Found \${item}\"\n")
-  file(APPEND ${testfile} "\tprotoc --proto_path=${CMAKE_CURRENT_LIST_DIR}/../proto --proto_path=${P4C_SOURCE_DIR}/control-plane/p4runtime/proto --proto_path=${P4C_SOURCE_DIR}/control-plane --encode=p4testgen.TestCase p4testgen.proto < \${item}\n")
+  file(APPEND ${testfile} "\tprotoc --proto_path=${CMAKE_CURRENT_LIST_DIR}/../proto --proto_path=${P4RUNTIME_STD_DIR} --proto_path=${P4C_SOURCE_DIR}/control-plane --encode=p4testgen.TestCase p4testgen.proto < \${item}\n")
   file(APPEND ${testfile} "done\n")
 endfunction(validate_protobuf)
 


### PR DESCRIPTION
Cheap workaround to deal with double quote characters within a trace object. Also fix up the Protobuf format for P4Testgen test messages. We are currently not testing these, so breakages were not detected.

Fixes #4202. @qobilidop 