### PR TITLE
Remove P4C options from gtest binary.

### DIFF
--- a/test/gtest/gtestp4c.cpp
+++ b/test/gtest/gtestp4c.cpp
@@ -14,17 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "frontends/common/options.h"
 #include "gtest/gtest.h"
 #include "helpers.h"
-#include "lib/log.h"
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     AutoCompileContext autoGTestContext(new GTestContext);
-
-    GTestContext::get().options().process(argc, argv);
-    if (diagnosticCount() > 0) return -1;
 
     // Initialize the global test environment.
     (void)P4CTestEnvironment::get();


### PR DESCRIPTION
The compiler gtest were always hard to use because the compiler options class shadows the actual gtest parameters. The compiler options are never used, so remove them. 

Now we can use flags such as `--gtest_filter=` to select for a particular gtest. 