### PR TITLE
Remove -static and rename static build appropriately.

### DIFF
--- a/.github/workflows/ci-static-build-test.yml
+++ b/.github/workflows/ci-static-build-test.yml
@@ -34,7 +34,8 @@ jobs:
         key: test-static-${{ runner.os }}
         max-size: 1000M
 
-    - name: Build (Ubuntu 20.04)
+    - shell: bash
+      name: Build (Ubuntu 20.04)
       run: |
         sudo -E tools/ci-build.sh
         # Disabling these checks until we find a better way to build a fully static binary.
@@ -47,11 +48,11 @@ jobs:
         # ldd ./build/p4test 2>&1  | grep -E -qi "(not a dynamic executable)|(statically linked)"
         # ldd ./build/p4testgen 2>&1  | grep -E -qi "(not a dynamic executable)|(statically linked)"
 
-        ldd ./build/p4c-bm2-psa 2>&1 | ! grep -E "libgc|libboost_iostreams"
-        ldd ./build/p4c-bm2-ss 2>&1 | ! grep -E "libgc|libboost_iostreams"
-        ldd ./build/p4c-dpdk 2>&1 | ! grep -E "libgc|libboost_iostreams"
-        ldd ./build/p4c-ebpf 2>&1 | ! grep -E "libgc|libboost_iostreams"
-        ldd ./build/p4c-pna-p4tc 2>&1 | ! grep -E "libgc|libboost_iostreams"
-        ldd ./build/p4c-ubpf 2>&1 | ! grep -E "libgc|libboost_iostreams"
-        ldd ./build/p4test 2>&1 | ! grep -E "libgc|libboost_iostreams"
-        ldd ./build/p4testgen 2>&1 | ! grep -E "libgc|libboost_iostreams"
+        ! ldd ./build/p4c-bm2-psa 2>&1 | grep -E "libgc|libboost_iostreams"
+        ! ldd ./build/p4c-bm2-ss 2>&1 | grep -E "libgc|libboost_iostreams"
+        ! ldd ./build/p4c-dpdk 2>&1 | grep -E "libgc|libboost_iostreams"
+        ! ldd ./build/p4c-ebpf 2>&1 | grep -E "libgc|libboost_iostreams"
+        ! ldd ./build/p4c-pna-p4tc 2>&1 | grep -E "libgc|libboost_iostreams"
+        ! ldd ./build/p4c-ubpf 2>&1 | grep -E "libgc|libboost_iostreams"
+        ! ldd ./build/p4test 2>&1 | grep -E "libgc|libboost_iostreams"
+        ! ldd ./build/p4testgen 2>&1 | grep -E "libgc|libboost_iostreams"

--- a/.github/workflows/ci-static-build-test.yml
+++ b/.github/workflows/ci-static-build-test.yml
@@ -37,12 +37,21 @@ jobs:
     - name: Build (Ubuntu 20.04)
       run: |
         sudo -E tools/ci-build.sh
-        # Disabling checks until we find a better way to build a fully static binary.
-        ldd ./build/p4c-bm2-psa 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
-        ldd ./build/p4c-bm2-ss 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
-        ldd ./build/p4c-dpdk 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
-        ldd ./build/p4c-ebpf 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
-        ldd ./build/p4c-pna-p4tc 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
-        ldd ./build/p4c-ubpf 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
-        ldd ./build/p4test 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
-        ldd ./build/p4testgen 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        # Disabling these checks until we find a better way to build a fully static binary.
+        # ldd ./build/p4c-bm2-psa 2>&1  | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        # ldd ./build/p4c-bm2-ss 2>&1  | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        # ldd ./build/p4c-dpdk 2>&1  | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        # ldd ./build/p4c-ebpf 2>&1  | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        # ldd ./build/p4c-pna-p4tc 2>&1  | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        # ldd ./build/p4c-ubpf 2>&1  | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        # ldd ./build/p4test 2>&1  | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        # ldd ./build/p4testgen 2>&1  | grep -E -qi "(not a dynamic executable)|(statically linked)"
+
+        ldd ./build/p4c-bm2-psa 2>&1 | ! grep -E "libgc|libboost_iostreams"
+        ldd ./build/p4c-bm2-ss 2>&1 | ! grep -E "libgc|libboost_iostreams"
+        ldd ./build/p4c-dpdk 2>&1 | ! grep -E "libgc|libboost_iostreams"
+        ldd ./build/p4c-ebpf 2>&1 | ! grep -E "libgc|libboost_iostreams"
+        ldd ./build/p4c-pna-p4tc 2>&1 | ! grep -E "libgc|libboost_iostreams"
+        ldd ./build/p4c-ubpf 2>&1 | ! grep -E "libgc|libboost_iostreams"
+        ldd ./build/p4test 2>&1 | ! grep -E "libgc|libboost_iostreams"
+        ldd ./build/p4testgen 2>&1 | ! grep -E "libgc|libboost_iostreams"

