### PR TITLE
Added range check of error codes

### DIFF
--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -72,6 +72,7 @@ const int ErrorType::WARN_MAX = 2141;
 
 // ------ Info messages -----------
 const int ErrorType::INFO_INFERRED = WARN_MAX + 1;
+const int ErrorType::INFO_PROGRESS = 2143;
 
 // Backends should extend this class with additional info messages in the range 3000-3999.
 const int ErrorType::INFO_MIN_BACKEND = 3000;
@@ -124,4 +125,5 @@ std::map<int, cstring> ErrorCatalog::errorCatalog = {
     {ErrorType::WARN_ENTRIES_OUT_OF_ORDER, "entries_out_of_priority_order"},
 
     // Info messages
-    {ErrorType::INFO_INFERRED, "inferred"}};
+    {ErrorType::INFO_INFERRED, "inferred"},
+    {ErrorType::INFO_PROGRESS, "progress"}};

--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -38,9 +38,6 @@ const int ErrorType::ERR_IO = 14;
 const int ErrorType::ERR_UNREACHABLE = 15;
 const int ErrorType::ERR_MODEL = 16;
 const int ErrorType::ERR_RESERVED = 17;
-// Backends should extend this class with additional errors in the range 500-999.
-const int ErrorType::ERR_MIN_BACKEND = 500;
-const int ErrorType::ERR_MAX = 999;
 
 // ------ Warnings -----------
 const int ErrorType::LEGACY_WARNING = ERR_MAX + 1;
@@ -66,17 +63,10 @@ const int ErrorType::WARN_UNINITIALIZED_USE = 1019;
 const int ErrorType::WARN_INVALID_HEADER = 1020;
 const int ErrorType::WARN_DUPLICATE_PRIORITIES = 1021;
 const int ErrorType::WARN_ENTRIES_OUT_OF_ORDER = 1022;
-// Backends should extend this class with additional warnings in the range 1500-2141.
-const int ErrorType::WARN_MIN_BACKEND = 1500;
-const int ErrorType::WARN_MAX = 2141;
 
 // ------ Info messages -----------
 const int ErrorType::INFO_INFERRED = WARN_MAX + 1;
 const int ErrorType::INFO_PROGRESS = 2143;
-
-// Backends should extend this class with additional info messages in the range 3000-3999.
-const int ErrorType::INFO_MIN_BACKEND = 3000;
-const int ErrorType::INFO_MAX = 3999;
 
 // map from errorCode to ErrorSig
 std::map<int, cstring> ErrorCatalog::errorCatalog = {

--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -38,11 +38,12 @@ const int ErrorType::ERR_IO = 14;
 const int ErrorType::ERR_UNREACHABLE = 15;
 const int ErrorType::ERR_MODEL = 16;
 const int ErrorType::ERR_RESERVED = 17;
-// If we specialize for 1000 error types we're good!
-const int ErrorType::ERR_MAX_ERRORS = 999;
+// Backends should extend this class with additional errors in the range 500-999.
+const int ErrorType::ERR_MIN_BACKEND = 500;
+const int ErrorType::ERR_MAX = 999;
 
 // ------ Warnings -----------
-const int ErrorType::LEGACY_WARNING = ERR_MAX_ERRORS + 1;
+const int ErrorType::LEGACY_WARNING = ERR_MAX + 1;
 const int ErrorType::WARN_FAILED = 1001;
 const int ErrorType::WARN_UNKNOWN = 1002;
 const int ErrorType::WARN_INVALID = 1003;
@@ -65,11 +66,16 @@ const int ErrorType::WARN_UNINITIALIZED_USE = 1019;
 const int ErrorType::WARN_INVALID_HEADER = 1020;
 const int ErrorType::WARN_DUPLICATE_PRIORITIES = 1021;
 const int ErrorType::WARN_ENTRIES_OUT_OF_ORDER = 1022;
-const int ErrorType::WARN_MAX_WARNINGS = 2142;
+// Backends should extend this class with additional warnings in the range 1500-2141.
+const int ErrorType::WARN_MIN_BACKEND = 1500;
+const int ErrorType::WARN_MAX = 2141;
 
-// ------ Info message -----------
-const int ErrorType::INFO_INFERRED = WARN_MAX_WARNINGS + 1;
-const int ErrorType::INFO_MAX_INFOS = 3999;
+// ------ Info messages -----------
+const int ErrorType::INFO_INFERRED = WARN_MAX + 1;
+
+// Backends should extend this class with additional info messages in the range 3000-3999.
+const int ErrorType::INFO_MIN_BACKEND = 3000;
+const int ErrorType::INFO_MAX = 3999;
 
 // map from errorCode to ErrorSig
 std::map<int, cstring> ErrorCatalog::errorCatalog = {

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -144,7 +144,7 @@ class ErrorCatalog {
     bool isError(cstring name) {
         int code = getCode(name);
         if (code == -1) return false;
-        if (code >= ErrorType::ERR_MAX) return false;
+        if (code > ErrorType::ERR_MAX) return false;
         return true;
     }
 

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -86,6 +86,7 @@ class ErrorType {
     // -------- Info messages -------------
     // info messages as initially defined with a format string
     static const int INFO_INFERRED;  // information inferred by compiler
+    static const int INFO_PROGRESS;  // compilation progress
 
     static const int INFO_MIN_BACKEND;  // first allowed backend info code
     static const int INFO_MAX;          // last allowed info code


### PR DESCRIPTION
The PR adds named constants for min and max values of error, warning, and info message codes to be used in backends. Also, the `ErrorCatalog::add` method now expects a code type so that it can perform range check. E.g.:

`ErrorCatalog::getCatalog().add<ErrorMessage::MessageType::Info, INFO_USER_CODE>("user-code");`

If the range check fails, a bug is triggered.

In addition, a new info code INFO_PROGRESS is added.