### PR TITLE
Add error on 0-size header stack

### DIFF
--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -160,15 +160,23 @@ bool TypeMap::equivalent(const IR::Type *left, const IR::Type *right, bool stric
         return lv->getVarName() == rv->getVarName() && lv->getDeclId() == rv->getDeclId();
     }
     if (auto ls = left->to<IR::Type_Stack>()) {
+        const auto isLegal = [](const IR::Type_Stack *stack) {
+            if (!stack->sizeKnown()) {
+                ::error(ErrorType::ERR_TYPE_ERROR,
+                        "%1%: Size of header stack type should be a constant", stack);
+                return false;
+            }
+            if (stack->getSize() < 1) {
+                ::error(ErrorType::ERR_TYPE_ERROR,
+                        "Invalid size of header stack %1%. The size must be a positive integer.",
+                        stack);
+                return false;
+            }
+            return true;
+        };
+
         auto rs = right->to<IR::Type_Stack>();
-        if (!ls->sizeKnown()) {
-            ::error(ErrorType::ERR_TYPE_ERROR,
-                    "%1%: Size of header stack type should be a constant", left);
-            return false;
-        }
-        if (!rs->sizeKnown()) {
-            ::error(ErrorType::ERR_TYPE_ERROR,
-                    "%1%: Size of header stack type should be a constant", right);
+        if (!isLegal(ls) || !isLegal(rs)) {
             return false;
         }
         return equivalent(ls->elementType, rs->elementType, strict) &&

--- a/testdata/p4_16_errors/stack0.p4
+++ b/testdata/p4_16_errors/stack0.p4
@@ -1,0 +1,9 @@
+header h {}
+const int SIZE = 0;
+
+control p()
+{
+    apply {
+        h[SIZE] stack;
+    }
+}

--- a/testdata/p4_16_errors_outputs/stack0.p4
+++ b/testdata/p4_16_errors_outputs/stack0.p4
@@ -1,0 +1,10 @@
+header h {
+}
+
+const int SIZE = 0;
+control p() {
+    apply {
+        h[SIZE] stack;
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/stack0.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack0.p4-stderr
@@ -1,0 +1,3 @@
+stack0.p4(7): [--Werror=type-error] error: Invalid size of header stack header h[0]. The size must be a positive integer.
+        h[SIZE] stack;
+        ^^^^^^^

--- a/testdata/p4_16_samples/minsize.p4
+++ b/testdata/p4_16_samples/minsize.p4
@@ -22,7 +22,7 @@ control c(out bit<32> v) {
     apply
     {
         bit<32> b;
-        H[0] h;
+        H[1] h;
 
         v = b.minSizeInBits() + T.minSizeInBits() + b.maxSizeInBits() + T.maxSizeInBits() + h[0].minSizeInBits();
     }

--- a/testdata/p4_16_samples_outputs/minsize-first.p4
+++ b/testdata/p4_16_samples_outputs/minsize-first.p4
@@ -5,7 +5,7 @@ header H {
 control c(out bit<32> v) {
     apply {
         bit<32> b;
-        H[0] h;
+        H[1] h;
         v = 32w128;
     }
 }

--- a/testdata/p4_16_samples_outputs/minsize.p4
+++ b/testdata/p4_16_samples_outputs/minsize.p4
@@ -5,7 +5,7 @@ header H {
 control c(out bit<32> v) {
     apply {
         bit<32> b;
-        H[0] h;
+        H[1] h;
         v = b.minSizeInBits() + T.minSizeInBits() + b.maxSizeInBits() + T.maxSizeInBits() + h[0].minSizeInBits();
     }
 }


### PR DESCRIPTION
[P4 spec section on header stacks](https://p4.org/p4-spec/docs/P4-16-v-1.2.3.html#sec-header-stacks) states that their size must be a positive integer, but that is currently not checked and stacks with size 0 are allowed.

This PR adds the check.