### PR TITLE
Allow method calls in index expressions in hsIndexSimplify

### DIFF
--- a/midend/hsIndexSimplify.cpp
+++ b/midend/hsIndexSimplify.cpp
@@ -20,6 +20,7 @@ void HSIndexFinder::addNewVariable() {
     if (locals != nullptr && (arrayIndex->right->is<IR::Operation_Ternary>() ||
                               arrayIndex->right->is<IR::Operation_Binary>() ||
                               arrayIndex->right->is<IR::Operation_Unary>() ||
+                              arrayIndex->right->is<IR::MethodCallExpression>() ||
                               arrayIndex->right->is<IR::PathExpression>())) {
         // Generate new local variable if needed.
         std::ostringstream ostr;


### PR DESCRIPTION
Before this, the compiler would fail i.e. on

```
hdr.h2.f3 = hdr.hs[r0.read((bit<32>)hdr.h0.idx0)].f0;

-->

Internal error: In file: ./build/p4c/ir/ir-generated.cpp:4173
Compiler Bug: ./build/p4c/ir/ir-generated.cpp:4173: Null left
```

The failure is in `validate()` method because the `aiFinder.newVariable` is null when creating `Eq` constraint in `eliminateArrayIndexes`.

