### PR TITLE
#noconstructor should also include the json loader constructor

### DIFF
--- a/ir/ir.def
+++ b/ir/ir.def
@@ -25,7 +25,7 @@
   #emit/#end      -> copy text literally to output header file
   #emit_impl/#end -> copy text literally to output C++ file
   #noXXX          -> do not emit the specified implementation for the XXX method
-                     e.g., #noconstructor, #nodbprint, #novisit_children
+                     e.g., #noconstructor, #nodbprint, #novisit_children, #nomethod_constructor
   #apply          -> generate apply overload for visitors
   method{ ... }   -> specifies an implementation for a default method
                      method can be 'operator=='
@@ -51,8 +51,7 @@
   Unless there is a '#noconstructor' tag in the class, a constructor
   will automatically be generated that takes as arguments values to
   initialize all fields of the IR class and its bases that do not have
-  explicit initializers.  Fields marked 'optional' will create multiple
-  constructors both with and without an argument for that field.
+  explicit initializers. There are some special method constructors which ignore #noconstructor, such as Class(JSONLoader &json). #nomethod_constructor will prevent these files from being generated. Fields marked 'optional' will create multiple constructors both with and without an argument for that field.
  */
 
 class ParserState : ISimpleNamespace, Declaration, IAnnotated {

--- a/tools/ir-generator/ir-generator-lex.l
+++ b/tools/ir-generator/ir-generator-lex.l
@@ -84,7 +84,7 @@ static std::string      comment_block;
 "virtual"       { return VIRTUAL; }
 "NullOK"        { return NULLOK; }
 "#apply"        { return APPLY; }
-"#no"[a-z_]*    { yylval.str = yytext+3; return NO; }
+"#no"[a-zA-Z_]*    { yylval.str = yytext+3; return NO; }
 "#nooperator==" { yylval.str = yytext+3; return NO; }
 "0"             { yylval.str = yytext; return ZERO; }
 -?[0-9]+        { yylval.str = yytext; return INTEGER; }

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -314,7 +314,7 @@ void IrClass::generateMethods() {
                     auto *m = new IrMethod(def.first, body);
                     if (def.second.flags & FRIEND) m->isFriend = true;
                     m->clss = this;
-                    if (!(def.second.flags & CONSTRUCTOR) || !shouldSkip("constructor")) {
+                    if (!(def.second.flags & CONSTRUCTOR) || !shouldSkip("method_constructor")) {
                         elements.push_back(m);
                     }
                 }

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -314,7 +314,9 @@ void IrClass::generateMethods() {
                     auto *m = new IrMethod(def.first, body);
                     if (def.second.flags & FRIEND) m->isFriend = true;
                     m->clss = this;
-                    elements.push_back(m);
+                    if (!(def.second.flags & CONSTRUCTOR) || !shouldSkip("constructor")) {
+                        elements.push_back(m);
+                    }
                 }
             }
         }


### PR DESCRIPTION
The JSONLoader constructor is not omitted when the `#noconstructor` directive is active. This is because it is generated via a non-standard way. 

This PR  adds a `#no_methodconstructor` directive, which allows you to ignore constructors generated via these special methods.

This PR also supports casing for the `#noXXX` directive. Some functions can not be ignored because they are written in camelcase.
