### PR TITLE
[P4Testgen] Generate NoMatch for selects without default

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -410,7 +410,7 @@ bool ExprStepper::preorder(const IR::SelectExpression *selectExpression) {
         missCondition = new IR::LAnd(new IR::LNot(matchCondition), missCondition);
     }
 
-    // generate implicit NoMatch
+    // Generate implicit NoMatch.
     if (!hasDefault) {
         auto &nextState = state.clone();
         nextState.replaceTopBody(Continuation::Exception::NoMatch);

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -413,6 +413,8 @@ bool ExprStepper::preorder(const IR::SelectExpression *selectExpression) {
     // Generate implicit NoMatch.
     if (!hasDefault) {
         auto &nextState = state.clone();
+        nextState.add(*new TraceEvents::GenericDescription("NoMatch",
+            "Parser select expression did not match any alternatives."));
         nextState.replaceTopBody(Continuation::Exception::NoMatch);
         result->emplace_back(missCondition, state, nextState);
     }

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.h
@@ -115,9 +115,10 @@ class ExprStepper : public AbstractStepper {
     void generateCopyIn(ExecutionState &nextState, const IR::StateVariable &targetPath,
                         const IR::StateVariable &srcPath, cstring dir, bool forceTaint) const;
 
-    /// Takes a step to reflect a "select" expression failing to match. The default implementation
+    /// Takes a step to reflect a "select" expression failing to match. If condition is given, this
+    /// will create a new state that is guarded by the given condition. The default implementation
     /// raises Continuation::Exception::NoMatch.
-    virtual void stepNoMatch();
+    virtual void stepNoMatch(std::string traceLog, const IR::Expression *condition = nullptr);
 
  public:
     ExprStepper(const ExprStepper &) = default;


### PR DESCRIPTION
Previously, the testgen would generate `NoMatch` exception in parser only if it was caused by explicitly set value, but not when it was an implicit option based on symbolic input. This is now fixed. If there is no default a new successor (guarded by composite `missCondition`) will be added to the select expression.

I've opted to implementing this explicitly in the stepper as opposed to adding the `HandleNoMatch` midend pass as the latter would explicitly set the `error` instead of raising the exception. Note that for header stack overflow, testgen already uses a midend pass that sets the error using `verify` and this might be wrong.

@fruffy, I'm not sure if I need to change anything else (e.g. `P4ProgramDCGCreator::preorder(const IR::SelectExpression *selectExpression)`. Also, I don't know how to test this automatically, is there a way for testgen test to check that coverage is 1?