### PR TITLE
Allow constructing PassRepeated from a PassManager

### DIFF
--- a/ir/pass_manager.h
+++ b/ir/pass_manager.h
@@ -142,8 +142,10 @@ class PassRepeated : virtual public PassManager {
     unsigned repeats;  // 0 = until convergence
  public:
     PassRepeated() : repeats(0) {}
-    PassRepeated(const std::initializer_list<VisitorRef> &init, unsigned repeats = 0)
+    explicit PassRepeated(const std::initializer_list<VisitorRef> &init, unsigned repeats = 0)
         : PassManager(init), repeats(repeats) {}
+    explicit PassRepeated(const PassManager &other, unsigned repeats = 0)
+        : PassManager(other), repeats(repeats) {}
     const IR::Node *apply_visitor(const IR::Node *, const char * = 0) override;
     PassRepeated *setRepeats(unsigned repeats) {
         this->repeats = repeats;


### PR DESCRIPTION
... and add `explicit` to the constructors that could be accidentally invoced by implicit casts otherwise