### PR TITLE
[P4Testgen] Implement a library for common control-plane symbolic variables.

### DIFF
--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -56,17 +56,8 @@ target_include_directories(
 
 add_dependencies(p4tools-common ir-generated frontend)
 
-set(
-  P4C_TOOLS_CONTROL_PLANE_SOURCES
-  control_plane/p4info_map.cpp
-)
-
-add_p4tools_library(p4tools-control-plane ${P4C_TOOLS_CONTROL_PLANE_SOURCES})
-
-target_include_directories(
-  p4tools-control-plane
-  SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIRS}
-)
+# Add control-plane-specific extensions.
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/control_plane)
 
 target_link_libraries(p4tools-control-plane controlplane)
 

--- a/backends/p4tools/common/control_plane/CMakeLists.txt
+++ b/backends/p4tools/common/control_plane/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(
+  P4C_TOOLS_CONTROL_PLANE_SOURCES
+  p4info_map.cpp
+  symbolic_variables.cpp
+)
+
+add_p4tools_library(p4tools-control-plane ${P4C_TOOLS_CONTROL_PLANE_SOURCES})
+
+target_include_directories(
+  p4tools-control-plane
+  SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIRS}
+)

--- a/backends/p4tools/common/control_plane/symbolic_variables.cpp
+++ b/backends/p4tools/common/control_plane/symbolic_variables.cpp
@@ -49,7 +49,7 @@ const IR::SymbolicVariable *getCloneActive() {
     return ToolsVariables::getSymbolicVariable(IR::Type_Boolean::get(), "clone_session_active");
 }
 
