### PR TITLE
Fix initialization order in gtest helper

### DIFF
--- a/test/gtest/helpers.h
+++ b/test/gtest/helpers.h
@@ -149,8 +149,8 @@ struct RedirectStderr {
     }
 
  private:
-    std::streambuf *old = nullptr;
     std::stringstream stream;
+    std::streambuf *old = nullptr;
 };
 
 }  // namespace Test


### PR DESCRIPTION
In #4287 I've accidentally create use of unitialized value in test because of initialization order of the `RedirectStderr`. This fixes it by making sure the stringstream is initialized first.