### PR TITLE
[P4Testgen] Fix append and prepend invocation.

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/extern_stepper.cpp
@@ -168,8 +168,10 @@ void ExprStepper::evalInternalExternMethodCall(const IR::MethodCallExpression *c
              // Prepend the field to the packet buffer.
              if (const auto *structExpr = prependVar->to<IR::StructExpression>()) {
                  auto exprList = IR::flattenStructExpression(structExpr);
-                 for (const auto *expr : exprList) {
-                     nextState.prependToPacketBuffer(expr);
+                 // We need to prepend in reverse order since we are prepending to the input
+                 // packet.
+                 for (auto fieldIt = exprList.rbegin(); fieldIt != exprList.rend(); ++fieldIt) {
+                     nextState.prependToPacketBuffer(*fieldIt);
                  }
              } else if (prependType->is<IR::Type_Bits>()) {
                  nextState.prependToPacketBuffer(prependVar);


### PR DESCRIPTION
@pkotikal This should help with the problems you have encountered in https://github.com/p4lang/p4c/commit/689e013d3d870fa906852d93acd76cfc5bbe5634#r135134661

Since we are recording an expression, fix also the way we print expressions. I should implement a more disciplined way to format these inputs without introducing linebreaks. 