### PR TITLE
Fix problem with bpftool in PTF tests

### DIFF
--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -180,9 +180,7 @@ function install_ptf_ebpf_test_deps() (
     sudo make install
 
     # install bpftool
-    # get tag for latest release, see https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release
-    BPFTOOL_RELEASE_TAG=$(curl -s https://api.github.com/repos/libbpf/bpftool/releases/latest | jq '.tag_name' | sed 's/\"//g')
-    git clone --recurse-submodules --branch "$BPFTOOL_RELEASE_TAG" https://github.com/libbpf/bpftool.git /tmp/bpftool
+    git clone --recurse-submodules --branch v7.3.0 https://github.com/libbpf/bpftool.git /tmp/bpftool
     cd /tmp/bpftool/src
     make "-j$(nproc)"
     sudo make install


### PR DESCRIPTION
PTF tests recently fail due to failing build of bpftool used for some test cases. Solution is to use latest release instead of HEAD of main branch.

At least should work with bpftool v7.3.0