### PR TITLE
[P4Testgen] Add EliminateInvalidHeaders midend pass

### DIFF
--- a/backends/p4tools/common/compiler/midend.cpp
+++ b/backends/p4tools/common/compiler/midend.cpp
@@ -15,6 +15,7 @@
 #include "midend/convertEnums.h"
 #include "midend/convertErrors.h"
 #include "midend/copyStructures.h"
+#include "midend/eliminateInvalidHeaders.h"
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateSerEnums.h"
 #include "midend/eliminateSwitch.h"
@@ -95,6 +96,8 @@ void MidEnd::addDefaultPasses() {
         new P4::EliminateSwitch(&refMap, &typeMap),
         // Replace types introduced by 'type' with 'typedef'.
         new P4::EliminateNewtype(&refMap, &typeMap),
+        // Remove the invalid header / header-union literal, except for constant expressions
+        new P4::EliminateInvalidHeaders(&refMap, &typeMap),
         // Replace serializable enum constants with their values.
         new P4::EliminateSerEnums(&refMap, &typeMap),
         // Make sure that we have no TypeDef left in the program.

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_valid_lit.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_valid_lit.p4
@@ -1,0 +1,68 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header h0_t {
+    bit<32> f0;
+    bit<32> f1;
+}
+
+struct headers {
+    ethernet_t eth_hdr;
+    h0_t h0;
+}
+
+struct Meta {}
+
+parser p(packet_in pkt, out headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h0);
+        transition select(hdr.h0.f0) {
+            0: invalidate;
+            default: accept;
+        }
+    }
+    state invalidate {
+        hdr.h0 = (h0_t){#};
+        transition accept;
+    }
+}
+
+control ingress(inout headers h, inout Meta m, inout standard_metadata_t sm) {
+    bit<32>  a = 0;
+    apply {
+        if (h.eth_hdr.isValid())
+            a = a | 1;
+        if (h.h0 == (h0_t){#})
+            a = a | 2;
+        h.eth_hdr = (ethernet_t){#};
+        h.h0.setValid();
+        h.h0.f0 = a;
+    }
+}
+
+control vrfy(inout headers h, inout Meta m) {
+    apply {}
+ }
+
+control update(inout headers hdr, inout Meta m) { apply {
+}}
+
+control egress(inout headers h, inout Meta m, inout standard_metadata_t sm) { apply {} }
+
+control deparser(packet_out pkt, in headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;
+


### PR DESCRIPTION
Previously, testgen would fail will errors like this (when #4238 is applied to make the error readable):

```
Internal error: In file: ./p4c/frontends/p4/typeChecking/typeChecker.cpp:172
Compiler Bug: build/init.p4(78): At this point in the compilation typechecking should not infer new types anymore, but it did: node (hdr_0_t){#}.isValid(); changed to 0;
        hdr.hdr_0 = (hdr_0_t){#};
                  ^
build/init.p4(78)
        hdr.hdr_0 = (hdr_0_t){#};
                  ^
```