### PR TITLE
[#4365] Do not allow `--Wdisable` or `--Wwarn` to demote errors. Allow `--Winfo=diagnostic` to work for `diagnostic`s that can be both warnings and errors.

### DIFF
--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -192,6 +192,10 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
         "--Wdisable", "diagnostic",
         [](const char *diagnostic) {
             if (diagnostic) {
+                if (ErrorCatalog::getCatalog().isError(diagnostic)) {
+                    ::error(ErrorType::ERR_INVALID, "Error %1% cannot be demoted.", diagnostic);
+                    return false;
+                }
                 P4CContext::get().setDiagnosticAction(diagnostic, DiagnosticAction::Ignore);
             } else {
                 auto action = DiagnosticAction::Ignore;
@@ -206,6 +210,10 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
         "--Winfo", "diagnostic",
         [](const char *diagnostic) {
             if (diagnostic) {
+                if (ErrorCatalog::getCatalog().isError(diagnostic)) {
+                    ::error(ErrorType::ERR_INVALID, "Error %1% cannot be demoted.", diagnostic);
+                    return false;
+                }
                 P4CContext::get().setDiagnosticAction(diagnostic, DiagnosticAction::Info);
             }
             return true;
@@ -215,6 +223,10 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
         "--Wwarn", "diagnostic",
         [](const char *diagnostic) {
             if (diagnostic) {
+                if (ErrorCatalog::getCatalog().isError(diagnostic)) {
+                    ::error(ErrorType::ERR_INVALID, "Error %1% cannot be demoted.", diagnostic);
+                    return false;
+                }
                 P4CContext::get().setDiagnosticAction(diagnostic, DiagnosticAction::Warn);
             } else {
                 auto action = DiagnosticAction::Warn;

--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -206,10 +206,6 @@ ParserOptions::ParserOptions() : Util::Options(defaultMessage) {
         "--Winfo", "diagnostic",
         [](const char *diagnostic) {
             if (diagnostic) {
-                if (ErrorCatalog::getCatalog().isError(diagnostic)) {
-                    ::error(ErrorType::ERR_INVALID, "Error %1% cannot be demoted", diagnostic);
-                    return false;
-                }
                 P4CContext::get().setDiagnosticAction(diagnostic, DiagnosticAction::Info);
             }
             return true;

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -132,17 +132,15 @@ class ErrorCatalog {
         // Some diagnostics might be both errors and warning/info
         // (e.g. "invalid" -> both ERR_INVALID and WARN_INVALID).
         bool error = false;
-        bool otherDiagnostic = false;
         for (const auto &pair : errorCatalog) {
             if (pair.second == name) {
-                if (pair.first < ErrorType::ERR_MAX)
-                    error = true;
-                else
-                    otherDiagnostic = true;
+                if (pair.first < ErrorType::LEGACY_ERROR || pair.first > ErrorType::ERR_MAX)
+                    return false;
+                error = true;
             }
         }
 
-        return error && !otherDiagnostic;
+        return error;
     }
 
  private:

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -127,6 +127,24 @@ class ErrorCatalog {
         return "--unknown--";
     }
 
+    /// return true if the given diagnostic can _only_ be an error; false otherwise
+    bool isError(cstring name) {
+        // Some diagnostics might be both errors and warning/info
+        // (e.g. "invalid" -> both ERR_INVALID and WARN_INVALID).
+        bool error = false;
+        bool otherDiagnostic = false;
+        for (const auto &pair : errorCatalog) {
+            if (pair.second == name) {
+                if (pair.first < ErrorType::ERR_MAX)
+                    error = true;
+                else
+                    otherDiagnostic = true;
+            }
+        }
+
+        return error && !otherDiagnostic;
+    }
+
  private:
     ErrorCatalog() {}
 

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -127,23 +127,6 @@ class ErrorCatalog {
         return "--unknown--";
     }
 
-    /// retrieve the code for name
-    int getCode(cstring name) {
-        auto it =
-            std::find_if(errorCatalog.begin(), errorCatalog.end(),
-                         [name](const std::pair<int, cstring> &p) { return p.second == name; });
-        if (it != errorCatalog.end()) return it->first;
-        return -1;
-    }
-
-    /// return true if the name is an error; false otherwise
-    bool isError(cstring name) {
-        int code = getCode(name);
-        if (code == -1) return false;
-        if (code > ErrorType::ERR_MAX) return false;
-        return true;
-    }
-
  private:
     ErrorCatalog() {}
 

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -231,11 +231,12 @@ class ErrorReporter {
     /// @return the action to take for the given diagnostic, falling back to the
     /// default action if it wasn't overridden via the command line or a pragma.
     DiagnosticAction getDiagnosticAction(cstring diagnostic, DiagnosticAction defaultAction) {
+        // Actions for errors can never be overridden.
         if (defaultAction == DiagnosticAction::Error) return defaultAction;
         auto it = diagnosticActions.find(diagnostic);
         if (it != diagnosticActions.end()) return it->second;
         // if we're dealing with warnings and they have been globally modified
-        // (ingnored or turned into errors), then return the global default
+        // (ignored or turned into errors), then return the global default
         if (defaultAction == DiagnosticAction::Warn &&
             defaultWarningDiagnosticAction != DiagnosticAction::Warn)
             return defaultWarningDiagnosticAction;

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -231,6 +231,7 @@ class ErrorReporter {
     /// @return the action to take for the given diagnostic, falling back to the
     /// default action if it wasn't overridden via the command line or a pragma.
     DiagnosticAction getDiagnosticAction(cstring diagnostic, DiagnosticAction defaultAction) {
+        if (defaultAction == DiagnosticAction::Error) return defaultAction;
         auto it = diagnosticActions.find(diagnostic);
         if (it != diagnosticActions.end()) return it->second;
         // if we're dealing with warnings and they have been globally modified


### PR DESCRIPTION
```
p4test testdata/p4_16_errors/accept_e.p4:

testdata/p4_16_errors/accept_e.p4(18): [--Werror=invalid] error: Invalid parser state: accept should not be implemented, it is built-in
    state accept { // reserved name
          ^^^^^^
testdata/p4_16_errors/accept_e.p4(16): [--Werror=invalid] error: Parser parser p has no 'start' state
parser p()
       ^
```
```
p4test testdata/p4_16_errors/accept_e.p4  --Wwarn=invalid:

testdata/p4_16_errors/accept_e.p4(18): [--Werror=invalid] error: Invalid parser state: accept should not be implemented, it is built-in
    state accept { // reserved name
          ^^^^^^
testdata/p4_16_errors/accept_e.p4(16): [--Werror=invalid] error: Parser parser p has no 'start' state
parser p()
       ^
```
```
p4test testdata/p4_16_errors/accept_e.p4  --Wdisable=invalid:

testdata/p4_16_errors/accept_e.p4(18): [--Werror=invalid] error: Invalid parser state: accept should not be implemented, it is built-in
    state accept { // reserved name
          ^^^^^^
testdata/p4_16_errors/accept_e.p4(16): [--Werror=invalid] error: Parser parser p has no 'start' state
parser p()
       ^
```
```
p4test testdata/p4_16_errors/accept_e.p4  --Winfo=invalid
testdata/p4_16_errors/accept_e.p4(18): [--Werror=invalid] error: Invalid parser state: accept should not be implemented, it is built-in
    state accept { // reserved name
          ^^^^^^
testdata/p4_16_errors/accept_e.p4(16): [--Werror=invalid] error: Parser parser p has no 'start' state
parser p()
       ^
```