### PR TITLE
[P4Testgen] Extend the CompilerTarget runProgram function with data structures which can pass on more information.

### DIFF
--- a/backends/p4tools/common/compiler/compiler_target.cpp
+++ b/backends/p4tools/common/compiler/compiler_target.cpp
@@ -1,5 +1,6 @@
 #include "backends/p4tools/common/compiler/compiler_target.h"
 
+#include <functional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -27,7 +28,7 @@ std::vector<const char *> *CompilerTarget::initCompiler(int argc, char **argv) {
     return get().initCompilerImpl(argc, argv);
 }
 
-std::optional<const CompilerResult *> CompilerTarget::runCompiler() {
+CompilerResultOrError CompilerTarget::runCompiler() {
     const auto *program = P4Tools::CompilerTarget::runParser();
     if (program == nullptr) {
         return std::nullopt;
@@ -36,7 +37,7 @@ std::optional<const CompilerResult *> CompilerTarget::runCompiler() {
     return runCompiler(program);
 }
 
-std::optional<const CompilerResult *> CompilerTarget::runCompiler(const std::string &source) {
+CompilerResultOrError CompilerTarget::runCompiler(const std::string &source) {
     const auto *program = P4::parseP4String(source, P4CContext::get().options().langVersion);
     if (program == nullptr) {
         return std::nullopt;
@@ -45,12 +46,11 @@ std::optional<const CompilerResult *> CompilerTarget::runCompiler(const std::str
     return runCompiler(program);
 }
 
-std::optional<const CompilerResult *> CompilerTarget::runCompiler(const IR::P4Program *program) {
+CompilerResultOrError CompilerTarget::runCompiler(const IR::P4Program *program) {
     return get().runCompilerImpl(program);
 }
 
-std::optional<const CompilerResult *> CompilerTarget::runCompilerImpl(
-    const IR::P4Program *program) const {
+CompilerResultOrError CompilerTarget::runCompilerImpl(const IR::P4Program *program) const {
     const auto &self = get();
 
     program = self.runFrontend(program);
@@ -63,7 +63,7 @@ std::optional<const CompilerResult *> CompilerTarget::runCompilerImpl(
         return std::nullopt;
     }
 
-    return new CompilerResult(*program);
+    return *new CompilerResult(*program);
 }
 
 ICompileContext *CompilerTarget::makeContextImpl() const {

--- a/backends/p4tools/common/compiler/compiler_target.cpp
+++ b/backends/p4tools/common/compiler/compiler_target.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "backends/p4tools/common/compiler/context.h"
-#include "backends/p4tools/common/compiler/convert_hs_index.h"
 #include "backends/p4tools/common/compiler/midend.h"
 #include "backends/p4tools/common/core/target.h"
 #include "frontends/common/applyOptionsPragmas.h"
@@ -18,13 +17,17 @@
 
 namespace P4Tools {
 
+const IR::P4Program &CompilerResult::getProgram() const { return program; }
+
+CompilerResult::CompilerResult(const IR::P4Program &program) : program(program) {}
+
 ICompileContext *CompilerTarget::makeContext() { return get().makeContextImpl(); }
 
 std::vector<const char *> *CompilerTarget::initCompiler(int argc, char **argv) {
     return get().initCompilerImpl(argc, argv);
 }
 
-std::optional<const IR::P4Program *> CompilerTarget::runCompiler() {
+std::optional<const CompilerResult *> CompilerTarget::runCompiler() {
     const auto *program = P4Tools::CompilerTarget::runParser();
     if (program == nullptr) {
         return std::nullopt;
@@ -33,7 +36,7 @@ std::optional<const IR::P4Program *> CompilerTarget::runCompiler() {
     return runCompiler(program);
 }
 
-std::optional<const IR::P4Program *> CompilerTarget::runCompiler(const std::string &source) {
+std::optional<const CompilerResult *> CompilerTarget::runCompiler(const std::string &source) {
     const auto *program = P4::parseP4String(source, P4CContext::get().options().langVersion);
     if (program == nullptr) {
         return std::nullopt;
@@ -42,11 +45,11 @@ std::optional<const IR::P4Program *> CompilerTarget::runCompiler(const std::stri
     return runCompiler(program);
 }
 
-std::optional<const IR::P4Program *> CompilerTarget::runCompiler(const IR::P4Program *program) {
+std::optional<const CompilerResult *> CompilerTarget::runCompiler(const IR::P4Program *program) {
     return get().runCompilerImpl(program);
 }
 
-std::optional<const IR::P4Program *> CompilerTarget::runCompilerImpl(
+std::optional<const CompilerResult *> CompilerTarget::runCompilerImpl(
     const IR::P4Program *program) const {
     const auto &self = get();
 
@@ -60,7 +63,7 @@ std::optional<const IR::P4Program *> CompilerTarget::runCompilerImpl(
         return std::nullopt;
     }
 
-    return program;
+    return new CompilerResult(*program);
 }
 
 ICompileContext *CompilerTarget::makeContextImpl() const {
@@ -119,5 +122,4 @@ CompilerTarget::CompilerTarget(std::string deviceName, std::string archName)
     : Target("compiler", std::move(deviceName), std::move(archName)) {}
 
 const CompilerTarget &CompilerTarget::get() { return Target::get<CompilerTarget>("compiler"); }
-
 }  // namespace P4Tools

--- a/backends/p4tools/common/compiler/compiler_target.h
+++ b/backends/p4tools/common/compiler/compiler_target.h
@@ -31,6 +31,10 @@ class CompilerResult : public ICastable {
     [[nodiscard]] const IR::P4Program &getProgram() const;
 };
 
+/// P4Tools compilers may return an error instead of a compiler result.
+/// This is a convenience definition for the return value.
+using CompilerResultOrError = std::optional<std::reference_wrapper<const CompilerResult>>;
+
 /// Encapsulates the details of invoking the P4 compiler for a target device and architecture.
 class CompilerTarget : public Target {
  public:
@@ -46,25 +50,25 @@ class CompilerTarget : public Target {
     /// program.
     ///
     /// @returns std::nullopt if an error occurs during compilation.
-    static std::optional<const CompilerResult *> runCompiler();
+    static CompilerResultOrError runCompiler();
 
     /// Runs the P4 compiler to produce an IR and other information for the given source code.
     ///
     /// @returns std::nullopt if an error occurs during compilation.
-    static std::optional<const CompilerResult *> runCompiler(const std::string &source);
+    static CompilerResultOrError runCompiler(const std::string &source);
 
  private:
     /// Runs the front and mid ends on the given parsed program.
     ///
     /// @returns std::nullopt if an error occurs during compilation.
-    static std::optional<const CompilerResult *> runCompiler(const IR::P4Program *);
+    static CompilerResultOrError runCompiler(const IR::P4Program *);
 
  protected:
     /// @see @makeContext.
     [[nodiscard]] virtual ICompileContext *makeContextImpl() const;
 
     /// @see runCompiler.
-    virtual std::optional<const CompilerResult *> runCompilerImpl(const IR::P4Program *) const;
+    virtual CompilerResultOrError runCompilerImpl(const IR::P4Program *) const;
 
     /// This implementation just forwards the given arguments to the compiler.
     ///

--- a/backends/p4tools/common/compiler/compiler_target.h
+++ b/backends/p4tools/common/compiler/compiler_target.h
@@ -1,6 +1,7 @@
 #ifndef BACKENDS_P4TOOLS_COMMON_COMPILER_COMPILER_TARGET_H_
 #define BACKENDS_P4TOOLS_COMMON_COMPILER_COMPILER_TARGET_H_
 
+#include <functional>
 #include <optional>
 #include <string>
 #include <vector>
@@ -10,9 +11,25 @@
 #include "frontends/common/options.h"
 #include "frontends/p4/frontend.h"
 #include "ir/ir.h"
+#include "lib/castable.h"
 #include "lib/compile_context.h"
 
 namespace P4Tools {
+
+/// An extensible result object which is returned by the CompilerTarget.
+/// In its simplest form, this holds the transformed P4 program after the front- and midend passes.
+class CompilerResult : public ICastable {
+ private:
+    /// The reference to the input P4 program, after it has been transformed by the compiler.
+    std::reference_wrapper<const IR::P4Program> program;
+
+ public:
+    explicit CompilerResult(const IR::P4Program &program);
+
+    /// @returns the reference to the input P4 program, after it has been transformed by the
+    /// compiler.
+    [[nodiscard]] const IR::P4Program &getProgram() const;
+};
 
 /// Encapsulates the details of invoking the P4 compiler for a target device and architecture.
 class CompilerTarget : public Target {
@@ -25,28 +42,29 @@ class CompilerTarget : public Target {
     /// @returns any unprocessed arguments, or nullptr if there was an error.
     static std::vector<const char *> *initCompiler(int argc, char **argv);
 
-    /// Runs the P4 compiler to produce an IR.
+    /// Runs the P4 compiler to produce an IR and various other kinds of information on the input
+    /// program.
     ///
     /// @returns std::nullopt if an error occurs during compilation.
-    static std::optional<const IR::P4Program *> runCompiler();
+    static std::optional<const CompilerResult *> runCompiler();
 
-    /// Runs the P4 compiler to produce an IR for the given source code.
+    /// Runs the P4 compiler to produce an IR and other information for the given source code.
     ///
     /// @returns std::nullopt if an error occurs during compilation.
-    static std::optional<const IR::P4Program *> runCompiler(const std::string &source);
+    static std::optional<const CompilerResult *> runCompiler(const std::string &source);
 
  private:
     /// Runs the front and mid ends on the given parsed program.
     ///
     /// @returns std::nullopt if an error occurs during compilation.
-    static std::optional<const IR::P4Program *> runCompiler(const IR::P4Program *);
+    static std::optional<const CompilerResult *> runCompiler(const IR::P4Program *);
 
  protected:
     /// @see @makeContext.
-    virtual ICompileContext *makeContextImpl() const;
+    [[nodiscard]] virtual ICompileContext *makeContextImpl() const;
 
     /// @see runCompiler.
-    virtual std::optional<const IR::P4Program *> runCompilerImpl(const IR::P4Program *) const;
+    virtual std::optional<const CompilerResult *> runCompilerImpl(const IR::P4Program *) const;
 
     /// This implementation just forwards the given arguments to the compiler.
     ///

--- a/backends/p4tools/common/p4ctool.h
+++ b/backends/p4tools/common/p4ctool.h
@@ -44,7 +44,7 @@ class AbstractP4cTool {
         if (!compilerResult.has_value()) {
             return EXIT_FAILURE;
         }
-        return mainImpl(*compilerResult.value());
+        return mainImpl(compilerResult.value());
     }
 };
 

--- a/backends/p4tools/common/p4ctool.h
+++ b/backends/p4tools/common/p4ctool.h
@@ -1,11 +1,10 @@
 #ifndef BACKENDS_P4TOOLS_COMMON_P4CTOOL_H_
 #define BACKENDS_P4TOOLS_COMMON_P4CTOOL_H_
 
+#include <cstdlib>
 #include <vector>
 
 #include "backends/p4tools/common/compiler/compiler_target.h"
-#include "backends/p4tools/common/core/target.h"
-#include "ir/ir.h"
 
 namespace P4Tools {
 
@@ -19,7 +18,7 @@ class AbstractP4cTool {
     /// Provides the implementation of the tool.
     ///
     /// @param program The P4 program after mid-end processing.
-    virtual int mainImpl(const IR::P4Program *program) = 0;
+    virtual int mainImpl(const CompilerResult &compilerResult) = 0;
 
     virtual void registerTarget() = 0;
 
@@ -41,11 +40,11 @@ class AbstractP4cTool {
         AutoCompileContext autoContext(*compileContext);
 
         // Run the compiler to get an IR and invoke the tool.
-        const auto program = P4Tools::CompilerTarget::runCompiler();
-        if (!program) {
-            return 1;
+        const auto compilerResult = P4Tools::CompilerTarget::runCompiler();
+        if (!compilerResult.has_value()) {
+            return EXIT_FAILURE;
         }
-        return mainImpl(*program);
+        return mainImpl(*compilerResult.value());
     }
 };
 

--- a/backends/p4tools/modules/testgen/main.cpp
+++ b/backends/p4tools/modules/testgen/main.cpp
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "lib/crash.h"
-#include "lib/exceptions.h"
 
 #include "backends/p4tools/modules/testgen/testgen.h"
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/binary.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/binary.cpp
@@ -21,14 +21,14 @@ TEST_F(SmallStepTest, Binary01) {
     const auto test = createSmallStepExprTest("bit<8> f;", "8w42 + hdr.h.f");
     ASSERT_TRUE(test);
 
-    const auto *opBin = extractExpr<IR::Operation_Binary>(test->program);
+    const auto *opBin = extractExpr<IR::Operation_Binary>(test->getProgram());
     ASSERT_TRUE(opBin);
 
     // Step on the binary operation and examine the resulting continuation
     // to include the rebuilt IR::Add node.
-    stepAndExamineOp(opBin, opBin->right, test->program, [opBin](const IR::PathExpression *expr) {
-        return new IR::Add(opBin->left, expr);
-    });
+    stepAndExamineOp(
+        opBin, opBin->right, test->getProgram(),
+        [opBin](const IR::PathExpression *expr) { return new IR::Add(opBin->left, expr); });
 }
 
 /// Test the step function for e + e binary operation.
@@ -39,14 +39,14 @@ TEST_F(SmallStepTest, Binary02) {
                                               "hdr.h.f1 + hdr.h.f2");
     ASSERT_TRUE(test);
 
-    const auto *opBin = extractExpr<IR::Operation_Binary>(test->program);
+    const auto *opBin = extractExpr<IR::Operation_Binary>(test->getProgram());
     ASSERT_TRUE(opBin);
 
     // Step on the binary operation and examine the resulting continuation
     // to include the rebuilt IR::Add node.
-    stepAndExamineOp(opBin, opBin->left, test->program, [opBin](const IR::PathExpression *expr) {
-        return new IR::Add(expr, opBin->right);
-    });
+    stepAndExamineOp(
+        opBin, opBin->left, test->getProgram(),
+        [opBin](const IR::PathExpression *expr) { return new IR::Add(expr, opBin->right); });
 }
 
 /// Test the step function for e == v binary operation.
@@ -54,14 +54,14 @@ TEST_F(SmallStepTest, Binary03) {
     const auto test = createSmallStepExprTest("bit<8> f;", "hdr.h.f == 8w42");
     ASSERT_TRUE(test);
 
-    const auto *opBin = extractExpr<IR::Operation_Binary>(test->program);
+    const auto *opBin = extractExpr<IR::Operation_Binary>(test->getProgram());
     ASSERT_TRUE(opBin);
 
     // Step on the binary operation and examine the resulting continuation
     // to include the rebuilt IR::Equ node.
-    stepAndExamineOp(opBin, opBin->left, test->program, [opBin](const IR::PathExpression *expr) {
-        return new IR::Equ(expr, opBin->right);
-    });
+    stepAndExamineOp(
+        opBin, opBin->left, test->getProgram(),
+        [opBin](const IR::PathExpression *expr) { return new IR::Equ(expr, opBin->right); });
 }
 
 /// Test the step function for v ++ e binary operation.
@@ -69,14 +69,14 @@ TEST_F(SmallStepTest, Binary04) {
     const auto test = createSmallStepExprTest("bit<8> f;", "8w42 ++ hdr.h.f");
     ASSERT_TRUE(test);
 
-    const auto *opBin = extractExpr<IR::Operation_Binary>(test->program);
+    const auto *opBin = extractExpr<IR::Operation_Binary>(test->getProgram());
     ASSERT_TRUE(opBin);
 
     // Step on the binary operation and examine the resulting continuation
     // to include the rebuilt IR::Concat node.
-    stepAndExamineOp(opBin, opBin->right, test->program, [opBin](const IR::PathExpression *expr) {
-        return new IR::Concat(opBin->left, expr);
-    });
+    stepAndExamineOp(
+        opBin, opBin->right, test->getProgram(),
+        [opBin](const IR::PathExpression *expr) { return new IR::Concat(opBin->left, expr); });
 }
 
 }  // anonymous namespace

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/unary.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/unary.cpp
@@ -21,12 +21,12 @@ TEST_F(SmallStepTest, Unary01) {
     const auto test = createSmallStepExprTest("bit<8> f;", "-(hdr.h.f)");
     ASSERT_TRUE(test);
 
-    const auto *opUn = extractExpr<IR::Operation_Unary>(test->program);
+    const auto *opUn = extractExpr<IR::Operation_Unary>(test->getProgram());
     ASSERT_TRUE(opUn);
 
     // Step on the unary operation and examine the resulting continuation
     // to include the rebuilt IR::Neg node.
-    stepAndExamineOp(opUn, opUn->expr, test->program,
+    stepAndExamineOp(opUn, opUn->expr, test->getProgram(),
                      [](const IR::PathExpression *expr) { return new IR::Neg(expr); });
 }
 
@@ -35,12 +35,12 @@ TEST_F(SmallStepTest, Unary02) {
     const auto test = createSmallStepExprTest("bool f;", "!(hdr.h.f)");
     ASSERT_TRUE(test);
 
-    const auto *opUn = extractExpr<IR::Operation_Unary>(test->program);
+    const auto *opUn = extractExpr<IR::Operation_Unary>(test->getProgram());
     ASSERT_TRUE(opUn);
 
     // Step on the unary operation and examine the resulting continuation
     // to include the rebuilt IR::LNot node.
-    stepAndExamineOp(opUn, opUn->expr, test->program, [](const IR::PathExpression *expr) {
+    stepAndExamineOp(opUn, opUn->expr, test->getProgram(), [](const IR::PathExpression *expr) {
         return new IR::LNot(IR::Type_Boolean::get(), expr);
     });
 }
@@ -50,12 +50,12 @@ TEST_F(SmallStepTest, Unary03) {
     const auto test = createSmallStepExprTest("bit<8> f;", "~(hdr.h.f)");
     ASSERT_TRUE(test);
 
-    const auto *opUn = extractExpr<IR::Operation_Unary>(test->program);
+    const auto *opUn = extractExpr<IR::Operation_Unary>(test->getProgram());
     ASSERT_TRUE(opUn);
 
     // Step on the unary operation and examine the resulting continuation
     // to include the rebuilt IR::Cmpl node.
-    stepAndExamineOp(opUn, opUn->expr, test->program,
+    stepAndExamineOp(opUn, opUn->expr, test->getProgram(),
                      [](const IR::PathExpression *expr) { return new IR::Cmpl(expr); });
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/value.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/value.cpp
@@ -21,11 +21,11 @@ TEST_F(SmallStepTest, Value01) {
     const auto test = createSmallStepExprTest("bit<8> f;", "8w42");
     ASSERT_TRUE(test);
 
-    const auto *opValue = extractExpr<IR::Constant>(test->program);
+    const auto *opValue = extractExpr<IR::Constant>(test->getProgram());
     ASSERT_TRUE(opValue);
 
     // Step on the value and examine the resulting state.
-    stepAndExamineValue(opValue, test->program);
+    stepAndExamineValue(opValue, test->getProgram());
 }
 
 /// Test the step function for a bool value.
@@ -33,11 +33,11 @@ TEST_F(SmallStepTest, Value02) {
     const auto test = createSmallStepExprTest("bit<1> f;", "true");
     ASSERT_TRUE(test);
 
-    const auto *opValue = extractExpr<IR::BoolLiteral>(test->program);
+    const auto *opValue = extractExpr<IR::BoolLiteral>(test->getProgram());
     ASSERT_TRUE(opValue);
 
     // Step on the value and examine the resulting state.
-    stepAndExamineValue(opValue, test->program);
+    stepAndExamineValue(opValue, test->getProgram());
 }
 
 }  // anonymous namespace

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/transformations/saturation_arithm.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/transformations/saturation_arithm.cpp
@@ -82,13 +82,13 @@ class Z3SolverSatTests : public ::testing::Test {
         }
 
         // Produce a ProgramInfo, which is needed to create a SmallStepEvaluator.
-        const auto *progInfo = TestgenTarget::initProgram(test->program);
+        const auto *progInfo = TestgenTarget::initProgram(&test->getProgram());
         if (progInfo == nullptr) {
             return;
         }
 
         // Extract the binary operation from the P4Program
-        auto *const declVector = test->program->getDeclsByName("mau")->toVector();
+        auto *const declVector = test->getProgram().getDeclsByName("mau")->toVector();
         const auto *decl = (*declVector)[0];
         const auto *control = decl->to<IR::P4Control>();
         for (const auto *st : control->body->components) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/asrt_model.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/asrt_model.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <optional>
 #include <string>
 #include <vector>
@@ -13,13 +12,11 @@
 #include "backends/p4tools/common/core/z3_solver.h"
 #include "backends/p4tools/common/lib/model.h"
 #include "ir/declaration.h"
-#include "ir/indexed_vector.h"
 #include "ir/ir.h"
 #include "lib/big_int_util.h"
 #include "lib/cstring.h"
 #include "lib/enumerator.h"
 #include "lib/exceptions.h"
-#include "lib/log.h"
 #include "test/gtest/helpers.h"
 
 #include "backends/p4tools/modules/testgen/core/target.h"
@@ -90,13 +87,13 @@ class Z3SolverTest : public P4ToolsTest {
         }
 
         // Produce a ProgramInfo, which is needed to create a SmallStepEvaluator.
-        const auto *progInfo = TestgenTarget::initProgram(test->program);
+        const auto *progInfo = TestgenTarget::initProgram(&test->getProgram());
         if (progInfo == nullptr) {
             return;
         }
 
         // Extract the binary operation from the P4Program
-        auto *const declVector = test->program->getDeclsByName("mau")->toVector();
+        auto *const declVector = test->getProgram().getDeclsByName("mau")->toVector();
         const auto *decl = (*declVector)[0];
         const auto *control = decl->to<IR::P4Control>();
         SymbolicConverter converter;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/expressions.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/expressions.cpp
@@ -81,13 +81,13 @@ class Z3SolverTests : public ::testing::Test {
         }
 
         // Produce a ProgramInfo, which is needed to create a SmallStepEvaluator.
-        const auto *progInfo = TestgenTarget::initProgram(test->program);
+        const auto *progInfo = TestgenTarget::initProgram(&test->getProgram());
         if (progInfo == nullptr) {
             return;
         }
 
         // Extract the binary operation from the P4Program
-        auto *const declVector = test->program->getDeclsByName("mau")->toVector();
+        auto *const declVector = test->getProgram().getDeclsByName("mau")->toVector();
         const auto *decl = (*declVector)[0];
         const auto *control = decl->to<IR::P4Control>();
         for (const auto *st : control->body->components) {

--- a/backends/p4tools/modules/testgen/test/gtest_utils.cpp
+++ b/backends/p4tools/modules/testgen/test/gtest_utils.cpp
@@ -31,7 +31,7 @@ std::optional<const P4ToolsTestCase> P4ToolsTestCase::create(
     if (!compilerResults.has_value()) {
         return std::nullopt;
     }
-    return P4ToolsTestCase{compilerResults.value()->getProgram()};
+    return P4ToolsTestCase(compilerResults.value().get().getProgram());
 }
 
 const IR::P4Program &P4ToolsTestCase::getProgram() const { return program.get(); }

--- a/backends/p4tools/modules/testgen/test/gtest_utils.h
+++ b/backends/p4tools/modules/testgen/test/gtest_utils.h
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -30,10 +31,14 @@ class P4ToolsTestCase {
                                                           std::string archName,
                                                           const std::string &source);
 
-    /// The output of the compiler's mid end.
-    const IR::P4Program *program;
+    explicit P4ToolsTestCase(const IR::P4Program &program);
+
+    [[nodiscard]] const IR::P4Program &getProgram() const;
 
  private:
+    /// The output of the compiler's mid end.
+    std::reference_wrapper<const IR::P4Program> program;
+
     /// Ensures target plug-ins are initialized.
     static void ensureInit();
 };

--- a/backends/p4tools/modules/testgen/test/small-step/util.h
+++ b/backends/p4tools/modules/testgen/test/small-step/util.h
@@ -8,7 +8,6 @@
 #include <stack>
 #include <string>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "backends/p4tools/common/core/z3_solver.h"
@@ -53,9 +52,9 @@ std::optional<const P4ToolsTestCase> createSmallStepExprTest(const std::string &
 
 /// Extract the expression from the P4Program.
 template <class T>
-const T *extractExpr(const IR::P4Program *program) {
+const T *extractExpr(const IR::P4Program &program) {
     // Get the mau declarations in the P4Program.
-    const auto *decls = program->getDeclsByName("mau")->toVector();
+    const auto *decls = program.getDeclsByName("mau")->toVector();
     if (decls->size() != 1) {
         return nullptr;
     }
@@ -83,9 +82,9 @@ const T *extractExpr(const IR::P4Program *program) {
 
 /// Step on the @value, and examine the resulting state in the @program.
 template <class T>
-void stepAndExamineValue(const T *value, const IR::P4Program *program) {
+void stepAndExamineValue(const T *value, const IR::P4Program &program) {
     // Produce a ProgramInfo, which is needed to create a SmallStepEvaluator.
-    const auto *progInfo = TestgenTarget::initProgram(program);
+    const auto *progInfo = TestgenTarget::initProgram(&program);
     ASSERT_TRUE(progInfo);
 
     // Create a base state with a parameter continuation to apply the value on.
@@ -127,10 +126,10 @@ void stepAndExamineValue(const T *value, const IR::P4Program *program) {
 ///     Rebuilds the pushed continuation body with the given parameter.
 template <class T>
 void stepAndExamineOp(
-    const T *op, const IR::Expression *subexpr, const IR::P4Program *program,
+    const T *op, const IR::Expression *subexpr, const IR::P4Program &program,
     std::function<const IR::Expression *(const IR::PathExpression *)> rebuildNode) {
     // Produce a ProgramInfo, which is needed to create a SmallStepEvaluator.
-    const auto *progInfo = TestgenTarget::initProgram(program);
+    const auto *progInfo = TestgenTarget::initProgram(&program);
     ASSERT_TRUE(progInfo);
 
     // Step on the operation.

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -2,7 +2,6 @@
 
 #include <cstdlib>
 #include <filesystem>
-#include <iostream>
 #include <optional>
 #include <string>
 #include <utility>
@@ -91,12 +90,12 @@ int generateAbstractTests(const TestgenOptions &testgenOptions, const ProgramInf
     return ::errorCount() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
-int Testgen::mainImpl(const IR::P4Program *program) {
+int Testgen::mainImpl(const CompilerResult &compilerResult) {
     // Register all available testgen targets.
     // These are discovered by CMAKE, which fills out the register.h.in file.
     registerTestgenTargets();
 
-    const auto *programInfo = TestgenTarget::initProgram(program);
+    const auto *programInfo = TestgenTarget::initProgram(&compilerResult.getProgram());
     if (programInfo == nullptr) {
         ::error("Program not supported by target device and architecture.");
         return EXIT_FAILURE;

--- a/backends/p4tools/modules/testgen/testgen.h
+++ b/backends/p4tools/modules/testgen/testgen.h
@@ -13,7 +13,7 @@ class Testgen : public AbstractP4cTool<TestgenOptions> {
  protected:
     void registerTarget() override;
 
-    int mainImpl(const IR::P4Program *program) override;
+    int mainImpl(const CompilerResult &compilerResult) override;
 
  public:
     virtual ~Testgen() = default;


### PR DESCRIPTION
Major rewrite of the ProgramInfo and CompilerTarget infrastructure. The basic idea is to compute all necessary static analysis information in the compilation phase, then pass this information forward to ProgramInfo.

For this, we introduce a CompilerResult object. This object is produced in the compilation phase. Any P4Tools module can add arbitrary information to this class. The results object is then passed to ProgramInfo.

This PR is part 1. It introduces the `CompilerResult` data structure, which records information produces by the compiler which runs before P4Testgen is invoked. This includes the P4 program after the mid end for now. 