### PR TITLE
Initialize cstrings with the empty string.

### DIFF
--- a/lib/cstring.cpp
+++ b/lib/cstring.cpp
@@ -164,6 +164,8 @@ const char *save_to_cache(const char *string, std::size_t length, table_entry_fl
 
 }  // namespace
 
+cstring::cstring() : str(cstring::empty) {}
+
 void cstring::construct_from_shared(const char *string, std::size_t length) {
     str = save_to_cache(string, length, table_entry_flags::none);
 }

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -72,7 +72,7 @@ class cstring {
     const char *str = nullptr;
 
  public:
-    cstring() = default;
+    cstring();
     // TODO (DanilLutsenko): Enable when initialization with 0 will be eliminated
     // cstring(std::nullptr_t) {} // NOLINT(runtime/explicit)
 


### PR DESCRIPTION
This PR is meant to raise a discussion. We stumbled across this in #4357 where an incorrectly initialized cstring caused a bug. This PR changes the default initializer to use the empty string instead of nullpointer. 

I am not sure about the motivation about making the default cstring invalid, could be performance related? 

Alternatively, we could forbid this empty constructor. This could expose a lot of incorrectly constructed cstrings. 

