### PR TITLE
Fixed checking of nested tuple fields

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -1478,20 +1478,6 @@ const IR::Node *TypeInference::postorder(IR::Type_List *type) {
     return type;
 }
 
-const IR::Node *TypeInference::postorder(IR::Type_Tuple *type) {
-    for (auto field : type->components) {
-        auto fieldType = getTypeType(field);
-        if (auto spec = fieldType->to<IR::Type_SpecializedCanonical>()) fieldType = spec->baseType;
-        if (fieldType->is<IR::IContainer>() || fieldType->is<IR::Type_ArchBlock>() ||
-            fieldType->is<IR::Type_Extern>()) {
-            typeError("%1%: not supported as a tuple field", field);
-            return type;
-        }
-    }
-    (void)setTypeType(type);
-    return type;
-}
-
 const IR::Node *TypeInference::postorder(IR::Type_P4List *type) {
     (void)setTypeType(type);
     return type;
@@ -1642,8 +1628,8 @@ const IR::Node *TypeInference::postorder(IR::Type_Stack *type) {
 /// Validate the fields of a struct type using the supplied checker.
 /// The checker returns "false" when a field is invalid.
 /// Return true on success
-bool TypeInference::validateFields(const IR::Type *type,
-                                   std::function<bool(const IR::Type *)> checker) const {
+bool TypeInference::validateStructLikeFields(const IR::Type *type,
+                                             std::function<bool(const IR::Type *)> checker) const {
     if (type == nullptr) return false;
     BUG_CHECK(type->is<IR::Type_StructLike>(), "%1%; expected a Struct-like", type);
     auto strct = type->to<IR::Type_StructLike>();
@@ -1654,6 +1640,23 @@ bool TypeInference::validateFields(const IR::Type *type,
         if (!checker(ftype)) {
             typeError("Field '%1%' of '%2%' cannot have type '%3%'", field, type->toString(),
                       field->type);
+            err = true;
+        }
+    }
+    return !err;
+}
+
+bool TypeInference::validateIndexedFields(const IR::Type *type,
+                                          std::function<bool(const IR::Type *)> checker) const {
+    if (type == nullptr) return false;
+    BUG_CHECK(type->is<IR::Type_Indexed>(), "%1%; expected Type_Indexed", type);
+    auto indexed = type->to<IR::Type_Indexed>();
+    bool err = false;
+    for (size_t i = 0; i < indexed->getSize(); i++) {
+        auto ftype = indexed->at(i);
+        if (ftype == nullptr) return false;
+        if (!checker(ftype)) {
+            typeError("Field '%1%' of '%2%' cannot have type '%3%'", i, type->toString(), ftype);
             err = true;
         }
     }
@@ -1679,22 +1682,36 @@ const IR::Node *TypeInference::postorder(IR::Type_Header *type) {
                t->is<IR::Type_Boolean>() || t->is<IR::Type_Var>() ||
                t->is<IR::Type_SpecializedCanonical>();
     };
-    validateFields(canon, validator);
+    (void)validateStructLikeFields(canon, validator);
     return type;
+}
+
+bool TypeInference::isStructTupleField(const IR::Type *t) {
+    return t->is<IR::Type_Struct>() || t->is<IR::Type_Bits>() || t->is<IR::Type_Header>() ||
+           t->is<IR::Type_HeaderUnion>() || t->is<IR::Type_Enum>() || t->is<IR::Type_Error>() ||
+           t->is<IR::Type_Boolean>() || t->is<IR::Type_Stack>() || t->is<IR::Type_Varbits>() ||
+           t->is<IR::Type_ActionEnum>() || t->is<IR::Type_Tuple>() || t->is<IR::Type_SerEnum>() ||
+           t->is<IR::Type_Var>() || t->is<IR::Type_SpecializedCanonical>() ||
+           t->is<IR::Type_MatchKind>();
 }
 
 const IR::Node *TypeInference::postorder(IR::Type_Struct *type) {
     auto canon = setTypeType(type);
     auto validator = [this](const IR::Type *t) {
         while (t->is<IR::Type_Newtype>()) t = getTypeType(t->to<IR::Type_Newtype>()->type);
-        return t->is<IR::Type_Struct>() || t->is<IR::Type_Bits>() || t->is<IR::Type_Header>() ||
-               t->is<IR::Type_HeaderUnion>() || t->is<IR::Type_Enum>() || t->is<IR::Type_Error>() ||
-               t->is<IR::Type_Boolean>() || t->is<IR::Type_Stack>() || t->is<IR::Type_Varbits>() ||
-               t->is<IR::Type_ActionEnum>() || t->is<IR::Type_Tuple>() ||
-               t->is<IR::Type_SerEnum>() || t->is<IR::Type_Var>() ||
-               t->is<IR::Type_SpecializedCanonical>() || t->is<IR::Type_MatchKind>();
+        return isStructTupleField(t);
     };
-    (void)validateFields(canon, validator);
+    (void)validateStructLikeFields(canon, validator);
+    return type;
+}
+
+const IR::Node *TypeInference::postorder(IR::Type_Tuple *type) {
+    auto canon = setTypeType(type);
+    auto validator = [this](const IR::Type *t) {
+        while (t->is<IR::Type_Newtype>()) t = getTypeType(t->to<IR::Type_Newtype>()->type);
+        return isStructTupleField(t);
+    };
+    (void)validateIndexedFields(canon, validator);
     return type;
 }
 
@@ -1704,7 +1721,7 @@ const IR::Node *TypeInference::postorder(IR::Type_HeaderUnion *type) {
         return t->is<IR::Type_Header>() || t->is<IR::Type_Var>() ||
                t->is<IR::Type_SpecializedCanonical>();
     };
-    (void)validateFields(canon, validator);
+    (void)validateStructLikeFields(canon, validator);
     return type;
 }
 

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -162,7 +162,10 @@ class TypeInference : public Transform {
     // various helpers
     bool onlyBitsOrBitStructs(const IR::Type *type) const;
     bool containsHeader(const IR::Type *canonType);
-    bool validateFields(const IR::Type *type, std::function<bool(const IR::Type *)> checker) const;
+    bool validateStructLikeFields(const IR::Type *type,
+                                  std::function<bool(const IR::Type *)> checker) const;
+    bool validateIndexedFields(const IR::Type *type,
+                               std::function<bool(const IR::Type *)> checker) const;
     const IR::Node *binaryBool(const IR::Operation_Binary *op);
     const IR::Node *binaryArith(const IR::Operation_Binary *op);
     const IR::Node *unsBinaryArith(const IR::Operation_Binary *op);
@@ -193,6 +196,9 @@ class TypeInference : public Transform {
     /// on success.
     const IR::ActionListElement *validateActionInitializer(const IR::Expression *actionCall);
     bool containsActionEnum(const IR::Type *type) const;
+
+    /// Checks type nesting rules for structs and tuples
+    static bool isStructTupleField(const IR::Type *t);
 
     //////////////////////////////////////////////////////////////
 
@@ -253,11 +259,11 @@ class TypeInference : public Transform {
     const IR::Node *postorder(IR::Type_Header *type) override;
     const IR::Node *postorder(IR::Type_Stack *type) override;
     const IR::Node *postorder(IR::Type_Struct *type) override;
+    const IR::Node *postorder(IR::Type_Tuple *type) override;
     const IR::Node *postorder(IR::Type_HeaderUnion *type) override;
     const IR::Node *postorder(IR::Type_Typedef *type) override;
     const IR::Node *postorder(IR::Type_Specialized *type) override;
     const IR::Node *postorder(IR::Type_SpecializedCanonical *type) override;
-    const IR::Node *postorder(IR::Type_Tuple *type) override;
     const IR::Node *postorder(IR::Type_P4List *type) override;
     const IR::Node *postorder(IR::Type_List *type) override;
     const IR::Node *postorder(IR::Type_Set *type) override;

--- a/ir/type.def
+++ b/ir/type.def
@@ -380,7 +380,7 @@ interface Type_Indexed {
     // Probably this sohuld be called 'size()', but some subclasses already
     // have a 'size' field.
     virtual size_t getSize() const = 0;
-    Type at(size_t index) const;
+    virtual Type at(size_t index) const = 0;
 }
 
 /// Base class for Type_List, and Type_Tuple
@@ -388,7 +388,7 @@ abstract Type_BaseList : Type, Type_Indexed {
     optional inline Vector<Type> components;
     validate{ components.check_null(); }
     size_t getSize() const override { return components.size(); }
-    Type at(size_t index) const { return components.at(index); }
+    Type at(size_t index) const override { return components.at(index); }
     int width_bits() const override {
         /// returning sum of the width of the elements
         int rv = 0;


### PR DESCRIPTION
According to the [spec](https://staging.p4.org/p4-spec/docs/P4-16-v1.2.4.html#sec-type-nesting), tuple fields should adhere to the same rules as struct fields.