### PR TITLE
[P4Testgen] Move common code of BMv2 test back ends into a common class.

### DIFF
--- a/backends/p4tools/BUILD.bazel
+++ b/backends/p4tools/BUILD.bazel
@@ -90,7 +90,6 @@ filegroup(
 cc_library(
     name = "testgen_lib",
     srcs = glob([
-        "modules/testgen/backend/*.h",
         "modules/testgen/core/**/*.h",
         "modules/testgen/lib/*.h",
         "modules/testgen/*.h",
@@ -99,7 +98,6 @@ cc_library(
         "modules/testgen/core/small_step/*.cpp",
         "modules/testgen/core/symbolic_executor/*.cpp",
         "modules/testgen/lib/*.cpp",
-        "modules/testgen/backend/*.cpp",
     ]) + [
         "common/options.h",
         "modules/testgen/options.cpp",

--- a/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 set(
   TESTGEN_SOURCES
   ${TESTGEN_SOURCES}
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_backend/common.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_backend/protobuf.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_backend/metadata.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_backend/ptf.cpp

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufXfail.cmake
@@ -9,6 +9,13 @@
 ####################################################################################################
 # These are failures in P4Testgen that need to be fixed.
 
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-protobuf"
+  "Non-numeric, non-boolean member expression: .* Type: Type_Stack"
+  # We can not expand stacks in parsers because information about .next is lost.
+  # P4Testgen needs to maintain its own internal .next variable for stacks.
+  array-copy-bmv2.p4
+)
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-protobuf"
@@ -115,6 +122,13 @@ p4tools_add_xfail_reason(
   "with type Type_Specialized is not a Type_Declaration"
   # Pipeline as a parameter of a switch, not a valid v1model program
   issue1304.p4
+)
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-protobuf"
+  "is not a constant"
+  # Using an uninitialized variable as a header stack index in the parser.
+  parser-unroll-test10.p4
 )
 
 ####################################################################################################

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
@@ -10,14 +10,6 @@
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-stf"
-  "Non-numeric, non-boolean member expression: .* Type: Type_Stack"
-  # We can not expand stacks in parsers because information about .next is lost.
-  # P4Testgen needs to maintain its own internal .next variable for stacks.
-  array-copy-bmv2.p4
-)
-
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2-stf"
   "simple_switch died with return code -6"
   # Assertion 'Default switch case should not be reachable' failed,
   # file '../../include/bm/bm_sim/actions.h' line '369'.
@@ -74,6 +66,14 @@ p4tools_add_xfail_reason(
 # 2. P4Testgen Issues
 # These are failures in P4Testgen that need to be fixed.
 ####################################################################################################
+
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-stf"
+  "Non-numeric, non-boolean member expression: .* Type: Type_Stack"
+  # We can not expand stacks in parsers because information about .next is lost.
+  # P4Testgen needs to maintain its own internal .next variable for stacks.
+  array-copy-bmv2.p4
+)
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-stf"

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/P4Tests.cmake
@@ -28,7 +28,7 @@ set(P4C_V1_TEST_SUITES_P416 ${P4_16_V1_TESTS} ${BMV2_P4_16_V1_TESTS})
 # TEST SUITES
 #############################################################################
 option(P4TOOLS_TESTGEN_BMV2_TEST_METADATA "Run tests on the Metadata test back end" ON)
-option(P4TOOLS_TESTGEN_BMV2_TEST_PROTOBUF "Run tests on the Protobuf test back end" OFF)
+option(P4TOOLS_TESTGEN_BMV2_TEST_PROTOBUF "Run tests on the Protobuf test back end" ON)
 option(P4TOOLS_TESTGEN_BMV2_TEST_PTF "Run tests on the PTF test back end" ON)
 option(P4TOOLS_TESTGEN_BMV2_TEST_STF "Run tests on the STF test back end" ON)
 # Test settings.

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/TestTemplate.cmake
@@ -46,7 +46,7 @@ function(validate_protobuf testfile testfolder)
   file(APPEND ${testfile} "for item in \${txtpbfiles[@]}\n")
   file(APPEND ${testfile} "do\n")
   file(APPEND ${testfile} "\techo \"Found \${item}\"\n")
-  file(APPEND ${testfile} "\tprotoc --proto_path=${CMAKE_CURRENT_LIST_DIR}/../proto --proto_path=${P4RUNTIME_STD_DIR} --proto_path=${P4C_SOURCE_DIR}/control-plane --encode=p4testgen.TestCase p4testgen.proto < \${item}\n")
+  file(APPEND ${testfile} "\t${PROTOBUF_PROTOC_EXECUTABLE} --proto_path=${CMAKE_CURRENT_LIST_DIR}/../proto --proto_path=${P4RUNTIME_STD_DIR} --proto_path=${P4C_SOURCE_DIR}/control-plane --encode=p4testgen.TestCase p4testgen.proto < \${item}\n")
   file(APPEND ${testfile} "done\n")
 endfunction(validate_protobuf)
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.cpp
@@ -1,0 +1,196 @@
+#include "backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.h"
+
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <inja/inja.hpp>
+
+#include "backends/p4tools/common/lib/format_int.h"
+#include "ir/ir.h"
+#include "nlohmann/json.hpp"
+
+#include "backends/p4tools/modules/testgen/lib/exceptions.h"
+#include "backends/p4tools/modules/testgen/lib/tf.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
+
+namespace P4Tools::P4Testgen::Bmv2 {
+
+Bmv2TF::Bmv2TF(std::filesystem::path basePath, std::optional<unsigned int> seed)
+    : TF(std::move(basePath), seed) {}
+
+inja::json Bmv2TF::getClone(const TestObjectMap &cloneSpecs) const {
+    auto cloneSpec = inja::json::object();
+    auto cloneJsons = inja::json::array_t();
+    auto hasClone = false;
+    for (auto cloneSpecTuple : cloneSpecs) {
+        inja::json cloneSpecJson;
+        const auto *cloneSpec = cloneSpecTuple.second->checkedTo<Bmv2V1ModelCloneSpec>();
+        cloneSpecJson["session_id"] = cloneSpec->getEvaluatedSessionId()->asUint64();
+        cloneSpecJson["clone_port"] = cloneSpec->getEvaluatedClonePort()->asInt();
+        cloneSpecJson["cloned"] = cloneSpec->isClonedPacket();
+        hasClone = hasClone || cloneSpec->isClonedPacket();
+        cloneJsons.push_back(cloneSpecJson);
+    }
+    cloneSpec["clone_pkts"] = cloneJsons;
+    cloneSpec["has_clone"] = hasClone;
+    return cloneSpec;
+}
+
+inja::json::array_t Bmv2TF::getMeter(const TestObjectMap &meterValues) const {
+    auto meterJson = inja::json::array_t();
+    for (auto meterValueInfoTuple : meterValues) {
+        const auto *meterValue = meterValueInfoTuple.second->checkedTo<Bmv2V1ModelMeterValue>();
+
+        const auto meterEntries = meterValue->unravelMap();
+        for (const auto &meterEntry : meterEntries) {
+            inja::json meterInfoJson;
+            meterInfoJson["name"] = meterValueInfoTuple.first;
+            meterInfoJson["value"] = formatHexExpr(meterEntry.second.second);
+            meterInfoJson["index"] = formatHex(meterEntry.first, meterEntry.second.first);
+            if (meterValue->isDirectMeter()) {
+                meterInfoJson["is_direct"] = "True";
+            } else {
+                meterInfoJson["is_direct"] = "False";
+            }
+            meterJson.push_back(meterInfoJson);
+        }
+    }
+    return meterJson;
+}
+
+inja::json Bmv2TF::getControlPlane(const TestSpec *testSpec) const {
+    auto controlPlaneJson = inja::json::object();
+    // Map of actionProfiles and actionSelectors for easy reference.
+    std::map<cstring, cstring> apAsMap;
+
+    auto tables = testSpec->getTestObjectCategory("tables");
+    if (!tables.empty()) {
+        controlPlaneJson["tables"] = inja::json::array();
+    }
+    for (const auto &testObject : tables) {
+        inja::json tblJson;
+        tblJson["table_name"] = testObject.first.c_str();
+        const auto *const tblConfig = testObject.second->checkedTo<TableConfig>();
+        const auto *tblRules = tblConfig->getRules();
+        tblJson["rules"] = inja::json::array();
+        for (const auto &tblRule : *tblRules) {
+            inja::json rule;
+            const auto *matches = tblRule.getMatches();
+            const auto *actionCall = tblRule.getActionCall();
+            const auto *actionArgs = actionCall->getArgs();
+            rule["action_name"] = actionCall->getActionName().c_str();
+            auto j = getControlPlaneForTable(*matches, *actionArgs);
+            rule["rules"] = std::move(j);
+            rule["priority"] = tblRule.getPriority();
+            tblJson["rules"].push_back(rule);
+        }
+
+        // Collect action profiles and selectors associated with the table.
+        checkForTableActionProfile<Bmv2V1ModelActionProfile, Bmv2V1ModelActionSelector>(
+            tblJson, apAsMap, tblConfig);
+
+        // Check whether the default action is overridden for this table.
+        checkForDefaultActionOverride(tblJson, tblConfig);
+
+        controlPlaneJson["tables"].push_back(tblJson);
+    }
+
+    // Collect declarations of action profiles.
+    collectActionProfileDeclarations<Bmv2V1ModelActionProfile>(testSpec, controlPlaneJson, apAsMap);
+
+    return controlPlaneJson;
+}
+
+inja::json Bmv2TF::getControlPlaneForTable(const TableMatchMap &matches,
+                                           const std::vector<ActionArg> &args) const {
+    inja::json rulesJson;
+
+    rulesJson["single_exact_matches"] = inja::json::array();
+    rulesJson["multiple_exact_matches"] = inja::json::array();
+    rulesJson["range_matches"] = inja::json::array();
+    rulesJson["ternary_matches"] = inja::json::array();
+    rulesJson["lpm_matches"] = inja::json::array();
+    rulesJson["optional_matches"] = inja::json::array();
+
+    rulesJson["act_args"] = inja::json::array();
+    rulesJson["needs_priority"] = false;
+
+    // Iterate over the match fields and segregate them.
+    for (const auto &match : matches) {
+        const auto fieldName = match.first;
+        const auto &fieldMatch = match.second;
+
+        inja::json j;
+        j["field_name"] = fieldName;
+        if (const auto *elem = fieldMatch->to<Exact>()) {
+            j["value"] = formatHexExpr(elem->getEvaluatedValue()).c_str();
+            rulesJson["single_exact_matches"].push_back(j);
+        } else if (const auto *elem = fieldMatch->to<Range>()) {
+            j["lo"] = formatHexExpr(elem->getEvaluatedLow()).c_str();
+            j["hi"] = formatHexExpr(elem->getEvaluatedHigh()).c_str();
+            rulesJson["range_matches"].push_back(j);
+        } else if (const auto *elem = fieldMatch->to<Ternary>()) {
+            j["value"] = formatHexExpr(elem->getEvaluatedValue()).c_str();
+            j["mask"] = formatHexExpr(elem->getEvaluatedMask()).c_str();
+            rulesJson["ternary_matches"].push_back(j);
+            // If the rule has a ternary match we need to add the priority.
+            rulesJson["needs_priority"] = true;
+        } else if (const auto *elem = fieldMatch->to<LPM>()) {
+            j["value"] = formatHexExpr(elem->getEvaluatedValue()).c_str();
+            j["prefix_len"] = elem->getEvaluatedPrefixLength()->value.str();
+            rulesJson["lpm_matches"].push_back(j);
+        } else if (const auto *elem = fieldMatch->to<Optional>()) {
+            j["value"] = formatHexExpr(elem->getEvaluatedValue()).c_str();
+            if (elem->addAsExactMatch()) {
+                j["use_exact"] = "True";
+            } else {
+                j["use_exact"] = "False";
+            }
+            rulesJson["needs_priority"] = true;
+            rulesJson["optional_matches"].push_back(j);
+        } else {
+            TESTGEN_UNIMPLEMENTED("Unsupported table key match type \"%1%\"",
+                                  fieldMatch->getObjectName());
+        }
+    }
+
+    for (const auto &actArg : args) {
+        inja::json j;
+        j["param"] = actArg.getActionParamName().c_str();
+        j["value"] = formatHexExpr(actArg.getEvaluatedValue()).c_str();
+        rulesJson["act_args"].push_back(j);
+    }
+
+    return rulesJson;
+}
+
+inja::json Bmv2TF::getSend(const TestSpec *testSpec) const {
+    const auto *iPacket = testSpec->getIngressPacket();
+    const auto *payload = iPacket->getEvaluatedPayload();
+    inja::json sendJson;
+    sendJson["ig_port"] = iPacket->getPort();
+    auto dataStr = formatHexExpr(payload, false, true, false);
+    sendJson["pkt"] = insertHexSeparators(dataStr);
+    sendJson["pkt_size"] = payload->type->width_bits();
+    return sendJson;
+}
+
+inja::json Bmv2TF::getExpectedPacket(const TestSpec *testSpec) const {
+    inja::json verifyData = inja::json::object();
+    auto egressPacket = testSpec->getEgressPacket();
+    if (egressPacket.has_value()) {
+        const auto *packet = egressPacket.value();
+        verifyData["eg_port"] = packet->getPort();
+        const auto *payload = packet->getEvaluatedPayload();
+        const auto *payloadMask = packet->getEvaluatedPayloadMask();
+        verifyData["ignore_mask"] = formatHexExpr(payloadMask);
+        verifyData["exp_pkt"] = formatHexExpr(payload);
+    }
+    return verifyData;
+}
+
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.h
@@ -13,6 +13,9 @@
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
+/// BMV2TF extends the TF (TestFramework) class.
+/// It provides common utility functions for BMv2-style test frameworks.
+/// TODO: Clean up naming, do not use TF, use "TestFramework" instead.
 class Bmv2TF : public TF {
  public:
     explicit Bmv2TF(std::filesystem::path basePath,

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.h
@@ -1,0 +1,43 @@
+#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_TEST_BACKEND_COMMON_H_
+#define BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_TEST_BACKEND_COMMON_H_
+
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include <inja/inja.hpp>
+
+#include "backends/p4tools/modules/testgen/lib/test_object.h"
+#include "backends/p4tools/modules/testgen/lib/test_spec.h"
+#include "backends/p4tools/modules/testgen/lib/tf.h"
+
+namespace P4Tools::P4Testgen::Bmv2 {
+
+class Bmv2TF : public TF {
+ public:
+    explicit Bmv2TF(std::filesystem::path basePath,
+                    std::optional<unsigned int> seed = std::nullopt);
+
+ protected:
+    /// Converts all the control plane objects into Inja format.
+    virtual inja::json getControlPlane(const TestSpec *testSpec) const;
+
+    /// Returns the configuration for a cloned packet configuration.
+    virtual inja::json getClone(const TestObjectMap &cloneSpecs) const;
+
+    /// @returns the configuration for a meter call (may set the meter to GREEN, YELLOW, or RED)
+    virtual inja::json::array_t getMeter(const TestObjectMap &meterValues) const;
+
+    /// Helper function for the control plane table inja objects.
+    virtual inja::json getControlPlaneForTable(const TableMatchMap &matches,
+                                               const std::vector<ActionArg> &args) const;
+
+    /// Converts the input packet and port into Inja format.
+    virtual inja::json getSend(const TestSpec *testSpec) const;
+
+    /// Converts the output packet, port, and mask into Inja format.
+    virtual inja::json getExpectedPacket(const TestSpec *testSpec) const;
+};
+}  // namespace P4Tools::P4Testgen::Bmv2
+
+#endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_TEST_BACKEND_COMMON_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/metadata.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/metadata.h
@@ -6,42 +6,30 @@
 #include <fstream>
 #include <optional>
 #include <string>
-#include <utility>
-#include <vector>
 
 #include <inja/inja.hpp>
 
-#include "ir/ir.h"
 #include "lib/cstring.h"
 
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
-#include "backends/p4tools/modules/testgen/lib/tf.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.h"
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
 /// Extracts information from the @testSpec to emit a Metadata test case.
-class Metadata : public TF {
-    /// The output file.
-    std::ofstream metadataFile;
-
+class Metadata : public Bmv2TF {
  public:
-    virtual ~Metadata() = default;
-
-    Metadata(const Metadata &) = delete;
-
-    Metadata(Metadata &&) = delete;
-
-    Metadata &operator=(const Metadata &) = delete;
-
-    Metadata &operator=(Metadata &&) = delete;
-
-    Metadata(std::filesystem::path basePath, std::optional<unsigned int> seed);
+    explicit Metadata(std::filesystem::path basePath,
+                      std::optional<unsigned int> seed = std::nullopt);
 
     /// Produce a Metadata test.
     void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testId,
                     float currentCoverage) override;
 
  private:
+    /// The output file.
+    std::ofstream metadataFile;
+
     /// Emits the test preamble. This is only done once for all generated tests.
     /// For the Metadata back end this is the "p4testgen.proto" file.
     void emitPreamble(const std::string &preamble);
@@ -61,16 +49,6 @@ class Metadata : public TF {
 
     /// @returns the inja test case template as a string.
     static std::string getTestCaseTemplate();
-
-    /// Converts the input packet and port into Inja format.
-    static inja::json getSend(const TestSpec *testSpec);
-
-    /// Converts the output packet, port, and mask into Inja format.
-    static inja::json getVerify(const TestSpec *testSpec);
-
-    /// Helper function for @getVerify. Matches the mask value against the input packet value and
-    /// generates the appropriate ignore ranges.
-    static std::vector<std::pair<size_t, size_t>> getIgnoreMasks(const IR::Constant *mask);
 };
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf.cpp
@@ -200,17 +200,6 @@ inja::json Protobuf::getControlPlaneForTable(const TableMatchMap &matches,
     return rulesJson;
 }
 
-inja::json Protobuf::getSend(const TestSpec *testSpec) const {
-    const auto *iPacket = testSpec->getIngressPacket();
-    const auto *payload = iPacket->getEvaluatedPayload();
-    inja::json sendJson;
-    sendJson["ig_port"] = iPacket->getPort();
-    auto dataStr = formatHexExprWithSep(payload);
-    sendJson["pkt"] = dataStr;
-    sendJson["pkt_size"] = payload->type->width_bits();
-    return sendJson;
-}
-
 inja::json Protobuf::getExpectedPacket(const TestSpec *testSpec) const {
     inja::json verifyData = inja::json::object();
     if (testSpec->getEgressPacket() != std::nullopt) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf.h
@@ -5,7 +5,6 @@
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <inja/inja.hpp>
@@ -17,7 +16,7 @@
 #include "lib/cstring.h"
 
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
-#include "backends/p4tools/modules/testgen/lib/tf.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.h"
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
@@ -25,19 +24,10 @@ using P4::ControlPlaneAPI::p4rt_id_t;
 using P4::ControlPlaneAPI::Standard::SymbolType;
 
 /// Extracts information from the @testSpec to emit a Protobuf test case.
-class Protobuf : public TF {
+class Protobuf : public Bmv2TF {
  public:
-    virtual ~Protobuf() = default;
-
-    Protobuf(const Protobuf &) = delete;
-
-    Protobuf(Protobuf &&) = delete;
-
-    Protobuf &operator=(const Protobuf &) = delete;
-
-    Protobuf &operator=(Protobuf &&) = delete;
-
-    Protobuf(std::filesystem::path basePath, std::optional<unsigned int> seed);
+    explicit Protobuf(std::filesystem::path basePath,
+                      std::optional<unsigned int> seed = std::nullopt);
 
     /// Produce a Protobuf test.
     void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testId,
@@ -59,22 +49,15 @@ class Protobuf : public TF {
     /// @returns the inja test case template as a string.
     static std::string getTestCaseTemplate();
 
-    /// Converts all the control plane objects into Inja format.
-    static inja::json getControlPlane(const TestSpec *testSpec);
+    inja::json getSend(const TestSpec *testSpec) const override;
 
-    /// Converts the input packet and port into Inja format.
-    static inja::json getSend(const TestSpec *testSpec);
+    inja::json getControlPlane(const TestSpec *testSpec) const override;
 
-    /// Converts the output packet, port, and mask into Inja format.
-    static inja::json getVerify(const TestSpec *testSpec);
-
-    /// Helper function for @getVerify. Matches the mask value against the input packet value and
-    /// generates the appropriate ignore ranges.
-    static std::vector<std::pair<size_t, size_t>> getIgnoreMasks(const IR::Constant *mask);
+    inja::json getExpectedPacket(const TestSpec *testSpec) const override;
 
     /// Helper function for the control plane table inja objects.
-    static inja::json getControlPlaneForTable(const TableMatchMap &matches,
-                                              const std::vector<ActionArg> &args);
+    inja::json getControlPlaneForTable(const TableMatchMap &matches,
+                                       const std::vector<ActionArg> &args) const override;
 
     /// @return the id allocated to the object through the @id annotation if any, or
     /// std::nullopt.

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf.h
@@ -49,8 +49,6 @@ class Protobuf : public Bmv2TF {
     /// @returns the inja test case template as a string.
     static std::string getTestCaseTemplate();
 
-    inja::json getSend(const TestSpec *testSpec) const override;
-
     inja::json getControlPlane(const TestSpec *testSpec) const override;
 
     inja::json getExpectedPacket(const TestSpec *testSpec) const override;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/ptf.cpp
@@ -1,10 +1,7 @@
 #include "backends/p4tools/modules/testgen/targets/bmv2/test_backend/ptf.h"
 
-#include <algorithm>
 #include <filesystem>
 #include <iomanip>
-#include <list>
-#include <map>
 #include <optional>
 #include <string>
 #include <utility>
@@ -18,54 +15,10 @@
 #include "lib/log.h"
 #include "nlohmann/json.hpp"
 
-#include "backends/p4tools/modules/testgen/lib/exceptions.h"
-#include "backends/p4tools/modules/testgen/lib/tf.h"
-#include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
-
 namespace P4Tools::P4Testgen::Bmv2 {
 
-PTF::PTF(std::filesystem::path basePath, std::optional<unsigned int> seed = std::nullopt)
-    : TF(std::move(basePath), seed) {}
-
-inja::json PTF::getClone(const TestObjectMap &cloneSpecs) {
-    auto cloneSpec = inja::json::object();
-    auto cloneJsons = inja::json::array_t();
-    auto hasClone = false;
-    for (auto cloneSpecTuple : cloneSpecs) {
-        inja::json cloneSpecJson;
-        const auto *cloneSpec = cloneSpecTuple.second->checkedTo<Bmv2V1ModelCloneSpec>();
-        cloneSpecJson["session_id"] = cloneSpec->getEvaluatedSessionId()->asUint64();
-        cloneSpecJson["clone_port"] = cloneSpec->getEvaluatedClonePort()->asInt();
-        cloneSpecJson["cloned"] = cloneSpec->isClonedPacket();
-        hasClone = hasClone || cloneSpec->isClonedPacket();
-        cloneJsons.push_back(cloneSpecJson);
-    }
-    cloneSpec["clone_pkts"] = cloneJsons;
-    cloneSpec["has_clone"] = hasClone;
-    return cloneSpec;
-}
-
-inja::json::array_t PTF::getMeter(const TestObjectMap &meterValues) {
-    auto meterJson = inja::json::array_t();
-    for (auto meterValueInfoTuple : meterValues) {
-        const auto *meterValue = meterValueInfoTuple.second->checkedTo<Bmv2V1ModelMeterValue>();
-
-        const auto meterEntries = meterValue->unravelMap();
-        for (const auto &meterEntry : meterEntries) {
-            inja::json meterInfoJson;
-            meterInfoJson["name"] = meterValueInfoTuple.first;
-            meterInfoJson["value"] = formatHexExpr(meterEntry.second.second);
-            meterInfoJson["index"] = formatHex(meterEntry.first, meterEntry.second.first);
-            if (meterValue->isDirectMeter()) {
-                meterInfoJson["is_direct"] = "True";
-            } else {
-                meterInfoJson["is_direct"] = "False";
-            }
-            meterJson.push_back(meterInfoJson);
-        }
-    }
-    return meterJson;
-}
+PTF::PTF(std::filesystem::path basePath, std::optional<unsigned int> seed)
+    : Bmv2TF(std::move(basePath), seed) {}
 
 std::vector<std::pair<size_t, size_t>> PTF::getIgnoreMasks(const IR::Constant *mask) {
     std::vector<std::pair<size_t, size_t>> ignoreMasks;
@@ -91,125 +44,7 @@ std::vector<std::pair<size_t, size_t>> PTF::getIgnoreMasks(const IR::Constant *m
     return ignoreMasks;
 }
 
-inja::json PTF::getControlPlane(const TestSpec *testSpec) {
-    inja::json controlPlaneJson = inja::json::object();
-
-    // Map of actionProfiles and actionSelectors for easy reference.
-    std::map<cstring, cstring> apAsMap;
-
-    auto tables = testSpec->getTestObjectCategory("tables");
-    if (!tables.empty()) {
-        controlPlaneJson["tables"] = inja::json::array();
-    }
-    for (const auto &testObject : tables) {
-        inja::json tblJson;
-        tblJson["table_name"] = testObject.first.c_str();
-        const auto *const tblConfig = testObject.second->checkedTo<TableConfig>();
-        const auto *tblRules = tblConfig->getRules();
-        tblJson["rules"] = inja::json::array();
-        for (const auto &tblRule : *tblRules) {
-            inja::json rule;
-            const auto *matches = tblRule.getMatches();
-            const auto *actionCall = tblRule.getActionCall();
-            const auto *actionArgs = actionCall->getArgs();
-            rule["action_name"] = actionCall->getActionName().c_str();
-            auto j = getControlPlaneForTable(*matches, *actionArgs);
-            rule["rules"] = std::move(j);
-            rule["priority"] = tblRule.getPriority();
-            tblJson["rules"].push_back(rule);
-        }
-
-        // Collect action profiles and selectors associated with the table.
-        checkForTableActionProfile<Bmv2V1ModelActionProfile, Bmv2V1ModelActionSelector>(
-            tblJson, apAsMap, tblConfig);
-
-        // Check whether the default action is overridden for this table.
-        checkForDefaultActionOverride(tblJson, tblConfig);
-
-        controlPlaneJson["tables"].push_back(tblJson);
-    }
-
-    // Collect declarations of action profiles.
-    collectActionProfileDeclarations<Bmv2V1ModelActionProfile>(testSpec, controlPlaneJson, apAsMap);
-
-    return controlPlaneJson;
-}
-
-inja::json PTF::getControlPlaneForTable(const TableMatchMap &matches,
-                                        const std::vector<ActionArg> &args) {
-    inja::json rulesJson;
-
-    rulesJson["single_exact_matches"] = inja::json::array();
-    rulesJson["multiple_exact_matches"] = inja::json::array();
-    rulesJson["range_matches"] = inja::json::array();
-    rulesJson["ternary_matches"] = inja::json::array();
-    rulesJson["lpm_matches"] = inja::json::array();
-    rulesJson["optional_matches"] = inja::json::array();
-
-    rulesJson["act_args"] = inja::json::array();
-    rulesJson["needs_priority"] = false;
-
-    // Iterate over the match fields and segregate them.
-    for (const auto &match : matches) {
-        const auto fieldName = match.first;
-        const auto &fieldMatch = match.second;
-
-        inja::json j;
-        j["field_name"] = fieldName;
-        if (const auto *elem = fieldMatch->to<Exact>()) {
-            j["value"] = formatHexExpr(elem->getEvaluatedValue()).c_str();
-            rulesJson["single_exact_matches"].push_back(j);
-        } else if (const auto *elem = fieldMatch->to<Range>()) {
-            j["lo"] = formatHexExpr(elem->getEvaluatedLow()).c_str();
-            j["hi"] = formatHexExpr(elem->getEvaluatedHigh()).c_str();
-            rulesJson["range_matches"].push_back(j);
-        } else if (const auto *elem = fieldMatch->to<Ternary>()) {
-            j["value"] = formatHexExpr(elem->getEvaluatedValue()).c_str();
-            j["mask"] = formatHexExpr(elem->getEvaluatedMask()).c_str();
-            rulesJson["ternary_matches"].push_back(j);
-            // If the rule has a ternary match we need to add the priority.
-            rulesJson["needs_priority"] = true;
-        } else if (const auto *elem = fieldMatch->to<LPM>()) {
-            j["value"] = formatHexExpr(elem->getEvaluatedValue()).c_str();
-            j["prefix_len"] = elem->getEvaluatedPrefixLength()->value.str();
-            rulesJson["lpm_matches"].push_back(j);
-        } else if (const auto *elem = fieldMatch->to<Optional>()) {
-            j["value"] = formatHexExpr(elem->getEvaluatedValue()).c_str();
-            if (elem->addAsExactMatch()) {
-                j["use_exact"] = "True";
-            } else {
-                j["use_exact"] = "False";
-            }
-            rulesJson["needs_priority"] = true;
-            rulesJson["optional_matches"].push_back(j);
-        } else {
-            TESTGEN_UNIMPLEMENTED("Unsupported table key match type \"%1%\"",
-                                  fieldMatch->getObjectName());
-        }
-    }
-
-    for (const auto &actArg : args) {
-        inja::json j;
-        j["param"] = actArg.getActionParamName().c_str();
-        j["value"] = formatHexExpr(actArg.getEvaluatedValue()).c_str();
-        rulesJson["act_args"].push_back(j);
-    }
-
-    return rulesJson;
-}
-
-inja::json PTF::getSend(const TestSpec *testSpec) {
-    const auto *iPacket = testSpec->getIngressPacket();
-    const auto *payload = iPacket->getEvaluatedPayload();
-    inja::json sendJson;
-    sendJson["ig_port"] = iPacket->getPort();
-    auto dataStr = formatHexExpr(payload, false, true, false);
-    sendJson["pkt"] = insertHexSeparators(dataStr);
-    sendJson["pkt_size"] = payload->type->width_bits();
-    return sendJson;
-}
-
-inja::json PTF::getVerify(const TestSpec *testSpec) {
+inja::json PTF::getExpectedPacket(const TestSpec *testSpec) const {
     inja::json verifyData = inja::json::object();
     auto egressPacket = testSpec->getEgressPacket();
     if (egressPacket.has_value()) {
@@ -435,7 +270,7 @@ void PTF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_
     dataJson["trace"] = getTrace(testSpec);
     dataJson["control_plane"] = getControlPlane(testSpec);
     dataJson["send"] = getSend(testSpec);
-    dataJson["verify"] = getVerify(testSpec);
+    dataJson["verify"] = getExpectedPacket(testSpec);
     dataJson["timestamp"] = Utils::getTimeStamp();
     std::stringstream coverageStr;
     coverageStr << std::setprecision(2) << currentCoverage;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/stf.cpp
@@ -2,8 +2,6 @@
 
 #include <fstream>
 #include <iomanip>
-#include <list>
-#include <map>
 #include <optional>
 #include <string>
 #include <utility>
@@ -24,60 +22,55 @@
 #include "nlohmann/json.hpp"
 
 #include "backends/p4tools/modules/testgen/lib/exceptions.h"
-#include "backends/p4tools/modules/testgen/lib/tf.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
-STF::STF(std::filesystem::path basePath, std::optional<unsigned int> seed = std::nullopt)
-    : TF(std::move(basePath), seed) {}
+STF::STF(std::filesystem::path basePath, std::optional<unsigned int> seed)
+    : Bmv2TF(std::move(basePath), seed) {}
 
-inja::json STF::getControlPlane(const TestSpec *testSpec) {
-    inja::json controlPlaneJson = inja::json::object();
+inja::json STF::getSend(const TestSpec *testSpec) const {
+    const auto *iPacket = testSpec->getIngressPacket();
+    const auto *payload = iPacket->getEvaluatedPayload();
+    inja::json sendJson;
+    sendJson["ig_port"] = iPacket->getPort();
+    sendJson["pkt"] = formatHexExpr(payload, false, true, false);
+    sendJson["pkt_size"] = payload->type->width_bits();
+    return sendJson;
+}
 
-    // Map of actionProfiles and actionSelectors for easy reference.
-    std::map<cstring, cstring> apAsMap;
-
-    auto tables = testSpec->getTestObjectCategory("tables");
-    if (!tables.empty()) {
-        controlPlaneJson["tables"] = inja::json::array();
-    }
-    for (const auto &testObject : tables) {
-        inja::json tblJson;
-        tblJson["table_name"] = testObject.first.c_str();
-        const auto *const tblConfig = testObject.second->checkedTo<TableConfig>();
-        const auto *tblRules = tblConfig->getRules();
-        tblJson["rules"] = inja::json::array();
-        for (const auto &tblRule : *tblRules) {
-            inja::json rule;
-            const auto *matches = tblRule.getMatches();
-            const auto *actionCall = tblRule.getActionCall();
-            const auto *actionArgs = actionCall->getArgs();
-            rule["action_name"] = actionCall->getActionName().c_str();
-            auto j = getControlPlaneForTable(*matches, *actionArgs);
-            rule["rules"] = std::move(j);
-            rule["priority"] = tblRule.getPriority();
-            tblJson["rules"].push_back(rule);
+inja::json STF::getExpectedPacket(const TestSpec *testSpec) const {
+    inja::json verifyData = inja::json::object();
+    if (testSpec->getEgressPacket() != std::nullopt) {
+        const auto &packet = **testSpec->getEgressPacket();
+        verifyData["eg_port"] = packet.getPort();
+        const auto *payload = packet.getEvaluatedPayload();
+        const auto *payloadMask = packet.getEvaluatedPayloadMask();
+        auto dataStr = formatHexExpr(payload, false, true, false);
+        if (payloadMask != nullptr) {
+            // If a mask is present, construct the packet data  with wildcard `*` where there are
+            // non zero nibbles
+            auto maskStr = formatHexExpr(payloadMask, false, true, false);
+            std::string packetData;
+            for (size_t dataPos = 0; dataPos < dataStr.size(); ++dataPos) {
+                if (maskStr.at(dataPos) != 'F') {
+                    // TODO: We are being conservative here and adding a wildcard for any 0
+                    // in the 4b nibble
+                    packetData += "*";
+                } else {
+                    packetData += dataStr[dataPos];
+                }
+            }
+            verifyData["exp_pkt"] = packetData;
+        } else {
+            verifyData["exp_pkt"] = dataStr;
         }
-
-        // Collect action profiles and selectors associated with the table.
-        checkForTableActionProfile<Bmv2V1ModelActionProfile, Bmv2V1ModelActionSelector>(
-            tblJson, apAsMap, tblConfig);
-
-        // Check whether the default action is overridden for this table.
-        checkForDefaultActionOverride(tblJson, tblConfig);
-
-        controlPlaneJson["tables"].push_back(tblJson);
     }
-
-    // Collect declarations of action profiles.
-    collectActionProfileDeclarations<Bmv2V1ModelActionProfile>(testSpec, controlPlaneJson, apAsMap);
-
-    return controlPlaneJson;
+    return verifyData;
 }
 
 inja::json STF::getControlPlaneForTable(const TableMatchMap &matches,
-                                        const std::vector<ActionArg> &args) {
+                                        const std::vector<ActionArg> &args) const {
     inja::json rulesJson;
 
     rulesJson["matches"] = inja::json::array();
@@ -155,60 +148,6 @@ inja::json STF::getControlPlaneForTable(const TableMatchMap &matches,
     return rulesJson;
 }
 
-inja::json STF::getSend(const TestSpec *testSpec) {
-    const auto *iPacket = testSpec->getIngressPacket();
-    const auto *payload = iPacket->getEvaluatedPayload();
-    inja::json sendJson;
-    sendJson["ig_port"] = iPacket->getPort();
-    auto dataStr = formatHexExpr(payload, false, true, false);
-    sendJson["pkt"] = dataStr;
-    sendJson["pkt_size"] = payload->type->width_bits();
-    return sendJson;
-}
-
-inja::json STF::getVerify(const TestSpec *testSpec) {
-    inja::json verifyData = inja::json::object();
-    if (testSpec->getEgressPacket() != std::nullopt) {
-        const auto &packet = **testSpec->getEgressPacket();
-        verifyData["eg_port"] = packet.getPort();
-        const auto *payload = packet.getEvaluatedPayload();
-        const auto *payloadMask = packet.getEvaluatedPayloadMask();
-        auto dataStr = formatHexExpr(payload, false, true, false);
-        if (payloadMask != nullptr) {
-            // If a mask is present, construct the packet data  with wildcard `*` where there are
-            // non zero nibbles
-            auto maskStr = formatHexExpr(payloadMask, false, true, false);
-            std::string packetData;
-            for (size_t dataPos = 0; dataPos < dataStr.size(); ++dataPos) {
-                if (maskStr.at(dataPos) != 'F') {
-                    // TODO: We are being conservative here and adding a wildcard for any 0
-                    // in the 4b nibble
-                    packetData += "*";
-                } else {
-                    packetData += dataStr[dataPos];
-                }
-            }
-            verifyData["exp_pkt"] = packetData;
-        } else {
-            verifyData["exp_pkt"] = dataStr;
-        }
-    }
-    return verifyData;
-}
-
-inja::json::array_t STF::getClone(const TestObjectMap &cloneSpecs) {
-    auto cloneJson = inja::json::array_t();
-    for (auto cloneSpecTuple : cloneSpecs) {
-        inja::json cloneSpecJson;
-        const auto *cloneSpec = cloneSpecTuple.second->checkedTo<Bmv2V1ModelCloneSpec>();
-        cloneSpecJson["session_id"] = cloneSpec->getEvaluatedSessionId()->asUint64();
-        cloneSpecJson["clone_port"] = cloneSpec->getEvaluatedClonePort()->asInt();
-        cloneSpecJson["cloned"] = cloneSpec->isClonedPacket();
-        cloneJson.push_back(cloneSpecJson);
-    }
-    return cloneJson;
-}
-
 std::string STF::getTestCaseTemplate() {
     static std::string TEST_CASE(
         R"""(# p4testgen seed: {{ default(seed, "none") }}
@@ -237,7 +176,7 @@ add "{{table.table_name}}" {% if rule.rules.needs_priority %}{{rule.priority}} {
 ## endif
 
 ## if exists("clone_specs")
-## for clone_spec in clone_specs
+## for clone_spec in clone_specs.clone_pkts
 mirroring_add {{clone_spec.session_id}} {{clone_spec.clone_port}}
 packet {{send.ig_port}} {{send.pkt}}
 ## if clone_spec.cloned
@@ -277,7 +216,7 @@ void STF::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_
     dataJson["trace"] = getTrace(testSpec);
     dataJson["control_plane"] = getControlPlane(testSpec);
     dataJson["send"] = getSend(testSpec);
-    dataJson["verify"] = getVerify(testSpec);
+    dataJson["verify"] = getExpectedPacket(testSpec);
     dataJson["timestamp"] = Utils::getTimeStamp();
     std::stringstream coverageStr;
     coverageStr << std::setprecision(2) << currentCoverage;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/stf.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/stf.h
@@ -3,7 +3,6 @@
 
 #include <cstddef>
 #include <filesystem>
-#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -12,26 +11,15 @@
 
 #include "lib/cstring.h"
 
-#include "backends/p4tools/modules/testgen/lib/test_object.h"
 #include "backends/p4tools/modules/testgen/lib/test_spec.h"
-#include "backends/p4tools/modules/testgen/lib/tf.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.h"
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
 /// Extracts information from the @testSpec to emit a STF test case.
-class STF : public TF {
+class STF : public Bmv2TF {
  public:
-    virtual ~STF() = default;
-
-    STF(const STF &) = delete;
-
-    STF(STF &&) = delete;
-
-    STF &operator=(const STF &) = delete;
-
-    STF &operator=(STF &&) = delete;
-
-    STF(std::filesystem::path basePath, std::optional<unsigned int> seed);
+    explicit STF(std::filesystem::path basePath, std::optional<unsigned int> seed = std::nullopt);
 
     /// Produce an STF test.
     void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testId,
@@ -49,21 +37,13 @@ class STF : public TF {
     /// @returns the inja test case template as a string.
     static std::string getTestCaseTemplate();
 
-    /// Converts all the control plane objects into Inja format.
-    static inja::json getControlPlane(const TestSpec *testSpec);
+    inja::json getExpectedPacket(const TestSpec *testSpec) const override;
 
-    /// Converts the input packet and port into Inja format.
-    static inja::json getSend(const TestSpec *testSpec);
+    /// TODO: Fix how BMv2 parses packet strings. We should support hex and octal prefixes.
+    inja::json getSend(const TestSpec *testSpec) const override;
 
-    /// Converts the output packet, port, and mask into Inja format.
-    static inja::json getVerify(const TestSpec *testSpec);
-
-    /// Returns the configuration for a cloned packet configuration.
-    static inja::json::array_t getClone(const TestObjectMap &cloneSpecs);
-
-    /// Helper function for the control plane table inja objects.
-    static inja::json getControlPlaneForTable(const TableMatchMap &matches,
-                                              const std::vector<ActionArg> &args);
+    inja::json getControlPlaneForTable(const TableMatchMap &matches,
+                                       const std::vector<ActionArg> &args) const override;
 };
 
 }  // namespace P4Tools::P4Testgen::Bmv2


### PR DESCRIPTION
This is the second PR of a series of three to refactor the BMv2 test back ends. 

This PR moves code that is common to the increasing amount of  test back ends into a `common` class. This makes it easier to add new test back ends to the BMv2 P4Testgen extension. 

It also renables the BMv2 Protobuf back end and updates its Xfails. 