### PR TITLE
Allow non-const checkedTo cast.

### DIFF
--- a/lib/castable.h
+++ b/lib/castable.h
@@ -57,6 +57,14 @@ class ICastable {
         BUG_CHECK(result, "Cast failed: %1% is not a %2%", this, typeid(T).name());
         return result;
     }
+
+    /// Performs a checked cast. A BUG occurs if the cast fails.
+    template <typename T>
+    T *checkedTo() {
+        auto *result = to<T>();
+        BUG_CHECK(result, "Cast failed: %1% is not a %2%", this, typeid(T).name());
+        return result;
+    }
 };
 
 #endif /* LIB_CASTABLE_H_ */


### PR DESCRIPTION
`ICastable` was missing a `checkedTo` cast for writable objects. We already had a `to`, but no `checkedTo`. 