--- a/.github/workflows/ci-static-build-test.yml
+++ b/.github/workflows/ci-static-build-test.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       IMAGE_TYPE: test
       CMAKE_UNITY_BUILD: ON
-      BUILD_STATIC_RELEASE: ON
+      BUILD_STATIC_RELEASE_SANS_GLIBC: ON
       ENABLE_TEST_TOOLS: ON
     steps:
     - uses: actions/checkout@v3
@@ -37,3 +37,12 @@ jobs:
     - name: Build (Ubuntu 20.04)
       run: |
         sudo -E tools/ci-build.sh
+        # Disabling checks until we find a better way to build a fully static binary.
+        ldd ./build/p4c-bm2-psa 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        ldd ./build/p4c-bm2-ss 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        ldd ./build/p4c-dpdk 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        ldd ./build/p4c-ebpf 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        ldd ./build/p4c-pna-p4tc 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        ldd ./build/p4c-ubpf 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        ldd ./build/p4test 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"
+        ldd ./build/p4testgen 2>&1 # | grep -E -qi "(not a dynamic executable)|(statically linked)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,9 @@ if(BUILD_STATIC_RELEASE_SANS_GLIBC)
   # TODO: Keep track of https://stackoverflow.com/questions/3430400/linux-static-linking-is-dead
   # and see whether static linking improves on Linux.
   # Do not bring in dynamic libstdcc and libgcc
-  set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -Wl,-z,muldefs")
+  set(CMAKE_EXE_LINKER_FLAGS
+      "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++ -Wl,-z,muldefs"
+  )
   add_definitions(-DP4C_STATIC_BUILD)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,9 @@ OPTION (ENABLE_MULTITHREAD "Use multithreading" OFF)
 OPTION (ENABLE_LTO "Enable Link Time Optimization (LTO)" OFF)
 OPTION (ENABLE_WERROR "Treat warnings as errors" OFF)
 OPTION (ENABLE_SANITIZERS "Enable sanitizers" OFF)
-OPTION (BUILD_STATIC_RELEASE "Build a statically linked release binary" OFF)
+option(BUILD_STATIC_RELEASE_SANS_GLIBC
+       "Build a (mostly) statically linked release binary. Glibc is linked dynamically." OFF
+)
 OPTION (BUILD_AUTO_VAR_INIT_PATTERN "Initialize variables with pattern during build" OFF)
 OPTION (ENABLE_IWYU "Enable checking includes with IWYU" OFF)
 # Support a legacy option. TODO: Remove?
@@ -116,8 +118,8 @@ endif ()
 # Always build position-independent code. This is important when linking with Protobuf.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# set the required options for a static release build
-if (BUILD_STATIC_RELEASE)
+# Set the required options for a (mostly) static release build.
+if(BUILD_STATIC_RELEASE_SANS_GLIBC)
   message(STATUS "Building static release binaries")
   set(BUILD_SHARED_LIBS OFF)
   set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
@@ -127,10 +129,13 @@ if (BUILD_STATIC_RELEASE)
   set(Boost_USE_STATIC_RUNTIME OFF)
   # Set the static variable
   set(P4C_STATIC_BUILD STATIC)
