### PR TITLE
Ignore clang-tidy complaints about macro do-while loops.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,4 +32,5 @@ CheckOptions:
   - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
   - { key: readability-identifier-naming.StaticConstantCase,  value: UPPER_CASE }
   - { key: readability-identifier-naming.StaticVariableCase,  value: UPPER_CASE }
+  - { key: cppcoreguidelines-avoid-do-while.IgnoreMacros,     value: true }
 ...


### PR DESCRIPTION
Fix a minor annoyance. We can't change the macros we currently use, which expand to do-while loops. 