### PR TITLE
Update MacOS runner to Ventura, add MacOS Sonoma (M1) runner

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -16,8 +16,6 @@ concurrency:
 jobs:
   # Build with gcc and test p4c on Ubuntu 22.04.
   test-ubuntu22:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-22.04
     env:
       CTEST_PARALLEL_LEVEL: 4
@@ -79,8 +77,6 @@ jobs:
 
   # Build and test p4c on Fedora.
   test-fedora-linux:
-    strategy:
-      fail-fast: false
     # This job runs in Fedora container that runs in Ubuntu VM.
     runs-on: ubuntu-latest
     container:
@@ -116,11 +112,42 @@ jobs:
       run: sudo -E ctest --output-on-failure --schedule-random
       working-directory: ./build
 
-  # Build and test p4c on MacOS 12
+  # Build and test p4c on MacOS for M1 Macs.
+  test-mac-os-m1:
+    runs-on: macos-14
+    env:
+      CTEST_PARALLEL_LEVEL: 4
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: test-${{ runner.os }}
+        max-size: 1000M
+
+    - name: Install dependencies (MacOS)
+      run: |
+           tools/install_mac_deps.sh
+
+    - name: Build (MacOS)
+      run: |
+          source ~/.bash_profile
+          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE \
+              -DCMAKE_UNITY_BUILD=ON
+          make -Cbuild -j$((`nproc`+1))
+
+    - name: Run tests (MacOS)
+      run: |
+        source ~/.bash_profile
+        ctest --output-on-failure --schedule-random -LE "bpf|ubpf"
+      working-directory: ./build
+
+  # Build and test p4c on MacOS 13 on x86.
   test-mac-os:
-    strategy:
-      fail-fast: false
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     env:
       CTEST_PARALLEL_LEVEL: 4
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -128,6 +128,15 @@ jobs:
         key: test-${{ runner.os }}
         max-size: 1000M
 
+    - name: Cache Homebrew Packages
+      id: cache-homebrew-packages
+      uses: actions/cache@v4
+      env:
+        cache-name: homebrew-packages
+      with:
+        path: $(brew --prefix)
+        key: ${{ runner.os }}-${{ hashFiles('tools/install_mac_deps.sh') }}
+
     - name: Install dependencies (MacOS)
       run: |
            tools/install_mac_deps.sh
@@ -160,6 +169,15 @@ jobs:
       with:
         key: test-${{ runner.os }}
         max-size: 1000M
+
+    - name: Cache Homebrew Packages
+      id: cache-homebrew-packages
+      uses: actions/cache@v4
+      env:
+        cache-name: homebrew-packages
+      with:
+        path: $(brew --prefix)
+        key: ${{ runner.os }}-${{ hashFiles('tools/install_mac_deps.sh') }}
 
     - name: Install dependencies (MacOS)
       run: |

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -120,7 +120,7 @@ jobs:
   test-mac-os:
     strategy:
       fail-fast: false
-    runs-on: macos-12
+    runs-on: macos-13-xlarge
     env:
       CTEST_PARALLEL_LEVEL: 4
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ clang-format==15.0.6
 black==22.3.0
 isort==5.10.0
 protobuf==3.20.2; python_version > '3.6'
-grpcio==1.51.1; python_version > '3.6'
+grpcio==1.59.3; python_version > '3.6'
 googleapis-common-protos==1.53.0; python_version > '3.6'
 # Ubuntu 18.04 uses Python 3.6, which is not supported by recent versions of Protobuf.
 protobuf==3.19.2; python_version <= '3.6'

--- a/tools/install_mac_deps.sh
+++ b/tools/install_mac_deps.sh
@@ -1,39 +1,64 @@
 #! /bin/bash
 
-# Script for building P4C on MacOS.
+# Script to install P4C dependencies on MacOS.
 
 set -e  # Exit on error.
 set -x  # Make command execution verbose
 
+# Installation helper.
+brew_install() {
+    echo "\nInstalling $1"
+    if brew list $1 &>/dev/null; then
+        echo "${1} is already installed"
+    else
+        brew install $1 && echo "$1 is installed"
+    fi
+}
 
