### PR TITLE
[P4Testgen] Fix stringliteral conversion. Value must be a literal, NOT a constant

### DIFF
--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <exception>
 #include <iterator>
-#include <list>
 #include <map>
 #include <string>
 #include <utility>
@@ -539,7 +538,7 @@ bool Z3Translator::preorder(const IR::BoolLiteral *boolLiteral) {
 }
 
 bool Z3Translator::preorder(const IR::StringLiteral *stringLiteral) {
-    result = solver.ctx().string_const(stringLiteral->value);
+    result = solver.ctx().string_val(stringLiteral->value);
     return false;
 }
 

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -52,6 +52,7 @@ set(
   test/lib/format_int.cpp
   test/lib/taint.cpp
   test/small-step/util.cpp
+  test/z3-solver/constraints.cpp
 )
 
 # Inja is needed to produce test templates.

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/expressions.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/expressions.cpp
@@ -6,9 +6,7 @@
 #include <vector>
 
 #include "backends/p4tools/common/core/z3_solver.h"
-#include "backends/p4tools/common/lib/model.h"
 #include "ir/declaration.h"
-#include "ir/indexed_vector.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 #include "lib/enumerator.h"
@@ -19,7 +17,6 @@
 
 namespace Test {
 
-using P4Tools::Model;
 using P4Tools::Z3Solver;
 using P4Tools::P4Testgen::TestgenTarget;
 using Value = IR::Literal;

--- a/backends/p4tools/modules/testgen/test/z3-solver/constraints.cpp
+++ b/backends/p4tools/modules/testgen/test/z3-solver/constraints.cpp
@@ -1,0 +1,191 @@
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <vector>
+
+#include "backends/p4tools/common/core/z3_solver.h"
+#include "backends/p4tools/common/lib/variables.h"
+#include "ir/ir-generated.h"
+#include "ir/ir.h"
+#include "ir/irutils.h"
+#include "lib/cstring.h"
+
+namespace Test {
+using ConstraintVector = const std::vector<const Constraint *>;
+
+class Z3SolverSatisfiabilityChecks : public ::testing::Test {
+    P4Tools::Z3Solver solver;
+
+ public:
+    /// Checks whether the result of the solver calculating @param expression matches @param
+    /// expectedResult.
+    void testCheckSat(const ConstraintVector &expression, std::optional<bool> expectedResult) {
+        auto result = solver.checkSat(expression);
+        EXPECT_EQ(result, expectedResult);
+    }
+};
+
+TEST_F(Z3SolverSatisfiabilityChecks, BitVectors) {
+    const auto *eightBitType = IR::getBitType(8);
+    const auto *fooVar = P4Tools::ToolsVariables::getSymbolicVariable(eightBitType, "foo");
+    const auto *barVar = P4Tools::ToolsVariables::getSymbolicVariable(eightBitType, "bar");
+    {
+        auto *expression =
+            new IR::Equ(IR::getConstant(eightBitType, 1), IR::getConstant(eightBitType, 1));
+        ConstraintVector inputExpression = {expression};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression =
+            new IR::Equ(IR::getConstant(eightBitType, 1), IR::getConstant(eightBitType, 2));
+        ConstraintVector inputExpression = {expression};
+        testCheckSat(inputExpression, false);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        ConstraintVector inputExpression = {expression};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        ConstraintVector inputExpression = {expression, constraint1};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, barVar);
+        auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        ConstraintVector inputExpression = {expression, constraint1};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, barVar);
+        auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        auto *constraint2 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        ConstraintVector inputExpression = {expression, constraint1, constraint2};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 2));
+        ConstraintVector inputExpression = {expression, constraint1};
+        testCheckSat(inputExpression, false);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, barVar);
+        auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        auto *constraint2 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 2));
+        ConstraintVector inputExpression = {expression, constraint1, constraint2};
+        testCheckSat(inputExpression, false);
+    }
+}
+
+TEST_F(Z3SolverSatisfiabilityChecks, Strings) {
+    const auto *stringType = IR::Type_String::get();
+    const auto *fooVar = P4Tools::ToolsVariables::getSymbolicVariable(stringType, "foo");
+    const auto *barVar = P4Tools::ToolsVariables::getSymbolicVariable(stringType, "bar");
+    {
+        auto *expression = new IR::Equ(new IR::StringLiteral(stringType, "dead"),
+                                       new IR::StringLiteral(stringType, "dead"));
+        ConstraintVector inputExpression = {expression};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(new IR::StringLiteral(stringType, "dead"),
+                                       new IR::StringLiteral(stringType, "beef"));
+        ConstraintVector inputExpression = {expression};
+        testCheckSat(inputExpression, false);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        ConstraintVector inputExpression = {expression};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        ConstraintVector inputExpression = {expression, constraint1};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, barVar);
+        auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        ConstraintVector inputExpression = {expression, constraint1};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, barVar);
+        auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        auto *constraint2 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        ConstraintVector inputExpression = {expression, constraint1, constraint2};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "beef"));
+        ConstraintVector inputExpression = {expression, constraint1};
+        testCheckSat(inputExpression, false);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, barVar);
+        auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        auto *constraint2 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "beef"));
+        ConstraintVector inputExpression = {expression, constraint1, constraint2};
+        testCheckSat(inputExpression, false);
+    }
+}
+
+TEST_F(Z3SolverSatisfiabilityChecks, Bools) {
+    const auto *boolType = IR::Type_Boolean::get();
+    const auto *fooVar = P4Tools::ToolsVariables::getSymbolicVariable(boolType, "foo");
+    const auto *barVar = P4Tools::ToolsVariables::getSymbolicVariable(boolType, "bar");
+    {
+        auto *expression = new IR::Equ(IR::getBoolLiteral(true), IR::getBoolLiteral(true));
+        ConstraintVector inputExpression = {expression};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(IR::getBoolLiteral(true), IR::getBoolLiteral(false));
+        ConstraintVector inputExpression = {expression};
+        testCheckSat(inputExpression, false);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        ConstraintVector inputExpression = {expression};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        ConstraintVector inputExpression = {expression, constraint1};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, barVar);
+        auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        ConstraintVector inputExpression = {expression, constraint1};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, barVar);
+        auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        auto *constraint2 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        ConstraintVector inputExpression = {expression, constraint1, constraint2};
+        testCheckSat(inputExpression, true);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(false));
+        ConstraintVector inputExpression = {expression, constraint1};
+        testCheckSat(inputExpression, false);
+    }
+    {
+        auto *expression = new IR::Equ(fooVar, barVar);
+        auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        auto *constraint2 = new IR::Equ(fooVar, IR::getBoolLiteral(false));
+        ConstraintVector inputExpression = {expression, constraint1, constraint2};
+        testCheckSat(inputExpression, false);
+    }
+}
+
+}  // namespace Test

