### PR TITLE
Trigger CI workflows based on assigned label.

### DIFF
--- a/.github/workflows/ci-ubuntu-18-nightly.yml
+++ b/.github/workflows/ci-ubuntu-18-nightly.yml
@@ -3,41 +3,40 @@ name: "test-p4c-ubuntu-18.04"
 on:
   schedule:
     # Every day on midnight UTC
-    - cron: '0 0 * * *'
-
-# Cancel any preceding run on the pull request.
-concurrency:
-  group: test-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    - cron: "0 0 * * *"
+  pull_request:
+    branches: [main]
 
 jobs:
   # Build with gcc and test p4c on Ubuntu 18.04.
   test-ubuntu18:
+    # Only run on pull requests with the "run-ubuntu18" label.
+    if: contains(github.event.pull_request.labels.*.name, 'run-ubuntu18')
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
     env:
       CTEST_PARALLEL_LEVEL: 4
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        fetch-depth: 0
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1
-      with:
-        key: test-ubuntu-18.04-gcc
-        max-size: 1000M
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: test-ubuntu-18.04-gcc
+          max-size: 1000M
 
-    - name: Build (Ubuntu 18.04, GCC)
-      run: |
-        docker build -t p4c --build-arg BASE_IMAGE=ubuntu:18.04 --build-arg IMAGE_TYPE=test \
-        --build-arg ENABLE_TEST_TOOLS=OFF .
-        ./tools/export_ccache.sh
+      - name: Build (Ubuntu 18.04, GCC)
+        run: |
+          docker build -t p4c --build-arg BASE_IMAGE=ubuntu:18.04 --build-arg IMAGE_TYPE=test \
+          --build-arg ENABLE_TEST_TOOLS=OFF .
+          ./tools/export_ccache.sh
 
-      # run with sudo (...) --privileged
-      # this is needed to create network namespaces for the ebpf tests.
-    - name: Run tests (Ubuntu 18.04)
-      run: |
-        sudo -E docker run --privileged -w /p4c/build -e $CTEST_PARALLEL_LEVEL p4c ctest --output-on-failure --schedule-random
+        # run with sudo (...) --privileged
+        # this is needed to create network namespaces for the ebpf tests.
+      - name: Run tests (Ubuntu 18.04)
+        run: |
+          sudo -E docker run --privileged -w /p4c/build -e $CTEST_PARALLEL_LEVEL p4c ctest --output-on-failure --schedule-random

--- a/.github/workflows/ci-ubuntu-20-sanitizer-nightly.yml
+++ b/.github/workflows/ci-ubuntu-20-sanitizer-nightly.yml
@@ -3,16 +3,16 @@ name: "test-p4c-ubuntu-20.04-sanitizers"
 on:
   schedule:
     # Every day on midnight UTC
-    - cron: '0 0 * * *'
-
-# Cancel any preceding run on the pull request.
-concurrency:
-  group: test-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    - cron: "0 0 * * *"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   # Build with clang and test p4c on Ubuntu 20.04.
   test-ubuntu20-clang-sanitizers:
+    # Only run on pull requests with the "run-sanitizer" label.
+    if: contains(github.event.pull_request.labels.*.name, 'run-sanitizer')
     strategy:
       fail-fast: false
     runs-on: ubuntu-20.04
@@ -25,21 +25,21 @@ jobs:
       UBSAN_OPTIONS: print_stacktrace=1
       ASAN_OPTIONS: print_stacktrace=1:detect_leaks=0
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1
-      with:
-        key: test-${{ runner.os }}-clang
-        max-size: 1000M
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: test-${{ runner.os }}-clang
+          max-size: 1000M
 
-    - name: Build (Ubuntu 20.04, Clang, Sanitizers)
-      run: |
-        tools/ci-build.sh
+      - name: Build (Ubuntu 20.04, Clang, Sanitizers)
+        run: |
+          tools/ci-build.sh
 
-    - name: Run tests (Ubuntu 20.04)
-      # Need to use sudo for the eBPF kernel tests.
-      run: sudo -E ctest --output-on-failure --schedule-random
-      working-directory: ./build
+      - name: Run tests (Ubuntu 20.04)
+        # Need to use sudo for the eBPF kernel tests.
+        run: sudo -E ctest --output-on-failure --schedule-random
+        working-directory: ./build

--- a/.github/workflows/ci-validation-nightly.yml
+++ b/.github/workflows/ci-validation-nightly.yml
@@ -3,39 +3,39 @@ name: "validate-p4c"
 on:
   schedule:
     # Every day on midnight UTC
-    - cron: '0 0 * * *'
-
-# Cancel any preceding run on the pull request.
-concurrency:
-  group: validation-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    - cron: "0 0 * * *"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   # We run validation in parallel with the normal tests.
   # Validation ensures that P4C compiles P4-16 programs correctly.
   # We only test the front end and some mid end passes for now.
   validate:
+    # Only run on pull requests with the "run-validation" label.
+    if: contains(github.event.pull_request.labels.*.name, 'run-validation')
     env:
       CTEST_PARALLEL_LEVEL: 4
       IMAGE_TYPE: test
       VALIDATION: ON
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1
-      with:
-        key: validation-${{ runner.os }}
-        max-size: 1000M
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: validation-${{ runner.os }}
+          max-size: 1000M
 
-    - name: Build (Ubuntu 20.04)
-      run: |
-        tools/ci-build.sh
+      - name: Build (Ubuntu 20.04)
+        run: |
+          tools/ci-build.sh
 
-    - name: Validate
-      run: |
+      - name: Validate
+        run: |
           ctest  -R toz3-validate-p4c --output-on-failure --schedule-random
-      working-directory: ./build
+        working-directory: ./build

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,10 @@ scapy==2.4.5
 clang-format==15.0.6
 black==22.3.0
 isort==5.10.0
-protobuf==3.20.1
-googleapis-common-protos==1.50.0
-grpcio==1.51.1
+protobuf==3.20.2; python_version > '3.6'
+grpcio==1.51.1; python_version > '3.6'
+googleapis-common-protos==1.53.0; python_version > '3.6'
+# Ubuntu 18.04 uses Python 3.6, which is not supported by recent versions of Protobuf.
+protobuf==3.19.2; python_version <= '3.6'
+googleapis-common-protos==1.53.0; python_version <= '3.6'
+grpcio==1.48.2; python_version <= '3.6'


### PR DESCRIPTION
This PR does two things. 

First, it adds a mechanism to optionally trigger certain CI runs (sanitizers, ubuntu18, validation) by adding the corresponding label to the PR. 

Second, it makes the installation of Python packages for Protobuf subject to the Python version. This way we can install the correct version of a Python package depending on the version being used. This fixes the Ubuntu 18 build issues. 