### PR TITLE
ConstantFolding hook to allow backends to do special stuff

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -23,6 +23,8 @@ limitations under the License.
 
 namespace P4 {
 
+ConstantFolding::filter_hook_t ConstantFolding::filter_hook;
+
 class CloneConstants : public Transform {
  public:
     CloneConstants() = default;
@@ -87,6 +89,9 @@ const IR::Expression *DoConstantFolding::getConstant(const IR::Expression *expr)
 }
 
 const IR::Node *DoConstantFolding::postorder(IR::PathExpression *e) {
+    if (ConstantFolding::filter_hook) {
+        if (auto *rv = ConstantFolding::filter_hook(this, e)) return rv;
+    }
     if (refMap == nullptr || assignmentTarget) return e;
     auto decl = refMap->getDeclaration(e->path);
     if (decl == nullptr) return e;

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -163,10 +163,21 @@ class ConstantFolding : public PassManager {
         setName("ConstantFolding");
     }
 
+    /** Function definition for hook to filter which Expression objects are processed.
+     *
+     * Function should return nullptr to process the Expression, or a non-null pointer
+     * to bypass processing. Returned value will be returned by the postorder function.
+     */
     typedef std::function<const IR::Expression *(Visitor *, const IR::Expression *)>
         filter_hook_t;
+
+    /** Active hook to filter which PathExpression objects are processed */
     static filter_hook_t filter_hook;
+
+    /** Set the filter hook to programatically skip processing of select expressions */
     static void setFilterHook(filter_hook_t filter) { filter_hook = filter; }
+
+    /** Clear the filter hook (process all expressions) */
     static void unsetFilterHook() { filter_hook = filter_hook_t(); }
 };
 

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -163,20 +163,19 @@ class ConstantFolding : public PassManager {
         setName("ConstantFolding");
     }
 
-    /** Function definition for hook to filter which Expression objects are processed.
-     *
-     * Function should return nullptr to process the Expression, or a non-null pointer
-     * to bypass processing. Returned value will be returned by the postorder function.
-     */
+    /// Function definition for hook to filter which Expression objects are processed.
+    ///
+    /// Function should return nullptr to process the Expression, or a non-null pointer
+    /// to bypass processing. Returned value will be returned by the postorder function.
     typedef std::function<const IR::Expression *(Visitor *, const IR::Expression *)> filter_hook_t;
 
-    /** Active hook to filter which PathExpression objects are processed */
+    /// Active hook to filter which PathExpression objects are processed
     static filter_hook_t filter_hook;
 
-    /** Set the filter hook to programatically skip processing of select expressions */
+    /// Set the filter hook to programatically skip processing of select expressions
     static void setFilterHook(filter_hook_t filter) { filter_hook = filter; }
 
-    /** Clear the filter hook (process all expressions) */
+    /// Clear the filter hook (process all expressions)
     static void unsetFilterHook() { filter_hook = filter_hook_t(); }
 };
 

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -162,6 +162,12 @@ class ConstantFolding : public PassManager {
         if (typeMap != nullptr) passes.push_back(new ClearTypeMap(typeMap));
         setName("ConstantFolding");
     }
