### PR TITLE
[P4Testgen] Change crash message

### DIFF
--- a/backends/p4tools/modules/testgen/main.cpp
+++ b/backends/p4tools/modules/testgen/main.cpp
@@ -10,7 +10,7 @@
 std::string updateErrorMsg(std::string errorMsg) {
     for (const std::string_view toReplace : {"Compiler", "compiler"}) {
         if (const auto pos = errorMsg.find(toReplace); pos != std::string::npos) {
-            errorMsg.replace(pos, toReplace.size(), "Testgen");
+            errorMsg.replace(pos, toReplace.size(), "P4Testgen");
             break;
         }
     }

--- a/backends/p4tools/modules/testgen/main.cpp
+++ b/backends/p4tools/modules/testgen/main.cpp
@@ -7,6 +7,17 @@
 
 #include "backends/p4tools/modules/testgen/testgen.h"
 
+std::string updateErrorMsg(std::string errorMsg) {
+    for (const std::string_view toReplace : {"Compiler", "compiler"}) {
+        if (const auto pos = errorMsg.find(toReplace); pos != std::string::npos) {
+            errorMsg.replace(pos, toReplace.size(), "Testgen");
+            break;
+        }
+    }
+
+    return errorMsg;
+}
+
 int main(int argc, char **argv) {
     setup_signals();
 
@@ -19,18 +30,18 @@ int main(int argc, char **argv) {
     try {
         return P4Tools::P4Testgen::Testgen().main(args);
     } catch (const Util::CompilerBug &e) {
-        std::cerr << "Internal error: " << e.what() << "\n";
+        std::cerr << "Internal error: " << updateErrorMsg(e.what()) << "\n";
         std::cerr << "Please submit a bug report with your code."
                   << "\n";
         return EXIT_FAILURE;
     } catch (const Util::CompilerUnimplemented &e) {
-        std::cerr << e.what() << "\n";
+        std::cerr << updateErrorMsg(e.what()) << "\n";
         return EXIT_FAILURE;
     } catch (const Util::CompilationError &e) {
-        std::cerr << e.what() << "\n";
+        std::cerr << updateErrorMsg(e.what()) << "\n";
         return EXIT_FAILURE;
     } catch (const std::exception &e) {
-        std::cerr << "Internal error: " << e.what() << "\n";
+        std::cerr << "Internal error: " << updateErrorMsg(e.what()) << "\n";
         std::cerr << "Please submit a bug report with your code."
                   << "\n";
         return EXIT_FAILURE;


### PR DESCRIPTION
Changed messages emitted when Testgen crashes to differentiate them from the ones reported by the compiler. Example:
```
Internal error: In file: ./p4c/backends/p4tools/modules/testgen/lib/execution_state.cpp:301
Testgen Bug: Did not find exception handler for Exception::NoMatch.

Please submit a bug report with your code.
```

I think this will be useful for example for CI flows where first Testgen is used to generate test cases and then a compiler is used on the same input. Currently it's not obvious if Testgen crashes because the message contains `Compiler Bug`.