### PR TITLE
Remove deprecated `std::allocator` members

### DIFF
--- a/lib/ordered_map.h
+++ b/lib/ordered_map.h
@@ -66,8 +66,8 @@ class ordered_map {
         COMP comp;
         bool operator()(const K *a, const K *b) const { return comp(*a, *b); }
     };
-    using map_alloc =
-        typename ALLOC::template rebind<std::pair<const K *const, list_iterator>>::other;
+    using map_alloc = typename std::allocator_traits<
+        ALLOC>::template rebind_alloc<std::pair<const K *const, list_iterator>>;
     using map_type = std::map<const K *, list_iterator, mapcmp, map_alloc>;
     map_type data_map;
     void init_data_map() {

--- a/lib/ordered_set.h
+++ b/lib/ordered_set.h
@@ -57,8 +57,8 @@ class ordered_set {
         COMP comp;
         bool operator()(const T *a, const T *b) const { return comp(*a, *b); }
     };
-    using map_alloc =
-        typename ALLOC::template rebind<std::pair<const T *const, list_iterator>>::other;
+    using map_alloc = typename std::allocator_traits<
+        ALLOC>::template rebind_alloc<std::pair<const T *const, list_iterator>>;
     using map_type = std::map<const T *, list_iterator, mapcmp, map_alloc>;
     map_type data_map;
     void init_data_map() {


### PR DESCRIPTION
The change replaces `std::allocator` members that were deprecated in C++17 and removed in C++20, see https://en.cppreference.com/w/cpp/memory/allocator for a detailed list.