-const IR::SymbolicVariable *getSessionId(const IR::Type *type) {
+const IR::SymbolicVariable *getCloneSessionId(const IR::Type *type) {
     return ToolsVariables::getSymbolicVariable(type, "clone_session_id");
 }
 

--- a/backends/p4tools/common/control_plane/symbolic_variables.cpp
+++ b/backends/p4tools/common/control_plane/symbolic_variables.cpp
@@ -1,0 +1,65 @@
+#include "backends/p4tools/common/control_plane/symbolic_variables.h"
+
+#include "backends/p4tools/common/lib/variables.h"
+#include "ir/irutils.h"
+
+namespace P4Tools {
+
+namespace ControlPlaneState {
+
+const IR::SymbolicVariable *getTableActive(cstring tableName) {
+    cstring label = tableName + "_configured";
+    return ToolsVariables::getSymbolicVariable(IR::Type_Boolean::get(), label);
+}
+
+const IR::SymbolicVariable *getTableKey(cstring tableName, cstring keyFieldName,
+                                        const IR::Type *type) {
+    cstring label = tableName + "_key_" + keyFieldName;
+    return ToolsVariables::getSymbolicVariable(type, label);
+}
+
+const IR::SymbolicVariable *getTableTernaryMask(cstring tableName, cstring keyFieldName,
+                                                const IR::Type *type) {
+    cstring label = tableName + "_mask_" + keyFieldName;
+    return ToolsVariables::getSymbolicVariable(type, label);
+}
+
+const IR::SymbolicVariable *getTableMatchLpmPrefix(cstring tableName, cstring keyFieldName,
+                                                   const IR::Type *type) {
+    cstring label = tableName + "_lpm_prefix_" + keyFieldName;
+    return ToolsVariables::getSymbolicVariable(type, label);
+}
+
+const IR::SymbolicVariable *getTableActionArgument(cstring tableName, cstring actionName,
+                                                   cstring parameterName, const IR::Type *type) {
+    cstring label = tableName + "_" + actionName + "_arg_" + parameterName;
+    return ToolsVariables::getSymbolicVariable(type, label);
+}
+
+const IR::SymbolicVariable *getTableActionChoice(cstring tableName) {
+    cstring label = tableName + "_action";
+    return ToolsVariables::getSymbolicVariable(IR::Type_String::get(), label);
+}
+
+}  // namespace ControlPlaneState
+
+namespace Bmv2ControlPlaneState {
+
+const IR::SymbolicVariable *getCloneActive() {
+    return ToolsVariables::getSymbolicVariable(IR::Type_Boolean::get(), "clone_session_active");
+}
+
+const IR::SymbolicVariable *getSessionId(const IR::Type *type) {
+    return ToolsVariables::getSymbolicVariable(type, "clone_session_id");
+}
+
+std::pair<const IR::SymbolicVariable *, const IR::SymbolicVariable *> getTableRange(
+    cstring tableName, cstring keyFieldName, const IR::Type *type) {
+    cstring minName = tableName + "_range_min_" + keyFieldName;
+    cstring maxName = tableName + "_range_max_" + keyFieldName;
+    return {new IR::SymbolicVariable(type, minName), new IR::SymbolicVariable(type, maxName)};
+}
+
+}  // namespace Bmv2ControlPlaneState
+
+}  // namespace P4Tools

--- a/backends/p4tools/common/control_plane/symbolic_variables.h
+++ b/backends/p4tools/common/control_plane/symbolic_variables.h
@@ -1,0 +1,59 @@
+#ifndef BACKENDS_P4TOOLS_COMMON_CONTROL_PLANE_SYMBOLIC_VARIABLES_H_
+#define BACKENDS_P4TOOLS_COMMON_CONTROL_PLANE_SYMBOLIC_VARIABLES_H_
+
+#include "ir/ir.h"
+#include "ir/irutils.h"
+
+/// Defines accessors and utility functions for state that is managed by the control plane.
+/// This class can be extended by targets to customize initialization behavior and add
+/// target-specific utility functions.
+namespace P4Tools {
+
+namespace ControlPlaneState {
+
+/// @returns the symbolic boolean variable describing whether a table is configured by the
+/// control plane.
+const IR::SymbolicVariable *getTableActive(cstring tableName);
+
+/// @returns the symbolic variable describing a table match key.
+/// The table and field name are needed to generate a unique variable.
+const IR::SymbolicVariable *getTableKey(cstring tableName, cstring keyFieldName,
+                                        const IR::Type *type);
+
+/// @returns the symbolic variable describing a table ternary mask.
+/// The table and field name are needed to generate a unique variable.
+const IR::SymbolicVariable *getTableTernaryMask(cstring tableName, cstring keyFieldName,
+                                                const IR::Type *type);
+
+/// @returns the symbolic variable describing a table LPM prefix match.
+/// The table and field name are needed to generate a unique variable.
+const IR::SymbolicVariable *getTableMatchLpmPrefix(cstring tableName, cstring keyFieldName,
+                                                   const IR::Type *type);
+
+/// @returns the symbolic variable describing an action argument as part of a match-action call. The
+/// table and action name are needed to generate a unique variable.
+const IR::SymbolicVariable *getTableActionArgument(cstring tableName, cstring actionName,
+                                                   cstring parameterName, const IR::Type *type);
+
+/// @returns the symbolic variable listing the chosen action for a particular table.
+const IR::SymbolicVariable *getTableActionChoice(cstring tableName);
+
+}  // namespace ControlPlaneState
+
+namespace Bmv2ControlPlaneState {
+
+/// @returns the symbolic boolean variable describing whether a clone session
+/// is active in the program.
+const IR::SymbolicVariable *getCloneActive();
+
+/// @returns the symbolic session id variable.
+const IR::SymbolicVariable *getSessionId(const IR::Type *type);
+
+std::pair<const IR::SymbolicVariable *, const IR::SymbolicVariable *> getTableRange(
+    cstring tableName, cstring keyFieldName, const IR::Type *type);
+
+}  // namespace Bmv2ControlPlaneState
+
+}  // namespace P4Tools
+
+#endif /* BACKENDS_P4TOOLS_COMMON_CONTROL_PLANE_SYMBOLIC_VARIABLES_H_ */

--- a/backends/p4tools/common/control_plane/symbolic_variables.h
+++ b/backends/p4tools/common/control_plane/symbolic_variables.h
@@ -4,11 +4,11 @@
 #include "ir/ir.h"
 #include "ir/irutils.h"
 
+namespace P4Tools {
+
 /// Defines accessors and utility functions for state that is managed by the control plane.
 /// This class can be extended by targets to customize initialization behavior and add
 /// target-specific utility functions.
-namespace P4Tools {
-
 namespace ControlPlaneState {
 
 /// @returns the symbolic boolean variable describing whether a table is configured by the
@@ -20,18 +20,22 @@ const IR::SymbolicVariable *getTableActive(cstring tableName);
 const IR::SymbolicVariable *getTableKey(cstring tableName, cstring keyFieldName,
                                         const IR::Type *type);
 
-/// @returns the symbolic variable describing a table ternary mask.
+/// @returns the symbolic variable representing the mask for a table ternary match.
+/// The symbolic mask may be applied to the left and right-hand side of a key match
+/// (|x| & |mask|== |y| & |mask|).
 /// The table and field name are needed to generate a unique variable.
 const IR::SymbolicVariable *getTableTernaryMask(cstring tableName, cstring keyFieldName,
                                                 const IR::Type *type);
 
 /// @returns the symbolic variable describing a table LPM prefix match.
+/// The symbolic prefix may be applied to the left and right-hand side of a key match
+/// (|x| << |lpm_prefix| == |y| << |lpm_prefix|).
 /// The table and field name are needed to generate a unique variable.
 const IR::SymbolicVariable *getTableMatchLpmPrefix(cstring tableName, cstring keyFieldName,
                                                    const IR::Type *type);
 
 /// @returns the symbolic variable describing an action argument as part of a match-action call. The
-/// table and action name are needed to generate a unique variable.
+/// table, action and argument name are needed to generate a unique variable.
 const IR::SymbolicVariable *getTableActionArgument(cstring tableName, cstring actionName,
                                                    cstring parameterName, const IR::Type *type);
 
@@ -46,9 +50,13 @@ namespace Bmv2ControlPlaneState {
 /// is active in the program.
 const IR::SymbolicVariable *getCloneActive();
 
-/// @returns the symbolic session id variable.
-const IR::SymbolicVariable *getSessionId(const IR::Type *type);
+/// @returns the symbolic clone session id variable.
+/// See also https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-clonesessionentry
+const IR::SymbolicVariable *getCloneSessionId(const IR::Type *type);
 
+/// @returns the symbolic variable describing a table Range match.
+/// The table and field name are needed to generate a unique variable.
+/// See also https://github.com/p4lang/behavioral-model/blob/main/docs/simple_switch.md#range-tables
 std::pair<const IR::SymbolicVariable *, const IR::SymbolicVariable *> getTableRange(
     cstring tableName, cstring keyFieldName, const IR::Type *type);
 

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -10,6 +10,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/multiprecision/number.hpp>
 
+#include "backends/p4tools/common/control_plane/symbolic_variables.h"
 #include "backends/p4tools/common/lib/constants.h"
 #include "backends/p4tools/common/lib/symbolic_env.h"
 #include "backends/p4tools/common/lib/taint.h"
@@ -83,8 +84,8 @@ const IR::Expression *TableStepper::computeTargetMatchType(
     const IR::Expression *hitCondition) {
     const IR::Expression *keyExpr = keyProperties.key->expression;
     // Create a new variable constant that corresponds to the key expression.
-    cstring keyName = properties.tableName + "_key_" + keyProperties.name;
-    const auto *ctrlPlaneKey = ToolsVariables::getSymbolicVariable(keyExpr->type, keyName);
+    const auto *ctrlPlaneKey =
+        ControlPlaneState::getTableKey(properties.tableName, keyProperties.name, keyExpr->type);
 
     if (keyProperties.matchType == P4Constants::MATCH_KIND_EXACT) {
         hitCondition = new IR::LAnd(hitCondition, new IR::Equ(keyExpr, ctrlPlaneKey));
@@ -92,14 +93,14 @@ const IR::Expression *TableStepper::computeTargetMatchType(
         return hitCondition;
     }
     if (keyProperties.matchType == P4Constants::MATCH_KIND_TERNARY) {
-        cstring maskName = properties.tableName + "_mask_" + keyProperties.name;
         const IR::Expression *ternaryMask = nullptr;
         // We can recover from taint by inserting a ternary match that is 0.
         if (keyProperties.isTainted) {
             ternaryMask = IR::getConstant(keyExpr->type, 0);
             keyExpr = ternaryMask;
         } else {
-            ternaryMask = ToolsVariables::getSymbolicVariable(keyExpr->type, maskName);
+            ternaryMask = ControlPlaneState::getTableTernaryMask(properties.tableName,
+                                                                 keyProperties.name, keyExpr->type);
         }
         matches->emplace(keyProperties.name,
                          new Ternary(keyProperties.key, ctrlPlaneKey, ternaryMask));
@@ -109,9 +110,8 @@ const IR::Expression *TableStepper::computeTargetMatchType(
     if (keyProperties.matchType == P4Constants::MATCH_KIND_LPM) {
         const auto *keyType = keyExpr->type->checkedTo<IR::Type_Bits>();
         auto keyWidth = keyType->width_bits();
-        cstring maskName = properties.tableName + "_lpm_prefix_" + keyProperties.name;
-        const IR::Expression *maskVar =
-            ToolsVariables::getSymbolicVariable(keyExpr->type, maskName);
+        const IR::Expression *maskVar = ControlPlaneState::getTableMatchLpmPrefix(
+            properties.tableName, keyProperties.name, keyExpr->type);
         // The maxReturn is the maximum vale for the given bit width. This value is shifted by
         // the mask variable to create a mask (and with that, a prefix).
         auto maxReturn = IR::getMaxBvVal(keyWidth);
@@ -254,14 +254,11 @@ void TableStepper::setTableDefaultEntries(
         const auto &parameters = actionType->parameters;
         auto *arguments = new IR::Vector<IR::Argument>();
         std::vector<ActionArg> ctrlPlaneArgs;
-        for (size_t argIdx = 0; argIdx < parameters->size(); ++argIdx) {
-            const auto *parameter = parameters->getParameter(argIdx);
+        for (const auto *parameter : *parameters) {
             // Synthesize a variable constant here that corresponds to a control plane argument.
-            // We get the unique name of the table coupled with the unique name of the action.
-            // Getting the unique name is needed to avoid generating duplicate arguments.
-            cstring paramName =
-                properties.tableName + "_arg_" + actionName + std::to_string(argIdx);
-            const auto &actionArg = ToolsVariables::getSymbolicVariable(parameter->type, paramName);
+            const auto &actionArg = ControlPlaneState::getTableActionArgument(
+                properties.tableName, actionName, parameter->name, parameter->type);
+
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.
@@ -325,14 +322,10 @@ void TableStepper::evalTableControlEntries(
         const auto &parameters = actionType->parameters;
         auto *arguments = new IR::Vector<IR::Argument>();
         std::vector<ActionArg> ctrlPlaneArgs;
-        for (size_t argIdx = 0; argIdx < parameters->size(); ++argIdx) {
-            const auto *parameter = parameters->getParameter(argIdx);
+        for (const auto *parameter : *parameters) {
             // Synthesize a variable constant here that corresponds to a control plane argument.
-            // We get the unique name of the table coupled with the unique name of the action.
-            // Getting the unique name is needed to avoid generating duplicate arguments.
-            cstring paramName =
-                properties.tableName + "_arg_" + actionName + std::to_string(argIdx);
-            const auto &actionArg = ToolsVariables::getSymbolicVariable(parameter->type, paramName);
+            const auto &actionArg = ControlPlaneState::getTableActionArgument(
+                properties.tableName, actionName, parameter->name, parameter->type);
             arguments->push_back(new IR::Argument(actionArg));
             // We also track the argument we synthesize for the control plane.
             // Note how we use the control plane name for the parameter here.

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -91,10 +91,8 @@ const IR::Expression *Bmv2V1ModelTableStepper::computeTargetMatchType(
             maxKey = IR::getConstant(keyExpr->type, IR::getMaxBvVal(keyExpr->type));
             keyExpr = minKey;
         } else {
-            auto symbolicTableRange = Bmv2ControlPlaneState::getTableRange(
+            std::tie(minKey, maxKey) = Bmv2ControlPlaneState::getTableRange(
                 properties.tableName, keyProperties.name, keyExpr->type);
-            minKey = symbolicTableRange.first;
-            maxKey = symbolicTableRange.second;
         }
         matches->emplace(keyProperties.name, new Range(keyProperties.key, minKey, maxKey));
         return new IR::LAnd(hitCondition, new IR::LAnd(new IR::LAnd(new IR::Lss(minKey, maxKey),

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/p4_asserts_parser_test.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/p4_asserts_parser_test.cpp
@@ -142,7 +142,7 @@ TEST_F(P4AssertsParserTest, RestrictionMiddleblockReferToInAction) {
         false);
     ASSERT_EQ(parsingResult.size(), (unsigned long)3);
     const auto *expr1 = P4Tools::ToolsVariables::getSymbolicVariable(
-        IR::Type_Bits::get(8), "ingress.table_1_arg_ingress.MyAction10");
+        IR::Type_Bits::get(8), "ingress.table_1_ingress.MyAction1_arg_input_val");
     const auto *expr2 = P4Tools::ToolsVariables::getSymbolicVariable(IR::Type_Bits::get(8),
                                                                      "ingress.table_1_key_h.h.a");
     auto *operation = new IR::Equ(expr1, expr2);

--- a/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
@@ -70,10 +70,8 @@ const IR::Expression *SharedPnaTableStepper::computeTargetMatchType(
             maxKey = IR::getConstant(keyExpr->type, IR::getMaxBvVal(keyExpr->type));
             keyExpr = minKey;
         } else {
-            auto symbolicTableRange = Bmv2ControlPlaneState::getTableRange(
+            std::tie(minKey, maxKey) = Bmv2ControlPlaneState::getTableRange(
                 properties.tableName, keyProperties.name, keyExpr->type);
-            minKey = symbolicTableRange.first;
-            maxKey = symbolicTableRange.second;
         }
         matches->emplace(keyProperties.name, new Range(keyProperties.key, minKey, maxKey));
         return new IR::LAnd(hitCondition, new IR::LAnd(new IR::LAnd(new IR::Lss(minKey, maxKey),


### PR DESCRIPTION
This is the first PR in a series of many to build a control-plane semantics for the P4Tools framework. For now, we just introduce a library which includes definitions for common control-plane-influenced symbolic variables. 

I have decided to keep BMv2-specific variables in the top level. The reason is that these variables may be used by multiple P4Tools frameworks. I do not have a good approach to handle common target-specific variables across multiple frameworks yet. 