### PR TITLE
Remove uses of `incompatible_use_toolchain_transition`.

### DIFF
--- a/bazel/p4_library.bzl
+++ b/bazel/p4_library.bzl
@@ -172,7 +172,6 @@ p4_library = rule(
         ),
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = use_cpp_toolchain(),
 )
 
@@ -253,6 +252,5 @@ p4_graphs = rule(
         ),
         "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = use_cpp_toolchain(),
 )


### PR DESCRIPTION
Now that Bazel 7.0 has been released, it's time to remove this tech debt.

This has been a no-op since Bazel 5.0, I've been waiting to remove the code for two years, it's time.

Part of https://github.com/bazelbuild/bazel/issues/14127.