### PR TITLE
frontend policy fix: missed ConstantFolding instance

### DIFF
--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -228,7 +228,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new SimplifyDefUse(&refMap, &typeMap),
         new UniqueParameters(&refMap, &typeMap),
         new SimplifyControlFlow(&refMap, &typeMap),
-        new SpecializeAll(&refMap, &typeMap),
+        new SpecializeAll(&refMap, &typeMap, constantFoldingPolicy),
         new RemoveParserControlFlow(&refMap, &typeMap),
         new RemoveReturns(&refMap),
         new RemoveDontcareArgs(&refMap, &typeMap),

--- a/frontends/p4/specialize.cpp
+++ b/frontends/p4/specialize.cpp
@@ -279,8 +279,10 @@ const IR::Node *Specialize::postorder(IR::Declaration_Instance *decl) {
     return instantiate(replacement);
 }
 
-SpecializeAll::SpecializeAll(ReferenceMap *refMap, TypeMap *typeMap) : PassRepeated({}) {
-    passes.emplace_back(new ConstantFolding(refMap, typeMap));
+SpecializeAll::SpecializeAll(ReferenceMap *refMap, TypeMap *typeMap,
+                             ConstantFoldingPolicy *constantFoldingPolicy)
+    : PassRepeated({}) {
+    passes.emplace_back(new ConstantFolding(refMap, typeMap, constantFoldingPolicy));
     passes.emplace_back(new TypeChecking(refMap, typeMap));
     passes.emplace_back(new FindSpecializations(&specMap));
     passes.emplace_back(new Specialize(&specMap));

--- a/frontends/p4/specialize.h
+++ b/frontends/p4/specialize.h
@@ -210,7 +210,8 @@ class SpecializeAll : public PassRepeated {
     SpecializationMap specMap;
 
  public:
-    SpecializeAll(ReferenceMap *refMap, TypeMap *typeMap);
+    SpecializeAll(ReferenceMap *refMap, TypeMap *typeMap,
+                  ConstantFoldingPolicy *constantFoldingPolicy);
 };
 
 }  // namespace P4


### PR DESCRIPTION
Pass the ConstantFoldingPolicy instance to the ConstantFolding instance in SpecializeAll. This was missed in #4406.