--- a/backends/p4tools/modules/testgen/test/z3-solver/constraints.cpp
+++ b/backends/p4tools/modules/testgen/test/z3-solver/constraints.cpp
@@ -61,7 +61,7 @@ TEST_F(Z3SolverSatisfiabilityChecks, BitVectors) {
     {
         auto *expression = new IR::Equ(fooVar, barVar);
         auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
-        auto *constraint2 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        auto *constraint2 = new IR::Equ(barVar, IR::getConstant(eightBitType, 1));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, true);
     }
@@ -74,7 +74,7 @@ TEST_F(Z3SolverSatisfiabilityChecks, BitVectors) {
     {
         auto *expression = new IR::Equ(fooVar, barVar);
         auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
-        auto *constraint2 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 2));
+        auto *constraint2 = new IR::Equ(barVar, IR::getConstant(eightBitType, 2));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, false);
     }
@@ -116,7 +116,7 @@ TEST_F(Z3SolverSatisfiabilityChecks, Strings) {
     {
         auto *expression = new IR::Equ(fooVar, barVar);
         auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
-        auto *constraint2 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        auto *constraint2 = new IR::Equ(barVar, new IR::StringLiteral(stringType, "dead"));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, true);
     }
@@ -129,7 +129,7 @@ TEST_F(Z3SolverSatisfiabilityChecks, Strings) {
     {
         auto *expression = new IR::Equ(fooVar, barVar);
         auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
-        auto *constraint2 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "beef"));
+        auto *constraint2 = new IR::Equ(barVar, new IR::StringLiteral(stringType, "beef"));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, false);
     }
@@ -169,7 +169,7 @@ TEST_F(Z3SolverSatisfiabilityChecks, Bools) {
     {
         auto *expression = new IR::Equ(fooVar, barVar);
         auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
-        auto *constraint2 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        auto *constraint2 = new IR::Equ(barVar, IR::getBoolLiteral(true));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, true);
     }
@@ -182,7 +182,7 @@ TEST_F(Z3SolverSatisfiabilityChecks, Bools) {
     {
         auto *expression = new IR::Equ(fooVar, barVar);
         auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
-        auto *constraint2 = new IR::Equ(fooVar, IR::getBoolLiteral(false));
+        auto *constraint2 = new IR::Equ(barVar, IR::getBoolLiteral(false));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, false);
     }


### PR DESCRIPTION
Quite the subtle issue I ran into. In the Z3 solver, string_constants are not constants but functions. We need to assign a value instead to get the correct semantic behavior. Otherwise, the solver can freely assign a value to the function. 
