### PR TITLE
Dpdk Backend: Fix incorrect field extraction arithmetic

### DIFF
--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -553,8 +553,8 @@ const IR::Node *AlignHdrMetaField::preorder(IR::Type_StructLike *st) {
                 fieldObj.headerStr = st->name.name;
                 fieldObj.modifiedWidth = size_sum_so_far;
                 fieldObj.fieldWidth = s->second.fieldWidth;
-                fieldObj.lsb = offset;
-                fieldObj.msb = offset + s->second.fieldWidth - 1;
+                fieldObj.lsb = size_sum_so_far - (offset + fieldObj.fieldWidth);
+                fieldObj.msb = fieldObj.lsb + s->second.fieldWidth - 1;
                 fieldObj.offset = offset;
                 structure->hdrFieldInfoList[s->first].push_back(fieldObj);
                 offset += s->second.fieldWidth;
@@ -620,8 +620,7 @@ const IR::Node *AlignHdrMetaField::preorder(IR::Member *m) {
                two different headers have field with same name */
             if (memVec.headerStr != hdrStrName) continue;
             auto mem = new IR::Member(m->expr, IR::ID(memVec.modifiedName));
-            auto sliceMem =
-                new IR::Slice(mem->clone(), (memVec.offset + memVec.fieldWidth - 1), memVec.offset);
+            auto sliceMem = new IR::Slice(mem->clone(), memVec.msb, memVec.lsb);
             return sliceMem;
         }
     }

