### PR TITLE
DoConstantFolding: make typeMap param const

### DIFF
--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -97,7 +97,7 @@ class DoConstantFolding : public Transform {
     Result setContains(const IR::Expression *keySet, const IR::Expression *constant) const;
 
  public:
-    DoConstantFolding(const ReferenceMap *refMap, TypeMap *typeMap, bool warnings = true)
+    DoConstantFolding(const ReferenceMap *refMap, const TypeMap *typeMap, bool warnings = true)
         : refMap(refMap), typeMap(typeMap), typesKnown(typeMap != nullptr), warnings(warnings) {
         visitDagOnce = true;
         setName("DoConstantFolding");


### PR DESCRIPTION
The DoConstantFolding constructor takes a `TypeMap` parameter (`typeMap`) and stores it in a `const TypeMap` variable. Add the `const` keyword for the parameter. (It does not need to be non-const.)