+
+    typedef std::function<const IR::Expression *(Visitor *, const IR::Expression *)>
+        filter_hook_t;
+    static filter_hook_t filter_hook;
+    static void setFilterHook(filter_hook_t filter) { filter_hook = filter; }
+    static void unsetFilterHook() { filter_hook = filter_hook_t(); }
 };
 
 }  // namespace P4

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -168,8 +168,7 @@ class ConstantFolding : public PassManager {
      * Function should return nullptr to process the Expression, or a non-null pointer
      * to bypass processing. Returned value will be returned by the postorder function.
      */
-    typedef std::function<const IR::Expression *(Visitor *, const IR::Expression *)>
-        filter_hook_t;
+    typedef std::function<const IR::Expression *(Visitor *, const IR::Expression *)> filter_hook_t;
 
     /** Active hook to filter which PathExpression objects are processed */
     static filter_hook_t filter_hook;

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -167,7 +167,7 @@ class ConstantFolding : public PassManager {
     ///
     /// Function should return nullptr to process the Expression, or a non-null pointer
     /// to bypass processing. Returned value will be returned by the postorder function.
-    typedef std::function<const IR::Expression *(Visitor *, const IR::Expression *)> filter_hook_t;
+    using filter_hook_t = std::function<const IR::Expression *(Visitor *, const IR::Expression *)>;
 
     /// Active hook to filter which PathExpression objects are processed
     static filter_hook_t filter_hook;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/call_graph_test.cpp
   gtest/complex_bitwise.cpp
   gtest/constant_expr_test.cpp
+  gtest/constant_folding.cpp
   gtest/cstring.cpp
   gtest/diagnostics.cpp
   gtest/dumpjson.cpp

--- a/test/gtest/constant_folding.cpp
+++ b/test/gtest/constant_folding.cpp
@@ -1,0 +1,132 @@
+#include "frontends/common/constantFolding.h"
+#include "frontends/common/parseInput.h"
+#include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/common/resolveReferences/resolveReferences.h"
+#include "gtest/gtest.h"
+#include "helpers.h"
+#include "ir/ir.h"
+#include "ir/pass_manager.h"
+#include "lib/log.h"
+
+using namespace P4;
+
+namespace Test {
+
+struct P4CFrontend : P4CTest {
+    void addPasses(std::initializer_list<PassManager::VisitorRef> passes) { pm.addPasses(passes); }
+
+    const IR::Node *parseAndProcess(std::string program) {
+        const auto *pgm = P4::parseP4String(program, CompilerOptions::FrontendVersion::P4_16);
+        EXPECT_TRUE(pgm);
+        EXPECT_EQ(::errorCount(), 0);
+        if (!pgm) {
+            return nullptr;
+        }
+        return pgm->apply(pm);
+    }
+
+    PassManager pm;
+};
+
+struct P4CConstantFoldingValidation : P4CFrontend {
+    P4CConstantFoldingValidation () {
+        addPasses({
+            new P4::ResolveReferences(&refMap),
+            new P4::ConstantFolding(&refMap, nullptr),
+        });
+    }
+
+    P4::ReferenceMap refMap;
+};
+
+/**
+ * Filter to prevent processing of fields in the "my_hdr_stack_1_t" struct
+ */
+class ConstantFoldFilter {
+ public:
+     const IR::Expression *operator()(Visitor *v, const IR::Expression *e) {
+         auto ts = v->findContext<IR::Type_Struct>();
+         if (ts && ts->name == "my_hdr_stack_1_t") {
+             return e;
+         }
+         return nullptr;
+     }
+};
+
+const IR::StructField *getStructField(const IR::P4Program *program, cstring struct_name,
+                                      cstring field_name) {
+    for (const auto *d : *program->getDeclarations()) {
+        const auto *ts = d->to<IR::Type_Struct>();
+        if (ts && ts->name == struct_name) {
+            for (const auto *f : ts->fields) {
+                const auto *sf = f->to<IR::StructField>();
+                if (sf && sf->name == field_name) {
+                    return sf;
+                }
+            }
+        }
+    }
+    return nullptr;
+}
+
+std::string constantFoldFilterCode = P4_SOURCE(R"(
+const bit<16> CONST_1 = 3;
+const bit<16> CONST_2 = 4;
+
+header my_hdr_t {
+    bit<16>   field;
+}
+
+struct my_hdr_stack_1_t {
+    my_hdr_t[CONST_1]    hdr;
+}
+
+struct my_hdr_stack_2_t {
+    my_hdr_t[CONST_2]    hdr;
+}
+)");
+
+// Constant folding without any filter
+TEST_F(P4CConstantFoldingValidation, no_filter) {
+    auto *program = parseAndProcess(constantFoldFilterCode)->to<IR::P4Program>();;
+    ASSERT_TRUE(program);
+
+    // my_hdr_stack_1_t.hdr should be a Constant
+    auto *sf_1 = getStructField(program, "my_hdr_stack_1_t", "hdr");
+    ASSERT_TRUE(sf_1);
+    auto *ts_1 = sf_1->type->to<IR::Type_Stack>();
+    ASSERT_TRUE(ts_1->size->is<IR::Constant>());
+
+    // my_hdr_stack_2_t.hdr should be a Constant
+    auto *sf_2 = getStructField(program, "my_hdr_stack_2_t", "hdr");
+    ASSERT_TRUE(sf_2);
+    auto *ts_2 = sf_2->type->to<IR::Type_Stack>();
+    ASSERT_TRUE(ts_2->size->is<IR::Constant>());
+
+}
+
+// Constant folding with filtering active
+TEST_F(P4CConstantFoldingValidation, filter) {
+    // Add a filter to skip processing of some structs
+    P4::ConstantFolding::setFilterHook(ConstantFoldFilter());
+
+    auto *program = parseAndProcess(constantFoldFilterCode)->to<IR::P4Program>();;
+    ASSERT_TRUE(program);
+
+    // my_hdr_stack_1_t.hdr should be a Constant
+    auto *sf_1 = getStructField(program, "my_hdr_stack_1_t", "hdr");
+    ASSERT_TRUE(sf_1);
+    auto *ts_1 = sf_1->type->to<IR::Type_Stack>();
+    ASSERT_TRUE(ts_1->size->is<IR::PathExpression>());
+
+    // my_hdr_stack_2_t.hdr should be a Constant
+    auto *sf_2 = getStructField(program, "my_hdr_stack_2_t", "hdr");
+    ASSERT_TRUE(sf_2);
+    auto *ts_2 = sf_2->type->to<IR::Type_Stack>();
+    ASSERT_TRUE(ts_2->size->is<IR::Constant>());
+
+    // Clear the filter
+    P4::ConstantFolding::unsetFilterHook();
+}
+
+}  // namespace Test

--- a/test/gtest/constant_folding.cpp
+++ b/test/gtest/constant_folding.cpp
@@ -29,7 +29,7 @@ struct P4CFrontend : P4CTest {
 };
 
 struct P4CConstantFoldingValidation : P4CFrontend {
-    P4CConstantFoldingValidation () {
+    P4CConstantFoldingValidation() {
         addPasses({
             new P4::ResolveReferences(&refMap),
             new P4::ConstantFolding(&refMap, nullptr),
@@ -44,13 +44,13 @@ struct P4CConstantFoldingValidation : P4CFrontend {
  */
 class ConstantFoldFilter {
  public:
-     const IR::Expression *operator()(Visitor *v, const IR::Expression *e) {
-         auto ts = v->findContext<IR::Type_Struct>();
-         if (ts && ts->name == "my_hdr_stack_1_t") {
-             return e;
-         }
-         return nullptr;
-     }
+    const IR::Expression *operator()(Visitor *v, const IR::Expression *e) {
+        auto ts = v->findContext<IR::Type_Struct>();
+        if (ts && ts->name == "my_hdr_stack_1_t") {
+            return e;
+        }
+        return nullptr;
+    }
 };
 
 const IR::StructField *getStructField(const IR::P4Program *program, cstring struct_name,
@@ -88,7 +88,7 @@ struct my_hdr_stack_2_t {
 
 // Constant folding without any filter
 TEST_F(P4CConstantFoldingValidation, no_filter) {
-    auto *program = parseAndProcess(constantFoldFilterCode)->to<IR::P4Program>();;
+    auto *program = parseAndProcess(constantFoldFilterCode)->to<IR::P4Program>();
     ASSERT_TRUE(program);
 
     // my_hdr_stack_1_t.hdr should be a Constant
@@ -102,7 +102,6 @@ TEST_F(P4CConstantFoldingValidation, no_filter) {
     ASSERT_TRUE(sf_2);
     auto *ts_2 = sf_2->type->to<IR::Type_Stack>();
     ASSERT_TRUE(ts_2->size->is<IR::Constant>());
-
 }
 
 // Constant folding with filtering active
@@ -110,10 +109,10 @@ TEST_F(P4CConstantFoldingValidation, filter) {
     // Add a filter to skip processing of some structs
     P4::ConstantFolding::setFilterHook(ConstantFoldFilter());
 
-    auto *program = parseAndProcess(constantFoldFilterCode)->to<IR::P4Program>();;
+    auto *program = parseAndProcess(constantFoldFilterCode)->to<IR::P4Program>();
     ASSERT_TRUE(program);
 
-    // my_hdr_stack_1_t.hdr should be a Constant
+    // my_hdr_stack_1_t.hdr should be a PathExpression, *not* a Constant
     auto *sf_1 = getStructField(program, "my_hdr_stack_1_t", "hdr");
     ASSERT_TRUE(sf_1);
     auto *ts_1 = sf_1->type->to<IR::Type_Stack>();


### PR DESCRIPTION
Hook allows skipping of PathExpression processing. Allows backends to do custom processing.