### PR TITLE
[P4Testgen] Basic support for `@p4runtime_translation` and `@p4runtime_translation_mappings`.

### DIFF
--- a/backends/bmv2/common/annotations.h
+++ b/backends/bmv2/common/annotations.h
@@ -29,8 +29,14 @@ class ParseAnnotations : public P4::ParseAnnotations {
  public:
     ParseAnnotations()
         : P4::ParseAnnotations("BMV2", false,
-                               {PARSE_EMPTY("metadata"), PARSE_EXPRESSION_LIST("field_list"),
-                                PARSE("alias", StringLiteral), PARSE("priority", Constant)}) {}
+                               {
+                                   PARSE_EMPTY("metadata"),
+                                   PARSE_EXPRESSION_LIST("field_list"),
+                                   PARSE("alias", StringLiteral),
+                                   PARSE("priority", Constant),
+                                   PARSE_EXPRESSION_LIST("p4runtime_translation_mappings"),
+                                   PARSE_P4RUNTIME_TRANSLATION("p4runtime_translation"),
+                               }) {}
 };
 
 }  // namespace BMV2

--- a/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TESTGEN_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/map_direct_externs.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/p4_asserts_parser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/p4_refers_to_parser.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/p4runtime_translation.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/program_info.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/table_stepper.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/target.cpp

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4runtime_translation.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4runtime_translation.cpp
@@ -1,0 +1,69 @@
+#include "backends/p4tools/modules/testgen/targets/bmv2/p4runtime_translation.h"
+
+std::vector<const IR::Annotation *>
+P4Tools::P4Testgen::Bmv2::PropagateP4RuntimeTranslation::lookupP4RuntimeAnnotations(
+    const P4::TypeMap &typeMap, const IR::Type *type) {
+    std::vector<const IR::Annotation *> p4RuntimeAnnotations;
+    const auto *typeName = type->to<IR::Type_Name>();
+    if (typeName != nullptr) {
+        type = typeMap.getType(typeName);
+        if (type == nullptr) {
+            ::error("Type %1% not found in the type map.", typeName);
+            return p4RuntimeAnnotations;
+        }
+        type = type->getP4Type();
+    }
+    const auto *annotatedType = type->to<IR::IAnnotated>();
+    if (annotatedType == nullptr) {
+        return p4RuntimeAnnotations;
+    }
+    const auto *p4runtimeAnnotation = annotatedType->getAnnotation("p4runtime_translation");
+    if (p4runtimeAnnotation != nullptr) {
+        BUG_CHECK(!p4runtimeAnnotation->needsParsing,
+                  "The @p4runtime_translation annotation should have been parsed already.");
+        p4RuntimeAnnotations.push_back(p4runtimeAnnotation);
+    }
+    const auto *p4runtimeTranslationMappings =
+        annotatedType->getAnnotation("p4runtime_translation_mappings");
+    if (p4runtimeTranslationMappings != nullptr) {
+        BUG_CHECK(
+            !p4runtimeTranslationMappings->needsParsing,
+            "The @p4runtime_translation_mappings annotation should have been parsed already.");
+        p4RuntimeAnnotations.push_back(p4runtimeTranslationMappings);
+    }
+    return p4RuntimeAnnotations;
+}
+
+const IR::Parameter *P4Tools::P4Testgen::Bmv2::PropagateP4RuntimeTranslation::preorder(
+    IR::Parameter *parameter) {
+    auto p4RuntimeAnnotations = lookupP4RuntimeAnnotations(_typeMap, parameter->type);
+    if (p4RuntimeAnnotations.empty()) {
+        return parameter;
+    }
+    auto *annotationsVector = parameter->annotations->clone();
+    for (const auto *p4runtimeAnnotation : p4RuntimeAnnotations) {
+        annotationsVector->annotations.push_back(p4runtimeAnnotation);
+    }
+    parameter->annotations = annotationsVector;
+    return parameter;
+}
+
+const IR::KeyElement *P4Tools::P4Testgen::Bmv2::PropagateP4RuntimeTranslation::preorder(
+    IR::KeyElement *keyElement) {
+    auto p4RuntimeAnnotations = lookupP4RuntimeAnnotations(_typeMap, keyElement->expression->type);
+    if (p4RuntimeAnnotations.empty()) {
+        return keyElement;
+    }
+    auto *annotationsVector = keyElement->annotations->clone();
+    for (const auto *p4runtimeAnnotation : p4RuntimeAnnotations) {
+        annotationsVector->annotations.push_back(p4runtimeAnnotation);
+    }
+    keyElement->annotations = annotationsVector;
+    return keyElement;
+}
+
+P4Tools::P4Testgen::Bmv2::PropagateP4RuntimeTranslation::PropagateP4RuntimeTranslation(
+    const P4::TypeMap &typeMap)
+    : _typeMap(typeMap) {
+    setName("PropagateP4RuntimeTranslation");
+}

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4runtime_translation.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4runtime_translation.h
@@ -1,0 +1,31 @@
+#ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_P4RUNTIME_TRANSLATION_H_
+#define BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_P4RUNTIME_TRANSLATION_H_
+#include <functional>
+
+#include "frontends/p4/typeMap.h"
+#include "ir/ir.h"
+#include "ir/visitor.h"
+
+namespace P4Tools::P4Testgen::Bmv2 {
+
+/// Propagates P4Runtime annotations attached to type definitions to the nodes which use these type
+/// definitions. For now, this is restricted to key elements and action parameters.
+class PropagateP4RuntimeTranslation : public Transform {
+    /// We use the typemap to look up the original declaration for type reference.
+    /// These declarations may have an annotation.
+    std::reference_wrapper<const P4::TypeMap> _typeMap;
+
+    /// Look up annotations relevant to P4Runtime. They may influence the control plane interfaces.
+    static std::vector<const IR::Annotation *> lookupP4RuntimeAnnotations(
+        const P4::TypeMap &typeMap, const IR::Type *type);
+
+    const IR::Parameter *preorder(IR::Parameter *parameter) override;
+    const IR::KeyElement *preorder(IR::KeyElement *keyElement) override;
+
+ public:
+    explicit PropagateP4RuntimeTranslation(const P4::TypeMap &typeMap);
+};
+
+}  // namespace P4Tools::P4Testgen::Bmv2
+
+#endif /* BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_P4RUNTIME_TRANSLATION_H_ */

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.h
@@ -72,12 +72,25 @@ class ProtobufIr : public Bmv2TestFramework {
     /// @returns the inja test case template as a string.
     static std::string getTestCaseTemplate();
 
-    /// Tries to find the @format annotation of a node and, if present, returns the format specified
-    /// in this annotation. Returns "hex" by default.
+    /// Checks whether the node has a `@p4runtime_translation` attached to it. If that is the case,
+    /// returns the name of the translated type contained within the annotation.
+    static std::optional<std::string> checkForP4RuntimeTranslationAnnotation(
+        const IR::IAnnotated *node);
+
+    /// Looks up annotations for the given node and returns the P4RuntimeTranslationMappings, if
+    /// they exist. Currently, this map is a pure cstring map.
+    static std::map<cstring, cstring> getP4RuntimeTranslationMappings(const IR::IAnnotated *node);
+
+    /// Tries to find the @format annotation of a node and, if present, returns  the format
+    /// specified in this annotation. Returns "hex" by default.
     static std::string getFormatOfNode(const IR::IAnnotated *node);
 
     /// Converts an IR::Expression into a formatted string value. The format depends on @param type.
     static std::string formatNetworkValue(const std::string &type, const IR::Expression *value);
+
+    /// see @formatNetworkValue. The node may have annotations which influence the format.
+    static std::string formatNetworkValue(const IR::IAnnotated *node, const std::string &type,
+                                          const IR::Expression *value);
 
     /// Fill in @param rulesJson by iterating over @param fieldMatch and creating the appropriate
     /// match key.

--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -107,6 +107,10 @@ namespace P4 {
 #define PARSE_STRING_LITERAL_LIST(aname) \
     { aname, &P4::ParseAnnotations::parseStringLiteralList }
 
+// Parses a P4Runtime translation which contains both types or expressions.
+#define PARSE_P4RUNTIME_TRANSLATION(aname) \
+    { aname, &P4::ParseAnnotations::parseP4rtTranslationAnnotation }
+
 class ParseAnnotations : public Modifier {
  public:
     using Modifier::postorder;


### PR DESCRIPTION
This PR adds support for `@p4runtime_translation` and `@p4runtime_translation_mappings` in the Protobuf IR back end of P4Testgen.  There are two phases.

1. Since the P4Runtime translation annotations are only attached to the basic type definitions, we add a pass which propagates the annotations to any control plane element which uses the type. We can now reference the annotations when generating tests. 

2. In the Protobuf IR back end, we add two checks for `@p4runtime_translation` and `@p4runtime_translation_mappings`. For @p4runtime_translation, we simply override the behavior of the `getFormatOfNode` function. If a `@p4runtime_translation` annotation is present, we return the value mapped in the annotation. Otherwise we default for normal behavior. 
3. `@p4runtime_translation_mappings` are experimental and not well defined, so we simply brute-force inference here. We generate a <cstring, cstring> map which maps the second element in the pair to the first. We also parse the annotation as a list expression.  We add a wrapper to `formatNetworkValue` which overrides the returned value if it is contained in the map. 
4. Tests are missing. These properties are difficult to test with the current infrastructure. We could try to parse some programs which have these annotations. 

