### PR TITLE
[P4Testgen] Add --assert-min-coverage option to check coverage of generated test cases

### DIFF
--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -123,7 +123,6 @@ bool TestBackEnd::run(const FinalState &state) {
         }
 
         const P4::Coverage::CoverageSet &visitedNodes = symbex.getVisitedNodes();
-        float coverage = NAN;
         if (coverableNodes.empty()) {
             printFeature("test_info", 4, "============ Test %1% ============", testCount);
         } else {
@@ -136,7 +135,7 @@ bool TestBackEnd::run(const FinalState &state) {
         }
 
         // Output the test.
-        Util::withTimer("backend", [this, &testSpec, &selectedBranches, &coverage] {
+        Util::withTimer("backend", [this, &testSpec, &selectedBranches] {
             testWriter->outputTest(testSpec, selectedBranches, testCount, coverage);
         });
 
@@ -149,7 +148,6 @@ bool TestBackEnd::run(const FinalState &state) {
         if (testgenOptions.stopMetric == "MAX_NODE_COVERAGE" && coverage == 1.0) {
             return true;
         }
-        maxCoverage = std::max(maxCoverage, coverage);
         return needsToTerminate(testCount);
     }
 }
@@ -246,6 +244,6 @@ void TestBackEnd::printPerformanceReport(bool write) const {
 
 int64_t TestBackEnd::getTestCount() const { return testCount; }
 
-float TestBackEnd::getCoverage() const { return maxCoverage; }
+float TestBackEnd::getCoverage() const { return coverage; }
 
 }  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -149,6 +149,7 @@ bool TestBackEnd::run(const FinalState &state) {
         if (testgenOptions.stopMetric == "MAX_NODE_COVERAGE" && coverage == 1.0) {
             return true;
         }
+        maxCoverage = std::max(maxCoverage, coverage);
         return needsToTerminate(testCount);
     }
 }
@@ -244,5 +245,7 @@ void TestBackEnd::printPerformanceReport(bool write) const {
 }
 
 int64_t TestBackEnd::getTestCount() const { return testCount; }
+
+float TestBackEnd::getCoverage() const { return maxCoverage; }
 
 }  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/test_backend.h
+++ b/backends/p4tools/modules/testgen/lib/test_backend.h
@@ -42,7 +42,8 @@ class TestBackEnd {
     /// Test maximum number of tests that are to be produced.
     int64_t maxTests;
 
-    float maxCoverage = 0;
+    /// The accumulated coverage of all finished test cases. Number in range [0, 1].
+    float coverage = 0;
 
     explicit TestBackEnd(const ProgramInfo &programInfo, SymbolicExecutor &symbex)
         : programInfo(programInfo), symbex(symbex), maxTests(TestgenOptions::get().maxTests) {
@@ -118,7 +119,7 @@ class TestBackEnd {
     /// enabled.
     void printPerformanceReport(bool write) const;
 
-    /// Accessors.
+    /// Returns test count.
     [[nodiscard]] int64_t getTestCount() const;
 
     /// Returns coverage achieved by all the processed tests.

--- a/backends/p4tools/modules/testgen/lib/test_backend.h
+++ b/backends/p4tools/modules/testgen/lib/test_backend.h
@@ -42,6 +42,8 @@ class TestBackEnd {
     /// Test maximum number of tests that are to be produced.
     int64_t maxTests;
 
+    float maxCoverage = 0;
+
     explicit TestBackEnd(const ProgramInfo &programInfo, SymbolicExecutor &symbex)
         : programInfo(programInfo), symbex(symbex), maxTests(TestgenOptions::get().maxTests) {
         // If we select a specific branch, the number of tests should be 1.
@@ -118,6 +120,9 @@ class TestBackEnd {
 
     /// Accessors.
     [[nodiscard]] int64_t getTestCount() const;
+
+    /// Retuns coverage achieved by all the processed tests
+    [[nodiscard]] float getCoverage() const;
 };
 
 }  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/lib/test_backend.h
+++ b/backends/p4tools/modules/testgen/lib/test_backend.h
@@ -121,7 +121,7 @@ class TestBackEnd {
     /// Accessors.
     [[nodiscard]] int64_t getTestCount() const;
 
-    /// Retuns coverage achieved by all the processed tests
+    /// Returns coverage achieved by all the processed tests.
     [[nodiscard]] float getCoverage() const;
 };
 

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -301,7 +301,7 @@ TestgenOptions::TestgenOptions()
                 }
             } catch (std::invalid_argument &) {
                 ::error(
-                    "Invalid input value %1% for --assert-min-coverag. "
+                    "Invalid input value %1% for --assert-min-coverage. "
                     "Expected float in range [0, 1].",
                     arg);
                 return false;

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -300,9 +300,10 @@ TestgenOptions::TestgenOptions()
                     throw std::invalid_argument("Invalid input.");
                 }
             } catch (std::invalid_argument &) {
-                ::error("Invalid input value %1% for --assert-min-coverag. "
-                        "Expected float in range [0, 1].",
-                        arg);
+                ::error(
+                    "Invalid input value %1% for --assert-min-coverag. "
+                    "Expected float in range [0, 1].",
+                    arg);
                 return false;
             }
             return true;

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -308,7 +308,7 @@ TestgenOptions::TestgenOptions()
             }
             return true;
         },
