### PR TITLE
Fix the option to pipe stdin to the compiler.

### DIFF
--- a/lib/options.cpp
+++ b/lib/options.cpp
@@ -67,7 +67,7 @@ std::vector<const char *> *Util::Options::process(int argc, char *const argv[]) 
                 usage();
                 return nullptr;
             }
-        } else if (opt.startsWith("-")) {
+        } else if (opt.startsWith("-") && opt.size() > 1) {
             // Support GCC-style long options that begin with a single '-'.
             option = get(options, opt);
 


### PR DESCRIPTION
This option was never working because `-` was interpreted as a flag parameter. This little change fixes that. Now it is possible to directly pipe a program to the compiler instead of reading a file. 

Open to suggestions on how to improve this option. The parser options in general are old and quite messy. 