### PR TITLE
[P4Testgen] Fix generation of specific fields in the Protobuf-IR test backend.

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.cpp
@@ -23,6 +23,10 @@ Bmv2TestFramework::Bmv2TestFramework(std::filesystem::path basePath,
                                      std::optional<unsigned int> seed)
     : TestFramework(std::move(basePath), seed) {}
 
+std::string Bmv2TestFramework::formatHexExpressionWithSeparators(const IR::Expression &expr) {
+    return insertHexSeparators(formatHexExpr(&expr, {false, true, false}));
+}
+
 inja::json Bmv2TestFramework::getClone(const TestObjectMap &cloneSpecs) const {
     auto cloneSpec = inja::json::object();
     auto cloneJsons = inja::json::array_t();

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/common.h
@@ -20,18 +20,21 @@ class Bmv2TestFramework : public TestFramework {
                                std::optional<unsigned int> seed = std::nullopt);
 
  protected:
+    /// Wrapper helper function that automatically inserts separators for hex strings.
+    static std::string formatHexExpressionWithSeparators(const IR::Expression &expr);
+
     /// Converts all the control plane objects into Inja format.
     virtual inja::json getControlPlane(const TestSpec *testSpec) const;
 
     /// Returns the configuration for a cloned packet configuration.
-    virtual inja::json getClone(const TestObjectMap &cloneSpecs) const;
+    [[nodiscard]] virtual inja::json getClone(const TestObjectMap &cloneSpecs) const;
 
     /// @returns the configuration for a meter call (may set the meter to GREEN, YELLOW, or RED)
-    virtual inja::json::array_t getMeter(const TestObjectMap &meterValues) const;
+    [[nodiscard]] virtual inja::json::array_t getMeter(const TestObjectMap &meterValues) const;
 
     /// Helper function for the control plane table inja objects.
-    virtual inja::json getControlPlaneForTable(const TableMatchMap &matches,
-                                               const std::vector<ActionArg> &args) const;
+    [[nodiscard]] virtual inja::json getControlPlaneForTable(
+        const TableMatchMap &matches, const std::vector<ActionArg> &args) const;
 
     /// Converts the input packet and port into Inja format.
     virtual inja::json getSend(const TestSpec *testSpec) const;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.h
@@ -33,6 +33,10 @@ class ProtobufIr : public Bmv2TestFramework {
     [[nodiscard]] inja::json getControlPlaneForTable(
         const TableMatchMap &matches, const std::vector<ActionArg> &args) const override;
 
+    [[nodiscard]] inja::json getSend(const TestSpec *testSpec) const override;
+
+    [[nodiscard]] inja::json getExpectedPacket(const TestSpec *testSpec) const override;
+
  private:
     /// Emits a test case.
     /// @param testId specifies the test name.


### PR DESCRIPTION
Also move  the hex separator utility to the common class.