-# Set up Homebrew differently for arm64.
-if [[ $(uname -m) == 'arm64' ]]; then
-    (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> ~/.zprofile
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-else
-    (echo; echo 'eval "$(/usr/local/bin/brew shellenv)"') >> ~/.zprofile
-    eval "$(/usr/local/bin/brew shellenv)"
+# Check if brew shellenv command is already in zprofile
+if ! grep -q 'brew shellenv' ~/.zprofile; then
+    # Set up Homebrew differently for arm64.
+    if [[ $(uname -m) == 'arm64' ]]; then
+        (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> ~/.zprofile
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    else
+        (echo; echo 'eval "$(/usr/local/bin/brew shellenv)"') >> ~/.zprofile
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
 fi
+# Source zprofile.
+source ~/.zprofile
 
-if [[ ! -x brew ]]; then
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# Check if Homebrew is already installed
+if ! which brew > /dev/null 2>&1; then
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 HOMEBREW_PREFIX=$(brew --prefix)
 
-# Install some custom requirements on OS X using brew
+
 BOOST_LIB="boost@1.84"
-brew install autoconf automake bdw-gc ccache cmake \
-      libtool openssl pkg-config coreutils bison grep \
-      ${BOOST_LIB}
+REQUIRED_PACKAGES=(
+    autoconf automake bdw-gc ccache cmake libtool
+    openssl pkg-config coreutils bison grep
+    ${BOOST_LIB}
+)
+for package in "${REQUIRED_PACKAGES[@]}"; do
+  brew_install ${package}
+done
 
-# We need to link boost and openssl.
-brew link ${BOOST_LIB} openssl
-# Prefer Homebrew's bison and grep over the macOS-provided version.
-# For Bison only `$(brew --prefix bison)/bin` seems to work...
-echo 'export PATH="$(brew --prefix bison)/bin:$PATH"' >> ~/.bash_profile
-echo 'export PATH="$HOMEBREW_PREFIX/opt/grep/libexec/gnubin:$PATH"' >> ~/.bash_profile
+# Check if linking is needed
+if ! brew ls --linked --formula ${BOOST_LIB} > /dev/null 2>&1; then
+  brew link ${BOOST_LIB}
+fi
+
+# Check if PATH modification is needed
+if ! grep -q "$(brew --prefix bison)/bin" ~/.bash_profile; then
+  echo 'export PATH="$(brew --prefix bison)/bin:$PATH"' >> ~/.bash_profile
+fi
+if ! grep -q "$HOMEBREW_PREFIX/opt/grep/libexec/gnubin" ~/.bash_profile; then
+  echo 'export PATH="$HOMEBREW_PREFIX/opt/grep/libexec/gnubin:$PATH"' >> ~/.bash_profile
+fi
 source ~/.bash_profile
-
 
 # Fixes for stuck grpcio installation.
 export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1

--- a/tools/install_mac_deps.sh
+++ b/tools/install_mac_deps.sh
@@ -3,7 +3,6 @@
 # Script to install P4C dependencies on MacOS.
 
 set -e  # Exit on error.
-set -x  # Make command execution verbose
 
 # Installation helper.
 brew_install() {
@@ -15,7 +14,7 @@ brew_install() {
     fi
 }
 
-# Check if brew shellenv command is already in zprofile
+# Check if brew shellenv command is already in zprofile.
 if ! grep -q 'brew shellenv' ~/.zprofile; then
     # Set up Homebrew differently for arm64.
     if [[ $(uname -m) == 'arm64' ]]; then
@@ -29,7 +28,7 @@ fi
 # Source zprofile.
 source ~/.zprofile
 
-# Check if Homebrew is already installed
+# Check if Homebrew is already installed.
 if ! which brew > /dev/null 2>&1; then
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
@@ -46,12 +45,12 @@ for package in "${REQUIRED_PACKAGES[@]}"; do
   brew_install ${package}
 done
 
-# Check if linking is needed
+# Check if linking is needed.
 if ! brew ls --linked --formula ${BOOST_LIB} > /dev/null 2>&1; then
   brew link ${BOOST_LIB}
 fi
 
-# Check if PATH modification is needed
+# Check if PATH modification is needed.
 if ! grep -q "$(brew --prefix bison)/bin" ~/.bash_profile; then
   echo 'export PATH="$(brew --prefix bison)/bin:$PATH"' >> ~/.bash_profile
 fi
@@ -60,8 +59,5 @@ if ! grep -q "$HOMEBREW_PREFIX/opt/grep/libexec/gnubin" ~/.bash_profile; then
 fi
 source ~/.bash_profile
 
-# Fixes for stuck grpcio installation.
-export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
-export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1
 # Install required pip packages
 pip3 install --user -r requirements.txt


### PR DESCRIPTION
Fixes #4390. Build P4C for MacOS Sonoma (M1) and Ventura. 
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

TODO: Add support for the behavioral model and P4Testgen. I might do that in a separate PR. 