### PR TITLE
Memoize & improve name lookup in `ResolveReferences` 

### DIFF
--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -52,9 +52,7 @@ Util::Enumerator<const IR::IDeclaration *> *ResolutionContext::getDeclsByName(
     auto nsIt = declNames.find(ns);
     std::function<const IR::IDeclaration *(
         const std::pair<const cstring, const IR::IDeclaration *> &)>
-        second = [](const std::pair<const cstring, const IR::IDeclaration *> &entry) {
-            return entry.second;
-        };
+        second = [](const auto &entry) { return entry.second; };
 
     if (nsIt != declNames.end()) {
         auto range = nsIt->second.equal_range(name);

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -28,6 +28,47 @@ static const std::vector<const IR::IDeclaration *> empty;
 
 ResolutionContext::ResolutionContext() { anyOrder = P4CContext::get().options().isv1(); }
 
+Util::Enumerator<const IR::IDeclaration*>*
+ResolutionContext::getDeclarations(const IR::INamespace *ns) const {
+    auto nsIt = namespaceDecls.find(ns);
+    auto *declVec = nsIt != namespaceDecls.end() ? nsIt->second : memoizeDeclarations(ns);
+    return Util::Enumerator<const IR::IDeclaration*>::createEnumerator(*declVec);
+}
+
+std::vector<const IR::IDeclaration*>*
+ResolutionContext::memoizeDeclarations(const IR::INamespace* ns) const {
+    auto decls = ns->getDeclarations();
+    if (auto nest = ns->to<IR::INestedNamespace>()) {
+        // boost bug -- trying to iterate with an adaptor over an unnamed temp crashes
+        auto temp = nest->getNestedNamespaces();
+        for (auto nn : boost::adaptors::reverse(temp))
+            decls = nn->getDeclarations()->concat(decls);
+    }
+
+    return (namespaceDecls[ns] = decls->toVector());
+}
+
+Util::Enumerator<const IR::IDeclaration*>*
+ResolutionContext::getDeclsByName(const IR::INamespace *ns, cstring name) const {
+    auto nsIt = declNames.find(ns);
+    std::function<const IR::IDeclaration*(const std::pair<const cstring,
+                                          const IR::IDeclaration *> &)> second =
+        [](const std::pair<const cstring, const IR::IDeclaration *> &entry){
+            return entry.second;
+        };
+
+    if (nsIt != declNames.end()) {
+        auto range = nsIt->second.equal_range(name);
+        return Util::enumerate(range.first, range.second)->map(second);
+    }
+
+    for (auto *d : *getDeclarations(ns))
+        declNames[ns].emplace(d->getName().name, d);
+
+    auto range = declNames[ns].equal_range(name);
+    return Util::enumerate(range.first, range.second)->map(second);
+}
+
 const std::vector<const IR::IDeclaration *> *ResolutionContext::resolve(
     IR::ID name, P4::ResolutionType type) const {
     const Context *ctxt = nullptr;
@@ -44,7 +85,7 @@ const std::vector<const IR::IDeclaration *> *ResolutionContext::lookup(
     LOG2("Trying to resolve in " << current->toString());
 
     if (auto gen = current->to<IR::IGeneralNamespace>()) {
-        Util::Enumerator<const IR::IDeclaration *> *decls = gen->getDeclsByName(name);
+        Util::Enumerator<const IR::IDeclaration *> *decls = getDeclsByName(gen, name);
         switch (type) {
             case P4::ResolutionType::Any:
                 break;
@@ -297,12 +338,7 @@ const IR::IDeclaration *ResolveReferences::resolvePath(const IR::Path *path, boo
 void ResolveReferences::checkShadowing(const IR::INamespace *ns) const {
     if (!checkShadow) return;
     std::map<cstring, const IR::Node *> prev_in_scope;  // check for shadowing within a scope
-    auto decls = ns->getDeclarations();
-    if (auto nest = ns->to<IR::INestedNamespace>()) {
-        // boost bug -- trying to iterate with an adaptor over an unnamed temp crashes
-        auto temp = nest->getNestedNamespaces();
-        for (auto nn : boost::adaptors::reverse(temp)) decls = nn->getDeclarations()->concat(decls);
-    }
+    auto decls = getDeclarations(ns);
     for (auto *decl : *decls) {
         const IR::Node *node = decl->getNode();
         if (node->is<IR::StructField>()) continue;

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -29,6 +29,12 @@ enum class ResolutionType { Any, Type, TypeVariable };
 
 /// Visitor mixin for looking up names in enclosing scopes from the Visitor::Context
 class ResolutionContext : virtual public Visitor, public DeclarationLookup {
+    mutable std::unordered_map<const IR::INamespace*,
+                               std::vector<const IR::IDeclaration*>*> namespaceDecls;
+    mutable std::unordered_map<const IR::INamespace*,
+                               std::unordered_multimap<cstring,
+                                                       const IR::IDeclaration *>> declNames;
+
  protected:
     // Note that all errors have been merged by the parser into
     // a single error { } namespace.
@@ -70,6 +76,12 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
 
     const IR::IDeclaration *getDeclaration(const IR::Path *path, bool notNull = false) const;
     const IR::IDeclaration *getDeclaration(const IR::This *, bool notNull = false) const;
+
+    Util::Enumerator<const IR::IDeclaration*>* getDeclarations(const IR::INamespace *ns) const;
+    std::vector<const IR::IDeclaration*>* memoizeDeclarations(const IR::INamespace* ns) const;
+
+    Util::Enumerator<const IR::IDeclaration*>* getDeclsByName(const IR::INamespace *ns,
+                                                              cstring name) const;
 };
 
 /** Inspector that computes `refMap`: a map from paths to declarations.

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -29,11 +29,11 @@ enum class ResolutionType { Any, Type, TypeVariable };
 
 /// Visitor mixin for looking up names in enclosing scopes from the Visitor::Context
 class ResolutionContext : virtual public Visitor, public DeclarationLookup {
-    mutable std::unordered_map<const IR::INamespace*,
-                               std::vector<const IR::IDeclaration*>*> namespaceDecls;
-    mutable std::unordered_map<const IR::INamespace*,
-                               std::unordered_multimap<cstring,
-                                                       const IR::IDeclaration *>> declNames;
+    mutable std::unordered_map<const IR::INamespace *, std::vector<const IR::IDeclaration *> *>
+        namespaceDecls;
+    mutable std::unordered_map<const IR::INamespace *,
+                               std::unordered_multimap<cstring, const IR::IDeclaration *>>
+        declNames;
 
  protected:
     // Note that all errors have been merged by the parser into
@@ -77,11 +77,11 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
     const IR::IDeclaration *getDeclaration(const IR::Path *path, bool notNull = false) const;
     const IR::IDeclaration *getDeclaration(const IR::This *, bool notNull = false) const;
 
-    Util::Enumerator<const IR::IDeclaration*>* getDeclarations(const IR::INamespace *ns) const;
-    std::vector<const IR::IDeclaration*>* memoizeDeclarations(const IR::INamespace* ns) const;
+    Util::Enumerator<const IR::IDeclaration *> *getDeclarations(const IR::INamespace *ns) const;
+    std::vector<const IR::IDeclaration *> *memoizeDeclarations(const IR::INamespace *ns) const;
 
-    Util::Enumerator<const IR::IDeclaration*>* getDeclsByName(const IR::INamespace *ns,
-                                                              cstring name) const;
+    Util::Enumerator<const IR::IDeclaration *> *getDeclsByName(const IR::INamespace *ns,
+                                                               cstring name) const;
 };
 
 /** Inspector that computes `refMap`: a map from paths to declarations.

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -29,11 +29,21 @@ enum class ResolutionType { Any, Type, TypeVariable };
 
 /// Visitor mixin for looking up names in enclosing scopes from the Visitor::Context
 class ResolutionContext : virtual public Visitor, public DeclarationLookup {
+ private:
+    // Returns a vector of the decls that exist in the given namespace, and caches the result
+    // for future lookups.
+    std::vector<const IR::IDeclaration *> *memoizeDeclarations(const IR::INamespace *ns) const;
+
+    // Returns a mapping from name -> decl for the given namespace, and caches the result for
+    // future lookups.
+    std::unordered_multimap<cstring, const IR::IDeclaration *> &memoizeDeclsByName(
+        const IR::INamespace *ns) const;
+
     mutable std::unordered_map<const IR::INamespace *, std::vector<const IR::IDeclaration *> *>
         namespaceDecls;
     mutable std::unordered_map<const IR::INamespace *,
                                std::unordered_multimap<cstring, const IR::IDeclaration *>>
-        declNames;
+        namespaceDeclNames;
 
  protected:
     // Note that all errors have been merged by the parser into
@@ -71,15 +81,16 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
     /// only return type nodes.
     virtual const IR::IDeclaration *resolvePath(const IR::Path *path, bool isType) const;
 
-    // Resolve a refrence to a type @p type.
+    /// Resolve a refrence to a type @p type.
     const IR::Type *resolveType(const IR::Type *type) const;
 
     const IR::IDeclaration *getDeclaration(const IR::Path *path, bool notNull = false) const;
     const IR::IDeclaration *getDeclaration(const IR::This *, bool notNull = false) const;
 
+    /// Returns the set of decls that exist in the given namespace.
     Util::Enumerator<const IR::IDeclaration *> *getDeclarations(const IR::INamespace *ns) const;
-    std::vector<const IR::IDeclaration *> *memoizeDeclarations(const IR::INamespace *ns) const;
 
+    /// Returns the set of decls with the given name that exist in the given namespace.
     Util::Enumerator<const IR::IDeclaration *> *getDeclsByName(const IR::INamespace *ns,
                                                                cstring name) const;
 };

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -560,5 +560,10 @@ bool EnumeratorHandle<T>::operator!=(const EnumeratorHandle<T> &other) const {
     return this->enumerator->state == EnumeratorState::Valid;
 }
 
+template <typename Iter>
+auto* enumerate(Iter begin, Iter end) {
+    return Enumerator<typename Iter::value_type>::createEnumerator(begin, end);
+}
+
 }  // namespace Util
 #endif /* LIB_ENUMERATOR_H_ */

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -561,7 +561,7 @@ bool EnumeratorHandle<T>::operator!=(const EnumeratorHandle<T> &other) const {
 }
 
 template <typename Iter>
-auto* enumerate(Iter begin, Iter end) {
+auto *enumerate(Iter begin, Iter end) {
     return Enumerator<typename Iter::value_type>::createEnumerator(begin, end);
 }
 


### PR DESCRIPTION
Improves performance of the `ResolveReferences` pass by using memoization.

For one of our backend apps, this improved compile-time performance by ~3x.

`time ninja check` on this branch:
```
real    1m14.940s
user    42m25.675s
sys     5m39.234s
```

`time ninja check` on `main` branch:
```
real    1m23.792s
user    49m4.392s
sys     5m39.192s
```

I can also run other benchmarks if requested.