### PR TITLE
Emit a reasonable error if someone uses type in place where expression is exprected

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -3052,6 +3052,9 @@ const IR::Node *TypeInference::postorder(IR::PathExpression *expression) {
         if (type != nullptr)
             // may be nullptr because typechecking may have failed
             type = cloneWithFreshTypeVariables(type->to<IR::Type_MethodBase>());
+    } else if (decl->is<IR::Type_Declaration>()) {
+        typeError("%1%: Type cannot be used here, expecting an expression.", expression);
+        return expression;
     }
 
     if (type == nullptr) {

--- a/testdata/p4_16_errors/type-in-expr-lex0.p4
+++ b/testdata/p4_16_errors/type-in-expr-lex0.p4
@@ -1,0 +1,9 @@
+// tests problems related to https://github.com/p4lang/p4c/pull/4411
+
+#include <core.p4>
+
+control ctrl<H>(bool val);
+
+package pkg<H>(
+    ctrl<H> val = ctrl(H > 3)
+);

--- a/testdata/p4_16_errors/type-in-expr-lex1.p4
+++ b/testdata/p4_16_errors/type-in-expr-lex1.p4
@@ -1,0 +1,10 @@
+// tests problems related to https://github.com/p4lang/p4c/pull/4411
+
+#include <core.p4>
+
+parser pars<H>(in bit<16> buf, out H hdrs) {
+    bool var;
+    state start {
+        var = buf > H; 
+    }
+}

--- a/testdata/p4_16_errors/type-in-expr.p4
+++ b/testdata/p4_16_errors/type-in-expr.p4
@@ -1,3 +1,5 @@
+// tests problem solved by https://github.com/p4lang/p4c/pull/4411
+
 #include <core.p4>
 
 @foo[bar=4<H]

--- a/testdata/p4_16_errors/type-in-expr.p4
+++ b/testdata/p4_16_errors/type-in-expr.p4
@@ -1,0 +1,8 @@
+#include <core.p4>
+
+@foo[bar=4<H]
+control p<H>(in H hdrs, out bool flag)
+{
+    apply {
+    }
+}

--- a/testdata/p4_16_errors_outputs/type-in-expr-lex0.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-in-expr-lex0.p4-stderr
@@ -1,0 +1,4 @@
+type-in-expr-lex0.p4(8):syntax error, unexpected >, expecting (
+    ctrl<H> val = ctrl(H >
+                         ^
+[--Werror=overlimit] error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/type-in-expr-lex1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-in-expr-lex1.p4-stderr
@@ -1,0 +1,4 @@
+type-in-expr-lex1.p4(8):syntax error, unexpected ;, expecting (
+        var = buf > H;
+                     ^
+[--Werror=overlimit] error: 1 errors encountered, aborting compilation

--- a/testdata/p4_16_errors_outputs/type-in-expr.p4
+++ b/testdata/p4_16_errors_outputs/type-in-expr.p4
@@ -1,0 +1,7 @@
+#include <core.p4>
+
+@foo[bar=4 < H] control p<H>(in H hdrs, out bool flag) {
+    apply {
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/type-in-expr.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-in-expr.p4-stderr
@@ -1,12 +1,12 @@
-type-in-expr.p4(3): [--Werror=type-error] error: H: Type cannot be used here, expecting an expression.
+type-in-expr.p4(5): [--Werror=type-error] error: H: Type cannot be used here, expecting an expression.
 @foo[bar=4<H]
            ^
-type-in-expr.p4(3): [--Werror=type-error] error: 4 < H: structured annotation must be compile-time constant values
+type-in-expr.p4(5): [--Werror=type-error] error: 4 < H: structured annotation must be compile-time constant values
 @foo[bar=4<H]
          ^^^
-type-in-expr.p4(3): [--Werror=type-error] error: H: Type cannot be used here, expecting an expression.
+type-in-expr.p4(5): [--Werror=type-error] error: H: Type cannot be used here, expecting an expression.
 @foo[bar=4<H]
            ^
-type-in-expr.p4(4): [--Werror=type-error] error: Error while analyzing control p
+type-in-expr.p4(6): [--Werror=type-error] error: Error while analyzing control p
 control p<H>(in H hdrs, out bool flag)
         ^

--- a/testdata/p4_16_errors_outputs/type-in-expr.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-in-expr.p4-stderr
@@ -1,0 +1,12 @@
+type-in-expr.p4(3): [--Werror=type-error] error: H: Type cannot be used here, expecting an expression.
+@foo[bar=4<H]
+           ^
+type-in-expr.p4(3): [--Werror=type-error] error: 4 < H: structured annotation must be compile-time constant values
+@foo[bar=4<H]
+         ^^^
+type-in-expr.p4(3): [--Werror=type-error] error: H: Type cannot be used here, expecting an expression.
+@foo[bar=4<H]
+           ^
+type-in-expr.p4(4): [--Werror=type-error] error: Error while analyzing control p
+control p<H>(in H hdrs, out bool flag)
+        ^


### PR DESCRIPTION
Found by fuzzy testing. Fuzzer created an annotation that contained something like `val=4<H>2` where `H` is a type variable. ~Interestingly, I was not able to reproduce this with p4test, I am getting parsing errors there (both when trying to use type name in annotation and in expression in a control).~ It seems like the only place where this can trigger is in an annotation on the thing that is parametrized by the type variable. The annotation is seemingly (and for parser) *before* the variable declaration, but `findDeclaration` finds it, probably since the declaration is semantically inside the object that introduces the variable. This is a very niche case, but still it should not hit a BUG as it did before (`type-in-expr.p4(4): Could not find type of <Type_Var>(201) H/7 H/7`).