### PR TITLE
[P4Testgen] Fix argument names in GenericDescription trace event

### DIFF
--- a/backends/p4tools/common/lib/trace_event_types.h
+++ b/backends/p4tools/common/lib/trace_event_types.h
@@ -49,7 +49,7 @@ class GenericDescription : public Generic {
     void print(std::ostream &os) const override;
 
  public:
-    explicit GenericDescription(cstring description, cstring label);
+    explicit GenericDescription(cstring label, cstring description);
 };
 
 /* =============================================================================================


### PR DESCRIPTION
... to match the implementation: https://github.com/p4lang/p4c/blob/main/backends/p4tools/common/lib/trace_event_types.cpp#L31.