### PR TITLE
[P4Testgen] Add a compiler pass to resolve Type_Name in StructExpressions.

### DIFF
--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -12,6 +12,7 @@ set(
 
   compiler/compiler_target.cpp
   compiler/convert_hs_index.cpp
+  compiler/convert_struct_expr.cpp
   compiler/convert_varbits.cpp
   compiler/midend.cpp
   compiler/reachability.cpp

--- a/backends/p4tools/common/compiler/convert_struct_expr.cpp
+++ b/backends/p4tools/common/compiler/convert_struct_expr.cpp
@@ -1,0 +1,25 @@
+#include "backends/p4tools/common/compiler/convert_struct_expr.h"
+
+#include "ir/irutils.h"
+
+namespace P4Tools {
+
+const IR::Node *ConvertStructExpr::postorder(IR::StructExpression *structExpr) {
+    auto structType = structExpr->type;
+    bool resolved = false;
+    if (structType->is<IR::Type_Name>()) {
+        structType = typeMap->getTypeType(structType, true);
+        resolved = true;
+    }
+    if (resolved) {
+        return new IR::StructExpression(structExpr->srcInfo, structType, structExpr->type,
+                                        structExpr->components);
+    }
+    return structExpr;
+}
+
+ConvertStructExpr::ConvertStructExpr(const P4::TypeMap *typeMap) : typeMap(typeMap) {
+    setName("ConvertStructExpr");
+    visitDagOnce = false;
+}
+}  // namespace P4Tools

--- a/backends/p4tools/common/compiler/convert_struct_expr.h
+++ b/backends/p4tools/common/compiler/convert_struct_expr.h
@@ -1,0 +1,23 @@
+#ifndef BACKENDS_P4TOOLS_COMMON_COMPILER_CONVERT_STRUCT_EXPR_H_
+#define BACKENDS_P4TOOLS_COMMON_COMPILER_CONVERT_STRUCT_EXPR_H_
+
+#include "frontends/p4/typeMap.h"
+#include "ir/ir.h"
+#include "ir/node.h"
+#include "ir/visitor.h"
+
+namespace P4Tools {
+
+class ConvertStructExpr : public Transform {
+ private:
+    const P4::TypeMap *typeMap;
+
+ public:
+    explicit ConvertStructExpr(const P4::TypeMap *typeMap);
+
+    const IR::Node *postorder(IR::StructExpression *expr) override;
+};
+
+}  // namespace P4Tools
+
+#endif /* BACKENDS_P4TOOLS_COMMON_COMPILER_CONVERT_STRUCT_EXPR_H_ */

--- a/backends/p4tools/common/compiler/midend.cpp
+++ b/backends/p4tools/common/compiler/midend.cpp
@@ -1,5 +1,6 @@
 #include "backends/p4tools/common/compiler/midend.h"
 
+#include "backends/p4tools/common/compiler/convert_struct_expr.h"
 #include "backends/p4tools/common/compiler/convert_varbits.h"
 #include "frontends/common/constantFolding.h"
 #include "frontends/common/options.h"
@@ -30,7 +31,6 @@
 #include "midend/orderArguments.h"
 #include "midend/parserUnroll.h"
 #include "midend/removeLeftSlices.h"
-#include "midend/removeMiss.h"
 #include "midend/removeSelectBooleans.h"
 #include "midend/replaceSelectRange.h"
 #include "midend/simplifyBitwise.h"
@@ -162,6 +162,8 @@ void MidEnd::addDefaultPasses() {
         new P4::HSIndexSimplifier(&refMap, &typeMap),
         // Convert Type_Varbits into a type that contains information about the assigned width.
         new ConvertVarbits(),
+        // Convert any StructExpressions with Type_Header into a HeaderExpression.
+        new ConvertStructExpr(&typeMap),
         // Cast all boolean table keys with a bit<1>.
         new P4::CastBooleanTableKeys(),
     });

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -463,15 +463,20 @@ class P4ListExpression : BaseListExpression {
 
 /// An expression that evaluates to a struct.
 class StructExpression : Expression {
-    /// The struct or header type that is being intialized.
+    /// The struct or header type that is being initialized.
     /// May only be known after type checking; so it can be nullptr.
     NullOK Type structType;
+
+    /// Allow the struct expression to have a Type_StructLike type.
+    optional bool structOkay = false;
+
     inline IndexedVector<NamedExpression> components;
     validate {
         components.check_null(); components.validate();
         BUG_CHECK(structType == nullptr || structType->is<IR::Type_Name>() ||
-                  structType->is<IR::Type_Specialized>(),
-                  "%1%: unexpected struct type", this);
+                  structType->is<IR::Type_Specialized>()
+                  || (structOkay && structType->is<IR::Type_StructLike>()),
+                  "%1%: unexpected struct type %2%", this, structType->node_type_name());
     }
     size_t size() const { return components.size(); }
     NamedExpression getField(cstring name) const {

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -463,20 +463,15 @@ class P4ListExpression : BaseListExpression {
 
 /// An expression that evaluates to a struct.
 class StructExpression : Expression {
-    /// The struct or header type that is being initialized.
+    /// The struct or header type that is being intialized.
     /// May only be known after type checking; so it can be nullptr.
     NullOK Type structType;
-
-    /// Allow the struct expression to have a Type_StructLike type.
-    optional bool structOkay = false;
-
     inline IndexedVector<NamedExpression> components;
     validate {
         components.check_null(); components.validate();
         BUG_CHECK(structType == nullptr || structType->is<IR::Type_Name>() ||
-                  structType->is<IR::Type_Specialized>()
-                  || (structOkay && structType->is<IR::Type_StructLike>()),
-                  "%1%: unexpected struct type %2%", this, structType->node_type_name());
+                  structType->is<IR::Type_Specialized>(),
+                  "%1%: unexpected struct type", this);
     }
     size_t size() const { return components.size(); }
     NamedExpression getField(cstring name) const {


### PR DESCRIPTION
~~In some cases, one may want to create a struct expression, which contains the relevant type directly, without having to use a `Type_Name` as indirection. This PR relaxes the constraints around the creation of struct expressions to make this possible. We simply add a new parameter that allows us to toggle whether or not to accept `IR::Type_StructLike` types.~~

When resolving struct expressions, simply preserve Type_Name for structType but assign the resolved type to type. This works for all dependent PRs and preserves functionality of passes such as toP4 etc.


