### PR TITLE
keep P4Control->body->srcInfo during init move

### DIFF
--- a/frontends/p4/moveDeclarations.cpp
+++ b/frontends/p4/moveDeclarations.cpp
@@ -150,7 +150,8 @@ const IR::Node *MoveInitializers::postorder(IR::ParserState *state) {
 const IR::Node *MoveInitializers::postorder(IR::P4Control *control) {
     if (toMove->empty()) return control;
     toMove->append(control->body->components);
-    auto newBody = new IR::BlockStatement(control->body->annotations, *toMove);
+    auto newBody =
+        new IR::BlockStatement(control->body->srcInfo, control->body->annotations, *toMove);
     control->body = newBody;
     toMove = new IR::IndexedVector<IR::StatOrDecl>();
     return control;

--- a/test/gtest/frontend_test.cpp
+++ b/test/gtest/frontend_test.cpp
@@ -172,8 +172,7 @@ TEST_F(P4CFrontendEnumValidation, InvalidType) {
 // Tests for MoveInitializers
 struct P4CFrontendMoveInitializers : P4CFrontend {
     P4CFrontendMoveInitializers() {
-        addPasses({new P4::ResolveReferences(&refMap),
-                   new P4::MoveInitializers(&refMap)});
+        addPasses({new P4::ResolveReferences(&refMap), new P4::MoveInitializers(&refMap)});
     }
 
     P4::ReferenceMap refMap;
@@ -194,14 +193,13 @@ TEST_F(P4CFrontendMoveInitializers, P4ControlSrcInfo) {
 
     // The P4Control->body should have a valid srcInfo if the information
     // is correctly maintained by MoveInitializers.
-    const auto* p4prog = prog->to<IR::P4Program>();
+    const auto *p4prog = prog->to<IR::P4Program>();
     ASSERT_TRUE(p4prog);
-    for (const auto* node : p4prog->objects) {
-        if (const auto* control = node->to<IR::P4Control>()) {
+    for (const auto *node : p4prog->objects) {
+        if (const auto *control = node->to<IR::P4Control>()) {
             ASSERT_TRUE(control->body->srcInfo.isValid());
         }
     }
 }
-
 
 }  // namespace Test

--- a/test/gtest/frontend_test.cpp
+++ b/test/gtest/frontend_test.cpp
@@ -2,6 +2,7 @@
 #include "frontends/common/parseInput.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
+#include "frontends/p4/moveDeclarations.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "gtest/gtest.h"
 #include "helpers.h"
@@ -167,5 +168,40 @@ TEST_F(P4CFrontendEnumValidation, InvalidType) {
     ASSERT_TRUE(errors.contains("Illegal type for enum;"));
     ASSERT_TRUE(errors.contains("type-declared types"));
 }
+
+// Tests for MoveInitializers
+struct P4CFrontendMoveInitializers : P4CFrontend {
+    P4CFrontendMoveInitializers() {
+        addPasses({new P4::ResolveReferences(&refMap),
+                   new P4::MoveInitializers(&refMap)});
+    }
+
+    P4::ReferenceMap refMap;
+};
+
+TEST_F(P4CFrontendMoveInitializers, P4ControlSrcInfo) {
+    std::string program = P4_SOURCE(R"(
+        control m() {
+            bool blah = false;
+            apply{}
+        }
+    )");
+    RedirectStderr errors;
+    const auto *prog = parseAndProcess(program);
+    errors.dumpAndReset();
+    ASSERT_TRUE(prog);
+    ASSERT_EQ(::errorCount(), 0);
+
+    // The P4Control->body should have a valid srcInfo if the information
+    // is correctly maintained by MoveInitializers.
+    const auto* p4prog = prog->to<IR::P4Program>();
+    ASSERT_TRUE(p4prog);
+    for (const auto* node : p4prog->objects) {
+        if (const auto* control = node->to<IR::P4Control>()) {
+            ASSERT_TRUE(control->body->srcInfo.isValid());
+        }
+    }
+}
+
 
 }  // namespace Test

--- a/test/gtest/frontend_test.cpp
+++ b/test/gtest/frontend_test.cpp
@@ -185,9 +185,7 @@ TEST_F(P4CFrontendMoveInitializers, P4ControlSrcInfo) {
             apply{}
         }
     )");
-    RedirectStderr errors;
     const auto *prog = parseAndProcess(program);
-    errors.dumpAndReset();
     ASSERT_TRUE(prog);
     ASSERT_EQ(::errorCount(), 0);
 


### PR DESCRIPTION
Ensure that MoveInitializers keeps the srcInfo when creating a new body for a P4Control.

Fix for issue #4315