### PR TITLE
[P4Testgen] Fix accidental system file categorization.

### DIFF
--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -44,10 +44,10 @@ target_link_libraries(
 
 target_include_directories(
   p4tools-common
-  SYSTEM BEFORE PUBLIC ${P4TOOLS_Z3_INCLUDE_DIR}
   PUBLIC "${CMAKE_BINARY_DIR}/common"
   PUBLIC "${P4C_SOURCE_DIR}"
   PUBLIC "${P4C_BINARY_DIR}"
+  SYSTEM BEFORE PUBLIC ${P4TOOLS_Z3_INCLUDE_DIR}
 )
 
 add_dependencies(p4tools-common ir-generated frontend)

--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -44,10 +44,13 @@ target_link_libraries(
 
 target_include_directories(
   p4tools-common
+  SYSTEM BEFORE PUBLIC ${P4TOOLS_Z3_INCLUDE_DIR}
+)
+target_include_directories(
+  p4tools-common
   PUBLIC "${CMAKE_BINARY_DIR}/common"
   PUBLIC "${P4C_SOURCE_DIR}"
   PUBLIC "${P4C_BINARY_DIR}"
-  SYSTEM BEFORE PUBLIC ${P4TOOLS_Z3_INCLUDE_DIR}
 )
 
 add_dependencies(p4tools-common ir-generated frontend)


### PR DESCRIPTION
Some files were accidentally classified as system files, although they were local. This causes problems with such as tools as include-fixer. 