### PR TITLE
Remove stale XFail.

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufIrXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufIrXfail.cmake
@@ -21,14 +21,6 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-protobuf-ir"
-  "Non-numeric, non-boolean member expression: .* Type: Type_Stack"
-  # We can not expand stacks in parsers because information about .next is lost.
-  # P4Testgen needs to maintain its own internal .next variable for stacks.
-  array-copy-bmv2.p4
-)
-
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2-protobuf-ir"
   "Unknown or unimplemented extern method: recirculate_preserving_field_list"
 )
 


### PR DESCRIPTION
There is a stale XFail which causes tests to fail. Remove it. 

I also changed the Github merge settings to only allow merging of pull requests that are up-to-date with the master branch. 