### PR TITLE
Remove XDP code generated for TC

### DIFF
--- a/backends/tc/ebpfCodeGen.cpp
+++ b/backends/tc/ebpfCodeGen.cpp
@@ -127,9 +127,7 @@ void PNAArchTC::emit(EBPF::CodeBuilder *builder) const {
      * 1. Automatically generated comment
      * 2. Includes
      * 3. Headers, structs
-     * 4. BPF map definitions.
-     * 5. XDP helper program.
-     * 6. TC Pipeline program for post-parser.
+     * 4. TC Pipeline program for post-parser.
      */
 
     // 1. Automatically generated comment.
@@ -149,12 +147,7 @@ void PNAArchTC::emit(EBPF::CodeBuilder *builder) const {
     emitTypes(builder);
 
     /*
-     * 4. XDP helper program.
-     */
-    xdp->emit(builder);
-
-    /*
-     * 5. TC Pipeline program for post-parser.
+     * 4. TC Pipeline program for post-parser.
      */
     pipeline->emit(builder);
 

--- a/testdata/p4tc_samples_outputs/calculator_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/calculator_control_blocks.c
@@ -34,35 +34,6 @@ struct __attribute__((__packed__)) MainControlImpl_calculate_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/checksum_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/checksum_control_blocks.c
@@ -25,35 +25,6 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct my_ingress_headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/const_entries_range_mask_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/const_entries_range_mask_control_blocks.c
@@ -23,35 +23,6 @@ struct __attribute__((__packed__)) MainControlImpl_t_range_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct Header_t *h, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
@@ -45,35 +45,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
@@ -30,35 +30,6 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
@@ -23,35 +23,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
@@ -45,35 +45,6 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct my_ingress_headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
@@ -46,35 +46,6 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct my_ingress_headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/hash1_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/hash1_control_blocks.c
@@ -4,35 +4,6 @@ struct internal_metadata {
 } __attribute__((aligned(4)));
 
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct my_ingress_headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/ipip_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/ipip_control_blocks.c
@@ -30,35 +30,6 @@ struct __attribute__((__packed__)) Main_fwd_table_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
@@ -89,35 +89,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_4_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
@@ -95,35 +95,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_4_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
@@ -166,35 +166,6 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
@@ -163,35 +163,6 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
@@ -44,35 +44,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/no_table_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/no_table_example_control_blocks.c
@@ -4,35 +4,6 @@ struct internal_metadata {
 } __attribute__((aligned(4)));
 
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
@@ -45,35 +45,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
@@ -36,35 +36,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
@@ -25,35 +25,6 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
@@ -25,35 +25,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
@@ -43,35 +43,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
@@ -25,35 +25,6 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct my_ingress_headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
@@ -25,35 +25,6 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct my_ingress_headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
@@ -31,35 +31,6 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct my_ingress_headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
@@ -44,35 +44,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/tc_type_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_type_annotation_example_control_blocks.c
@@ -38,35 +38,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
@@ -21,35 +21,6 @@ struct __attribute__((__packed__)) MainControlImpl_tbl_default_value {
     } u;
 };
 
-SEC("xdp/xdp-ingress")
-int xdp_func(struct xdp_md *skb) {
-        void *data_end = (void *)(long)skb->data_end;
-    struct ethhdr *eth = (struct ethhdr *)(long)skb->data;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    if (eth->h_proto == bpf_htons(0x0800) || eth->h_proto == bpf_htons(0x86DD)) {
-        return XDP_PASS;
-    }
-
-    struct internal_metadata *meta;
-    int ret = bpf_xdp_adjust_meta(skb, -(int)sizeof(*meta));
-    if (ret < 0) {
-        return XDP_ABORTED;
-    }
-    meta = (struct internal_metadata *)(unsigned long)skb->data_meta;
-    eth = (void *)(long)skb->data;
-    data_end = (void *)(long)skb->data_end;
-    if ((void *) ((struct internal_metadata *) meta + 1) > (void *)(long)skb->data)
-        return XDP_ABORTED;
-    if ((void *)((struct ethhdr *) eth + 1) > data_end) {
-        return XDP_ABORTED;
-    }
-    meta->pkt_ether_type = eth->h_proto;
-    eth->h_proto = bpf_htons(0x0800);
-
-    return XDP_PASS;
-}
 static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr, struct pna_global_metadata *compiler_meta__)
 {
     struct hdr_md *hdrMd;


### PR DESCRIPTION
Remove XDP section that is always generated for the TC backend. This XDP code generated for TC was responsible for setting the skb->protocol field which is not writable in TC. We have a found better way to do that with an extern, hence this XDP section isn't needed anymore.