### PR TITLE
Add missing equiv implementation to Type_Any.

### DIFF
--- a/ir/type.def
+++ b/ir/type.def
@@ -78,6 +78,10 @@ class Type_Any : Type, ITypeVar {
     operator== { return declid == a.declid; }
     static Type_Any get();
     const Type* getP4Type() const override { return nullptr; }
+    equiv {
+        (void)a;  // silence unused warning
+        return true; /* ignore declid */
+    }
 }
 
 /// This type is a fragment of another type.


### PR DESCRIPTION
`Type_Any` has a `declid` member but does not have a corresponding equiv function that ignores. All other IR nodes with `declid` have this implementation, it seems it was forgotten here. Fix it. 