### PR TITLE
Still parse STF files, even when BMv2 model is not present in system

### DIFF
--- a/backends/bmv2/run-bmv2-test.py
+++ b/backends/bmv2/run-bmv2-test.py
@@ -214,9 +214,6 @@ timeout = 10 * 60
 
 
 def run_model(options, tmpdir, jsonfile):
-    if not options.hasBMv2:
-        return SUCCESS
-
     # We can do this if an *.stf file is present
     basename = os.path.basename(options.p4filename)
     base, _ = os.path.splitext(basename)
@@ -242,6 +239,11 @@ def run_model(options, tmpdir, jsonfile):
     result = bmv2.generate_model_inputs(stf_map)
     if result != SUCCESS:
         return result
+
+    if not options.hasBMv2:
+        reportError("config.h indicates that BMv2 is not installed. Will skip running BMv2 tests")
+        return SUCCESS
+
     result = bmv2.run(stf_map)
     if result != SUCCESS:
         return result
@@ -393,8 +395,6 @@ if __name__ == "__main__":
     logging.getLogger().addHandler(stderr_log)
 
     options.hasBMv2 = "HAVE_SIMPLE_SWITCH" in config.vars
-    if not options.hasBMv2:
-        reportError("config.h indicates that BMv2 is not installedwill skip running BMv2 tests")
     if options.p4filename.startswith(options.compilerBuildDir):
         options.testName = options.p4filename[len(options.compilerBuildDir) :]
         if options.testName.startswith("/"):


### PR DESCRIPTION
Small quality-of-life improvement. Still parse STF files even though the BMv2 model cannot be run. 