### PR TITLE
[P4Testgen] Add an option to only generate tests with dropped packets. 

### DIFF
--- a/backends/p4tools/modules/testgen/lib/test_backend.h
+++ b/backends/p4tools/modules/testgen/lib/test_backend.h
@@ -53,18 +53,9 @@ class TestBackEnd {
 
     explicit TestBackEnd(const ProgramInfo &programInfo,
                          const TestBackendConfiguration &testBackendConfiguration,
-                         SymbolicExecutor &symbex)
-        : programInfo(programInfo),
-          testBackendConfiguration(testBackendConfiguration),
-          symbex(symbex),
-          maxTests(TestgenOptions::get().maxTests) {
-        // If we select a specific branch, the number of tests should be 1.
-        if (!TestgenOptions::get().selectedBranches.empty()) {
-            maxTests = 1;
-        }
-    }
+                         SymbolicExecutor &symbex);
 
-    [[nodiscard]] bool needsToTerminate(int64_t testCount) const { return testCount == maxTests; }
+    [[nodiscard]] bool needsToTerminate(int64_t testCount) const;
 
  public:
     TestBackEnd(const TestBackEnd &) = default;

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -216,7 +216,21 @@ TestgenOptions::TestgenOptions()
             }
             return true;
         },
-        "Produced tests must have an output packet.");
+        "Produced tests must have an output packet as outcome.");
+
+    registerOption(
+        "--dropped-packet-only", nullptr,
+        [this](const char *) {
+            droppedPacketOnly = true;
+            if (!selectedBranches.empty()) {
+                ::error(
+                    "--input-branches cannot guarantee --dropped-packet-only."
+                    " Aborting.");
+                return false;
+            }
+            return true;
+        },
+        "Produced tests must have a dropped packet as outcome.");
 
     registerOption(
         "--path-selection", "pathSelectionPolicy",

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -72,6 +72,9 @@ class TestgenOptions : public AbstractP4cToolOptions {
     /// Enforces the test generation of tests with mandatory output packet.
     bool outputPacketOnly = false;
 
+    /// Enforces the test generation of tests with mandatory dropped packet.
+    bool droppedPacketOnly = false;
+
     /// Add conditions defined in assert/assume to the path conditions.
     /// Only tests which satisfy these conditions can be generated. This is active by default.
     bool enforceAssumptions = true;

--- a/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TESTGEN_SOURCES
 
 set(TESTGEN_GTEST_SOURCES
   ${TESTGEN_GTEST_SOURCES}
+  ${CMAKE_CURRENT_SOURCE_DIR}/test/testgen_api/output_option_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test/testgen_api/api_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test/test_backend/ptf.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test/test_backend/stf.cpp

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/api_test.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/api_test.cpp
@@ -74,13 +74,9 @@ V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), depa
         ASSERT_TRUE(testListOpt.has_value());
         auto testList = testListOpt.value();
         ASSERT_EQ(testList.size(), 1);
-        const auto *test = testList[0];
-        const auto *protobufIrTest = test->to<P4Tools::P4Testgen::Bmv2::ProtobufIrTest>();
-        ASSERT_TRUE(protobufIrTest != nullptr);
-        EXPECT_THAT(protobufIrTest->getFormattedTest(), ::testing::HasSubstr(R"(input_packet {
-  packet: "\xDE\xAD\xDE\xAD\xDE\xAD\xBE\xEF\xBE\xEF\xBE\xEF\xF0\x0D"
-  port: 0
-})"));
+        const auto *protobufIrTest =
+            testList[0]->checkedTo<P4Tools::P4Testgen::Bmv2::ProtobufIrTest>();
+        EXPECT_THAT(protobufIrTest->getFormattedTest(), ::testing::HasSubstr(R"(input_packet)"));
     }
     /// Now try running again with the test back end set to Protobuf. The result should be the same.
     testgenOptions.testBackend = "PROTOBUF";
@@ -91,12 +87,7 @@ V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), depa
     ASSERT_TRUE(testListOpt.has_value());
     auto testList = testListOpt.value();
     ASSERT_EQ(testList.size(), 1);
