### PR TITLE
[P4Testgen] Add a silent mode to P4Tools. Add performance counting at the top level.

### DIFF
--- a/backends/p4tools/common/options.cpp
+++ b/backends/p4tools/common/options.cpp
@@ -181,6 +181,14 @@ AbstractP4cToolOptions::AbstractP4cToolOptions(cstring message) : Options(messag
         },
         "Provides a randomization seed");
 
+    registerOption(
+        "--disable-info-logging", nullptr,
+        [this](const char * /*arg*/) {
+            disableInformationLogging = true;
+            return true;
+        },
+        "Disable printing of information messages to standard output.");
+
     for (const auto &optionSpec : inheritedCompilerOptions) {
         registerOption(
             optionSpec.option, optionSpec.argName,

--- a/backends/p4tools/common/options.h
+++ b/backends/p4tools/common/options.h
@@ -21,6 +21,9 @@ class AbstractP4cToolOptions : protected Util::Options {
     /// A seed for the PRNG.
     std::optional<uint32_t> seed = std::nullopt;
 
+    /// Disable information logging.
+    bool disableInformationLogging = false;
+
     /// Processes options.
     ///
     /// @returns a compilation context on success, std::nullopt on error.

--- a/backends/p4tools/modules/testgen/main.cpp
+++ b/backends/p4tools/modules/testgen/main.cpp
@@ -3,7 +3,9 @@
 #include <vector>
 
 #include "lib/crash.h"
+#include "lib/timer.h"
 
+#include "backends/p4tools/modules/testgen/lib/logging.h"
 #include "backends/p4tools/modules/testgen/testgen.h"
 
 std::string updateErrorMsg(std::string errorMsg) {
@@ -26,27 +28,31 @@ int main(int argc, char **argv) {
         args.push_back(argv[i]);
     }
 
+    int result = EXIT_SUCCESS;
     try {
-        return P4Tools::P4Testgen::Testgen().main(args);
+        Util::ScopedTimer timer("P4Testgen Main");
+        result = P4Tools::P4Testgen::Testgen().main(args);
     } catch (const Util::CompilerBug &e) {
         std::cerr << "Internal error: " << updateErrorMsg(e.what()) << "\n";
         std::cerr << "Please submit a bug report with your code."
                   << "\n";
-        return EXIT_FAILURE;
+        result = EXIT_FAILURE;
     } catch (const Util::CompilerUnimplemented &e) {
         std::cerr << updateErrorMsg(e.what()) << "\n";
-        return EXIT_FAILURE;
+        result = EXIT_FAILURE;
     } catch (const Util::CompilationError &e) {
         std::cerr << updateErrorMsg(e.what()) << "\n";
-        return EXIT_FAILURE;
+        result = EXIT_FAILURE;
     } catch (const std::exception &e) {
         std::cerr << "Internal error: " << updateErrorMsg(e.what()) << "\n";
         std::cerr << "Please submit a bug report with your code."
                   << "\n";
-        return EXIT_FAILURE;
+        result = EXIT_FAILURE;
     } catch (...) {
         std::cerr << "Internal error. Please submit a bug report with your code."
                   << "\n";
-        return EXIT_FAILURE;
+        result = EXIT_FAILURE;
     }
+    P4Tools::printPerformanceReport();
+    return result;
 }

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -22,8 +22,6 @@
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/selected_branches.h"
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/symbolic_executor.h"
 #include "backends/p4tools/modules/testgen/core/target.h"
-#include "backends/p4tools/modules/testgen/lib/logging.h"
-#include "backends/p4tools/modules/testgen/lib/test_backend.h"
 #include "backends/p4tools/modules/testgen/options.h"
 #include "backends/p4tools/modules/testgen/register.h"
 
@@ -81,9 +79,6 @@ int generateAbstractTests(const TestgenOptions &testgenOptions, const ProgramInf
 
     symbex.run(callBack);
 
-    // Emit a performance report, if desired.
-    printPerformanceReport(testPath);
-
     // Do not print this warning if assertion mode is enabled.
     if (testBackend->getTestCount() == 0 && !testgenOptions.assertionModeEnabled) {
         ::warning(
@@ -115,9 +110,6 @@ int Testgen::mainImpl(const CompilerResult &compilerResult) {
         ::error("Testgen: Encountered errors during preprocessing. Exiting");
         return EXIT_FAILURE;
     }
-
-    // Print basic information for each test.
-    enableInformationLogging();
 
     // Get the options and the seed.
     const auto &testgenOptions = TestgenOptions::get();


### PR DESCRIPTION
Add an option to disable printing any information to standard output. This does not disable warnings, errors, or outputs which may be enabled by other options. 

Also add a timer to the top-level and print metrics there for better collection of statics. 