### PR TITLE
[P4Testgen]  Add struct and header expressions as a first-class expression to P4Testgen. 

### DIFF
--- a/backends/p4tools/common/compiler/convert_struct_expr.cpp
+++ b/backends/p4tools/common/compiler/convert_struct_expr.cpp
@@ -11,6 +11,10 @@ const IR::Node *ConvertStructExpr::postorder(IR::StructExpression *structExpr) {
         structType = typeMap->getTypeType(structType, true);
         resolved = true;
     }
+    if (structType->is<IR::Type_Header>()) {
+        return new IR::HeaderExpression(structExpr->srcInfo, structType, structExpr->type,
+                                        structExpr->components, IR::getBoolLiteral(true));
+    }
     if (resolved) {
         return new IR::StructExpression(structExpr->srcInfo, structType, structExpr->type,
                                         structExpr->components);

--- a/backends/p4tools/common/compiler/convert_struct_expr.cpp
+++ b/backends/p4tools/common/compiler/convert_struct_expr.cpp
@@ -5,7 +5,7 @@
 namespace P4Tools {
 
 const IR::Node *ConvertStructExpr::postorder(IR::StructExpression *structExpr) {
-    auto structType = structExpr->type;
+    const auto *structType = structExpr->type;
     bool resolved = false;
     if (structType->is<IR::Type_Name>()) {
         structType = typeMap->getTypeType(structType, true);

--- a/backends/p4tools/common/compiler/convert_struct_expr.h
+++ b/backends/p4tools/common/compiler/convert_struct_expr.h
@@ -8,6 +8,9 @@
 
 namespace P4Tools {
 
+/// This pass does two things. First, it converts any type member of struct expression that is a
+/// Type_Name into a Tupe_StructLike. Second, if the type is a Type_Header, it converts the
+/// StructExpression into a HeaderExpression.
 class ConvertStructExpr : public Transform {
  private:
     const P4::TypeMap *typeMap;

--- a/backends/p4tools/common/core/abstract_execution_state.cpp
+++ b/backends/p4tools/common/core/abstract_execution_state.cpp
@@ -122,8 +122,8 @@ std::vector<const IR::Expression *> AbstractExecutionState::flattenComplexExpres
             auto subList = flattenComplexExpression(listElem->expression, flatValids);
             exprList.insert(exprList.end(), subList.begin(), subList.end());
         }
-        if (auto richStructExpr = structExpr->to<IR::HeaderExpression>()) {
-            flatValids.emplace_back(richStructExpr->validity);
+        if (auto headerExpr = structExpr->to<IR::HeaderExpression>()) {
+            flatValids.emplace_back(headerExpr->validity);
         }
     } else if (const auto *headerStackExpr = inputExpression->to<IR::HeaderStackExpression>()) {
         for (const auto *headerStackElem : headerStackExpr->components) {
@@ -189,19 +189,15 @@ void AbstractExecutionState::assignStructLike(const IR::StateVariable &left,
         std::vector<const IR::Expression *> flatRightValids;
         auto flatTargetFields = getFlatFields(left, &flatLeftValids);
         auto flatStructFields = flattenComplexExpression(structExpr, flatRightValids);
-        auto flatTargetSize = flatTargetFields.size();
-        auto flatStructSize = flatStructFields.size();
-        BUG_CHECK(flatTargetSize == flatStructSize,
+        BUG_CHECK(flatTargetFields.size() == flatStructFields.size(),
                   "The size of target fields (%1%) and the size of source fields (%2%) are "
                   "different.",
-                  flatTargetSize, flatStructSize);
-        auto flatLeftValidSize = flatLeftValids.size();
-        auto flatRightValidSize = flatRightValids.size();
+                  flatTargetFields.size(), flatStructFields.size());
         BUG_CHECK(
-            flatLeftValidSize == flatRightValidSize,
+            flatLeftValids.size() == flatRightValids.size(),
             "The size of target valid fields (%1%) and the size of source valid fields (%2%) are "
             "different.",
-            flatLeftValidSize, flatRightValidSize);
+            flatLeftValids.size(), flatRightValids.size());
         // First, complete the validity assignments for the data structure.
         for (size_t idx = 0; idx < flatLeftValids.size(); ++idx) {
             const auto &flatLeftValidRef = flatLeftValids[idx];

--- a/backends/p4tools/common/core/abstract_execution_state.cpp
+++ b/backends/p4tools/common/core/abstract_execution_state.cpp
@@ -74,6 +74,68 @@ void AbstractExecutionState::popNamespace() { namespaces = namespaces->pop(); }
  *  General utilities involving execution state.
  * ========================================================================================= */
 
+const IR::Expression *AbstractExecutionState::convertToComplexExpression(
+    const IR::StateVariable &parent) const {
+    if (auto ts = parent->type->to<IR::Type_StructLike>()) {
+        IR::IndexedVector<IR::NamedExpression> components;
+        for (auto structField : ts->fields) {
+            auto fieldName = structField->name;
+            const auto *fieldType = resolveType(structField->type);
+            auto ref = new IR::Member(fieldType, parent, fieldName);
+            if (fieldType->is<IR::Type_StructLike>() || fieldType->to<IR::Type_Stack>()) {
+                components.push_back(
+                    new IR::NamedExpression(fieldName, convertToComplexExpression(ref)));
+            } else {
+                components.push_back(new IR::NamedExpression(fieldName, get(ref)));
+            }
+        }
+        if (ts->is<IR::Type_Header>()) {
+            auto validity = ToolsVariables::getHeaderValidity(parent);
+            // We do not know the underlying type name of the struct, so keep it anonymous.
+            return new IR::HeaderExpression(ts, nullptr, components, get(validity));
+        } else {
+            // We do not know the underlying type name of the struct, so keep it anonymous.
+            return new IR::StructExpression(ts, nullptr, components);
+        }
+    } else if (auto ts = parent->type->to<IR::Type_Stack>()) {
+        IR::Vector<IR::Expression> components;
+        const auto *elementType = resolveType(ts->elementType);
+        for (size_t idx = 0; idx < ts->getSize(); idx++) {
+            auto ref = new IR::ArrayIndex(elementType, parent, new IR::Constant(idx));
+            if (elementType->is<IR::Type_StructLike>() || elementType->to<IR::Type_Stack>()) {
+                components.push_back(convertToComplexExpression(ref));
+            } else {
+                components.push_back(get(ref));
+            }
+        }
+        return new IR::HeaderStackExpression(parent->type, components, parent->type);
+    }
+    P4C_UNIMPLEMENTED("Unsupported struct-like type %1% for member %2%",
+                      parent->type->node_type_name(), parent);
+}
+
+std::vector<const IR::Expression *> AbstractExecutionState::flattenComplexExpression(
+    const IR::Expression *inputExpression, std::vector<const IR::Expression *> &flatValids) {
+    std::vector<const IR::Expression *> exprList;
+    if (const auto *structExpr = inputExpression->to<IR::StructExpression>()) {
+        for (const auto *listElem : structExpr->components) {
+            auto subList = flattenComplexExpression(listElem->expression, flatValids);
+            exprList.insert(exprList.end(), subList.begin(), subList.end());
+        }
+        if (auto richStructExpr = structExpr->to<IR::HeaderExpression>()) {
+            flatValids.emplace_back(richStructExpr->validity);
+        }
+    } else if (const auto *headerStackExpr = inputExpression->to<IR::HeaderStackExpression>()) {
+        for (const auto *headerStackElem : headerStackExpr->components) {
+            auto subList = flattenComplexExpression(headerStackElem, flatValids);
+            exprList.insert(exprList.end(), subList.begin(), subList.end());
+        }
+    } else {
+        exprList.emplace_back(inputExpression);
+    }
+    return exprList;
+}
+
 std::vector<IR::StateVariable> AbstractExecutionState::getFlatFields(
     const IR::StateVariable &parent, std::vector<IR::StateVariable> *validVector) const {
     std::vector<IR::StateVariable> flatFields;
@@ -120,19 +182,54 @@ void AbstractExecutionState::initializeStructLike(const Target &target,
     }
 }
 
-const IR::P4Table *AbstractExecutionState::findTable(const IR::Member *member) const {
-    if (member->member != IR::IApply::applyMethodName) {
-        return nullptr;
+void AbstractExecutionState::assignStructLike(const IR::StateVariable &left,
+                                              const IR::Expression *right) {
+    if (const auto *structExpr = right->to<IR::StructExpression>()) {
+        std::vector<IR::StateVariable> flatLeftValids;
+        std::vector<const IR::Expression *> flatRightValids;
+        auto flatTargetFields = getFlatFields(left, &flatLeftValids);
+        auto flatStructFields = flattenComplexExpression(structExpr, flatRightValids);
+        auto flatTargetSize = flatTargetFields.size();
+        auto flatStructSize = flatStructFields.size();
+        BUG_CHECK(flatTargetSize == flatStructSize,
+                  "The size of target fields (%1%) and the size of source fields (%2%) are "
+                  "different.",
+                  flatTargetSize, flatStructSize);
+        auto flatLeftValidSize = flatLeftValids.size();
+        auto flatRightValidSize = flatRightValids.size();
+        BUG_CHECK(
+            flatLeftValidSize == flatRightValidSize,
+            "The size of target valid fields (%1%) and the size of source valid fields (%2%) are "
+            "different.",
+            flatLeftValidSize, flatRightValidSize);
+        // First, complete the validity assignments for the data structure.
+        for (size_t idx = 0; idx < flatLeftValids.size(); ++idx) {
+            const auto &flatLeftValidRef = flatLeftValids[idx];
+            const auto *flatRightValidExpr = flatRightValids[idx];
+            set(flatLeftValidRef, flatRightValidExpr);
+        }
+
+        // Then, complete the assignments for the data structure.
+        for (size_t idx = 0; idx < flatTargetFields.size(); ++idx) {
+            const auto &flatTargetRef = flatTargetFields[idx];
+            const auto *flatStructField = flatStructFields[idx];
+            set(flatTargetRef, flatStructField);
+        }
+    } else if (auto stackExpression = right->to<IR::HeaderStackExpression>()) {
+        auto stackType = stackExpression->headerStackType->checkedTo<IR::Type_Stack>();
+        auto stackSize = stackExpression->components.size();
+        for (size_t idx = 0; idx < stackSize; idx++) {
+            const auto *ref = HSIndexToMember::produceStackIndex(stackType->elementType, left, idx);
+            const auto *rightElem = stackExpression->components.at(idx);
+            assignStructLike(ref, rightElem);
+        }
+    } else if (right->is<IR::PathExpression>() || right->is<IR::Member>() ||
+               right->is<IR::ArrayIndex>()) {
+        setStructLike(left, ToolsVariables::convertReference(right));
+    } else {
+        P4C_UNIMPLEMENTED("Unsupported assignment rval %1% of type %2%", right,
+                          right->node_type_name());
     }
-    if (member->expr->is<IR::PathExpression>()) {
-        const auto *declaration = findDecl(member->expr->to<IR::PathExpression>());
-        return declaration->to<IR::P4Table>();
-    }
-    const auto *type = member->expr->type;
-    if (const auto *tableType = type->to<IR::Type_Table>()) {
-        return tableType->table;
-    }
-    return nullptr;
 }
 
 void AbstractExecutionState::setStructLike(const IR::StateVariable &targetVar,
@@ -284,6 +381,21 @@ const IR::P4Action *AbstractExecutionState::getP4Action(
     const auto *actionPath = tableAction->method->checkedTo<IR::PathExpression>();
     const auto *declaration = findDecl(actionPath);
     return declaration->checkedTo<IR::P4Action>();
+}
+
+const IR::P4Table *AbstractExecutionState::findTable(const IR::Member *member) const {
+    if (member->member != IR::IApply::applyMethodName) {
+        return nullptr;
+    }
+    if (member->expr->is<IR::PathExpression>()) {
+        const auto *declaration = findDecl(member->expr->to<IR::PathExpression>());
+        return declaration->to<IR::P4Table>();
+    }
+    const auto *type = member->expr->type;
+    if (const auto *tableType = type->to<IR::Type_Table>()) {
+        return tableType->table;
+    }
+    return nullptr;
 }
 
 }  // namespace P4Tools

--- a/backends/p4tools/common/core/abstract_execution_state.h
+++ b/backends/p4tools/common/core/abstract_execution_state.h
@@ -87,11 +87,20 @@ class AbstractExecutionState {
     /* =========================================================================================
      *  General utilities involving ExecutionState.
      * ========================================================================================= */
+ protected:
+    /// Convert the input reference into a complex expression such as a HeaderExpression,
+    /// StructExpression, or HeaderStackExpression. @returns nullptr if the expression is not
+    /// complex.
+    const IR::Expression *convertToComplexExpression(const IR::StateVariable &parent) const;
 
-    /// Looks up the @param member in the environment of @param state. Returns nullptr if the member
-    /// is not a table type.
-    const IR::P4Table *findTable(const IR::Member *member) const;
+    /// Takes in a complex expression as a StructExpression, ListExpression, or
+    /// HeaderStackExpression, flattens it into a vector and @returns this vector. In parallel this
+    /// function fills a vector of the validity variables of any Type_Header encountered in this
+    /// expression.
+    static std::vector<const IR::Expression *> flattenComplexExpression(
+        const IR::Expression *inputExpression, std::vector<const IR::Expression *> &flatValids);
 
+ public:
     /// Takes an input struct type @ts and a prefix @parent and returns a vector of references to
     /// members of the struct. The vector contains all the Type_Base (bit and bool) members in
     /// canonical representation (e.g.,
@@ -105,6 +114,10 @@ class AbstractExecutionState {
     /// the active target. Headers validity is set to "false".
     void initializeStructLike(const Target &target, const IR::StateVariable &targetVar,
                               bool forceTaint);
+
+    /// Assign a struct-like expression to @param left. Unrolls @param right into a series of
+    /// individual assignments.
+    void assignStructLike(const IR::StateVariable &left, const IR::Expression *right);
 
     /// Set the members of struct-like @target with the values of struct-like @source.
     void setStructLike(const IR::StateVariable &targetVar, const IR::StateVariable &sourceVar);
@@ -126,6 +139,10 @@ class AbstractExecutionState {
     /// default values are specified by the target.
     void initializeBlockParams(const Target &target, const IR::Type_Declaration *typeDecl,
                                const std::vector<cstring> *blockParams);
+
+    /// Looks up the @param member in the environment of @param state. Returns nullptr if the member
+    /// is not a table type.
+    const IR::P4Table *findTable(const IR::Member *member) const;
 
     // Try to extract and @return the IR::P4Action from the action call.
     /// This is done by looking up the reference in the execution state.

--- a/backends/p4tools/common/lib/model.h
+++ b/backends/p4tools/common/lib/model.h
@@ -71,10 +71,11 @@ class Model {
         const IR::StructExpression *structExpr, bool doComplete,
         ExpressionMap *resolvedExpressions = nullptr) const;
 
-    // Evaluates a P4 ListExpression in the context of this model. Recursively calls into @evaluate
-    // and substitutes all members of this list with a Value type.
-    const IR::ListExpression *evaluateListExpr(const IR::ListExpression *listExpr, bool doComplete,
-                                               ExpressionMap *resolvedExpressions = nullptr) const;
+    // Evaluates a P4 BaseListExpression in the context of this model. Recursively calls into
+    // @evaluate and substitutes all members of this list with a Value type.
+    const IR::BaseListExpression *evaluateListExpr(
+        const IR::BaseListExpression *listExpr, bool doComplete,
+        ExpressionMap *resolvedExpressions = nullptr) const;
 
     /// Tries to retrieve @param var from the model.
     /// If @param checked is true, this function throws a BUG if the variable can not be found.

--- a/backends/p4tools/common/lib/symbolic_env.cpp
+++ b/backends/p4tools/common/lib/symbolic_env.cpp
@@ -130,16 +130,22 @@ bool SymbolicEnv::isSymbolicValue(const IR::Node *node) {
         return isSymbolicValue(slice->e0) && isSymbolicValue(slice->e1) &&
                isSymbolicValue(slice->e2);
     }
-    if (const auto *listExpr = expr->to<IR::ListExpression>()) {
+    if (const auto *listExpr = expr->to<IR::BaseListExpression>()) {
         return std::all_of(
             listExpr->components.begin(), listExpr->components.end(),
             [](const IR::Expression *component) { return isSymbolicValue(component); });
     }
     if (const auto *structExpr = expr->to<IR::StructExpression>()) {
-        return std::all_of(structExpr->components.begin(), structExpr->components.end(),
-                           [](const IR::NamedExpression *component) {
-                               return isSymbolicValue(component->expression);
-                           });
+        auto symbolicMembers =
+            std::all_of(structExpr->components.begin(), structExpr->components.end(),
+                        [](const IR::NamedExpression *component) {
+                            return isSymbolicValue(component->expression);
+                        });
+        if (const auto *headerExpr = structExpr->to<IR::HeaderExpression>()) {
+            auto isValid = isSymbolicValue(headerExpr->validity);
+            return isValid && symbolicMembers;
+        }
+        return symbolicMembers;
     }
 
     return false;

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
@@ -102,9 +102,9 @@ bool AbstractStepper::stepToSubexpr(
 }
 
 bool AbstractStepper::stepToListSubexpr(
-    const IR::ListExpression *subexpr, SmallStepEvaluator::Result &result,
+    const IR::BaseListExpression *subexpr, SmallStepEvaluator::Result &result,
     const ExecutionState &state,
-    std::function<const Continuation::Command(const IR::ListExpression *)> rebuildCmd) {
+    std::function<const Continuation::Command(const IR::BaseListExpression *)> rebuildCmd) {
     // Rewrite the list expression to replace the first non-value expression with the continuation
     // parameter.
     // XXX This results in the small-step evaluator evaluating list expressions in quadratic time.

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.h
@@ -106,12 +106,12 @@ class AbstractStepper : public Inspector {
     ///
     /// @returns false
     static bool stepToListSubexpr(
-        const IR::ListExpression *subexpr, SmallStepEvaluator::Result &result,
+        const IR::BaseListExpression *subexpr, SmallStepEvaluator::Result &result,
         const ExecutionState &state,
-        std::function<const Continuation::Command(const IR::ListExpression *)> rebuildCmd);
+        std::function<const Continuation::Command(const IR::BaseListExpression *)> rebuildCmd);
 
-    /// @see stepToListSubexpr.IR::StructExpression differs slightly from IR::ListExpression in that
-    /// the components are IR::NamedExpression instead of just IR::Expression.  To keep things
+    /// @see stepToListSubexpr.IR::StructExpression differs slightly from IR::BaseListExpression in
+    /// that the components are IR::NamedExpression instead of just IR::Expression.  To keep things
     /// simple, and to avoid excessive type casting, these two functions are kept separate.
     static bool stepToStructSubexpr(
         const IR::StructExpression *subexpr, SmallStepEvaluator::Result &result,

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.h
@@ -146,7 +146,7 @@ class ExprStepper : public AbstractStepper {
     bool preorder(const IR::Operation_Binary *binary) override;
     bool preorder(const IR::Operation_Unary *unary) override;
     bool preorder(const IR::SelectExpression *selectExpression) override;
-    bool preorder(const IR::ListExpression *listExpression) override;
+    bool preorder(const IR::BaseListExpression *listExpression) override;
     bool preorder(const IR::StructExpression *structExpression) override;
     bool preorder(const IR::Slice *slice) override;
     bool preorder(const IR::P4Table *table) override;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
@@ -11,14 +11,6 @@
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-metadata"
-  "Non-numeric, non-boolean member expression: .* Type: Type_Stack"
-  # We can not expand stacks in parsers because information about .next is lost.
-  # P4Testgen needs to maintain its own internal .next variable for stacks.
-  array-copy-bmv2.p4
-)
-
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2-metadata"
   "Unknown or unimplemented extern method: recirculate_preserving_field_list"
 )
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -84,14 +84,6 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
-  "Non-numeric, non-boolean member expression: .* Type: Type_Stack"
-  # We can not expand stacks in parsers because information about .next is lost.
-  # P4Testgen needs to maintain its own internal .next variable for stacks.
-  array-copy-bmv2.p4
-)
-
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2-ptf"
   "Computations are not supported in update_checksum"
 )
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufXfail.cmake
@@ -11,14 +11,6 @@
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-protobuf"
-  "Non-numeric, non-boolean member expression: .* Type: Type_Stack"
-  # We can not expand stacks in parsers because information about .next is lost.
-  # P4Testgen needs to maintain its own internal .next variable for stacks.
-  array-copy-bmv2.p4
-)
-
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2-protobuf"
   "Unknown or unimplemented extern method: recirculate_preserving_field_list"
 )
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
@@ -69,14 +69,6 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-stf"
-  "Non-numeric, non-boolean member expression: .* Type: Type_Stack"
-  # We can not expand stacks in parsers because information about .next is lost.
-  # P4Testgen needs to maintain its own internal .next variable for stacks.
-  array-copy-bmv2.p4
-)
-
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2-stf"
   "Cast failed"
   # push front can not handle tainted header validity.
   header-stack-ops-bmv2.p4

--- a/backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.cpp
@@ -174,9 +174,10 @@ void EBPFExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
              }
              // Input must be the headers struct.
              headers->type->checkedTo<IR::Type_Struct>();
+             const auto *oneBitType = IR::getBitType(1);
              const auto *tcpRef = new IR::Member(headers, "tcp");
-             const auto *syn = state.get(new IR::Member(tcpRef, "syn"));
-             const auto *ack = state.get(new IR::Member(tcpRef, "ack"));
+             const auto *syn = state.get(new IR::Member(oneBitType, tcpRef, "syn"));
+             const auto *ack = state.get(new IR::Member(oneBitType, tcpRef, "ack"));
 
              // Implement the simple conntrack case since we do not support multiple packets here
              // yet.

--- a/backends/p4tools/p4tools.def
+++ b/backends/p4tools/p4tools.def
@@ -241,3 +241,20 @@ public:
           concolicId(concolicId),
           concolicMethodName(methodName) {}
 }
+
+/// An extension of a struct expression. Also tracks validity as an expression.
+class HeaderExpression : StructExpression {
+    /// Whether this struct expression is valid. Mostly relevant to header expressions.
+    Expression validity;
+
+    dbprint {
+        out << "(" << validity << "){" << IndentCtl::indent;
+        for (auto &field : components) out << Log::endl << field << ';';
+        out << " }" << IndentCtl::unindent;
+    }
+
+    validate {
+        components.check_null(); components.validate();
+        BUG_CHECK(structType == nullptr || structType->is<IR::Type_Header>(), "%1%: unexpected header type", structType->node_type_name());
+    }
+}

--- a/backends/p4tools/p4tools.def
+++ b/backends/p4tools/p4tools.def
@@ -248,9 +248,12 @@ class HeaderExpression : StructExpression {
     Expression validity;
 
     dbprint {
-        out << "(" << validity << "){" << IndentCtl::indent;
-        for (auto &field : components) out << Log::endl << field << ';';
-        out << " }" << IndentCtl::unindent;
+        out <<"{" << Log::endl << IndentCtl::indent;
+        out << "$headerValid:" << validity <<";" << Log::endl;
+        for (auto &field : components) {
+            out << Log::endl << field << ';';
+        }
+        out << Log::endl << IndentCtl::unindent << "}";
     }
 
     validate {


### PR DESCRIPTION
This PR adds support for struct expressions in P4Testgen. Concretely, it adds utility functions to handle assignments and pass struct expressions as full argument. It also generalizes some utility functions to support BaseListExpressions, StructExpressions, and HeaderStackExpressions.

The goal of these changes is to enable two features:
- Support of meta information of complex P4 objects (such as validity and the `next` index of header stacks)
- Support of struct expressions as method call arguments. This will make implementation of externs significantly easier because we do not have to resolve the arguments within the extern any longer. Instead, we are able to access all necessary arguments directly. 

It also introduces a new IR type. HeaderExpressions. HeaderExpressions track the validity of the header as an expression, which makes it possible to track validity of a header symbolically and not just as a boolean constant. 