### PR TITLE
Introduce a frontend policy as a customization point for frontend

### DIFF
--- a/backends/tc/tc.cpp
+++ b/backends/tc/tc.cpp
@@ -55,7 +55,8 @@ int main(int argc, char *const argv[]) {
     try {
         P4::P4COptionPragmaParser optionsPragmaParser;
         program->apply(P4::ApplyOptionsPragmas(optionsPragmaParser));
-        P4::FrontEnd frontend(hook);
+        P4::FrontEnd frontend;
+        frontend.addDebugHook(hook);
         program = frontend.run(options, program);
     } catch (const Util::P4CExceptionBase &bug) {
         std::cerr << bug.what() << std::endl;

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -87,6 +87,7 @@ const IR::Expression *DoConstantFolding::getConstant(const IR::Expression *expr)
 }
 
 const IR::Node *DoConstantFolding::postorder(IR::PathExpression *e) {
+    if (auto *r = policy->hook(*this, e)) return r;
     if (refMap == nullptr || assignmentTarget) return e;
     auto decl = refMap->getDeclaration(e->path);
     if (decl == nullptr) return e;

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -87,7 +87,7 @@ const IR::Expression *DoConstantFolding::getConstant(const IR::Expression *expr)
 }
 
 const IR::Node *DoConstantFolding::postorder(IR::PathExpression *e) {
-    if (auto *r = policy->hook(*this, e)) return r;
+    if (const auto *r = policy->hook(*this, e)) return r;
     if (refMap == nullptr || assignmentTarget) return e;
     auto decl = refMap->getDeclaration(e->path);
     if (decl == nullptr) return e;

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -23,6 +23,18 @@ limitations under the License.
 
 namespace P4 {
 
+/// A policy for constant folding that allows customization of the folding.
+/// Currently we only have hook for customizing IR::PathExpression, but more can be added.
+/// Each hook takes a visitor and a node and is called from the visitor's preorder function on that
+/// node. If the hook returns a non-null value, so will the preorder. Otherwise the preorder
+/// continues with its normal processing. The hooks can be stateful, they are non-const member
+/// functions.
+class ConstantFoldingPolicy {
+ public:
+    /// The default hook does not modify anything.
+    virtual IR::Node *hook(Visitor &, IR::PathExpression *) { return nullptr; }
+};
+
 /** @brief statically evaluates many constant expressions.
  *
  * This pass can be invoked either with or without the `refMap` and
@@ -45,6 +57,8 @@ namespace P4 {
  */
 class DoConstantFolding : public Transform {
  protected:
+    ConstantFoldingPolicy *policy;
+
     /// Used to resolve IR nodes to declarations.
     /// If `nullptr`, then `const` values cannot be resolved.
     const ReferenceMap *refMap;
@@ -97,8 +111,14 @@ class DoConstantFolding : public Transform {
     Result setContains(const IR::Expression *keySet, const IR::Expression *constant) const;
 
  public:
-    DoConstantFolding(const ReferenceMap *refMap, const TypeMap *typeMap, bool warnings = true)
+    DoConstantFolding(const ReferenceMap *refMap, const TypeMap *typeMap, bool warnings = true,
+        ConstantFoldingPolicy *policy = nullptr)
         : refMap(refMap), typeMap(typeMap), typesKnown(typeMap != nullptr), warnings(warnings) {
+        if (policy) {
+            this->policy = policy;
+        } else {
+            this->policy = new ConstantFoldingPolicy();
+        }
         visitDagOnce = true;
         setName("DoConstantFolding");
         assignmentTarget = false;
@@ -149,16 +169,18 @@ class DoConstantFolding : public Transform {
 
 /** Optionally runs @ref TypeChecking if @p typeMap is not
  *  `nullptr`, and then runs @ref DoConstantFolding.
+ * If policy is provided, it can modify behaviour of the constant folder.
  */
 class ConstantFolding : public PassManager {
  public:
     ConstantFolding(ReferenceMap *refMap, TypeMap *typeMap, bool warnings = true,
-                    TypeChecking *typeChecking = nullptr) {
+                    TypeChecking *typeChecking = nullptr,
+                    ConstantFoldingPolicy *policy = nullptr) {
         if (typeMap != nullptr) {
             if (!typeChecking) typeChecking = new TypeChecking(refMap, typeMap);
             passes.push_back(typeChecking);
         }
-        passes.push_back(new DoConstantFolding(refMap, typeMap, warnings));
+        passes.push_back(new DoConstantFolding(refMap, typeMap, warnings, policy));
         if (typeMap != nullptr) passes.push_back(new ClearTypeMap(typeMap));
         setName("ConstantFolding");
     }

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -112,7 +112,7 @@ class DoConstantFolding : public Transform {
 
  public:
     DoConstantFolding(const ReferenceMap *refMap, const TypeMap *typeMap, bool warnings = true,
-        ConstantFoldingPolicy *policy = nullptr)
+                      ConstantFoldingPolicy *policy = nullptr)
         : refMap(refMap), typeMap(typeMap), typesKnown(typeMap != nullptr), warnings(warnings) {
         if (policy) {
             this->policy = policy;
@@ -174,8 +174,7 @@ class DoConstantFolding : public Transform {
 class ConstantFolding : public PassManager {
  public:
     ConstantFolding(ReferenceMap *refMap, TypeMap *typeMap, bool warnings = true,
-                    TypeChecking *typeChecking = nullptr,
-                    ConstantFoldingPolicy *policy = nullptr) {
+                    TypeChecking *typeChecking = nullptr, ConstantFoldingPolicy *policy = nullptr) {
         if (typeMap != nullptr) {
             if (!typeChecking) typeChecking = new TypeChecking(refMap, typeMap);
             passes.push_back(typeChecking);

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -173,6 +173,9 @@ class DoConstantFolding : public Transform {
  */
 class ConstantFolding : public PassManager {
  public:
+    ConstantFolding(ReferenceMap *refMap, TypeMap *typeMap, ConstantFoldingPolicy *policy)
+        : ConstantFolding(refMap, typeMap, true, nullptr, policy) {}
+
     ConstantFolding(ReferenceMap *refMap, TypeMap *typeMap, bool warnings = true,
                     TypeChecking *typeChecking = nullptr, ConstantFoldingPolicy *policy = nullptr) {
         if (typeMap != nullptr) {

--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -32,7 +32,7 @@ namespace P4 {
 class ConstantFoldingPolicy {
  public:
     /// The default hook does not modify anything.
-    virtual IR::Node *hook(Visitor &, IR::PathExpression *) { return nullptr; }
+    virtual const IR::Node *hook(Visitor &, IR::PathExpression *) { return nullptr; }
 };
 
 /** @brief statically evaluates many constant expressions.

--- a/frontends/common/options.cpp
+++ b/frontends/common/options.cpp
@@ -34,7 +34,7 @@ CompilerOptions::CompilerOptions() : ParserOptions() {
         [this](const char *) {
             listFrontendPasses = true;
             P4::FrontEnd frontend;
-            frontend.run(*this, nullptr, false, outStream);
+            frontend.run(*this, nullptr, outStream);
             exit(0);
             return false;
         },

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -23,7 +23,7 @@ limitations under the License.
 
 namespace P4 {
 
-class ConstantFoldingPolicy; // forward declare to avoid having to include
+class ConstantFoldingPolicy;  // forward declare to avoid having to include
 
 /// A customization point for frotend. The each tool can provide their own implementation of the
 /// policy that customazes its behaviour, or use instance of this class directly to provide the
@@ -50,7 +50,9 @@ class FrontEndPolicy {
     /// etc.).
     /// @returns default to enabled optimizations unless -O0 was given in the options (i.e. enabled
     /// unless options.optimizationLevel == 0).
-    virtual bool optimize(const CompilerOptions &options) const { return options.optimizationLevel > 0; }
+    virtual bool optimize(const CompilerOptions &options) const {
+        return options.optimizationLevel > 0;
+    }
 
     /// Get policy for the constant folding pass. @see ConstantFoldingPolicy
     /// @returns Defaults to nullptr, which causes constant folding to use the default policy, which

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -23,25 +23,52 @@ limitations under the License.
 
 namespace P4 {
 
-class FrontEnd {
-    /// A pass for parsing annotations.
-    ParseAnnotations parseAnnotations;
+class ConstantFoldingPolicy; // forward declare to avoid having to include
 
+/// A customization point for frotend. The each tool can provide their own implementation of the
+/// policy that customazes its behaviour, or use instance of this class directly to provide the
+/// defaults.
+class FrontEndPolicy {
+ public:
+    virtual ~FrontEndPolicy() = default;
+
+    /// Get a vector of debug hooks that will be added to frontend and all the pass managers it
+    /// uses internally.
+    /// @returns Defaults to no hooks.
+    virtual std::vector<DebugHook> getDebugHooks() const { return {}; }
+
+    /// A specialized instance of annotations parser for the target, or nullptr to use the
+    /// default configuration.
+    /// @returns Defaults to nullptr.
+    virtual ParseAnnotations *getParseAnnotations() const { return nullptr; }
+
+    /// Indicates whether the side-effect-ordering pass should be skipped.
+    /// @returns Defaults to false.
+    virtual bool skipSideEffectOrdering() const { return false; }
+
+    /// Indicates whether the frontend shoud run some optimizations (inlining, action localization,
+    /// etc.).
+    /// @returns default to enabled optimizations unless -O0 was given in the options (i.e. enabled
+    /// unless options.optimizationLevel == 0).
+    virtual bool optimize(const CompilerOptions &options) const { return options.optimizationLevel > 0; }
+
+    /// Get policy for the constant folding pass. @see ConstantFoldingPolicy
+    /// @returns Defaults to nullptr, which causes constant folding to use the default policy, which
+    /// does not modify the pass defaults in any way.
+    virtual ConstantFoldingPolicy *getConstantFoldingPolicy() const { return nullptr; }
+};
+
+class FrontEnd {
+    FrontEndPolicy *policy;
     std::vector<DebugHook> hooks;
 
  public:
-    FrontEnd() = default;
-    explicit FrontEnd(const ParseAnnotations &parseAnnotations)
-        : parseAnnotations(parseAnnotations) {}
-    explicit FrontEnd(const DebugHook &hook) { hooks.push_back(hook); }
-    explicit FrontEnd(const ParseAnnotations &parseAnnotations, const DebugHook &hook)
-        : FrontEnd(parseAnnotations) {
-        hooks.push_back(hook);
-    }
+    FrontEnd() : FrontEnd(new FrontEndPolicy()) {}
+    explicit FrontEnd(FrontEndPolicy *policy) : policy(policy), hooks(policy->getDebugHooks()) {}
+
     void addDebugHook(const DebugHook &hook) { hooks.push_back(hook); }
     // If p4c is run with option '--listFrontendPasses', outStream is used for printing passes names
     const IR::P4Program *run(const CompilerOptions &options, const IR::P4Program *program,
-                             bool skipSideEffectOrdering = false,
                              std::ostream *outStream = nullptr);
 };
 

--- a/test/gtest/helpers.cpp
+++ b/test/gtest/helpers.cpp
@@ -155,7 +155,8 @@ struct FrontEndAnnoPolicy : P4::FrontEndPolicy {
 
     /// Pass given ParseAnnotations instance to frontend. The parameter can be null to indicate to
     /// use the default.
-    explicit FrontEndAnnoPolicy(P4::ParseAnnotations *parseAnnotations) : parseAnnotations(parseAnnotations) {}
+    explicit FrontEndAnnoPolicy(P4::ParseAnnotations *parseAnnotations)
+        : parseAnnotations(parseAnnotations) {}
 
     P4::ParseAnnotations *getParseAnnotations() const override { return parseAnnotations; }
 };

--- a/test/gtest/helpers.cpp
+++ b/test/gtest/helpers.cpp
@@ -150,12 +150,22 @@ P4CTestEnvironment::P4CTestEnvironment() {
 
 namespace Test {
 
+struct FrontEndAnnoPolicy : P4::FrontEndPolicy {
+    P4::ParseAnnotations *parseAnnotations;
+
+    /// Pass given ParseAnnotations instance to frontend. The parameter can be null to indicate to
+    /// use the default.
+    explicit FrontEndAnnoPolicy(P4::ParseAnnotations *parseAnnotations) : parseAnnotations(parseAnnotations) {}
+
+    P4::ParseAnnotations *getParseAnnotations() const override { return parseAnnotations; }
+};
+
 /* static */ std::optional<FrontendTestCase> FrontendTestCase::create(
     const std::string &source,
     CompilerOptions::FrontendVersion langVersion
     /* = CompilerOptions::FrontendVersion::P4_16 */,
-    const P4::ParseAnnotations &parseAnnotations
-    /* = P4::ParseAnnotations() */) {
+    P4::ParseAnnotations *parseAnnotations
+    /* = nullptr */) {
     auto *program = P4::parseP4String(source, langVersion);
     if (program == nullptr) {
         std::cerr << "Couldn't parse test case source" << std::endl;
@@ -177,7 +187,7 @@ namespace Test {
 
     CompilerOptions options;
     options.langVersion = langVersion;
-    program = P4::FrontEnd(parseAnnotations).run(options, program, true);
+    program = P4::FrontEnd(new FrontEndAnnoPolicy(parseAnnotations)).run(options, program);
     if (program == nullptr) {
         std::cerr << "Frontend failed" << std::endl;
         return std::nullopt;

--- a/test/gtest/helpers.h
+++ b/test/gtest/helpers.h
@@ -117,10 +117,10 @@ struct FrontendTestCase {
     /// Create a test case that only requires the frontend to run.
     static std::optional<FrontendTestCase> create(
         const std::string &source, CompilerOptions::FrontendVersion langVersion = defaultVersion,
-        const P4::ParseAnnotations &parseAnnotations = P4::ParseAnnotations());
+        P4::ParseAnnotations *parseAnnotations = nullptr);
 
     static std::optional<FrontendTestCase> create(const std::string &source,
-                                                  const P4::ParseAnnotations &parseAnnotations) {
+                                                  P4::ParseAnnotations *parseAnnotations) {
         return create(source, defaultVersion, parseAnnotations);
     }
 

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -76,14 +76,14 @@ std::optional<P4::P4RuntimeAPI> createP4RuntimeTestCase(
     const std::string &source,
     CompilerOptions::FrontendVersion langVersion = FrontendTestCase::defaultVersion,
     const cstring arch = defaultArch,
-    P4::ParseAnnotations parseAnnotations = P4::ParseAnnotations()) {
+    P4::ParseAnnotations *parseAnnotations = new P4::ParseAnnotations()) {
     auto frontendTestCase = FrontendTestCase::create(source, langVersion, parseAnnotations);
     if (!frontendTestCase) return std::nullopt;
     return P4::generateP4Runtime(frontendTestCase->program, arch);
 }
 
 std::optional<P4::P4RuntimeAPI> createP4RuntimeTestCase(const std::string &source,
-                                                        P4::ParseAnnotations parseAnnotations) {
+                                                        P4::ParseAnnotations *parseAnnotations) {
     return createP4RuntimeTestCase(source, FrontendTestCase::defaultVersion, defaultArch,
                                    parseAnnotations);
 }
@@ -1251,7 +1251,7 @@ TEST_F(P4Runtime, ValueSet) {
         V1Switch(parse(), verifyChecksum(), ingress(), egress(),
                  computeChecksum(), deparse()) main;
     )"),
-                                        ParseAnnotations());
+                                        new ParseAnnotations());
 
     ASSERT_TRUE(test);
     EXPECT_EQ(0U, ::diagnosticCount());
@@ -1312,7 +1312,7 @@ TEST_F(P4Runtime, Register) {
         V1Switch(parse(), verifyChecksum(), ingress(), egress(),
                  computeChecksum(), deparse()) main;
     )"),
-                                        ParseAnnotations());
+                                        new ParseAnnotations());
 
     ASSERT_TRUE(test);
     EXPECT_EQ(0U, ::diagnosticCount());


### PR DESCRIPTION
This was spurred by #4402, but the scope is a bit more general. I've tried to allow customization (almost) all the customizations of frontend into one class that a backend tool can override to tweak certain behaviours.

On top of the things that were already there, and the customization of constant folding that @grg had in #4402, I've added a hook for deciding if optimizations should run -- that is a use case that I have.