### PR TITLE
[P4Testgen] Flatten the genEq function and support struct expressions.

### DIFF
--- a/backends/p4tools/common/lib/gen_eq.cpp
+++ b/backends/p4tools/common/lib/gen_eq.cpp
@@ -1,103 +1,56 @@
 #include "backends/p4tools/common/lib/gen_eq.h"
 
 #include <cstddef>
-#include <string>
-#include <vector>
 
+#include "ir/irutils.h"
 #include "ir/vector.h"
-#include "lib/cstring.h"
 #include "lib/exceptions.h"
 
 namespace P4Tools {
 
-const IR::Expression *GenEq::equate(const IR::Expression *target, const IR::Expression *keyset) {
-    if (const auto *defaultKey = keyset->to<IR::DefaultExpression>()) {
-        return equate(target, defaultKey);
+const IR::Expression *GenEq::checkSingleton(const IR::Expression *expr) {
+    if (const auto *listExpr = expr->to<IR::BaseListExpression>()) {
+        if (listExpr->size() == 1) {
+            expr = checkSingleton(listExpr->components.at(0));
+        }
+    } else if (const auto *structExpr = expr->to<IR::StructExpression>()) {
+        if (structExpr->size() == 1) {
+            expr = checkSingleton(structExpr->components.at(0)->expression);
+        }
     }
-
-    if (const auto *listKey = keyset->to<IR::ListExpression>()) {
-        return equate(target, listKey);
-    }
-
-    if (const auto *maskKey = keyset->to<IR::Mask>()) {
-        return equate(target, maskKey);
-    }
-
-    if (const auto *rangeKey = keyset->to<IR::Range>()) {
-        return equate(target, rangeKey);
-    }
-
-    // If the target is a list expression, it had better be a singleton. In this case, recurse into
-    // the singleton element.
-    if (const auto *listTarget = target->to<IR::ListExpression>()) {
-        BUG_CHECK(listTarget->size() == 1, "Cannot match %1% with %2%", target, keyset);
-        return equate(listTarget->components.at(0), keyset);
-    }
-
-    return mkEq(target, keyset);
+    return expr;
 }
 
-const IR::Expression *GenEq::equate(const IR::Expression * /*target*/,
-                                    const IR::DefaultExpression * /*keyset*/) {
-    return new IR::BoolLiteral(IR::Type::Boolean::get(), true);
-}
-
-const IR::Expression *GenEq::equate(const IR::Expression *target,
-                                    const IR::ListExpression *keyset) {
-    // If the keyset is a singleton list, recurse into the singleton element.
-    if (keyset->size() == 1) {
-        return equate(target, keyset->components.at(0));
+const IR::Expression *GenEq::equateListTypes(const IR::Expression *left,
+                                             const IR::Expression *right) {
+    std::vector<const IR::Expression *> leftElems;
+    if (auto listExpr = left->to<IR::BaseListExpression>()) {
+        leftElems = IR::flattenListExpression(listExpr);
+    } else if (auto structExpr = left->to<IR::StructExpression>()) {
+        leftElems = IR::flattenStructExpression(structExpr);
+    } else {
+        BUG("Unsupported list expression %1% of type %2%.", left, left->node_type_name());
     }
 
-    const auto *listTarget = target->to<IR::ListExpression>();
-    BUG_CHECK(listTarget, "Cannot match %1% with %2%", target, keyset);
-    return equate(listTarget, keyset);
-}
-
-const IR::Expression *GenEq::equate(const IR::Expression *target, const IR::Mask *keyset) {
-    // If the target is a list expression, it had better be a singleton. In this case, recurse into
-    // the singleton element.
-    if (const auto *listTarget = target->to<IR::ListExpression>()) {
-        BUG_CHECK(listTarget->size() == 1, "Cannot match %1% with %2%", target, keyset);
-        return equate(listTarget->components.at(0), keyset);
+    std::vector<const IR::Expression *> rightElems;
+    if (auto listExpr = right->to<IR::BaseListExpression>()) {
+        rightElems = IR::flattenListExpression(listExpr);
+    } else if (auto structExpr = right->to<IR::StructExpression>()) {
+        rightElems = IR::flattenStructExpression(structExpr);
+    } else {
+        BUG("Unsupported right list expression %1% of type %2%.", right, right->node_type_name());
     }
-
-    // Let a &&& b represent the keyset.
-    // We return a & b == target & b.
-    return mkEq(new IR::BAnd(target->type, keyset->left, keyset->right),
-                new IR::BAnd(target->type, target, keyset->right));
-}
-
-const IR::Expression *GenEq::equate(const IR::Expression *target, const IR::Range *keyset) {
-    // If the target is a list expression, it had better be a singleton. In this case, recurse into
-    // the singleton element.
-    if (const auto *listTarget = target->to<IR::ListExpression>()) {
-        BUG_CHECK(listTarget->size() == 1, "Cannot match %1% with %2%", target, keyset);
-        return equate(listTarget->components.at(0), keyset);
-    }
-
-    const auto *boolType = IR::Type::Boolean::get();
-    return new IR::LAnd(boolType, new IR::Leq(boolType, keyset->left, target),
-                        new IR::Leq(boolType, target, keyset->right));
-}
-
-const IR::Expression *GenEq::equate(const IR::ListExpression *target,
-                                    const IR::ListExpression *keyset) {
-    // If the keyset is a singleton list, recurse into the singleton element. Similarly for the
-    // target.
-    if (keyset->size() == 1) {
-        return equate(target, keyset->components.at(0));
-    }
-    if (target->size() == 1) {
-        return equate(target->components.at(0), keyset);
-    }
-
-    BUG_CHECK(target->size() == keyset->size(), "Cannot match %1% with %2%", target, keyset);
+    auto leftElemsSize = leftElems.size();
+    auto rightElemsSize = rightElems.size();
+    BUG_CHECK(leftElemsSize == rightElemsSize,
+              "The size of left elements (%1%) and the size of right elements (%2%) are "
+              "different.",
+              leftElemsSize, rightElemsSize);
 
     const IR::Expression *result = new IR::BoolLiteral(IR::Type::Boolean::get(), true);
     bool firstLoop = true;
-    for (size_t i = 0; i < target->size(); i++) {
-        const auto *conjunct = equate(target->components.at(i), keyset->components.at(i));
+    for (size_t i = 0; i < leftElems.size(); i++) {
+        const auto *conjunct = equate(leftElems.at(i), rightElems.at(i));
         if (firstLoop) {
             result = conjunct;
             firstLoop = false;
@@ -105,8 +58,42 @@ const IR::Expression *GenEq::equate(const IR::ListExpression *target,
             result = new IR::LAnd(IR::Type::Boolean::get(), result, conjunct);
         }
     }
-
     return result;
+}
+
+const IR::Expression *GenEq::equate(const IR::Expression *left, const IR::Expression *right) {
+    // First, recursively unroll any singleton elements.
+    left = checkSingleton(left);
+    right = checkSingleton(right);
+
+    // A single default expression can be matched with a list expression.
+    if (left->is<IR::DefaultExpression>() || right->is<IR::DefaultExpression>()) {
+        return new IR::BoolLiteral(IR::Type::Boolean::get(), true);
+    }
+
+    // If we still have lists after unrolling, compare them.
+    if (left->is<IR::BaseListExpression>() || left->is<IR::StructExpression>()) {
+        BUG_CHECK(right->is<IR::BaseListExpression>() || right->is<IR::StructExpression>(),
+                  "Right expression must be a list expression. Is %1% of type %2%.", right,
+                  right->node_type_name());
+        return equateListTypes(left, right);
+    }
+
+    // At this point, all lists must be resolved.
+    if (const auto *maskKey = right->to<IR::Mask>()) {
+        // Let a &&& b represent the keyset.
+        // We return a & b == target & b.
+        return mkEq(new IR::BAnd(left->type, maskKey->left, maskKey->right),
+                    new IR::BAnd(left->type, left, maskKey->right));
+    }
+
+    if (const auto *rangeKey = right->to<IR::Range>()) {
+        const auto *boolType = IR::Type::Boolean::get();
+        return new IR::LAnd(boolType, new IR::Leq(boolType, rangeKey->left, left),
+                            new IR::Leq(boolType, left, rangeKey->right));
+    }
+
+    return mkEq(left, right);
 }
 
 const IR::Equ *GenEq::mkEq(const IR::Expression *e1, const IR::Expression *e2) {

--- a/backends/p4tools/common/lib/gen_eq.cpp
+++ b/backends/p4tools/common/lib/gen_eq.cpp
@@ -24,8 +24,8 @@ const IR::Expression *GenEq::resolveSingletonList(const IR::Expression *expr) {
 
 const IR::Expression *GenEq::equateListTypes(const IR::Expression *left,
                                              const IR::Expression *right) {
-    std::vector<const IR::Expression *> leftElems = flattenListOrStructExpression(left);
-    std::vector<const IR::Expression *> rightElems = flattenListOrStructExpression(right);
+    std::vector<const IR::Expression *> leftElems = IR::flattenListOrStructExpression(left);
+    std::vector<const IR::Expression *> rightElems = IR::flattenListOrStructExpression(right);
 
     auto leftElemsSize = leftElems.size();
     auto rightElemsSize = rightElems.size();

--- a/backends/p4tools/common/lib/gen_eq.cpp
+++ b/backends/p4tools/common/lib/gen_eq.cpp
@@ -6,9 +6,10 @@
 #include "ir/vector.h"
 #include "lib/exceptions.h"
 
-namespace P4Tools {
+namespace P4Tools::GenEq {
 
-const IR::Expression *GenEq::resolveSingletonList(const IR::Expression *expr) {
+/// Recursively resolve lists of size 1 by returning the expression contained within.
+const IR::Expression *resolveSingletonList(const IR::Expression *expr) {
     if (const auto *listExpr = expr->to<IR::BaseListExpression>()) {
         if (listExpr->size() == 1) {
             return resolveSingletonList(listExpr->components.at(0));
@@ -22,8 +23,9 @@ const IR::Expression *GenEq::resolveSingletonList(const IR::Expression *expr) {
     return expr;
 }
 
-const IR::Expression *GenEq::equateListTypes(const IR::Expression *left,
-                                             const IR::Expression *right) {
+/// Flatten and compare two lists.
+/// Members of struct expressions are ordered and compared based on the underlying type.
+const IR::Expression *equateListTypes(const IR::Expression *left, const IR::Expression *right) {
     std::vector<const IR::Expression *> leftElems = IR::flattenListOrStructExpression(left);
     std::vector<const IR::Expression *> rightElems = IR::flattenListOrStructExpression(right);
 
@@ -48,7 +50,12 @@ const IR::Expression *GenEq::equateListTypes(const IR::Expression *left,
     return result;
 }
 
-const IR::Expression *GenEq::equate(const IR::Expression *left, const IR::Expression *right) {
+/// Construct an equality expression.
+const IR::Equ *mkEq(const IR::Expression *e1, const IR::Expression *e2) {
+    return new IR::Equ(IR::Type::Boolean::get(), e1, e2);
+}
+
+const IR::Expression *equate(const IR::Expression *left, const IR::Expression *right) {
     // First, recursively unroll any singleton elements.
     left = resolveSingletonList(left);
     right = resolveSingletonList(right);
@@ -83,8 +90,4 @@ const IR::Expression *GenEq::equate(const IR::Expression *left, const IR::Expres
     return mkEq(left, right);
 }
 
-const IR::Equ *GenEq::mkEq(const IR::Expression *e1, const IR::Expression *e2) {
-    return new IR::Equ(IR::Type::Boolean::get(), e1, e2);
-}
-
-}  // namespace P4Tools
+}  // namespace P4Tools::GenEq

--- a/backends/p4tools/common/lib/gen_eq.h
+++ b/backends/p4tools/common/lib/gen_eq.h
@@ -15,7 +15,7 @@ class GenEq {
 
  private:
     /// Recursively resolve lists of size 1 by returning the expression contained within.
-    static const IR::Expression *checkSingleton(const IR::Expression *expr);
+    static const IR::Expression *resolveSingletonList(const IR::Expression *expr);
 
     /// Flatten and compare two lists.
     /// Important, this equation assumes that struct expressions have been ordered.

--- a/backends/p4tools/common/lib/gen_eq.h
+++ b/backends/p4tools/common/lib/gen_eq.h
@@ -5,7 +5,7 @@
 
 namespace P4Tools {
 
-/// Generates an equality on two input expressions, recursing into lists and structs.
+/// Generates an semantic equality on two input expressions, recursing into lists and structs.
 /// This supports fuzzy matching on singleton lists: singleton lists are considered the same as
 /// their singleton elements. This is implemented by eagerly recursing into singleton lists before
 /// attempting to generate the equality.

--- a/backends/p4tools/common/lib/gen_eq.h
+++ b/backends/p4tools/common/lib/gen_eq.h
@@ -5,27 +5,23 @@
 
 namespace P4Tools {
 
-/// Generates an equality on a target expression and a keyset expression, recursing into lists.
+/// Generates an equality on two input expressions, recursing into lists and structs.
 /// This supports fuzzy matching on singleton lists: singleton lists are considered the same as
 /// their singleton elements. This is implemented by eagerly recursing into singleton lists before
 /// attempting to generate the equality.
 class GenEq {
  public:
-    static const IR::Expression *equate(const IR::Expression *target, const IR::Expression *keyset);
+    static const IR::Expression *equate(const IR::Expression *left, const IR::Expression *right);
 
  private:
-    static const IR::Expression *equate(const IR::Expression *target,
-                                        const IR::DefaultExpression *keyset);
+    /// Recursively resolve lists of size 1 by returning the expression contained within.
+    static const IR::Expression *checkSingleton(const IR::Expression *expr);
 
-    static const IR::Expression *equate(const IR::Expression *target,
-                                        const IR::ListExpression *keyset);
-
-    static const IR::Expression *equate(const IR::Expression *target, const IR::Mask *keyset);
-
-    static const IR::Expression *equate(const IR::Expression *target, const IR::Range *keyset);
-
-    static const IR::Expression *equate(const IR::ListExpression *target,
-                                        const IR::ListExpression *keyset);
+    /// Flatten and compare two lists.
+    /// Important, this equation assumes that struct expressions have been ordered.
+    /// This calculation does not match the names of the struct expressions.
+    static const IR::Expression *equateListTypes(const IR::Expression *left,
+                                                 const IR::Expression *right);
 
     /// Convenience method for producing a typed Eq node on the given expressions.
     static const IR::Equ *mkEq(const IR::Expression *e1, const IR::Expression *e2);

--- a/backends/p4tools/common/lib/gen_eq.h
+++ b/backends/p4tools/common/lib/gen_eq.h
@@ -3,30 +3,14 @@
 
 #include "ir/ir.h"
 
-namespace P4Tools {
+namespace P4Tools::GenEq {
 
-/// Generates an semantic equality on two input expressions, recursing into lists and structs.
+/// Generates a semantic equality on two input expressions, recursing into lists and structs.
 /// This supports fuzzy matching on singleton lists: singleton lists are considered the same as
 /// their singleton elements. This is implemented by eagerly recursing into singleton lists before
-/// attempting to generate the equality.
-class GenEq {
- public:
-    static const IR::Expression *equate(const IR::Expression *left, const IR::Expression *right);
+/// attempting to generate the equality. The expression types need to be semantically compatible.
+const IR::Expression *equate(const IR::Expression *left, const IR::Expression *right);
 
- private:
-    /// Recursively resolve lists of size 1 by returning the expression contained within.
-    static const IR::Expression *resolveSingletonList(const IR::Expression *expr);
-
-    /// Flatten and compare two lists.
-    /// Important, this equation assumes that struct expressions have been ordered.
-    /// This calculation does not match the names of the struct expressions.
-    static const IR::Expression *equateListTypes(const IR::Expression *left,
-                                                 const IR::Expression *right);
-
-    /// Convenience method for producing a typed Eq node on the given expressions.
-    static const IR::Equ *mkEq(const IR::Expression *e1, const IR::Expression *e2);
-};
-
-}  // namespace P4Tools
+}  // namespace P4Tools::GenEq
 
 #endif /* BACKENDS_P4TOOLS_COMMON_LIB_GEN_EQ_H_ */

--- a/ir/irutils.cpp
+++ b/ir/irutils.cpp
@@ -1,6 +1,5 @@
 #include "ir/irutils.h"
 
-#include <algorithm>
 #include <cmath>
 #include <map>
 #include <tuple>
@@ -176,18 +175,21 @@ const IR::Expression *getDefaultValue(const IR::Type *type, const Util::SourceIn
 
 std::vector<const Expression *> flattenStructExpression(const StructExpression *structExpr) {
     std::vector<const Expression *> exprList;
-    for (const auto *listElem : structExpr->components) {
+    // Ensure that the underlying type is a Type_StructLike.
+    // TODO: How do fail gracefully if we get a Type_Name?
+    const auto *structType = structExpr->type->to<IR::Type_StructLike>();
+    BUG_CHECK(structType != nullptr, "%1%: expected a struct type, received %2%", structExpr->type,
+              structExpr->node_type_name());
+
+    // We use the underlying struct type, which will gives us the right field ordering.
+    for (const auto *typeField : structType->fields) {
+        const auto *listElem = structExpr->getField(typeField->name);
         if (const auto *subStructExpr = listElem->expression->to<StructExpression>()) {
             auto subList = flattenStructExpression(subStructExpr);
             exprList.insert(exprList.end(), subList.begin(), subList.end());
-        } else if (const auto *headerStackExpr =
-                       listElem->expression->to<HeaderStackExpression>()) {
-            for (const auto *headerStackElem : headerStackExpr->components) {
-                // We assume there are no nested header stacks.
-                auto subList =
-                    flattenStructExpression(headerStackElem->checkedTo<IR::StructExpression>());
-                exprList.insert(exprList.end(), subList.begin(), subList.end());
-            }
+        } else if (const auto *subListExpr = listElem->to<BaseListExpression>()) {
+            auto subList = flattenListExpression(subListExpr);
+            exprList.insert(exprList.end(), subList.begin(), subList.end());
         } else {
             exprList.emplace_back(listElem->expression);
         }
@@ -198,8 +200,11 @@ std::vector<const Expression *> flattenStructExpression(const StructExpression *
 std::vector<const Expression *> flattenListExpression(const BaseListExpression *listExpr) {
     std::vector<const Expression *> exprList;
     for (const auto *listElem : listExpr->components) {
-        if (const auto *subListExpr = listElem->to<ListExpression>()) {
+        if (const auto *subListExpr = listElem->to<BaseListExpression>()) {
             auto subList = flattenListExpression(subListExpr);
+            exprList.insert(exprList.end(), subList.begin(), subList.end());
+        } else if (const auto *subStructExpr = listElem->to<IR::StructExpression>()) {
+            auto subList = flattenStructExpression(subStructExpr);
             exprList.insert(exprList.end(), subList.begin(), subList.end());
         } else {
             exprList.emplace_back(listElem);

--- a/ir/irutils.cpp
+++ b/ir/irutils.cpp
@@ -195,7 +195,7 @@ std::vector<const Expression *> flattenStructExpression(const StructExpression *
     return exprList;
 }
 
-std::vector<const Expression *> flattenListExpression(const ListExpression *listExpr) {
+std::vector<const Expression *> flattenListExpression(const BaseListExpression *listExpr) {
     std::vector<const Expression *> exprList;
     for (const auto *listElem : listExpr->components) {
         if (const auto *subListExpr = listElem->to<ListExpression>()) {

--- a/ir/irutils.cpp
+++ b/ir/irutils.cpp
@@ -176,10 +176,9 @@ const IR::Expression *getDefaultValue(const IR::Type *type, const Util::SourceIn
 std::vector<const Expression *> flattenStructExpression(const StructExpression *structExpr) {
     std::vector<const Expression *> exprList;
     // Ensure that the underlying type is a Type_StructLike.
-    // TODO: How do fail gracefully if we get a Type_Name?
     const auto *structType = structExpr->type->to<IR::Type_StructLike>();
-    BUG_CHECK(structType != nullptr, "%1%: expected a struct type, received %2%", structExpr->type,
-              structExpr->node_type_name());
+    BUG_CHECK(structType != nullptr, "%1%: expected a struct-like type, received %2%",
+              structExpr->type, structExpr->node_type_name());
 
     // We use the underlying struct type, which will gives us the right field ordering.
     for (const auto *typeField : structType->fields) {

--- a/ir/irutils.cpp
+++ b/ir/irutils.cpp
@@ -257,4 +257,15 @@ big_int getMinBvVal(const Type *t) {
     P4C_UNIMPLEMENTED("Maximum value calculation for type %1% not implemented.", t);
 }
 
+std::vector<const Expression *> flattenListOrStructExpression(const Expression *listLikeExpr) {
+    if (const auto *listExpr = listLikeExpr->to<IR::BaseListExpression>()) {
+        return IR::flattenListExpression(listExpr);
+    }
+    if (const auto *structExpr = listLikeExpr->to<IR::StructExpression>()) {
+        return IR::flattenStructExpression(structExpr);
+    }
+    P4C_UNIMPLEMENTED("Unsupported list-like expression %1% of type %2%.", listLikeExpr,
+                      listLikeExpr->node_type_name());
+}
+
 }  // namespace IR

--- a/ir/irutils.h
+++ b/ir/irutils.h
@@ -80,6 +80,8 @@ std::vector<const Expression *> flattenStructExpression(const StructExpression *
 /// list.
 std::vector<const Expression *> flattenListExpression(const BaseListExpression *listExpr);
 
+std::vector<const Expression *> flattenListOrStructExpression(const Expression *listLikeExpr);
+
 /* =========================================================================================
  *  Other helper functions
  * ========================================================================================= */

--- a/ir/irutils.h
+++ b/ir/irutils.h
@@ -74,12 +74,16 @@ const IR::Constant *convertBoolLiteral(const IR::BoolLiteral *lit);
 /// Given an StructExpression, returns a flat vector of the expressions contained in that
 /// struct. Unfortunately, list and struct expressions are similar but have no common ancestors.
 /// This is why we require two separate methods.
+/// Note that this function will fail if the type of @param structExpr is not a Type_Name.
 std::vector<const Expression *> flattenStructExpression(const StructExpression *structExpr);
 
 /// Given an BaseListExpression, returns a flat vector of the expressions contained in that
 /// list.
 std::vector<const Expression *> flattenListExpression(const BaseListExpression *listExpr);
 
+/// Given a StructExpression or BaseListExpression, returns a flat vector of the expressions
+/// contained in that list.
+/// Note that this function will fail if the type of any input struct expression is not a Type_Name.
 std::vector<const Expression *> flattenListOrStructExpression(const Expression *listLikeExpr);
 
 /* =========================================================================================

--- a/ir/irutils.h
+++ b/ir/irutils.h
@@ -12,7 +12,7 @@ namespace IR {
 class BoolLiteral;
 class Constant;
 class Expression;
-class ListExpression;
+class BaseListExpression;
 class Literal;
 class StructExpression;
 class Type;
@@ -76,9 +76,9 @@ const IR::Constant *convertBoolLiteral(const IR::BoolLiteral *lit);
 /// This is why we require two separate methods.
 std::vector<const Expression *> flattenStructExpression(const StructExpression *structExpr);
 
-/// Given an ListExpression, returns a flat vector of the expressions contained in that
+/// Given an BaseListExpression, returns a flat vector of the expressions contained in that
 /// list.
-std::vector<const Expression *> flattenListExpression(const ListExpression *listExpr);
+std::vector<const Expression *> flattenListExpression(const BaseListExpression *listExpr);
 
 /* =========================================================================================
  *  Other helper functions


### PR DESCRIPTION
Simplify `genEq` by performing all checks within a single function and resolving nested expressions recursively. Also ensure support of struct expressions. Note that this assumes that the elements within the struct expression are already ordered, i.e, they are enumerated the same way the underlying type is. The struct expression comparison is also on the basis of the contained expressions. We do not check whether the names are the same. 