### PR TITLE
Improve diagnostics for `AssignmentStatement`

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -749,7 +749,7 @@ const IR::Expression *TypeInference::assignment(const IR::Node *errorPosition,
     }
     if (destType->is<IR::Type_SerEnum>() && !typeMap->equivalent(destType, initType) &&
         !initType->is<IR::Type_Any>()) {
-        typeError("%1%: values of type '%2%' cannot be implicitly cast to type '%3%'",
+        typeError("'%1%': values of type '%2%' cannot be implicitly cast to type '%3%'",
                   errorPosition, initType, destType);
         return sourceExpression;
     }

--- a/frontends/p4/typeChecking/typeConstraints.h
+++ b/frontends/p4/typeChecking/typeConstraints.h
@@ -160,7 +160,7 @@ class TypeConstraint : public IHasDbPrint, public ICastable {
         if (lastIsEmpty) message += "\n";
 
         CHECK_NULL(o);
-        ::errorWithSuffix(ErrorType::ERR_TYPE_ERROR, "%1%", message.c_str(), o);
+        ::errorWithSuffix(ErrorType::ERR_TYPE_ERROR, "'%1%'", message.c_str(), o);
         return false;
     }
     // Default error message; returns 'false'

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -442,6 +442,7 @@ class EmptyStatement : Statement {
 class AssignmentStatement : Statement {
     Expression left;
     Expression right;
+    toString{ return left->toString() + " = " + right->toString(); }
 }
 
 class IfStatement : Statement {

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -505,7 +505,7 @@ class ParserSymbolicInterpreter {
             }
             std::stringstream errorStr;
             errorStr << errorValue;
-            ::warning(ErrorType::WARN_IGNORE_PROPERTY, "Result of %1% is not defined: %2%", sord,
+            ::warning(ErrorType::WARN_IGNORE_PROPERTY, "Result of '%1%' is not defined: %2%", sord,
                       errorStr.str());
         }
         ParserStateRewriter rewriter(structure, state, valueMap, refMap, typeMap, &ev,

--- a/testdata/p4_16_dpdk_errors_outputs/pna-example-ipsec-err3.p4-error
+++ b/testdata/p4_16_dpdk_errors_outputs/pna-example-ipsec-err3.p4-error
@@ -1,4 +1,4 @@
-pna-example-ipsec-err3.p4(144): [--Werror=type-error] error: ipsec.set_sa_index
+pna-example-ipsec-err3.p4(144): [--Werror=type-error] error: 'ipsec.set_sa_index'
   ipsec.set_sa_index<bit<32>, bit<8>>(sa_index);
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/constructor3_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/constructor3_e.p4-stderr
@@ -1,4 +1,4 @@
-constructor3_e.p4(22): [--Werror=type-error] error: e
+constructor3_e.p4(22): [--Werror=type-error] error: 'e'
     E(true) e;
             ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/enumCast.p4-stderr
+++ b/testdata/p4_16_errors_outputs/enumCast.p4-stderr
@@ -1,16 +1,16 @@
-enumCast.p4(26): [--Werror=type-error] error: y: values of type 'int' cannot be implicitly cast to type 'X'
+enumCast.p4(26): [--Werror=type-error] error: 'y': values of type 'int' cannot be implicitly cast to type 'X'
         X y = 1; // Error: no implicit cast to enum
         ^^^^^^^^
 enumCast.p4(3)
 enum bit<32> X {
              ^
-enumCast.p4(27): [--Werror=type-error] error: AssignmentStatement: values of type 'bit<32>' cannot be implicitly cast to type 'X'
+enumCast.p4(27): [--Werror=type-error] error: 'y = 32w1': values of type 'bit<32>' cannot be implicitly cast to type 'X'
         y = 32w1; // Error: no implicit cast to enum
           ^
 enumCast.p4(3)
 enum bit<32> X {
              ^
-enumCast.p4(33): [--Werror=type-error] error: AssignmentStatement: values of type 'E2' cannot be implicitly cast to type 'E1'
+enumCast.p4(33): [--Werror=type-error] error: 'a = b': values of type 'E2' cannot be implicitly cast to type 'E1'
         a = b; // Error: b is automatically cast to bit<8>,
           ^
 enumCast.p4(12)
@@ -19,13 +19,13 @@ enum bit<8> E2 {
 enumCast.p4(8)
 enum bit<8> E1 {
             ^^
-enumCast.p4(35): [--Werror=type-error] error: AssignmentStatement: values of type 'bit<8>' cannot be implicitly cast to type 'E1'
+enumCast.p4(35): [--Werror=type-error] error: 'a = 0 + 1': values of type 'bit<8>' cannot be implicitly cast to type 'E1'
         a = E1.e1 + 1; // Error: E.e1 is automatically cast to bit<8>,
           ^
 enumCast.p4(8)
 enum bit<8> E1 {
             ^^
-enumCast.p4(38): [--Werror=type-error] error: AssignmentStatement: values of type 'bit<8>' cannot be implicitly cast to type 'E1'
+enumCast.p4(38): [--Werror=type-error] error: 'a = 0 + 1': values of type 'bit<8>' cannot be implicitly cast to type 'E1'
         a = E1.e1 + E1.e2; // Error: both arguments to the addition are automatically
           ^
 enumCast.p4(8)

--- a/testdata/p4_16_errors_outputs/factory-err2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/factory-err2.p4-stderr
@@ -1,4 +1,4 @@
-factory-err2.p4(31): [--Werror=type-error] error: createWidget
+factory-err2.p4(31): [--Werror=type-error] error: 'createWidget'
     c1<bit<16>>(createWidget(hdr.f1, hdr.f2)) c; // factory args must be constants
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/function1_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function1_e.p4-stderr
@@ -1,4 +1,4 @@
-function1_e.p4(21): [--Werror=type-error] error: f
+function1_e.p4(21): [--Werror=type-error] error: 'f'
         f(1w1 & 1w0); // non lvalue passed to out parameter
         ^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/function_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/function_e.p4-stderr
@@ -1,4 +1,4 @@
-function_e.p4(22): [--Werror=type-error] error: f
+function_e.p4(22): [--Werror=type-error] error: 'f'
         f(); // not enough arguments
         ^^^
   ---- Actual error:
@@ -12,7 +12,7 @@ function_e.p4(16): Function type 'f' does not match invocation type '<Method cal
 function_e.p4(22)
           f(); // not enough arguments
           ^^^
-function_e.p4(23): [--Werror=type-error] error: f
+function_e.p4(23): [--Werror=type-error] error: 'f'
         f(1w1, 1w0); // too many arguments
         ^^^^^^^^^^^
   ---- Actual error:
@@ -26,7 +26,7 @@ function_e.p4(16): Function type 'f' does not match invocation type '<Method cal
 function_e.p4(23)
           f(1w1, 1w0); // too many arguments
           ^^^^^^^^^^^
-function_e.p4(24): [--Werror=type-error] error: f
+function_e.p4(24): [--Werror=type-error] error: 'f'
         f<bit>(1w0); // too many type arguments
         ^^^^^^^^^^^
   ---- Actual error:
@@ -40,7 +40,7 @@ function_e.p4(16): Function type 'f' does not match invocation type '<Method cal
 function_e.p4(24)
           f<bit>(1w0); // too many type arguments
           ^^^^^^^^^^^
-function_e.p4(25): [--Werror=type-error] error: g
+function_e.p4(25): [--Werror=type-error] error: 'g'
         g<bit, bit>(); // too many type arguments
         ^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/implicit.p4-stderr
+++ b/testdata/p4_16_errors_outputs/implicit.p4-stderr
@@ -1,4 +1,4 @@
-implicit.p4(19): [--Werror=type-error] error: b
+implicit.p4(19): [--Werror=type-error] error: 'b'
     bit<32> b = 32s1;
     ^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue1006-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1006-1.p4-stderr
@@ -1,4 +1,4 @@
-issue1006-1.p4(14): [--Werror=type-error] error: reg2
+issue1006-1.p4(14): [--Werror=type-error] error: 'reg2'
     R<bit<8>>(16w1) reg2;
                     ^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue1986-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1986-1.p4-stderr
@@ -1,4 +1,4 @@
-issue1986-1.p4(22): [--Werror=type-error] error: SelectExpression
+issue1986-1.p4(22): [--Werror=type-error] error: 'SelectExpression'
         transition select(2w0) {
                    ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue1986.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue1986.p4-stderr
@@ -1,4 +1,4 @@
-issue1986.p4(17): [--Werror=type-error] error: SelectExpression
+issue1986.p4(17): [--Werror=type-error] error: 'SelectExpression'
         transition select(1w0) {
                    ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2021.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2021.p4-stderr
@@ -1,7 +1,7 @@
 issue2021.p4(8): [--Werror=type-error] error: Expression .x cannot be the target of an assignment
         .x = 8w3;
          ^
-issue2021.p4(9): [--Werror=type-error] error: f
+issue2021.p4(9): [--Werror=type-error] error: 'f'
         f(.x);
         ^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2036-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2036-1.p4-stderr
@@ -1,4 +1,4 @@
-issue2036-1.p4(10): [--Werror=type-error] error: f
+issue2036-1.p4(10): [--Werror=type-error] error: 'f'
         f(b);
         ^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2036-2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2036-2.p4-stderr
@@ -1,4 +1,4 @@
-issue2036-2.p4(10): [--Werror=type-error] error: f
+issue2036-2.p4(10): [--Werror=type-error] error: 'f'
         f(b);
         ^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2036.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2036.p4-stderr
@@ -1,4 +1,4 @@
-issue2036.p4(23): [--Werror=type-error] error: d.apply
+issue2036.p4(23): [--Werror=type-error] error: 'd.apply'
     d.apply(a);
     ^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2220.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2220.p4-stderr
@@ -1,4 +1,4 @@
-issue2220.p4(11): [--Werror=type-error] error: { val = 8w0 }: values of type 'bit<8>' cannot be implicitly cast to type 'myEnum'
+issue2220.p4(11): [--Werror=type-error] error: '{ val = 8w0 }': values of type 'bit<8>' cannot be implicitly cast to type 'myEnum'
  S s1 = { val = (bit<8>)0 };
         ^^^^^^^^^^^^^^^^^^^
 issue2220.p4(3)

--- a/testdata/p4_16_errors_outputs/issue2230-1-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2230-1-bmv2.p4-stderr
@@ -1,4 +1,4 @@
-issue2230-1-bmv2.p4(115): [--Werror=type-error] error: c1.apply
+issue2230-1-bmv2.p4(115): [--Werror=type-error] error: 'c1.apply'
         c1.apply(hdr.h1, s1);
         ^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:
@@ -25,7 +25,7 @@ issue2230-1-bmv2.p4(43)
 issue2230-1-bmv2.p4(115): Function type 'myCtrl' does not match invocation type '<Method call>'
           c1.apply(hdr.h1, s1);
           ^^^^^^^^^^^^^^^^^^^^
-issue2230-1-bmv2.p4(137): [--Werror=type-error] error: funky_swap
+issue2230-1-bmv2.p4(137): [--Werror=type-error] error: 'funky_swap'
         s1 = funky_swap(s1);
              ^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2230.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2230.p4-stderr
@@ -1,4 +1,4 @@
-issue2230.p4(70): [--Werror=type-error] error: AssignmentStatement
+issue2230.p4(70): [--Werror=type-error] error: 'hdr.h2 = hdr.h1'
         hdr.h2 = hdr.h1;
                ^
   ---- Actual error:
@@ -18,7 +18,7 @@ issue2230.p4(28)
 issue2230.p4(33)
   header h2_t {
          ^^^^
-issue2230.p4(74): [--Werror=type-error] error: AssignmentStatement
+issue2230.p4(74): [--Werror=type-error] error: 'hdr.h1b = s1'
         hdr.h1b = s1;
                 ^
   ---- Actual error:
@@ -38,7 +38,7 @@ issue2230.p4(38)
 issue2230.p4(28)
   header h1_t {
          ^^^^
-issue2230.p4(80): [--Werror=type-error] error: AssignmentStatement
+issue2230.p4(80): [--Werror=type-error] error: 's1 = hdr.h1'
         s1 = hdr.h1;
            ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue2260-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2260-1.p4-stderr
@@ -1,4 +1,4 @@
-issue2260-1.p4(8): [--Werror=type-error] error: f
+issue2260-1.p4(8): [--Werror=type-error] error: 'f'
         bit<8> y = f(255);
                    ^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue3045-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3045-1.p4-stderr
@@ -1,4 +1,4 @@
-issue3045-1.p4(16): [--Werror=type-error] error: f
+issue3045-1.p4(16): [--Werror=type-error] error: 'f'
         f(r, exact);
         ^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue3045-2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3045-2.p4-stderr
@@ -1,4 +1,4 @@
-issue3045-2.p4(16): [--Werror=type-error] error: f
+issue3045-2.p4(16): [--Werror=type-error] error: 'f'
         f(r, exact);
         ^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue3045.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3045.p4-stderr
@@ -1,4 +1,4 @@
-issue3045.p4(16): [--Werror=type-error] error: f
+issue3045.p4(16): [--Werror=type-error] error: 'f'
         f(r, 8w2);
         ^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue3221.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3221.p4-stderr
@@ -1,4 +1,4 @@
-issue3221.p4(8): [--Werror=type-error] error: (t1)a
+issue3221.p4(8): [--Werror=type-error] error: '(t1)a'
   return (t1)a;
          ^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue3246.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3246.p4-stderr
@@ -1,4 +1,4 @@
-issue3246.p4(3): [--Werror=type-error] error: 1w1.minSizeInBits
+issue3246.p4(3): [--Werror=type-error] error: '1w1.minSizeInBits'
   return (1w1).minSizeInBits<int, int, int, int, int>();
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:
@@ -7,7 +7,7 @@ issue3246.p4(3): [--Werror=type-error] error: 1w1.minSizeInBits
 issue3246.p4(3): Function type 'minSizeInBits' does not match invocation type '<Method call>'
     return (1w1).minSizeInBits<int, int, int, int, int>();
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-issue3246.p4(8): [--Werror=type-error] error: 1w1.minSizeInBits
+issue3246.p4(8): [--Werror=type-error] error: '1w1.minSizeInBits'
   return (1w1).minSizeInBits<int, int, int, int, int>(_,_,_);
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:
@@ -16,7 +16,7 @@ issue3246.p4(8): [--Werror=type-error] error: 1w1.minSizeInBits
 issue3246.p4(8): Function type 'minSizeInBits' does not match invocation type '<Method call>'
     return (1w1).minSizeInBits<int, int, int, int, int>(_,_,_);
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-issue3246.p4(13): [--Werror=type-error] error: 1w1.minSizeInBits
+issue3246.p4(13): [--Werror=type-error] error: '1w1.minSizeInBits'
   return (1w1).minSizeInBits<int, int, int, int, int>(a = 1, b = 1, c = 1);
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue3345.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3345.p4-stderr
@@ -1,4 +1,4 @@
-issue3345.p4(3): [--Werror=type-error] error: SelectExpression
+issue3345.p4(3): [--Werror=type-error] error: 'SelectExpression'
     transition select(t) {
                ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue345.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue345.p4-stderr
@@ -1,4 +1,4 @@
-issue345.p4(19): [--Werror=type-error] error: h
+issue345.p4(19): [--Werror=type-error] error: 'h'
         H h = 0;
         ^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue3534.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3534.p4-stderr
@@ -1,10 +1,10 @@
-issue3534.p4(5): [--Werror=type-error] error: return ?:: values of type 'bit<2>' cannot be implicitly cast to type 'e'
+issue3534.p4(5): [--Werror=type-error] error: 'return ?:': values of type 'bit<2>' cannot be implicitly cast to type 'e'
   return c ? v0 : v1; // { dg-error "" }
   ^^^^^^
 issue3534.p4(1)
 enum bit<2> e{ t = 1}
             ^
-issue3534.p4(9): [--Werror=type-error] error: ?:
+issue3534.p4(9): [--Werror=type-error] error: '?:'
   return c ? v0 : v1; // { dg-error "" }
          ^^^^^^^^^^^
   ---- Actual error:
@@ -15,7 +15,7 @@ issue3534.p4(1): Cannot unify type 'e' with type 'bit<2>'
 issue3534.p4(1): The expressions in a ?: conditional have different types 'bit<2>' and 'e'
   enum bit<2> e{ t = 1}
               ^
-issue3534.p4(13): [--Werror=type-error] error: ?:
+issue3534.p4(13): [--Werror=type-error] error: '?:'
   return c ? v0 : v1; // { dg-error "" }
          ^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue401.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue401.p4-stderr
@@ -1,4 +1,4 @@
-issue401.p4(42): [--Werror=type-error] error: (bit<1>){ 0 }
+issue401.p4(42): [--Werror=type-error] error: '(bit<1>){ 0 }'
     bit<1> b = (bit<1>) { 0 };
                ^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue561-1.p4-stderr
@@ -1,4 +1,4 @@
-issue561-1.p4(29): [--Werror=type-error] error: u
+issue561-1.p4(29): [--Werror=type-error] error: 'u'
         U u = { { 10 }, { 20 } }; // illegal to initialize unions
         ^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue67.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue67.p4-stderr
@@ -1,4 +1,4 @@
-issue67.p4(1): [--Werror=type-error] error: x
+issue67.p4(1): [--Werror=type-error] error: 'x'
 const bool x = 20; // error
            ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue774-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue774-1.p4-stderr
@@ -1,4 +1,4 @@
-issue774-1.p4(7): [--Werror=type-error] error: f
+issue774-1.p4(7): [--Werror=type-error] error: 'f'
         f(_);
         ^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/issue803-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue803-1.p4-stderr
@@ -1,4 +1,4 @@
-issue803-1.p4(3): [--Werror=type-error] error: package Ingress
+issue803-1.p4(3): [--Werror=type-error] error: 'package Ingress'
 package Ingress<IH>();
         ^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/list-error.p4-stderr
+++ b/testdata/p4_16_errors_outputs/list-error.p4-stderr
@@ -1,4 +1,4 @@
-list-error.p4(9): [--Werror=type-error] error: e
+list-error.p4(9): [--Werror=type-error] error: 'e'
     E((list<bit<16>>){2, 3, 4}) e;
                                 ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/module_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/module_e.p4-stderr
@@ -1,4 +1,4 @@
-module_e.p4(18): [--Werror=type-error] error: package top
+module_e.p4(18): [--Werror=type-error] error: 'package top'
 package top(Filter f);
         ^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/mux_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/mux_e.p4-stderr
@@ -1,5 +1,5 @@
 [--Werror=type-error] error: Selector of ?: must be bool, not bit<1>
-mux_e.p4(25): [--Werror=type-error] error: ?:
+mux_e.p4(25): [--Werror=type-error] error: '?:'
         d = d ? a : d; // wrong types a <-> d
             ^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/named-fail1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/named-fail1.p4-stderr
@@ -1,4 +1,4 @@
-named-fail1.p4(8): [--Werror=type-error] error: f
+named-fail1.p4(8): [--Werror=type-error] error: 'f'
         f(z = b, y = b); // No such parameter
         ^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/newtype-err.p4-stderr
+++ b/testdata/p4_16_errors_outputs/newtype-err.p4-stderr
@@ -1,4 +1,4 @@
-newtype-err.p4(10): [--Werror=type-error] error: AssignmentStatement
+newtype-err.p4(10): [--Werror=type-error] error: 'n = b + b'
         n = b + b;
           ^
   ---- Actual error:
@@ -15,7 +15,7 @@ newtype-err.p4(2)
 newtype-err.p4(11): [--Werror=type-error] error: +: cannot be applied to expression 'n' with type 'N32'
         n1 = n + 0;
              ^
-newtype-err.p4(12): [--Werror=type-error] error: AssignmentStatement
+newtype-err.p4(12): [--Werror=type-error] error: 'x = n'
         x = n;
           ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/psa-meter2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/psa-meter2.p4-stderr
@@ -1,4 +1,4 @@
-psa-meter2.p4(57): [--Werror=type-error] error: (bit<16>)meter0.execute
+psa-meter2.p4(57): [--Werror=type-error] error: '(bit<16>)meter0.execute'
         b.data = (bit<16>)meter0.execute(index, PSA_MeterColor_t.GREEN);
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/push_nonconstant.p4-stderr
+++ b/testdata/p4_16_errors_outputs/push_nonconstant.p4-stderr
@@ -1,4 +1,4 @@
-push_nonconstant.p4(10): [--Werror=type-error] error: h.push_front
+push_nonconstant.p4(10): [--Werror=type-error] error: 'h.push_front'
         h.push_front(x);
         ^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/serenum-type.p4-stderr
+++ b/testdata/p4_16_errors_outputs/serenum-type.p4-stderr
@@ -1,7 +1,7 @@
 serenum-type.p4(8): [--Werror=type-error] error: EthT: Illegal type for enum; only bit<> and int<> are allowed; note that type-declared types are not allowed even if they are fixed-size
 enum EthT EthTypes {
      ^^^^
-serenum-type.p4(49): [--Werror=type-error] error: (EthTypes)16w0
+serenum-type.p4(49): [--Werror=type-error] error: '(EthTypes)16w0'
             h.eth.type = (EthTypes)(bit<16>)0;
                          ^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/serenum-typedef.p4-stderr
+++ b/testdata/p4_16_errors_outputs/serenum-typedef.p4-stderr
@@ -25,7 +25,7 @@ serenum-typedef.p4(31): [--Werror=type-error] error: unrepresentable_p: Serializ
 serenum-typedef.p4(28)
 enum bit<4> UnrepresentableBit {
      ^^^^^^
-serenum-typedef.p4(65): [--Werror=type-error] error: (EthTypes)16w0
+serenum-typedef.p4(65): [--Werror=type-error] error: '(EthTypes)16w0'
             h.eth.type = (EthTypes)(bit<16>)0;
                          ^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/signed.p4-stderr
+++ b/testdata/p4_16_errors_outputs/signed.p4-stderr
@@ -1,4 +1,4 @@
-signed.p4(5): [--Werror=type-error] error: AssignmentStatement
+signed.p4(5): [--Werror=type-error] error: 'signed_int1[7:0] = signed_int2'
         signed_int1[7:0] = signed_int2;
                          ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/signs.p4-stderr
+++ b/testdata/p4_16_errors_outputs/signs.p4-stderr
@@ -1,4 +1,4 @@
-signs.p4(18): [--Werror=type-error] error: b
+signs.p4(18): [--Werror=type-error] error: 'b'
     int<8> b = 8w0;
     ^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/stack2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack2.p4-stderr
@@ -1,4 +1,4 @@
-stack2.p4(24): [--Werror=type-error] error: AssignmentStatement
+stack2.p4(24): [--Werror=type-error] error: 'stack1 = stack2'
         stack1 = stack2; // assignment between different stacks
                ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/structure-valued-expr-errs-1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/structure-valued-expr-errs-1.p4-stderr
@@ -1,4 +1,4 @@
-structure-valued-expr-errs-1.p4(100): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(100): [--Werror=type-error] error: 'hdr.h1 = { }'
             hdr.h1 = {};
                    ^
   ---- Actual error:
@@ -18,7 +18,7 @@ structure-valued-expr-errs-1.p4(100)
 structure-valued-expr-errs-1.p4(31)
   header h1_t {
          ^^^^
-structure-valued-expr-errs-1.p4(101): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(101): [--Werror=type-error] error: 'hdr.h2 = { }'
             hdr.h2 = {};
                    ^
   ---- Actual error:
@@ -38,7 +38,7 @@ structure-valued-expr-errs-1.p4(100)
 structure-valued-expr-errs-1.p4(35)
   header h2_t {
          ^^^^
-structure-valued-expr-errs-1.p4(102): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(102): [--Werror=type-error] error: 'hdr.h0 = { 4 }'
             hdr.h0 = {4};
                    ^
   ---- Actual error:
@@ -58,7 +58,7 @@ structure-valued-expr-errs-1.p4(102)
 structure-valued-expr-errs-1.p4(28)
   header h0_t {
          ^^^^
-structure-valued-expr-errs-1.p4(103): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(103): [--Werror=type-error] error: 'hdr.h1 = { 1, 2 }'
             hdr.h1 = {1, 2};
                    ^
   ---- Actual error:
@@ -78,7 +78,7 @@ structure-valued-expr-errs-1.p4(103)
 structure-valued-expr-errs-1.p4(31)
   header h1_t {
          ^^^^
-structure-valued-expr-errs-1.p4(104): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(104): [--Werror=type-error] error: 'hdr.h2 = { 3 }'
             hdr.h2 = {3};
                    ^
   ---- Actual error:
@@ -98,7 +98,7 @@ structure-valued-expr-errs-1.p4(104)
 structure-valued-expr-errs-1.p4(35)
   header h2_t {
          ^^^^
-structure-valued-expr-errs-1.p4(105): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(105): [--Werror=type-error] error: 'hdr.hstructs.s0 = { 1 }'
             hdr.hstructs.s0 = {1};
                             ^
   ---- Actual error:
@@ -118,7 +118,7 @@ structure-valued-expr-errs-1.p4(105)
 structure-valued-expr-errs-1.p4(40)
   struct s0_t {
          ^^^^
-structure-valued-expr-errs-1.p4(106): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(106): [--Werror=type-error] error: 'hdr.hstructs.s1 = { 1, 2 }'
             hdr.hstructs.s1 = {1, 2};
                             ^
   ---- Actual error:
@@ -138,7 +138,7 @@ structure-valued-expr-errs-1.p4(106)
 structure-valued-expr-errs-1.p4(43)
   struct s1_t {
          ^^^^
-structure-valued-expr-errs-1.p4(107): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(107): [--Werror=type-error] error: 'hdr.hstructs.s2 = { 3 }'
             hdr.hstructs.s2 = {3};
                             ^
   ---- Actual error:
@@ -158,7 +158,7 @@ structure-valued-expr-errs-1.p4(107)
 structure-valued-expr-errs-1.p4(47)
   struct s2_t {
          ^^^^
-structure-valued-expr-errs-1.p4(112): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(112): [--Werror=type-error] error: 'hdr.h1 = { f2 = 5, f1 = 2 }'
             hdr.h1 = {f2=5, f1=2};
                    ^
   ---- Actual error:
@@ -178,7 +178,7 @@ structure-valued-expr-errs-1.p4(112)
 structure-valued-expr-errs-1.p4(31)
   header h1_t {
          ^^^^
-structure-valued-expr-errs-1.p4(113): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(113): [--Werror=type-error] error: 'hdr.h1 = { f2 = 5 }'
             hdr.h1 = {f2=5};
                    ^
   ---- Actual error:
@@ -195,7 +195,7 @@ structure-valued-expr-errs-1.p4(113)
 structure-valued-expr-errs-1.p4(31)
   header h1_t {
          ^^^^
-structure-valued-expr-errs-1.p4(114): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(114): [--Werror=type-error] error: 'hdr.hstructs.s1 = { f2 = 5, f1 = 2 }'
             hdr.hstructs.s1 = {f2=5, f1=2};
                             ^
   ---- Actual error:
@@ -215,7 +215,7 @@ structure-valued-expr-errs-1.p4(114)
 structure-valued-expr-errs-1.p4(43)
   struct s1_t {
          ^^^^
-structure-valued-expr-errs-1.p4(115): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(115): [--Werror=type-error] error: 'hdr.hstructs.s1 = { f2 = 5 }'
             hdr.hstructs.s1 = {f2=5};
                             ^
   ---- Actual error:
@@ -232,7 +232,7 @@ structure-valued-expr-errs-1.p4(115)
 structure-valued-expr-errs-1.p4(43)
   struct s1_t {
          ^^^^
-structure-valued-expr-errs-1.p4(120): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(120): [--Werror=type-error] error: 'hdr.h2 = { f2 = 5 }'
             hdr.h2 = {f2=5};
                    ^
   ---- Actual error:
@@ -252,7 +252,7 @@ structure-valued-expr-errs-1.p4(120)
 structure-valued-expr-errs-1.p4(35)
   header h2_t {
          ^^^^
-structure-valued-expr-errs-1.p4(121): [--Werror=type-error] error: AssignmentStatement
+structure-valued-expr-errs-1.p4(121): [--Werror=type-error] error: 'hdr.hstructs.s2 = { f2 = 5 }'
             hdr.hstructs.s2 = {f2=5};
                             ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-exact.p4-stderr
@@ -1,4 +1,4 @@
-table-entries-exact.p4(72): [--Werror=type-error] error: Entry
+table-entries-exact.p4(72): [--Werror=type-error] error: 'Entry'
             (0x1111 &&& 0xF, 0x1 ) : a(); // invalid exact key
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm.p4-stderr
@@ -1,4 +1,4 @@
-table-entries-lpm.p4(72): [--Werror=type-error] error: Entry
+table-entries-lpm.p4(72): [--Werror=type-error] error: 'Entry'
             (0x1, 0x11 &&& 0xF0): a(); // invalid keyset
             ^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-range.p4-stderr
@@ -1,4 +1,4 @@
-table-entries-range.p4(71): [--Werror=type-error] error: Entry
+table-entries-range.p4(71): [--Werror=type-error] error: 'Entry'
             (0x18, 0xF) : a_with_control_params(24); // not a range
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/tuple-to-header.p4-stderr
+++ b/testdata/p4_16_errors_outputs/tuple-to-header.p4-stderr
@@ -1,4 +1,4 @@
-tuple-to-header.p4(23): [--Werror=type-error] error: AssignmentStatement
+tuple-to-header.p4(23): [--Werror=type-error] error: 'h = t'
         h = t; // illegal assignment between tuple and header
           ^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/typecheck_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/typecheck_e.p4-stderr
@@ -1,4 +1,4 @@
-typecheck_e.p4(21): [--Werror=type-error] error: f
+typecheck_e.p4(21): [--Werror=type-error] error: 'f'
         f(x);
         ^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/virtual1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual1.p4-stderr
@@ -1,4 +1,4 @@
-virtual1.p4(24): [--Werror=type-error] error: return ix + 1
+virtual1.p4(24): [--Werror=type-error] error: 'return ix + 1'
             return (ix + 1);
             ^^^^^^
   ---- Actual error:
@@ -12,7 +12,7 @@ virtual1.p4(24): Source expression 'ix + 1' produces a result of type 'bit<16>' 
 virtual1.p4(23)
           bool f(in bit<16> ix) {
           ^^^^
-virtual1.p4(22): [--Werror=type-error] error: cntr
+virtual1.p4(22): [--Werror=type-error] error: 'cntr'
     Virtual() cntr = {
               ^^^^
   ---- Actual error:

--- a/testdata/p4_16_errors_outputs/virtual2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/virtual2.p4-stderr
@@ -1,7 +1,7 @@
 virtual2.p4(24): [--Werror=type-error] error: return ix + 1: return expression in function with void return
             return (ix + 1);
             ^^^^^^
-virtual2.p4(22): [--Werror=type-error] error: cntr
+virtual2.p4(22): [--Werror=type-error] error: 'cntr'
     Virtual() cntr = {
               ^^^^
   ---- Actual error:

--- a/testdata/p4_16_pna_errors_outputs/pna-example-mirror-packet-error2.p4-error
+++ b/testdata/p4_16_pna_errors_outputs/pna-example-mirror-packet-error2.p4-error
@@ -1,4 +1,4 @@
-pna-example-mirror-packet-error2.p4(83): [--Werror=type-error] error: mirror_packet
+pna-example-mirror-packet-error2.p4(83): [--Werror=type-error] error: 'mirror_packet'
  mirror_packet(mirror_slot, mirror_session);
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:
@@ -15,7 +15,7 @@ pna.p4(582): Function type 'mirror_packet' does not match invocation type '<Meth
 pna-example-mirror-packet-error2.p4(83)
    mirror_packet(mirror_slot, mirror_session);
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-pna-example-mirror-packet-error2.p4(88): [--Werror=type-error] error: mirror_packet
+pna-example-mirror-packet-error2.p4(88): [--Werror=type-error] error: 'mirror_packet'
  mirror_packet(mirror_slot, mirror_session);
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_pna_errors_outputs/pna-example-mirror-packet-error3.p4-error
+++ b/testdata/p4_16_pna_errors_outputs/pna-example-mirror-packet-error3.p4-error
@@ -1,4 +1,4 @@
-pna-example-mirror-packet-error3.p4(79): [--Werror=type-error] error: mirror_packet
+pna-example-mirror-packet-error3.p4(79): [--Werror=type-error] error: 'mirror_packet'
  mirror_packet(MIRROR_SLOT_ID);
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ---- Actual error:

--- a/testdata/p4_16_samples_outputs/pna-dpdk-header-union-stack1.p4-error
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-header-union-stack1.p4-error
@@ -34,6 +34,6 @@ pna-dpdk-header-union-stack1.p4(83): [--Wwarn=invalid_header] warning: accessing
 pna-dpdk-header-union-stack1.p4(84): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.u[0].h3
         hdr.u[0].h3.data = 1;
         ^^^^^^^^^^^
-pna-dpdk-header-union-stack1.p4(37): [--Wwarn=ignore-prop] warning: Result of AssignmentStatement is not defined: Error: Reading field from invalid header
+pna-dpdk-header-union-stack1.p4(37): [--Wwarn=ignore-prop] warning: Result of 'hdr.h2[0].data = 16w1' is not defined: Error: Reading field from invalid header
         hdr.h2[0].data = 1;
                        ^


### PR DESCRIPTION
I surrounded several places that can print `AssignmentStatement`s with '', but now other types of nodes get surrounded with '' when they don't necessarily need to be. @fruffy Let me know if you prefer it this way or without quotes in these places.