### PR TITLE
Simplify jsonAssignment in ParserConverter and ActionConverter

### DIFF
--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -20,8 +20,8 @@ limitations under the License.
 
 namespace BMV2 {
 
-cstring ActionConverter::jsonAssignment(const IR::Type *type, bool inParser) {
-    if (!inParser && type->is<IR::Type_Varbits>()) return "assign_VL";
+cstring ActionConverter::jsonAssignment(const IR::Type *type) {
+    if (type->is<IR::Type_Varbits>()) return "assign_VL";
     if (type->is<IR::Type_HeaderUnion>()) return "assign_union";
     if (type->is<IR::Type_Header>() || type->is<IR::Type_Struct>()) return "assign_header";
     if (auto ts = type->to<IR::Type_Stack>()) {
@@ -31,12 +31,7 @@ cstring ActionConverter::jsonAssignment(const IR::Type *type, bool inParser) {
         else
             return "assign_header_stack";
     }
-    if (inParser)
-        // Unfortunately set can do some things that assign cannot,
-        // e.g., handle lookahead on the RHS.
-        return "set";
-    else
-        return "assign";
+    return "assign";
 }
 
 void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl> *body,
@@ -113,7 +108,7 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl> *body,
             l = assign->left;
             r = assign->right;
             auto type = ctxt->typeMap->getType(l, true);
-            cstring operation = jsonAssignment(type, false);
+            cstring operation = jsonAssignment(type);
             auto primitive = mkPrimitive(operation, result);
             auto parameters = mkParameters(primitive);
             primitive->emplace_non_null("source_info", assign->sourceInfoJsonObj());

--- a/backends/bmv2/common/action.h
+++ b/backends/bmv2/common/action.h
@@ -27,7 +27,7 @@ class ActionConverter : public Inspector {
 
     void convertActionBody(const IR::Vector<IR::StatOrDecl> *body, Util::JsonArray *result);
     void convertActionParams(const IR::ParameterList *parameters, Util::JsonArray *params);
-    cstring jsonAssignment(const IR::Type *type, bool inParser);
+    cstring jsonAssignment(const IR::Type *type);
     void postorder(const IR::P4Action *action) override;
 
  public:

--- a/backends/bmv2/common/parser.cpp
+++ b/backends/bmv2/common/parser.cpp
@@ -25,8 +25,7 @@ limitations under the License.
 
 namespace BMV2 {
 
-cstring ParserConverter::jsonAssignment(const IR::Type *type, bool inParser) {
-    if (!inParser && type->is<IR::Type_Varbits>()) return "assign_VL";
+cstring ParserConverter::jsonAssignment(const IR::Type *type) {
     if (type->is<IR::Type_HeaderUnion>()) return "assign_union";
     if (type->is<IR::Type_Header>() || type->is<IR::Type_Struct>()) return "assign_header";
     if (auto ts = type->to<IR::Type_Stack>()) {
@@ -36,12 +35,9 @@ cstring ParserConverter::jsonAssignment(const IR::Type *type, bool inParser) {
         else
             return "assign_header_stack";
     }
-    if (inParser)
-        // Unfortunately set can do some things that assign cannot,
-        // e.g., handle lookahead on the RHS.
-        return "set";
-    else
-        return "assign";
+    // Unfortunately set can do some things that assign cannot, e.g., handle
+    // lookahead on the RHS.
+    return "set";
 }
 
 Util::IJson *ParserConverter::convertParserStatement(const IR::StatOrDecl *stat) {
@@ -107,7 +103,7 @@ Util::IJson *ParserConverter::convertParserStatement(const IR::StatOrDecl *stat)
     if (stat->is<IR::AssignmentStatement>()) {
         auto assign = stat->to<IR::AssignmentStatement>();
         auto type = ctxt->typeMap->getType(assign->left, true);
-        cstring operation = jsonAssignment(type, true);
+        cstring operation = jsonAssignment(type);
         result->emplace("op", operation);
         auto l = ctxt->conv->convertLeftValue(assign->left);
         bool convertBool = type->is<IR::Type_Boolean>();

--- a/backends/bmv2/common/parser.h
+++ b/backends/bmv2/common/parser.h
@@ -42,7 +42,7 @@ class ParserConverter : public Inspector {
     Util::IJson *convertSelectKey(const IR::SelectExpression *expr);
     Util::IJson *convertPathExpression(const IR::PathExpression *expr);
     Util::IJson *createDefaultTransition();
-    cstring jsonAssignment(const IR::Type *type, bool inParser);
+    cstring jsonAssignment(const IR::Type *type);
     std::vector<Util::IJson *> convertSelectExpression(const IR::SelectExpression *expr);
     void addValueSets(const IR::P4Parser *parser);
 


### PR DESCRIPTION
The inParser parameter is not actually used. I think it was introduced back when both converters shared the same implementation.