### PR TITLE
Dpdk backend:Explicitly use method toString() while moving isValid() Methodcall used as table key, to metadata.

### DIFF
--- a/backends/dpdk/dpdkArch.cpp
+++ b/backends/dpdk/dpdkArch.cpp
@@ -1666,6 +1666,16 @@ const IR::Node *CopyMatchKeysToSingleStruct::postorder(IR::KeyElement *element) 
     }
 
     auto keyName = element->expression->toString();
+    if (auto m = element->expression->to<IR::MethodCallExpression>()) {
+        /* Moving <hdr>.isValid() used as table key to Metadata */
+        auto mi = P4::MethodInstance::resolve(m, refMap, typeMap);
+        if (auto b = mi->to<P4::BuiltInMethod>()) {
+            if (b->name == "isValid") {
+                keyName = m->method->toString();
+            }
+        }
+    }
+
     bool isHeader = false;
     /* All header fields are prefixed with "h." and metadata fields are prefixed with "m."
      * Prefix the match field with control and table name */

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -841,6 +841,7 @@ class CopyMatchKeysToSingleStruct : public P4::KeySideEffect {
     const IR::Node *doStatement(const IR::Statement *statement,
                                 const IR::Expression *expression) override;
     struct keyInfo *getKeyInfo(IR::Key *keys);
+    cstring getTableKeyName(const IR::Expression *e);
     int getFieldSizeBits(const IR::Type *field_type);
     bool isLearnerTable(const IR::P4Table *t);
 };

--- a/backends/dpdk/dpdkUtils.cpp
+++ b/backends/dpdk/dpdkUtils.cpp
@@ -93,6 +93,16 @@ bool isInsideHeader(const IR::Expression *expr) {
     return false;
 }
 
+bool isValidCall(const IR::MethodCallExpression *m) {
+    CHECK_NULL(m->method);
+    if (auto mc = m->method->to<IR::Member>()) {
+        if (mc->member.name == IR::Type_Header::isValid) {
+            return true;
+        }
+    }
+    return false;
+}
+
 const IR::Type_Bits *getEightBitAlignedType(const IR::Type_Bits *tb) {
     auto width = (tb->width_bits() + 7) & (~7);
     return IR::Type_Bits::get(width);

--- a/backends/dpdk/dpdkUtils.cpp
+++ b/backends/dpdk/dpdkUtils.cpp
@@ -103,6 +103,17 @@ bool isValidCall(const IR::MethodCallExpression *m) {
     return false;
 }
 
+bool isValidMemberField(const IR::Member *mem) {
+    if (auto mexpr = mem->expr->to<IR::Member>()) {
+        auto pe = mexpr->expr->to<IR::PathExpression>();
+        CHECK_NULL(pe);
+        if (pe->path->name == "h") return true;
+    } else if (auto mexpr = mem->expr->to<IR::PathExpression>()) {
+        if (mexpr->path->name == "m") return true;
+    }
+    return false;
+}
+
 const IR::Type_Bits *getEightBitAlignedType(const IR::Type_Bits *tb) {
     auto width = (tb->width_bits() + 7) & (~7);
     return IR::Type_Bits::get(width);

--- a/backends/dpdk/dpdkUtils.h
+++ b/backends/dpdk/dpdkUtils.h
@@ -32,6 +32,7 @@ bool isHeadersStruct(const IR::Type_Struct *st);
 bool isLargeFieldOperand(const IR::Expression *e);
 bool isInsideHeader(const IR::Expression *e);
 bool isValidCall(const IR::MethodCallExpression *m);
+bool isValidMemberField(const IR::Member *mem);
 int getMetadataFieldWidth(int width);
 const IR::Type_Bits *getEightBitAlignedType(const IR::Type_Bits *tb);
 

--- a/backends/dpdk/dpdkUtils.h
+++ b/backends/dpdk/dpdkUtils.h
@@ -31,6 +31,7 @@ bool isDirection(const IR::Member *m);
 bool isHeadersStruct(const IR::Type_Struct *st);
 bool isLargeFieldOperand(const IR::Expression *e);
 bool isInsideHeader(const IR::Expression *e);
+bool isValidCall(const IR::MethodCallExpression *m);
 int getMetadataFieldWidth(int width);
 const IR::Type_Bits *getEightBitAlignedType(const IR::Type_Bits *tb);
 


### PR DESCRIPTION
This is required for https://github.com/p4lang/p4c/pull/4354#issuecomment-1914141950
No changes in test output currently, however once above PR is merged in main, some dpdk tests will be broken. Hence, fixing it before merging @kfcripps  PR #4354 .

