### PR TITLE
[P4Testgen] Introduce a compiler target for P4Testgen. Move computation from the ProgramInfo to the midend.

### DIFF
--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -14,6 +14,7 @@ set(
   options.cpp
   testgen.cpp
 
+  core/compiler_target.cpp
   core/externs.cpp
   core/program_info.cpp
   core/small_step/abstract_stepper.cpp

--- a/backends/p4tools/modules/testgen/core/compiler_target.cpp
+++ b/backends/p4tools/modules/testgen/core/compiler_target.cpp
@@ -1,0 +1,58 @@
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
+
+#include <utility>
+
+#include "backends/p4tools/common/compiler/reachability.h"
+#include "midend/coverage.h"
+
+#include "backends/p4tools/modules/testgen/options.h"
+
+namespace P4Tools::P4Testgen {
+
+TestgenCompilerResult::TestgenCompilerResult(CompilerResult compilerResult,
+                                             P4::Coverage::CoverageSet coverableNodes,
+                                             const NodesCallGraph *callGraph)
+    : CompilerResult(std::move(compilerResult)),
+      coverableNodes(std::move(coverableNodes)),
+      callGraph(callGraph) {}
+
+const NodesCallGraph &TestgenCompilerResult::getCallGraph() const {
+    BUG_CHECK(callGraph != nullptr, "The call graph has not been initialized.");
+    return *callGraph;
+}
+
+const P4::Coverage::CoverageSet &TestgenCompilerResult::getCoverableNodes() const {
+    return coverableNodes;
+}
+
+TestgenCompilerTarget::TestgenCompilerTarget(std::string deviceName, std::string archName)
+    : CompilerTarget(std::move(deviceName), std::move(archName)) {}
+
+CompilerResultOrError TestgenCompilerTarget::runCompilerImpl(const IR::P4Program *program) const {
+    program = runFrontend(program);
+    if (program == nullptr) {
+        return std::nullopt;
+    }
+
+    program = runMidEnd(program);
+    if (program == nullptr) {
+        return std::nullopt;
+    }
+
+    // Create DCG.
+    NodesCallGraph *dcg = nullptr;
+    if (TestgenOptions::get().dcg || !TestgenOptions::get().pattern.empty()) {
+        dcg = new NodesCallGraph("NodesCallGraph");
+        P4ProgramDCGCreator dcgCreator(dcg);
+        program->apply(dcgCreator);
+    }
+
+    /// Collect coverage information about the program.
+    auto coverage = P4::Coverage::CollectNodes(TestgenOptions::get().coverageOptions);
+    program->apply(coverage);
+
+    return {
+        *new TestgenCompilerResult(CompilerResult(*program), coverage.getCoverableNodes(), dcg)};
+}
+
+}  // namespace P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/compiler_target.h
+++ b/backends/p4tools/modules/testgen/core/compiler_target.h
@@ -13,7 +13,7 @@ class TestgenCompilerResult : public CompilerResult {
     /// The coverabled Nodes in the analyzed P4 program.
     P4::Coverage::CoverageSet coverableNodes;
 
-    /// The call graph of the analyzed P4 program.
+    /// The call graph of the analyzed P4 program, if flag --dcg is set.
     const NodesCallGraph *callGraph;
 
  public:
@@ -21,7 +21,9 @@ class TestgenCompilerResult : public CompilerResult {
                                    P4::Coverage::CoverageSet coverableNodes,
                                    const NodesCallGraph *callGraph = nullptr);
 
-    /// @returns the call graph of the analyzed P4 program.
+    /// @returns the call graph of the analyzed P4 program, if flag --dcg is set.
+    /// If this function is called when the call graph is not set, if will throw an exception.
+    /// TODO: Replace this with std::nullopt?
     [[nodiscard]] const NodesCallGraph &getCallGraph() const;
 
     /// @returns the coverable nodes in the analyzed P4 program.

--- a/backends/p4tools/modules/testgen/core/compiler_target.h
+++ b/backends/p4tools/modules/testgen/core/compiler_target.h
@@ -1,0 +1,41 @@
+#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_COMPILER_TARGET_H_
+#define BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_COMPILER_TARGET_H_
+
+#include "backends/p4tools/common/compiler/compiler_target.h"
+#include "backends/p4tools/common/compiler/reachability.h"
+#include "midend/coverage.h"
+
+namespace P4Tools::P4Testgen {
+
+/// Extends the CompilerResult with the associated P4RuntimeApi
+class TestgenCompilerResult : public CompilerResult {
+ private:
+    /// The coverabled Nodes in the analyzed P4 program.
+    P4::Coverage::CoverageSet coverableNodes;
+
+    /// The call graph of the analyzed P4 program.
+    const NodesCallGraph *callGraph;
+
+ public:
+    explicit TestgenCompilerResult(CompilerResult compilerResult,
+                                   P4::Coverage::CoverageSet coverableNodes,
+                                   const NodesCallGraph *callGraph = nullptr);
+
+    /// @returns the call graph of the analyzed P4 program.
+    [[nodiscard]] const NodesCallGraph &getCallGraph() const;
+
+    /// @returns the coverable nodes in the analyzed P4 program.
+    [[nodiscard]] const P4::Coverage::CoverageSet &getCoverableNodes() const;
+};
+
+class TestgenCompilerTarget : public CompilerTarget {
+ protected:
+    explicit TestgenCompilerTarget(std::string deviceName, std::string archName);
+
+ private:
+    CompilerResultOrError runCompilerImpl(const IR::P4Program *program) const override;
+};
+
+}  // namespace P4Tools::P4Testgen
+
+#endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_CORE_COMPILER_TARGET_H_ */

--- a/backends/p4tools/modules/testgen/core/program_info.h
+++ b/backends/p4tools/modules/testgen/core/program_info.h
@@ -101,7 +101,7 @@ class ProgramInfo : public ICastable {
     /// @returns the P4 program associated with this ProgramInfo.
     [[nodiscard]] const IR::P4Program &getP4Program() const;
 
-    /// @returns the call graph associated with this ProgramInfo..
+    /// @returns the call graph associated with this ProgramInfo.
     [[nodiscard]] const NodesCallGraph &getCallGraph() const;
 
     /// Helper function to produce copy-in and copy-out helper calls.

--- a/backends/p4tools/modules/testgen/core/program_info.h
+++ b/backends/p4tools/modules/testgen/core/program_info.h
@@ -5,13 +5,13 @@
 #include <optional>
 #include <vector>
 
-#include "backends/p4tools/common/compiler/compiler_target.h"
 #include "backends/p4tools/common/compiler/reachability.h"
 #include "backends/p4tools/common/lib/arch_spec.h"
 #include "ir/ir.h"
 #include "lib/castable.h"
 #include "midend/coverage.h"
 
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
 
@@ -22,17 +22,14 @@ class ProgramInfo : public ICastable {
  private:
     /// The program info object stores the results of the compilation, which includes the P4 program
     /// and any information extracted from the program using static analysis.
-    std::reference_wrapper<const CompilerResult> compilerResult;
+    std::reference_wrapper<const TestgenCompilerResult> compilerResult;
 
  protected:
-    explicit ProgramInfo(const CompilerResult &compilerResult);
+    explicit ProgramInfo(const TestgenCompilerResult &compilerResult);
 
     /// The list of concolic methods implemented by the target. This list is assembled during
     /// initialization.
     ConcolicMethodImpls concolicMethodImpls;
-
-    /// Set of all visitable nodes in the input P4 program.
-    P4::Coverage::CoverageSet coverableNodes;
 
     /// The execution sequence of the P4 program.
     std::vector<Continuation::Command> pipelineSequence;
@@ -53,9 +50,6 @@ class ProgramInfo : public ICastable {
     ProgramInfo &operator=(ProgramInfo &&) = default;
 
     ~ProgramInfo() override = default;
-
-    /// The generated dcg.
-    const NodesCallGraph *dcg = nullptr;
 
     /// A vector that maps the architecture parameters of each pipe to the corresponding
     /// global architecture variables. For example, this map specifies which parameter of each pipe
@@ -102,9 +96,13 @@ class ProgramInfo : public ICastable {
 
     /// @returns a reference to the compiler result that this program info object was initialized
     /// with.
-    [[nodiscard]] const CompilerResult &getCompilerResult() const;
+    [[nodiscard]] virtual const TestgenCompilerResult &getCompilerResult() const;
 
+    /// @returns the P4 program associated with this ProgramInfo.
     [[nodiscard]] const IR::P4Program &getP4Program() const;
+
+    /// @returns the call graph associated with this ProgramInfo..
+    [[nodiscard]] const NodesCallGraph &getCallGraph() const;
 
     /// Helper function to produce copy-in and copy-out helper calls.
     /// Copy-in and copy-out is needed to correctly model the value changes of data when it is

--- a/backends/p4tools/modules/testgen/core/small_step/small_step.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/small_step.cpp
@@ -70,7 +70,7 @@ SmallStepEvaluator::SmallStepEvaluator(AbstractSolver &solver, const ProgramInfo
     : programInfo(programInfo), solver(solver) {
     if (!TestgenOptions::get().pattern.empty()) {
         reachabilityEngine =
-            new ReachabilityEngine(*programInfo.dcg, TestgenOptions::get().pattern, true);
+            new ReachabilityEngine(programInfo.getCallGraph(), TestgenOptions::get().pattern, true);
     }
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/bmv2.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/bmv2.cpp
@@ -1,6 +1,7 @@
 #include "backends/p4tools/modules/testgen/targets/bmv2/bmv2.h"
 
 #include <string>
+#include <utility>
 
 #include "backends/bmv2/common/annotations.h"
 #include "backends/p4tools/common/compiler/compiler_target.h"
@@ -10,17 +11,36 @@
 #include "frontends/common/options.h"
 #include "lib/cstring.h"
 
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
 #include "backends/p4tools/modules/testgen/options.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.h"
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
-BMv2V1ModelCompilerResult::BMv2V1ModelCompilerResult(const IR::P4Program &program,
-                                                     P4::P4RuntimeAPI p4runtimeApi)
-    : CompilerResult(program), p4runtimeApi(p4runtimeApi) {}
+BMv2V1ModelCompilerResult::BMv2V1ModelCompilerResult(
+    TestgenCompilerResult compilerResult, P4::P4RuntimeAPI p4runtimeApi,
+    std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap,
+    std::vector<std::vector<const IR::Expression *>> p4ConstraintsRestrictions)
+    : TestgenCompilerResult(std::move(compilerResult)),
+      p4runtimeApi(p4runtimeApi),
+      directExternMap(std::move(directExternMap)),
+      p4ConstraintsRestrictions(std::move(p4ConstraintsRestrictions)) {}
 
 const P4::P4RuntimeAPI &BMv2V1ModelCompilerResult::getP4RuntimeApi() const { return p4runtimeApi; }
 
-Bmv2V1ModelCompilerTarget::Bmv2V1ModelCompilerTarget() : CompilerTarget("bmv2", "v1model") {}
+std::vector<std::vector<const IR::Expression *>>
+BMv2V1ModelCompilerResult::getP4ConstraintsRestrictions() const {
+    return p4ConstraintsRestrictions;
+}
+
+const std::map<const IR::IDeclaration *, const IR::P4Table *>
+    &BMv2V1ModelCompilerResult::getDirectExternMap() const {
+    return directExternMap;
+}
+
+Bmv2V1ModelCompilerTarget::Bmv2V1ModelCompilerTarget() : TestgenCompilerTarget("bmv2", "v1model") {}
 
 void Bmv2V1ModelCompilerTarget::make() {
     static Bmv2V1ModelCompilerTarget *INSTANCE = nullptr;
@@ -35,6 +55,7 @@ CompilerResultOrError Bmv2V1ModelCompilerTarget::runCompilerImpl(
     if (program == nullptr) {
         return std::nullopt;
     }
+
     /// After the front end, get the P4Runtime API for the V1model architecture.
     auto p4runtimeApi = P4::P4RuntimeSerializer::get()->generateP4Runtime(program, "v1model");
 
@@ -43,7 +64,48 @@ CompilerResultOrError Bmv2V1ModelCompilerTarget::runCompilerImpl(
         return std::nullopt;
     }
 
-    return {*new BMv2V1ModelCompilerResult{*program, p4runtimeApi}};
+    // Create DCG.
+    NodesCallGraph *dcg = nullptr;
+    if (TestgenOptions::get().dcg || !TestgenOptions::get().pattern.empty()) {
+        dcg = new NodesCallGraph("NodesCallGraph");
+        P4ProgramDCGCreator dcgCreator(dcg);
+        program->apply(dcgCreator);
+    }
+    if (::errorCount() > 0) {
+        return std::nullopt;
+    }
+    /// Collect coverage information about the program.
+    auto coverage = P4::Coverage::CollectNodes(TestgenOptions::get().coverageOptions);
+    program->apply(coverage);
+    if (::errorCount() > 0) {
+        return std::nullopt;
+    }
+
+    // Vector containing pairs of restrictions and nodes to which these restrictions apply.
+    std::vector<std::vector<const IR::Expression *>> p4ConstraintsRestrictions;
+    // Defines all "entry_restriction" and then converts restrictions from string to IR
+    // expressions, and stores them in p4ConstraintsRestrictions to move targetConstraints further.
+    program->apply(AssertsParser::AssertsParser(p4ConstraintsRestrictions));
+    if (::errorCount() > 0) {
+        return std::nullopt;
+    }
+    // Defines all "refers_to" and then converts restrictions from string to IR expressions,
+    // and stores them in p4ConstraintsRestrictions to move targetConstraints further.
+    program->apply(RefersToParser::RefersToParser(p4ConstraintsRestrictions));
+    if (::errorCount() > 0) {
+        return std::nullopt;
+    }
+    // Try to map all instances of direct externs to the table they are attached to.
+    // Save the map in @var directExternMap.
+    auto directExternMapper = MapDirectExterns();
+    program->apply(directExternMapper);
+    if (::errorCount() > 0) {
+        return std::nullopt;
+    }
+
+    return {*new BMv2V1ModelCompilerResult{
+        TestgenCompilerResult(CompilerResult(*program), coverage.getCoverableNodes(), dcg),
+        p4runtimeApi, directExternMapper.getdirectExternMap(), p4ConstraintsRestrictions}};
 }
 
 MidEnd Bmv2V1ModelCompilerTarget::mkMidEnd(const CompilerOptions &options) const {

--- a/backends/p4tools/modules/testgen/targets/bmv2/bmv2.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/bmv2.cpp
@@ -19,10 +19,10 @@
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
-BMv2V1ModelCompilerResult::BMv2V1ModelCompilerResult(
-    TestgenCompilerResult compilerResult, P4::P4RuntimeAPI p4runtimeApi,
-    std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap,
-    std::vector<std::vector<const IR::Expression *>> p4ConstraintsRestrictions)
+BMv2V1ModelCompilerResult::BMv2V1ModelCompilerResult(TestgenCompilerResult compilerResult,
+                                                     P4::P4RuntimeAPI p4runtimeApi,
+                                                     DirectExternMap directExternMap,
+                                                     P4ConstraintsVector p4ConstraintsRestrictions)
     : TestgenCompilerResult(std::move(compilerResult)),
       p4runtimeApi(p4runtimeApi),
       directExternMap(std::move(directExternMap)),
@@ -30,13 +30,11 @@ BMv2V1ModelCompilerResult::BMv2V1ModelCompilerResult(
 
 const P4::P4RuntimeAPI &BMv2V1ModelCompilerResult::getP4RuntimeApi() const { return p4runtimeApi; }
 
-std::vector<std::vector<const IR::Expression *>>
-BMv2V1ModelCompilerResult::getP4ConstraintsRestrictions() const {
+P4ConstraintsVector BMv2V1ModelCompilerResult::getP4ConstraintsRestrictions() const {
     return p4ConstraintsRestrictions;
 }
 
-const std::map<const IR::IDeclaration *, const IR::P4Table *>
-    &BMv2V1ModelCompilerResult::getDirectExternMap() const {
+const DirectExternMap &BMv2V1ModelCompilerResult::getDirectExternMap() const {
     return directExternMap;
 }
 
@@ -82,16 +80,16 @@ CompilerResultOrError Bmv2V1ModelCompilerTarget::runCompilerImpl(
     }
 
     // Vector containing pairs of restrictions and nodes to which these restrictions apply.
-    std::vector<std::vector<const IR::Expression *>> p4ConstraintsRestrictions;
+    P4ConstraintsVector p4ConstraintsRestrictions;
     // Defines all "entry_restriction" and then converts restrictions from string to IR
     // expressions, and stores them in p4ConstraintsRestrictions to move targetConstraints further.
-    program->apply(AssertsParser::AssertsParser(p4ConstraintsRestrictions));
+    program->apply(AssertsParser(p4ConstraintsRestrictions));
     if (::errorCount() > 0) {
         return std::nullopt;
     }
     // Defines all "refers_to" and then converts restrictions from string to IR expressions,
     // and stores them in p4ConstraintsRestrictions to move targetConstraints further.
-    program->apply(RefersToParser::RefersToParser(p4ConstraintsRestrictions));
+    program->apply(RefersToParser(p4ConstraintsRestrictions));
     if (::errorCount() > 0) {
         return std::nullopt;
     }

--- a/backends/p4tools/modules/testgen/targets/bmv2/bmv2.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/bmv2.h
@@ -5,21 +5,43 @@
 #include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
 
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
+
 namespace P4Tools::P4Testgen::Bmv2 {
 
-/// Extends the CompilerResult with the associated P4RuntimeApi
-class BMv2V1ModelCompilerResult : public CompilerResult {
+/// Extends the CompilerResult with information specific to the V1Model running on BMv2.
+class BMv2V1ModelCompilerResult : public TestgenCompilerResult {
  private:
-    /// The runtimeAPI inferred from this particular BMv2 V1Model P4 program.
+    /// The P4RuntimeAPI inferred from this particular BMv2 V1Model P4 program.
     P4::P4RuntimeAPI p4runtimeApi;
 
- public:
-    explicit BMv2V1ModelCompilerResult(const IR::P4Program &program, P4::P4RuntimeAPI p4runtimeApi);
+    /// Map of direct extern declarations which are attached to a table.
+    std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap;
 
+    // Vector containing pairs of P4Constraints restrictions and nodes to which these restrictions
+    // apply.
+    std::vector<std::vector<const IR::Expression *>> p4ConstraintsRestrictions;
+
+ public:
+    explicit BMv2V1ModelCompilerResult(
+        TestgenCompilerResult compilerResult, P4::P4RuntimeAPI p4runtimeApi,
+        std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap,
+        std::vector<std::vector<const IR::Expression *>> p4ConstraintsRestrictions);
+
+    /// @returns the P4RuntimeAPI inferred from this particular BMv2 V1Model P4 program.
     [[nodiscard]] const P4::P4RuntimeAPI &getP4RuntimeApi() const;
+
+    /// @returns the vector of pairs of P4Constraints restrictions and nodes to which these
+    // apply.
+    [[nodiscard]] std::vector<std::vector<const IR::Expression *>> getP4ConstraintsRestrictions()
+        const;
+
+    /// @returns the map of direct extern declarations which are attached to a table.
+    [[nodiscard]] const std::map<const IR::IDeclaration *, const IR::P4Table *>
+        &getDirectExternMap() const;
 };
 
-class Bmv2V1ModelCompilerTarget : public CompilerTarget {
+class Bmv2V1ModelCompilerTarget : public TestgenCompilerTarget {
  public:
     /// Registers this target.
     static void make();

--- a/backends/p4tools/modules/testgen/targets/bmv2/bmv2.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/bmv2.h
@@ -6,6 +6,8 @@
 #include "frontends/common/options.h"
 
 #include "backends/p4tools/modules/testgen/core/compiler_target.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.h"
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
@@ -16,29 +18,27 @@ class BMv2V1ModelCompilerResult : public TestgenCompilerResult {
     P4::P4RuntimeAPI p4runtimeApi;
 
     /// Map of direct extern declarations which are attached to a table.
-    std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap;
+    DirectExternMap directExternMap;
 
-    // Vector containing pairs of P4Constraints restrictions and nodes to which these restrictions
+    // Vector containing vectors of P4Constraints restrictions and nodes to which these restrictions
     // apply.
-    std::vector<std::vector<const IR::Expression *>> p4ConstraintsRestrictions;
+    P4ConstraintsVector p4ConstraintsRestrictions;
 
  public:
-    explicit BMv2V1ModelCompilerResult(
-        TestgenCompilerResult compilerResult, P4::P4RuntimeAPI p4runtimeApi,
-        std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap,
-        std::vector<std::vector<const IR::Expression *>> p4ConstraintsRestrictions);
+    explicit BMv2V1ModelCompilerResult(TestgenCompilerResult compilerResult,
+                                       P4::P4RuntimeAPI p4runtimeApi,
+                                       DirectExternMap directExternMap,
+                                       P4ConstraintsVector p4ConstraintsRestrictions);
 
     /// @returns the P4RuntimeAPI inferred from this particular BMv2 V1Model P4 program.
     [[nodiscard]] const P4::P4RuntimeAPI &getP4RuntimeApi() const;
 
     /// @returns the vector of pairs of P4Constraints restrictions and nodes to which these
     // apply.
-    [[nodiscard]] std::vector<std::vector<const IR::Expression *>> getP4ConstraintsRestrictions()
-        const;
+    [[nodiscard]] P4ConstraintsVector getP4ConstraintsRestrictions() const;
 
     /// @returns the map of direct extern declarations which are attached to a table.
-    [[nodiscard]] const std::map<const IR::IDeclaration *, const IR::P4Table *>
-        &getDirectExternMap() const;
+    [[nodiscard]] const DirectExternMap &getDirectExternMap() const;
 };
 
 class Bmv2V1ModelCompilerTarget : public TestgenCompilerTarget {

--- a/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.cpp
@@ -41,9 +41,6 @@ bool MapDirectExterns::preorder(const IR::P4Table *table) {
     return true;
 }
 
-const std::map<const IR::IDeclaration *, const IR::P4Table *>
-    &MapDirectExterns::getdirectExternMap() {
-    return directExternMap;
-}
+const DirectExternMap &MapDirectExterns::getdirectExternMap() { return directExternMap; }
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h
@@ -8,6 +8,9 @@
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
+/// A map of direct extern declarations which are attached to a table.
+using DirectExternMap = std::map<const IR::IDeclaration *, const IR::P4Table *>;
+
 /// A lightweight visitor, which collects all the declarations in the program then checks whether a
 /// table is referencing the declaration as an direct extern. The direct externs are collected in a
 /// map. Currently checks for "counters" or "meters" properties in the table.
@@ -17,7 +20,7 @@ class MapDirectExterns : public Inspector {
     std::map<cstring, const IR::Declaration_Instance *> declaredExterns;
 
     /// Maps direct extern declarations to the table they are attached to.
-    std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap;
+    DirectExternMap directExternMap;
 
  public:
     bool preorder(const IR::Declaration_Instance *declInstance) override;

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
@@ -16,7 +16,7 @@
 #include "lib/error.h"
 #include "lib/exceptions.h"
 
-namespace P4Tools::AssertsParser {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 static const std::vector<std::string> NAMES{
     "Priority",    "Text",           "True",         "False",       "LineStatementClose",
@@ -28,8 +28,7 @@ static const std::vector<std::string> NAMES{
     "Mul",         "Comment",        "Unknown",      "EndString",   "End",
 };
 
-AssertsParser::AssertsParser(std::vector<std::vector<const IR::Expression *>> &output)
-    : restrictionsVec(output) {
+AssertsParser::AssertsParser(P4ConstraintsVector &output) : restrictionsVec(output) {
     setName("Restrictions");
 }
 
@@ -655,4 +654,4 @@ Token Lexer::next() noexcept {
             return atom(Token::Kind::Mul);
     }
 }
-}  // namespace P4Tools::AssertsParser
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.h
@@ -12,13 +12,15 @@
 #include "ir/visitor.h"
 #include "lib/cstring.h"
 
-namespace P4Tools::AssertsParser {
+namespace P4Tools::P4Testgen::Bmv2 {
+
+using P4ConstraintsVector = std::vector<std::vector<const IR::Expression *>>;
 
 class AssertsParser : public Transform {
-    std::vector<std::vector<const IR::Expression *>> &restrictionsVec;
+    P4ConstraintsVector &restrictionsVec;
 
  public:
-    explicit AssertsParser(std::vector<std::vector<const IR::Expression *>> &output);
+    explicit AssertsParser(P4ConstraintsVector &output);
     /// A function that calls the beginning of the transformation of restrictions from a string into
     /// an IR::Expression. Internally calls all other necessary functions, for example
     /// combineTokensToNames and the like, to eventually get an IR expression that meets the string
@@ -112,6 +114,6 @@ class Lexer {
     char prev() noexcept;
     char get() noexcept;
 };
-}  // namespace P4Tools::AssertsParser
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_P4_ASSERTS_PARSER_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.cpp
@@ -14,7 +14,7 @@
 #include "lib/exceptions.h"
 #include "lib/null.h"
 
-namespace P4Tools::RefersToParser {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 RefersToParser::RefersToParser(std::vector<std::vector<const IR::Expression *>> &output)
     : restrictionsVec(output) {
@@ -120,4 +120,4 @@ bool RefersToParser::preorder(const IR::P4Table *table) {
     return false;
 }
 
-}  // namespace P4Tools::RefersToParser
+}  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.h
@@ -6,7 +6,7 @@
 #include "ir/ir.h"
 #include "ir/visitor.h"
 
-namespace P4Tools::RefersToParser {
+namespace P4Tools::P4Testgen::Bmv2 {
 
 class RefersToParser : public Inspector {
     std::vector<std::vector<const IR::Expression *>> &restrictionsVec;
@@ -24,6 +24,6 @@ class RefersToParser : public Inspector {
     explicit RefersToParser(std::vector<std::vector<const IR::Expression *>> &output);
 };
 
-}  // namespace P4Tools::RefersToParser
+}  // namespace P4Tools::P4Testgen::Bmv2
 
 #endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_P4_REFERS_TO_PARSER_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -25,18 +25,16 @@
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
 #include "backends/p4tools/modules/testgen/lib/packet_vars.h"
 #include "backends/p4tools/modules/testgen/options.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/bmv2.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/concolic.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/constants.h"
-#include "backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h"
-#include "backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.h"
-#include "backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.h"
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
 const IR::Type_Bits Bmv2V1ModelProgramInfo::PARSER_ERR_BITS = IR::Type_Bits(32, false);
 
 Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(
-    const CompilerResult &compilerResult,
+    const BMv2V1ModelCompilerResult &compilerResult,
     ordered_map<cstring, const IR::Type_Declaration *> inputBlocks,
     std::map<int, int> declIdToGress)
     : ProgramInfo(compilerResult),
@@ -76,25 +74,12 @@ Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(
     const IR::Expression *constraint =
         new IR::Grt(IR::Type::Boolean::get(), ExecutionState::getInputPacketSizeVar(),
                     IR::getConstant(&PacketVars::PACKET_SIZE_VAR_TYPE, minPktSize));
-    // Vector containing pairs of restrictions and nodes to which these restrictions apply.
-    std::vector<std::vector<const IR::Expression *>> restrictionsVec;
-    // Defines all "entry_restriction" and then converts restrictions from string to IR
-    // expressions, and stores them in restrictionsVec to move targetConstraints further.
-    compilerResult.getProgram().apply(AssertsParser::AssertsParser(restrictionsVec));
-    // Defines all "refers_to" and then converts restrictions from string to IR expressions,
-    // and stores them in restrictionsVec to move targetConstraints further.
-    compilerResult.getProgram().apply(RefersToParser::RefersToParser(restrictionsVec));
-    for (const auto &element : restrictionsVec) {
+
+    for (const auto &element : compilerResult.getP4ConstraintsRestrictions()) {
         for (const auto *restriction : element) {
             constraint = new IR::LAnd(constraint, restriction);
         }
     }
-    // Try to map all instances of direct externs to the table they are attached to.
-    // Save the map in @var directExternMap.
-    auto directExternMapper = MapDirectExterns();
-    compilerResult.getProgram().apply(directExternMapper);
-    auto mappedDirectExterns = directExternMapper.getdirectExternMap();
-    directExternMap.insert(mappedDirectExterns.begin(), mappedDirectExterns.end());
 
     /// Finally, set the target constraints.
     targetConstraints = constraint;
@@ -102,6 +87,7 @@ Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(
 
 const IR::P4Table *Bmv2V1ModelProgramInfo::getTableofDirectExtern(
     const IR::IDeclaration *directExternDecl) const {
+    const auto &directExternMap = getCompilerResult().getDirectExternMap();
     auto it = directExternMap.find(directExternDecl);
     if (it == directExternMap.end()) {
         BUG("No table associated with this direct extern %1%. The extern should have been removed.",
@@ -240,6 +226,10 @@ const IR::PathExpression *Bmv2V1ModelProgramInfo::getBlockParam(cstring blockLab
     auto archIndex = archSpec.getBlockIndex(blockLabel);
     auto archRef = archSpec.getParamName(archIndex, paramIndex);
     return new IR::PathExpression(paramType, new IR::Path(archRef));
+}
+
+const BMv2V1ModelCompilerResult &Bmv2V1ModelProgramInfo::getCompilerResult() const {
+    return *ProgramInfo::getCompilerResult().checkedTo<BMv2V1ModelCompilerResult>();
 }
 
 const IR::Member *Bmv2V1ModelProgramInfo::getParserParamVar(const IR::P4Parser *parser,

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.h
@@ -11,6 +11,7 @@
 
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/bmv2.h"
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
@@ -31,11 +32,8 @@ class Bmv2V1ModelProgramInfo : public ProgramInfo {
     std::vector<Continuation::Command> processDeclaration(const IR::Type_Declaration *typeDecl,
                                                           size_t blockIdx) const;
 
-    /// Map of direct extern declarations which are attached to a table.
-    std::map<const IR::IDeclaration *, const IR::P4Table *> directExternMap;
-
  public:
-    Bmv2V1ModelProgramInfo(const CompilerResult &compilerResult,
+    Bmv2V1ModelProgramInfo(const BMv2V1ModelCompilerResult &compilerResult,
                            ordered_map<cstring, const IR::Type_Declaration *> inputBlocks,
                            std::map<int, int> declIdToGress);
 
@@ -69,6 +67,8 @@ class Bmv2V1ModelProgramInfo : public ProgramInfo {
     [[nodiscard]] const IR::Expression *dropIsActive() const override;
 
     [[nodiscard]] const IR::Type_Bits *getParserErrorType() const override;
+
+    [[nodiscard]] const BMv2V1ModelCompilerResult &getCompilerResult() const override;
 
     /// @returns the Member variable corresponding to the parameter index for the given parameter.
     /// The Member variable uses the parameter struct label as parent and the @param paramLabel as

--- a/backends/p4tools/modules/testgen/targets/bmv2/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/target.cpp
@@ -15,6 +15,7 @@
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/execution_state.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/bmv2.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/constants.h"
 #include "backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.h"
@@ -65,7 +66,8 @@ const Bmv2V1ModelProgramInfo *Bmv2V1ModelTestgenTarget::produceProgramInfoImpl(
         }
     }
 
-    return new Bmv2V1ModelProgramInfo(compilerResult, programmableBlocks, declIdToGress);
+    return new Bmv2V1ModelProgramInfo(*compilerResult.checkedTo<BMv2V1ModelCompilerResult>(),
+                                      programmableBlocks, declIdToGress);
 }
 
 Bmv2TestBackend *Bmv2V1ModelTestgenTarget::getTestBackendImpl(

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/p4_asserts_parser_test.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/p4_asserts_parser_test.cpp
@@ -77,9 +77,9 @@ Restrictions loadExample(const char *curFile, bool flag) {
     program = program->apply(midEnd);
     Restrictions result;
     if (flag) {
-        program->apply(P4Tools::AssertsParser::AssertsParser(result));
+        program->apply(P4Tools::P4Testgen::Bmv2::AssertsParser(result));
     } else {
-        program->apply(P4Tools::RefersToParser::RefersToParser(result));
+        program->apply(P4Tools::P4Testgen::Bmv2::RefersToParser(result));
     }
     return result;
 }

--- a/backends/p4tools/modules/testgen/targets/ebpf/ebpf.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/ebpf.cpp
@@ -2,13 +2,12 @@
 
 #include <string>
 
-#include "backends/p4tools/common/compiler/compiler_target.h"
 #include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
 
 namespace P4Tools::P4Testgen::EBPF {
 
-EBPFCompilerTarget::EBPFCompilerTarget() : CompilerTarget("ebpf", "ebpf") {}
+EBPFCompilerTarget::EBPFCompilerTarget() : TestgenCompilerTarget("ebpf", "ebpf") {}
 
 void EBPFCompilerTarget::make() {
     static EBPFCompilerTarget *INSTANCE = nullptr;

--- a/backends/p4tools/modules/testgen/targets/ebpf/ebpf.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/ebpf.h
@@ -1,13 +1,14 @@
 #ifndef TESTGEN_TARGETS_EBPF_EBPF_H_
 #define TESTGEN_TARGETS_EBPF_EBPF_H_
 
-#include "backends/p4tools/common/compiler/compiler_target.h"
 #include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
 
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
+
 namespace P4Tools::P4Testgen::EBPF {
 
-class EBPFCompilerTarget : public CompilerTarget {
+class EBPFCompilerTarget : public TestgenCompilerTarget {
  public:
     /// Registers this target.
     static void make();

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
@@ -18,6 +18,7 @@
 #include "lib/exceptions.h"
 
 #include "backends/p4tools/modules/testgen//lib/exceptions.h"
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
@@ -31,7 +32,7 @@ namespace P4Tools::P4Testgen::EBPF {
 
 const IR::Type_Bits EBPFProgramInfo::PARSER_ERR_BITS = IR::Type_Bits(32, false);
 
-EBPFProgramInfo::EBPFProgramInfo(const CompilerResult &compilerResult,
+EBPFProgramInfo::EBPFProgramInfo(const TestgenCompilerResult &compilerResult,
                                  ordered_map<cstring, const IR::Type_Declaration *> inputBlocks)
     : ProgramInfo(compilerResult), programmableBlocks(std::move(inputBlocks)) {
     concolicMethodImpls.add(*EBPFConcolic::getEBPFConcolicMethodImpls());

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.h
@@ -1,8 +1,6 @@
 #ifndef TESTGEN_TARGETS_EBPF_PROGRAM_INFO_H_
 #define TESTGEN_TARGETS_EBPF_PROGRAM_INFO_H_
 
-#include <stddef.h>
-
 #include <vector>
 
 #include "ir/ir.h"
@@ -29,7 +27,7 @@ class EBPFProgramInfo : public ProgramInfo {
                                                           size_t blockIdx) const;
 
  public:
-    EBPFProgramInfo(const CompilerResult &compilerResult,
+    EBPFProgramInfo(const TestgenCompilerResult &compilerResult,
                     ordered_map<cstring, const IR::Type_Declaration *> inputBlocks);
 
     /// @see ProgramInfo::getArchSpec

--- a/backends/p4tools/modules/testgen/targets/ebpf/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/target.cpp
@@ -12,6 +12,7 @@
 #include "lib/exceptions.h"
 #include "lib/ordered_map.h"
 
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
@@ -65,7 +66,8 @@ const EBPFProgramInfo *EBPFTestgenTarget::produceProgramInfoImpl(
         testgenOptions.maxPktSize = 12000;
     }
 
-    return new EBPFProgramInfo(compilerResult, programmableBlocks);
+    return new EBPFProgramInfo(*compilerResult.checkedTo<TestgenCompilerResult>(),
+                               programmableBlocks);
 }
 
 EBPFTestBackend *EBPFTestgenTarget::getTestBackendImpl(

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
@@ -12,6 +12,7 @@
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/concolic.h"
 #include "backends/p4tools/modules/testgen/lib/continuation.h"
@@ -22,7 +23,7 @@
 namespace P4Tools::P4Testgen::Pna {
 
 PnaDpdkProgramInfo::PnaDpdkProgramInfo(
-    const CompilerResult &compilerResult,
+    const TestgenCompilerResult &compilerResult,
     ordered_map<cstring, const IR::Type_Declaration *> inputBlocks)
     : SharedPnaProgramInfo(compilerResult, std::move(inputBlocks)) {
     concolicMethodImpls.add(*PnaDpdkConcolic::getPnaDpdkConcolicMethodImpls());

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.h
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.h
@@ -21,7 +21,7 @@ class PnaDpdkProgramInfo : public SharedPnaProgramInfo {
                                                           size_t blockIdx) const;
 
  public:
-    PnaDpdkProgramInfo(const CompilerResult &compilerResult,
+    PnaDpdkProgramInfo(const TestgenCompilerResult &compilerResult,
                        ordered_map<cstring, const IR::Type_Declaration *> inputBlocks);
 
     /// @see ProgramInfo::getArchSpec

--- a/backends/p4tools/modules/testgen/targets/pna/pna.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/pna.cpp
@@ -2,13 +2,12 @@
 
 #include <string>
 
-#include "backends/p4tools/common/compiler/compiler_target.h"
 #include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
 
 namespace P4Tools::P4Testgen::Pna {
 
-PnaDpdkCompilerTarget::PnaDpdkCompilerTarget() : CompilerTarget("dpdk", "pna") {}
+PnaDpdkCompilerTarget::PnaDpdkCompilerTarget() : TestgenCompilerTarget("dpdk", "pna") {}
 
 void PnaDpdkCompilerTarget::make() {
     static PnaDpdkCompilerTarget *INSTANCE = nullptr;

--- a/backends/p4tools/modules/testgen/targets/pna/pna.h
+++ b/backends/p4tools/modules/testgen/targets/pna/pna.h
@@ -1,15 +1,16 @@
 #ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_PNA_PNA_H_
 #define BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_PNA_PNA_H_
 
-#include "backends/p4tools/common/compiler/compiler_target.h"
 #include "backends/p4tools/common/compiler/midend.h"
 #include "frontends/common/options.h"
+
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
 
 namespace P4Tools::P4Testgen {
 
 namespace Pna {
 
-class PnaDpdkCompilerTarget : public CompilerTarget {
+class PnaDpdkCompilerTarget : public TestgenCompilerTarget {
  public:
     /// Registers this target.
     static void make();

--- a/backends/p4tools/modules/testgen/targets/pna/shared_program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_program_info.cpp
@@ -21,7 +21,7 @@ namespace P4Tools::P4Testgen::Pna {
 const IR::Type_Bits SharedPnaProgramInfo::PARSER_ERR_BITS = IR::Type_Bits(32, false);
 
 SharedPnaProgramInfo::SharedPnaProgramInfo(
-    const CompilerResult &compilerResult,
+    const TestgenCompilerResult &compilerResult,
     ordered_map<cstring, const IR::Type_Declaration *> inputBlocks)
     : ProgramInfo(compilerResult), programmableBlocks(std::move(inputBlocks)) {
     concolicMethodImpls.add(*PnaDpdkConcolic::getPnaDpdkConcolicMethodImpls());

--- a/backends/p4tools/modules/testgen/targets/pna/shared_program_info.h
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_program_info.h
@@ -20,7 +20,7 @@ class SharedPnaProgramInfo : public ProgramInfo {
     static const IR::Type_Bits PARSER_ERR_BITS;
 
  public:
-    SharedPnaProgramInfo(const CompilerResult &compilerResult,
+    SharedPnaProgramInfo(const TestgenCompilerResult &compilerResult,
                          ordered_map<cstring, const IR::Type_Declaration *> inputBlocks);
 
     /// @returns the programmable blocks of the program.

--- a/backends/p4tools/modules/testgen/targets/pna/target.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/target.cpp
@@ -10,6 +10,7 @@
 #include "lib/exceptions.h"
 #include "lib/ordered_map.h"
 
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
@@ -55,7 +56,8 @@ const PnaDpdkProgramInfo *PnaDpdkTestgenTarget::produceProgramInfoImpl(
         programmableBlocks.emplace(canonicalName, declType);
     }
 
-    return new PnaDpdkProgramInfo(compilerResult, programmableBlocks);
+    return new PnaDpdkProgramInfo(*compilerResult.checkedTo<TestgenCompilerResult>(),
+                                  programmableBlocks);
 }
 
 PnaTestBackend *PnaDpdkTestgenTarget::getTestBackendImpl(

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -13,6 +13,7 @@
 #include "lib/cstring.h"
 #include "lib/error.h"
 
+#include "backends/p4tools/modules/testgen/core/compiler_target.h"
 #include "backends/p4tools/modules/testgen/core/program_info.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/depth_first.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/greedy_node_cov.h"
@@ -95,7 +96,10 @@ int Testgen::mainImpl(const CompilerResult &compilerResult) {
     // These are discovered by CMAKE, which fills out the register.h.in file.
     registerTestgenTargets();
 
-    const auto *programInfo = TestgenTarget::produceProgramInfo(compilerResult);
+    // Make sure the input result corresponds to the result we expect.
+    const auto *testgenCompilerResult = compilerResult.checkedTo<TestgenCompilerResult>();
+
+    const auto *programInfo = TestgenTarget::produceProgramInfo(*testgenCompilerResult);
     if (programInfo == nullptr) {
         ::error("Program not supported by target device and architecture.");
         return EXIT_FAILURE;


### PR DESCRIPTION
Builds on top of #4323 and  #4324. Now that we have the CompilerResults structure and it is a part of the ProgramInfo, we can move some computation out of the ProgramInfo class into the compilation stage. This way we can also fail early, if errors occur.  Examples include the reachability analysis, collecting externs and constraints for BMv2, or collecting coverage information. 

This PR also adds a testgen compiler target, which collects information common to all P4Testgen targets. 