### PR TITLE
gtest include: quotes -> angled brackets

### DIFF
--- a/test/gtest/arch_test.cpp
+++ b/test/gtest/arch_test.cpp
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <gtest/gtest.h>
+
 #include "frontends/common/parseInput.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/createBuiltins.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/p4/typeMap.h"
-#include "gtest/gtest.h"
 #include "helpers.h"
 #include "ir/ir.h"
 #include "lib/log.h"

--- a/test/gtest/bitvec_test.cpp
+++ b/test/gtest/bitvec_test.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include "lib/bitvec.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 namespace Test {
 

--- a/test/gtest/call_graph_test.cpp
+++ b/test/gtest/call_graph_test.cpp
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <gtest/gtest.h>
+
 #include <vector>
 
 #include "frontends/p4/callGraph.h"
-#include "gtest/gtest.h"
 
 namespace Test {
 

--- a/test/gtest/complex_bitwise.cpp
+++ b/test/gtest/complex_bitwise.cpp
@@ -1,3 +1,5 @@
+#include <gtest/gtest.h>
+
 #include <optional>
 
 #include <boost/algorithm/string/replace.hpp>
@@ -7,7 +9,6 @@
 #include "frontends/p4/toP4/toP4.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/p4/typeMap.h"
-#include "gtest/gtest.h"
 #include "helpers.h"
 #include "ir/ir.h"
 #include "lib/log.h"

--- a/test/gtest/constant_expr_test.cpp
+++ b/test/gtest/constant_expr_test.cpp
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "helpers.h"
 #include "ir/ir.h"
 

--- a/test/gtest/cstring.cpp
+++ b/test/gtest/cstring.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "lib/cstring.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 namespace Test {
 

--- a/test/gtest/diagnostics.cpp
+++ b/test/gtest/diagnostics.cpp
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <gtest/gtest.h>
+
 #include <optional>
 #include <vector>
 
 #include <boost/algorithm/string/replace.hpp>
 
 #include "frontends/common/applyOptionsPragmas.h"
-#include "gtest/gtest.h"
 #include "ir/ir.h"
 #include "test/gtest/helpers.h"
 

--- a/test/gtest/dumpjson.cpp
+++ b/test/gtest/dumpjson.cpp
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <gtest/gtest.h>
+
 #include <iostream>
 
-#include "gtest/gtest.h"
 #include "ir/ir.h"
 #include "ir/json_loader.h"
 #include "ir/visitor.h"

--- a/test/gtest/enumerator_test.cpp
+++ b/test/gtest/enumerator_test.cpp
@@ -16,10 +16,10 @@ limitations under the License.
 
 #include "lib/enumerator.h"
 
+#include <gtest/gtest.h>
+
 #include <exception>
 #include <vector>
-
-#include "gtest/gtest.h"
 
 namespace Util {
 

--- a/test/gtest/equiv_test.cpp
+++ b/test/gtest/equiv_test.cpp
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "ir/ir.h"
 #include "ir/visitor.h"
 #include "lib/exceptions.h"

--- a/test/gtest/exception_test.cpp
+++ b/test/gtest/exception_test.cpp
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <gtest/gtest.h>
+
 #include <exception>
 
-#include "gtest/gtest.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 

--- a/test/gtest/expr_uses_test.cpp
+++ b/test/gtest/expr_uses_test.cpp
@@ -16,7 +16,8 @@ limitations under the License.
 
 #include "midend/expr_uses.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "ir/ir.h"
 #include "ir/visitor.h"
 #include "lib/exceptions.h"

--- a/test/gtest/format_test.cpp
+++ b/test/gtest/format_test.cpp
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "lib/cstring.h"
 #include "lib/error.h"
 #include "lib/stringify.h"

--- a/test/gtest/frontend_test.cpp
+++ b/test/gtest/frontend_test.cpp
@@ -1,10 +1,11 @@
+#include <gtest/gtest.h>
+
 #include "frontends/common/constantFolding.h"
 #include "frontends/common/parseInput.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/moveDeclarations.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
-#include "gtest/gtest.h"
 #include "helpers.h"
 #include "ir/ir.h"
 #include "ir/pass_manager.h"

--- a/test/gtest/gtestp4c.cpp
+++ b/test/gtest/gtestp4c.cpp
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "helpers.h"
 
 int main(int argc, char **argv) {

--- a/test/gtest/hvec_map.cpp
+++ b/test/gtest/hvec_map.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "lib/hvec_map.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 namespace Test {
 

--- a/test/gtest/indexed_vector.cpp
+++ b/test/gtest/indexed_vector.cpp
@@ -1,6 +1,7 @@
 #include "ir/indexed_vector.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "ir/ir.h"
 
 namespace Test {

--- a/test/gtest/json_test.cpp
+++ b/test/gtest/json_test.cpp
@@ -16,9 +16,9 @@ limitations under the License.
 
 #include "lib/json.h"
 
-#include <sstream>
+#include <gtest/gtest.h>
 
-#include "gtest/gtest.h"
+#include <sstream>
 
 namespace Util {
 

--- a/test/gtest/load_ir_from_json.cpp
+++ b/test/gtest/load_ir_from_json.cpp
@@ -18,13 +18,14 @@ limitations under the License.
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <gtest/gtest.h>
+
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <thread>
 
-#include "gtest/gtest.h"
 #include "helpers.h"
 #include "ir/ir.h"
 #include "lib/log.h"

--- a/test/gtest/midend_test.cpp
+++ b/test/gtest/midend_test.cpp
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <gtest/gtest.h>
+
 #include "frontends/common/parseInput.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/p4/typeMap.h"
-#include "gtest/gtest.h"
 #include "helpers.h"
 #include "ir/ir.h"
 #include "lib/log.h"

--- a/test/gtest/opeq_test.cpp
+++ b/test/gtest/opeq_test.cpp
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "ir/ir.h"
 #include "ir/visitor.h"
 #include "lib/exceptions.h"

--- a/test/gtest/ordered_map.cpp
+++ b/test/gtest/ordered_map.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "lib/ordered_map.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 namespace Test {
 

--- a/test/gtest/ordered_set.cpp
+++ b/test/gtest/ordered_set.cpp
@@ -16,9 +16,9 @@ limitations under the License.
 
 #include "lib/ordered_set.h"
 
-#include <algorithm>
+#include <gtest/gtest.h>
 
-#include "gtest/gtest.h"
+#include <algorithm>
 
 namespace Test {
 

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -1,3 +1,5 @@
+#include <gtest/gtest.h>
+
 #include <cstdlib>
 #include <fstream>
 
@@ -16,7 +18,6 @@
 #include "frontends/p4/typeMap.h"
 #include "frontends/p4/uniqueNames.h"
 #include "frontends/p4/unusedDeclarations.h"
-#include "gtest/gtest.h"
 #include "ir/ir.h"
 #include "lib/log.h"
 #include "midend/actionSynthesis.h"

--- a/test/gtest/path_test.cpp
+++ b/test/gtest/path_test.cpp
@@ -16,7 +16,8 @@ limitations under the License.
 
 #include "lib/path.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "lib/exceptions.h"
 #include "lib/stringref.h"
 

--- a/test/gtest/rtti_test.cpp
+++ b/test/gtest/rtti_test.cpp
@@ -12,9 +12,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <gtest/gtest.h>
+
 #include <sstream>
 
-#include "gtest/gtest.h"
 #include "ir/ir.h"
 #include "ir/json_loader.h"
 #include "ir/node.h"

--- a/test/gtest/source_file_test.cpp
+++ b/test/gtest/source_file_test.cpp
@@ -16,7 +16,8 @@ limitations under the License.
 
 #include "lib/source_file.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "lib/compile_context.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -15,9 +15,10 @@ limitations under the License.
 */
 #include "lib/stringify.h"
 
+#include <gtest/gtest.h>
+
 #include <cstdarg>
 
-#include "gtest/gtest.h"
 #include "lib/cstring.h"
 
 namespace Test {

--- a/test/gtest/transforms.cpp
+++ b/test/gtest/transforms.cpp
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+
 #include "helpers.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"


### PR DESCRIPTION
Convert quotes to angle brackets in `#include "gtest/gtest.h"`. Suggested by @fruffy in #4421.