### PR TITLE
Allow constant-folding of arbitrary-precision integer casts

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -808,6 +808,16 @@ const IR::Node *DoConstantFolding::postorder(IR::Cast *e) {
         } else {
             return e;
         }
+    } else if (etype->is<IR::Type_InfInt>()) {
+        if (const auto *constant = expr->to<IR::Constant>()) {
+            const auto *ctype = constant->type;
+            if (!ctype->is<IR::Type_Bits>() && !ctype->is<IR::Type_InfInt>()) {
+                ::error(ErrorType::ERR_INVALID, "%1%: Cannot cast %1% to arbitrary presion integer",
+                        ctype);
+                return e;
+            }
+            return new IR::Constant(e->srcInfo, etype, constant->value, constant->base);
+        }
     } else if (etype->is<IR::Type_Boolean>()) {
         if (expr->is<IR::BoolLiteral>()) return expr;
         if (expr->is<IR::Constant>()) {

--- a/testdata/p4_16_samples/constant-fold-infint.p4
+++ b/testdata/p4_16_samples/constant-fold-infint.p4
@@ -1,0 +1,9 @@
+const bit<4> a = 0b0101;
+const int b = (int)a; // 5
+const bit<7> c = (bit<7>)b; // 5
+
+const int<4> d = -1;
+const int e = (int)d; // -1
+const bit<7> f = (bit<7>)e; // 0b1111111 = 127
+const int<7> g = (int<7>)e; // 0b1111111 = -1
+const int h = (int)g; // -1

--- a/testdata/p4_16_samples_outputs/constant-fold-infint-first.p4
+++ b/testdata/p4_16_samples_outputs/constant-fold-infint-first.p4
@@ -1,0 +1,8 @@
+const bit<4> a = 4w0b101;
+const int b = 0b101;
+const bit<7> c = 7w0b101;
+const int<4> d = -4s1;
+const int e = -1;
+const bit<7> f = 7w127;
+const int<7> g = -7s1;
+const int h = -1;

--- a/testdata/p4_16_samples_outputs/constant-fold-infint.p4
+++ b/testdata/p4_16_samples_outputs/constant-fold-infint.p4
@@ -1,0 +1,8 @@
+const bit<4> a = 0b101;
+const int b = (int)a;
+const bit<7> c = (bit<7>)b;
+const int<4> d = -1;
+const int e = (int)d;
+const bit<7> f = (bit<7>)e;
+const int<7> g = (int<7>)e;
+const int h = (int)g;

--- a/testdata/p4_16_samples_outputs/constant-fold-infint.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constant-fold-infint.p4-stderr
@@ -1,0 +1,4 @@
+constant-fold-infint.p4(6): [--Wwarn=mismatch] warning: -7w1: negative value with unsigned type
+const int e = (int)d; // -1
+              ^^^^^^
+[--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue2444-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2444-first.p4
@@ -1,7 +1,7 @@
 const int a = 1;
 const bool b = true;
-const int z = (int)2w1;
-const bool w = (bool)(int)2w1;
+const int z = 1;
+const bool w = true;
 const int z1 = 1;
 const bool w1 = true;
 const int z2 = 3;

--- a/testdata/p4_16_samples_outputs/issue3219-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3219-first.p4
@@ -1,9 +1,9 @@
 bit<4> func1() {
-    bit<4> t = (bit<4>)(int)1;
+    bit<4> t = 4w1;
     return t;
 }
 bit<4> func2() {
-    bit<4> t = (bit<4>)(int)4w1;
+    bit<4> t = 4w1;
     return t;
 }
 control c(out bit<4> result) {

--- a/testdata/p4_16_samples_outputs/issue3219-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue3219-frontend.p4
@@ -2,7 +2,7 @@ control c(out bit<4> result) {
     @name("c.retval") bit<4> retval;
     @name("c.t") bit<4> t_0;
     apply {
-        t_0 = (bit<4>)(int)1;
+        t_0 = 4w1;
         retval = t_0;
         result = retval;
     }

--- a/testdata/p4_16_samples_outputs/issue3219-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue3219-midend.p4
@@ -1,6 +1,6 @@
 control c(out bit<4> result) {
     @hidden action issue3219l13() {
-        result = (bit<4>)(int)1;
+        result = 4w1;
     }
     @hidden table tbl_issue3219l13 {
         actions = {


### PR DESCRIPTION
This showed as bug in testgen, but the core of the issue is that the constant folder was not handling `(int)` cast. That is fixed by this PR.