### PR TITLE
Fix warnings on signed integer initialization

### DIFF
--- a/test/gtest/constant_expr_test.cpp
+++ b/test/gtest/constant_expr_test.cpp
@@ -141,4 +141,43 @@ TEST_F(ConstantExpr, TestIntegerFuncs) {
     EXPECT_EQ(neg_res.asInt(), -123);
 }
 
+TEST_F(ConstantExpr, TestSignedUnsigned) {
+    const bool isSigned = true;
+    const bool isUnsigned = false;
+
+    auto t7s = IR::Type_Bits(7, isSigned);
+    auto t7u = IR::Type_Bits(7, isUnsigned);
+    auto t13s = IR::Type_Bits(13, isSigned);
+    auto t13u = IR::Type_Bits(13, isUnsigned);
+
+    auto c0 = IR::Constant(&t7s, 0x7f);
+    EXPECT_EQ(c0.asInt(), -1);
+    EXPECT_ANY_THROW(c0.asUnsigned());  // will also print error message
+
+    auto c1 = IR::Constant(&t7u, 0x7f);
+    EXPECT_EQ(c1.asUnsigned(), 127);
+
+    // overflow, but this should not even generate a warning under regular settings
+    auto c2 = IR::Constant(&t7s, 0xff);
+    EXPECT_EQ(c2.asInt(), -1);
+
+    // overflow, but this should not even generate a warning under regular settings
+    auto c3 = IR::Constant(&t7u, 0xff);
+    EXPECT_EQ(c3.asUnsigned(), 127);
+
+    auto c4 = IR::Constant(&t13s, 0x1555);  // 0b1_0101_0101_0101
+    EXPECT_EQ(c4.asInt(), -2731);
+    EXPECT_ANY_THROW(c4.asUnsigned());  // will also print error message
+
+    auto c5 = IR::Constant(&t13u, 0x1555);
+    EXPECT_EQ(c5.asUnsigned(), 5461);
+
+    // overflow, but this should not even generate a warning under regular settings
+    auto c6 = IR::Constant(&t13s, 0x3555);  // 0b1_0101_0101_0101
+    EXPECT_EQ(c6.asInt(), -2731);
+
+    // overflow, but this should not even generate a warning under regular settings
+    auto c7 = IR::Constant(&t13u, 0x3555);
+    EXPECT_EQ(c7.asUnsigned(), 5461);
+}
 }  // namespace Test

--- a/testdata/p4_16_errors_outputs/stack1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack1_e.p4-stderr
@@ -1,6 +1,3 @@
-stack1_e.p4(21): [--Wwarn=overflow] warning: 3s5: signed value does not fit in 3 bits
-        int<3> w = 5;
-                   ^
 stack1_e.p4(22): [--Werror=type-error] error: header h[?]: Size of header stack type should be a constant
         h[w] stack;
         ^^^^

--- a/testdata/p4_16_errors_outputs/width1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/width1_e.p4-stderr
@@ -1,6 +1,3 @@
-width1_e.p4(16): [--Wwarn=overflow] warning: 32s0xffffffff: signed value does not fit in 32 bits
-const int<32> c1 = 0xFFFFFFFF;
-                   ^^^^^^^^^^
 width1_e.p4(17): [--Werror=invalid] error: int<-2>: invalid type size
 const int<(c1 + c1)> c2 = 0;
       ^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/constsigned.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constsigned.p4-stderr
@@ -1,24 +1,6 @@
-constsigned.p4(37): [--Wwarn=overflow] warning: 8s128: signed value does not fit in 8 bits
-const int<8> e0 = -8s128
-                   ^^^^^
-constsigned.p4(38): [--Wwarn=overflow] warning: 8s129: signed value does not fit in 8 bits
-const int<8> f0 = -8s129
-                   ^^^^^
-constsigned.p4(39): [--Wwarn=overflow] warning: 8s255: signed value does not fit in 8 bits
-const int<8> g0 = -8s255
-                   ^^^^^
 constsigned.p4(40): [--Wwarn=overflow] warning: 8s256: signed value does not fit in 8 bits
 const int<8> h0 = -8s256
                    ^^^^^
-constsigned.p4(44): [--Wwarn=overflow] warning: 8s128: signed value does not fit in 8 bits
-const int<8> l0 = 8s128
-                  ^^^^^
-constsigned.p4(45): [--Wwarn=overflow] warning: 8s129: signed value does not fit in 8 bits
-const int<8> m0 = 8s129
-                  ^^^^^
-constsigned.p4(46): [--Wwarn=overflow] warning: 8s255: signed value does not fit in 8 bits
-const int<8> n0 = 8s255
-                  ^^^^^
 constsigned.p4(47): [--Wwarn=overflow] warning: 8s256: signed value does not fit in 8 bits
 const int<8> o0 = 8s256
                   ^^^^^
@@ -31,22 +13,7 @@ const int<8> g = -255;
 constsigned.p4(24): [--Wwarn=overflow] warning: -8s256: signed value does not fit in 8 bits
 const int<8> h = -256;
                   ^^^
-constsigned.p4(28): [--Wwarn=overflow] warning: 8s128: signed value does not fit in 8 bits
-const int<8> l = 128;
-                 ^^^
-constsigned.p4(29): [--Wwarn=overflow] warning: 8s129: signed value does not fit in 8 bits
-const int<8> m = 129;
-                 ^^^
-constsigned.p4(30): [--Wwarn=overflow] warning: 8s255: signed value does not fit in 8 bits
-const int<8> n = 255;
-                 ^^^
 constsigned.p4(31): [--Wwarn=overflow] warning: 8s256: signed value does not fit in 8 bits
 const int<8> o = 256;
                  ^^^
-constsigned.p4(50): [--Wwarn=overflow] warning: 1s1: signed value does not fit in 1 bits
-const int<1> zz1 = 1;
-                   ^
-constsigned.p4(51): [--Wwarn=overflow] warning: 2s2: signed value does not fit in 2 bits
-const int<2> zz2 = 2;
-                   ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue2444.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2444.p4-stderr
@@ -1,4 +1,1 @@
-issue2444.p4(11): [--Wwarn=overflow] warning: 2s3: signed value does not fit in 2 bits
-const int z3 = 2s3
-               ^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex04.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex04.p4-stderr
@@ -1,4 +1,1 @@
-spec-ex04.p4(24): [--Wwarn=overflow] warning: 8s0b10101010: signed value does not fit in 8 bits
-const int<8> b8 = 8s0b1010_1010
-                  ^^^^^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/strength.p4-stderr
+++ b/testdata/p4_16_samples_outputs/strength.p4-stderr
@@ -1,6 +1,3 @@
-strength.p4(50): [--Wwarn=overflow] warning: 4s0xf: signed value does not fit in 4 bits
-        w = w - 4s0xF
-                ^^^^^
 strength.p4(38): [--Wwarn=mismatch] warning: 4w16: value does not fit in 4 bits
         y = y * 16;
                 ^^


### PR DESCRIPTION
Remove misleading overflow warning for correct-width signed integer literals with MSBit set, i.e. representing negative numbers. This is actually the only way integer literals of explicitly-declared width can be specified (as per language specs, Section 6.3.3.2).

As these warnings are mentioned in the language specs, Section 7.1.6.6, this change is accompanied with one to the specs content, PR [#1270](https://github.com/p4lang/p4-spec/pull/1270).