### PR TITLE
[P4Testgen] Ensure accurate typing for functions that work with references.

### DIFF
--- a/backends/p4tools/common/core/abstract_execution_state.h
+++ b/backends/p4tools/common/core/abstract_execution_state.h
@@ -98,16 +98,16 @@ class AbstractExecutionState {
     /// {"prefix.h.ethernet.dst_address", "prefix.h.ethernet.src_address", ...}). If @arg
     /// validVector is provided, this function also collects the validity bits of the headers.
     [[nodiscard]] std::vector<IR::StateVariable> getFlatFields(
-        const IR::Expression *parent, const IR::Type_StructLike *ts,
+        const IR::StateVariable &parent,
         std::vector<IR::StateVariable> *validVector = nullptr) const;
 
     /// Initialize all the members of a struct-like object by calling the initialization function of
     /// the active target. Headers validity is set to "false".
-    void initializeStructLike(const Target &target, const IR::Expression *targetVar,
+    void initializeStructLike(const Target &target, const IR::StateVariable &targetVar,
                               bool forceTaint);
 
     /// Set the members of struct-like @target with the values of struct-like @source.
-    void setStructLike(const IR::Expression *targetVar, const IR::Expression *sourceVar);
+    void setStructLike(const IR::StateVariable &targetVar, const IR::StateVariable &sourceVar);
 
     /// Initialize a Declaration_Variable to its default value.
     /// Does not expect an initializer.

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h
@@ -124,11 +124,12 @@ class AbstractStepper : public Inspector {
     ///     either Members or PathExpressions.
     ///
     /// @returns false
-    bool stepGetHeaderValidity(const IR::Expression *headerRef);
+    bool stepGetHeaderValidity(const IR::StateVariable &headerRef);
 
     /// Sets validity for a header if @a expr is a header. if @a expr is a part of a header union
     /// then it sets invalid for other headers in the union. Otherwise it generates an exception.
-    void setHeaderValidity(const IR::Expression *expr, bool validity, ExecutionState &state);
+    void setHeaderValidity(const IR::StateVariable &headerRef, bool validity,
+                           ExecutionState &state);
 
     /// Transition function for setValid and setInvalid calls.
     ///
@@ -137,7 +138,7 @@ class AbstractStepper : public Inspector {
     /// @param validity the validity state being assigned to the header instance.
     ///
     /// @returns false
-    bool stepSetHeaderValidity(const IR::Expression *headerRef, bool validity);
+    bool stepSetHeaderValidity(const IR::StateVariable &headerRef, bool validity);
 
     /// Transition function for push_front/pop_front calls.
     ///
@@ -167,8 +168,8 @@ class AbstractStepper : public Inspector {
     /// This is a helper function to declare structlike data structures.
     /// This also is used to declare the members of a stack. This function is primarily used by the
     /// Declaration_Variable preorder function.
-    void declareStructLike(ExecutionState &nextState, const IR::Expression *parentExpr,
-                           const IR::Type_StructLike *structType, bool forceTaint = false) const;
+    void declareStructLike(ExecutionState &nextState, const IR::StateVariable &parentExpr,
+                           bool forceTaint = false) const;
 
     /// This is a helper function to declare base type variables. Because all variables need to be a
     /// member in the execution state environment, this helper function suffixes a "*".

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -69,11 +69,11 @@ bool CmdStepper::preorder(const IR::AssignmentStatement *assign) {
     // not always expand these return values as we do with the expandLookahead pass.
     // Correspondingly, we need to retrieve the fields and set each member individually. This
     // assumes that all headers and structures have been flattened and no nesting is left.
-    if (const auto *structType = leftType->to<IR::Type_StructLike>()) {
+    if (leftType->is<IR::Type_StructLike>()) {
         const auto *listExpr = assign->right->checkedTo<IR::ListExpression>();
 
         std::vector<IR::StateVariable> flatRefValids;
-        auto flatRefFields = state.getFlatFields(left, structType, &flatRefValids);
+        auto flatRefFields = state.getFlatFields(left, &flatRefValids);
         // First, complete the assignments for the data structure.
         for (size_t idx = 0; idx < flatRefFields.size(); ++idx) {
             const auto &leftFieldRef = flatRefFields[idx];

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -166,16 +166,17 @@ bool ExprStepper::preorder(const IR::MethodCallExpression *call) {
             // Handle calls to header methods.
             if (method->expr->type->is<IR::Type_Header>() ||
                 method->expr->type->is<IR::Type_HeaderUnion>()) {
+                auto ref = ToolsVariables::convertReference(method->expr);
                 if (method->member == "isValid") {
-                    return stepGetHeaderValidity(method->expr);
+                    return stepGetHeaderValidity(ref);
                 }
 
                 if (method->member == "setInvalid") {
-                    return stepSetHeaderValidity(method->expr, false);
+                    return stepSetHeaderValidity(ref, false);
                 }
 
                 if (method->member == "setValid") {
-                    return stepSetHeaderValidity(method->expr, true);
+                    return stepSetHeaderValidity(ref, true);
                 }
 
                 BUG("Unknown method call on header instance: %1%", call);

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
@@ -106,9 +106,7 @@ const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionS
         auto *metadataCollection = new MetadataCollection();
         const auto *bmv2ProgInfo = programInfo.checkedTo<Bmv2V1ModelProgramInfo>();
         const auto *localMetadataVar = bmv2ProgInfo->getBlockParam("Parser", 2);
-        const auto *localMetadataType = executionState->resolveType(localMetadataVar->type);
-        const auto &flatFields = executionState->getFlatFields(
-            localMetadataVar, localMetadataType->checkedTo<IR::Type_Struct>(), {});
+        const auto &flatFields = executionState->getFlatFields(localMetadataVar, {});
         for (const auto &fieldRef : flatFields) {
             const auto *fieldVal = completedModel->evaluate(executionState->get(fieldRef), true);
             // Try to remove the leading internal name for the metadata field.

--- a/backends/p4tools/modules/testgen/targets/pna/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/test_backend.cpp
@@ -85,9 +85,7 @@ const TestSpec *PnaTestBackend::createTestSpec(const ExecutionState *executionSt
         auto *metadataCollection = new MetadataCollection();
         const auto *pnaProgInfo = programInfo.checkedTo<PnaDpdkProgramInfo>();
         const auto *localMetadataVar = pnaProgInfo->getBlockParam("MainParserT", 2);
-        const auto *localMetadataType = executionState->resolveType(localMetadataVar->type);
-        const auto &flatFields = executionState->getFlatFields(
-            localMetadataVar, localMetadataType->checkedTo<IR::Type_Struct>(), {});
+        const auto &flatFields = executionState->getFlatFields(localMetadataVar, {});
         for (const auto &fieldRef : flatFields) {
             const auto *fieldVal = finalModel->evaluate(executionState->get(fieldRef), true);
             // Try to remove the leading internal name for the metadata field.


### PR DESCRIPTION
This PR tightens the API around state management:

- Make typing stricter for P4Testgen functions that work with StateVariables. Do not allow generic IR::Expression anymore.  

- Clean up `getFlatFields`, we do not actually need to pass in the struct type. Also make sure we handle header stacks correctly. 