### PR TITLE
Allow overriding of 'usage' method in the Options class

### DIFF
--- a/lib/options.h
+++ b/lib/options.h
@@ -98,7 +98,7 @@ class Options {
     cstring getCompileCommand() { return compileCommand; }
     cstring getBuildDate() { return buildDate; }
     cstring getBinaryName() { return cstring(binaryName); }
-    void usage();
+    virtual void usage();
 };
 
 }  // namespace Util


### PR DESCRIPTION
This change allows to override default usage() method in Options.