-        "Specifies minimum coverage that needs to be achived for testgen to exit successuflly. "
+        "Specifies minimum coverage that needs to be achieved for P4Testgen to exit successfully. "
         "The input needs to be value in range [0, 1] (where 1 means the metric is fully covered). "
         "Defaults to 0 which means no checking.");
 

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -292,6 +292,26 @@ TestgenOptions::TestgenOptions()
         "covered nodes.");
 
     registerOption(
+        "--assert-min-coverage", "minCoverage",
+        [this](const char *arg) {
+            try {
+                minCoverage = std::stof(arg);
+                if (minCoverage < 0 || minCoverage > 1) {
+                    throw std::invalid_argument("Invalid input.");
+                }
+            } catch (std::invalid_argument &) {
+                ::error("Invalid input value %1% for --assert-min-coverag. "
+                        "Expected float in range [0, 1].",
+                        arg);
+                return false;
+            }
+            return true;
+        },
+        "Specifies minimum coverage that needs to be achived for testgen to exit successuflly. "
+        "The input needs to be value in range [0, 1] (where 1 means the metric is fully covered). "
+        "Defaults to 0 which means no checking.");
+
+    registerOption(
         "--print-traces", nullptr,
         [](const char *) {
             P4Testgen::enableTraceLogging();

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -83,6 +83,7 @@ class TestgenOptions : public AbstractP4cToolOptions {
     /// Multiple options are possible. Currently supported: STATEMENTS, TABLE_ENTRIES.
     P4::Coverage::CoverageOptions coverageOptions;
 
+    /// Specifies minimum coverage that needs to be achieved for P4Testgen to exit successfully.
     float minCoverage = 0;
 
     const char *getIncludePath() override;

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -83,6 +83,8 @@ class TestgenOptions : public AbstractP4cToolOptions {
     /// Multiple options are possible. Currently supported: STATEMENTS, TABLE_ENTRIES.
     P4::Coverage::CoverageOptions coverageOptions;
 
+    float minCoverage = 0;
+
     const char *getIncludePath() override;
 
  private:

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -83,6 +83,11 @@ int generateAbstractTests(const TestgenOptions &testgenOptions, const ProgramInf
             "Unable to generate tests with given inputs. Double-check provided options and "
             "parameters.\n");
     }
+    if (testBackend->getCoverage() < testgenOptions.minCoverage) {
+        ::error("The tests did not achieve requested coverage of %1%, the coverage is %2%.",
+                testgenOptions.minCoverage, testBackend->getCoverage());
+    }
+
     return ::errorCount() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 


### PR DESCRIPTION
This is intended for running testgen in CI and catching cases when the test is not properly covered, either through test or testgen fault.

Example output on uncoverable tests:

```
============ Test 0: Nodes covered: 0.266667 (4/15) ============
============ Test 1: Nodes covered: 0.4 (6/15) ============
============ Test 2: Nodes covered: 0.533333 (8/15) ============
============ Test 3: Nodes covered: 0.6 (9/15) ============
error: The tests did not achieve requested coverage of 1, the coverage is 0.6.
```