### PR TITLE
Allow one more round of type inference after specialization

### DIFF
--- a/frontends/p4/specialize.cpp
+++ b/frontends/p4/specialize.cpp
@@ -284,6 +284,8 @@ SpecializeAll::SpecializeAll(ReferenceMap *refMap, TypeMap *typeMap) : PassRepea
     passes.emplace_back(new TypeChecking(refMap, typeMap));
     passes.emplace_back(new FindSpecializations(&specMap));
     passes.emplace_back(new Specialize(&specMap));
+    passes.emplace_back(new ResolveReferences(refMap));
+    passes.emplace_back(new TypeInference(refMap, typeMap, false));  // more casts may be needed
     passes.emplace_back(new RemoveAllUnusedDeclarations(refMap));
     specMap.refMap = refMap;
     specMap.typeMap = typeMap;

--- a/testdata/p4_16_samples/issue4288.p4
+++ b/testdata/p4_16_samples/issue4288.p4
@@ -1,0 +1,16 @@
+#include <core.p4>
+
+control Deparser(packet_out packet);
+package SimpleArch(Deparser dep);
+
+header hdr_t {
+   bit<8> f0;
+}
+
+control MyDeparser(packet_out packet) (hdr_t h) {
+    apply {
+      packet.emit(h);
+    }
+}
+
+SimpleArch(MyDeparser({0})) main;

--- a/testdata/p4_16_samples_outputs/issue4288-first.p4
+++ b/testdata/p4_16_samples_outputs/issue4288-first.p4
@@ -1,0 +1,15 @@
+#include <core.p4>
+
+control Deparser(packet_out packet);
+package SimpleArch(Deparser dep);
+header hdr_t {
+    bit<8> f0;
+}
+
+control MyDeparser(packet_out packet)(hdr_t h) {
+    apply {
+        packet.emit<hdr_t>(h);
+    }
+}
+
+SimpleArch(MyDeparser({ 8w0 })) main;

--- a/testdata/p4_16_samples_outputs/issue4288-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue4288-frontend.p4
@@ -1,0 +1,15 @@
+#include <core.p4>
+
+control Deparser(packet_out packet);
+package SimpleArch(Deparser dep);
+header hdr_t {
+    bit<8> f0;
+}
+
+control MyDeparser_0(packet_out packet) {
+    apply {
+        packet.emit<hdr_t>((hdr_t){f0 = 8w0});
+    }
+}
+
+SimpleArch(MyDeparser_0()) main;

--- a/testdata/p4_16_samples_outputs/issue4288-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue4288-midend.p4
@@ -1,0 +1,24 @@
+#include <core.p4>
+
+control Deparser(packet_out packet);
+package SimpleArch(Deparser dep);
+header hdr_t {
+    bit<8> f0;
+}
+
+control MyDeparser_0(packet_out packet) {
+    @hidden action issue4288l12() {
+        packet.emit<hdr_t>((hdr_t){f0 = 8w0});
+    }
+    @hidden table tbl_issue4288l12 {
+        actions = {
+            issue4288l12();
+        }
+        const default_action = issue4288l12();
+    }
+    apply {
+        tbl_issue4288l12.apply();
+    }
+}
+
+SimpleArch(MyDeparser_0()) main;

--- a/testdata/p4_16_samples_outputs/issue4288.p4
+++ b/testdata/p4_16_samples_outputs/issue4288.p4
@@ -1,0 +1,15 @@
+#include <core.p4>
+
+control Deparser(packet_out packet);
+package SimpleArch(Deparser dep);
+header hdr_t {
+    bit<8> f0;
+}
+
+control MyDeparser(packet_out packet)(hdr_t h) {
+    apply {
+        packet.emit(h);
+    }
+}
+
+SimpleArch(MyDeparser({ 0 })) main;


### PR DESCRIPTION
This is not the most principled fix, but hopefully it will work.
A principled fix would require more work.
I can describe the principled solution if anyone is interested to do it.
It basically boils down to improving `TypeChecking::containerInstantiation` to treat arguments like the `assign` function does.