### PR TITLE
Report offending node in the type-checker immutability check

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -159,12 +159,12 @@ Visitor::profile_t TypeInference::init_apply(const IR::Node *node) {
 }
 
 void TypeInference::end_apply(const IR::Node *node) {
-    if (readOnly && !(*node == *initialNode)) {
-        BUG("At this point in the compilation typechecking "
-            "should not infer new types anymore, but it did.");
-    }
+    BUG_CHECK(!readOnly || node == initialNode,
+              "At this point in the compilation typechecking should not infer new types anymore, "
+              "but it did.");
     typeMap->updateMap(node);
     if (node->is<IR::P4Program>()) LOG3("Typemap: " << std::endl << typeMap);
+    Transform::end_apply(node);
 }
 
 const IR::Node *TypeInference::apply_visitor(const IR::Node *orig, const char *name) {

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -171,7 +171,8 @@ const IR::Node *TypeInference::apply_visitor(const IR::Node *orig, const char *n
     const auto *transformed = Transform::apply_visitor(orig, name);
     BUG_CHECK(!readOnly || orig == transformed,
               "At this point in the compilation typechecking should not infer new types anymore, "
-              "but it did: node %1% changed to %2%", orig, transformed);
+              "but it did: node %1% changed to %2%",
+              orig, transformed);
     return transformed;
 }
 

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -167,6 +167,14 @@ void TypeInference::end_apply(const IR::Node *node) {
     if (node->is<IR::P4Program>()) LOG3("Typemap: " << std::endl << typeMap);
 }
 
+const IR::Node *TypeInference::apply_visitor(const IR::Node *orig, const char *name) {
+    const auto *transformed = Transform::apply_visitor(orig, name);
+    BUG_CHECK(!readOnly || orig == transformed,
+              "At this point in the compilation typechecking should not infer new types anymore, "
+              "but it did: node %1% changed to %2%", orig, transformed);
+    return transformed;
+}
+
 TypeInference *TypeInference::clone() const {
     return new TypeInference(this->refMap, this->typeMap, true);
 }

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -334,6 +334,7 @@ class TypeInference : public Transform {
 
     Visitor::profile_t init_apply(const IR::Node *node) override;
     void end_apply(const IR::Node *Node) override;
+    const IR::Node *apply_visitor(const IR::Node *, const char *name = 0) override;
 
     TypeInference *clone() const override;
     // Apply recursively the typechecker to the newly created node


### PR DESCRIPTION
Currently, the compiler would produce only a very vague error message if type checking runs in immutable mode and the IR tree is actually modified. This is extremely annoying to debug. Therefore, I've added the check after each node is processed and the check now reports the offending node.

I've also modified the `end_apply` function (which still prints the generic check, although it is probably redundant):
- calling parent `end_apply`
- the nodes should be comparend for exact pointer equality, not for internal semantic equality -- it is not OK if the transform produces new tree that is equivalent in the readOnly mode. It must keep the original tree.