### PR TITLE
Rename eBPF section names for tc backend

### DIFF
--- a/backends/tc/ebpfCodeGen.cpp
+++ b/backends/tc/ebpfCodeGen.cpp
@@ -182,7 +182,7 @@ void PNAArchTC::emitParser(EBPF::CodeBuilder *builder) const {
     builder->newline();
     builder->newline();
     pipeline->name = "tc-parse";
-    pipeline->sectionName = "classifier/" + pipeline->name;
+    pipeline->sectionName = "p4tc/parse";
     pipeline->functionName = pipeline->name.replace("-", "_") + "_func";
     pipeline->emit(builder);
     builder->target->emitLicense(builder, pipeline->license);
@@ -1108,6 +1108,7 @@ bool ConvertToEbpfPipelineTC::preorder(const IR::PackageBlock *block) {
     (void)block;
 
     pipeline = new TCIngressPipelinePNA(name, options, refmap, typemap);
+    pipeline->sectionName = "p4tc/main";
     auto parser_converter = new ConvertToEBPFParserPNA(pipeline, typemap);
     parserBlock->apply(*parser_converter);
     pipeline->parser = parser_converter->getEBPFParser();

--- a/testdata/p4tc_samples_outputs/calculator_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/calculator_control_blocks.c
@@ -296,7 +296,7 @@ if (/* hdr->p4calc.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/calculator_parser.c
+++ b/testdata/p4tc_samples_outputs/calculator_parser.c
@@ -215,7 +215,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/checksum_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/checksum_control_blocks.c
@@ -252,7 +252,7 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/checksum_parser.c
+++ b/testdata/p4tc_samples_outputs/checksum_parser.c
@@ -154,7 +154,7 @@ ck_0_state;             goto accept;
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/const_entries_range_mask_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/const_entries_range_mask_control_blocks.c
@@ -116,7 +116,7 @@ static __always_inline int process(struct __sk_buff *skb, struct Header_t *h, st
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/const_entries_range_mask_parser.c
+++ b/testdata/p4tc_samples_outputs/const_entries_range_mask_parser.c
@@ -70,7 +70,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct Header_t *h,
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
@@ -325,7 +325,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/default_action_example_parser.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
@@ -175,7 +175,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/default_hit_const_example_parser.c
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example_parser.c
@@ -166,7 +166,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
@@ -253,7 +253,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/drop_packet_example_parser.c
+++ b/testdata/p4tc_samples_outputs/drop_packet_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
@@ -320,7 +320,7 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/global_action_example_01_parser.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_01_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct my_ingress_h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
@@ -322,7 +322,7 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/global_action_example_02_parser.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_02_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct my_ingress_h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/hash1_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/hash1_control_blocks.c
@@ -157,7 +157,7 @@ crc16_finalize(ingress_h_reg);
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/hash1_parser.c
+++ b/testdata/p4tc_samples_outputs/hash1_parser.c
@@ -97,7 +97,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct my_ingress_h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/ipip_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/ipip_control_blocks.c
@@ -378,7 +378,7 @@ if (/* hdr->outer.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/ipip_parser.c
+++ b/testdata/p4tc_samples_outputs/ipip_parser.c
@@ -172,7 +172,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
@@ -464,7 +464,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/matchtype_parser.c
+++ b/testdata/p4tc_samples_outputs/matchtype_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
@@ -471,7 +471,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example_parser.c
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
@@ -724,7 +724,7 @@ if (hdr->ipv4.protocol != 4 || (hdr->tcp.srcPort <= 3)) {
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01_parser.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01_parser.c
@@ -166,7 +166,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
@@ -724,7 +724,7 @@ if (hdr->ipv4.protocol == 6 || ((hdr->ipv4.version > 1) && (hdr->ipv4.ihl <= 2))
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02_parser.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02_parser.c
@@ -166,7 +166,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
@@ -323,7 +323,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/name_annotation_example_parser.c
+++ b/testdata/p4tc_samples_outputs/name_annotation_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/no_table_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/no_table_example_control_blocks.c
@@ -225,7 +225,7 @@ if ((u32)istd.input_port == 4) {
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/no_table_example_parser.c
+++ b/testdata/p4tc_samples_outputs/no_table_example_parser.c
@@ -141,7 +141,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
@@ -326,7 +326,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/noaction_example_01_parser.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_01_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
@@ -302,7 +302,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/noaction_example_02_parser.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_02_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
@@ -170,7 +170,7 @@ if (((u32)istd.input_port == 2 && /* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example_parser.c
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example_parser.c
@@ -166,7 +166,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
@@ -257,7 +257,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/send_to_port_example_parser.c
+++ b/testdata/p4tc_samples_outputs/send_to_port_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
@@ -335,7 +335,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example_parser.c
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
@@ -252,7 +252,7 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/simple_exact_example_parser.c
+++ b/testdata/p4tc_samples_outputs/simple_exact_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct my_ingress_h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
@@ -252,7 +252,7 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/simple_lpm_example_parser.c
+++ b/testdata/p4tc_samples_outputs/simple_lpm_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct my_ingress_h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
@@ -259,7 +259,7 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/simple_ternary_example_parser.c
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct my_ingress_h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
@@ -323,7 +323,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/size_param_example_parser.c
+++ b/testdata/p4tc_samples_outputs/size_param_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/tc_type_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_type_annotation_example_control_blocks.c
@@ -305,7 +305,7 @@ if (/* hdr->ipv4.isValid() */
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/tc_type_annotation_example_parser.c
+++ b/testdata/p4tc_samples_outputs/tc_type_annotation_example_parser.c
@@ -118,7 +118,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;

--- a/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
@@ -273,7 +273,7 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
     }
     return -1;
 }
-SEC("classifier/tc-ingress")
+SEC("p4tc/main")
 int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;

--- a/testdata/p4tc_samples_outputs/test_ipv6_example_parser.c
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example_parser.c
@@ -136,7 +136,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
     return -1;
 }
 
-SEC("classifier/tc-parse")
+SEC("p4tc/parse")
 int tc_parse_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     struct hdr_md *hdrMd;


### PR DESCRIPTION
Rename parser C file's eBPF section to "p4tc/parse" and control blocks C file's eBPF section to "p4tc/main".