### PR TITLE
[P4Testgen] Add support for @format annotations in P4 programs for protobuf-ir tests

### DIFF
--- a/backends/p4tools/common/lib/format_int.cpp
+++ b/backends/p4tools/common/lib/format_int.cpp
@@ -269,7 +269,8 @@ std::string insertHexSeparators(const std::string &dataStr) {
     return insertSeparators(dataStr, "\\x", 2, false);
 }
 
-std::vector<uint8_t> convertBigIntToBytes(const big_int &dataInt, int targetWidthBits) {
+std::vector<uint8_t> convertBigIntToBytes(const big_int &dataInt, int targetWidthBits,
+                                          bool padLeft) {
     /// Chunk size is 8 bits, i.e., a byte.
     constexpr uint8_t chunkSize = 8U;
 
@@ -282,7 +283,11 @@ std::vector<uint8_t> convertBigIntToBytes(const big_int &dataInt, int targetWidt
     auto diff = targetWidthBytes - bytes.size();
     if (targetWidthBytes > bytes.size() && diff > 0UL) {
         for (size_t i = 0; i < diff; ++i) {
-            bytes.push_back(0);
+            if (padLeft) {
+                bytes.insert(bytes.begin(), 0);
+            } else {
+                bytes.push_back(0);
+            }
         }
     }
     return bytes;

--- a/backends/p4tools/common/lib/format_int.cpp
+++ b/backends/p4tools/common/lib/format_int.cpp
@@ -17,12 +17,6 @@
 
 namespace P4Tools {
 
-static constexpr uint8_t IPV4_BYTE_SIZE = 4U;
-static constexpr uint8_t IPV6_BYTE_SIZE = 16U;
-static constexpr uint8_t MAC_BYTE_SIZE = 6U;
-/// Chunk size is 8 bits, i.e., a byte.
-static constexpr uint8_t CHUNK_SIZE = 8U;
-
 std::string formatBin(const big_int &value, int width, bool useSep, bool pad, bool usePrefix) {
     std::stringstream out;
     // Ensure we output at least _something_.
@@ -276,10 +270,13 @@ std::string insertHexSeparators(const std::string &dataStr) {
 }
 
 std::vector<uint8_t> convertBigIntToBytes(const big_int &dataInt, int targetWidthBits) {
+    /// Chunk size is 8 bits, i.e., a byte.
+    constexpr uint8_t chunkSize = 8U;
+
     std::vector<uint8_t> bytes;
     // Convert the input bit width to bytes and round up.
-    size_t targetWidthBytes = (targetWidthBits + CHUNK_SIZE - 1) / CHUNK_SIZE;
-    boost::multiprecision::export_bits(dataInt, std::back_inserter(bytes), CHUNK_SIZE);
+    size_t targetWidthBytes = (targetWidthBits + chunkSize - 1) / chunkSize;
+    boost::multiprecision::export_bits(dataInt, std::back_inserter(bytes), chunkSize);
     // If the number of bytes produced by the export is lower than the desired width pad the byte
     // array with zeroes.
     auto diff = targetWidthBytes - bytes.size();
@@ -292,13 +289,15 @@ std::vector<uint8_t> convertBigIntToBytes(const big_int &dataInt, int targetWidt
 }
 
 std::optional<std::string> convertToIpv4String(const std::vector<uint8_t> &byteArray) {
-    if (byteArray.size() != IPV4_BYTE_SIZE) {
+    constexpr uint8_t ipv4ByteSize = 4U;
+
+    if (byteArray.size() != ipv4ByteSize) {
         ::error("Invalid IPv4 address byte array of size %1%", byteArray.size());
         return std::nullopt;
     }
 
     std::stringstream ss;
-    for (int i = 0; i < IPV4_BYTE_SIZE; ++i) {
+    for (int i = 0; i < ipv4ByteSize; ++i) {
         if (i > 0) {
             ss << ".";
         }
@@ -308,31 +307,35 @@ std::optional<std::string> convertToIpv4String(const std::vector<uint8_t> &byteA
 }
 
 std::optional<std::string> convertToIpv6String(const std::vector<uint8_t> &byteArray) {
-    if (byteArray.size() != IPV6_BYTE_SIZE) {
+    /// Chunk size is 8 bits, i.e., a byte.
+    constexpr uint8_t chunkSize = 8U;
+    constexpr uint8_t ipv6ByteSize = 16U;
+    if (byteArray.size() != ipv6ByteSize) {
         ::error("Invalid IPv6 address byte array of size %1%", byteArray.size());
         return std::nullopt;
     }
 
     std::stringstream ss;
-    for (int i = 0; i < IPV6_BYTE_SIZE; i += 2) {
+    for (int i = 0; i < ipv6ByteSize; i += 2) {
         if (i > 0) {
             ss << ":";
         }
 
-        uint16_t segment = (static_cast<uint16_t>(byteArray[i]) << CHUNK_SIZE) | byteArray[i + 1];
+        uint16_t segment = (static_cast<uint16_t>(byteArray[i]) << chunkSize) | byteArray[i + 1];
         ss << std::hex << std::setw(4) << std::setfill('0') << segment;
     }
     return ss.str();
 }
 
 std::optional<std::string> convertToMacString(const std::vector<uint8_t> &byteArray) {
-    if (byteArray.size() != MAC_BYTE_SIZE) {
+    constexpr uint8_t macByteSize = 6U;
+    if (byteArray.size() != macByteSize) {
         ::error("Invalid MAC address byte array of size %1%", byteArray.size());
         return std::nullopt;
     }
 
     std::stringstream ss;
-    for (int i = 0; i < MAC_BYTE_SIZE; ++i) {
+    for (int i = 0; i < macByteSize; ++i) {
         if (i > 0) {
             ss << ":";
         }

--- a/backends/p4tools/common/lib/format_int.cpp
+++ b/backends/p4tools/common/lib/format_int.cpp
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <ostream>
 #include <string>
+#include <vector>
 
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/multiprecision/cpp_int/bitwise.hpp>
@@ -18,7 +19,7 @@ namespace P4Tools {
 
 static constexpr uint8_t IPV4_BYTE_SIZE = 4U;
 static constexpr uint8_t IPV6_BYTE_SIZE = 16U;
-static constexpr uint8_t MAC_BYTE_SIZE = 16U;
+static constexpr uint8_t MAC_BYTE_SIZE = 6U;
 /// Chunk size is 8 bits, i.e., a byte.
 static constexpr uint8_t CHUNK_SIZE = 8U;
 
@@ -284,7 +285,7 @@ std::vector<uint8_t> convertBigIntToBytes(const big_int &dataInt, int targetWidt
     auto diff = targetWidthBytes - bytes.size();
     if (targetWidthBytes > bytes.size() && diff > 0UL) {
         for (size_t i = 0; i < diff; ++i) {
-            bytes.insert(bytes.begin(), 0);
+            bytes.push_back(0);
         }
     }
     return bytes;

--- a/backends/p4tools/common/lib/format_int.h
+++ b/backends/p4tools/common/lib/format_int.h
@@ -78,8 +78,8 @@ std::string insertOctalSeparators(const std::string &dataStr);
 std::string insertHexSeparators(const std::string &dataStr);
 
 /// Converts a big integer input into a vector of bytes with the size targetWidthBits /8.
-/// If the integer value is smaller than the request bit size, padding is added on the left-hand
-/// side.
+/// If the integer value is smaller than the request bit size, padding is added on the right-hand
+/// side of the vector (the "least-significant" side).
 std::vector<uint8_t> convertBigIntToBytes(const big_int &dataInt, int targetWidthBits);
 
 /// Convert a byte array into a IPv4 string of the form "x.x.x.x".

--- a/backends/p4tools/common/lib/format_int.h
+++ b/backends/p4tools/common/lib/format_int.h
@@ -77,6 +77,23 @@ std::string insertOctalSeparators(const std::string &dataStr);
 /// Takes a hex-formatted string as input and inserts slashes as separators.
 std::string insertHexSeparators(const std::string &dataStr);
 
+/// Converts a big integer input into a vector of bytes with the size targetWidthBits /8.
+/// If the integer value is smaller than the request bit size, padding is added on the left-hand
+/// side.
+std::vector<uint8_t> convertBigIntToBytes(const big_int &dataInt, int targetWidthBits);
+
+/// Convert a byte array into a IPv4 string of the form "x.x.x.x".
+/// @returns std::nullopt if the conversion fails.
+std::optional<std::string> convertToIpv4String(const std::vector<uint8_t> &byteArray);
+
+/// Convert a byte array into a IPv4 string of the form "xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx".
+/// @returns std::nullopt if the conversion fails.
+std::optional<std::string> convertToIpv6String(const std::vector<uint8_t> &byteArray);
+
+/// Convert a byte array into a MAC string of the form "xx:xx:xx:xx:xx:xx".
+/// @returns std::nullopt if the conversion fails.
+std::optional<std::string> convertToMacString(const std::vector<uint8_t> &byteArray);
+
 }  // namespace P4Tools
 
 #endif /* BACKENDS_P4TOOLS_COMMON_LIB_FORMAT_INT_H_ */

--- a/backends/p4tools/common/lib/format_int.h
+++ b/backends/p4tools/common/lib/format_int.h
@@ -78,9 +78,11 @@ std::string insertOctalSeparators(const std::string &dataStr);
 std::string insertHexSeparators(const std::string &dataStr);
 
 /// Converts a big integer input into a vector of bytes with the size targetWidthBits /8.
-/// If the integer value is smaller than the request bit size, padding is added on the right-hand
-/// side of the vector (the "least-significant" side).
-std::vector<uint8_t> convertBigIntToBytes(const big_int &dataInt, int targetWidthBits);
+/// If the integer value is smaller than the request bit size and @param padLeft is false, padding
+/// is added on the right-hand side of the vector (the "least-significant" side). Otherwise, padding
+/// is added on the left-hand side, (the "most-significant side")
+std::vector<uint8_t> convertBigIntToBytes(const big_int &dataInt, int targetWidthBits,
+                                          bool padLeft = false);
 
 /// Convert a byte array into a IPv4 string of the form "x.x.x.x".
 /// @returns std::nullopt if the conversion fails.

--- a/backends/p4tools/modules/testgen/targets/bmv2/concolic.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/concolic.h
@@ -16,7 +16,7 @@ namespace P4Tools::P4Testgen::Bmv2 {
 class Bmv2Concolic : public Concolic {
  private:
     /// In the behavioral model, checksum functions have the following signature.
-    using ChecksumFunction = std::function<big_int(const char *buf, size_t len)>;
+    using ChecksumFunction = std::function<big_int(const uint8_t *buf, size_t len)>;
 
     /// Chunk size is 8 bits, i.e., a byte.
     static constexpr int CHUNK_SIZE = 8;
@@ -52,11 +52,6 @@ class Bmv2Concolic : public Concolic {
     /// just returns the payload expression.
     static const IR::Expression *setAndComputePayload(
         const Model &finalModel, ConcolicVariableMap *resolvedConcolicVariables, int payloadSize);
-
-    /// Converts a big integer input into a vector of bytes. This byte vector is fed into the
-    /// hash function.
-    /// This function mimics the conversion of data structures to bytes in the behavioral model.
-    static std::vector<char> convertBigIntToBytes(big_int &dataInt, int targetWidthBits);
 
  public:
     /// @returns the concolic  functions that are implemented for this particular target.

--- a/backends/p4tools/modules/testgen/targets/bmv2/contrib/bmv2_hash/calculations.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/contrib/bmv2_hash/calculations.cpp
@@ -91,7 +91,7 @@ static uint32_t table_crc32[256] = {
     0x89B8FD09, 0x8D79E0BE, 0x803AC667, 0x84FBDBD0, 0x9ABC8BD5, 0x9E7D9662, 0x933EB0BB, 0x97FFAD0C,
     0xAFB010B1, 0xAB710D06, 0xA6322BDF, 0xA2F33668, 0xBCB4666D, 0xB8757BDA, 0xB5365D03, 0xB1F740B4};
 
-uint16_t BMv2Hash::crc16(const char *buf, size_t len) {
+uint16_t BMv2Hash::crc16(const uint8_t *buf, size_t len) {
     uint16_t remainder = 0x0000;
     uint16_t final_xor_value = 0x0000;
     for (unsigned int byte = 0; byte < len; byte++) {
@@ -101,7 +101,7 @@ uint16_t BMv2Hash::crc16(const char *buf, size_t len) {
     return reflect<uint16_t>(remainder, 16) ^ final_xor_value;
 }
 
-uint32_t BMv2Hash::crc32(const char *buf, size_t len) {
+uint32_t BMv2Hash::crc32(const uint8_t *buf, size_t len) {
     uint32_t remainder = 0xFFFFFFFF;
     uint32_t final_xor_value = 0xFFFFFFFF;
     for (unsigned int byte = 0; byte < len; byte++) {
@@ -111,17 +111,17 @@ uint32_t BMv2Hash::crc32(const char *buf, size_t len) {
     return reflect<uint32_t>(remainder, 32) ^ final_xor_value;
 }
 
-uint16_t BMv2Hash::crcCCITT(const char *buf, size_t len) {
+uint16_t BMv2Hash::crcCCITT(const uint8_t *buf, size_t len) {
     uint16_t remainder = 0xFFFF;
     uint16_t final_xor_value = 0x0000;
     for (unsigned int byte = 0; byte < len; byte++) {
-        int data = static_cast<unsigned char>(buf[byte]) ^ (remainder >> 8);
+        int data = static_cast<uint8_t>(buf[byte]) ^ (remainder >> 8);
         remainder = table_crcCCITT[data] ^ (remainder << 8);
     }
     return remainder ^ final_xor_value;
 }
 
-uint16_t BMv2Hash::csum16(const char *buf, size_t len) {
+uint16_t BMv2Hash::csum16(const uint8_t *buf, size_t len) {
     uint64_t sum = 0;
     const uint64_t *b = reinterpret_cast<const uint64_t *>(buf);
     uint32_t t1, t2;
@@ -165,7 +165,7 @@ uint16_t BMv2Hash::csum16(const char *buf, size_t len) {
     return ntohs(~t3);
 }
 
-uint16_t BMv2Hash::xor16(const char *buf, size_t len) {
+uint16_t BMv2Hash::xor16(const uint8_t *buf, size_t len) {
     uint16_t mask = 0x00ff;
     uint16_t final_xor_value = 0x0000;
     unsigned int byte = 0;
@@ -185,7 +185,7 @@ uint16_t BMv2Hash::xor16(const char *buf, size_t len) {
     return final_xor_value;
 }
 
-uint64_t BMv2Hash::identity(const char *buf, size_t len) {
+uint64_t BMv2Hash::identity(const uint8_t *buf, size_t len) {
     uint64_t res = 0ULL;
     for (size_t i = 0; i < std::min(sizeof(res), len); i++) {
         if (i > 0) res <<= 8;

--- a/backends/p4tools/modules/testgen/targets/bmv2/contrib/bmv2_hash/calculations.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/contrib/bmv2_hash/calculations.h
@@ -48,17 +48,17 @@ class BMv2Hash {
     }
 
  public:
-    static uint16_t crc16(const char *buf, size_t len);
+    static uint16_t crc16(const uint8_t *buf, size_t len);
 
-    static uint32_t crc32(const char *buf, size_t len);
+    static uint32_t crc32(const uint8_t *buf, size_t len);
 
-    static uint16_t crcCCITT(const char *buf, size_t len);
+    static uint16_t crcCCITT(const uint8_t *buf, size_t len);
 
-    static uint16_t csum16(const char *buf, size_t len);
+    static uint16_t csum16(const uint8_t *buf, size_t len);
 
-    static uint16_t xor16(const char *buf, size_t len);
+    static uint16_t xor16(const uint8_t *buf, size_t len);
 
-    static uint64_t identity(const char *buf, size_t len);
+    static uint64_t identity(const uint8_t *buf, size_t len);
 };
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.cpp
@@ -9,13 +9,37 @@
 #include <inja/inja.hpp>
 
 #include "backends/p4tools/common/lib/util.h"
+#include "lib/exceptions.h"
 #include "lib/log.h"
 #include "nlohmann/json.hpp"
+
+#include "backends/p4tools/modules/testgen/lib/exceptions.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/test_spec.h"
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
 ProtobufIr::ProtobufIr(std::filesystem::path basePath, std::optional<unsigned int> seed)
     : Bmv2TestFramework(std::move(basePath), seed) {}
+
+std::string ProtobufIr::getFormatOfNode(const IR::IAnnotated *node) {
+    const auto *formatAnnotation = node->getAnnotation("format");
+    std::string formatString = "hex_str";
+    if (formatAnnotation != nullptr) {
+        BUG_CHECK(formatAnnotation->body.size() == 1,
+                  "@format annotation can only have one member.");
+        auto formatString = formatAnnotation->body.at(0)->text;
+        if (formatString == "IPV4_ADDRESS") {
+            formatString = "ipv4";
+        } else if (formatString == "IPV6_ADDRESS") {
+            formatString = "ipv6";
+        } else if (formatString == "MAC_ADDRESS") {
+            formatString = "mac";
+        } else {
+            TESTGEN_UNIMPLEMENTED("Unsupported @format string %1%", formatString);
+        }
+    }
+    return formatString;
+}
 
 std::string ProtobufIr::getTestCaseTemplate() {
     static std::string TEST_CASE(
@@ -61,7 +85,7 @@ entities {
     # Match field {{r.field_name}}
     matches {
       name: "{{r.field_name}}"
-      exact: { hex_str: "{{r.value}}" }
+      exact: { {{r.format}}: "{{r.value}}" }
     }
 ## endfor
 ## for r in rule.rules.optional_matches
@@ -69,7 +93,7 @@ entities {
   matches {
     name: "{{r.field_name}}"
     optional {
-      value: { hex_str: "{{r.value}}" }
+      value: { {{r.format}}: "{{r.value}}" }
     }
   }
 ## endfor
@@ -78,8 +102,8 @@ entities {
     matches {
       name: "{{r.field_name}}"
       range {
-        low: { hex_str: "{{r.lo}}" }
-        high: { hex_str:  "{{r.hi}}" }
+        low: { {{r.format}}: "{{r.lo}}" }
+        high: { {{r.format}}:  "{{r.hi}}" }
       }
     }
 ## endfor
@@ -88,8 +112,8 @@ entities {
     matches {
       name: "{{r.field_name}}"
       ternary {
-        value: { hex_str: "{{r.value}}" }
-        mask: { hex_str: "{{r.mask}}" }
+        value: { {{r.format}}: "{{r.value}}" }
+        mask: { {{r.format}}: "{{r.mask}}" }
       }
     }
 ## endfor
@@ -98,7 +122,7 @@ entities {
     matches {
       name: "{{r.field_name}}"
       lpm {
-        value: { hex_str: "{{r.value}}" }
+        value: { {{r.format}}: "{{r.value}}" }
         prefix_length: {{r.prefix_len}}
       }
     }
@@ -113,7 +137,7 @@ entities {
             # Param {{act_param.param}}
             params {
               name: "{{act_param.param}}"
-              value: { hex_str: "{{act_param.value}}" }
+              value: { {{act_param.format}}: "{{act_param.value}}" }
             }
 ## endfor
           }
@@ -126,7 +150,7 @@ entities {
         # Param {{act_param.param}}
         params {
           name: "{{act_param.param}}"
-          value: { hex_str: "{{act_param.value}}" }
+          value: { {{act_param.format}}: "{{act_param.value}}" }
       }
 ## endfor
     }
@@ -138,6 +162,105 @@ entities {
 ## endif
 )""");
     return TEST_CASE;
+}
+
+std::string ProtobufIr::formatNetworkValue(const std::string &type, const IR::Expression *value) {
+    if (type == "hex_str") {
+        return formatHexExpr(value);
+    }
+    // At this point, any value must be a constant.
+    const auto *constant = value->checkedTo<IR::Constant>();
+    if (type == "ipv4") {
+        auto convertedString = convertToIpv4String(convertBigIntToBytes(constant->value, 32));
+        if (convertedString.has_value()) {
+            return convertedString.value();
+        }
+        BUG("Failed to convert IPv4 string.");
+    }
+    if (type == "ipv6") {
+        auto convertedString = convertToIpv6String(convertBigIntToBytes(constant->value, 128));
+        if (convertedString.has_value()) {
+            return convertedString.value();
+        }
+        BUG("Failed to convert IPv6 string.");
+    }
+    if (type == "mac") {
+        auto convertedString = convertToMacString(convertBigIntToBytes(constant->value, 48));
+        if (convertedString.has_value()) {
+            return convertedString.value();
+        }
+        BUG("Failed to convert MAC string.");
+    }
+    TESTGEN_UNIMPLEMENTED("Unsupported network value type %1%", type);
+}
+
+void ProtobufIr::createKeyMatch(cstring fieldName, const TableMatch &fieldMatch,
+                                inja::json &rulesJson) {
+    inja::json j;
+    j["field_name"] = fieldName;
+    j["format"] = getFormatOfNode(fieldMatch.getKey());
+
+    if (const auto *elem = fieldMatch.to<Exact>()) {
+        j["value"] = formatNetworkValue(j["format"], elem->getEvaluatedValue()).c_str();
+        rulesJson["single_exact_matches"].push_back(j);
+    } else if (const auto *elem = fieldMatch.to<Range>()) {
+        j["lo"] = formatNetworkValue(j["format"], elem->getEvaluatedLow()).c_str();
+        j["hi"] = formatNetworkValue(j["format"], elem->getEvaluatedHigh()).c_str();
+        rulesJson["range_matches"].push_back(j);
+    } else if (const auto *elem = fieldMatch.to<Ternary>()) {
+        j["value"] = formatNetworkValue(j["format"], elem->getEvaluatedValue()).c_str();
+        j["mask"] = formatNetworkValue(j["format"], elem->getEvaluatedMask()).c_str();
+        rulesJson["ternary_matches"].push_back(j);
+        // If the rule has a ternary match we need to add the priority.
+        rulesJson["needs_priority"] = true;
+    } else if (const auto *elem = fieldMatch.to<LPM>()) {
+        j["value"] = formatNetworkValue(j["format"], elem->getEvaluatedValue()).c_str();
+        j["prefix_len"] = elem->getEvaluatedPrefixLength()->value.str();
+        rulesJson["lpm_matches"].push_back(j);
+    } else if (const auto *elem = fieldMatch.to<Optional>()) {
+        j["value"] = formatNetworkValue(j["format"], elem->getEvaluatedValue()).c_str();
+        if (elem->addAsExactMatch()) {
+            j["use_exact"] = "True";
+        } else {
+            j["use_exact"] = "False";
+        }
+        rulesJson["needs_priority"] = true;
+        rulesJson["optional_matches"].push_back(j);
+    } else {
+        TESTGEN_UNIMPLEMENTED("Unsupported table key match type \"%1%\"",
+                              fieldMatch.getObjectName());
+    }
+}
+
+inja::json ProtobufIr::getControlPlaneForTable(const TableMatchMap &matches,
+                                               const std::vector<ActionArg> &args) const {
+    inja::json rulesJson;
+
+    rulesJson["single_exact_matches"] = inja::json::array();
+    rulesJson["multiple_exact_matches"] = inja::json::array();
+    rulesJson["range_matches"] = inja::json::array();
+    rulesJson["ternary_matches"] = inja::json::array();
+    rulesJson["lpm_matches"] = inja::json::array();
+    rulesJson["optional_matches"] = inja::json::array();
+
+    rulesJson["act_args"] = inja::json::array();
+    rulesJson["needs_priority"] = false;
+
+    // Iterate over the match fields and segregate them.
+    for (const auto &match : matches) {
+        createKeyMatch(match.first, *match.second, rulesJson);
+    }
+
+    for (const auto &actArg : args) {
+        inja::json j;
+        j["format"] = getFormatOfNode(actArg.getActionParam());
+
+        j["param"] = actArg.getActionParamName().c_str();
+        j["value"] = formatNetworkValue(j["format"], actArg.getEvaluatedValue()).c_str();
+        rulesJson["act_args"].push_back(j);
+    }
+
+    return rulesJson;
 }
 
 void ProtobufIr::emitTestcase(const TestSpec *testSpec, cstring selectedBranches, size_t testId,

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.cpp
@@ -34,6 +34,8 @@ std::string ProtobufIr::getFormatOfNode(const IR::IAnnotated *node) {
             formatString = "ipv6";
         } else if (formatString == "MAC_ADDRESS") {
             formatString = "mac";
+        } else if (formatString == "HEX_STR") {
+            formatString = "hex_str";
         } else {
             TESTGEN_UNIMPLEMENTED("Unsupported @format string %1%", formatString);
         }
@@ -175,21 +177,21 @@ std::string ProtobufIr::formatNetworkValue(const std::string &type, const IR::Ex
         if (convertedString.has_value()) {
             return convertedString.value();
         }
-        BUG("Failed to convert IPv4 string.");
+        BUG("Failed to convert \"%1%\" to an IPv4 string.", value);
     }
     if (type == "ipv6") {
         auto convertedString = convertToIpv6String(convertBigIntToBytes(constant->value, 128));
         if (convertedString.has_value()) {
             return convertedString.value();
         }
-        BUG("Failed to convert IPv6 string.");
+        BUG("Failed to convert \"%1%\" to an IPv6 string.", value);
     }
     if (type == "mac") {
         auto convertedString = convertToMacString(convertBigIntToBytes(constant->value, 48));
         if (convertedString.has_value()) {
             return convertedString.value();
         }
-        BUG("Failed to convert MAC string.");
+        BUG("Failed to convert \"%1%\" to an MAC string.", value);
     }
     TESTGEN_UNIMPLEMENTED("Unsupported network value type %1%", type);
 }

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.h
@@ -21,9 +21,17 @@ class ProtobufIr : public Bmv2TestFramework {
     explicit ProtobufIr(std::filesystem::path basePath,
                         std::optional<unsigned int> seed = std::nullopt);
 
-    /// Produce a ProtobufIr test.
+    virtual ~ProtobufIr() = default;
+    ProtobufIr(const ProtobufIr &) = default;
+    ProtobufIr(ProtobufIr &&) = default;
+    ProtobufIr &operator=(const ProtobufIr &) = default;
+    ProtobufIr &operator=(ProtobufIr &&) = default;
+
     void outputTest(const TestSpec *spec, cstring selectedBranches, size_t testId,
                     float currentCoverage) override;
+
+    [[nodiscard]] inja::json getControlPlaneForTable(
+        const TableMatchMap &matches, const std::vector<ActionArg> &args) const override;
 
  private:
     /// Emits a test case.
@@ -36,6 +44,18 @@ class ProtobufIr : public Bmv2TestFramework {
 
     /// @returns the inja test case template as a string.
     static std::string getTestCaseTemplate();
+
+    /// Tries to find the @format annotation of a node and, if present, returns the format specified
+    /// in this annotation. Returns "hex" by default.
+    static std::string getFormatOfNode(const IR::IAnnotated *node);
+
+    /// Converts an IR::Expression into a formatted string value. The format depends on @param type.
+    static std::string formatNetworkValue(const std::string &type, const IR::Expression *value);
+
+    /// Fill in @param rulesJson by iterating over @param fieldMatch and creating the appropriate
+    /// match key.
+    static void createKeyMatch(cstring fieldName, const TableMatch &fieldMatch,
+                               inja::json &rulesJson);
 };
 
 }  // namespace P4Tools::P4Testgen::Bmv2


### PR DESCRIPTION
P4 SAI annotations such as `@format` dictate a specific format, which must be respected by P4Testgen when generating Protobuf PDPI tests. Hence, we add a couple utility functions to the Protobuf PDPI test back end to produce the right format in the case that a key has such an annotation. 

Fixes #4273.