### PR TITLE
[P4Testgen] Move arch spec to ProgramInfo to allow it to depend on P4 program

### DIFF
--- a/backends/p4tools/modules/testgen/core/program_info.h
+++ b/backends/p4tools/modules/testgen/core/program_info.h
@@ -55,6 +55,13 @@ class ProgramInfo : public ICastable {
     /// The generated dcg.
     const NodesCallGraph *dcg = nullptr;
 
+    /// A vector that maps the architecture parameters of each pipe to the corresponding
+    /// global architecture variables. For example, this map specifies which parameter of each pipe
+    /// refers to the input header.
+    // The arch map needs to be public to be subclassed.
+    /// @returns a reference to the architecture map defined in this target
+    [[nodiscard]] virtual const ArchSpec &getArchSpec() const = 0;
+
     /// @returns the series of nodes that has been computed by this particular target.
     [[nodiscard]] const std::vector<Continuation::Command> *getPipelineSequence() const;
 

--- a/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
@@ -292,10 +292,10 @@ void ExprStepper::evalInternalExternMethodCall(const IR::MethodCallExpression *c
                 const ExecutionState &state, SmallStepEvaluator::Result &result) {
              const auto *blockRef = args->at(0)->expression->checkedTo<IR::StringLiteral>();
              const auto *block = state.findDecl(new IR::Path(blockRef->value));
-             const auto *archSpec = TestgenTarget::getArchSpec();
              auto blockName = block->getName().name;
              auto &nextState = state.clone();
              auto canonicalName = getProgramInfo().getCanonicalBlockName(blockName);
+             const auto &archSpec = getProgramInfo().getArchSpec();
              const auto *blockApply = block->to<IR::IApply>();
              CHECK_NULL(blockApply);
              const auto *blockParams = blockApply->getApplyParameters();
@@ -306,7 +306,7 @@ void ExprStepper::evalInternalExternMethodCall(const IR::MethodCallExpression *c
              nextState.setProperty("inUndefinedState", false);
              for (size_t paramIdx = 0; paramIdx < blockParams->size(); ++paramIdx) {
                  const auto *internalParam = blockParams->getParameter(paramIdx);
-                 auto externalParamName = archSpec->getParamName(canonicalName, paramIdx);
+                 auto externalParamName = archSpec.getParamName(canonicalName, paramIdx);
                  nextState.copyIn(TestgenTarget::get(), internalParam, externalParamName);
              }
              nextState.setProperty("inUndefinedState", currentTaint);
@@ -327,7 +327,7 @@ void ExprStepper::evalInternalExternMethodCall(const IR::MethodCallExpression *c
                 const ExecutionState &state, SmallStepEvaluator::Result &result) {
              const auto *blockRef = args->at(0)->expression->checkedTo<IR::StringLiteral>();
              const auto *block = state.findDecl(new IR::Path(blockRef->value));
-             const auto *archSpec = TestgenTarget::getArchSpec();
+             const auto &archSpec = getProgramInfo().getArchSpec();
              auto blockName = block->getName().name;
              auto &nextState = state.clone();
              auto canonicalName = getProgramInfo().getCanonicalBlockName(blockName);
@@ -341,7 +341,7 @@ void ExprStepper::evalInternalExternMethodCall(const IR::MethodCallExpression *c
              nextState.setProperty("inUndefinedState", false);
              for (size_t paramIdx = 0; paramIdx < blockParams->size(); ++paramIdx) {
                  const auto *internalParam = blockParams->getParameter(paramIdx);
-                 auto externalParamName = archSpec->getParamName(canonicalName, paramIdx);
+                 auto externalParamName = archSpec.getParamName(canonicalName, paramIdx);
                  nextState.copyOut(internalParam, externalParamName);
              }
              nextState.setProperty("inUndefinedState", currentTaint);

--- a/backends/p4tools/modules/testgen/core/target.cpp
+++ b/backends/p4tools/modules/testgen/core/target.cpp
@@ -47,8 +47,6 @@ const ProgramInfo *TestgenTarget::initProgram(const IR::P4Program *program) {
     return get().initProgramImpl(program);
 }
 
-const ArchSpec *TestgenTarget::getArchSpec() { return get().getArchSpecImpl(); }
-
 ExprStepper *TestgenTarget::getExprStepper(ExecutionState &state, AbstractSolver &solver,
                                            const ProgramInfo &programInfo) {
     return get().getExprStepperImpl(state, solver, programInfo);

--- a/backends/p4tools/modules/testgen/core/target.h
+++ b/backends/p4tools/modules/testgen/core/target.h
@@ -44,13 +44,6 @@ class TestgenTarget : public Target {
     static ExprStepper *getExprStepper(ExecutionState &state, AbstractSolver &solver,
                                        const ProgramInfo &programInfo);
 
-    /// A vector that maps the architecture parameters of each pipe to the corresponding
-    /// global architecture variables. For example, this map specifies which parameter of each pipe
-    /// refers to the input header.
-    // The arch map needs to be public to be subclassed.
-    /// @returns a reference to the architecture map defined in this target
-    static const ArchSpec *getArchSpec();
-
  protected:
     /// @see @initProgram.
     const ProgramInfo *initProgramImpl(const IR::P4Program *program) const;
@@ -71,9 +64,6 @@ class TestgenTarget : public Target {
     /// @see getExprStepper.
     virtual ExprStepper *getExprStepperImpl(ExecutionState &state, AbstractSolver &solver,
                                             const ProgramInfo &programInfo) const = 0;
-
-    /// @see getArchSpec
-    [[nodiscard]] virtual const ArchSpec *getArchSpecImpl() const = 0;
 
     explicit TestgenTarget(std::string deviceName, std::string archName);
 };

--- a/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
@@ -63,8 +63,7 @@ void Bmv2V1ModelCmdStepper::initializeTargetEnvironment(ExecutionState &nextStat
     // error parser_error;
     // bit<3> priority;
 
-    auto programInfo = getProgramInfo();
-    const auto *archSpec = TestgenTarget::getArchSpec();
+    const auto &programInfo = getProgramInfo();
     const auto &target = TestgenTarget::get();
     const auto *programmableBlocks = programInfo.getProgrammableBlocks();
 
@@ -73,7 +72,7 @@ void Bmv2V1ModelCmdStepper::initializeTargetEnvironment(ExecutionState &nextStat
     size_t blockIdx = 0;
     for (const auto &blockTuple : *programmableBlocks) {
         const auto *typeDecl = blockTuple.second;
-        const auto *archMember = archSpec->getArchMember(blockIdx);
+        const auto *archMember = programInfo.getArchSpec().getArchMember(blockIdx);
         nextState.initializeBlockParams(target, typeDecl, &archMember->blockParams);
         blockIdx++;
     }

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -160,8 +160,7 @@ void Bmv2V1ModelExprStepper::processClone(const ExecutionState &state,
         const auto *applyBlock = typeDecl->checkedTo<IR::P4Control>();
         const auto *params = applyBlock->getApplyParameters();
         auto blockIndex = 2;
-        const auto *archSpec = TestgenTarget::getArchSpec();
-        const auto *archMember = archSpec->getArchMember(blockIndex);
+        const auto *archMember = progInfo->getArchSpec().getArchMember(blockIndex);
         for (size_t paramIdx = 0; paramIdx < params->size(); ++paramIdx) {
             const auto *param = params->getParameter(paramIdx);
             const auto &archRef = archMember->blockParams.at(paramIdx);

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
@@ -45,6 +45,9 @@ class Bmv2V1ModelProgramInfo : public ProgramInfo {
     /// @returns the table associated with the direct extern
     const IR::P4Table *getTableofDirectExtern(const IR::IDeclaration *directExternDecl) const;
 
+    /// @see ProgramInfo::getArchSpec
+    [[nodiscard]] const ArchSpec &getArchSpec() const override;
+
     /// @returns the programmable blocks of the program. Should be 6.
     [[nodiscard]] const ordered_map<cstring, const IR::Type_Declaration *> *getProgrammableBlocks()
         const;
@@ -74,6 +77,9 @@ class Bmv2V1ModelProgramInfo : public ProgramInfo {
     /// variable.
     static const IR::Member *getParserParamVar(const IR::P4Parser *parser, const IR::Type *type,
                                                size_t paramIndex, cstring paramLabel);
+
+    /// @see ProgramInfo::getArchSpec
+    static const ArchSpec ARCH_SPEC;
 };
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/target.cpp
@@ -54,7 +54,7 @@ const Bmv2V1ModelProgramInfo *Bmv2V1ModelTestgenTarget::initProgramImpl(
     for (size_t idx = 0; idx < blocks.size(); ++idx) {
         const auto *declType = blocks.at(idx);
 
-        auto canonicalName = ARCH_SPEC.getArchMember(idx)->blockName;
+        auto canonicalName = Bmv2V1ModelProgramInfo::ARCH_SPEC.getArchMember(idx)->blockName;
         programmableBlocks.emplace(canonicalName, declType);
 
         if (idx < 3) {
@@ -82,30 +82,5 @@ Bmv2V1ModelExprStepper *Bmv2V1ModelTestgenTarget::getExprStepperImpl(
     ExecutionState &state, AbstractSolver &solver, const ProgramInfo &programInfo) const {
     return new Bmv2V1ModelExprStepper(state, solver, programInfo);
 }
-
-const ArchSpec Bmv2V1ModelTestgenTarget::ARCH_SPEC =
-    ArchSpec("V1Switch", {// parser Parser<H, M>(packet_in b,
-                          //                     out H parsedHdr,
-                          //                     inout M meta,
-                          //                     inout standard_metadata_t standard_metadata);
-                          {"Parser", {nullptr, "*hdr", "*meta", "*standard_metadata"}},
-                          // control VerifyChecksum<H, M>(inout H hdr,
-                          //                              inout M meta);
-                          {"VerifyChecksum", {"*hdr", "*meta"}},
-                          // control Ingress<H, M>(inout H hdr,
-                          //                       inout M meta,
-                          //                       inout standard_metadata_t standard_metadata);
-                          {"Ingress", {"*hdr", "*meta", "*standard_metadata"}},
-                          // control Egress<H, M>(inout H hdr,
-                          //            inout M meta,
-                          //            inout standard_metadata_t standard_metadata);
-                          {"Egress", {"*hdr", "*meta", "*standard_metadata"}},
-                          // control ComputeChecksum<H, M>(inout H hdr,
-                          //                       inout M meta);
-                          {"ComputeChecksum", {"*hdr", "*meta"}},
-                          // control Deparser<H>(packet_out b, in H hdr);
-                          {"Deparser", {nullptr, "*hdr"}}});
-
-const ArchSpec *Bmv2V1ModelTestgenTarget::getArchSpecImpl() const { return &ARCH_SPEC; }
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/target.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/target.h
@@ -38,12 +38,8 @@ class Bmv2V1ModelTestgenTarget : public TestgenTarget {
     Bmv2V1ModelExprStepper *getExprStepperImpl(ExecutionState &state, AbstractSolver &solver,
                                                const ProgramInfo &programInfo) const override;
 
-    [[nodiscard]] const ArchSpec *getArchSpecImpl() const override;
-
  private:
     Bmv2V1ModelTestgenTarget();
-
-    static const ArchSpec ARCH_SPEC;
 };
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/ebpf/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/cmd_stepper.cpp
@@ -35,8 +35,7 @@ const EBPFProgramInfo &EBPFCmdStepper::getProgramInfo() const {
 }
 
 void EBPFCmdStepper::initializeTargetEnvironment(ExecutionState &nextState) const {
-    auto programInfo = getProgramInfo();
-    const auto *archSpec = TestgenTarget::getArchSpec();
+    const auto &programInfo = getProgramInfo();
     const auto &target = TestgenTarget::get();
     const auto *programmableBlocks = programInfo.getProgrammableBlocks();
 
@@ -45,7 +44,7 @@ void EBPFCmdStepper::initializeTargetEnvironment(ExecutionState &nextState) cons
     size_t blockIdx = 0;
     for (const auto &blockTuple : *programmableBlocks) {
         const auto *typeDecl = blockTuple.second;
-        const auto *archMember = archSpec->getArchMember(blockIdx);
+        const auto *archMember = programInfo.getArchSpec().getArchMember(blockIdx);
         nextState.initializeBlockParams(target, typeDecl, &archMember->blockParams);
         blockIdx++;
     }

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
@@ -38,10 +38,10 @@ EBPFProgramInfo::EBPFProgramInfo(const IR::P4Program *program,
 
     // Just concatenate everything together.
     // Iterate through the (ordered) pipes of the target architecture.
-    const auto *archSpec = TestgenTarget::getArchSpec();
-    BUG_CHECK(archSpec->getArchVectorSize() == programmableBlocks.size(),
+    const auto &archSpec = getArchSpec();
+    BUG_CHECK(archSpec.getArchVectorSize() == programmableBlocks.size(),
               "The eBPF architecture requires %1% pipes (provided %2% pipes).",
-              archSpec->getArchVectorSize(), programmableBlocks.size());
+              archSpec.getArchVectorSize(), programmableBlocks.size());
 
     /// Compute the series of nodes corresponding to the in-order execution of top-level
     /// pipeline-component instantiations. For a standard ebpf_model, this produces
@@ -62,6 +62,8 @@ EBPFProgramInfo::EBPFProgramInfo(const IR::P4Program *program,
                     IR::getConstant(&PacketVars::PACKET_SIZE_VAR_TYPE, 0));
 }
 
+const ArchSpec &EBPFProgramInfo::getArchSpec() const { return ARCH_SPEC; }
+
 const ordered_map<cstring, const IR::Type_Declaration *> *EBPFProgramInfo::getProgrammableBlocks()
     const {
     return &programmableBlocks;
@@ -69,9 +71,6 @@ const ordered_map<cstring, const IR::Type_Declaration *> *EBPFProgramInfo::getPr
 
 std::vector<Continuation::Command> EBPFProgramInfo::processDeclaration(
     const IR::Type_Declaration *typeDecl, size_t blockIdx) const {
-    // Get the architecture specification for this target.
-    const auto *archSpec = TestgenTarget::getArchSpec();
-
     // Collect parameters.
     const auto *applyBlock = typeDecl->to<IR::IApply>();
     if (applyBlock == nullptr) {
@@ -79,7 +78,7 @@ std::vector<Continuation::Command> EBPFProgramInfo::processDeclaration(
                               typeDecl->node_type_name());
     }
     // Retrieve the current canonical pipe in the architecture spec using the pipe index.
-    const auto *archMember = archSpec->getArchMember(blockIdx);
+    const auto *archMember = getArchSpec().getArchMember(blockIdx);
 
     std::vector<Continuation::Command> cmds;
 
@@ -124,5 +123,11 @@ const IR::Expression *EBPFProgramInfo::dropIsActive() const {
 }
 
 const IR::Type_Bits *EBPFProgramInfo::getParserErrorType() const { return &PARSER_ERR_BITS; }
+
+const ArchSpec EBPFProgramInfo::ARCH_SPEC =
+    ArchSpec("ebpfFilter", {// parser parse<H>(packet_in packet, out H headers);
+                            {"parse", {nullptr, "*hdr"}},
+                            // control filter<H>(inout H headers, out bool accept);
+                            {"filter", {"*hdr", "*accept"}}});
 
 }  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.h
@@ -32,6 +32,9 @@ class EBPFProgramInfo : public ProgramInfo {
     EBPFProgramInfo(const IR::P4Program *program,
                     ordered_map<cstring, const IR::Type_Declaration *> inputBlocks);
 
+    /// @see ProgramInfo::getArchSpec
+    [[nodiscard]] const ArchSpec &getArchSpec() const override;
+
     /// @returns the programmable blocks of the program. Should be 6.
     [[nodiscard]] const ordered_map<cstring, const IR::Type_Declaration *> *getProgrammableBlocks()
         const;
@@ -43,6 +46,9 @@ class EBPFProgramInfo : public ProgramInfo {
     [[nodiscard]] const IR::Expression *dropIsActive() const override;
 
     [[nodiscard]] const IR::Type_Bits *getParserErrorType() const override;
+
+    /// @see ProgramInfo::getArchSpec
+    static const ArchSpec ARCH_SPEC;
 };
 
 }  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/target.cpp
@@ -51,7 +51,7 @@ const EBPFProgramInfo *EBPFTestgenTarget::initProgramImpl(
     ordered_map<cstring, const IR::Type_Declaration *> programmableBlocks;
     for (size_t idx = 0; idx < blocks.size(); ++idx) {
         const auto *declType = blocks.at(idx);
-        auto canonicalName = archSpec.getArchMember(idx)->blockName;
+        auto canonicalName = EBPFProgramInfo::ARCH_SPEC.getArchMember(idx)->blockName;
         programmableBlocks.emplace(canonicalName, declType);
     }
 
@@ -83,13 +83,5 @@ EBPFExprStepper *EBPFTestgenTarget::getExprStepperImpl(ExecutionState &state,
                                                        const ProgramInfo &programInfo) const {
     return new EBPFExprStepper(state, solver, programInfo);
 }
-
-const ArchSpec EBPFTestgenTarget::archSpec =
-    ArchSpec("ebpfFilter", {// parser parse<H>(packet_in packet, out H headers);
-                            {"parse", {nullptr, "*hdr"}},
-                            // control filter<H>(inout H headers, out bool accept);
-                            {"filter", {"*hdr", "*accept"}}});
-
-const ArchSpec *EBPFTestgenTarget::getArchSpecImpl() const { return &archSpec; }
 
 }  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/ebpf/target.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/target.h
@@ -38,12 +38,8 @@ class EBPFTestgenTarget : public TestgenTarget {
     EBPFExprStepper *getExprStepperImpl(ExecutionState &state, AbstractSolver &solver,
                                         const ProgramInfo &programInfo) const override;
 
-    const ArchSpec *getArchSpecImpl() const override;
-
  private:
     EBPFTestgenTarget();
-
-    static const ArchSpec archSpec;
 };
 
 }  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/cmd_stepper.cpp
@@ -37,7 +37,6 @@ const PnaDpdkProgramInfo &PnaDpdkCmdStepper::getProgramInfo() const {
 
 void PnaDpdkCmdStepper::initializeTargetEnvironment(ExecutionState &nextState) const {
     const auto &programInfo = getProgramInfo();
-    const auto *archSpec = TestgenTarget::getArchSpec();
     const auto &target = TestgenTarget::get();
     const auto *programmableBlocks = programInfo.getProgrammableBlocks();
 
@@ -46,7 +45,7 @@ void PnaDpdkCmdStepper::initializeTargetEnvironment(ExecutionState &nextState) c
     size_t blockIdx = 0;
     for (const auto &blockTuple : *programmableBlocks) {
         const auto *typeDecl = blockTuple.second;
-        const auto *archMember = archSpec->getArchMember(blockIdx);
+        const auto *archMember = programInfo.getArchSpec().getArchMember(blockIdx);
         nextState.initializeBlockParams(target, typeDecl, &archMember->blockParams);
         blockIdx++;
     }

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.h
@@ -23,6 +23,12 @@ class PnaDpdkProgramInfo : public SharedPnaProgramInfo {
  public:
     PnaDpdkProgramInfo(const IR::P4Program *program,
                        ordered_map<cstring, const IR::Type_Declaration *> inputBlocks);
+
+    /// @see ProgramInfo::getArchSpec
+    const ArchSpec &getArchSpec() const override;
+
+    /// @see ProgramInfo::getArchSpec
+    static const ArchSpec ARCH_SPEC;
 };
 
 }  // namespace P4Tools::P4Testgen::Pna

--- a/backends/p4tools/modules/testgen/targets/pna/shared_program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_program_info.cpp
@@ -62,9 +62,9 @@ const IR::PathExpression *SharedPnaProgramInfo::getBlockParam(cstring blockLabel
         paramType = resolveProgramType(program, tn);
     }
 
-    const auto *archSpec = TestgenTarget::getArchSpec();
-    auto archIndex = archSpec->getBlockIndex(blockLabel);
-    auto archRef = archSpec->getParamName(archIndex, paramIndex);
+    const auto &archSpec = getArchSpec();
+    auto archIndex = archSpec.getBlockIndex(blockLabel);
+    auto archRef = archSpec.getParamName(archIndex, paramIndex);
     return new IR::PathExpression(paramType, new IR::Path(archRef));
 }
 

--- a/backends/p4tools/modules/testgen/targets/pna/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/target.cpp
@@ -50,7 +50,7 @@ const PnaDpdkProgramInfo *PnaDpdkTestgenTarget::initProgramImpl(
     for (size_t idx = 0; idx < blocks.size(); ++idx) {
         const auto *declType = blocks.at(idx);
 
-        auto canonicalName = getArchSpec()->getArchMember(idx)->blockName;
+        auto canonicalName = PnaDpdkProgramInfo::ARCH_SPEC.getArchMember(idx)->blockName;
         programmableBlocks.emplace(canonicalName, declType);
     }
 
@@ -74,37 +74,5 @@ PnaDpdkExprStepper *PnaDpdkTestgenTarget::getExprStepperImpl(ExecutionState &sta
                                                              const ProgramInfo &programInfo) const {
     return new PnaDpdkExprStepper(state, solver, programInfo);
 }
-
-const ArchSpec PnaDpdkTestgenTarget::ARCH_SPEC = ArchSpec(
-    "PNA_NIC", {
-                   // parser MainParserT<MH, MM>(
-                   //     packet_in pkt,
-                   //     //in    PM pre_user_meta,
-                   //     out   MH main_hdr,
-                   //     inout MM main_user_meta,
-                   //     in    pna_main_parser_input_metadata_t istd);
-                   {"MainParserT", {nullptr, "*main_hdr", "*main_user_meta", "*parser_istd"}},
-                   // control PreControlT<PH, PM>(
-                   //     in    PH pre_hdr,
-                   //     inout PM pre_user_meta,
-                   //     in    pna_pre_input_metadata_t  istd,
-                   //     inout pna_pre_output_metadata_t ostd);
-                   {"PreControlT", {"*main_hdr", "*main_user_meta", "*pre_istd", "*pre_ostd"}},
-                   // control MainControlT<MH, MM>(
-                   //     //in    PM pre_user_meta,
-                   //     inout MH main_hdr,
-                   //     inout MM main_user_meta,
-                   //     in    pna_main_input_metadata_t  istd,
-                   //     inout pna_main_output_metadata_t ostd);
-                   {"MainControlT", {"*main_hdr", "*main_user_meta", "*main_istd", "*ostd"}},
-                   // control MainDeparserT<MH, MM>(
-                   //     packet_out pkt,
-                   //     in    MH main_hdr,
-                   //     in    MM main_user_meta,
-                   //     in    pna_main_output_metadata_t ostd);
-                   {"MainDeparserT", {nullptr, "*main_hdr", "*main_user_meta", "*ostd"}},
-               });
-
-const ArchSpec *PnaDpdkTestgenTarget::getArchSpecImpl() const { return &ARCH_SPEC; }
 
 }  // namespace P4Tools::P4Testgen::Pna

--- a/backends/p4tools/modules/testgen/targets/pna/target.h
+++ b/backends/p4tools/modules/testgen/targets/pna/target.h
@@ -38,12 +38,8 @@ class PnaDpdkTestgenTarget : public TestgenTarget {
     PnaDpdkExprStepper *getExprStepperImpl(ExecutionState &state, AbstractSolver &solver,
                                            const ProgramInfo &programInfo) const override;
 
-    [[nodiscard]] const ArchSpec *getArchSpecImpl() const override;
-
  private:
     PnaDpdkTestgenTarget();
-
-    static const ArchSpec ARCH_SPEC;
 };
 
 }  // namespace P4Tools::P4Testgen::Pna


### PR DESCRIPTION
Before this change, the `ArchSpec` was defined in each target. However, this approach is too restrictive for the targets that allow variability in the exact signature of the pipeline. In these cases, it is necessary to have the ArchSpec depend not only on the architecture itself, but also on the actual P4 code (on the instances used in the `main` package). Therefore, I propose moving the ArchSpec definition to program info.

This should not pose any problem as:
* the places that use it either have access to ProgramInfo
* or it is accessed when program info is being created (i.e. `TestgenTarget::initProgramImpl`) 
  * For existing targets I make the arch spec also available as static const value member of the `*ProgramInfo` class so it can be accessed -- this also demostrates clearly that it is not dependent on the instance of Program Info.
  * For targets where ArchSpec is dependend on the P4 program presumably it can be built first and then it will be passed to the program info.