--- a/testdata/p4_16_samples/pna-dpdk-parser-wrong-arith.p4
+++ b/testdata/p4_16_samples/pna-dpdk-parser-wrong-arith.p4
@@ -1,0 +1,134 @@
+/*
+Copyright 2023 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "dpdk/pna.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct user_metadata_t {
+    bit<1> ipv4_hdr_truncated;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t ipv4;
+}
+
+control PreControlImpl(
+    in    headers_t  hdr,
+    inout user_metadata_t meta,
+    in    pna_pre_input_metadata_t  istd,
+    inout pna_pre_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+parser MainParserImpl(
+    packet_in pkt,
+    out   headers_t       hdr,
+    inout user_metadata_t user_meta,
+    in    pna_main_parser_input_metadata_t istd)
+{
+    state start {
+        user_meta.ipv4_hdr_truncated = 0;
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        bit<4> ihl = pkt.lookahead<ipv4_t>().ihl;
+        transition select (ihl) {
+            0x0 &&& 0xC : parse_ipv4_ihl_too_small; //0-3
+                    0x4 : parse_ipv4_ihl_too_small;
+                default : parse_ipv4_ok;
+        }
+    }
+    state parse_ipv4_ihl_too_small {
+        user_meta.ipv4_hdr_truncated = 1;
+        transition accept;
+    }
+    state parse_ipv4_ok {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(
+    inout headers_t       hdr,           // from main parser
+    inout user_metadata_t user_meta,     // from main parser, to "next block"
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd)
+{
+    apply {
+        if (hdr.ethernet.isValid()) {
+            bit<8> tmp;
+            tmp = 0;
+            tmp[0:0] = user_meta.ipv4_hdr_truncated;
+            tmp[1:1] = (bit<1>) hdr.ipv4.isValid();
+            hdr.ethernet.srcAddr[7:0] = tmp;
+        }
+    }
+}
+
+control MainDeparserImpl(
+    packet_out pkt,
+    in    headers_t hdr,                // from main control
+    in    user_metadata_t user_meta,    // from main control
+    in    pna_main_output_metadata_t ostd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+// BEGIN:Package_Instantiation_Example
+PNA_NIC(
+    MainParserImpl(),
+    PreControlImpl(),
+    MainControlImpl(),
+    MainDeparserImpl()
+    // Hoping to make this optional parameter later, but not supported
+    // by p4c yet.
+    //, PreParserImpl()
+    ) main;
+// END:Package_Instantiation_Example

--- a/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment.p4.spec
@@ -122,38 +122,38 @@ action encap_one_tunnel_layer_ipv4 args instanceof encap_one_tunnel_layer_ipv4_a
 	mov h.mac.type 0x800
 	validate h.ipv4_0
 	mov m.MainControlT_tmp h.ipv4_0.version_ihl
-	and m.MainControlT_tmp 0xF0
+	and m.MainControlT_tmp 0xF
 	mov h.ipv4_0.version_ihl m.MainControlT_tmp
-	or h.ipv4_0.version_ihl 0x4
+	or h.ipv4_0.version_ihl 0x40
 	mov m.MainControlT_tmp_0 h.ipv4_0.version_ihl
-	and m.MainControlT_tmp_0 0xF
+	and m.MainControlT_tmp_0 0xF0
 	mov h.ipv4_0.version_ihl m.MainControlT_tmp_0
-	or h.ipv4_0.version_ihl 0x50
+	or h.ipv4_0.version_ihl 0x5
 	mov m.MainControlT_tmp_1 h.ipv4_0.dscp_ecn
-	and m.MainControlT_tmp_1 0xC0
+	and m.MainControlT_tmp_1 0x3
 	mov h.ipv4_0.dscp_ecn m.MainControlT_tmp_1
-	or h.ipv4_0.dscp_ecn 0x5
+	or h.ipv4_0.dscp_ecn 0x14
 	mov m.MainControlT_tmp_2 h.ipv4_0.dscp_ecn
-	and m.MainControlT_tmp_2 0x3F
+	and m.MainControlT_tmp_2 0xFC
 	mov h.ipv4_0.dscp_ecn m.MainControlT_tmp_2
 	or h.ipv4_0.dscp_ecn 0x0
 	mov h.ipv4_0.length 0x14
 	add h.ipv4_0.length m.local_metadata_L2_packet_len_bytes
 	mov h.ipv4_0.identification 0x0
 	mov m.MainControlT_tmp_3 h.ipv4_0.rsvd_df_mf_frag_off
-	and m.MainControlT_tmp_3 0xFFFE
+	and m.MainControlT_tmp_3 0x7FFF
 	mov h.ipv4_0.rsvd_df_mf_frag_off m.MainControlT_tmp_3
 	or h.ipv4_0.rsvd_df_mf_frag_off 0x0
 	mov m.MainControlT_tmp_4 h.ipv4_0.rsvd_df_mf_frag_off
-	and m.MainControlT_tmp_4 0xFFFD
+	and m.MainControlT_tmp_4 0xBFFF
 	mov h.ipv4_0.rsvd_df_mf_frag_off m.MainControlT_tmp_4
 	or h.ipv4_0.rsvd_df_mf_frag_off 0x0
 	mov m.MainControlT_tmp_5 h.ipv4_0.rsvd_df_mf_frag_off
-	and m.MainControlT_tmp_5 0xFFFB
+	and m.MainControlT_tmp_5 0xDFFF
 	mov h.ipv4_0.rsvd_df_mf_frag_off m.MainControlT_tmp_5
 	or h.ipv4_0.rsvd_df_mf_frag_off 0x0
 	mov m.MainControlT_tmp_6 h.ipv4_0.rsvd_df_mf_frag_off
-	and m.MainControlT_tmp_6 0x7
+	and m.MainControlT_tmp_6 0xE000
 	mov h.ipv4_0.rsvd_df_mf_frag_off m.MainControlT_tmp_6
 	or h.ipv4_0.rsvd_df_mf_frag_off 0x0
 	mov h.ipv4_0.ttl 0x40

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith-first.p4
@@ -1,0 +1,86 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct user_metadata_t {
+    bit<1> ipv4_hdr_truncated;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout user_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout user_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        user_meta.ipv4_hdr_truncated = 1w0;
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        bit<4> ihl = (pkt.lookahead<ipv4_t>()).ihl;
+        transition select(ihl) {
+            4w0x0 &&& 4w0xc: parse_ipv4_ihl_too_small;
+            4w0x4: parse_ipv4_ihl_too_small;
+            default: parse_ipv4_ok;
+        }
+    }
+    state parse_ipv4_ihl_too_small {
+        user_meta.ipv4_hdr_truncated = 1w1;
+        transition accept;
+    }
+    state parse_ipv4_ok {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout user_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    apply {
+        if (hdr.ethernet.isValid()) {
+            bit<8> tmp;
+            tmp = 8w0;
+            tmp[0:0] = user_meta.ipv4_hdr_truncated;
+            tmp[1:1] = (bit<1>)hdr.ipv4.isValid();
+            hdr.ethernet.srcAddr[7:0] = tmp;
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in user_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, user_metadata_t, headers_t, user_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith-frontend.p4
@@ -1,0 +1,89 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct user_metadata_t {
+    bit<1> ipv4_hdr_truncated;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout user_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout user_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+    @name("MainParserImpl.ihl") bit<4> ihl_0;
+    @name("MainParserImpl.tmp") ipv4_t tmp;
+    state start {
+        user_meta.ipv4_hdr_truncated = 1w0;
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        tmp = pkt.lookahead<ipv4_t>();
+        ihl_0 = tmp.ihl;
+        transition select(ihl_0) {
+            4w0x0 &&& 4w0xc: parse_ipv4_ihl_too_small;
+            4w0x4: parse_ipv4_ihl_too_small;
+            default: parse_ipv4_ok;
+        }
+    }
+    state parse_ipv4_ihl_too_small {
+        user_meta.ipv4_hdr_truncated = 1w1;
+        transition accept;
+    }
+    state parse_ipv4_ok {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout user_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<8> tmp_0;
+    apply {
+        if (hdr.ethernet.isValid()) {
+            tmp_0 = 8w0;
+            tmp_0[0:0] = user_meta.ipv4_hdr_truncated;
+            tmp_0[1:1] = (bit<1>)hdr.ipv4.isValid();
+            hdr.ethernet.srcAddr[7:0] = tmp_0;
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in user_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+}
+
+PNA_NIC<headers_t, user_metadata_t, headers_t, user_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith-midend.p4
@@ -1,0 +1,118 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct user_metadata_t {
+    bit<1> ipv4_hdr_truncated;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout user_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout user_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+    @name("MainParserImpl.tmp") ipv4_t tmp;
+    bit<160> tmp_1;
+    state start {
+        user_meta.ipv4_hdr_truncated = 1w0;
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        tmp_1 = pkt.lookahead<bit<160>>();
+        tmp.setValid();
+        tmp.version = tmp_1[159:156];
+        tmp.ihl = tmp_1[155:152];
+        tmp.diffserv = tmp_1[151:144];
+        tmp.totalLen = tmp_1[143:128];
+        tmp.identification = tmp_1[127:112];
+        tmp.flags = tmp_1[111:109];
+        tmp.fragOffset = tmp_1[108:96];
+        tmp.ttl = tmp_1[95:88];
+        tmp.protocol = tmp_1[87:80];
+        tmp.hdrChecksum = tmp_1[79:64];
+        tmp.srcAddr = tmp_1[63:32];
+        tmp.dstAddr = tmp_1[31:0];
+        transition select(tmp_1[155:152]) {
+            4w0x0 &&& 4w0xc: parse_ipv4_ihl_too_small;
+            4w0x4: parse_ipv4_ihl_too_small;
+            default: parse_ipv4_ok;
+        }
+    }
+    state parse_ipv4_ihl_too_small {
+        user_meta.ipv4_hdr_truncated = 1w1;
+        transition accept;
+    }
+    state parse_ipv4_ok {
+        pkt.extract<ipv4_t>(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout user_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp") bit<8> tmp_0;
+    @hidden action pnadpdkparserwrongarith104() {
+        tmp_0 = 8w0;
+        tmp_0[0:0] = user_meta.ipv4_hdr_truncated;
+        tmp_0[1:1] = (bit<1>)hdr.ipv4.isValid();
+        hdr.ethernet.srcAddr[7:0] = tmp_0;
+    }
+    @hidden table tbl_pnadpdkparserwrongarith104 {
+        actions = {
+            pnadpdkparserwrongarith104();
+        }
+        const default_action = pnadpdkparserwrongarith104();
+    }
+    apply {
+        if (hdr.ethernet.isValid()) {
+            tbl_pnadpdkparserwrongarith104.apply();
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in user_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    @hidden action pnadpdkparserwrongarith119() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<ipv4_t>(hdr.ipv4);
+    }
+    @hidden table tbl_pnadpdkparserwrongarith119 {
+        actions = {
+            pnadpdkparserwrongarith119();
+        }
+        const default_action = pnadpdkparserwrongarith119();
+    }
+    apply {
+        tbl_pnadpdkparserwrongarith119.apply();
+    }
+}
+
+PNA_NIC<headers_t, user_metadata_t, headers_t, user_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith.p4
@@ -1,0 +1,86 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct user_metadata_t {
+    bit<1> ipv4_hdr_truncated;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+control PreControlImpl(in headers_t hdr, inout user_metadata_t meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+parser MainParserImpl(packet_in pkt, out headers_t hdr, inout user_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        user_meta.ipv4_hdr_truncated = 0;
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        bit<4> ihl = (pkt.lookahead<ipv4_t>()).ihl;
+        transition select(ihl) {
+            0x0 &&& 0xc: parse_ipv4_ihl_too_small;
+            0x4: parse_ipv4_ihl_too_small;
+            default: parse_ipv4_ok;
+        }
+    }
+    state parse_ipv4_ihl_too_small {
+        user_meta.ipv4_hdr_truncated = 1;
+        transition accept;
+    }
+    state parse_ipv4_ok {
+        pkt.extract(hdr.ipv4);
+        transition accept;
+    }
+}
+
+control MainControlImpl(inout headers_t hdr, inout user_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    apply {
+        if (hdr.ethernet.isValid()) {
+            bit<8> tmp;
+            tmp = 0;
+            tmp[0:0] = user_meta.ipv4_hdr_truncated;
+            tmp[1:1] = (bit<1>)hdr.ipv4.isValid();
+            hdr.ethernet.srcAddr[7:0] = tmp;
+        }
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in headers_t hdr, in user_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.ipv4);
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith.p4.bfrt.json
@@ -1,0 +1,5 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-parser-wrong-arith.p4.spec
@@ -1,0 +1,97 @@
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct ipv4_t {
+	bit<8> version_ihl
+	bit<8> diffserv
+	bit<16> totalLen
+	bit<16> identification
+	bit<16> flags_fragOffset
+	bit<8> ttl
+	bit<8> protocol
+	bit<16> hdrChecksum
+	bit<32> srcAddr
+	bit<32> dstAddr
+}
+
+struct user_metadata_t {
+	bit<32> pna_main_input_metadata_input_port
+	bit<32> local_metadata_ipv4_hdr_truncated
+	bit<32> pna_main_output_metadata_output_port
+	bit<8> MainParserT_parser_tmp
+	bit<8> MainParserT_parser_tmp_0
+	bit<32> MainParserT_parser_tmp_1
+	bit<8> MainControlT_tmp
+	bit<8> MainControlT_tmp_1
+	bit<8> MainControlT_tmp_2
+	bit<8> MainControlT_tmp_4
+	bit<8> MainControlT_tmp_5
+	bit<48> MainControlT_tmp_6
+	bit<48> MainControlT_tmp_8
+	bit<8> MainControlT_tmp_9
+	bit<32> MainControlT_tmp_10
+	bit<8> tmpMask
+}
+metadata instanceof user_metadata_t
+
+header ethernet instanceof ethernet_t
+header ipv4 instanceof ipv4_t
+header MainParserT_parser_tmp_2 instanceof ipv4_t
+
+regarray direction size 0x100 initval 0
+apply {
+	rx m.pna_main_input_metadata_input_port
+	mov m.local_metadata_ipv4_hdr_truncated 0x0
+	extract h.ethernet
+	jmpeq MAINPARSERIMPL_PARSE_IPV4 h.ethernet.etherType 0x800
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4 :	lookahead h.MainParserT_parser_tmp_2
+	mov m.MainParserT_parser_tmp h.MainParserT_parser_tmp_2.version_ihl
+	and m.MainParserT_parser_tmp 0xF
+	mov m.MainParserT_parser_tmp_0 m.MainParserT_parser_tmp
+	and m.MainParserT_parser_tmp_0 0xF
+	mov m.MainParserT_parser_tmp_1 m.MainParserT_parser_tmp_0
+	mov m.tmpMask m.MainParserT_parser_tmp_1
+	and m.tmpMask 0xC
+	jmpeq MAINPARSERIMPL_PARSE_IPV4_IHL_TOO_SMALL m.tmpMask 0x0
+	jmpeq MAINPARSERIMPL_PARSE_IPV4_IHL_TOO_SMALL m.MainParserT_parser_tmp_1 0x4
+	extract h.ipv4
+	jmp MAINPARSERIMPL_ACCEPT
+	MAINPARSERIMPL_PARSE_IPV4_IHL_TOO_SMALL :	mov m.local_metadata_ipv4_hdr_truncated 0x1
+	MAINPARSERIMPL_ACCEPT :	jmpnv LABEL_END h.ethernet
+	mov m.MainControlT_tmp_9 0x0
+	mov m.MainControlT_tmp m.MainControlT_tmp_9
+	and m.MainControlT_tmp 0xFE
+	mov m.MainControlT_tmp_1 m.local_metadata_ipv4_hdr_truncated
+	and m.MainControlT_tmp_1 0x1
+	mov m.MainControlT_tmp_9 m.MainControlT_tmp
+	or m.MainControlT_tmp_9 m.MainControlT_tmp_1
+	jmpnv LABEL_FALSE_0 h.ipv4
+	mov m.MainControlT_tmp_10 0x1
+	jmp LABEL_END_0
+	LABEL_FALSE_0 :	mov m.MainControlT_tmp_10 0x0
+	LABEL_END_0 :	mov m.MainControlT_tmp_2 m.MainControlT_tmp_9
+	and m.MainControlT_tmp_2 0xFD
+	mov m.MainControlT_tmp_4 m.MainControlT_tmp_10
+	shl m.MainControlT_tmp_4 0x1
+	mov m.MainControlT_tmp_5 m.MainControlT_tmp_4
+	and m.MainControlT_tmp_5 0x2
+	mov m.MainControlT_tmp_9 m.MainControlT_tmp_2
+	or m.MainControlT_tmp_9 m.MainControlT_tmp_5
+	mov m.MainControlT_tmp_6 h.ethernet.srcAddr
+	and m.MainControlT_tmp_6 0xFFFFFFFFFF00
+	mov m.MainControlT_tmp_8 m.MainControlT_tmp_9
+	and m.MainControlT_tmp_8 0xFF
+	mov h.ethernet.srcAddr m.MainControlT_tmp_6
+	or h.ethernet.srcAddr m.MainControlT_tmp_8
+	LABEL_END :	emit h.ethernet
+	emit h.ipv4
+	tx m.pna_main_output_metadata_output_port
+}
+
+

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex-1.p4.spec
@@ -29,27 +29,19 @@ struct main_metadata_t {
 	bit<16> MainControlT_tmp_5
 	bit<16> MainControlT_tmp_6
 	bit<16> MainControlT_tmp_7
-	bit<16> MainControlT_tmp_8
+	bit<16> MainControlT_tmp_10
 	bit<16> MainControlT_tmp_11
-	bit<16> MainControlT_tmp_12
 	bit<16> MainControlT_tmp_13
+	bit<16> MainControlT_tmp_14
 	bit<16> MainControlT_tmp_15
 	bit<16> MainControlT_tmp_16
-	bit<16> MainControlT_tmp_17
-	bit<16> MainControlT_tmp_18
 	bit<16> MainControlT_tmp_19
 	bit<16> MainControlT_tmp_20
+	bit<16> MainControlT_tmp_22
 	bit<16> MainControlT_tmp_23
 	bit<16> MainControlT_tmp_24
 	bit<16> MainControlT_tmp_25
-	bit<16> MainControlT_tmp_27
-	bit<16> MainControlT_tmp_28
-	bit<16> MainControlT_tmp_29
-	bit<16> MainControlT_tmp_30
-	bit<16> MainControlT_tmp_31
-	bit<16> MainControlT_tmp_32
-	bit<16> MainControlT_tmp_33
-	bit<16> MainControlT_tmp_34
+	bit<16> MainControlT_tmp_26
 	bit<32> MainControlT_hsVar
 	bit<32> MainControlT_key
 }
@@ -67,32 +59,26 @@ action execute_1 args none {
 	and m.MainControlT_tmp_0 0x3
 	jmpneq LABEL_FALSE_4 m.MainControlT_tmp_0 0x1
 	mov m.MainControlT_tmp_5 h.vlan_tag_0.pcp_cfi_vid
-	and m.MainControlT_tmp_5 0xF
+	and m.MainControlT_tmp_5 0xF000
 	mov m.MainControlT_tmp_6 h.vlan_tag_1.pcp_cfi_vid
-	shr m.MainControlT_tmp_6 0x4
+	and m.MainControlT_tmp_6 0xFFF
 	mov m.MainControlT_tmp_7 m.MainControlT_tmp_6
 	and m.MainControlT_tmp_7 0xFFF
-	mov m.MainControlT_tmp_8 m.MainControlT_tmp_7
-	and m.MainControlT_tmp_8 0xFFF
-	mov m.MainControlT_tmp_11 m.MainControlT_tmp_8
-	shl m.MainControlT_tmp_11 0x4
-	mov m.MainControlT_tmp_12 m.MainControlT_tmp_11
-	and m.MainControlT_tmp_12 0xFFF0
+	mov m.MainControlT_tmp_10 m.MainControlT_tmp_7
+	and m.MainControlT_tmp_10 0xFFF
 	mov h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_5
-	or h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_12
+	or h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_10
 	jmp LABEL_END_3
 	LABEL_FALSE_4 :	mov m.MainControlT_tmp m.local_metadata_depth
 	add m.MainControlT_tmp 0x3
 	and m.MainControlT_tmp 0x3
 	jmplt LABEL_END_3 m.MainControlT_tmp 0x1
-	mov m.MainControlT_tmp_13 h.vlan_tag_0.pcp_cfi_vid
-	and m.MainControlT_tmp_13 0xF
-	mov m.MainControlT_tmp_15 m.MainControlT_hsVar
-	shl m.MainControlT_tmp_15 0x4
-	mov m.MainControlT_tmp_16 m.MainControlT_tmp_15
-	and m.MainControlT_tmp_16 0xFFF0
-	mov h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_13
-	or h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_16
+	mov m.MainControlT_tmp_11 h.vlan_tag_0.pcp_cfi_vid
+	and m.MainControlT_tmp_11 0xF000
+	mov m.MainControlT_tmp_13 m.MainControlT_hsVar
+	and m.MainControlT_tmp_13 0xFFF
+	mov h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_11
+	or h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_13
 	jmp LABEL_END_3
 	jmp LABEL_END_3
 	LABEL_FALSE_2 :	jmpneq LABEL_END_3 m.local_metadata_depth 0x1
@@ -100,20 +86,16 @@ action execute_1 args none {
 	add m.MainControlT_tmp_4 0x3
 	and m.MainControlT_tmp_4 0x3
 	jmpneq LABEL_FALSE_7 m.MainControlT_tmp_4 0x0
-	mov m.MainControlT_tmp_17 h.vlan_tag_1.pcp_cfi_vid
-	and m.MainControlT_tmp_17 0xF
-	mov m.MainControlT_tmp_18 h.vlan_tag_0.pcp_cfi_vid
-	shr m.MainControlT_tmp_18 0x4
-	mov m.MainControlT_tmp_19 m.MainControlT_tmp_18
+	mov m.MainControlT_tmp_14 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_14 0xF000
+	mov m.MainControlT_tmp_15 h.vlan_tag_0.pcp_cfi_vid
+	and m.MainControlT_tmp_15 0xFFF
+	mov m.MainControlT_tmp_16 m.MainControlT_tmp_15
+	and m.MainControlT_tmp_16 0xFFF
+	mov m.MainControlT_tmp_19 m.MainControlT_tmp_16
 	and m.MainControlT_tmp_19 0xFFF
-	mov m.MainControlT_tmp_20 m.MainControlT_tmp_19
-	and m.MainControlT_tmp_20 0xFFF
-	mov m.MainControlT_tmp_23 m.MainControlT_tmp_20
-	shl m.MainControlT_tmp_23 0x4
-	mov m.MainControlT_tmp_24 m.MainControlT_tmp_23
-	and m.MainControlT_tmp_24 0xFFF0
-	mov h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_17
-	or h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_24
+	mov h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_14
+	or h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_19
 	jmp LABEL_END_3
 	LABEL_FALSE_7 :	mov m.MainControlT_tmp_3 m.local_metadata_depth
 	add m.MainControlT_tmp_3 0x3
@@ -123,14 +105,12 @@ action execute_1 args none {
 	add m.MainControlT_tmp_2 0x3
 	and m.MainControlT_tmp_2 0x3
 	jmplt LABEL_END_3 m.MainControlT_tmp_2 0x1
-	mov m.MainControlT_tmp_25 h.vlan_tag_1.pcp_cfi_vid
-	and m.MainControlT_tmp_25 0xF
-	mov m.MainControlT_tmp_27 m.MainControlT_hsVar
-	shl m.MainControlT_tmp_27 0x4
-	mov m.MainControlT_tmp_28 m.MainControlT_tmp_27
-	and m.MainControlT_tmp_28 0xFFF0
-	mov h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_25
-	or h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_28
+	mov m.MainControlT_tmp_20 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_20 0xF000
+	mov m.MainControlT_tmp_22 m.MainControlT_hsVar
+	and m.MainControlT_tmp_22 0xFFF
+	mov h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_20
+	or h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_22
 	LABEL_END_3 :	return
 }
 
@@ -164,22 +144,18 @@ apply {
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_VLAN_TAG2 :	mov m.pna_pre_input_metadata_parser_error 0x3
 	MAINPARSERIMPL_ACCEPT :	jmpneq LABEL_FALSE m.local_metadata_depth 0x0
-	mov m.MainControlT_tmp_29 h.vlan_tag_0.pcp_cfi_vid
-	shr m.MainControlT_tmp_29 0x4
-	mov m.MainControlT_tmp_30 m.MainControlT_tmp_29
-	and m.MainControlT_tmp_30 0xFFF
-	mov m.MainControlT_tmp_31 m.MainControlT_tmp_30
-	and m.MainControlT_tmp_31 0xFFF
-	mov m.MainControlT_key m.MainControlT_tmp_31
+	mov m.MainControlT_tmp_23 h.vlan_tag_0.pcp_cfi_vid
+	and m.MainControlT_tmp_23 0xFFF
+	mov m.MainControlT_tmp_24 m.MainControlT_tmp_23
+	and m.MainControlT_tmp_24 0xFFF
+	mov m.MainControlT_key m.MainControlT_tmp_24
 	jmp LABEL_END_0
 	LABEL_FALSE :	jmpneq LABEL_FALSE_0 m.local_metadata_depth 0x1
-	mov m.MainControlT_tmp_32 h.vlan_tag_1.pcp_cfi_vid
-	shr m.MainControlT_tmp_32 0x4
-	mov m.MainControlT_tmp_33 m.MainControlT_tmp_32
-	and m.MainControlT_tmp_33 0xFFF
-	mov m.MainControlT_tmp_34 m.MainControlT_tmp_33
-	and m.MainControlT_tmp_34 0xFFF
-	mov m.MainControlT_key m.MainControlT_tmp_34
+	mov m.MainControlT_tmp_25 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_25 0xFFF
+	mov m.MainControlT_tmp_26 m.MainControlT_tmp_25
+	and m.MainControlT_tmp_26 0xFFF
+	mov m.MainControlT_key m.MainControlT_tmp_26
 	jmp LABEL_END_0
 	LABEL_FALSE_0 :	jmplt LABEL_END_0 m.local_metadata_depth 0x1
 	mov m.MainControlT_key m.MainControlT_hsVar

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex-2.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex-2.p4.spec
@@ -22,30 +22,22 @@ struct main_metadata_t {
 	bit<32> pna_main_output_metadata_output_port
 	bit<16> MainControlT_tmp
 	bit<16> MainControlT_tmp_0
-	bit<16> MainControlT_tmp_1
-	bit<32> MainControlT_tmp_2
+	bit<32> MainControlT_tmp_1
+	bit<16> MainControlT_tmp_2
 	bit<16> MainControlT_tmp_3
-	bit<16> MainControlT_tmp_4
+	bit<32> MainControlT_tmp_4
 	bit<16> MainControlT_tmp_5
-	bit<32> MainControlT_tmp_6
+	bit<16> MainControlT_tmp_6
 	bit<16> MainControlT_tmp_7
-	bit<16> MainControlT_tmp_8
-	bit<16> MainControlT_tmp_9
 	bit<16> MainControlT_tmp_10
+	bit<16> MainControlT_tmp_11
+	bit<16> MainControlT_tmp_12
 	bit<16> MainControlT_tmp_13
-	bit<16> MainControlT_tmp_14
-	bit<16> MainControlT_tmp_15
 	bit<16> MainControlT_tmp_16
 	bit<16> MainControlT_tmp_17
 	bit<16> MainControlT_tmp_18
-	bit<16> MainControlT_tmp_21
-	bit<16> MainControlT_tmp_22
-	bit<16> MainControlT_tmp_23
-	bit<16> MainControlT_tmp_24
-	bit<16> MainControlT_tmp_25
-	bit<16> MainControlT_tmp_26
-	bit<16> MainControlT_tmp_27
-	bit<16> MainControlT_tmp_28
+	bit<16> MainControlT_tmp_19
+	bit<16> MainControlT_tmp_20
 	bit<32> MainControlT_key
 }
 metadata instanceof main_metadata_t
@@ -53,36 +45,28 @@ metadata instanceof main_metadata_t
 regarray direction size 0x100 initval 0
 action execute_1 args none {
 	jmpneq LABEL_FALSE_1 m.local_metadata_depth 0x0
-	mov m.MainControlT_tmp_7 h.vlan_tag_0.pcp_cfi_vid
-	and m.MainControlT_tmp_7 0xF
-	mov m.MainControlT_tmp_8 h.vlan_tag_0.pcp_cfi_vid
-	shr m.MainControlT_tmp_8 0x4
-	mov m.MainControlT_tmp_9 m.MainControlT_tmp_8
-	and m.MainControlT_tmp_9 0xFFF
-	mov m.MainControlT_tmp_10 m.MainControlT_tmp_9
+	mov m.MainControlT_tmp_5 h.vlan_tag_0.pcp_cfi_vid
+	and m.MainControlT_tmp_5 0xF000
+	mov m.MainControlT_tmp_6 h.vlan_tag_0.pcp_cfi_vid
+	and m.MainControlT_tmp_6 0xFFF
+	mov m.MainControlT_tmp_7 m.MainControlT_tmp_6
+	and m.MainControlT_tmp_7 0xFFF
+	mov m.MainControlT_tmp_10 m.MainControlT_tmp_7
 	and m.MainControlT_tmp_10 0xFFF
-	mov m.MainControlT_tmp_13 m.MainControlT_tmp_10
-	shl m.MainControlT_tmp_13 0x4
-	mov m.MainControlT_tmp_14 m.MainControlT_tmp_13
-	and m.MainControlT_tmp_14 0xFFF0
-	mov h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_7
-	or h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_14
+	mov h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_5
+	or h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_10
 	jmp LABEL_END_2
 	LABEL_FALSE_1 :	jmpneq LABEL_END_2 m.local_metadata_depth 0x1
-	mov m.MainControlT_tmp_15 h.vlan_tag_1.pcp_cfi_vid
-	and m.MainControlT_tmp_15 0xF
-	mov m.MainControlT_tmp_16 h.vlan_tag_0.pcp_cfi_vid
-	shr m.MainControlT_tmp_16 0x4
-	mov m.MainControlT_tmp_17 m.MainControlT_tmp_16
-	and m.MainControlT_tmp_17 0xFFF
-	mov m.MainControlT_tmp_18 m.MainControlT_tmp_17
-	and m.MainControlT_tmp_18 0xFFF
-	mov m.MainControlT_tmp_21 m.MainControlT_tmp_18
-	shl m.MainControlT_tmp_21 0x4
-	mov m.MainControlT_tmp_22 m.MainControlT_tmp_21
-	and m.MainControlT_tmp_22 0xFFF0
-	mov h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_15
-	or h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_22
+	mov m.MainControlT_tmp_11 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_11 0xF000
+	mov m.MainControlT_tmp_12 h.vlan_tag_0.pcp_cfi_vid
+	and m.MainControlT_tmp_12 0xFFF
+	mov m.MainControlT_tmp_13 m.MainControlT_tmp_12
+	and m.MainControlT_tmp_13 0xFFF
+	mov m.MainControlT_tmp_16 m.MainControlT_tmp_13
+	and m.MainControlT_tmp_16 0xFFF
+	mov h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_11
+	or h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_16
 	LABEL_END_2 :	return
 }
 
@@ -134,44 +118,36 @@ apply {
 	MAINPARSERIMPL_PARSE_VLAN_TAG2 :	mov m.pna_pre_input_metadata_parser_error 0x3
 	MAINPARSERIMPL_ACCEPT :	jmpneq LABEL_FALSE m.local_metadata_depth 0x0
 	mov m.MainControlT_tmp h.vlan_tag_0.pcp_cfi_vid
-	shr m.MainControlT_tmp 0x4
+	and m.MainControlT_tmp 0xFFF
 	mov m.MainControlT_tmp_0 m.MainControlT_tmp
 	and m.MainControlT_tmp_0 0xFFF
 	mov m.MainControlT_tmp_1 m.MainControlT_tmp_0
-	and m.MainControlT_tmp_1 0xFFF
-	mov m.MainControlT_tmp_2 m.MainControlT_tmp_1
-	jmpeq LABEL_SWITCH m.MainControlT_tmp_2 0x1
-	jmpeq LABEL_SWITCH_0 m.MainControlT_tmp_2 0x2
+	jmpeq LABEL_SWITCH m.MainControlT_tmp_1 0x1
+	jmpeq LABEL_SWITCH_0 m.MainControlT_tmp_1 0x2
 	jmp LABEL_END_0
-	LABEL_SWITCH :	mov m.MainControlT_tmp_23 h.vlan_tag_0.pcp_cfi_vid
-	shr m.MainControlT_tmp_23 0x4
-	mov m.MainControlT_tmp_24 m.MainControlT_tmp_23
-	and m.MainControlT_tmp_24 0xFFF
-	mov m.MainControlT_tmp_25 m.MainControlT_tmp_24
-	and m.MainControlT_tmp_25 0xFFF
-	mov m.MainControlT_key m.MainControlT_tmp_25
+	LABEL_SWITCH :	mov m.MainControlT_tmp_17 h.vlan_tag_0.pcp_cfi_vid
+	and m.MainControlT_tmp_17 0xFFF
+	mov m.MainControlT_tmp_18 m.MainControlT_tmp_17
+	and m.MainControlT_tmp_18 0xFFF
+	mov m.MainControlT_key m.MainControlT_tmp_18
 	table stub
 	jmp LABEL_END_0
 	LABEL_SWITCH_0 :	table stub1
 	jmp LABEL_END_0
 	LABEL_FALSE :	jmpneq LABEL_END_0 m.local_metadata_depth 0x1
-	mov m.MainControlT_tmp_3 h.vlan_tag_1.pcp_cfi_vid
-	shr m.MainControlT_tmp_3 0x4
+	mov m.MainControlT_tmp_2 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_2 0xFFF
+	mov m.MainControlT_tmp_3 m.MainControlT_tmp_2
+	and m.MainControlT_tmp_3 0xFFF
 	mov m.MainControlT_tmp_4 m.MainControlT_tmp_3
-	and m.MainControlT_tmp_4 0xFFF
-	mov m.MainControlT_tmp_5 m.MainControlT_tmp_4
-	and m.MainControlT_tmp_5 0xFFF
-	mov m.MainControlT_tmp_6 m.MainControlT_tmp_5
-	jmpeq LABEL_SWITCH_1 m.MainControlT_tmp_6 0x1
-	jmpeq LABEL_SWITCH_2 m.MainControlT_tmp_6 0x2
+	jmpeq LABEL_SWITCH_1 m.MainControlT_tmp_4 0x1
+	jmpeq LABEL_SWITCH_2 m.MainControlT_tmp_4 0x2
 	jmp LABEL_END_0
-	LABEL_SWITCH_1 :	mov m.MainControlT_tmp_26 h.vlan_tag_1.pcp_cfi_vid
-	shr m.MainControlT_tmp_26 0x4
-	mov m.MainControlT_tmp_27 m.MainControlT_tmp_26
-	and m.MainControlT_tmp_27 0xFFF
-	mov m.MainControlT_tmp_28 m.MainControlT_tmp_27
-	and m.MainControlT_tmp_28 0xFFF
-	mov m.MainControlT_key m.MainControlT_tmp_28
+	LABEL_SWITCH_1 :	mov m.MainControlT_tmp_19 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_19 0xFFF
+	mov m.MainControlT_tmp_20 m.MainControlT_tmp_19
+	and m.MainControlT_tmp_20 0xFFF
+	mov m.MainControlT_key m.MainControlT_tmp_20
 	table stub
 	jmp LABEL_END_0
 	LABEL_SWITCH_2 :	table stub1

--- a/testdata/p4_16_samples_outputs/pna-example-varIndex.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-example-varIndex.p4.spec
@@ -35,27 +35,19 @@ struct main_metadata_t {
 	bit<16> MainControlT_tmp_13
 	bit<16> MainControlT_tmp_14
 	bit<16> MainControlT_tmp_15
-	bit<16> MainControlT_tmp_16
+	bit<16> MainControlT_tmp_19
 	bit<16> MainControlT_tmp_20
 	bit<16> MainControlT_tmp_21
 	bit<16> MainControlT_tmp_22
-	bit<16> MainControlT_tmp_23
-	bit<16> MainControlT_tmp_24
 	bit<16> MainControlT_tmp_25
+	bit<16> MainControlT_tmp_26
+	bit<16> MainControlT_tmp_27
 	bit<16> MainControlT_tmp_28
-	bit<16> MainControlT_tmp_29
-	bit<16> MainControlT_tmp_30
 	bit<16> MainControlT_tmp_31
 	bit<16> MainControlT_tmp_32
 	bit<16> MainControlT_tmp_33
-	bit<16> MainControlT_tmp_36
-	bit<16> MainControlT_tmp_37
-	bit<16> MainControlT_tmp_38
-	bit<16> MainControlT_tmp_39
-	bit<16> MainControlT_tmp_40
-	bit<16> MainControlT_tmp_41
-	bit<16> MainControlT_tmp_42
-	bit<16> MainControlT_tmp_43
+	bit<16> MainControlT_tmp_34
+	bit<16> MainControlT_tmp_35
 	bit<16> MainControlT_hsVar
 	bit<32> MainControlT_key
 }
@@ -93,66 +85,54 @@ action execute_1 args none {
 	mov h.vlan_tag_1.ether_type 0x2
 	LABEL_END_5 :	jmpneq LABEL_FALSE_6 m.local_metadata_depth 0x0
 	mov m.MainControlT_tmp_4 h.vlan_tag_0.pcp_cfi_vid
-	and m.MainControlT_tmp_4 0xF
+	and m.MainControlT_tmp_4 0xF000
 	mov m.MainControlT_tmp_5 h.vlan_tag_0.pcp_cfi_vid
-	shr m.MainControlT_tmp_5 0x3
+	shr m.MainControlT_tmp_5 0xC
 	mov m.MainControlT_tmp_6 m.MainControlT_tmp_5
 	and m.MainControlT_tmp_6 0x1
 	mov m.MainControlT_tmp_7 m.MainControlT_tmp_6
 	and m.MainControlT_tmp_7 0x1
 	mov m.MainControlT_tmp_11 m.MainControlT_tmp_7
-	shl m.MainControlT_tmp_11 0x4
-	mov m.MainControlT_tmp_12 m.MainControlT_tmp_11
-	and m.MainControlT_tmp_12 0xFFF0
+	and m.MainControlT_tmp_11 0xFFF
 	mov h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_4
-	or h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_12
+	or h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_11
 	jmp LABEL_END_7
 	LABEL_FALSE_6 :	jmpneq LABEL_END_7 m.local_metadata_depth 0x1
+	mov m.MainControlT_tmp_12 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_12 0xF000
 	mov m.MainControlT_tmp_13 h.vlan_tag_1.pcp_cfi_vid
-	and m.MainControlT_tmp_13 0xF
-	mov m.MainControlT_tmp_14 h.vlan_tag_1.pcp_cfi_vid
-	shr m.MainControlT_tmp_14 0x3
+	shr m.MainControlT_tmp_13 0xC
+	mov m.MainControlT_tmp_14 m.MainControlT_tmp_13
+	and m.MainControlT_tmp_14 0x1
 	mov m.MainControlT_tmp_15 m.MainControlT_tmp_14
 	and m.MainControlT_tmp_15 0x1
-	mov m.MainControlT_tmp_16 m.MainControlT_tmp_15
-	and m.MainControlT_tmp_16 0x1
-	mov m.MainControlT_tmp_20 m.MainControlT_tmp_16
-	shl m.MainControlT_tmp_20 0x4
-	mov m.MainControlT_tmp_21 m.MainControlT_tmp_20
-	and m.MainControlT_tmp_21 0xFFF0
-	mov h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_13
-	or h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_21
+	mov m.MainControlT_tmp_19 m.MainControlT_tmp_15
+	and m.MainControlT_tmp_19 0xFFF
+	mov h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_12
+	or h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_19
 	LABEL_END_7 :	jmpneq LABEL_FALSE_8 m.local_metadata_depth 0x0
-	mov m.MainControlT_tmp_22 h.vlan_tag_0.pcp_cfi_vid
-	and m.MainControlT_tmp_22 0xF
-	mov m.MainControlT_tmp_23 h.vlan_tag_1.pcp_cfi_vid
-	shr m.MainControlT_tmp_23 0x4
-	mov m.MainControlT_tmp_24 m.MainControlT_tmp_23
-	and m.MainControlT_tmp_24 0xFFF
-	mov m.MainControlT_tmp_25 m.MainControlT_tmp_24
+	mov m.MainControlT_tmp_20 h.vlan_tag_0.pcp_cfi_vid
+	and m.MainControlT_tmp_20 0xF000
+	mov m.MainControlT_tmp_21 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_21 0xFFF
+	mov m.MainControlT_tmp_22 m.MainControlT_tmp_21
+	and m.MainControlT_tmp_22 0xFFF
+	mov m.MainControlT_tmp_25 m.MainControlT_tmp_22
 	and m.MainControlT_tmp_25 0xFFF
-	mov m.MainControlT_tmp_28 m.MainControlT_tmp_25
-	shl m.MainControlT_tmp_28 0x4
-	mov m.MainControlT_tmp_29 m.MainControlT_tmp_28
-	and m.MainControlT_tmp_29 0xFFF0
-	mov h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_22
-	or h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_29
+	mov h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_20
+	or h.vlan_tag_0.pcp_cfi_vid m.MainControlT_tmp_25
 	jmp LABEL_END_9
 	LABEL_FALSE_8 :	jmpneq LABEL_END_9 m.local_metadata_depth 0x1
-	mov m.MainControlT_tmp_30 h.vlan_tag_1.pcp_cfi_vid
-	and m.MainControlT_tmp_30 0xF
-	mov m.MainControlT_tmp_31 h.vlan_tag_1.pcp_cfi_vid
-	shr m.MainControlT_tmp_31 0x4
-	mov m.MainControlT_tmp_32 m.MainControlT_tmp_31
-	and m.MainControlT_tmp_32 0xFFF
-	mov m.MainControlT_tmp_33 m.MainControlT_tmp_32
-	and m.MainControlT_tmp_33 0xFFF
-	mov m.MainControlT_tmp_36 m.MainControlT_tmp_33
-	shl m.MainControlT_tmp_36 0x4
-	mov m.MainControlT_tmp_37 m.MainControlT_tmp_36
-	and m.MainControlT_tmp_37 0xFFF0
-	mov h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_30
-	or h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_37
+	mov m.MainControlT_tmp_26 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_26 0xF000
+	mov m.MainControlT_tmp_27 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_27 0xFFF
+	mov m.MainControlT_tmp_28 m.MainControlT_tmp_27
+	and m.MainControlT_tmp_28 0xFFF
+	mov m.MainControlT_tmp_31 m.MainControlT_tmp_28
+	and m.MainControlT_tmp_31 0xFFF
+	mov h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_26
+	or h.vlan_tag_1.pcp_cfi_vid m.MainControlT_tmp_31
 	LABEL_END_9 :	return
 }
 
@@ -187,24 +167,20 @@ apply {
 	MAINPARSERIMPL_PARSE_VLAN_TAG2 :	mov m.pna_pre_input_metadata_parser_error 0x3
 	MAINPARSERIMPL_ACCEPT :	jmpneq LABEL_FALSE m.local_metadata_depth 0x0
 	jmpneq LABEL_FALSE h.vlan_tag_0.ether_type h.ethernet.etherType
-	mov m.MainControlT_tmp_38 h.vlan_tag_0.pcp_cfi_vid
-	shr m.MainControlT_tmp_38 0x4
-	mov m.MainControlT_tmp_39 m.MainControlT_tmp_38
-	and m.MainControlT_tmp_39 0xFFF
-	mov m.MainControlT_tmp_40 m.MainControlT_tmp_39
-	and m.MainControlT_tmp_40 0xFFF
-	mov m.MainControlT_key m.MainControlT_tmp_40
+	mov m.MainControlT_tmp_32 h.vlan_tag_0.pcp_cfi_vid
+	and m.MainControlT_tmp_32 0xFFF
+	mov m.MainControlT_tmp_33 m.MainControlT_tmp_32
+	and m.MainControlT_tmp_33 0xFFF
+	mov m.MainControlT_key m.MainControlT_tmp_33
 	table stub
 	jmp LABEL_END_0
 	LABEL_FALSE :	jmpneq LABEL_END_0 m.local_metadata_depth 0x1
 	jmpneq LABEL_END_0 h.vlan_tag_1.ether_type h.ethernet.etherType
-	mov m.MainControlT_tmp_41 h.vlan_tag_1.pcp_cfi_vid
-	shr m.MainControlT_tmp_41 0x4
-	mov m.MainControlT_tmp_42 m.MainControlT_tmp_41
-	and m.MainControlT_tmp_42 0xFFF
-	mov m.MainControlT_tmp_43 m.MainControlT_tmp_42
-	and m.MainControlT_tmp_43 0xFFF
-	mov m.MainControlT_key m.MainControlT_tmp_43
+	mov m.MainControlT_tmp_34 h.vlan_tag_1.pcp_cfi_vid
+	and m.MainControlT_tmp_34 0xFFF
+	mov m.MainControlT_tmp_35 m.MainControlT_tmp_34
+	and m.MainControlT_tmp_35 0xFFF
+	mov m.MainControlT_key m.MainControlT_tmp_35
 	table stub
 	LABEL_END_0 :	emit h.ethernet
 	emit h.vlan_tag_0

--- a/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-ipv6-actions.p4.spec
@@ -75,15 +75,14 @@ struct main_metadata_t {
 	bit<32> MainControlT_tmp
 	bit<32> MainControlT_tmp_1
 	bit<32> MainControlT_tmp_2
-	bit<32> MainControlT_tmp_3
+	bit<32> MainControlT_tmp_4
 	bit<32> MainControlT_tmp_5
 	bit<32> MainControlT_tmp_6
-	bit<32> MainControlT_tmp_7
+	bit<32> MainControlT_tmp_8
 	bit<32> MainControlT_tmp_9
-	bit<32> MainControlT_tmp_10
 	bit<32> MainControlT_tmp_11
-	bit<32> MainControlT_tmp_13
-	bit<128> MainControlT_tmp_14
+	bit<32> MainControlT_tmp_12
+	bit<128> MainControlT_tmp_13
 	bit<32> MainControlT_tmp1
 }
 metadata instanceof main_metadata_t
@@ -106,51 +105,49 @@ action ipv6_modify_dstAddr args instanceof ipv6_modify_dstAddr_arg_t {
 
 action ipv6_swap_addr args none {
 	mov h.ipv6.dstAddr h.ipv6.srcAddr
-	mov h.ipv6.srcAddr m.MainControlT_tmp_14
+	mov h.ipv6.srcAddr m.MainControlT_tmp_13
 	return
 }
 
 action set_flowlabel args instanceof set_flowlabel_arg_t {
 	mov m.MainControlT_tmp h.ipv6.version_trafficClass_flowLabel
-	and m.MainControlT_tmp 0xFFF
+	and m.MainControlT_tmp 0xFFF00000
 	mov m.MainControlT_tmp_1 t.label
-	shl m.MainControlT_tmp_1 0xC
-	mov m.MainControlT_tmp_2 m.MainControlT_tmp_1
-	and m.MainControlT_tmp_2 0xFFFFF000
+	and m.MainControlT_tmp_1 0xFFFFF
 	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp
-	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_2
+	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_1
 	return
 }
 
 action set_traffic_class_flow_label args instanceof set_traffic_class_flow_label_arg_t {
-	mov m.MainControlT_tmp_3 h.ipv6.version_trafficClass_flowLabel
-	and m.MainControlT_tmp_3 0xFFFFF00F
-	mov m.MainControlT_tmp_5 t.trafficClass
-	shl m.MainControlT_tmp_5 0x4
-	mov m.MainControlT_tmp_6 m.MainControlT_tmp_5
-	and m.MainControlT_tmp_6 0xFF0
-	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_3
-	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_6
-	mov m.MainControlT_tmp_7 h.ipv6.version_trafficClass_flowLabel
-	and m.MainControlT_tmp_7 0xFFF
-	mov m.MainControlT_tmp_9 t.label
-	shl m.MainControlT_tmp_9 0xC
-	mov m.MainControlT_tmp_10 m.MainControlT_tmp_9
-	and m.MainControlT_tmp_10 0xFFFFF000
-	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_7
-	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_10
+	mov m.MainControlT_tmp_2 h.ipv6.version_trafficClass_flowLabel
+	and m.MainControlT_tmp_2 0xF00FFFFF
+	mov m.MainControlT_tmp_4 t.trafficClass
+	shl m.MainControlT_tmp_4 0x14
+	mov m.MainControlT_tmp_5 m.MainControlT_tmp_4
+	and m.MainControlT_tmp_5 0xFF00000
+	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_2
+	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_5
+	mov m.MainControlT_tmp_6 h.ipv6.version_trafficClass_flowLabel
+	and m.MainControlT_tmp_6 0xFFF00000
+	mov m.MainControlT_tmp_8 t.label
+	and m.MainControlT_tmp_8 0xFFFFF
+	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_6
+	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_8
 	mov h.dpdk_pseudo_header.pseudo_0 m.MainControlT_tmp1
 	mov h.ipv6.srcAddr h.dpdk_pseudo_header.pseudo_0
 	return
 }
 
 action set_ipv6_version args instanceof set_ipv6_version_arg_t {
-	mov m.MainControlT_tmp_11 h.ipv6.version_trafficClass_flowLabel
-	and m.MainControlT_tmp_11 0xFFFFFFF0
-	mov m.MainControlT_tmp_13 t.version
-	and m.MainControlT_tmp_13 0xF
-	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_11
-	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_13
+	mov m.MainControlT_tmp_9 h.ipv6.version_trafficClass_flowLabel
+	and m.MainControlT_tmp_9 0xFFFFFFF
+	mov m.MainControlT_tmp_11 t.version
+	shl m.MainControlT_tmp_11 0x1C
+	mov m.MainControlT_tmp_12 m.MainControlT_tmp_11
+	and m.MainControlT_tmp_12 0xF0000000
+	mov h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_9
+	or h.ipv6.version_trafficClass_flowLabel m.MainControlT_tmp_12
 	return
 }
 
@@ -196,7 +193,7 @@ apply {
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_IPV6 :	extract h.ipv6
 	MAINPARSERIMPL_ACCEPT :	mov h.dpdk_pseudo_header.pseudo_1 0x76
-	mov m.MainControlT_tmp_14 h.dpdk_pseudo_header.pseudo_1
+	mov m.MainControlT_tmp_13 h.dpdk_pseudo_header.pseudo_1
 	table filter_tbl
 	emit h.ethernet
 	emit h.mpls

--- a/testdata/p4_16_samples_outputs/pna-issue3041.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-issue3041.p4.spec
@@ -42,10 +42,9 @@ struct main_metadata_t {
 	bit<32> pna_main_output_metadata_output_port
 	bit<8> MainParserT_parser_tmp
 	bit<8> MainParserT_parser_tmp_0
-	bit<8> MainParserT_parser_tmp_1
-	bit<32> MainParserT_parser_tmp_3
-	bit<32> MainParserT_parser_tmp_5
-	bit<32> MainParserT_parser_tmp_5_extract_tmp
+	bit<32> MainParserT_parser_tmp_2
+	bit<32> MainParserT_parser_tmp_4
+	bit<32> MainParserT_parser_tmp_4_extract_tmp
 }
 metadata instanceof main_metadata_t
 
@@ -102,22 +101,20 @@ apply {
 	jmp MAINPARSERIMPL_ACCEPT
 	MAINPARSERIMPL_PARSE_IPV4 :	extract h.ipv4_base
 	mov m.MainParserT_parser_tmp h.ipv4_base.version_ihl
-	shr m.MainParserT_parser_tmp 0x4
+	and m.MainParserT_parser_tmp 0xF
 	mov m.MainParserT_parser_tmp_0 m.MainParserT_parser_tmp
 	and m.MainParserT_parser_tmp_0 0xF
-	mov m.MainParserT_parser_tmp_1 m.MainParserT_parser_tmp_0
-	and m.MainParserT_parser_tmp_1 0xF
-	jmpeq MAINPARSERIMPL_ACCEPT m.MainParserT_parser_tmp_1 0x5
+	jmpeq MAINPARSERIMPL_ACCEPT m.MainParserT_parser_tmp_0 0x5
 	lookahead h.option
 	jmpeq MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP h.option.type 0x44
 	jmp MAINPARSERIMPL_ACCEPT
-	MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP :	mov m.MainParserT_parser_tmp_3 h.option.len
-	shl m.MainParserT_parser_tmp_3 0x3
-	mov m.MainParserT_parser_tmp_5 m.MainParserT_parser_tmp_3
-	add m.MainParserT_parser_tmp_5 0xFFFFFFF0
-	mov m.MainParserT_parser_tmp_5_extract_tmp m.MainParserT_parser_tmp_5
-	shr m.MainParserT_parser_tmp_5_extract_tmp 0x3
-	extract h.ipv4_option_timestamp m.MainParserT_parser_tmp_5_extract_tmp
+	MAINPARSERIMPL_PARSE_IPV4_OPTION_TIMESTAMP :	mov m.MainParserT_parser_tmp_2 h.option.len
+	shl m.MainParserT_parser_tmp_2 0x3
+	mov m.MainParserT_parser_tmp_4 m.MainParserT_parser_tmp_2
+	add m.MainParserT_parser_tmp_4 0xFFFFFFF0
+	mov m.MainParserT_parser_tmp_4_extract_tmp m.MainParserT_parser_tmp_4
+	shr m.MainParserT_parser_tmp_4_extract_tmp 0x3
+	extract h.ipv4_option_timestamp m.MainParserT_parser_tmp_4_extract_tmp
 	MAINPARSERIMPL_ACCEPT :	mov m.pna_main_output_metadata_output_port 0x0
 	table tbl
 	table tbl2

--- a/testdata/p4_16_samples_outputs/psa-dpdk-checksum-arg-header.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-checksum-arg-header.p4.spec
@@ -110,11 +110,12 @@ struct local_metadata_t {
 	bit<32> local_metadata_mem1
 	bit<8> Ingress_tmp
 	bit<8> Ingress_tmp_0
-	bit<16> Ingress_tmp_1
+	bit<8> Ingress_tmp_1
 	bit<16> Ingress_tmp_2
-	bit<32> Ingress_tmp_3
+	bit<16> Ingress_tmp_3
 	bit<32> Ingress_tmp_4
 	bit<32> Ingress_tmp_5
+	bit<32> Ingress_tmp_6
 }
 metadata instanceof local_metadata_t
 
@@ -143,20 +144,22 @@ action vxlan_encap args instanceof vxlan_encap_arg_t {
 	ckadd h.cksum_state.state_1 h.outer_ipv4
 	mov h.dpdk_pseudo_header.pseudo_0 0x7
 	ckadd h.cksum_state.state_1 h.dpdk_pseudo_header.pseudo_0
-	mov m.Ingress_tmp_1 h.outer_ipv4.hdr_checksum
-	mov m.Ingress_tmp_2 h.ipv4.total_len
+	mov m.Ingress_tmp_2 h.outer_ipv4.hdr_checksum
+	mov m.Ingress_tmp_3 h.ipv4.total_len
 	mov m.Ingress_tmp h.ipv4.ver_ihl
-	and m.Ingress_tmp 0xF
+	shr m.Ingress_tmp 0x4
 	mov m.Ingress_tmp_0 m.Ingress_tmp
 	and m.Ingress_tmp_0 0xF
-	mov m.Ingress_tmp_3 m.Ingress_tmp_0
-	mov m.Ingress_tmp_4 0x6
-	mov m.Ingress_tmp_5 m.local_metadata_mem1
-	mov h.dpdk_pseudo_header.pseudo_1 m.Ingress_tmp_1
-	mov h.dpdk_pseudo_header.pseudo_2 m.Ingress_tmp_2
-	mov h.dpdk_pseudo_header.pseudo_3 m.Ingress_tmp_3
-	mov h.dpdk_pseudo_header.pseudo_4 m.Ingress_tmp_4
-	mov h.dpdk_pseudo_header.pseudo_5 m.Ingress_tmp_5
+	mov m.Ingress_tmp_1 m.Ingress_tmp_0
+	and m.Ingress_tmp_1 0xF
+	mov m.Ingress_tmp_4 m.Ingress_tmp_1
+	mov m.Ingress_tmp_5 0x6
+	mov m.Ingress_tmp_6 m.local_metadata_mem1
+	mov h.dpdk_pseudo_header.pseudo_1 m.Ingress_tmp_2
+	mov h.dpdk_pseudo_header.pseudo_2 m.Ingress_tmp_3
+	mov h.dpdk_pseudo_header.pseudo_3 m.Ingress_tmp_4
+	mov h.dpdk_pseudo_header.pseudo_4 m.Ingress_tmp_5
+	mov h.dpdk_pseudo_header.pseudo_5 m.Ingress_tmp_6
 	ckadd h.cksum_state.state_1 h.dpdk_pseudo_header.pseudo_1
 	ckadd h.cksum_state.state_1 h.dpdk_pseudo_header.pseudo_2
 	ckadd h.cksum_state.state_1 h.dpdk_pseudo_header.pseudo_3

--- a/testdata/p4_16_samples_outputs/psa-dpdk-tmp-mask-align.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-tmp-mask-align.p4.spec
@@ -59,7 +59,8 @@ struct metadata {
 	bit<16> local_metadata_data
 	bit<16> IngressParser_parser_tmp
 	bit<16> IngressParser_parser_tmp_0
-	bit<8> IngressParser_parser_tmp_2
+	bit<16> IngressParser_parser_tmp_1
+	bit<8> IngressParser_parser_tmp_3
 	bit<8> Ingress_err
 	bit<16> tmpMask
 	bit<8> tmpMask_0
@@ -99,10 +100,10 @@ apply {
 	mov m.psa_ingress_output_metadata_drop 0x1
 	extract h.ethernet
 	jmplt LABEL_FALSE h.ethernet.etherType 0x800
-	mov m.IngressParser_parser_tmp_2 0x1
+	mov m.IngressParser_parser_tmp_3 0x1
 	jmp LABEL_END
-	LABEL_FALSE :	mov m.IngressParser_parser_tmp_2 0x0
-	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_2 0
+	LABEL_FALSE :	mov m.IngressParser_parser_tmp_3 0x0
+	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_3 0
 	mov m.psa_ingress_input_metadata_parser_error 0x7
 	jmp INGRESSPARSERIMPL_ACCEPT
 	LABEL_END_0 :	mov m.tmpMask h.ethernet.etherType
@@ -111,10 +112,12 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4.flags_fragOffset
-	and m.IngressParser_parser_tmp 0x7
+	shr m.IngressParser_parser_tmp 0xD
 	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
 	and m.IngressParser_parser_tmp_0 0x7
-	mov m.tmpMask_0 m.IngressParser_parser_tmp_0
+	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
+	and m.IngressParser_parser_tmp_1 0x7
+	mov m.tmpMask_0 m.IngressParser_parser_tmp_1
 	and m.tmpMask_0 0x4
 	jmpeq INGRESSPARSERIMPL_PARSE_TCP m.tmpMask_0 0x4
 	jmp INGRESSPARSERIMPL_ACCEPT

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.spec
@@ -55,7 +55,7 @@ struct metadata_t {
 	bit<32> local_metadata_port_out
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
-	bit<8> IngressParser_parser_tmp_1
+	bit<8> IngressParser_parser_tmp_2
 	bit<8> IngressParser_parser_tmp_3
 	bit<8> IngressParser_parser_tmp_4
 	bit<8> IngressParser_parser_tmp_5
@@ -64,19 +64,22 @@ struct metadata_t {
 	bit<16> Ingress_tmp_0
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
-	bit<8> Ingress_tmp_5
+	bit<8> Ingress_tmp_4
 	bit<8> Ingress_tmp_6
+	bit<8> Ingress_tmp_7
 	bit<8> Ingress_tmp_8
-	bit<8> Ingress_tmp_9
 	bit<8> Ingress_tmp_10
-	bit<16> Ingress_tmp_11
+	bit<8> Ingress_tmp_11
 	bit<8> Ingress_tmp_12
-	bit<8> Ingress_tmp_13
-	bit<32> Ingress_tmp_15
-	bit<16> Ingress_tmp_17
+	bit<16> Ingress_tmp_13
+	bit<8> Ingress_tmp_14
+	bit<8> Ingress_tmp_15
+	bit<8> Ingress_tmp_16
+	bit<32> Ingress_tmp_18
+	bit<16> Ingress_tmp_20
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
-	bit<32> Ingress_tmp_19
+	bit<32> Ingress_tmp_22
 }
 metadata instanceof metadata_t
 
@@ -95,35 +98,37 @@ action NoAction args none {
 }
 
 action execute_1 args instanceof execute_1_arg_t {
-	mov m.Ingress_tmp_8 h.ipv4.version_ihl
-	and m.Ingress_tmp_8 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_8
-	or h.ipv4.version_ihl 0x50
+	mov m.Ingress_tmp_10 h.ipv4.version_ihl
+	and m.Ingress_tmp_10 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_10
+	or h.ipv4.version_ihl 0x5
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in m.Ingress_color_out
 	jmpneq LABEL_FALSE_2 m.Ingress_color_out 0x0
-	mov m.Ingress_tmp_19 0x1
+	mov m.Ingress_tmp_22 0x1
 	jmp LABEL_END_3
-	LABEL_FALSE_2 :	mov m.Ingress_tmp_19 0x0
-	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_19
+	LABEL_FALSE_2 :	mov m.Ingress_tmp_22 0x0
+	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_22
 	regwr reg_0 t.index m.local_metadata_port_out
 	mov m.Ingress_tmp h.ipv4.hdrChecksum
 	and m.Ingress_tmp 0x3F
 	mov m.Ingress_tmp_0 m.Ingress_tmp
 	and m.Ingress_tmp_0 0x3F
 	jmpneq LABEL_END_4 m.Ingress_tmp_0 0x6
-	mov m.Ingress_tmp_9 h.ipv4.version_ihl
-	and m.Ingress_tmp_9 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_9
-	or h.ipv4.version_ihl 0x50
+	mov m.Ingress_tmp_11 h.ipv4.version_ihl
+	and m.Ingress_tmp_11 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_11
+	or h.ipv4.version_ihl 0x5
 	LABEL_END_4 :	mov m.Ingress_tmp_2 h.ipv4.version_ihl
-	and m.Ingress_tmp_2 0xF
+	shr m.Ingress_tmp_2 0x4
 	mov m.Ingress_tmp_3 m.Ingress_tmp_2
 	and m.Ingress_tmp_3 0xF
-	jmpneq LABEL_END_5 m.Ingress_tmp_3 0x6
-	mov m.Ingress_tmp_10 h.ipv4.version_ihl
-	and m.Ingress_tmp_10 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_10
-	or h.ipv4.version_ihl 0x60
+	mov m.Ingress_tmp_4 m.Ingress_tmp_3
+	and m.Ingress_tmp_4 0xF
+	jmpneq LABEL_END_5 m.Ingress_tmp_4 0x6
+	mov m.Ingress_tmp_12 h.ipv4.version_ihl
+	and m.Ingress_tmp_12 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_12
+	or h.ipv4.version_ihl 0x6
 	LABEL_END_5 :	return
 }
 
@@ -148,19 +153,19 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4.version_ihl
-	shr m.IngressParser_parser_tmp 0x4
+	and m.IngressParser_parser_tmp 0xF
 	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
 	and m.IngressParser_parser_tmp_0 0xF
-	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
-	and m.IngressParser_parser_tmp_1 0xF
-	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_1 0x5
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
 	mov m.IngressParser_parser_tmp_5 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.IngressParser_parser_tmp_5 0x1
 	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_5 0
 	mov m.psa_ingress_input_metadata_parser_error 0x7
 	jmp INGRESSPARSERIMPL_ACCEPT
-	LABEL_END_0 :	mov m.IngressParser_parser_tmp_3 h.ipv4.version_ihl
+	LABEL_END_0 :	mov m.IngressParser_parser_tmp_2 h.ipv4.version_ihl
+	shr m.IngressParser_parser_tmp_2 0x4
+	mov m.IngressParser_parser_tmp_3 m.IngressParser_parser_tmp_2
 	and m.IngressParser_parser_tmp_3 0xF
 	mov m.IngressParser_parser_tmp_4 m.IngressParser_parser_tmp_3
 	and m.IngressParser_parser_tmp_4 0xF
@@ -173,24 +178,28 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3FF 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_5 h.ipv4.version_ihl
-	and m.Ingress_tmp_5 0xF
-	mov m.Ingress_tmp_6 m.Ingress_tmp_5
-	and m.Ingress_tmp_6 0xF
-	jmpneq LABEL_END_1 m.Ingress_tmp_6 0x4
-	mov m.Ingress_tmp_11 h.ipv4.hdrChecksum
-	and m.Ingress_tmp_11 0xFFF0
-	mov m.Ingress_tmp_12 h.ipv4.version_ihl
-	and m.Ingress_tmp_12 0xF
-	mov m.Ingress_tmp_13 m.Ingress_tmp_12
-	and m.Ingress_tmp_13 0xF
-	mov m.Ingress_tmp_15 m.Ingress_tmp_13
-	add m.Ingress_tmp_15 0x5
+	mov m.Ingress_tmp_6 h.ipv4.version_ihl
+	shr m.Ingress_tmp_6 0x4
+	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	and m.Ingress_tmp_7 0xF
+	mov m.Ingress_tmp_8 m.Ingress_tmp_7
+	and m.Ingress_tmp_8 0xF
+	jmpneq LABEL_END_1 m.Ingress_tmp_8 0x4
+	mov m.Ingress_tmp_13 h.ipv4.hdrChecksum
+	and m.Ingress_tmp_13 0xFFF0
+	mov m.Ingress_tmp_14 h.ipv4.version_ihl
+	shr m.Ingress_tmp_14 0x4
+	mov m.Ingress_tmp_15 m.Ingress_tmp_14
 	and m.Ingress_tmp_15 0xF
-	mov m.Ingress_tmp_17 m.Ingress_tmp_15
-	and m.Ingress_tmp_17 0xF
-	mov h.ipv4.hdrChecksum m.Ingress_tmp_11
-	or h.ipv4.hdrChecksum m.Ingress_tmp_17
+	mov m.Ingress_tmp_16 m.Ingress_tmp_15
+	and m.Ingress_tmp_16 0xF
+	mov m.Ingress_tmp_18 m.Ingress_tmp_16
+	add m.Ingress_tmp_18 0x5
+	and m.Ingress_tmp_18 0xF
+	mov m.Ingress_tmp_20 m.Ingress_tmp_18
+	and m.Ingress_tmp_20 0xF
+	mov h.ipv4.hdrChecksum m.Ingress_tmp_13
+	or h.ipv4.hdrChecksum m.Ingress_tmp_20
 	LABEL_END_1 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	mov h.ipv4.hdrChecksum 0x4
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4.spec
@@ -54,24 +54,28 @@ struct metadata_t {
 	bit<32> local_metadata_port_out
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
-	bit<32> IngressParser_parser_tmp_1
+	bit<8> IngressParser_parser_tmp_1
+	bit<32> IngressParser_parser_tmp_2
 	bit<16> Ingress_tmp
 	bit<16> Ingress_tmp_0
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
-	bit<8> Ingress_tmp_5
+	bit<8> Ingress_tmp_4
 	bit<8> Ingress_tmp_6
+	bit<8> Ingress_tmp_7
 	bit<8> Ingress_tmp_8
-	bit<8> Ingress_tmp_9
 	bit<8> Ingress_tmp_10
-	bit<16> Ingress_tmp_11
+	bit<8> Ingress_tmp_11
 	bit<8> Ingress_tmp_12
-	bit<8> Ingress_tmp_13
-	bit<32> Ingress_tmp_15
-	bit<16> Ingress_tmp_17
+	bit<16> Ingress_tmp_13
+	bit<8> Ingress_tmp_14
+	bit<8> Ingress_tmp_15
+	bit<8> Ingress_tmp_16
+	bit<32> Ingress_tmp_18
+	bit<16> Ingress_tmp_20
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
-	bit<32> Ingress_tmp_19
+	bit<32> Ingress_tmp_22
 	bit<16> IngressDeparser_deparser_tmp
 	bit<8> IngressDeparser_deparser_tmp_0
 }
@@ -92,35 +96,37 @@ action NoAction args none {
 }
 
 action execute_1 args instanceof execute_1_arg_t {
-	mov m.Ingress_tmp_8 h.ipv4.version_ihl
-	and m.Ingress_tmp_8 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_8
-	or h.ipv4.version_ihl 0x50
+	mov m.Ingress_tmp_10 h.ipv4.version_ihl
+	and m.Ingress_tmp_10 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_10
+	or h.ipv4.version_ihl 0x5
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in m.Ingress_color_out
 	jmpneq LABEL_FALSE_1 m.Ingress_color_out 0x0
-	mov m.Ingress_tmp_19 0x1
+	mov m.Ingress_tmp_22 0x1
 	jmp LABEL_END_1
-	LABEL_FALSE_1 :	mov m.Ingress_tmp_19 0x0
-	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_19
+	LABEL_FALSE_1 :	mov m.Ingress_tmp_22 0x0
+	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_22
 	regwr reg_0 t.index m.local_metadata_port_out
 	mov m.Ingress_tmp h.ipv4.hdrChecksum
 	and m.Ingress_tmp 0x3F
 	mov m.Ingress_tmp_0 m.Ingress_tmp
 	and m.Ingress_tmp_0 0x3F
 	jmpneq LABEL_END_2 m.Ingress_tmp_0 0x6
-	mov m.Ingress_tmp_9 h.ipv4.version_ihl
-	and m.Ingress_tmp_9 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_9
-	or h.ipv4.version_ihl 0x50
+	mov m.Ingress_tmp_11 h.ipv4.version_ihl
+	and m.Ingress_tmp_11 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_11
+	or h.ipv4.version_ihl 0x5
 	LABEL_END_2 :	mov m.Ingress_tmp_2 h.ipv4.version_ihl
-	and m.Ingress_tmp_2 0xF
+	shr m.Ingress_tmp_2 0x4
 	mov m.Ingress_tmp_3 m.Ingress_tmp_2
 	and m.Ingress_tmp_3 0xF
-	jmpneq LABEL_END_3 m.Ingress_tmp_3 0x6
-	mov m.Ingress_tmp_10 h.ipv4.version_ihl
-	and m.Ingress_tmp_10 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_10
-	or h.ipv4.version_ihl 0x60
+	mov m.Ingress_tmp_4 m.Ingress_tmp_3
+	and m.Ingress_tmp_4 0xF
+	jmpneq LABEL_END_3 m.Ingress_tmp_4 0x6
+	mov m.Ingress_tmp_12 h.ipv4.version_ihl
+	and m.Ingress_tmp_12 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_12
+	or h.ipv4.version_ihl 0x6
 	LABEL_END_3 :	return
 }
 
@@ -145,10 +151,12 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4.version_ihl
-	and m.IngressParser_parser_tmp 0xF
+	shr m.IngressParser_parser_tmp 0x4
 	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
 	and m.IngressParser_parser_tmp_0 0xF
 	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
+	and m.IngressParser_parser_tmp_1 0xF
+	mov m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_1
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
 	jmpneq LABEL_END m.local_metadata_port_out 0x1
 	table tbl
@@ -157,33 +165,37 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3FF 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_5 h.ipv4.version_ihl
-	and m.Ingress_tmp_5 0xF
-	mov m.Ingress_tmp_6 m.Ingress_tmp_5
-	and m.Ingress_tmp_6 0xF
-	jmpneq LABEL_END m.Ingress_tmp_6 0x4
-	mov m.Ingress_tmp_11 h.ipv4.hdrChecksum
-	and m.Ingress_tmp_11 0xFFF0
-	mov m.Ingress_tmp_12 h.ipv4.version_ihl
-	and m.Ingress_tmp_12 0xF
-	mov m.Ingress_tmp_13 m.Ingress_tmp_12
-	and m.Ingress_tmp_13 0xF
-	mov m.Ingress_tmp_15 m.Ingress_tmp_13
-	add m.Ingress_tmp_15 0x5
+	mov m.Ingress_tmp_6 h.ipv4.version_ihl
+	shr m.Ingress_tmp_6 0x4
+	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	and m.Ingress_tmp_7 0xF
+	mov m.Ingress_tmp_8 m.Ingress_tmp_7
+	and m.Ingress_tmp_8 0xF
+	jmpneq LABEL_END m.Ingress_tmp_8 0x4
+	mov m.Ingress_tmp_13 h.ipv4.hdrChecksum
+	and m.Ingress_tmp_13 0xFFF0
+	mov m.Ingress_tmp_14 h.ipv4.version_ihl
+	shr m.Ingress_tmp_14 0x4
+	mov m.Ingress_tmp_15 m.Ingress_tmp_14
 	and m.Ingress_tmp_15 0xF
-	mov m.Ingress_tmp_17 m.Ingress_tmp_15
-	and m.Ingress_tmp_17 0xF
-	mov h.ipv4.hdrChecksum m.Ingress_tmp_11
-	or h.ipv4.hdrChecksum m.Ingress_tmp_17
+	mov m.Ingress_tmp_16 m.Ingress_tmp_15
+	and m.Ingress_tmp_16 0xF
+	mov m.Ingress_tmp_18 m.Ingress_tmp_16
+	add m.Ingress_tmp_18 0x5
+	and m.Ingress_tmp_18 0xF
+	mov m.Ingress_tmp_20 m.Ingress_tmp_18
+	and m.Ingress_tmp_20 0xF
+	mov h.ipv4.hdrChecksum m.Ingress_tmp_13
+	or h.ipv4.hdrChecksum m.Ingress_tmp_20
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	mov m.IngressDeparser_deparser_tmp h.ipv4.hdrChecksum
 	and m.IngressDeparser_deparser_tmp 0xFFF0
 	mov h.ipv4.hdrChecksum m.IngressDeparser_deparser_tmp
 	or h.ipv4.hdrChecksum 0x4
 	mov m.IngressDeparser_deparser_tmp_0 h.ipv4.version_ihl
-	and m.IngressDeparser_deparser_tmp_0 0xF0
+	and m.IngressDeparser_deparser_tmp_0 0xF
 	mov h.ipv4.version_ihl m.IngressDeparser_deparser_tmp_0
-	or h.ipv4.version_ihl 0x4
+	or h.ipv4.version_ihl 0x40
 	emit h.ethernet
 	emit h.ipv4
 	tx m.psa_ingress_output_metadata_egress_port

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.spec
@@ -57,28 +57,33 @@ struct metadata_t {
 	bit<32> ingress_tbl_key_0
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
-	bit<32> IngressParser_parser_tmp_1
+	bit<8> IngressParser_parser_tmp_1
+	bit<32> IngressParser_parser_tmp_2
 	bit<16> Ingress_tmp
 	bit<16> Ingress_tmp_0
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
-	bit<8> Ingress_tmp_5
+	bit<8> Ingress_tmp_4
 	bit<8> Ingress_tmp_6
+	bit<8> Ingress_tmp_7
 	bit<8> Ingress_tmp_8
-	bit<8> Ingress_tmp_9
 	bit<8> Ingress_tmp_10
-	bit<16> Ingress_tmp_11
+	bit<8> Ingress_tmp_11
 	bit<8> Ingress_tmp_12
-	bit<8> Ingress_tmp_13
-	bit<32> Ingress_tmp_15
-	bit<16> Ingress_tmp_17
-	bit<16> Ingress_tmp_18
-	bit<16> Ingress_tmp_19
-	bit<8> Ingress_tmp_20
-	bit<8> Ingress_tmp_21
+	bit<16> Ingress_tmp_13
+	bit<8> Ingress_tmp_14
+	bit<8> Ingress_tmp_15
+	bit<8> Ingress_tmp_16
+	bit<32> Ingress_tmp_18
+	bit<16> Ingress_tmp_20
+	bit<16> Ingress_tmp_21
+	bit<16> Ingress_tmp_22
+	bit<8> Ingress_tmp_23
+	bit<8> Ingress_tmp_24
+	bit<8> Ingress_tmp_25
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
-	bit<32> Ingress_tmp_23
+	bit<32> Ingress_tmp_27
 }
 metadata instanceof metadata_t
 
@@ -97,35 +102,37 @@ action NoAction args none {
 }
 
 action execute_1 args instanceof execute_1_arg_t {
-	mov m.Ingress_tmp_8 h.ipv4.version_ihl
-	and m.Ingress_tmp_8 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_8
-	or h.ipv4.version_ihl 0x50
+	mov m.Ingress_tmp_10 h.ipv4.version_ihl
+	and m.Ingress_tmp_10 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_10
+	or h.ipv4.version_ihl 0x5
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in m.Ingress_color_out
 	jmpneq LABEL_FALSE_1 m.Ingress_color_out 0x0
-	mov m.Ingress_tmp_23 0x1
+	mov m.Ingress_tmp_27 0x1
 	jmp LABEL_END_1
-	LABEL_FALSE_1 :	mov m.Ingress_tmp_23 0x0
-	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_23
+	LABEL_FALSE_1 :	mov m.Ingress_tmp_27 0x0
+	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_27
 	regwr reg_0 t.index m.local_metadata_port_out
 	mov m.Ingress_tmp h.ipv4.hdrChecksum
 	and m.Ingress_tmp 0x3F
 	mov m.Ingress_tmp_0 m.Ingress_tmp
 	and m.Ingress_tmp_0 0x3F
 	jmpneq LABEL_END_2 m.Ingress_tmp_0 0x6
-	mov m.Ingress_tmp_9 h.ipv4.version_ihl
-	and m.Ingress_tmp_9 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_9
-	or h.ipv4.version_ihl 0x50
+	mov m.Ingress_tmp_11 h.ipv4.version_ihl
+	and m.Ingress_tmp_11 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_11
+	or h.ipv4.version_ihl 0x5
 	LABEL_END_2 :	mov m.Ingress_tmp_2 h.ipv4.version_ihl
-	and m.Ingress_tmp_2 0xF
+	shr m.Ingress_tmp_2 0x4
 	mov m.Ingress_tmp_3 m.Ingress_tmp_2
 	and m.Ingress_tmp_3 0xF
-	jmpneq LABEL_END_3 m.Ingress_tmp_3 0x6
-	mov m.Ingress_tmp_10 h.ipv4.version_ihl
-	and m.Ingress_tmp_10 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_10
-	or h.ipv4.version_ihl 0x60
+	mov m.Ingress_tmp_4 m.Ingress_tmp_3
+	and m.Ingress_tmp_4 0xF
+	jmpneq LABEL_END_3 m.Ingress_tmp_4 0x6
+	mov m.Ingress_tmp_12 h.ipv4.version_ihl
+	and m.Ingress_tmp_12 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_12
+	or h.ipv4.version_ihl 0x6
 	LABEL_END_3 :	return
 }
 
@@ -152,47 +159,55 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4.version_ihl
-	and m.IngressParser_parser_tmp 0xF
+	shr m.IngressParser_parser_tmp 0x4
 	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
 	and m.IngressParser_parser_tmp_0 0xF
 	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
+	and m.IngressParser_parser_tmp_1 0xF
+	mov m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_1
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
 	jmpneq LABEL_END m.local_metadata_port_out 0x1
-	mov m.Ingress_tmp_18 h.ipv4.hdrChecksum
-	and m.Ingress_tmp_18 0x1F
-	mov m.Ingress_tmp_19 m.Ingress_tmp_18
-	and m.Ingress_tmp_19 0x1F
-	mov m.Ingress_tmp_20 h.ipv4.version_ihl
-	and m.Ingress_tmp_20 0xF
-	mov m.Ingress_tmp_21 m.Ingress_tmp_20
-	and m.Ingress_tmp_21 0xF
+	mov m.Ingress_tmp_21 h.ipv4.hdrChecksum
+	and m.Ingress_tmp_21 0x1F
+	mov m.Ingress_tmp_22 m.Ingress_tmp_21
+	and m.Ingress_tmp_22 0x1F
+	mov m.Ingress_tmp_23 h.ipv4.version_ihl
+	shr m.Ingress_tmp_23 0x4
+	mov m.Ingress_tmp_24 m.Ingress_tmp_23
+	and m.Ingress_tmp_24 0xF
+	mov m.Ingress_tmp_25 m.Ingress_tmp_24
+	and m.Ingress_tmp_25 0xF
 	mov m.ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
-	mov m.ingress_tbl_key m.Ingress_tmp_19
-	mov m.ingress_tbl_key_0 m.Ingress_tmp_21
+	mov m.ingress_tbl_key m.Ingress_tmp_22
+	mov m.ingress_tbl_key_0 m.Ingress_tmp_25
 	table tbl
 	regadd counter0_0_packets 0x3FF 1
 	regadd counter0_0_bytes 0x3FF 0x14
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3FF 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_5 h.ipv4.version_ihl
-	and m.Ingress_tmp_5 0xF
-	mov m.Ingress_tmp_6 m.Ingress_tmp_5
-	and m.Ingress_tmp_6 0xF
-	jmpneq LABEL_END m.Ingress_tmp_6 0x4
-	mov m.Ingress_tmp_11 h.ipv4.hdrChecksum
-	and m.Ingress_tmp_11 0xFFF0
-	mov m.Ingress_tmp_12 h.ipv4.version_ihl
-	and m.Ingress_tmp_12 0xF
-	mov m.Ingress_tmp_13 m.Ingress_tmp_12
-	and m.Ingress_tmp_13 0xF
-	mov m.Ingress_tmp_15 m.Ingress_tmp_13
-	add m.Ingress_tmp_15 0x5
+	mov m.Ingress_tmp_6 h.ipv4.version_ihl
+	shr m.Ingress_tmp_6 0x4
+	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	and m.Ingress_tmp_7 0xF
+	mov m.Ingress_tmp_8 m.Ingress_tmp_7
+	and m.Ingress_tmp_8 0xF
+	jmpneq LABEL_END m.Ingress_tmp_8 0x4
+	mov m.Ingress_tmp_13 h.ipv4.hdrChecksum
+	and m.Ingress_tmp_13 0xFFF0
+	mov m.Ingress_tmp_14 h.ipv4.version_ihl
+	shr m.Ingress_tmp_14 0x4
+	mov m.Ingress_tmp_15 m.Ingress_tmp_14
 	and m.Ingress_tmp_15 0xF
-	mov m.Ingress_tmp_17 m.Ingress_tmp_15
-	and m.Ingress_tmp_17 0xF
-	mov h.ipv4.hdrChecksum m.Ingress_tmp_11
-	or h.ipv4.hdrChecksum m.Ingress_tmp_17
+	mov m.Ingress_tmp_16 m.Ingress_tmp_15
+	and m.Ingress_tmp_16 0xF
+	mov m.Ingress_tmp_18 m.Ingress_tmp_16
+	add m.Ingress_tmp_18 0x5
+	and m.Ingress_tmp_18 0xF
+	mov m.Ingress_tmp_20 m.Ingress_tmp_18
+	and m.Ingress_tmp_20 0xF
+	mov h.ipv4.hdrChecksum m.Ingress_tmp_13
+	or h.ipv4.hdrChecksum m.Ingress_tmp_20
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	mov h.ipv4.hdrChecksum 0x4
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.spec
@@ -54,24 +54,28 @@ struct metadata_t {
 	bit<32> local_metadata_port_out
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
-	bit<32> IngressParser_parser_tmp_1
+	bit<8> IngressParser_parser_tmp_1
+	bit<32> IngressParser_parser_tmp_2
 	bit<16> Ingress_tmp
 	bit<16> Ingress_tmp_0
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
-	bit<8> Ingress_tmp_5
+	bit<8> Ingress_tmp_4
 	bit<8> Ingress_tmp_6
+	bit<8> Ingress_tmp_7
 	bit<8> Ingress_tmp_8
-	bit<8> Ingress_tmp_9
 	bit<8> Ingress_tmp_10
-	bit<16> Ingress_tmp_11
+	bit<8> Ingress_tmp_11
 	bit<8> Ingress_tmp_12
-	bit<8> Ingress_tmp_13
-	bit<32> Ingress_tmp_15
-	bit<16> Ingress_tmp_17
+	bit<16> Ingress_tmp_13
+	bit<8> Ingress_tmp_14
+	bit<8> Ingress_tmp_15
+	bit<8> Ingress_tmp_16
+	bit<32> Ingress_tmp_18
+	bit<16> Ingress_tmp_20
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
-	bit<32> Ingress_tmp_19
+	bit<32> Ingress_tmp_22
 }
 metadata instanceof metadata_t
 
@@ -90,35 +94,37 @@ action NoAction args none {
 }
 
 action execute_1 args instanceof execute_1_arg_t {
-	mov m.Ingress_tmp_8 h.ipv4.version_ihl
-	and m.Ingress_tmp_8 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_8
-	or h.ipv4.version_ihl 0x50
+	mov m.Ingress_tmp_10 h.ipv4.version_ihl
+	and m.Ingress_tmp_10 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_10
+	or h.ipv4.version_ihl 0x5
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in m.Ingress_color_out
 	jmpneq LABEL_FALSE_1 m.Ingress_color_out 0x0
-	mov m.Ingress_tmp_19 0x1
+	mov m.Ingress_tmp_22 0x1
 	jmp LABEL_END_1
-	LABEL_FALSE_1 :	mov m.Ingress_tmp_19 0x0
-	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_19
+	LABEL_FALSE_1 :	mov m.Ingress_tmp_22 0x0
+	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_22
 	regwr reg_0 t.index m.local_metadata_port_out
 	mov m.Ingress_tmp h.ipv4.hdrChecksum
 	and m.Ingress_tmp 0x3F
 	mov m.Ingress_tmp_0 m.Ingress_tmp
 	and m.Ingress_tmp_0 0x3F
 	jmpneq LABEL_END_2 m.Ingress_tmp_0 0x6
-	mov m.Ingress_tmp_9 h.ipv4.version_ihl
-	and m.Ingress_tmp_9 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_9
-	or h.ipv4.version_ihl 0x50
+	mov m.Ingress_tmp_11 h.ipv4.version_ihl
+	and m.Ingress_tmp_11 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_11
+	or h.ipv4.version_ihl 0x5
 	LABEL_END_2 :	mov m.Ingress_tmp_2 h.ipv4.version_ihl
-	and m.Ingress_tmp_2 0xF
+	shr m.Ingress_tmp_2 0x4
 	mov m.Ingress_tmp_3 m.Ingress_tmp_2
 	and m.Ingress_tmp_3 0xF
-	jmpneq LABEL_END_3 m.Ingress_tmp_3 0x6
-	mov m.Ingress_tmp_10 h.ipv4.version_ihl
-	and m.Ingress_tmp_10 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_10
-	or h.ipv4.version_ihl 0x60
+	mov m.Ingress_tmp_4 m.Ingress_tmp_3
+	and m.Ingress_tmp_4 0xF
+	jmpneq LABEL_END_3 m.Ingress_tmp_4 0x6
+	mov m.Ingress_tmp_12 h.ipv4.version_ihl
+	and m.Ingress_tmp_12 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_12
+	or h.ipv4.version_ihl 0x6
 	LABEL_END_3 :	return
 }
 
@@ -143,10 +149,12 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4.version_ihl
-	and m.IngressParser_parser_tmp 0xF
+	shr m.IngressParser_parser_tmp 0x4
 	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
 	and m.IngressParser_parser_tmp_0 0xF
 	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
+	and m.IngressParser_parser_tmp_1 0xF
+	mov m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_1
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
 	jmpneq LABEL_END m.local_metadata_port_out 0x1
 	table tbl
@@ -155,24 +163,28 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3FF 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_5 h.ipv4.version_ihl
-	and m.Ingress_tmp_5 0xF
-	mov m.Ingress_tmp_6 m.Ingress_tmp_5
-	and m.Ingress_tmp_6 0xF
-	jmpneq LABEL_END m.Ingress_tmp_6 0x4
-	mov m.Ingress_tmp_11 h.ipv4.hdrChecksum
-	and m.Ingress_tmp_11 0xFFF0
-	mov m.Ingress_tmp_12 h.ipv4.version_ihl
-	and m.Ingress_tmp_12 0xF
-	mov m.Ingress_tmp_13 m.Ingress_tmp_12
-	and m.Ingress_tmp_13 0xF
-	mov m.Ingress_tmp_15 m.Ingress_tmp_13
-	add m.Ingress_tmp_15 0x5
+	mov m.Ingress_tmp_6 h.ipv4.version_ihl
+	shr m.Ingress_tmp_6 0x4
+	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	and m.Ingress_tmp_7 0xF
+	mov m.Ingress_tmp_8 m.Ingress_tmp_7
+	and m.Ingress_tmp_8 0xF
+	jmpneq LABEL_END m.Ingress_tmp_8 0x4
+	mov m.Ingress_tmp_13 h.ipv4.hdrChecksum
+	and m.Ingress_tmp_13 0xFFF0
+	mov m.Ingress_tmp_14 h.ipv4.version_ihl
+	shr m.Ingress_tmp_14 0x4
+	mov m.Ingress_tmp_15 m.Ingress_tmp_14
 	and m.Ingress_tmp_15 0xF
-	mov m.Ingress_tmp_17 m.Ingress_tmp_15
-	and m.Ingress_tmp_17 0xF
-	mov h.ipv4.hdrChecksum m.Ingress_tmp_11
-	or h.ipv4.hdrChecksum m.Ingress_tmp_17
+	mov m.Ingress_tmp_16 m.Ingress_tmp_15
+	and m.Ingress_tmp_16 0xF
+	mov m.Ingress_tmp_18 m.Ingress_tmp_16
+	add m.Ingress_tmp_18 0x5
+	and m.Ingress_tmp_18 0xF
+	mov m.Ingress_tmp_20 m.Ingress_tmp_18
+	and m.Ingress_tmp_20 0xF
+	mov h.ipv4.hdrChecksum m.Ingress_tmp_13
+	or h.ipv4.hdrChecksum m.Ingress_tmp_20
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	mov h.ipv4.hdrChecksum 0x4
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.spec
@@ -57,29 +57,32 @@ struct metadata_t {
 	bit<32> local_metadata_temp
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
-	bit<8> IngressParser_parser_tmp_1
+	bit<8> IngressParser_parser_tmp_2
 	bit<8> IngressParser_parser_tmp_3
 	bit<8> IngressParser_parser_tmp_4
 	bit<8> IngressParser_parser_tmp_5
 	bit<32> IngressParser_parser_tmp_6
 	bit<8> Ingress_tmp
 	bit<8> Ingress_tmp_0
-	bit<8> Ingress_tmp_2
+	bit<8> Ingress_tmp_1
 	bit<8> Ingress_tmp_3
+	bit<8> Ingress_tmp_4
 	bit<8> Ingress_tmp_5
-	bit<8> Ingress_tmp_6
 	bit<8> Ingress_tmp_7
 	bit<8> Ingress_tmp_8
 	bit<8> Ingress_tmp_9
 	bit<8> Ingress_tmp_10
-	bit<16> Ingress_tmp_11
+	bit<8> Ingress_tmp_11
 	bit<8> Ingress_tmp_12
-	bit<8> Ingress_tmp_13
-	bit<32> Ingress_tmp_15
-	bit<16> Ingress_tmp_17
+	bit<16> Ingress_tmp_13
+	bit<8> Ingress_tmp_14
+	bit<8> Ingress_tmp_15
+	bit<8> Ingress_tmp_16
+	bit<32> Ingress_tmp_18
+	bit<16> Ingress_tmp_20
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
-	bit<32> Ingress_tmp_19
+	bit<32> Ingress_tmp_22
 }
 metadata instanceof metadata_t
 
@@ -98,44 +101,46 @@ action NoAction args none {
 }
 
 action execute_1 args instanceof execute_1_arg_t {
-	mov m.Ingress_tmp_5 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_5 0xF
-	mov h.ipv4._version0__ihl1 m.Ingress_tmp_5
-	or h.ipv4._version0__ihl1 0x50
+	mov m.Ingress_tmp_7 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_7 0xF0
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_7
+	or h.ipv4._version0__ihl1 0x5
 	meter meter0_0 t.index h.ipv4._totalLen3 m.Ingress_color_in m.Ingress_color_out
 	jmpneq LABEL_FALSE_2 m.Ingress_color_out 0x0
-	mov m.Ingress_tmp_19 0x1
+	mov m.Ingress_tmp_22 0x1
 	jmp LABEL_END_3
-	LABEL_FALSE_2 :	mov m.Ingress_tmp_19 0x0
-	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_19
+	LABEL_FALSE_2 :	mov m.Ingress_tmp_22 0x0
+	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_22
 	regwr reg_0 t.index m.local_metadata_port_out
 	mov m.Ingress_tmp h.ipv4._version0__ihl1
-	and m.Ingress_tmp 0xF
+	shr m.Ingress_tmp 0x4
 	mov m.Ingress_tmp_0 m.Ingress_tmp
 	and m.Ingress_tmp_0 0xF
-	jmpneq LABEL_END_4 m.Ingress_tmp_0 0x6
-	mov m.Ingress_tmp_6 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_6 0xF
-	mov h.ipv4._version0__ihl1 m.Ingress_tmp_6
-	or h.ipv4._version0__ihl1 0x60
+	mov m.Ingress_tmp_1 m.Ingress_tmp_0
+	and m.Ingress_tmp_1 0xF
+	jmpneq LABEL_END_4 m.Ingress_tmp_1 0x6
+	mov m.Ingress_tmp_8 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_8 0xF0
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_8
+	or h.ipv4._version0__ihl1 0x6
 	LABEL_END_4 :	jmpneq LABEL_FALSE_4 m.local_metadata_temp 0x6
-	mov m.Ingress_tmp_7 h.ipv4._s1_f112__s1_f213
-	and m.Ingress_tmp_7 0xF0
-	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_7
-	or h.ipv4._s1_f112__s1_f213 0x7
-	mov m.Ingress_tmp_8 h.ipv4._s1_f112__s1_f213
-	and m.Ingress_tmp_8 0xF
-	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_8
-	or h.ipv4._s1_f112__s1_f213 0x80
-	jmp LABEL_END_5
-	LABEL_FALSE_4 :	mov m.Ingress_tmp_9 h.ipv4._s1_f112__s1_f213
-	and m.Ingress_tmp_9 0xF0
+	mov m.Ingress_tmp_9 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_9 0xF
 	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_9
-	or h.ipv4._s1_f112__s1_f213 0x7
+	or h.ipv4._s1_f112__s1_f213 0x70
 	mov m.Ingress_tmp_10 h.ipv4._s1_f112__s1_f213
-	and m.Ingress_tmp_10 0xF
+	and m.Ingress_tmp_10 0xF0
 	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_10
-	or h.ipv4._s1_f112__s1_f213 0x90
+	or h.ipv4._s1_f112__s1_f213 0x8
+	jmp LABEL_END_5
+	LABEL_FALSE_4 :	mov m.Ingress_tmp_11 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_11 0xF
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_11
+	or h.ipv4._s1_f112__s1_f213 0x70
+	mov m.Ingress_tmp_12 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_12 0xF0
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_12
+	or h.ipv4._s1_f112__s1_f213 0x9
 	LABEL_END_5 :	return
 }
 
@@ -160,19 +165,19 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4._version0__ihl1
-	shr m.IngressParser_parser_tmp 0x4
+	and m.IngressParser_parser_tmp 0xF
 	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
 	and m.IngressParser_parser_tmp_0 0xF
-	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
-	and m.IngressParser_parser_tmp_1 0xF
-	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_1 0x5
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
 	mov m.IngressParser_parser_tmp_5 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.IngressParser_parser_tmp_5 0x1
 	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_5 0
 	mov m.psa_ingress_input_metadata_parser_error 0x7
 	jmp INGRESSPARSERIMPL_ACCEPT
-	LABEL_END_0 :	mov m.IngressParser_parser_tmp_3 h.ipv4._version0__ihl1
+	LABEL_END_0 :	mov m.IngressParser_parser_tmp_2 h.ipv4._version0__ihl1
+	shr m.IngressParser_parser_tmp_2 0x4
+	mov m.IngressParser_parser_tmp_3 m.IngressParser_parser_tmp_2
 	and m.IngressParser_parser_tmp_3 0xF
 	mov m.IngressParser_parser_tmp_4 m.IngressParser_parser_tmp_3
 	and m.IngressParser_parser_tmp_4 0xF
@@ -185,24 +190,28 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3FF 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_2 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_2 0xF
-	mov m.Ingress_tmp_3 m.Ingress_tmp_2
-	and m.Ingress_tmp_3 0xF
-	jmpneq LABEL_END_1 m.Ingress_tmp_3 0x4
-	mov m.Ingress_tmp_11 h.ipv4._hdrChecksum9
-	and m.Ingress_tmp_11 0xFFF0
-	mov m.Ingress_tmp_12 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_12 0xF
-	mov m.Ingress_tmp_13 m.Ingress_tmp_12
-	and m.Ingress_tmp_13 0xF
-	mov m.Ingress_tmp_15 m.Ingress_tmp_13
-	add m.Ingress_tmp_15 0x5
+	mov m.Ingress_tmp_3 h.ipv4._version0__ihl1
+	shr m.Ingress_tmp_3 0x4
+	mov m.Ingress_tmp_4 m.Ingress_tmp_3
+	and m.Ingress_tmp_4 0xF
+	mov m.Ingress_tmp_5 m.Ingress_tmp_4
+	and m.Ingress_tmp_5 0xF
+	jmpneq LABEL_END_1 m.Ingress_tmp_5 0x4
+	mov m.Ingress_tmp_13 h.ipv4._hdrChecksum9
+	and m.Ingress_tmp_13 0xFFF0
+	mov m.Ingress_tmp_14 h.ipv4._version0__ihl1
+	shr m.Ingress_tmp_14 0x4
+	mov m.Ingress_tmp_15 m.Ingress_tmp_14
 	and m.Ingress_tmp_15 0xF
-	mov m.Ingress_tmp_17 m.Ingress_tmp_15
-	and m.Ingress_tmp_17 0xF
-	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_11
-	or h.ipv4._hdrChecksum9 m.Ingress_tmp_17
+	mov m.Ingress_tmp_16 m.Ingress_tmp_15
+	and m.Ingress_tmp_16 0xF
+	mov m.Ingress_tmp_18 m.Ingress_tmp_16
+	add m.Ingress_tmp_18 0x5
+	and m.Ingress_tmp_18 0xF
+	mov m.Ingress_tmp_20 m.Ingress_tmp_18
+	and m.Ingress_tmp_20 0xF
+	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_13
+	or h.ipv4._hdrChecksum9 m.Ingress_tmp_20
 	LABEL_END_1 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	mov h.ipv4._hdrChecksum9 0x4
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.spec
@@ -58,17 +58,17 @@ struct metadata_t {
 	bit<32> local_metadata_temp
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
-	bit<8> IngressParser_parser_tmp_1
+	bit<8> IngressParser_parser_tmp_2
 	bit<8> IngressParser_parser_tmp_3
 	bit<8> IngressParser_parser_tmp_4
 	bit<8> IngressParser_parser_tmp_5
 	bit<32> IngressParser_parser_tmp_6
 	bit<8> Ingress_tmp
 	bit<8> Ingress_tmp_0
-	bit<8> Ingress_tmp_2
+	bit<8> Ingress_tmp_1
 	bit<8> Ingress_tmp_3
+	bit<8> Ingress_tmp_4
 	bit<8> Ingress_tmp_5
-	bit<8> Ingress_tmp_6
 	bit<8> Ingress_tmp_7
 	bit<8> Ingress_tmp_8
 	bit<8> Ingress_tmp_9
@@ -77,14 +77,17 @@ struct metadata_t {
 	bit<8> Ingress_tmp_12
 	bit<8> Ingress_tmp_13
 	bit<8> Ingress_tmp_14
-	bit<16> Ingress_tmp_15
+	bit<8> Ingress_tmp_15
 	bit<8> Ingress_tmp_16
-	bit<8> Ingress_tmp_17
-	bit<32> Ingress_tmp_19
-	bit<16> Ingress_tmp_21
+	bit<16> Ingress_tmp_17
+	bit<8> Ingress_tmp_18
+	bit<8> Ingress_tmp_19
+	bit<8> Ingress_tmp_20
+	bit<32> Ingress_tmp_22
+	bit<16> Ingress_tmp_24
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
-	bit<32> Ingress_tmp_23
+	bit<32> Ingress_tmp_26
 }
 metadata instanceof metadata_t
 
@@ -103,60 +106,62 @@ action NoAction args none {
 }
 
 action execute_1 args instanceof execute_1_arg_t {
-	mov m.Ingress_tmp_5 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_5 0xF
-	mov h.ipv4._version0__ihl1 m.Ingress_tmp_5
-	or h.ipv4._version0__ihl1 0x50
+	mov m.Ingress_tmp_7 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_7 0xF0
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_7
+	or h.ipv4._version0__ihl1 0x5
 	meter meter0_0 t.index h.ipv4._totalLen3 m.Ingress_color_in m.Ingress_color_out
 	jmpneq LABEL_FALSE_2 m.Ingress_color_out 0x0
-	mov m.Ingress_tmp_23 0x1
+	mov m.Ingress_tmp_26 0x1
 	jmp LABEL_END_3
-	LABEL_FALSE_2 :	mov m.Ingress_tmp_23 0x0
-	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_23
+	LABEL_FALSE_2 :	mov m.Ingress_tmp_26 0x0
+	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_26
 	regwr reg_0 t.index m.local_metadata_port_out
 	mov m.Ingress_tmp h.ipv4._version0__ihl1
-	and m.Ingress_tmp 0xF
+	shr m.Ingress_tmp 0x4
 	mov m.Ingress_tmp_0 m.Ingress_tmp
 	and m.Ingress_tmp_0 0xF
-	jmpneq LABEL_END_4 m.Ingress_tmp_0 0x6
-	mov m.Ingress_tmp_6 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_6 0xF
-	mov h.ipv4._version0__ihl1 m.Ingress_tmp_6
-	or h.ipv4._version0__ihl1 0x60
+	mov m.Ingress_tmp_1 m.Ingress_tmp_0
+	and m.Ingress_tmp_1 0xF
+	jmpneq LABEL_END_4 m.Ingress_tmp_1 0x6
+	mov m.Ingress_tmp_8 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_8 0xF0
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_8
+	or h.ipv4._version0__ihl1 0x6
 	LABEL_END_4 :	jmpneq LABEL_FALSE_4 m.local_metadata_temp 0x6
-	mov m.Ingress_tmp_7 h.ipv4._s1_f112__s1_f213
-	and m.Ingress_tmp_7 0xF8
-	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_7
-	or h.ipv4._s1_f112__s1_f213 0x2
-	mov m.Ingress_tmp_8 h.ipv4._s1_f112__s1_f213
-	and m.Ingress_tmp_8 0x7
-	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_8
-	or h.ipv4._s1_f112__s1_f213 0x18
-	mov m.Ingress_tmp_9 h.ipv4._s2_f114__s2_f215
-	and m.Ingress_tmp_9 0xE0
-	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_9
-	or h.ipv4._s2_f114__s2_f215 0x2
-	mov m.Ingress_tmp_10 h.ipv4._s2_f114__s2_f215
-	and m.Ingress_tmp_10 0x1F
-	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_10
-	or h.ipv4._s2_f114__s2_f215 0x60
-	jmp LABEL_END_5
-	LABEL_FALSE_4 :	mov m.Ingress_tmp_11 h.ipv4._s1_f112__s1_f213
-	and m.Ingress_tmp_11 0xF8
-	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_11
+	mov m.Ingress_tmp_9 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_9 0x1F
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_9
+	or h.ipv4._s1_f112__s1_f213 0x40
+	mov m.Ingress_tmp_10 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_10 0xE0
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_10
 	or h.ipv4._s1_f112__s1_f213 0x3
-	mov m.Ingress_tmp_12 h.ipv4._s1_f112__s1_f213
-	and m.Ingress_tmp_12 0x7
-	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_12
-	or h.ipv4._s1_f112__s1_f213 0x10
-	mov m.Ingress_tmp_13 h.ipv4._s2_f114__s2_f215
-	and m.Ingress_tmp_13 0xE0
-	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_13
+	mov m.Ingress_tmp_11 h.ipv4._s2_f114__s2_f215
+	and m.Ingress_tmp_11 0x7
+	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_11
+	or h.ipv4._s2_f114__s2_f215 0x10
+	mov m.Ingress_tmp_12 h.ipv4._s2_f114__s2_f215
+	and m.Ingress_tmp_12 0xF8
+	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_12
 	or h.ipv4._s2_f114__s2_f215 0x3
-	mov m.Ingress_tmp_14 h.ipv4._s2_f114__s2_f215
-	and m.Ingress_tmp_14 0x1F
-	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_14
-	or h.ipv4._s2_f114__s2_f215 0x40
+	jmp LABEL_END_5
+	LABEL_FALSE_4 :	mov m.Ingress_tmp_13 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_13 0x1F
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_13
+	or h.ipv4._s1_f112__s1_f213 0x60
+	mov m.Ingress_tmp_14 h.ipv4._s1_f112__s1_f213
+	and m.Ingress_tmp_14 0xE0
+	mov h.ipv4._s1_f112__s1_f213 m.Ingress_tmp_14
+	or h.ipv4._s1_f112__s1_f213 0x2
+	mov m.Ingress_tmp_15 h.ipv4._s2_f114__s2_f215
+	and m.Ingress_tmp_15 0x7
+	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_15
+	or h.ipv4._s2_f114__s2_f215 0x18
+	mov m.Ingress_tmp_16 h.ipv4._s2_f114__s2_f215
+	and m.Ingress_tmp_16 0xF8
+	mov h.ipv4._s2_f114__s2_f215 m.Ingress_tmp_16
+	or h.ipv4._s2_f114__s2_f215 0x2
 	LABEL_END_5 :	return
 }
 
@@ -181,19 +186,19 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4._version0__ihl1
-	shr m.IngressParser_parser_tmp 0x4
+	and m.IngressParser_parser_tmp 0xF
 	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
 	and m.IngressParser_parser_tmp_0 0xF
-	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
-	and m.IngressParser_parser_tmp_1 0xF
-	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_1 0x5
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
 	mov m.IngressParser_parser_tmp_5 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.IngressParser_parser_tmp_5 0x1
 	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_5 0
 	mov m.psa_ingress_input_metadata_parser_error 0x7
 	jmp INGRESSPARSERIMPL_ACCEPT
-	LABEL_END_0 :	mov m.IngressParser_parser_tmp_3 h.ipv4._version0__ihl1
+	LABEL_END_0 :	mov m.IngressParser_parser_tmp_2 h.ipv4._version0__ihl1
+	shr m.IngressParser_parser_tmp_2 0x4
+	mov m.IngressParser_parser_tmp_3 m.IngressParser_parser_tmp_2
 	and m.IngressParser_parser_tmp_3 0xF
 	mov m.IngressParser_parser_tmp_4 m.IngressParser_parser_tmp_3
 	and m.IngressParser_parser_tmp_4 0xF
@@ -206,24 +211,28 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3FF 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_2 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_2 0xF
-	mov m.Ingress_tmp_3 m.Ingress_tmp_2
-	and m.Ingress_tmp_3 0xF
-	jmpneq LABEL_END_1 m.Ingress_tmp_3 0x4
-	mov m.Ingress_tmp_15 h.ipv4._hdrChecksum9
-	and m.Ingress_tmp_15 0xFFF0
-	mov m.Ingress_tmp_16 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_16 0xF
-	mov m.Ingress_tmp_17 m.Ingress_tmp_16
-	and m.Ingress_tmp_17 0xF
-	mov m.Ingress_tmp_19 m.Ingress_tmp_17
-	add m.Ingress_tmp_19 0x5
+	mov m.Ingress_tmp_3 h.ipv4._version0__ihl1
+	shr m.Ingress_tmp_3 0x4
+	mov m.Ingress_tmp_4 m.Ingress_tmp_3
+	and m.Ingress_tmp_4 0xF
+	mov m.Ingress_tmp_5 m.Ingress_tmp_4
+	and m.Ingress_tmp_5 0xF
+	jmpneq LABEL_END_1 m.Ingress_tmp_5 0x4
+	mov m.Ingress_tmp_17 h.ipv4._hdrChecksum9
+	and m.Ingress_tmp_17 0xFFF0
+	mov m.Ingress_tmp_18 h.ipv4._version0__ihl1
+	shr m.Ingress_tmp_18 0x4
+	mov m.Ingress_tmp_19 m.Ingress_tmp_18
 	and m.Ingress_tmp_19 0xF
-	mov m.Ingress_tmp_21 m.Ingress_tmp_19
-	and m.Ingress_tmp_21 0xF
-	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_15
-	or h.ipv4._hdrChecksum9 m.Ingress_tmp_21
+	mov m.Ingress_tmp_20 m.Ingress_tmp_19
+	and m.Ingress_tmp_20 0xF
+	mov m.Ingress_tmp_22 m.Ingress_tmp_20
+	add m.Ingress_tmp_22 0x5
+	and m.Ingress_tmp_22 0xF
+	mov m.Ingress_tmp_24 m.Ingress_tmp_22
+	and m.Ingress_tmp_24 0xF
+	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_17
+	or h.ipv4._hdrChecksum9 m.Ingress_tmp_24
 	LABEL_END_1 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	mov h.ipv4._hdrChecksum9 0x4
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.spec
@@ -59,29 +59,32 @@ struct metadata_t {
 	bit<32> local_metadata_temp
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
-	bit<8> IngressParser_parser_tmp_1
+	bit<8> IngressParser_parser_tmp_2
 	bit<8> IngressParser_parser_tmp_3
 	bit<8> IngressParser_parser_tmp_4
 	bit<8> IngressParser_parser_tmp_5
 	bit<32> IngressParser_parser_tmp_6
 	bit<8> Ingress_tmp
 	bit<8> Ingress_tmp_0
-	bit<8> Ingress_tmp_2
+	bit<8> Ingress_tmp_1
 	bit<8> Ingress_tmp_3
+	bit<8> Ingress_tmp_4
 	bit<8> Ingress_tmp_5
-	bit<8> Ingress_tmp_6
 	bit<8> Ingress_tmp_7
 	bit<8> Ingress_tmp_8
 	bit<8> Ingress_tmp_9
 	bit<8> Ingress_tmp_10
-	bit<16> Ingress_tmp_11
+	bit<8> Ingress_tmp_11
 	bit<8> Ingress_tmp_12
-	bit<8> Ingress_tmp_13
-	bit<32> Ingress_tmp_15
-	bit<16> Ingress_tmp_17
+	bit<16> Ingress_tmp_13
+	bit<8> Ingress_tmp_14
+	bit<8> Ingress_tmp_15
+	bit<8> Ingress_tmp_16
+	bit<32> Ingress_tmp_18
+	bit<16> Ingress_tmp_20
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
-	bit<32> Ingress_tmp_19
+	bit<32> Ingress_tmp_22
 }
 metadata instanceof metadata_t
 
@@ -100,47 +103,49 @@ action NoAction args none {
 }
 
 action execute_1 args instanceof execute_1_arg_t {
-	mov m.Ingress_tmp_5 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_5 0xF
-	mov h.ipv4._version0__ihl1 m.Ingress_tmp_5
-	or h.ipv4._version0__ihl1 0x50
+	mov m.Ingress_tmp_7 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_7 0xF0
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_7
+	or h.ipv4._version0__ihl1 0x5
 	meter meter0_0 t.index h.ipv4._totalLen3 m.Ingress_color_in m.Ingress_color_out
 	jmpneq LABEL_FALSE_2 m.Ingress_color_out 0x0
-	mov m.Ingress_tmp_19 0x1
+	mov m.Ingress_tmp_22 0x1
 	jmp LABEL_END_3
-	LABEL_FALSE_2 :	mov m.Ingress_tmp_19 0x0
-	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_19
+	LABEL_FALSE_2 :	mov m.Ingress_tmp_22 0x0
+	LABEL_END_3 :	mov m.local_metadata_port_out m.Ingress_tmp_22
 	regwr reg_0 t.index m.local_metadata_port_out
 	mov m.Ingress_tmp h.ipv4._version0__ihl1
-	and m.Ingress_tmp 0xF
+	shr m.Ingress_tmp 0x4
 	mov m.Ingress_tmp_0 m.Ingress_tmp
 	and m.Ingress_tmp_0 0xF
-	jmpneq LABEL_END_4 m.Ingress_tmp_0 0x6
-	mov m.Ingress_tmp_6 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_6 0xF
-	mov h.ipv4._version0__ihl1 m.Ingress_tmp_6
-	or h.ipv4._version0__ihl1 0x60
+	mov m.Ingress_tmp_1 m.Ingress_tmp_0
+	and m.Ingress_tmp_1 0xF
+	jmpneq LABEL_END_4 m.Ingress_tmp_1 0x6
+	mov m.Ingress_tmp_8 h.ipv4._version0__ihl1
+	and m.Ingress_tmp_8 0xF0
+	mov h.ipv4._version0__ihl1 m.Ingress_tmp_8
+	or h.ipv4._version0__ihl1 0x6
 	LABEL_END_4 :	jmpneq LABEL_FALSE_4 m.local_metadata_temp 0x6
 	mov h.ipv4._s1_f112 0x2
-	mov m.Ingress_tmp_7 h.ipv4._s1_f213__s2_f114
-	and m.Ingress_tmp_7 0xF8
-	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_7
-	or h.ipv4._s1_f213__s2_f114 0x3
-	mov m.Ingress_tmp_8 h.ipv4._s1_f213__s2_f114
-	and m.Ingress_tmp_8 0x7
-	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_8
-	or h.ipv4._s1_f213__s2_f114 0x10
+	mov m.Ingress_tmp_9 h.ipv4._s1_f213__s2_f114
+	and m.Ingress_tmp_9 0x1F
+	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_9
+	or h.ipv4._s1_f213__s2_f114 0x60
+	mov m.Ingress_tmp_10 h.ipv4._s1_f213__s2_f114
+	and m.Ingress_tmp_10 0xE0
+	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_10
+	or h.ipv4._s1_f213__s2_f114 0x2
 	mov h.ipv4._s2_f215 0x3
 	jmp LABEL_END_5
 	LABEL_FALSE_4 :	mov h.ipv4._s1_f112 0x3
-	mov m.Ingress_tmp_9 h.ipv4._s1_f213__s2_f114
-	and m.Ingress_tmp_9 0xF8
-	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_9
-	or h.ipv4._s1_f213__s2_f114 0x2
-	mov m.Ingress_tmp_10 h.ipv4._s1_f213__s2_f114
-	and m.Ingress_tmp_10 0x7
-	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_10
-	or h.ipv4._s1_f213__s2_f114 0x18
+	mov m.Ingress_tmp_11 h.ipv4._s1_f213__s2_f114
+	and m.Ingress_tmp_11 0x1F
+	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_11
+	or h.ipv4._s1_f213__s2_f114 0x40
+	mov m.Ingress_tmp_12 h.ipv4._s1_f213__s2_f114
+	and m.Ingress_tmp_12 0xE0
+	mov h.ipv4._s1_f213__s2_f114 m.Ingress_tmp_12
+	or h.ipv4._s1_f213__s2_f114 0x3
 	mov h.ipv4._s2_f215 0x2
 	LABEL_END_5 :	return
 }
@@ -166,19 +171,19 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4._version0__ihl1
-	shr m.IngressParser_parser_tmp 0x4
+	and m.IngressParser_parser_tmp 0xF
 	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
 	and m.IngressParser_parser_tmp_0 0xF
-	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
-	and m.IngressParser_parser_tmp_1 0xF
-	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_1 0x5
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
 	mov m.IngressParser_parser_tmp_5 0x0
 	jmp LABEL_END
 	LABEL_TRUE :	mov m.IngressParser_parser_tmp_5 0x1
 	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_5 0
 	mov m.psa_ingress_input_metadata_parser_error 0x7
 	jmp INGRESSPARSERIMPL_ACCEPT
-	LABEL_END_0 :	mov m.IngressParser_parser_tmp_3 h.ipv4._version0__ihl1
+	LABEL_END_0 :	mov m.IngressParser_parser_tmp_2 h.ipv4._version0__ihl1
+	shr m.IngressParser_parser_tmp_2 0x4
+	mov m.IngressParser_parser_tmp_3 m.IngressParser_parser_tmp_2
 	and m.IngressParser_parser_tmp_3 0xF
 	mov m.IngressParser_parser_tmp_4 m.IngressParser_parser_tmp_3
 	and m.IngressParser_parser_tmp_4 0xF
@@ -191,24 +196,28 @@ apply {
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3FF 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_2 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_2 0xF
-	mov m.Ingress_tmp_3 m.Ingress_tmp_2
-	and m.Ingress_tmp_3 0xF
-	jmpneq LABEL_END_1 m.Ingress_tmp_3 0x4
-	mov m.Ingress_tmp_11 h.ipv4._hdrChecksum9
-	and m.Ingress_tmp_11 0xFFF0
-	mov m.Ingress_tmp_12 h.ipv4._version0__ihl1
-	and m.Ingress_tmp_12 0xF
-	mov m.Ingress_tmp_13 m.Ingress_tmp_12
-	and m.Ingress_tmp_13 0xF
-	mov m.Ingress_tmp_15 m.Ingress_tmp_13
-	add m.Ingress_tmp_15 0x5
+	mov m.Ingress_tmp_3 h.ipv4._version0__ihl1
+	shr m.Ingress_tmp_3 0x4
+	mov m.Ingress_tmp_4 m.Ingress_tmp_3
+	and m.Ingress_tmp_4 0xF
+	mov m.Ingress_tmp_5 m.Ingress_tmp_4
+	and m.Ingress_tmp_5 0xF
+	jmpneq LABEL_END_1 m.Ingress_tmp_5 0x4
+	mov m.Ingress_tmp_13 h.ipv4._hdrChecksum9
+	and m.Ingress_tmp_13 0xFFF0
+	mov m.Ingress_tmp_14 h.ipv4._version0__ihl1
+	shr m.Ingress_tmp_14 0x4
+	mov m.Ingress_tmp_15 m.Ingress_tmp_14
 	and m.Ingress_tmp_15 0xF
-	mov m.Ingress_tmp_17 m.Ingress_tmp_15
-	and m.Ingress_tmp_17 0xF
-	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_11
-	or h.ipv4._hdrChecksum9 m.Ingress_tmp_17
+	mov m.Ingress_tmp_16 m.Ingress_tmp_15
+	and m.Ingress_tmp_16 0xF
+	mov m.Ingress_tmp_18 m.Ingress_tmp_16
+	add m.Ingress_tmp_18 0x5
+	and m.Ingress_tmp_18 0xF
+	mov m.Ingress_tmp_20 m.Ingress_tmp_18
+	and m.Ingress_tmp_20 0xF
+	mov h.ipv4._hdrChecksum9 m.Ingress_tmp_13
+	or h.ipv4._hdrChecksum9 m.Ingress_tmp_20
 	LABEL_END_1 :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	mov h.ipv4._hdrChecksum9 0x4
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.spec
@@ -57,26 +57,31 @@ struct metadata_t {
 	bit<32> ingress_tbl_key
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
-	bit<32> IngressParser_parser_tmp_1
+	bit<8> IngressParser_parser_tmp_1
+	bit<32> IngressParser_parser_tmp_2
 	bit<16> Ingress_tmp
 	bit<16> Ingress_tmp_0
 	bit<8> Ingress_tmp_2
 	bit<8> Ingress_tmp_3
-	bit<8> Ingress_tmp_5
+	bit<8> Ingress_tmp_4
 	bit<8> Ingress_tmp_6
+	bit<8> Ingress_tmp_7
 	bit<8> Ingress_tmp_8
-	bit<8> Ingress_tmp_9
 	bit<8> Ingress_tmp_10
-	bit<16> Ingress_tmp_11
+	bit<8> Ingress_tmp_11
 	bit<8> Ingress_tmp_12
-	bit<8> Ingress_tmp_13
-	bit<32> Ingress_tmp_15
-	bit<16> Ingress_tmp_17
-	bit<8> Ingress_tmp_18
-	bit<8> Ingress_tmp_19
+	bit<16> Ingress_tmp_13
+	bit<8> Ingress_tmp_14
+	bit<8> Ingress_tmp_15
+	bit<8> Ingress_tmp_16
+	bit<32> Ingress_tmp_18
+	bit<16> Ingress_tmp_20
+	bit<8> Ingress_tmp_21
+	bit<8> Ingress_tmp_22
+	bit<8> Ingress_tmp_23
 	bit<32> Ingress_color_out
 	bit<32> Ingress_color_in
-	bit<32> Ingress_tmp_21
+	bit<32> Ingress_tmp_25
 }
 metadata instanceof metadata_t
 
@@ -95,35 +100,37 @@ action NoAction args none {
 }
 
 action execute_1 args instanceof execute_1_arg_t {
-	mov m.Ingress_tmp_8 h.ipv4.version_ihl
-	and m.Ingress_tmp_8 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_8
-	or h.ipv4.version_ihl 0x50
+	mov m.Ingress_tmp_10 h.ipv4.version_ihl
+	and m.Ingress_tmp_10 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_10
+	or h.ipv4.version_ihl 0x5
 	meter meter0_0 t.index h.ipv4.totalLen m.Ingress_color_in m.Ingress_color_out
 	jmpneq LABEL_FALSE_1 m.Ingress_color_out 0x0
-	mov m.Ingress_tmp_21 0x1
+	mov m.Ingress_tmp_25 0x1
 	jmp LABEL_END_1
-	LABEL_FALSE_1 :	mov m.Ingress_tmp_21 0x0
-	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_21
+	LABEL_FALSE_1 :	mov m.Ingress_tmp_25 0x0
+	LABEL_END_1 :	mov m.local_metadata_port_out m.Ingress_tmp_25
 	regwr reg_0 t.index m.local_metadata_port_out
 	mov m.Ingress_tmp h.ipv4.hdrChecksum
 	and m.Ingress_tmp 0x3F
 	mov m.Ingress_tmp_0 m.Ingress_tmp
 	and m.Ingress_tmp_0 0x3F
 	jmpneq LABEL_END_2 m.Ingress_tmp_0 0x6
-	mov m.Ingress_tmp_9 h.ipv4.version_ihl
-	and m.Ingress_tmp_9 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_9
-	or h.ipv4.version_ihl 0x50
+	mov m.Ingress_tmp_11 h.ipv4.version_ihl
+	and m.Ingress_tmp_11 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_11
+	or h.ipv4.version_ihl 0x5
 	LABEL_END_2 :	mov m.Ingress_tmp_2 h.ipv4.version_ihl
-	and m.Ingress_tmp_2 0xF
+	shr m.Ingress_tmp_2 0x4
 	mov m.Ingress_tmp_3 m.Ingress_tmp_2
 	and m.Ingress_tmp_3 0xF
-	jmpneq LABEL_END_3 m.Ingress_tmp_3 0x6
-	mov m.Ingress_tmp_10 h.ipv4.version_ihl
-	and m.Ingress_tmp_10 0xF
-	mov h.ipv4.version_ihl m.Ingress_tmp_10
-	or h.ipv4.version_ihl 0x60
+	mov m.Ingress_tmp_4 m.Ingress_tmp_3
+	and m.Ingress_tmp_4 0xF
+	jmpneq LABEL_END_3 m.Ingress_tmp_4 0x6
+	mov m.Ingress_tmp_12 h.ipv4.version_ihl
+	and m.Ingress_tmp_12 0xF0
+	mov h.ipv4.version_ihl m.Ingress_tmp_12
+	or h.ipv4.version_ihl 0x6
 	LABEL_END_3 :	return
 }
 
@@ -150,43 +157,51 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4.version_ihl
-	and m.IngressParser_parser_tmp 0xF
+	shr m.IngressParser_parser_tmp 0x4
 	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
 	and m.IngressParser_parser_tmp_0 0xF
 	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
+	and m.IngressParser_parser_tmp_1 0xF
+	mov m.IngressParser_parser_tmp_2 m.IngressParser_parser_tmp_1
 	INGRESSPARSERIMPL_ACCEPT :	mov m.Ingress_color_in 0x2
 	jmpneq LABEL_END m.local_metadata_port_out 0x1
-	mov m.Ingress_tmp_18 h.ipv4.version_ihl
-	and m.Ingress_tmp_18 0xF
-	mov m.Ingress_tmp_19 m.Ingress_tmp_18
-	and m.Ingress_tmp_19 0xF
+	mov m.Ingress_tmp_21 h.ipv4.version_ihl
+	shr m.Ingress_tmp_21 0x4
+	mov m.Ingress_tmp_22 m.Ingress_tmp_21
+	and m.Ingress_tmp_22 0xF
+	mov m.Ingress_tmp_23 m.Ingress_tmp_22
+	and m.Ingress_tmp_23 0xF
 	mov m.ingress_tbl_ethernet_srcAddr h.ethernet.srcAddr
 	mov m.ingress_tbl_ipv4_hdrChecksum h.ipv4.hdrChecksum
-	mov m.ingress_tbl_key m.Ingress_tmp_19
+	mov m.ingress_tbl_key m.Ingress_tmp_23
 	table tbl
 	regadd counter0_0_packets 0x3FF 1
 	regadd counter0_0_bytes 0x3FF 0x14
 	regadd counter1_0 0x200 1
 	regadd counter2_0 0x3FF 0x40
 	regrd m.local_metadata_port_out reg_0 0x1
-	mov m.Ingress_tmp_5 h.ipv4.version_ihl
-	and m.Ingress_tmp_5 0xF
-	mov m.Ingress_tmp_6 m.Ingress_tmp_5
-	and m.Ingress_tmp_6 0xF
-	jmpneq LABEL_END m.Ingress_tmp_6 0x4
-	mov m.Ingress_tmp_11 h.ipv4.hdrChecksum
-	and m.Ingress_tmp_11 0xFFF0
-	mov m.Ingress_tmp_12 h.ipv4.version_ihl
-	and m.Ingress_tmp_12 0xF
-	mov m.Ingress_tmp_13 m.Ingress_tmp_12
-	and m.Ingress_tmp_13 0xF
-	mov m.Ingress_tmp_15 m.Ingress_tmp_13
-	add m.Ingress_tmp_15 0x5
+	mov m.Ingress_tmp_6 h.ipv4.version_ihl
+	shr m.Ingress_tmp_6 0x4
+	mov m.Ingress_tmp_7 m.Ingress_tmp_6
+	and m.Ingress_tmp_7 0xF
+	mov m.Ingress_tmp_8 m.Ingress_tmp_7
+	and m.Ingress_tmp_8 0xF
+	jmpneq LABEL_END m.Ingress_tmp_8 0x4
+	mov m.Ingress_tmp_13 h.ipv4.hdrChecksum
+	and m.Ingress_tmp_13 0xFFF0
+	mov m.Ingress_tmp_14 h.ipv4.version_ihl
+	shr m.Ingress_tmp_14 0x4
+	mov m.Ingress_tmp_15 m.Ingress_tmp_14
 	and m.Ingress_tmp_15 0xF
-	mov m.Ingress_tmp_17 m.Ingress_tmp_15
-	and m.Ingress_tmp_17 0xF
-	mov h.ipv4.hdrChecksum m.Ingress_tmp_11
-	or h.ipv4.hdrChecksum m.Ingress_tmp_17
+	mov m.Ingress_tmp_16 m.Ingress_tmp_15
+	and m.Ingress_tmp_16 0xF
+	mov m.Ingress_tmp_18 m.Ingress_tmp_16
+	add m.Ingress_tmp_18 0x5
+	and m.Ingress_tmp_18 0xF
+	mov m.Ingress_tmp_20 m.Ingress_tmp_18
+	and m.Ingress_tmp_20 0xF
+	mov h.ipv4.hdrChecksum m.Ingress_tmp_13
+	or h.ipv4.hdrChecksum m.Ingress_tmp_20
 	LABEL_END :	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
 	mov h.ipv4.hdrChecksum 0x4
 	emit h.ethernet

--- a/testdata/p4_16_samples_outputs/psa-example-parser-checksum.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-example-parser-checksum.p4.spec
@@ -86,31 +86,30 @@ struct metadata {
 	bit<32> table_entry_index
 	bit<8> IngressParser_parser_tmp
 	bit<8> IngressParser_parser_tmp_0
-	bit<8> IngressParser_parser_tmp_1
+	bit<8> IngressParser_parser_tmp_2
 	bit<8> IngressParser_parser_tmp_3
 	bit<8> IngressParser_parser_tmp_4
 	bit<8> IngressParser_parser_tmp_5
 	bit<8> IngressParser_parser_tmp_6
-	bit<8> IngressParser_parser_tmp_7
+	bit<16> IngressParser_parser_tmp_7
 	bit<16> IngressParser_parser_tmp_8
 	bit<16> IngressParser_parser_tmp_9
 	bit<16> IngressParser_parser_tmp_10
 	bit<16> IngressParser_parser_tmp_11
 	bit<16> IngressParser_parser_tmp_12
-	bit<16> IngressParser_parser_tmp_13
-	bit<8> IngressParser_parser_tmp_14
+	bit<8> IngressParser_parser_tmp_13
+	bit<32> IngressParser_parser_tmp_14
 	bit<32> IngressParser_parser_tmp_15
-	bit<32> IngressParser_parser_tmp_16
-	bit<8> IngressParser_parser_tmp_17
+	bit<8> IngressParser_parser_tmp_16
+	bit<16> IngressParser_parser_tmp_17
 	bit<16> IngressParser_parser_tmp_18
-	bit<16> IngressParser_parser_tmp_19
+	bit<32> IngressParser_parser_tmp_19
 	bit<32> IngressParser_parser_tmp_20
-	bit<32> IngressParser_parser_tmp_21
+	bit<8> IngressParser_parser_tmp_21
 	bit<8> IngressParser_parser_tmp_22
-	bit<8> IngressParser_parser_tmp_23
+	bit<32> IngressParser_parser_tmp_23
 	bit<32> IngressParser_parser_tmp_24
-	bit<32> IngressParser_parser_tmp_25
-	bit<8> IngressParser_parser_tmp_26
+	bit<8> IngressParser_parser_tmp_25
 }
 metadata instanceof metadata
 
@@ -147,61 +146,59 @@ apply {
 	jmp INGRESSPARSERIMPL_ACCEPT
 	INGRESSPARSERIMPL_PARSE_IPV4 :	extract h.ipv4
 	mov m.IngressParser_parser_tmp h.ipv4.version_ihl
-	shr m.IngressParser_parser_tmp 0x4
+	and m.IngressParser_parser_tmp 0xF
 	mov m.IngressParser_parser_tmp_0 m.IngressParser_parser_tmp
 	and m.IngressParser_parser_tmp_0 0xF
-	mov m.IngressParser_parser_tmp_1 m.IngressParser_parser_tmp_0
-	and m.IngressParser_parser_tmp_1 0xF
-	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_1 0x5
-	mov m.IngressParser_parser_tmp_14 0x0
+	jmpeq LABEL_TRUE m.IngressParser_parser_tmp_0 0x5
+	mov m.IngressParser_parser_tmp_13 0x0
 	jmp LABEL_END
-	LABEL_TRUE :	mov m.IngressParser_parser_tmp_14 0x1
-	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_14 0
+	LABEL_TRUE :	mov m.IngressParser_parser_tmp_13 0x1
+	LABEL_END :	jmpneq LABEL_END_0 m.IngressParser_parser_tmp_13 0
 	mov m.psa_ingress_input_metadata_parser_error 0x7
 	jmp INGRESSPARSERIMPL_ACCEPT
 	LABEL_END_0 :	mov h.cksum_state.state_0 0x0
-	mov m.IngressParser_parser_tmp_3 h.ipv4.version_ihl
+	mov m.IngressParser_parser_tmp_2 h.ipv4.version_ihl
+	shr m.IngressParser_parser_tmp_2 0x4
+	mov m.IngressParser_parser_tmp_3 m.IngressParser_parser_tmp_2
 	and m.IngressParser_parser_tmp_3 0xF
 	mov m.IngressParser_parser_tmp_4 m.IngressParser_parser_tmp_3
 	and m.IngressParser_parser_tmp_4 0xF
-	mov m.IngressParser_parser_tmp_15 m.IngressParser_parser_tmp_4
+	mov m.IngressParser_parser_tmp_14 m.IngressParser_parser_tmp_4
 	mov m.IngressParser_parser_tmp_5 h.ipv4.version_ihl
-	shr m.IngressParser_parser_tmp_5 0x4
+	and m.IngressParser_parser_tmp_5 0xF
 	mov m.IngressParser_parser_tmp_6 m.IngressParser_parser_tmp_5
 	and m.IngressParser_parser_tmp_6 0xF
-	mov m.IngressParser_parser_tmp_7 m.IngressParser_parser_tmp_6
-	and m.IngressParser_parser_tmp_7 0xF
-	mov m.IngressParser_parser_tmp_16 m.IngressParser_parser_tmp_7
-	mov m.IngressParser_parser_tmp_17 h.ipv4.diffserv
-	mov m.IngressParser_parser_tmp_18 h.ipv4.totalLen
-	mov m.IngressParser_parser_tmp_19 h.ipv4.identification
-	mov m.IngressParser_parser_tmp_8 h.ipv4.flags_fragOffset
+	mov m.IngressParser_parser_tmp_15 m.IngressParser_parser_tmp_6
+	mov m.IngressParser_parser_tmp_16 h.ipv4.diffserv
+	mov m.IngressParser_parser_tmp_17 h.ipv4.totalLen
+	mov m.IngressParser_parser_tmp_18 h.ipv4.identification
+	mov m.IngressParser_parser_tmp_7 h.ipv4.flags_fragOffset
+	shr m.IngressParser_parser_tmp_7 0xD
+	mov m.IngressParser_parser_tmp_8 m.IngressParser_parser_tmp_7
 	and m.IngressParser_parser_tmp_8 0x7
 	mov m.IngressParser_parser_tmp_9 m.IngressParser_parser_tmp_8
 	and m.IngressParser_parser_tmp_9 0x7
-	mov m.IngressParser_parser_tmp_20 m.IngressParser_parser_tmp_9
+	mov m.IngressParser_parser_tmp_19 m.IngressParser_parser_tmp_9
 	mov m.IngressParser_parser_tmp_10 h.ipv4.flags_fragOffset
-	shr m.IngressParser_parser_tmp_10 0x3
+	and m.IngressParser_parser_tmp_10 0x1FFF
 	mov m.IngressParser_parser_tmp_11 m.IngressParser_parser_tmp_10
 	and m.IngressParser_parser_tmp_11 0x1FFF
-	mov m.IngressParser_parser_tmp_12 m.IngressParser_parser_tmp_11
-	and m.IngressParser_parser_tmp_12 0x1FFF
-	mov m.IngressParser_parser_tmp_21 m.IngressParser_parser_tmp_12
-	mov m.IngressParser_parser_tmp_22 h.ipv4.ttl
-	mov m.IngressParser_parser_tmp_23 h.ipv4.protocol
-	mov m.IngressParser_parser_tmp_24 h.ipv4.srcAddr
-	mov m.IngressParser_parser_tmp_25 h.ipv4.dstAddr
-	mov h.dpdk_pseudo_header.pseudo m.IngressParser_parser_tmp_15
-	mov h.dpdk_pseudo_header.pseudo_0 m.IngressParser_parser_tmp_16
-	mov h.dpdk_pseudo_header.pseudo_1 m.IngressParser_parser_tmp_17
-	mov h.dpdk_pseudo_header.pseudo_2 m.IngressParser_parser_tmp_18
-	mov h.dpdk_pseudo_header.pseudo_3 m.IngressParser_parser_tmp_19
-	mov h.dpdk_pseudo_header.pseudo_4 m.IngressParser_parser_tmp_20
-	mov h.dpdk_pseudo_header.pseudo_5 m.IngressParser_parser_tmp_21
-	mov h.dpdk_pseudo_header.pseudo_6 m.IngressParser_parser_tmp_22
-	mov h.dpdk_pseudo_header.pseudo_7 m.IngressParser_parser_tmp_23
-	mov h.dpdk_pseudo_header.pseudo_8 m.IngressParser_parser_tmp_24
-	mov h.dpdk_pseudo_header.pseudo_9 m.IngressParser_parser_tmp_25
+	mov m.IngressParser_parser_tmp_20 m.IngressParser_parser_tmp_11
+	mov m.IngressParser_parser_tmp_21 h.ipv4.ttl
+	mov m.IngressParser_parser_tmp_22 h.ipv4.protocol
+	mov m.IngressParser_parser_tmp_23 h.ipv4.srcAddr
+	mov m.IngressParser_parser_tmp_24 h.ipv4.dstAddr
+	mov h.dpdk_pseudo_header.pseudo m.IngressParser_parser_tmp_14
+	mov h.dpdk_pseudo_header.pseudo_0 m.IngressParser_parser_tmp_15
+	mov h.dpdk_pseudo_header.pseudo_1 m.IngressParser_parser_tmp_16
+	mov h.dpdk_pseudo_header.pseudo_2 m.IngressParser_parser_tmp_17
+	mov h.dpdk_pseudo_header.pseudo_3 m.IngressParser_parser_tmp_18
+	mov h.dpdk_pseudo_header.pseudo_4 m.IngressParser_parser_tmp_19
+	mov h.dpdk_pseudo_header.pseudo_5 m.IngressParser_parser_tmp_20
+	mov h.dpdk_pseudo_header.pseudo_6 m.IngressParser_parser_tmp_21
+	mov h.dpdk_pseudo_header.pseudo_7 m.IngressParser_parser_tmp_22
+	mov h.dpdk_pseudo_header.pseudo_8 m.IngressParser_parser_tmp_23
+	mov h.dpdk_pseudo_header.pseudo_9 m.IngressParser_parser_tmp_24
 	ckadd h.cksum_state.state_0 h.dpdk_pseudo_header.pseudo
 	ckadd h.cksum_state.state_0 h.dpdk_pseudo_header.pseudo_0
 	ckadd h.cksum_state.state_0 h.dpdk_pseudo_header.pseudo_1
@@ -213,12 +210,12 @@ apply {
 	ckadd h.cksum_state.state_0 h.dpdk_pseudo_header.pseudo_7
 	ckadd h.cksum_state.state_0 h.dpdk_pseudo_header.pseudo_8
 	ckadd h.cksum_state.state_0 h.dpdk_pseudo_header.pseudo_9
-	mov m.IngressParser_parser_tmp_13 h.cksum_state.state_0
-	jmpeq LABEL_TRUE_0 m.IngressParser_parser_tmp_13 h.ipv4.hdrChecksum
-	mov m.IngressParser_parser_tmp_26 0x0
+	mov m.IngressParser_parser_tmp_12 h.cksum_state.state_0
+	jmpeq LABEL_TRUE_0 m.IngressParser_parser_tmp_12 h.ipv4.hdrChecksum
+	mov m.IngressParser_parser_tmp_25 0x0
 	jmp LABEL_END_1
-	LABEL_TRUE_0 :	mov m.IngressParser_parser_tmp_26 0x1
-	LABEL_END_1 :	jmpneq LABEL_END_2 m.IngressParser_parser_tmp_26 0
+	LABEL_TRUE_0 :	mov m.IngressParser_parser_tmp_25 0x1
+	LABEL_END_1 :	jmpneq LABEL_END_2 m.IngressParser_parser_tmp_25 0
 	mov m.psa_ingress_input_metadata_parser_error 0x8
 	jmp INGRESSPARSERIMPL_ACCEPT
 	LABEL_END_2 :	jmpeq INGRESSPARSERIMPL_PARSE_TCP h.ipv4.protocol 0x6

--- a/testdata/p4_16_samples_outputs/psa-variable-index.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-variable-index.p4.spec
@@ -39,16 +39,12 @@ struct EMPTY_M {
 	bit<16> local_metadata_ret
 	bit<16> Ingress_tmp
 	bit<16> Ingress_tmp_0
-	bit<16> Ingress_tmp_1
+	bit<16> Ingress_tmp_2
 	bit<16> Ingress_tmp_3
-	bit<16> Ingress_tmp_4
 	bit<16> Ingress_tmp_5
+	bit<16> Ingress_tmp_6
 	bit<16> Ingress_tmp_7
 	bit<16> Ingress_tmp_8
-	bit<16> Ingress_tmp_9
-	bit<16> Ingress_tmp_10
-	bit<16> Ingress_tmp_11
-	bit<16> Ingress_tmp_12
 	bit<16> Ingress_hsVar
 	bit<32> Ingress_hsVar_0
 	bit<32> Ingress_vid
@@ -96,43 +92,35 @@ apply {
 	MYIP_PARSE_VLAN_TAG2 :	mov m.psa_ingress_input_metadata_parser_error 0x3
 	MYIP_ACCEPT :	jmpneq LABEL_FALSE m.local_metadata_depth 0x0
 	mov m.Ingress_tmp h.vlan_tag_0.pcp_cfi_vid
-	shr m.Ingress_tmp 0x4
+	and m.Ingress_tmp 0xFFF
 	mov m.Ingress_tmp_0 m.Ingress_tmp
 	and m.Ingress_tmp_0 0xFFF
-	mov m.Ingress_tmp_1 m.Ingress_tmp_0
-	and m.Ingress_tmp_1 0xFFF
-	mov m.local_metadata_ret m.Ingress_tmp_1
+	mov m.local_metadata_ret m.Ingress_tmp_0
 	jmp LABEL_END_0
 	LABEL_FALSE :	jmpneq LABEL_FALSE_0 m.local_metadata_depth 0x1
-	mov m.Ingress_tmp_3 h.vlan_tag_1.pcp_cfi_vid
-	shr m.Ingress_tmp_3 0x4
-	mov m.Ingress_tmp_4 m.Ingress_tmp_3
-	and m.Ingress_tmp_4 0xFFF
-	mov m.Ingress_tmp_5 m.Ingress_tmp_4
-	and m.Ingress_tmp_5 0xFFF
-	mov m.local_metadata_ret m.Ingress_tmp_5
+	mov m.Ingress_tmp_2 h.vlan_tag_1.pcp_cfi_vid
+	and m.Ingress_tmp_2 0xFFF
+	mov m.Ingress_tmp_3 m.Ingress_tmp_2
+	and m.Ingress_tmp_3 0xFFF
+	mov m.local_metadata_ret m.Ingress_tmp_3
 	jmp LABEL_END_0
 	LABEL_FALSE_0 :	jmplt LABEL_END_0 m.local_metadata_depth 0x1
 	mov m.local_metadata_ret m.Ingress_hsVar
 	LABEL_END_0 :	jmpnv LABEL_FALSE_2 h.ethernet
 	jmp LABEL_END_3
 	LABEL_FALSE_2 :	jmpneq LABEL_FALSE_3 m.local_metadata_depth 0x0
-	mov m.Ingress_tmp_7 h.vlan_tag_0.pcp_cfi_vid
-	shr m.Ingress_tmp_7 0x4
-	mov m.Ingress_tmp_8 m.Ingress_tmp_7
-	and m.Ingress_tmp_8 0xFFF
-	mov m.Ingress_tmp_9 m.Ingress_tmp_8
-	and m.Ingress_tmp_9 0xFFF
-	mov m.Ingress_vid m.Ingress_tmp_9
+	mov m.Ingress_tmp_5 h.vlan_tag_0.pcp_cfi_vid
+	and m.Ingress_tmp_5 0xFFF
+	mov m.Ingress_tmp_6 m.Ingress_tmp_5
+	and m.Ingress_tmp_6 0xFFF
+	mov m.Ingress_vid m.Ingress_tmp_6
 	jmp LABEL_END_4
 	LABEL_FALSE_3 :	jmpneq LABEL_FALSE_4 m.local_metadata_depth 0x1
-	mov m.Ingress_tmp_10 h.vlan_tag_1.pcp_cfi_vid
-	shr m.Ingress_tmp_10 0x4
-	mov m.Ingress_tmp_11 m.Ingress_tmp_10
-	and m.Ingress_tmp_11 0xFFF
-	mov m.Ingress_tmp_12 m.Ingress_tmp_11
-	and m.Ingress_tmp_12 0xFFF
-	mov m.Ingress_vid m.Ingress_tmp_12
+	mov m.Ingress_tmp_7 h.vlan_tag_1.pcp_cfi_vid
+	and m.Ingress_tmp_7 0xFFF
+	mov m.Ingress_tmp_8 m.Ingress_tmp_7
+	and m.Ingress_tmp_8 0xFFF
+	mov m.Ingress_vid m.Ingress_tmp_8
 	jmp LABEL_END_4
 	LABEL_FALSE_4 :	jmplt LABEL_END_4 m.local_metadata_depth 0x1
 	mov m.Ingress_vid m.Ingress_hsVar_0


### PR DESCRIPTION
when multiple non-byte aligned header fields are combined into single byte aligned field. The references of these fields are updated with incorrect slice operation.

For ex: when 
```
 header ipv4_t {
                            ...
                            bit<3>  flags;
                            bit<13> fragOffset;
                            ...
                        }
```


 is converted into

 ```
                   header ipv4_t {
                            ...
                            bit<16>  flags_fragOffset;
                            ...
                        }
```

_flags_ field should be converted to _flags_fragOffset[15:13]_
_fragOffset_ should be converted to _flags_fragOffset[12:0]_

But currently the conversion happens like this
_flags_ field is converted to  _flags_fragOffset[2:0]_
_fragOffset_ is converted to  _flags_fragOffset[15:3]_


Fixes https://github.com/p4lang/p4c/issues/4077