+  # TODO: We can not use -static here because of compilation and portability problems:
+  # TODO: Keep track of https://stackoverflow.com/questions/3430400/linux-static-linking-is-dead
+  # and see whether static linking improves on Linux.
   # Do not bring in dynamic libstdcc and libgcc
-  set(CMAKE_EXE_LINKER_FLAGS "-static -static-libgcc -static-libstdc++ -Wl,-z,muldefs")
+  set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -Wl,-z,muldefs")
   add_definitions(-DP4C_STATIC_BUILD)
-endif ()
+endif()
 
 # Required tools and libraries.
 find_package (PythonInterp 3 REQUIRED)
@@ -280,7 +285,7 @@ endif ()
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # We want to optimize the binary size for a static release binary.
     # This only works with modern versions of GCC.
-    if (BUILD_STATIC_RELEASE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
+    if (BUILD_STATIC_RELEASE_SANS_GLIBC AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
         if (BUILD_LINK_WITH_LLD)
           message(WARNING "LLD does not work with GCC's LTO object format, switching to Gold.")
           set(BUILD_LINK_WITH_LLD OFF)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG CMAKE_UNITY_BUILD=ON
 ARG VALIDATION=OFF
 # This creates a release build that includes link time optimization and links
 # all libraries statically.
-ARG BUILD_STATIC_RELEASE=OFF
+ARG BUILD_STATIC_RELEASE_SANS_GLIBC=OFF
 # No questions asked during package installation.
 ARG DEBIAN_FRONTEND=noninteractive
 # Whether to install dependencies required to run PTF-ebpf tests

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -23,7 +23,7 @@ P4C_DIR=$(readlink -f ${THIS_DIR}/..)
 : "${VALIDATION:=OFF}"
 # This creates a release build that includes link time optimization and links
 # all libraries statically.
-: "${BUILD_STATIC_RELEASE:=OFF}"
+: "${BUILD_STATIC_RELEASE_SANS_GLIBC:=OFF}"
 # No questions asked during package installation.
 : "${DEBIAN_FRONTEND:=noninteractive}"
 # Whether to install dependencies required to run PTF-ebpf tests
@@ -236,7 +236,7 @@ export CXXFLAGS="${CXXFLAGS} -O3"
 # Toggle unity compilation.
 CMAKE_FLAGS+="-DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} "
 # Toggle static builds.
-CMAKE_FLAGS+="-DBUILD_STATIC_RELEASE=${BUILD_STATIC_RELEASE} "
+CMAKE_FLAGS+="-DBUILD_STATIC_RELEASE_SANS_GLIBC=${BUILD_STATIC_RELEASE_SANS_GLIBC} "
 # Toggle the installation of the tools back end.
 CMAKE_FLAGS+="-DENABLE_TEST_TOOLS=${ENABLE_TEST_TOOLS} "
 # RELEASE should be default, but we want to make sure.

--- a/tools/debian-build/packaging.conf
+++ b/tools/debian-build/packaging.conf
@@ -14,7 +14,7 @@ CONFOPT+="-DCMAKE_UNITY_BUILD=ON "
 # RELEASE should be default, but we want to make sure.
 CONFOPT+="-DCMAKE_BUILD_TYPE=RELEASE "
 # The binaries we produce should not depend on system libraries.
-CONFOPT+="-DBUILD_STATIC_RELEASE=ON "
+CONFOPT+="-DBUILD_STATIC_RELEASE_SANS_GLIBC=ON "
 MAKE_DIST="cd ${P4C_DIR}/backends/ebpf && ./build_libbpf && mkdir -p ${P4C_DIR}/build && cd ${P4C_DIR}/build && cmake .. $CONFOPT && make && make dist"
 # Distributions which are *not* supported!
 NOT_TARGET_DISTRIBUTIONS="lucid precise trusty xenial bionic"


### PR DESCRIPTION
Turns out we can not really build a clean static binary on Linux because of limitations of the glibc library. 

https://stackoverflow.com/questions/3430400/linux-static-linking-is-dead

Also, linking with `-static` causes problems when building Protobuf and [bdwgc](https://github.com/ivmai/bdwgc) from scratch. Hence, we remove `-static` from our build process and rename the CMake parameters appropriately. 