### PR TITLE
Fix clang-tidy config file.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,7 +21,6 @@ google-*,
 FormatStyle: file
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 UseColor: true
 CheckOptions:
   - { key: misc-const-correctness.AnalyzeValues,              value: false }
@@ -33,6 +32,4 @@ CheckOptions:
   - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
   - { key: readability-identifier-naming.StaticConstantCase,  value: UPPER_CASE }
   - { key: readability-identifier-naming.StaticVariableCase,  value: UPPER_CASE }
-ExtraArgs:
-  - '--std=c++17'
 ...


### PR DESCRIPTION
`AnalyzeTemporaryDtors` is deprecated and throws and error. 

`--std=c++17` does not have any effect, it seems. It only throws an error. 