### PR TITLE
Do not check for shadowing repeatedly in inlining passes.

### DIFF
--- a/frontends/common/resolveReferences/referenceMap.cpp
+++ b/frontends/common/resolveReferences/referenceMap.cpp
@@ -32,6 +32,7 @@ void ReferenceMap::clear() {
     LOG2("Clearing reference map");
     pathToDeclaration.clear();
     usedNames.clear();
+    program = nullptr;
     used.clear();
     thisToDeclaration.clear();
     for (auto &reserved : P4::reservedWords) usedNames.insert({reserved, 0});

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -349,7 +349,8 @@ void ResolveReferences::checkShadowing(const IR::INamespace *ns) const {
 
 Visitor::profile_t ResolveReferences::init_apply(const IR::Node *node) {
     anyOrder = refMap->isV1();
-    if (!refMap->checkMap(node)) refMap->clear();
+    // Check shadowing even if the program map is up-to-date.
+    if (!refMap->checkMap(node) || checkShadow) refMap->clear();
     return Inspector::init_apply(node);
 }
 

--- a/frontends/p4/actionsInlining.cpp
+++ b/frontends/p4/actionsInlining.cpp
@@ -45,7 +45,8 @@ void DiscoverActionsInlining::postorder(const IR::MethodCallStatement *mcs) {
 }
 
 Visitor::profile_t ActionsInliner::init_apply(const IR::Node *node) {
-    P4::ResolveReferences solver(refMap, true);
+    P4::ResolveReferences solver(refMap);
+    refMap->clear();
     node->apply(solver);
     LOG2("ActionsInliner " << toInline);
     return Transform::init_apply(node);

--- a/frontends/p4/actionsInlining.h
+++ b/frontends/p4/actionsInlining.h
@@ -51,9 +51,7 @@ class ActionsInliner : public AbstractInliner<ActionsInlineList, AInlineWorkList
     std::map<const IR::MethodCallStatement *, const IR::P4Action *> *replMap;
 
  public:
-    explicit ActionsInliner(bool isv1) : refMap(new P4::ReferenceMap()), replMap(nullptr) {
-        refMap->setIsV1(isv1);
-    }
+    explicit ActionsInliner(P4::ReferenceMap *refMap) : refMap(refMap), replMap(nullptr) {}
     Visitor::profile_t init_apply(const IR::Node *node) override;
     const IR::Node *preorder(IR::P4Parser *cont) override {
         prune();
@@ -73,8 +71,7 @@ class InlineActions : public PassManager {
     InlineActions(ReferenceMap *refMap, TypeMap *typeMap) {
         passes.push_back(new TypeChecking(refMap, typeMap));
         passes.push_back(new DiscoverActionsInlining(&actionsToInline, refMap, typeMap));
-        passes.push_back(
-            new InlineActionsDriver(&actionsToInline, new ActionsInliner(refMap->isV1())));
+        passes.push_back(new InlineActionsDriver(&actionsToInline, new ActionsInliner(refMap)));
         passes.push_back(new RemoveAllUnusedDeclarations(refMap));
         setName("InlineActions");
     }

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -167,14 +167,14 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new ValidateParsedProgram(),
         // Synthesize some built-in constructs
         new CreateBuiltins(),
-        new ResolveReferences(&refMap, true),  // check shadowing
+        new ResolveReferences(&refMap, /* checkShadow */ true),
         // First pass of constant folding, before types are known --
         // may be needed to compute types.
         new ConstantFolding(&refMap, nullptr),
         // Desugars direct parser and control applications
         // into instantiations followed by application
         new InstantiateDirectCalls(&refMap),
-        new ResolveReferences(&refMap),  // check shadowing
+        new ResolveReferences(&refMap),
         new Deprecated(&refMap),
         new CheckNamedArgs(),
         // Type checking and type inference.  Also inserts
@@ -258,6 +258,9 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
             new SimplifyControlFlow(&refMap, &typeMap),
         });
     passes.addPasses({
+        // Check for shadowing after all inlining passes. We disable this
+        // check during inlining since it significantly slows compilation.
+        new ResolveReferences(&refMap, /* checkShadow */ true),
         new HierarchicalNames(),
         new FrontEndLast(),
     });

--- a/frontends/p4/functionsInlining.cpp
+++ b/frontends/p4/functionsInlining.cpp
@@ -48,7 +48,8 @@ void FunctionsInliner::end_apply(const IR::Node *) {
 }
 
 Visitor::profile_t FunctionsInliner::init_apply(const IR::Node *node) {
-    P4::ResolveReferences solver(refMap, true);
+    P4::ResolveReferences solver(refMap);
+    refMap->clear();
     node->apply(solver);
     LOG2("FunctionsInliner " << toInline);
     return Transform::init_apply(node);

--- a/frontends/p4/inlining.cpp
+++ b/frontends/p4/inlining.cpp
@@ -446,6 +446,7 @@ bool DiscoverInlining::preorder(const IR::ParserBlock *block) {
 Visitor::profile_t GeneralInliner::init_apply(const IR::Node *node) {
     ResolveReferences solver(refMap);
     TypeChecking typeChecker(refMap, typeMap);
+    refMap->clear();
     node->apply(solver);
     (void)node->apply(typeChecker);
     return AbstractInliner::init_apply(node);

--- a/frontends/p4/inlining.h
+++ b/frontends/p4/inlining.h
@@ -402,13 +402,12 @@ class GeneralInliner : public AbstractInliner<InlineList, InlineSummary> {
     bool optimizeParserInlining;
 
  public:
-    explicit GeneralInliner(bool isv1, bool _optimizeParserInlining)
-        : refMap(new ReferenceMap()),
+    explicit GeneralInliner(ReferenceMap *refMap, bool _optimizeParserInlining)
+        : refMap(refMap),
           typeMap(new TypeMap()),
           workToDo(nullptr),
           optimizeParserInlining(_optimizeParserInlining) {
         setName("GeneralInliner");
-        refMap->setIsV1(isv1);
         visitDagOnce = false;
     }
     // controlled visiting order
@@ -436,7 +435,7 @@ class InlinePass : public PassManager {
         : PassManager({new TypeChecking(refMap, typeMap),
                        new DiscoverInlining(&toInline, refMap, typeMap, evaluator),
                        new InlineDriver<InlineList, InlineSummary>(
-                           &toInline, new GeneralInliner(refMap->isV1(), optimizeParserInlining)),
+                           &toInline, new GeneralInliner(refMap, optimizeParserInlining)),
                        new RemoveAllUnusedDeclarations(refMap)}) {
         setName("InlinePass");
     }


### PR DESCRIPTION
We found that checking shadowing in `ResolveReferences` was a big bottleneck for one of our apps, and it is done each time an inlining pass is repeated. We turned this off and added a new `ResolveReferences` pass to check shadowing after all inlining is completed. This greatly helped to speed up these passes, which were taking the longest.

Compilation times for one of our apps without these changes:
```
real    22m7.669s
user    21m55.887s
sys     0m14.823s
```

and with them:
```
real    16m36.850s
user    16m24.559s
sys     0m15.304s
```