### PR TITLE
[P4Testgen] Resolve method call arguments before stepping into an extern - preserve InOut references

### DIFF
--- a/backends/p4tools/common/lib/symbolic_env.cpp
+++ b/backends/p4tools/common/lib/symbolic_env.cpp
@@ -105,11 +105,14 @@ bool SymbolicEnv::isSymbolicValue(const IR::Node *node) {
     if (expr->is<IR::ConcolicVariable>()) {
         return true;
     }
-    // DefaultExpresssions are symbolic values.
+    // DefaultExpressions are symbolic values.
     if (expr->is<IR::DefaultExpression>()) {
         return true;
     }
-
+    // InOut references are symbolic when the resolved input argument is symbolic.
+    if (const auto *inout = expr->to<IR::InOutReference>()) {
+        return isSymbolicValue(inout->resolvedRef);
+    }
     // Symbolic values can be composed using several IR nodes.
     if (const auto *unary = expr->to<IR::Operation_Unary>()) {
         return (unary->is<IR::Neg>() || unary->is<IR::LNot>() || unary->is<IR::Cmpl>() ||

--- a/backends/p4tools/common/lib/trace_event_types.h
+++ b/backends/p4tools/common/lib/trace_event_types.h
@@ -228,19 +228,15 @@ class ExtractFailure : public TraceEvent {
 /// A field being emitted by a deparser.
 class Emit : public TraceEvent {
  private:
-    /// The label of the emitted header. Either a PathExpression or a member.
-    const IR::Expression *emitHeader;
-
-    /// The list of fields and their values of the emitted header.
-    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields;
+    /// The emitted header structure.
+    const IR::HeaderExpression *emitHeader;
 
  public:
     [[nodiscard]] const Emit *subst(const SymbolicEnv &env) const override;
     const Emit *apply(Transform &visitor) const override;
     [[nodiscard]] const Emit *evaluate(const Model &model, bool doComplete) const override;
 
-    Emit(const IR::Expression *emitHeader,
-         std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields);
+    explicit Emit(const IR::HeaderExpression *emitHeader);
     ~Emit() override = default;
     Emit(const Emit &) = default;
     Emit(Emit &&) = default;

--- a/backends/p4tools/common/lib/util.cpp
+++ b/backends/p4tools/common/lib/util.cpp
@@ -91,14 +91,14 @@ const IR::Constant *Utils::getRandConstantForType(const IR::Type_Bits *type) {
 
 const IR::MethodCallExpression *Utils::generateInternalMethodCall(
     cstring methodName, const std::vector<const IR::Expression *> &argVector,
-    const IR::Type *returnType) {
+    const IR::Type *returnType, const IR::ParameterList *paramList) {
     auto *args = new IR::Vector<IR::Argument>();
     for (const auto *expr : argVector) {
         args->push_back(new IR::Argument(expr));
     }
     return new IR::MethodCallExpression(
         returnType,
-        new IR::Member(new IR::Type_Method(new IR::ParameterList(), methodName),
+        new IR::Member(new IR::Type_Method(paramList, methodName),
                        new IR::PathExpression(new IR::Type_Extern("*"), new IR::Path("*")),
                        methodName),
         args);

--- a/backends/p4tools/common/lib/util.h
+++ b/backends/p4tools/common/lib/util.h
@@ -89,7 +89,8 @@ class Utils {
     /// is typically Type_Void.
     static const IR::MethodCallExpression *generateInternalMethodCall(
         cstring methodName, const std::vector<const IR::Expression *> &argVector,
-        const IR::Type *returnType = IR::Type_Void::get());
+        const IR::Type *returnType = IR::Type_Void::get(),
+        const IR::ParameterList *paramList = new IR::ParameterList());
 
     /// Shuffles the given iterable @param inp
     template <typename T>

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -125,6 +125,36 @@ bool ExprStepper::preorder(const IR::MethodCallExpression *call) {
     logStep(call);
     // A method call expression represents an invocation of an action, a table, an extern, or
     // setValid/setInvalid.
+
+    // Resolve all arguments to the method call.
+    IR::Vector<IR::Argument> resolvedArgs;
+    auto method = call->method->type->checkedTo<IR::Type_MethodBase>();
+    auto &methodParams = method->parameters->parameters;
+    const auto *callArguments = call->arguments;
+    for (size_t idx = 0; idx < callArguments->size(); ++idx) {
+        auto arg = callArguments->at(idx);
+        auto param = methodParams.at(idx);
+        auto argExpr = arg->expression;
+        if (!(param->direction == IR::Direction::Out || SymbolicEnv::isSymbolicValue(argExpr))) {
+            stepToSubexpr(argExpr, result, state,
+                          [call, idx, param](const Continuation::Parameter *v) {
+                              auto *clonedCall = call->clone();
+                              auto *arguments = clonedCall->arguments->clone();
+                              auto *arg = arguments->at(idx)->clone();
+                              const IR::Expression *computedExpr = v->param;
+                              if (param->direction == IR::Direction::InOut) {
+                                  auto stateVar = ToolsVariables::convertReference(arg->expression);
+                                  computedExpr = new IR::InOutReference(stateVar, computedExpr);
+                              }
+                              arg->expression = computedExpr;
+                              (*arguments)[idx] = arg;
+                              clonedCall->arguments = arguments;
+                              return Continuation::Return(clonedCall);
+                          });
+            return false;
+        }
+    }
+
     // Handle method calls. These are either table invocations or extern calls.
     if (call->method->type->is<IR::Type_Method>()) {
         if (const auto *path = call->method->to<IR::PathExpression>()) {
@@ -255,6 +285,13 @@ bool ExprStepper::preorder(const IR::Mux *mux) {
 
 bool ExprStepper::preorder(const IR::PathExpression *pathExpression) {
     logStep(pathExpression);
+    // If the path expression is a Type_MatchKind, convert it to a StringLiteral.
+    if (pathExpression->type->is<IR::Type_MatchKind>()) {
+        state.replaceTopBody(Continuation::Return(
+            new IR::StringLiteral(IR::Type_MatchKind::get(), pathExpression->path->name)));
+        result->emplace_back(state);
+        return false;
+    }
     // Otherwise convert the path expression into a qualified member and return it.
     state.replaceTopBody(Continuation::Return(state.get(pathExpression)));
     result->emplace_back(state);

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -121,38 +121,52 @@ void ExprStepper::evalActionCall(const IR::P4Action *action, const IR::MethodCal
     result->emplace_back(state);
 }
 
+bool ExprStepper::resolveMethodCallArguments(const IR::MethodCallExpression *call) {
+    IR::Vector<IR::Argument> resolvedArgs;
+    const auto *method = call->method->type->checkedTo<IR::Type_MethodBase>();
+    const auto &methodParams = method->parameters->parameters;
+    const auto *callArguments = call->arguments;
+    for (size_t idx = 0; idx < callArguments->size(); ++idx) {
+        const auto *arg = callArguments->at(idx);
+        const auto *param = methodParams.at(idx);
+        const auto *argExpr = arg->expression;
+        if (param->direction == IR::Direction::Out || SymbolicEnv::isSymbolicValue(argExpr)) {
+            continue;
+        }
+        // If the parameter is not an out parameter (meaning we do not care about its content) and
+        // the argument is not yet symbolic, try to resolve it.
+        return stepToSubexpr(
+            argExpr, result, state, [call, idx, param](const Continuation::Parameter *v) {
+                // TODO: It seems expensive to copy the function every time we resolve an argument.
+                // We should do this all at once. But how?
+                // This is the same problem as in stepToListSubexpr
+                // Thankfully, most method calls have less than 10 arguments.
+                auto *clonedCall = call->clone();
+                auto *arguments = clonedCall->arguments->clone();
+                auto *arg = arguments->at(idx)->clone();
+                const IR::Expression *computedExpr = v->param;
+                // A parameter with direction InOut might be read and also written to.
+                // We capture this ambiguity with an InOutReference.
+                if (param->direction == IR::Direction::InOut) {
+                    auto stateVar = ToolsVariables::convertReference(arg->expression);
+                    computedExpr = new IR::InOutReference(stateVar, computedExpr);
+                }
+                arg->expression = computedExpr;
+                (*arguments)[idx] = arg;
+                clonedCall->arguments = arguments;
+                return Continuation::Return(clonedCall);
+            });
+    }
+    return true;
+}
+
 bool ExprStepper::preorder(const IR::MethodCallExpression *call) {
     logStep(call);
     // A method call expression represents an invocation of an action, a table, an extern, or
     // setValid/setInvalid.
 
-    // Resolve all arguments to the method call.
-    IR::Vector<IR::Argument> resolvedArgs;
-    auto method = call->method->type->checkedTo<IR::Type_MethodBase>();
-    auto &methodParams = method->parameters->parameters;
-    const auto *callArguments = call->arguments;
-    for (size_t idx = 0; idx < callArguments->size(); ++idx) {
-        auto arg = callArguments->at(idx);
-        auto param = methodParams.at(idx);
-        auto argExpr = arg->expression;
-        if (!(param->direction == IR::Direction::Out || SymbolicEnv::isSymbolicValue(argExpr))) {
-            stepToSubexpr(argExpr, result, state,
-                          [call, idx, param](const Continuation::Parameter *v) {
-                              auto *clonedCall = call->clone();
-                              auto *arguments = clonedCall->arguments->clone();
-                              auto *arg = arguments->at(idx)->clone();
-                              const IR::Expression *computedExpr = v->param;
-                              if (param->direction == IR::Direction::InOut) {
-                                  auto stateVar = ToolsVariables::convertReference(arg->expression);
-                                  computedExpr = new IR::InOutReference(stateVar, computedExpr);
-                              }
-                              arg->expression = computedExpr;
-                              (*arguments)[idx] = arg;
-                              clonedCall->arguments = arguments;
-                              return Continuation::Return(clonedCall);
-                          });
-            return false;
-        }
+    if (!resolveMethodCallArguments(call)) {
+        return false;
     }
 
     // Handle method calls. These are either table invocations or extern calls.

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.h
@@ -67,6 +67,11 @@ class ExprStepper : public AbstractStepper {
     /// values for hit, miss and action_run after that.
     void handleHitMissActionRun(const IR::Member *member);
 
+    /// Resolve all arguments to the method call by stepping into each argument that is not yet
+    /// symbolic or a pure reference (represented as Out direction).
+    /// @returns false when an argument needs to be resolved, true otherwise.
+    bool resolveMethodCallArguments(const IR::MethodCallExpression *call);
+
     /// Evaluates a call to an extern method. Upon return, the given result will be augmented with
     /// the successor states resulting from evaluating the call.
     ///

--- a/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
@@ -293,8 +293,8 @@ void ExprStepper::evalInternalExternMethodCall(const IR::MethodCallExpression *c
          [this](const IR::MethodCallExpression * /*call*/, const IR::Expression * /*receiver*/,
                 IR::ID & /*methodName*/, const IR::Vector<IR::Argument> *args,
                 const ExecutionState &state, SmallStepEvaluator::Result &result) {
-             const auto *blockRef = args->at(0)->expression->checkedTo<IR::PathExpression>();
-             const auto *block = state.findDecl(blockRef);
+             const auto *blockRef = args->at(0)->expression->checkedTo<IR::StringLiteral>();
+             const auto *block = state.findDecl(new IR::Path(blockRef->value));
              const auto *archSpec = TestgenTarget::getArchSpec();
              auto blockName = block->getName().name;
              auto &nextState = state.clone();
@@ -328,8 +328,8 @@ void ExprStepper::evalInternalExternMethodCall(const IR::MethodCallExpression *c
          [this](const IR::MethodCallExpression * /*call*/, const IR::Expression * /*receiver*/,
                 IR::ID & /*methodName*/, const IR::Vector<IR::Argument> *args,
                 const ExecutionState &state, SmallStepEvaluator::Result &result) {
-             const auto *blockRef = args->at(0)->expression->checkedTo<IR::PathExpression>();
-             const auto *block = state.findDecl(blockRef);
+             const auto *blockRef = args->at(0)->expression->checkedTo<IR::StringLiteral>();
+             const auto *block = state.findDecl(new IR::Path(blockRef->value));
              const auto *archSpec = TestgenTarget::getArchSpec();
              auto blockName = block->getName().name;
              auto &nextState = state.clone();
@@ -722,13 +722,8 @@ void ExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
          [](const IR::MethodCallExpression * /*call*/, const IR::Expression * /*receiver*/,
             IR::ID & /*methodName*/, const IR::Vector<IR::Argument> *args,
             const ExecutionState &state, SmallStepEvaluator::Result &result) {
-             const auto *emitOutput = args->at(0)->expression;
-             const auto *emitType = emitOutput->type->checkedTo<IR::Type_StructLike>();
-             if (!(emitOutput->is<IR::Member>() || emitOutput->is<IR::ArrayIndex>())) {
-                 TESTGEN_UNIMPLEMENTED("Emit input %1% of type %2% not supported", emitOutput,
-                                       emitType);
-             }
-             const auto *validVar = state.get(ToolsVariables::getHeaderValidity(emitOutput));
+             const auto *emitHeader = args->at(0)->expression->checkedTo<IR::HeaderExpression>();
+             const auto *validVar = emitHeader->validity;
 
              // Check whether the validity bit of the header is tainted. If it is, the entire
              // emit is tainted. There is not much we can do here, so throw an error.
@@ -738,25 +733,20 @@ void ExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
                      "The validity bit of %1% is tainted. Tainted emit calls can not be "
                      "mitigated "
                      "because it is unclear whether the header will be emitted. Abort.",
-                     emitOutput);
+                     emitHeader);
              }
              // This call assumes that the "expandEmit" midend pass is being used. expandEmit
              // unravels emit calls on structs into emit calls on the header members.
              {
                  auto &nextState = state.clone();
+                 // Append to the emit buffer.
                  std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields;
-                 for (const auto *field : emitType->fields) {
-                     const auto *fieldType = field->type;
+                 auto flatFields = IR::flattenStructExpression(emitHeader);
+                 for (const auto *fieldExpr : flatFields) {
+                     const auto *fieldType = fieldExpr->type;
                      if (fieldType->is<IR::Type_StructLike>()) {
-                         BUG("Unexpected emit field %1% of type %2%", field, fieldType);
+                         BUG("Unexpected emit field %1% of type %2%", fieldExpr, fieldType);
                      }
-                     const auto *fieldRef = new IR::Member(fieldType, emitOutput, field->name);
-                     const IR::Expression *fieldExpr = nextState.get(fieldRef);
-                     fieldType = fieldExpr->type;
-                     if (const auto *varbits = fieldType->to<IR::Extracted_Varbits>()) {
-                         fieldType = IR::getBitType(varbits->assignedSize);
-                     }
-                     fields.emplace_back(fieldRef, fieldExpr);
                      auto fieldWidth = fieldType->width_bits();
                      // If the width is zero, do not bother with emitting.
                      if (fieldWidth == 0) {
@@ -780,7 +770,7 @@ void ExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
                      // Append to the emit buffer.
                      nextState.appendToEmitBuffer(fieldExpr);
                  }
-                 nextState.add(*new TraceEvents::Emit(emitOutput, fields));
+                 nextState.add(*new TraceEvents::Emit(emitHeader, fields));
                  nextState.popBody();
                  // Only when the header is valid, the members are emitted and the packet
                  // delta is adjusted.
@@ -789,7 +779,7 @@ void ExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
              {
                  auto &invalidState = state.clone();
                  std::stringstream traceString;
-                 traceString << "Invalid emit: " << emitOutput->toString();
+                 traceString << "Invalid emit: " << emitHeader->toString();
                  invalidState.add(*new TraceEvents::Generic(traceString));
                  invalidState.popBody();
                  result->emplace_back(new IR::LNot(IR::Type::Boolean::get(), validVar), state,

--- a/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
@@ -3,7 +3,6 @@
 #include <functional>
 #include <optional>
 #include <ostream>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -15,13 +14,11 @@
 #include "backends/p4tools/common/lib/trace_event_types.h"
 #include "backends/p4tools/common/lib/variables.h"
 #include "ir/id.h"
-#include "ir/indexed_vector.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"
 #include "ir/vector.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
-#include "lib/log.h"
 
 #include "backends/p4tools/modules/testgen//lib/exceptions.h"
 #include "backends/p4tools/modules/testgen/core/externs.h"
@@ -743,9 +740,8 @@ void ExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
                  auto flatFields = IR::flattenStructExpression(emitHeader);
                  for (const auto *fieldExpr : flatFields) {
                      const auto *fieldType = fieldExpr->type;
-                     if (fieldType->is<IR::Type_StructLike>()) {
-                         BUG("Unexpected emit field %1% of type %2%", fieldExpr, fieldType);
-                     }
+                     BUG_CHECK(!fieldType->is<IR::Type_StructLike>(),
+                               "Unexpected emit field %1% of type %2%", fieldExpr, fieldType);
                      if (const auto *varbits = fieldType->to<IR::Extracted_Varbits>()) {
                          fieldType = IR::getBitType(varbits->assignedSize);
                      }

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -137,14 +137,18 @@ std::vector<Continuation::Command> Bmv2V1ModelProgramInfo::processDeclaration(
 
     std::vector<Continuation::Command> cmds;
     // Copy-in.
-    const auto *copyInCall = new IR::MethodCallStatement(
-        Utils::generateInternalMethodCall("copy_in", {new IR::PathExpression(typeDecl->name)}));
+    const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
+        "copy_in", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        new IR::ParameterList(
+            {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyInCall);
     // Insert the actual pipeline.
     cmds.emplace_back(typeDecl);
     // Copy-out.
-    const auto *copyOutCall = new IR::MethodCallStatement(
-        Utils::generateInternalMethodCall("copy_out", {new IR::PathExpression(typeDecl->name)}));
+    const auto *copyOutCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
+        "copy_out", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        new IR::ParameterList(
+            {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyOutCall);
     auto *dropStmt =
         new IR::MethodCallStatement(Utils::generateInternalMethodCall("drop_and_exit", {}));

--- a/backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.cpp
@@ -167,24 +167,25 @@ void EBPFExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
          [](const IR::MethodCallExpression * /*call*/, const IR::Expression * /*receiver*/,
             IR::ID & /*methodName*/, const IR::Vector<IR::Argument> *args,
             const ExecutionState &state, SmallStepEvaluator::Result &result) {
-             const auto *headers = args->at(0)->expression;
-             if (!(headers->is<IR::Member>() || headers->is<IR::PathExpression>())) {
-                 TESTGEN_UNIMPLEMENTED("IP header input %1% of type %2% not supported", headers,
-                                       headers->type);
-             }
              // Input must be the headers struct.
-             headers->type->checkedTo<IR::Type_Struct>();
-             const auto *oneBitType = IR::getBitType(1);
-             const auto *tcpRef = new IR::Member(headers, "tcp");
-             const auto *syn = state.get(new IR::Member(oneBitType, tcpRef, "syn"));
-             const auto *ack = state.get(new IR::Member(oneBitType, tcpRef, "ack"));
+             const auto *headers = args->at(0)->expression->checkedTo<IR::StructExpression>();
+             const auto *tcpRef = headers->getField("tcp");
+             CHECK_NULL(tcpRef);
+             const auto *tcpHeader = tcpRef->expression->checkedTo<IR::HeaderExpression>();
+             const auto *syn = tcpHeader->getField("syn");
+             CHECK_NULL(syn);
+             const auto *ack = tcpHeader->getField("ack");
+             CHECK_NULL(ack);
+             const auto *synExpr = syn->expression;
+             const auto *ackExpr = ack->expression;
 
              // Implement the simple conntrack case since we do not support multiple packets here
              // yet.
              // TODO: We need custom test objects to implement richer, stateful testing here.
              auto &nextState = state.clone();
-             const auto *cond = new IR::LAnd(new IR::Equ(syn, IR::getConstant(syn->type, 1)),
-                                             new IR::Equ(ack, IR::getConstant(ack->type, 0)));
+             const auto *cond =
+                 new IR::LAnd(new IR::Equ(synExpr, IR::getConstant(synExpr->type, 1)),
+                              new IR::Equ(ackExpr, IR::getConstant(ackExpr->type, 0)));
              nextState.replaceTopBody(Continuation::Return(cond));
              result->emplace_back(nextState);
          }},

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
@@ -84,14 +84,18 @@ std::vector<Continuation::Command> EBPFProgramInfo::processDeclaration(
     std::vector<Continuation::Command> cmds;
 
     // Copy-in.
-    const auto *copyInCall = new IR::MethodCallStatement(
-        Utils::generateInternalMethodCall("copy_in", {new IR::PathExpression(typeDecl->name)}));
+    const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
+        "copy_in", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        new IR::ParameterList(
+            {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyInCall);
     // Insert the actual pipeline.
     cmds.emplace_back(typeDecl);
     // Copy-out.
-    const auto *copyOutCall = new IR::MethodCallStatement(
-        Utils::generateInternalMethodCall("copy_out", {new IR::PathExpression(typeDecl->name)}));
+    const auto *copyOutCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
+        "copy_out", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        new IR::ParameterList(
+            {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyOutCall);
 
     // After some specific pipelines (filter), we check whether the packet has been dropped.

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
@@ -67,14 +67,18 @@ std::vector<Continuation::Command> PnaDpdkProgramInfo::processDeclaration(
 
     std::vector<Continuation::Command> cmds;
     // Copy-in.
-    const auto *copyInCall = new IR::MethodCallStatement(
-        Utils::generateInternalMethodCall("copy_in", {new IR::PathExpression(typeDecl->name)}));
+    const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
+        "copy_in", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        new IR::ParameterList(
+            {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyInCall);
     // Insert the actual pipeline.
     cmds.emplace_back(typeDecl);
     // Copy-out.
-    const auto *copyOutCall = new IR::MethodCallStatement(
-        Utils::generateInternalMethodCall("copy_out", {new IR::PathExpression(typeDecl->name)}));
+    const auto *copyOutCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
+        "copy_out", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        new IR::ParameterList(
+            {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyOutCall);
 
     auto *dropStmt =

--- a/backends/p4tools/p4tools.def
+++ b/backends/p4tools/p4tools.def
@@ -285,7 +285,7 @@ class InOutReference : Expression {
         Expression(ref.type), ref(ref), resolvedRef(resolvedRef)
         { validate(); }
 
-    toString { return resolvedRef->toString() + "(" + ref->toString() + ")"; }
+    toString { return ref->toString() + "(" + resolvedRef->toString() + ")"; }
 
-    dbprint { out << resolvedRef << "(" << ref << ")"; }
+    dbprint { out << ref << "(" << resolvedRef << ")"; }
 }

--- a/backends/p4tools/p4tools.def
+++ b/backends/p4tools/p4tools.def
@@ -261,3 +261,31 @@ class HeaderExpression : StructExpression {
         BUG_CHECK(structType == nullptr || structType->is<IR::Type_Header>(), "%1%: unexpected header type", structType->node_type_name());
     }
 }
+
+/// An wrapper which models an InOut argument.
+/// Contains both a copy of the original reference as well as the resolved value of that reference.
+class InOutReference : Expression {
+/// Because we do not use a reference we need to construct the value normally.
+#noconstructor
+#nomethod_constructor
+    /// The original reference.
+    inline StateVariable ref;
+    /// The value of the reference after it was resolved.
+    Expression resolvedRef;
+
+    InOutReference(JSONLoader & json) : Expression(json), ref(json) {
+        json.load("resolvedRef", resolvedRef);
+    }
+
+    InOutReference(Util::SourceInfo srcInfo, IR::StateVariable &ref, const Expression* resolvedRef) :
+        Expression(srcInfo, ref.type), ref(ref), resolvedRef(resolvedRef)
+        { validate(); }
+
+    InOutReference(IR::StateVariable &ref, const Expression* resolvedRef) :
+        Expression(ref.type), ref(ref), resolvedRef(resolvedRef)
+        { validate(); }
+
+    toString { return resolvedRef->toString() + "(" + ref->toString() + ")"; }
+
+    dbprint { out << resolvedRef << "(" << ref << ")"; }
+}

--- a/backends/p4tools/p4tools.def
+++ b/backends/p4tools/p4tools.def
@@ -265,7 +265,8 @@ class HeaderExpression : StructExpression {
 /// An wrapper which models an InOut argument.
 /// Contains both a copy of the original reference as well as the resolved value of that reference.
 class InOutReference : Expression {
-/// Because we do not use a reference we need to construct the value normally.
+/// Because we do not use a reference for "ref" and also inline the member the irgenerator produces
+/// a constructor that does not compile. We need to write the constructor manually instead.
 #noconstructor
 #nomethod_constructor
     /// The original reference.


### PR DESCRIPTION
Finally fixing this longstanding issue. We always had to resolve method call arguments within an extern, which often resulted in unnecessary redundant code. Further, for `InOut` parameters, the original reference was lost.

Now we frontload this directly in the method call expression. We resolve arguments `In` and `InOut` parameters before stepping into the extern. For `InOut` arguments, we replace the expression with an `InOutReference`, which preserves the reference. This way we can read the input argument and also write to the original reference once we step into an extern. With #4215 merged, we can also pass in any complex expression such as header or struct expressions as arguments.
