### PR TITLE
Fix build order for extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,10 @@ set(P4RUNTIME_STD_DIR ${p4runtime_SOURCE_DIR}/proto CACHE INTERNAL
 )
 ########################################## P4Runtime End ##########################################
 
+add_subdirectory (frontends)
+add_subdirectory (midend)
+add_subdirectory (control-plane)
+
 file (GLOB p4c_extensions RELATIVE ${P4C_SOURCE_DIR}/extensions ${P4C_SOURCE_DIR}/extensions/*)
 MESSAGE ("-- Available extensions ${p4c_extensions}")
 foreach (ext ${p4c_extensions})
@@ -412,10 +416,6 @@ foreach (ext ${p4c_extensions})
     endif()
   endif()
 endforeach(ext)
-
-add_subdirectory (frontends)
-add_subdirectory (midend)
-add_subdirectory (control-plane)
 
 # With the current implementation of ir-generator, all targets share the
 # same ir-generated.h and ir-generated.cpp file, which means all targets


### PR DESCRIPTION
According to the cmake docs, the order of `add_subdirectory` commands should not matter, but it seems like it does -- if anything in extensions wants to include the p4parser.hpp (bison output) generated as part of the `frontends`, it must be after `frontends` to get built in the right order.  This might just be a bug in some version(s) of cmake we're tripping over as it doesn't always fail with the wrong order, but seems to (reliably?) work with this order.