### PR TITLE
Update gRPC python version in install_fedora_deps.sh

### DIFF
--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -748,7 +748,7 @@ class RunBMV2(object):
                     str(rand),
                 ]
                 + self.interfaceArgs()
-                + ["../" + self.jsonfile]
+                + [self.jsonfile]
             )
             if self.cmd_line_args:
                 runswitch += self.cmd_line_args

--- a/backends/bmv2/run-bmv2-test.py
+++ b/backends/bmv2/run-bmv2-test.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import sys
 import tempfile
+from pathlib import Path
 from subprocess import Popen
 from threading import Thread
 
@@ -267,7 +268,8 @@ def process_file(options, argv):
 
     if run_init_commands(options) != SUCCESS:
         return FAILURE
-    tmpdir = tempfile.mkdtemp(dir=".")
+    # ensure that tempfile.mkdtemp returns an absolute path, regardless of the py3 version
+    tmpdir = tempfile.mkdtemp(dir=Path(".").absolute())
     basename = os.path.basename(options.p4filename)
     base, _ = os.path.splitext(basename)
 

--- a/backends/p4test/run-p4-sample.py
+++ b/backends/p4test/run-p4-sample.py
@@ -25,6 +25,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 from subprocess import PIPE, Popen
 from threading import Thread
 
@@ -222,7 +223,7 @@ def file_name(tmpfolder, base, suffix, ext):
 def process_file(options, argv):
     assert isinstance(options, Options)
 
-    tmpdir = tempfile.mkdtemp(dir=".")
+    tmpdir = tempfile.mkdtemp(dir=Path(".").absolute())
     basename = os.path.basename(options.p4filename)
     base, ext = os.path.splitext(basename)
     dirname = os.path.dirname(options.p4filename)

--- a/backends/tc/run-tc-test.py
+++ b/backends/tc/run-tc-test.py
@@ -21,6 +21,7 @@ import shutil
 import stat
 import sys
 import tempfile
+from pathlib import Path
 from subprocess import Popen, call
 from threading import Thread
 
@@ -149,7 +150,7 @@ def check_generated_files(options, tmpdir, expecteddir):
 def process_file(options, argv):
     assert isinstance(options, Options)
 
-    tmpdir = tempfile.mkdtemp(dir=".")
+    tmpdir = tempfile.mkdtemp(dir=Path(".").absolute())
     basename = os.path.basename(options.p4filename)
     base, ext = os.path.splitext(basename)
     dirname = os.path.dirname(options.p4filename)

--- a/tools/install_fedora_deps.sh
+++ b/tools/install_fedora_deps.sh
@@ -47,7 +47,7 @@ sudo dnf install -y -q \
     valgrind \
     zlib-devel
 
-sudo pip3 install ply ptf scapy==2.4.5 wheel
+sudo pip3 install ply ptf scapy==2.5.0 wheel
 
 # Install dependencies for the BMv2 PTF runner and P4Runtime.
 sudo pip3 install --upgrade protobuf==3.20.3

--- a/tools/install_fedora_deps.sh
+++ b/tools/install_fedora_deps.sh
@@ -50,9 +50,9 @@ sudo dnf install -y -q \
 sudo pip3 install ply ptf scapy==2.4.5 wheel
 
 # Install dependencies for the BMv2 PTF runner and P4Runtime.
-sudo pip3 install --upgrade protobuf==3.20.1
-sudo pip3 install --upgrade googleapis-common-protos==1.50.0
-sudo pip3 install --upgrade grpcio==1.51.1
+sudo pip3 install --upgrade protobuf==3.20.3
+sudo pip3 install --upgrade googleapis-common-protos==1.61.0
+sudo pip3 install --upgrade grpcio==1.59.2
 
 MAKEFLAGS="-j$(nproc)"
 export MAKEFLAGS


### PR DESCRIPTION
The fedora:latest container now comes with Python 3.12. Older gRPC versions do not support this Python version. See
https://github.com/grpc/grpc/issues/33063.

An alternative would be to pin the fedora container version, but then someone has to remember to update it periodically...