-    auto &test = testList[0];
-    const auto *protobufTest = test->to<P4Tools::P4Testgen::Bmv2::ProtobufTest>();
-    ASSERT_TRUE(protobufTest != nullptr);
-    EXPECT_THAT(protobufTest->getFormattedTest(), ::testing::HasSubstr(R"(input_packet {
-  packet: "\xDE\xAD\xDE\xAD\xDE\xAD\xBE\xEF\xBE\xEF\xBE\xEF\xF0\x0D"
-  port: 0
-})"));
+    const auto *protobufTest = testList[0]->checkedTo<P4Tools::P4Testgen::Bmv2::ProtobufTest>();
+    EXPECT_THAT(protobufTest->getFormattedTest(), ::testing::HasSubstr(R"(input_packet)"));
 }
 }  // namespace Test

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/output_option_test.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/output_option_test.cpp
@@ -1,0 +1,103 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "test/gtest/helpers.h"
+
+#include "backends/p4tools/modules/testgen/options.h"
+#include "backends/p4tools/modules/testgen/targets/bmv2/test_backend/protobuf_ir.h"
+#include "backends/p4tools/modules/testgen/testgen.h"
+
+namespace Test {
+
+TEST(P4TestgenOutputOptionTest, GenerateOuputsCorrectly) {
+    std::stringstream streamTest;
+    streamTest << R"p4(
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> ether_type;
+}
+
+struct Headers {
+  ethernet_t eth_hdr;
+}
+
+struct Metadata {  }
+parser parse(packet_in pkt, out Headers hdr, inout Metadata m, inout standard_metadata_t sm) {
+  state start {
+      pkt.extract(hdr.eth_hdr);
+      transition accept;
+  }
+}
+control ingress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t sm) {
+  apply {
+      if (hdr.eth_hdr.dst_addr == 0xDEADDEADDEAD && hdr.eth_hdr.src_addr == 0xBEEFBEEFBEEF && hdr.eth_hdr.ether_type == 0xF00D) {
+          mark_to_drop(sm);
+      }
+  }
+}
+control egress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t sm) {
+  apply {}
+}
+control deparse(packet_out pkt, in Headers hdr) {
+  apply {
+    pkt.emit(hdr.eth_hdr);
+  }
+}
+control verifyChecksum(inout Headers hdr, inout Metadata meta) {
+  apply {}
+}
+control computeChecksum(inout Headers hdr, inout Metadata meta) {
+  apply {}
+}
+V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), deparse()) main;
+)p4";
+
+    auto source = P4_SOURCE(P4Headers::V1MODEL, streamTest.str().c_str());
+    auto compilerOptions = CompilerOptions();
+    compilerOptions.target = "bmv2";
+    compilerOptions.arch = "v1model";
+    auto &testgenOptions = P4Tools::P4Testgen::TestgenOptions::get();
+    testgenOptions.testBackend = "PROTOBUF_IR";
+    testgenOptions.testBaseName = "dummy";
+    testgenOptions.seed = 1;
+    testgenOptions.maxTests = 0;
+    // Create a bespoke packet for the Ethernet extract call.
+    testgenOptions.minPktSize = 112;
+    testgenOptions.maxPktSize = 112;
+
+    // In this test we only generate tests with dropped packets.
+    {
+        testgenOptions.droppedPacketOnly = true;
+
+        auto testListOpt =
+            P4Tools::P4Testgen::Testgen::generateTests(source, compilerOptions, testgenOptions);
+
+        ASSERT_TRUE(testListOpt.has_value());
+        auto testList = testListOpt.value();
+        ASSERT_EQ(testList.size(), 1);
+        const auto *protobufIrTest =
+            testList[0]->checkedTo<P4Tools::P4Testgen::Bmv2::ProtobufIrTest>();
+        EXPECT_THAT(protobufIrTest->getFormattedTest(),
+                    testing::Not(testing::HasSubstr(R"(expected_output_packet)")));
+    }
+
+    // Here we flip the option and only generate tests with forwarded packets.
+    {
+        testgenOptions.droppedPacketOnly = false;
+        testgenOptions.outputPacketOnly = true;
+
+        auto testListOpt =
+            P4Tools::P4Testgen::Testgen::generateTests(source, compilerOptions, testgenOptions);
+
+        ASSERT_TRUE(testListOpt.has_value());
+        auto testList = testListOpt.value();
+        ASSERT_EQ(testList.size(), 1);
+        const auto *protobufIrTest =
+            testList[0]->checkedTo<P4Tools::P4Testgen::Bmv2::ProtobufIrTest>();
+        EXPECT_THAT(protobufIrTest->getFormattedTest(),
+                    testing::HasSubstr(R"(expected_output_packet)"));
+    }
+}
+
+}  // namespace Test


### PR DESCRIPTION
Add an option to P4Testgen to only generate tests where the packet is dropped. This PR also shows the benefits of the new API. We can now write targeted gtests to exercise a feature. Very useful! 

I added tests for both `--dropped-packet-only` and `--output-packet-only`. 