### PR TITLE
Provide better hash functions and boilerplate

### DIFF
--- a/lib/cstring.cpp
+++ b/lib/cstring.cpp
@@ -135,7 +135,7 @@ namespace std {
 template <>
 struct hash<table_entry> {
     std::size_t operator()(const table_entry &entry) const {
-        return Util::Hash::murmur(entry.string(), entry.length());
+        return Util::hash(entry.string(), entry.length());
     }
 };
 }  // namespace std

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -381,4 +381,12 @@ struct hash<cstring> {
 };
 }  // namespace std
 
+namespace Util {
+template <>
+struct Hasher<cstring> {
+    size_t operator()(const cstring &c) const { return Util::Hash{}(c.c_str()); }
+};
+
+}  // namespace Util
+
 #endif /* LIB_CSTRING_H_ */

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -374,12 +374,9 @@ namespace std {
 template <>
 struct hash<cstring> {
     std::size_t operator()(const cstring &c) const {
-        // cstrings are internalized, therefore their addresses are unique. Therefore we
-        // can just use their address as hash. However, pointers are bad hashes: their low 2-3 bits
-        // are zero, likewise for the upper bits depending on the ABI. Also, the middle bits might
-        // not have enough entropy as addresses come from some common pool. To solve this problem we
-        // just use a single iteration of hash_avalanche to improve mixing.
-        return Util::hash_avalanche(reinterpret_cast<uint64_t>(c.c_str()));
+        // cstrings are internalized, therefore their addresses are unique; we
+        // can just use their address to produce hash.
+        return Util::Hash{}(c.c_str());
     }
 };
 }  // namespace std

--- a/lib/hash.cpp
+++ b/lib/hash.cpp
@@ -6,6 +6,8 @@
 namespace Util {
 
 namespace {
+using namespace Detail;
+
 constexpr size_t XXH3_SECRETSIZE_MIN = 136;
 constexpr size_t XXH_SECRET_DEFAULT_SIZE = 192;
 
@@ -26,9 +28,6 @@ constexpr uint8_t kSecret[XXH_SECRET_DEFAULT_SIZE] = {
     0x45, 0xcb, 0x3a, 0x8f, 0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
 };
 // clang-format on
-
-constexpr uint64_t PRIME_MX1 = UINT64_C(0x165667919E3779F9);
-constexpr uint64_t PRIME_MX2 = UINT64_C(0x9FB21C651E98DF25);
 
 #if defined(_WIN32) /* Windows is always little endian */ \
     || defined(__LITTLE_ENDIAN__) ||                      \
@@ -126,40 +125,15 @@ constexpr size_t XXH_STRIPE_LEN = 64;
 constexpr size_t XXH_SECRET_CONSUME_RATE = 8;
 constexpr size_t XXH_ACC_NB = XXH_STRIPE_LEN / sizeof(uint64_t);
 
-static uint64_t rotl64(uint64_t X, size_t R) { return (X << R) | (X >> (64 - R)); }
-
 constexpr uint32_t PRIME32_1 = UINT32_C(0x9E3779B1);
 constexpr uint32_t PRIME32_2 = UINT32_C(0x85EBCA77);
 constexpr uint32_t PRIME32_3 = UINT32_C(0xC2B2AE3D);
-
-static const uint64_t PRIME64_1 = UINT64_C(11400714785074694791);
-static const uint64_t PRIME64_2 = UINT64_C(14029467366897019727);
-static const uint64_t PRIME64_3 = UINT64_C(1609587929392839161);
-static const uint64_t PRIME64_4 = UINT64_C(9650029242287828579);
-static const uint64_t PRIME64_5 = UINT64_C(2870177450012600261);
-
-static uint64_t XXH64_avalanche(uint64_t hash) {
-    hash ^= hash >> 33;
-    hash *= PRIME64_2;
-    hash ^= hash >> 29;
-    hash *= PRIME64_3;
-    hash ^= hash >> 32;
-    return hash;
-}
 
 static uint64_t XXH3_avalanche(uint64_t hash) {
     hash ^= hash >> 37;
     hash *= PRIME_MX1;
     hash ^= hash >> 32;
     return hash;
-}
-
-static uint64_t XXH3_rrmxmx(uint64_t acc, uint64_t len) {
-    acc ^= rotl64(acc, 49) ^ rotl64(acc, 24);
-    acc *= PRIME_MX2;
-    acc ^= (acc >> 35) + len;
-    acc *= PRIME_MX2;
-    return acc ^ (acc >> 28);
 }
 
 static uint64_t XXH3_len_1to3_64b(const uint8_t *input, size_t len, const uint8_t *secret,

--- a/lib/hash.cpp
+++ b/lib/hash.cpp
@@ -36,6 +36,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <cassert>
 
 namespace Util {
 

--- a/lib/hash.cpp
+++ b/lib/hash.cpp
@@ -4,105 +4,338 @@
 #include <cstring>
 
 namespace Util {
-namespace Hash {
 
-namespace Detail {
-std::uint32_t murmur32(const void *data, std::uint32_t size) {
-    const std::uint32_t m = 0x5bd1e995;
-    const std::uint64_t seed = 0xc70f6907UL;
-    std::uint32_t result = seed ^ size;
-    const char *raw = static_cast<const char *>(data);
+namespace {
+constexpr size_t XXH3_SECRETSIZE_MIN = 136;
+constexpr size_t XXH_SECRET_DEFAULT_SIZE = 192;
 
-    while (size >= sizeof(std::uint32_t)) {
-        std::uint32_t k;
-        std::memcpy(&k, raw, sizeof(k));
-        k *= m;
-        k ^= k >> 24;
-        k *= m;
-        result *= m;
-        result ^= k;
-        raw += 4;
-        size -= 4;
-    }
+/* Pseudorandom data taken directly from FARSH */
+// clang-format off
+constexpr uint8_t kSecret[XXH_SECRET_DEFAULT_SIZE] = {
+    0xb8, 0xfe, 0x6c, 0x39, 0x23, 0xa4, 0x4b, 0xbe, 0x7c, 0x01, 0x81, 0x2c, 0xf7, 0x21, 0xad, 0x1c,
+    0xde, 0xd4, 0x6d, 0xe9, 0x83, 0x90, 0x97, 0xdb, 0x72, 0x40, 0xa4, 0xa4, 0xb7, 0xb3, 0x67, 0x1f,
+    0xcb, 0x79, 0xe6, 0x4e, 0xcc, 0xc0, 0xe5, 0x78, 0x82, 0x5a, 0xd0, 0x7d, 0xcc, 0xff, 0x72, 0x21,
+    0xb8, 0x08, 0x46, 0x74, 0xf7, 0x43, 0x24, 0x8e, 0xe0, 0x35, 0x90, 0xe6, 0x81, 0x3a, 0x26, 0x4c,
+    0x3c, 0x28, 0x52, 0xbb, 0x91, 0xc3, 0x00, 0xcb, 0x88, 0xd0, 0x65, 0x8b, 0x1b, 0x53, 0x2e, 0xa3,
+    0x71, 0x64, 0x48, 0x97, 0xa2, 0x0d, 0xf9, 0x4e, 0x38, 0x19, 0xef, 0x46, 0xa9, 0xde, 0xac, 0xd8,
+    0xa8, 0xfa, 0x76, 0x3f, 0xe3, 0x9c, 0x34, 0x3f, 0xf9, 0xdc, 0xbb, 0xc7, 0xc7, 0x0b, 0x4f, 0x1d,
+    0x8a, 0x51, 0xe0, 0x4b, 0xcd, 0xb4, 0x59, 0x31, 0xc8, 0x9f, 0x7e, 0xc9, 0xd9, 0x78, 0x73, 0x64,
+    0xea, 0xc5, 0xac, 0x83, 0x34, 0xd3, 0xeb, 0xc3, 0xc5, 0x81, 0xa0, 0xff, 0xfa, 0x13, 0x63, 0xeb,
+    0x17, 0x0d, 0xdd, 0x51, 0xb7, 0xf0, 0xda, 0x49, 0xd3, 0x16, 0x55, 0x26, 0x29, 0xd4, 0x68, 0x9e,
+    0x2b, 0x16, 0xbe, 0x58, 0x7d, 0x47, 0xa1, 0xfc, 0x8f, 0xf8, 0xb8, 0xd1, 0x7a, 0xd0, 0x31, 0xce,
+    0x45, 0xcb, 0x3a, 0x8f, 0x95, 0x16, 0x04, 0x28, 0xaf, 0xd7, 0xfb, 0xca, 0xbb, 0x4b, 0x40, 0x7e,
+};
+// clang-format on
 
-    switch (size) {
-        case 3:
-            result ^= static_cast<unsigned char>(raw[2]) << 16;
-            [[fallthrough]];
-        case 2:
-            result ^= static_cast<unsigned char>(raw[1]) << 8;
-            [[fallthrough]];
-        case 1:
-            result ^= static_cast<unsigned char>(raw[0]);
-            result *= m;
-            break;
-    }
+constexpr uint64_t PRIME_MX1 = UINT64_C(0x165667919E3779F9);
+constexpr uint64_t PRIME_MX2 = UINT64_C(0x9FB21C651E98DF25);
 
-    result ^= result >> 13;
-    result *= m;
-    result ^= result >> 15;
-    return result;
+#if defined(_WIN32) /* Windows is always little endian */ \
+    || defined(__LITTLE_ENDIAN__) ||                      \
+    (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define XXH_CPU_LITTLE_ENDIAN 1
+#elif defined(__BIG_ENDIAN__) || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define XXH_CPU_LITTLE_ENDIAN 0
+#else
+static int XXH_isLittleEndian(void) {
+    const union {
+        uint32_t u;
+        uint8_t c[4];
+    } one = {1};
+    return one.c[0];
+}
+#define XXH_CPU_LITTLE_ENDIAN XXH_isLittleEndian()
+#endif
+
+inline __attribute__((always_inline)) static uint32_t XXH_read32(const void *memPtr) {
+    uint32_t val;
+    memcpy(&val, memPtr, sizeof(val));
+    return val;
 }
 
-std::uint64_t murmur64(const void *data, std::uint64_t size) {
-    const std::uint64_t mul = (UINT64_C(0xc6a4a793) << 32) + UINT64_C(0x5bd1e995);
+inline __attribute__((always_inline)) static uint64_t XXH_read64(const void *memPtr) {
+    uint64_t val;
+    memcpy(&val, memPtr, sizeof(val));
+    return val;
+}
 
-    const std::uint64_t seed = UINT64_C(0xc70f6907);
+#if defined(_MSC_VER) /* Visual Studio */
+#define XXH_swap32 _byteswap_ulong
+#elif defined(__GNUC__)
+#define XXH_swap32 __builtin_bswap32
+#else
+static uint32_t XXH_swap32(uint32_t x) {
+    return ((x << 24) & 0xff000000) | ((x << 8) & 0x00ff0000) | ((x >> 8) & 0x0000ff00) |
+           ((x >> 24) & 0x000000ff);
+}
+#endif
 
-    const char *const buf = static_cast<const char *>(data);
+#if defined(_MSC_VER) /* Visual Studio */
+#define XXH_swap64 _byteswap_uint64
+#elif defined(__GNUC__)
+#define XXH_swap64 __builtin_bswap64
+#else
+static uint32_t XXH_swap64(uint32_t x) {
+    return ((x << 56) & UINT64_C(0xff00000000000000)) | ((x << 40) & UINT64_C(0x00ff000000000000)) |
+           ((x << 24) & UINT64_C(0x0000ff0000000000)) | ((x << 8) & UINT64_C(0x000000ff00000000)) |
+           ((x >> 8) & UINT64_C(0x00000000ff000000)) | ((x >> 24) & UINT64_C(0x0000000000ff0000)) |
+           ((x >> 40) & UINT64_C(0x000000000000ff00)) | ((x >> 56) & UINT64_C(0x00000000000000ff));
+}
+#endif
 
-    const int alignedSize = size & ~0x7;
-    const char *const end = buf + alignedSize;
+#if (defined(__GNUC__) && (__GNUC__ >= 3)) || \
+    (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 800)) || defined(__clang__)
+#define XXH_likely(x) __builtin_expect(x, 1)
+#define XXH_unlikely(x) __builtin_expect(x, 0)
+#else
+#define XXH_likely(x) (x)
+#define XXH_unlikely(x) (x)
+#endif
 
-    std::uint64_t hash = seed ^ (size * mul);
+inline __attribute__((always_inline)) static uint32_t XXH_readLE32(const void *ptr) {
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_read32(ptr) : XXH_swap32(XXH_read32(ptr));
+}
 
-    for (const char *p = buf; p != end; p += 8) {
-        std::uint64_t k;
-        std::memcpy(&k, p, sizeof(k));
-        k *= mul;
-        k ^= k >> 47;
-        const uint64_t data = (k)*mul;
-        hash ^= data;
-        hash *= mul;
-    }
+inline __attribute__((always_inline)) static uint64_t XXH_readLE64(const void *ptr) {
+    return XXH_CPU_LITTLE_ENDIAN ? XXH_read64(ptr) : XXH_swap64(XXH_read64(ptr));
+}
 
-    if (size & 0x7) {
-        std::uint64_t data = 0;
+// Calculates a 64-bit to 128-bit multiply, then XOR folds it.
+static uint64_t XXH3_mul128_fold64(uint64_t lhs, uint64_t rhs) {
+#if defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
+    __uint128_t product = (__uint128_t)lhs * (__uint128_t)rhs;
+    return uint64_t(product) ^ uint64_t(product >> 64);
 
-        for (std::size_t n = (size & 0x7) - 1;; --n) {
-            data = (data << 8) + static_cast<unsigned char>(end[n]);
+#else
+    /* First calculate all of the cross products. */
+    const uint64_t lo_lo = (lhs & 0xFFFFFFFF) * (rhs & 0xFFFFFFFF);
+    const uint64_t hi_lo = (lhs >> 32) * (rhs & 0xFFFFFFFF);
+    const uint64_t lo_hi = (lhs & 0xFFFFFFFF) * (rhs >> 32);
+    const uint64_t hi_hi = (lhs >> 32) * (rhs >> 32);
 
-            if (n == 0) {
-                break;
-            }
-        }
+    /* Now add the products together. These will never overflow. */
+    const uint64_t cross = (lo_lo >> 32) + (hi_lo & 0xFFFFFFFF) + lo_hi;
+    const uint64_t upper = (hi_lo >> 32) + (cross >> 32) + hi_hi;
+    const uint64_t lower = (cross << 32) | (lo_lo & 0xFFFFFFFF);
 
-        hash ^= data;
-        hash *= mul;
-    }
+    return upper ^ lower;
+#endif
+}
 
-    hash ^= hash >> 47;
-    hash *= mul;
-    hash ^= hash >> 47;
+constexpr size_t XXH_STRIPE_LEN = 64;
+constexpr size_t XXH_SECRET_CONSUME_RATE = 8;
+constexpr size_t XXH_ACC_NB = XXH_STRIPE_LEN / sizeof(uint64_t);
+
+static uint64_t rotl64(uint64_t X, size_t R) { return (X << R) | (X >> (64 - R)); }
+
+constexpr uint32_t PRIME32_1 = UINT32_C(0x9E3779B1);
+constexpr uint32_t PRIME32_2 = UINT32_C(0x85EBCA77);
+constexpr uint32_t PRIME32_3 = UINT32_C(0xC2B2AE3D);
+
+static const uint64_t PRIME64_1 = UINT64_C(11400714785074694791);
+static const uint64_t PRIME64_2 = UINT64_C(14029467366897019727);
+static const uint64_t PRIME64_3 = UINT64_C(1609587929392839161);
+static const uint64_t PRIME64_4 = UINT64_C(9650029242287828579);
+static const uint64_t PRIME64_5 = UINT64_C(2870177450012600261);
+
+static uint64_t XXH64_avalanche(uint64_t hash) {
+    hash ^= hash >> 33;
+    hash *= PRIME64_2;
+    hash ^= hash >> 29;
+    hash *= PRIME64_3;
+    hash ^= hash >> 32;
     return hash;
 }
 
-template <std::size_t Size = sizeof(std::size_t)>
-struct murmur;
-
-template <>
-struct murmur<sizeof(std::uint32_t)> {
-    static std::size_t hash(const void *data, std::size_t size) { return murmur32(data, size); }
-};
-
-template <>
-struct murmur<sizeof(std::uint64_t)> {
-    static std::size_t hash(const void *data, std::size_t size) { return murmur64(data, size); }
-};
-}  // namespace Detail
-
-std::size_t murmur(const void *data, std::size_t size) {
-    return Detail::murmur<>::hash(data, size);
+static uint64_t XXH3_avalanche(uint64_t hash) {
+    hash ^= hash >> 37;
+    hash *= PRIME_MX1;
+    hash ^= hash >> 32;
+    return hash;
 }
-}  // namespace Hash
+
+static uint64_t XXH3_rrmxmx(uint64_t acc, uint64_t len) {
+    acc ^= rotl64(acc, 49) ^ rotl64(acc, 24);
+    acc *= PRIME_MX2;
+    acc ^= (acc >> 35) + len;
+    acc *= PRIME_MX2;
+    return acc ^ (acc >> 28);
+}
+
+static uint64_t XXH3_len_1to3_64b(const uint8_t *input, size_t len, const uint8_t *secret,
+                                  uint64_t seed) {
+    const uint8_t c1 = input[0];
+    const uint8_t c2 = input[len >> 1];
+    const uint8_t c3 = input[len - 1];
+    uint32_t combined =
+        ((uint32_t)c1 << 16) | ((uint32_t)c2 << 24) | ((uint32_t)c3 << 0) | ((uint32_t)len << 8);
+    uint64_t bitflip = (uint64_t)(XXH_readLE32(secret) ^ XXH_readLE32(secret + 4)) + seed;
+    return XXH64_avalanche(uint64_t(combined) ^ bitflip);
+}
+
+static uint64_t XXH3_len_4to8_64b(const uint8_t *input, size_t len, const uint8_t *secret,
+                                  uint64_t seed) {
+    seed ^= (uint64_t)XXH_swap32(uint32_t(seed)) << 32;
+    const uint32_t input1 = XXH_readLE32(input);
+    const uint32_t input2 = XXH_readLE32(input + len - 4);
+    uint64_t acc = (XXH_readLE64(secret + 8) ^ XXH_readLE64(secret + 16)) - seed;
+    const uint64_t input64 = (uint64_t)input2 | ((uint64_t)input1 << 32);
+    acc ^= input64;
+    // XXH3_rrmxmx(acc, len)
+    acc ^= rotl64(acc, 49) ^ rotl64(acc, 24);
+    acc *= PRIME_MX2;
+    acc ^= (acc >> 35) + (uint64_t)len;
+    acc *= PRIME_MX2;
+    return acc ^ (acc >> 28);
+}
+
+static uint64_t XXH3_len_9to16_64b(const uint8_t *input, size_t len, const uint8_t *secret,
+                                   uint64_t const seed) {
+    uint64_t input_lo = (XXH_readLE64(secret + 24) ^ XXH_readLE64(secret + 32)) + seed;
+    uint64_t input_hi = (XXH_readLE64(secret + 40) ^ XXH_readLE64(secret + 48)) - seed;
+    input_lo ^= XXH_readLE64(input);
+    input_hi ^= XXH_readLE64(input + len - 8);
+    uint64_t acc =
+        uint64_t(len) + XXH_swap64(input_lo) + input_hi + XXH3_mul128_fold64(input_lo, input_hi);
+    return XXH3_avalanche(acc);
+}
+
+inline __attribute__((always_inline)) static uint64_t XXH3_len_0to16_64b(const uint8_t *input,
+                                                                         size_t len,
+                                                                         const uint8_t *secret,
+                                                                         uint64_t const seed) {
+    if (XXH_likely(len > 8)) return XXH3_len_9to16_64b(input, len, secret, seed);
+    if (XXH_likely(len >= 4)) return XXH3_len_4to8_64b(input, len, secret, seed);
+    if (len != 0) return XXH3_len_1to3_64b(input, len, secret, seed);
+    return XXH64_avalanche(seed ^ XXH_readLE64(secret + 56) ^ XXH_readLE64(secret + 64));
+}
+
+static uint64_t XXH3_mix16B(const uint8_t *input, uint8_t const *secret, uint64_t seed) {
+    uint64_t lhs = seed;
+    uint64_t rhs = 0U - seed;
+    lhs += XXH_readLE64(secret);
+    rhs += XXH_readLE64(secret + 8);
+    lhs ^= XXH_readLE64(input);
+    rhs ^= XXH_readLE64(input + 8);
+    return XXH3_mul128_fold64(lhs, rhs);
+}
+
+/* For mid range keys, XXH3 uses a Mum-hash variant. */
+inline __attribute__((always_inline)) static uint64_t XXH3_len_17to128_64b(const uint8_t *input,
+                                                                           size_t len,
+                                                                           const uint8_t *secret,
+                                                                           uint64_t const seed) {
+    uint64_t acc = len * PRIME64_1, acc_end;
+    acc += XXH3_mix16B(input + 0, secret + 0, seed);
+    acc_end = XXH3_mix16B(input + len - 16, secret + 16, seed);
+    if (len > 32) {
+        acc += XXH3_mix16B(input + 16, secret + 32, seed);
+        acc_end += XXH3_mix16B(input + len - 32, secret + 48, seed);
+        if (len > 64) {
+            acc += XXH3_mix16B(input + 32, secret + 64, seed);
+            acc_end += XXH3_mix16B(input + len - 48, secret + 80, seed);
+            if (len > 96) {
+                acc += XXH3_mix16B(input + 48, secret + 96, seed);
+                acc_end += XXH3_mix16B(input + len - 64, secret + 112, seed);
+            }
+        }
+    }
+    return XXH3_avalanche(acc + acc_end);
+}
+
+constexpr size_t XXH3_MIDSIZE_MAX = 240;
+
+__attribute__((noinline)) static uint64_t XXH3_len_129to240_64b(const uint8_t *input, size_t len,
+                                                                const uint8_t *secret,
+                                                                uint64_t seed) {
+    constexpr size_t XXH3_MIDSIZE_STARTOFFSET = 3;
+    constexpr size_t XXH3_MIDSIZE_LASTOFFSET = 17;
+    uint64_t acc = (uint64_t)len * PRIME64_1;
+    const unsigned nbRounds = len / 16;
+    for (unsigned i = 0; i < 8; ++i) acc += XXH3_mix16B(input + 16 * i, secret + 16 * i, seed);
+    acc = XXH3_avalanche(acc);
+
+    for (unsigned i = 8; i < nbRounds; ++i) {
+        acc += XXH3_mix16B(input + 16 * i, secret + 16 * (i - 8) + XXH3_MIDSIZE_STARTOFFSET, seed);
+    }
+    /* last bytes */
+    acc +=
+        XXH3_mix16B(input + len - 16, secret + XXH3_SECRETSIZE_MIN - XXH3_MIDSIZE_LASTOFFSET, seed);
+    return XXH3_avalanche(acc);
+}
+
+inline __attribute__((always_inline)) static void XXH3_accumulate_512_scalar(
+    uint64_t *acc, const uint8_t *input, const uint8_t *secret) {
+    for (size_t i = 0; i < XXH_ACC_NB; ++i) {
+        uint64_t data_val = XXH_readLE64(input + 8 * i);
+        uint64_t data_key = data_val ^ XXH_readLE64(secret + 8 * i);
+        acc[i ^ 1] += data_val;
+        acc[i] += uint32_t(data_key) * (data_key >> 32);
+    }
+}
+
+inline __attribute__((always_inline)) static void XXH3_accumulate_scalar(uint64_t *acc,
+                                                                         const uint8_t *input,
+                                                                         const uint8_t *secret,
+                                                                         size_t nbStripes) {
+    for (size_t n = 0; n < nbStripes; ++n)
+        XXH3_accumulate_512_scalar(acc, input + n * XXH_STRIPE_LEN,
+                                   secret + n * XXH_SECRET_CONSUME_RATE);
+}
+
+static void XXH3_scrambleAcc(uint64_t *acc, const uint8_t *secret) {
+    for (size_t i = 0; i < XXH_ACC_NB; ++i) {
+        acc[i] ^= acc[i] >> 47;
+        acc[i] ^= XXH_readLE64(secret + 8 * i);
+        acc[i] *= PRIME32_1;
+    }
+}
+
+static uint64_t XXH3_mix2Accs(const uint64_t *acc, const uint8_t *secret) {
+    return XXH3_mul128_fold64(acc[0] ^ XXH_readLE64(secret), acc[1] ^ XXH_readLE64(secret + 8));
+}
+
+static uint64_t XXH3_mergeAccs(const uint64_t *acc, const uint8_t *key, uint64_t start) {
+    uint64_t result64 = start;
+    for (size_t i = 0; i < 4; ++i) result64 += XXH3_mix2Accs(acc + 2 * i, key + 16 * i);
+    return XXH3_avalanche(result64);
+}
+
+__attribute__((noinline)) static uint64_t XXH3_hashLong_64b(const uint8_t *input, size_t len,
+                                                            const uint8_t *secret,
+                                                            size_t secretSize) {
+    const size_t nbStripesPerBlock = (secretSize - XXH_STRIPE_LEN) / XXH_SECRET_CONSUME_RATE;
+    const size_t block_len = XXH_STRIPE_LEN * nbStripesPerBlock;
+    const size_t nb_blocks = (len - 1) / block_len;
+    alignas(16) uint64_t acc[XXH_ACC_NB] = {
+        PRIME32_3, PRIME64_1, PRIME64_2, PRIME64_3, PRIME64_4, PRIME32_2, PRIME64_5, PRIME32_1,
+    };
+    for (size_t n = 0; n < nb_blocks; ++n) {
+        XXH3_accumulate_scalar(acc, input + n * block_len, secret, nbStripesPerBlock);
+        XXH3_scrambleAcc(acc, secret + secretSize - XXH_STRIPE_LEN);
+    }
+
+    /* last partial block */
+    const size_t nbStripes = (len - 1 - (block_len * nb_blocks)) / XXH_STRIPE_LEN;
+    assert(nbStripes <= secretSize / XXH_SECRET_CONSUME_RATE);
+    XXH3_accumulate_scalar(acc, input + nb_blocks * block_len, secret, nbStripes);
+
+    /* last stripe */
+    constexpr size_t XXH_SECRET_LASTACC_START = 7;
+    XXH3_accumulate_512_scalar(acc, input + len - XXH_STRIPE_LEN,
+                               secret + secretSize - XXH_STRIPE_LEN - XXH_SECRET_LASTACC_START);
+
+    /* converge into final hash */
+    constexpr size_t XXH_SECRET_MERGEACCS_START = 11;
+    return XXH3_mergeAccs(acc, secret + XXH_SECRET_MERGEACCS_START, (uint64_t)len * PRIME64_1);
+}
+}  // namespace
+
+uint64_t hash(const void *in, size_t len) {
+    const uint8_t *data = reinterpret_cast<const uint8_t *>(in);
+    if (len <= 16) return XXH3_len_0to16_64b(data, len, kSecret, 0);
+    if (len <= 128) return XXH3_len_17to128_64b(data, len, kSecret, 0);
+    if (len <= XXH3_MIDSIZE_MAX) return XXH3_len_129to240_64b(data, len, kSecret, 0);
+    return XXH3_hashLong_64b(data, len, kSecret, sizeof(kSecret));
+}
 }  // namespace Util

--- a/lib/hash.cpp
+++ b/lib/hash.cpp
@@ -7,37 +7,6 @@ namespace Util {
 namespace Hash {
 
 namespace Detail {
-
-template <std::size_t Size = sizeof(std::size_t)>
-struct fnv1a_traits;
-
-template <>
-struct fnv1a_traits<sizeof(std::uint32_t)> {
-    static const std::size_t offset_basis = static_cast<std::size_t>(2166136261);
-    static const std::size_t prime = static_cast<std::size_t>(16777619);
-};
-
-template <>
-struct fnv1a_traits<sizeof(std::uint64_t)> {
-    static const std::size_t offset_basis = static_cast<std::size_t>(14695981039346656037ULL);
-    static const std::size_t prime = static_cast<std::size_t>(1099511628211ULL);
-};
-
-}  // namespace Detail
-
-std::size_t fnv1a(const void *data, std::size_t size) {
-    auto raw = reinterpret_cast<const unsigned char *>(data);
-    std::size_t result = Detail::fnv1a_traits<>::offset_basis;
-
-    for (std::size_t byte = 0; byte < size; ++byte) {
-        result ^= (std::size_t)raw[byte];
-        result *= Detail::fnv1a_traits<>::prime;
-    }
-
-    return result;
-}
-
-namespace Detail {
 std::uint32_t murmur32(const void *data, std::uint32_t size) {
     const std::uint32_t m = 0x5bd1e995;
     const std::uint64_t seed = 0xc70f6907UL;

--- a/lib/hash.cpp
+++ b/lib/hash.cpp
@@ -34,9 +34,9 @@
 
 #include "hash.h"
 
+#include <cassert>
 #include <cstdint>
 #include <cstring>
-#include <cassert>
 
 namespace Util {
 

--- a/lib/hash.cpp
+++ b/lib/hash.cpp
@@ -1,3 +1,37 @@
+/*
+ *  xxHash - Fast Hash algorithm
+ *  Copyright (C) 2012-2021, Yann Collet
+ *
+ *  BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are
+ *  met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *  copyright notice, this list of conditions and the following disclaimer
+ *  in the documentation and/or other materials provided with the
+ *  distribution.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  You can contact the author at :
+ *  - xxHash homepage: http://www.xxhash.com
+ *  - xxHash source repository : https://github.com/Cyan4973/xxHash
+ */
+
 #include "hash.h"
 
 #include <cstdint>

--- a/lib/hash.cpp
+++ b/lib/hash.cpp
@@ -125,10 +125,6 @@ constexpr size_t XXH_STRIPE_LEN = 64;
 constexpr size_t XXH_SECRET_CONSUME_RATE = 8;
 constexpr size_t XXH_ACC_NB = XXH_STRIPE_LEN / sizeof(uint64_t);
 
-constexpr uint32_t PRIME32_1 = UINT32_C(0x9E3779B1);
-constexpr uint32_t PRIME32_2 = UINT32_C(0x85EBCA77);
-constexpr uint32_t PRIME32_3 = UINT32_C(0xC2B2AE3D);
-
 static uint64_t XXH3_avalanche(uint64_t hash) {
     hash ^= hash >> 37;
     hash *= PRIME_MX1;

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -5,23 +5,14 @@
 #include <type_traits>
 
 namespace Util {
-namespace Hash {
-std::size_t murmur(const void *data, std::size_t size);
+uint64_t hash(const void *data, std::size_t size);
 
-// returns Murmur hash sum for object with public methods size() and data()
 template <typename T>
-auto murmur(const T &obj) -> decltype(murmur(obj.data(), obj.size())) {
-    return murmur(obj.data(), obj.size());
+auto hash(
+    const T &obj,
+    typename std::enable_if_t<std::is_standard_layout_v<T> && !std::is_pointer_v<T>> * = nullptr) {
+    return hash(reinterpret_cast<const void *>(&obj), sizeof(T));
 }
-
-// returns fnv1a hash sum for object with standard layout
-template <typename T>
-auto murmur(const T &obj, typename std::enable_if<std::is_standard_layout<T>::value &&
-                                                  !std::is_pointer<T>::value>::type * = nullptr)
-    -> decltype(murmur(reinterpret_cast<const void *>(&obj), sizeof(T))) {
-    return murmur(reinterpret_cast<const void *>(&obj), sizeof(T));
-}
-}  // namespace Hash
 }  // namespace Util
 
 #endif /* LIB_HASH_H_ */

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -2,12 +2,14 @@
 #define LIB_HASH_H_
 
 #include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <limits>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <tuple>
 #include <type_traits>
-#include <memory>
 
 namespace Util {
 
@@ -163,14 +165,6 @@ struct Hasher<signed char> : Detail::IntegerHasher<signed char> {};
 
 template <>
 struct Hasher<char> : Detail::IntegerHasher<char> {};
-
-#if defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
-template <>
-struct Hasher<signed __int128> : Detail::IntegerHasher<signed __int128> {};
-
-template <>
-struct Hasher<unsigned __int128> : Detail::IntegerHasher<unsigned __int128> {};
-#endif
 
 template <>
 struct Hasher<float> : Detail::FloatHasher<float> {};

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -107,12 +107,12 @@ auto hash(const T &obj) -> decltype(hash(obj.data(), obj.size())) {
 }
 
 template <class Key, class Enable = void>
-struct hasher;
+struct Hasher;
 
 struct Hash {
     template <class T>
-    constexpr size_t operator()(const T &v) const noexcept(noexcept(hasher<T>()(v))) {
-        return hasher<T>()(v);
+    constexpr size_t operator()(const T &v) const noexcept(noexcept(Hasher<T>()(v))) {
+        return Hasher<T>()(v);
     }
 
     template <class T, class... Types>
@@ -124,79 +124,79 @@ struct Hash {
 };
 
 template <>
-struct hasher<bool> {
+struct Hasher<bool> {
     constexpr size_t operator()(bool val) const noexcept {
         return val ? std::numeric_limits<size_t>::max() : 0;
     }
 };
 
 template <>
-struct hasher<unsigned long long> : Detail::IntegerHasher<unsigned long long> {};
+struct Hasher<unsigned long long> : Detail::IntegerHasher<unsigned long long> {};
 
 template <>
-struct hasher<signed long long> : Detail::IntegerHasher<signed long long> {};
+struct Hasher<signed long long> : Detail::IntegerHasher<signed long long> {};
 
 template <>
-struct hasher<unsigned long> : Detail::IntegerHasher<unsigned long> {};
+struct Hasher<unsigned long> : Detail::IntegerHasher<unsigned long> {};
 
 template <>
-struct hasher<signed long> : Detail::IntegerHasher<signed long> {};
+struct Hasher<signed long> : Detail::IntegerHasher<signed long> {};
 
 template <>
-struct hasher<unsigned int> : Detail::IntegerHasher<unsigned int> {};
+struct Hasher<unsigned int> : Detail::IntegerHasher<unsigned int> {};
 
 template <>
-struct hasher<signed int> : Detail::IntegerHasher<signed int> {};
+struct Hasher<signed int> : Detail::IntegerHasher<signed int> {};
 
 template <>
-struct hasher<unsigned short> : Detail::IntegerHasher<unsigned short> {};
+struct Hasher<unsigned short> : Detail::IntegerHasher<unsigned short> {};
 
 template <>
-struct hasher<signed short> : Detail::IntegerHasher<signed short> {};
+struct Hasher<signed short> : Detail::IntegerHasher<signed short> {};
 
 template <>
-struct hasher<unsigned char> : Detail::IntegerHasher<unsigned char> {};
+struct Hasher<unsigned char> : Detail::IntegerHasher<unsigned char> {};
 
 template <>
-struct hasher<signed char> : Detail::IntegerHasher<signed char> {};
+struct Hasher<signed char> : Detail::IntegerHasher<signed char> {};
 
 template <>
-struct hasher<char> : Detail::IntegerHasher<char> {};
+struct Hasher<char> : Detail::IntegerHasher<char> {};
 
 #if defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
 template <>
-struct hasher<signed __int128> : Detail::IntegerHasher<signed __int128> {};
+struct Hasher<signed __int128> : Detail::IntegerHasher<signed __int128> {};
 
 template <>
-struct hasher<unsigned __int128> : Detail::IntegerHasher<unsigned __int128> {};
+struct Hasher<unsigned __int128> : Detail::IntegerHasher<unsigned __int128> {};
 #endif
 
 template <>
-struct hasher<float> : Detail::FloatHasher<float> {};
+struct Hasher<float> : Detail::FloatHasher<float> {};
 
 template <>
-struct hasher<double> : Detail::FloatHasher<double> {};
+struct Hasher<double> : Detail::FloatHasher<double> {};
 
 template <>
-struct hasher<std::string> {
+struct Hasher<std::string> {
     size_t operator()(const std::string &val) const {
         return static_cast<size_t>(hash(val.data(), val.size()));
     }
 };
 
 template <>
-struct hasher<std::string_view> {
+struct Hasher<std::string_view> {
     size_t operator()(const std::string_view &val) const {
         return static_cast<size_t>(hash(val.data(), val.size()));
     }
 };
 
 template <typename T1, typename T2>
-struct hasher<std::pair<T1, T2>> {
+struct Hasher<std::pair<T1, T2>> {
     size_t operator()(const std::pair<T1, T2> &val) const { return Hash()(val.first, val.second); }
 };
 template <typename... Types>
-struct hasher<std::tuple<Types...>> {
+struct Hasher<std::tuple<Types...>> {
     size_t operator()(const std::tuple<Types...> &val) const { return apply(Hash(), val); }
 };
 
@@ -205,24 +205,24 @@ struct hasher<std::tuple<Types...>> {
 // enough entropy as addresses come from some common pool. To solve this problem
 // we just use a single iteration of hash_avalanche to improve mixing.
 template <typename T>
-struct hasher<T *> {
+struct Hasher<T *> {
     // FIXME: better use std::bit_cast from C++20
     size_t operator()(T *val) const { return Hash()(reinterpret_cast<std::uintptr_t>(val)); }
 };
 
 template <typename T>
-struct hasher<std::unique_ptr<T>> {
+struct Hasher<std::unique_ptr<T>> {
     size_t operator()(const std::unique_ptr<T> &val) const { return Hash()(val.get()); }
 };
 
 template <typename T>
-struct hasher<std::shared_ptr<T>> {
+struct Hasher<std::shared_ptr<T>> {
     size_t operator()(const std::shared_ptr<T> &val) const { return Hash()(val.get()); }
 };
 
 template <class Iter, class Hash = std::hash<typename std::iterator_traits<Iter>::value_type>>
-uint64_t hash_range(Iter begin, Iter end, uint64_t hash = 0, Hash hasher = Hash()) {
-    for (; begin != end; ++begin) hash = hash_combine(hash, hasher(*begin));
+uint64_t hash_range(Iter begin, Iter end, uint64_t hash = 0, Hash Hasher = Hash()) {
+    for (; begin != end; ++begin) hash = hash_combine(hash, Hasher(*begin));
 
     return hash;
 }

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -6,22 +6,6 @@
 
 namespace Util {
 namespace Hash {
-std::size_t fnv1a(const void *data, std::size_t size);
-
-// returns fnv1a hash sum for object with public methods size() and data()
-template <typename T>
-auto fnv1a(const T &obj) -> decltype(fnv1a(obj.data(), obj.size())) {
-    return fnv1a(obj.data(), obj.size());
-}
-
-// returns fnv1a hash sum for object with standard layout
-template <typename T>
-auto fnv1a(const T &obj, typename std::enable_if<std::is_standard_layout<T>::value &&
-                                                 !std::is_pointer<T>::value>::type * = nullptr)
-    -> decltype(fnv1a(reinterpret_cast<const void *>(&obj), sizeof(T))) {
-    return fnv1a(reinterpret_cast<const void *>(&obj), sizeof(T));
-}
-
 std::size_t murmur(const void *data, std::size_t size);
 
 // returns Murmur hash sum for object with public methods size() and data()

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <tuple>
 #include <type_traits>
+#include <memory>
 
 namespace Util {
 

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -2,11 +2,19 @@
 #define LIB_HASH_H_
 
 #include <cstddef>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <tuple>
 #include <type_traits>
 
 namespace Util {
 
 namespace Detail {
+constexpr uint32_t PRIME32_1 = UINT32_C(0x9E3779B1);
+constexpr uint32_t PRIME32_2 = UINT32_C(0x85EBCA77);
+constexpr uint32_t PRIME32_3 = UINT32_C(0xC2B2AE3D);
+
 constexpr uint64_t PRIME64_1 = UINT64_C(11400714785074694791);
 constexpr uint64_t PRIME64_2 = UINT64_C(14029467366897019727);
 constexpr uint64_t PRIME64_3 = UINT64_C(1609587929392839161);
@@ -16,7 +24,16 @@ constexpr uint64_t PRIME64_5 = UINT64_C(2870177450012600261);
 constexpr uint64_t PRIME_MX1 = UINT64_C(0x165667919E3779F9);
 constexpr uint64_t PRIME_MX2 = UINT64_C(0x9FB21C651E98DF25);
 
-static uint64_t XXH64_avalanche(uint64_t hash) {
+static constexpr uint32_t XXH32_avalanche(uint32_t hash) {
+    hash ^= hash >> 15;
+    hash *= PRIME32_2;
+    hash ^= hash >> 13;
+    hash *= PRIME32_3;
+    hash ^= hash >> 16;
+    return hash;
+}
+
+static constexpr uint64_t XXH64_avalanche(uint64_t hash) {
     hash ^= hash >> 33;
     hash *= PRIME64_2;
     hash ^= hash >> 29;
@@ -25,9 +42,9 @@ static uint64_t XXH64_avalanche(uint64_t hash) {
     return hash;
 }
 
-static uint64_t rotl64(uint64_t X, size_t R) { return (X << R) | (X >> (64 - R)); }
+static constexpr uint64_t rotl64(uint64_t X, size_t R) { return (X << R) | (X >> (64 - R)); }
 
-static uint64_t XXH3_rrmxmx(uint64_t acc, uint64_t len) {
+static constexpr uint64_t XXH3_rrmxmx(uint64_t acc, uint64_t len) {
     acc ^= rotl64(acc, 49) ^ rotl64(acc, 24);
     acc *= PRIME_MX2;
     acc ^= (acc >> 35) + len;
@@ -35,6 +52,45 @@ static uint64_t XXH3_rrmxmx(uint64_t acc, uint64_t len) {
     return acc ^ (acc >> 28);
 }
 
+template <typename Int>
+struct IntegerHasher {
+    constexpr size_t operator()(const Int &i) const noexcept {
+        static_assert(sizeof(Int) <= 16, "unsupported input type");
+        if constexpr (sizeof(Int) <= 4) {
+            return static_cast<size_t>(XXH32_avalanche(static_cast<uint32_t>(i)));
+        } else if constexpr (sizeof(Int) <= 8) {
+            return static_cast<size_t>(XXH64_avalanche(static_cast<uint64_t>(i)));
+        } else {
+            using unsigned_type = std::make_unsigned_t<Int>;
+            auto const u = static_cast<unsigned_type>(i);
+            auto const hi = static_cast<uint64_t>(u >> sizeof(Int) * 4);
+            auto const lo = static_cast<uint64_t>(u);
+            return static_cast<size_t>(XXH3_rrmxmx(hi, lo));
+        }
+    }
+};
+
+template <typename Float>
+struct FloatHasher {
+    size_t operator()(const Float &f) const noexcept {
+        static_assert(sizeof(Float) <= 8, "unsupported input type");
+
+        // Ensure 0 and -0 get the same hash value
+        if (f == Float{}) return 0;
+
+        uint64_t u64 = 0;
+        memcpy(&u64, &f, sizeof(Float));
+        return static_cast<size_t>(XXH64_avalanche(u64));
+    }
+};
+
+class StdHasher {
+ public:
+    template <typename T>
+    size_t operator()(const T &t) const noexcept(noexcept(std::hash<T>()(t))) {
+        return std::hash<T>()(t);
+    }
+};
 }  // namespace Detail
 
 uint64_t hash(const void *data, std::size_t size);
@@ -46,11 +102,188 @@ static inline uint64_t hash_combine(uint64_t lhs, uint64_t rhs) {
 }
 
 template <typename T>
-auto hash(
-    const T &obj,
-    typename std::enable_if_t<std::is_standard_layout_v<T> && !std::is_pointer_v<T>> * = nullptr) {
-    return hash(reinterpret_cast<const void *>(&obj), sizeof(T));
+auto hash(const T &obj) -> decltype(hash(obj.data(), obj.size())) {
+    return hash(obj.data(), obj.size());
 }
+
+template <class Key, class Enable = void>
+struct hasher;
+
+struct Hash {
+    template <class T>
+    constexpr size_t operator()(const T &v) const noexcept(noexcept(hasher<T>()(v))) {
+        return hasher<T>()(v);
+    }
+
+    template <class T, class... Types>
+    constexpr size_t operator()(const T &t, const Types &...ts) const {
+        return hash_combine((*this)(t), (*this)(ts...));
+    }
+
+    constexpr size_t operator()() const noexcept { return 0; }
+};
+
+template <>
+struct hasher<bool> {
+    constexpr size_t operator()(bool val) const noexcept {
+        return val ? std::numeric_limits<size_t>::max() : 0;
+    }
+};
+
+template <>
+struct hasher<unsigned long long> : Detail::IntegerHasher<unsigned long long> {};
+
+template <>
+struct hasher<signed long long> : Detail::IntegerHasher<signed long long> {};
+
+template <>
+struct hasher<unsigned long> : Detail::IntegerHasher<unsigned long> {};
+
+template <>
+struct hasher<signed long> : Detail::IntegerHasher<signed long> {};
+
+template <>
+struct hasher<unsigned int> : Detail::IntegerHasher<unsigned int> {};
+
+template <>
+struct hasher<signed int> : Detail::IntegerHasher<signed int> {};
+
+template <>
+struct hasher<unsigned short> : Detail::IntegerHasher<unsigned short> {};
+
+template <>
+struct hasher<signed short> : Detail::IntegerHasher<signed short> {};
+
+template <>
+struct hasher<unsigned char> : Detail::IntegerHasher<unsigned char> {};
+
+template <>
+struct hasher<signed char> : Detail::IntegerHasher<signed char> {};
+
+template <>
+struct hasher<char> : Detail::IntegerHasher<char> {};
+
+#if defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
+template <>
+struct hasher<signed __int128> : Detail::IntegerHasher<signed __int128> {};
+
+template <>
+struct hasher<unsigned __int128> : Detail::IntegerHasher<unsigned __int128> {};
+#endif
+
+template <>
+struct hasher<float> : Detail::FloatHasher<float> {};
+
+template <>
+struct hasher<double> : Detail::FloatHasher<double> {};
+
+template <>
+struct hasher<std::string> {
+    size_t operator()(const std::string &val) const {
+        return static_cast<size_t>(hash(val.data(), val.size()));
+    }
+};
+
+template <>
+struct hasher<std::string_view> {
+    size_t operator()(const std::string_view &val) const {
+        return static_cast<size_t>(hash(val.data(), val.size()));
+    }
+};
+
+template <typename T1, typename T2>
+struct hasher<std::pair<T1, T2>> {
+    size_t operator()(const std::pair<T1, T2> &val) const { return Hash()(val.first, val.second); }
+};
+template <typename... Types>
+struct hasher<std::tuple<Types...>> {
+    size_t operator()(const std::tuple<Types...> &val) const { return apply(Hash(), val); }
+};
+
+// In general, pointers are bad hashes: their low 2-3 bits are zero, likewise
+// for the upper bits depending on the ABI. Also, the middle bits might not have
+// enough entropy as addresses come from some common pool. To solve this problem
+// we just use a single iteration of hash_avalanche to improve mixing.
+template <typename T>
+struct hasher<T *> {
+    // FIXME: better use std::bit_cast from C++20
+    size_t operator()(T *val) const { return Hash()(reinterpret_cast<std::uintptr_t>(val)); }
+};
+
+template <typename T>
+struct hasher<std::unique_ptr<T>> {
+    size_t operator()(const std::unique_ptr<T> &val) const { return Hash()(val.get()); }
+};
+
+template <typename T>
+struct hasher<std::shared_ptr<T>> {
+    size_t operator()(const std::shared_ptr<T> &val) const { return Hash()(val.get()); }
+};
+
+template <class Iter, class Hash = std::hash<typename std::iterator_traits<Iter>::value_type>>
+uint64_t hash_range(Iter begin, Iter end, uint64_t hash = 0, Hash hasher = Hash()) {
+    for (; begin != end; ++begin) hash = hash_combine(hash, hasher(*begin));
+
+    return hash;
+}
+
+template <class Hasher>
+inline size_t hash_combine_generic(const Hasher &) noexcept {
+    return 0;
+}
+
+template <class Hasher, typename T, typename... Types>
+size_t hash_combine_generic(const Hasher &h, const T &t, const Types &...ts) {
+    size_t seed = h(t);
+    if (sizeof...(ts) == 0) return seed;
+
+    size_t remainder = hash_combine_generic(h, ts...);
+    if constexpr (sizeof(size_t) == sizeof(uint32_t))
+        return static_cast<size_t>(
+            hash_combine(static_cast<uint64_t>(seed) << 32, static_cast<uint64_t>(remainder)));
+    else
+        return static_cast<size_t>(hash_combine(seed, remainder));
+}
+
+template <typename T, typename... Types>
+size_t hash_combine(const T &t, const Types &...ts) {
+    return hash_combine_generic(Detail::StdHasher{}, t, ts...);
+}
+
+namespace Detail {
+template <size_t index, typename... Types>
+struct TupleHasher {
+    size_t operator()(std::tuple<Types...> const &val) const {
+        return hash_combine(TupleHasher<index - 1, Types...>()(val), std::get<index>(val));
+    }
+};
+
+template <typename... Types>
+struct TupleHasher<0, Types...> {
+    size_t operator()(std::tuple<Types...> const &val) const {
+        return hash_combine(std::get<0>(val));
+    }
+};
+}  // namespace Detail
 }  // namespace Util
+
+namespace std {
+template <typename T1, typename T2>
+struct hash<std::pair<T1, T2>> {
+    size_t operator()(const std::pair<T1, T2> &x) const {
+        return Util::hash_combine(x.first, x.second);
+    }
+};
+
+template <typename... Types>
+struct hash<std::tuple<Types...>> {
+ public:
+    size_t operator()(std::tuple<Types...> const &key) const {
+        Util::Detail::TupleHasher<sizeof...(Types) - 1, Types...> hasher;
+
+        return hasher(key);
+    }
+};
+}  // namespace std
 
 #endif /* LIB_HASH_H_ */

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -206,9 +206,10 @@ struct Hasher<std::tuple<Types...>> {
 };
 
 /// In general, pointers are bad hashes: their low 2-3 bits are zero, likewise
-/// for the upper bits depending on the ABI. Also, the middle bits might not have
-/// enough entropy as addresses come from some common pool. To solve this problem
-/// we just use a single iteration of hash_avalanche to improve mixing.
+/// for the upper bits depending on the ABI. Also, the middle bits might not
+/// have enough entropy as addresses come from some common pool. To solve this
+/// problem we just use a single iteration of hash_avalanche to improve mixing
+/// (see Detail::IntegerHasher).
 template <typename T>
 struct Hasher<T *> {
     // FIXME: better use std::bit_cast from C++20

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -5,7 +5,45 @@
 #include <type_traits>
 
 namespace Util {
+
+namespace Detail {
+constexpr uint64_t PRIME64_1 = UINT64_C(11400714785074694791);
+constexpr uint64_t PRIME64_2 = UINT64_C(14029467366897019727);
+constexpr uint64_t PRIME64_3 = UINT64_C(1609587929392839161);
+constexpr uint64_t PRIME64_4 = UINT64_C(9650029242287828579);
+constexpr uint64_t PRIME64_5 = UINT64_C(2870177450012600261);
+
+constexpr uint64_t PRIME_MX1 = UINT64_C(0x165667919E3779F9);
+constexpr uint64_t PRIME_MX2 = UINT64_C(0x9FB21C651E98DF25);
+
+static uint64_t XXH64_avalanche(uint64_t hash) {
+    hash ^= hash >> 33;
+    hash *= PRIME64_2;
+    hash ^= hash >> 29;
+    hash *= PRIME64_3;
+    hash ^= hash >> 32;
+    return hash;
+}
+
+static uint64_t rotl64(uint64_t X, size_t R) { return (X << R) | (X >> (64 - R)); }
+
+static uint64_t XXH3_rrmxmx(uint64_t acc, uint64_t len) {
+    acc ^= rotl64(acc, 49) ^ rotl64(acc, 24);
+    acc *= PRIME_MX2;
+    acc ^= (acc >> 35) + len;
+    acc *= PRIME_MX2;
+    return acc ^ (acc >> 28);
+}
+
+}  // namespace Detail
+
 uint64_t hash(const void *data, std::size_t size);
+
+static inline uint64_t hash_avalanche(uint64_t hash) { return Detail::XXH64_avalanche(hash); }
+
+static inline uint64_t hash_combine(uint64_t lhs, uint64_t rhs) {
+    return Detail::XXH3_rrmxmx(lhs, rhs);
+}
 
 template <typename T>
 auto hash(

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -33,14 +33,14 @@ bool StackVariable::operator==(const StackVariable &other) const {
 size_t StackVariableHash::operator()(const StackVariable &var) const {
     // hash for path expression.
     if (const auto *path = var.variable->to<IR::PathExpression>()) {
-        return std::hash<cstring>()(path->path->name.name);
+        return Util::Hash{}(path->path->name.name);
     }
     const IR::Member *curMember = var.variable->to<IR::Member>();
     uint64_t hash = UINT64_C(0xDEADBEEF);
     while (curMember) {
-        hash = Util::hash_combine(hash, std::hash<cstring>()(curMember->member.name));
+        hash = Util::hash_combine(hash, curMember->member.name);
         if (auto *path = curMember->expr->to<IR::PathExpression>()) {
-            hash = Util::hash_combine(hash, std::hash<cstring>()(path->path->name));
+            hash = Util::hash_combine(hash, path->path->name.name);
             break;
         }
         curMember = curMember->expr->checkedTo<IR::Member>();

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -36,18 +36,16 @@ size_t StackVariableHash::operator()(const StackVariable &var) const {
         return std::hash<cstring>()(path->path->name.name);
     }
     const IR::Member *curMember = var.variable->to<IR::Member>();
-    // FIXME: Implement sane hash combining, there is no need to have
-    // vector here
-    std::vector<size_t> h;
+    uint64_t hash = UINT64_C(0xDEADBEEF);
     while (curMember) {
-      h.push_back(std::hash<cstring>()(curMember->member.name));
+        hash = Util::hash_combine(hash, std::hash<cstring>()(curMember->member.name));
         if (auto *path = curMember->expr->to<IR::PathExpression>()) {
-          h.push_back(std::hash<cstring>()(path->path->name));
+            hash = Util::hash_combine(hash, std::hash<cstring>()(path->path->name));
             break;
         }
         curMember = curMember->expr->checkedTo<IR::Member>();
     }
-    return Util::hash(h.data(), sizeof(size_t) * h.size());
+    return hash;
 }
 
 /// The main class for parsers' states key for visited checking.

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -47,7 +47,7 @@ size_t StackVariableHash::operator()(const StackVariable &var) const {
         }
         curMember = curMember->expr->checkedTo<IR::Member>();
     }
-    return Util::Hash::murmur(h.data(), sizeof(size_t) * h.size());
+    return Util::hash(h.data(), sizeof(size_t) * h.size());
 }
 
 /// The main class for parsers' states key for visited checking.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/expr_uses_test.cpp
   gtest/format_test.cpp
   gtest/helpers.cpp
+  gtest/hash.cpp
   gtest/hvec_map.cpp
   gtest/indexed_vector.cpp
   gtest/json_test.cpp

--- a/test/gtest/hash.cpp
+++ b/test/gtest/hash.cpp
@@ -40,8 +40,8 @@ TEST(Hash, XXHash) {
     EXPECT_EQ(Util::hash(s3), s1_hash);
 }
 
-TEST(Hash, hasher) {
-    std::unordered_map<int32_t, int32_t, Util::hasher<int32_t>> m;
+TEST(Hash, Hasher) {
+    std::unordered_map<int32_t, int32_t, Util::Hasher<int32_t>> m;
     m.emplace(123, 42);
     EXPECT_EQ(m.at(123), 42);
 }
@@ -84,7 +84,7 @@ TEST(Hash, IntegerTypes) {
 }
 
 TEST(Hash, IntegerConversion) {
-    Util::hasher<uint64_t> h;
+    Util::Hasher<uint64_t> h;
     uint64_t k = 10;
     EXPECT_EQ(h(k), h(10));
 }
@@ -201,7 +201,7 @@ TEST(Hash, EmptyStdTuple) {
     m[{}] = "foo";
     EXPECT_EQ(m[{}], "foo");
 
-    Util::hasher<std::tuple<>> h;
+    Util::Hasher<std::tuple<>> h;
     EXPECT_EQ(h({}), 0);
 }
 

--- a/test/gtest/hash.cpp
+++ b/test/gtest/hash.cpp
@@ -14,10 +14,11 @@ limitations under the License.
 
 #include "lib/hash.h"
 
+#include <gtest/gtest.h>
+
 #include <unordered_map>
 #include <unordered_set>
 
-#include "gtest/gtest.h"
 #include "lib/cstring.h"
 
 namespace Test {

--- a/test/gtest/hash.cpp
+++ b/test/gtest/hash.cpp
@@ -184,7 +184,7 @@ TEST(Hash, HashCombine10Bool) {
             }
         }
     }
-    EXPECT_EQ(values.size(), 1U << 10); // All hash values must be distinct
+    EXPECT_EQ(values.size(), 1U << 10);  // All hash values must be distinct
 }
 
 TEST(Hash, HashCombine10Int) {
@@ -212,7 +212,7 @@ TEST(Hash, HashCombine10Int) {
             }
         }
     }
-    EXPECT_EQ(values.size(), 59049); // All hash values must be distinct
+    EXPECT_EQ(values.size(), 59049);  // All hash values must be distinct
 }
 
 TEST(Hash, StdTuple) {

--- a/test/gtest/hash.cpp
+++ b/test/gtest/hash.cpp
@@ -184,7 +184,35 @@ TEST(Hash, HashCombine10Bool) {
             }
         }
     }
-    EXPECT_EQ(values.size(), 1U << 10);
+    EXPECT_EQ(values.size(), 1U << 10); // All hash values must be distinct
+}
+
+TEST(Hash, HashCombine10Int) {
+    const auto hash = Util::Hash();
+    std::set<size_t> values;
+    for (int i1 : {1, 2, 3}) {
+        for (int i2 : {1, 2, 3}) {
+            for (int i3 : {1, 2, 3}) {
+                for (int i4 : {1, 2, 3}) {
+                    for (int i5 : {1, 2, 3}) {
+                        for (int i6 : {1, 2, 3}) {
+                            for (int i7 : {1, 2, 3}) {
+                                for (int i8 : {1, 2, 3}) {
+                                    for (int i9 : {1, 2, 3}) {
+                                        for (int i10 : {1, 2, 3}) {
+                                            values.insert(
+                                                hash(i1, i2, i3, i4, i5, i6, i7, i8, i9, i10));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    EXPECT_EQ(values.size(), 59049); // All hash values must be distinct
 }
 
 TEST(Hash, StdTuple) {

--- a/test/gtest/hash.cpp
+++ b/test/gtest/hash.cpp
@@ -75,11 +75,6 @@ TEST(Hash, IntegerTypes) {
     hashes.insert(hasher((size_t)24));
 
     size_t hashesSize = 24;
-#if defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
-    hashes.insert(hasher((__int128_t)25));
-    hashes.insert(hasher((__uint128_t)26));
-    hashesSize += 2;
-#endif
     EXPECT_EQ(hashesSize, hashes.size());
 }
 
@@ -88,20 +83,6 @@ TEST(Hash, IntegerConversion) {
     uint64_t k = 10;
     EXPECT_EQ(h(k), h(10));
 }
-
-#if defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
-TEST(Hash, Int128StdHash) {
-    std::unordered_set<__int128> hs;
-    hs.insert(__int128_t{1});
-    hs.insert(__int128_t{2});
-    EXPECT_EQ(2, hs.size());
-
-    std::set<unsigned __int128> s;
-    s.insert(static_cast<unsigned __int128>(1));
-    s.insert(static_cast<unsigned __int128>(2));
-    EXPECT_EQ(2, s.size());
-}
-#endif
 
 TEST(Hash, FloatTypes) {
     Util::Hash hasher;

--- a/test/gtest/hash.cpp
+++ b/test/gtest/hash.cpp
@@ -1,0 +1,283 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "lib/hash.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "gtest/gtest.h"
+#include "lib/cstring.h"
+
+namespace Test {
+
+TEST(Hash, SimpleHashCombine) {
+    constexpr uint64_t upper = UINT64_C(0xDEADBEEF12345678);
+    constexpr uint64_t lower = UINT64_C(0xBADF00D910111213);
+    EXPECT_NE(Util::hash_combine(upper, lower), Util::hash_combine(lower, upper));
+}
+
+TEST(Hash, XXHash) {
+    const char *s1 = "hello, world!";
+    const uint64_t s1_hash = UINT64_C(4021878480306939596);
+    EXPECT_EQ(Util::hash(s1, strlen(s1)), s1_hash);
+
+    cstring s2(s1);
+    EXPECT_EQ(Util::hash(s2.c_str(), s2.size()), s1_hash);
+
+    std::string s3(s1);
+    EXPECT_EQ(Util::hash(s3), s1_hash);
+}
+
+TEST(Hash, hasher) {
+    std::unordered_map<int32_t, int32_t, Util::hasher<int32_t>> m;
+    m.emplace(123, 42);
+    EXPECT_EQ(m.at(123), 42);
+}
+
+TEST(Hash, IntegerTypes) {
+    std::unordered_set<size_t> hashes;
+    Util::Hash hasher;
+    hashes.insert(hasher((char)1));
+    hashes.insert(hasher((signed char)2));
+    hashes.insert(hasher((unsigned char)3));
+    hashes.insert(hasher((short)4));
+    hashes.insert(hasher((signed short)5));
+    hashes.insert(hasher((unsigned short)6));
+    hashes.insert(hasher((int)7));
+    hashes.insert(hasher((signed int)8));
+    hashes.insert(hasher((unsigned int)9));
+    hashes.insert(hasher((long)10));
+    hashes.insert(hasher((signed long)11));
+    hashes.insert(hasher((unsigned long)12));
+    hashes.insert(hasher((long long)13));
+    hashes.insert(hasher((signed long long)14));
+    hashes.insert(hasher((unsigned long long)15));
+    hashes.insert(hasher((int8_t)16));
+    hashes.insert(hasher((uint8_t)17));
+    hashes.insert(hasher((int16_t)18));
+    hashes.insert(hasher((uint16_t)19));
+    hashes.insert(hasher((int32_t)20));
+    hashes.insert(hasher((uint32_t)21));
+    hashes.insert(hasher((int64_t)22));
+    hashes.insert(hasher((uint64_t)23));
+    hashes.insert(hasher((size_t)24));
+
+    size_t hashesSize = 24;
+#if defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
+    hashes.insert(hasher((__int128_t)25));
+    hashes.insert(hasher((__uint128_t)26));
+    hashesSize += 2;
+#endif
+    EXPECT_EQ(hashesSize, hashes.size());
+}
+
+TEST(Hash, IntegerConversion) {
+    Util::hasher<uint64_t> h;
+    uint64_t k = 10;
+    EXPECT_EQ(h(k), h(10));
+}
+
+#if defined(__SIZEOF_INT128__) || (defined(_INTEGRAL_MAX_BITS) && _INTEGRAL_MAX_BITS >= 128)
+TEST(Hash, Int128StdHash) {
+    std::unordered_set<__int128> hs;
+    hs.insert(__int128_t{1});
+    hs.insert(__int128_t{2});
+    EXPECT_EQ(2, hs.size());
+
+    std::set<unsigned __int128> s;
+    s.insert(static_cast<unsigned __int128>(1));
+    s.insert(static_cast<unsigned __int128>(2));
+    EXPECT_EQ(2, s.size());
+}
+#endif
+
+TEST(Hash, FloatTypes) {
+    Util::Hash hasher;
+
+    EXPECT_EQ(hasher(0.0f), hasher(-0.0f));
+    EXPECT_EQ(hasher(0.0), hasher(-0.0));
+
+    std::unordered_set<size_t> hashes;
+    hashes.insert(hasher(0.0f));
+    hashes.insert(hasher(0.1f));
+    hashes.insert(hasher(0.2));
+    hashes.insert(hasher(0.2f));
+    hashes.insert(hasher(-0.3));
+    hashes.insert(hasher(-0.3f));
+
+    EXPECT_EQ(6, hashes.size());
+}
+
+class TestHasher {
+ public:
+    size_t operator()(const std::pair<unsigned, unsigned> &val) const {
+        return val.first + val.second;
+    }
+};
+
+template <typename T, typename... Ts>
+size_t hash_combine_test(const T &t, const Ts &...ts) {
+    return Util::hash_combine_generic(TestHasher{}, t, ts...);
+}
+
+TEST(Hash, Pair) {
+    auto a = std::make_pair(1, 2);
+    auto b = std::make_pair(3, 4);
+    auto c = std::make_pair(1, 2);
+    auto d = std::make_pair(2, 1);
+    EXPECT_EQ(Util::hash_combine(a), Util::hash_combine(c));
+    EXPECT_NE(Util::hash_combine(b), Util::hash_combine(c));
+    EXPECT_NE(Util::hash_combine(d), Util::hash_combine(c));
+
+    EXPECT_EQ(Util::hash_combine(a, b), Util::hash_combine(c, b));
+    EXPECT_NE(Util::hash_combine(a, b), Util::hash_combine(b, a));
+
+    EXPECT_EQ(hash_combine_test(a), hash_combine_test(c));
+    EXPECT_NE(hash_combine_test(b), hash_combine_test(c));
+    EXPECT_EQ(hash_combine_test(d), hash_combine_test(c));
+    EXPECT_EQ(hash_combine_test(a, b), hash_combine_test(c, b));
+    EXPECT_NE(hash_combine_test(a, b), hash_combine_test(b, a));
+    EXPECT_EQ(hash_combine_test(a, b), hash_combine_test(d, b));
+}
+
+TEST(Hash, Bool) {
+    const auto hash = Util::Hash();
+    EXPECT_NE(hash(true), hash(false));
+}
+
+TEST(Hash, HashCombine) { EXPECT_NE(Util::hash_combine(1, 2), Util::hash_combine(2, 1)); }
+
+TEST(Hash, HashCombine10Bool) {
+    const auto hash = Util::Hash();
+    std::set<size_t> values;
+    for (bool b1 : {false, true}) {
+        for (bool b2 : {false, true}) {
+            for (bool b3 : {false, true}) {
+                for (bool b4 : {false, true}) {
+                    for (bool b5 : {false, true}) {
+                        for (bool b6 : {false, true}) {
+                            for (bool b7 : {false, true}) {
+                                for (bool b8 : {false, true}) {
+                                    for (bool b9 : {false, true}) {
+                                        for (bool b10 : {false, true}) {
+                                            values.insert(
+                                                hash(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    EXPECT_EQ(values.size(), 1U << 10);
+}
+
+TEST(Hash, StdTuple) {
+    typedef std::tuple<int64_t, std::string, int32_t> triple;
+    triple t(42, "foo", 1);
+
+    std::unordered_map<triple, std::string> m;
+    m[t] = "bar";
+    EXPECT_EQ("bar", m[t]);
+}
+
+TEST(Hash, EmptyStdTuple) {
+    std::unordered_map<std::tuple<>, std::string, Util::Hash> m;
+    m[{}] = "foo";
+    EXPECT_EQ(m[{}], "foo");
+
+    Util::hasher<std::tuple<>> h;
+    EXPECT_EQ(h({}), 0);
+}
+
+TEST(Hash, PairHash) {
+    typedef std::pair<int64_t, int32_t> pair2;
+    pair2 p(42, 1);
+
+    std::unordered_map<pair2, std::string, Util::Hash> m;
+    m[p] = "foo";
+    EXPECT_EQ("foo", m[p]);
+}
+
+TEST(Hash, TupleHash) {
+    typedef std::tuple<int64_t, int32_t, int32_t> triple;
+    typedef std::tuple<int64_t, std::string, int32_t> triple2;
+    triple t(42, 1, 2);
+
+    std::unordered_map<triple, std::string, Util::Hash> m;
+    m[t] = "bar";
+    EXPECT_EQ("bar", m[t]);
+
+    triple2 t1(42, "foo", 1);
+    triple2 t2(9, "bar", 3);
+    triple2 t3(42, "foo", 3);
+
+    EXPECT_NE(std::hash<triple2>()(t1), std::hash<triple2>()(t2));
+    EXPECT_NE(std::hash<triple2>()(t1), std::hash<triple2>()(t3));
+}
+
+namespace {
+template <class T>
+size_t hashVector(const std::vector<T> &v) {
+    return Util::hash_range(v.begin(), v.end());
+}
+}  // namespace
+
+TEST(Hash, HashRange) {
+    EXPECT_EQ(hashVector<int32_t>({1, 2}), hashVector<int16_t>({1, 2}));
+    EXPECT_NE(hashVector<int>({2, 1}), hashVector<int>({1, 2}));
+    EXPECT_EQ(hashVector<int>({}), hashVector<float>({}));
+}
+
+TEST(Hash, Strings) {
+    const char *a1 = "1234567", *b1 = "34957834";
+    Util::Hash h;
+    EXPECT_NE(h(a1), h(b1));
+
+    EXPECT_EQ(h(std::string{a1}), h(std::string_view{a1}));
+    EXPECT_EQ(h(std::string{b1}), h(std::string_view{b1}));
+}
+
+namespace {
+void deletePointer(const std::unique_ptr<std::string> &) {}
+void deletePointer(const std::shared_ptr<std::string> &) {}
+void deletePointer(std::string *pointer) { delete pointer; }
+
+template <template <typename...> typename Pointer>
+void pointerTestWithHash() {
+    std::unordered_set<Pointer<std::string>, Util::Hash> set;
+
+    for (auto i = 0; i < 1000; ++i) set.emplace(new std::string{std::to_string(i)});
+
+    for (auto &pointer : set) {
+        EXPECT_TRUE(set.find(pointer) != set.end());
+        deletePointer(pointer);
+    }
+}
+
+template <typename T>
+using Pointer = T *;
+}  // namespace
+
+TEST(Hash, UniquePtr) { pointerTestWithHash<std::unique_ptr>(); }
+
+TEST(Hash, SharedPtr) { pointerTestWithHash<std::shared_ptr>(); }
+
+TEST(Hash, Pointer) { pointerTestWithHash<Pointer>(); }
+
+}  // namespace Test


### PR DESCRIPTION
This PR provides a bit more comprehensive implementation of hashes that could be used within compiler. In particular:
 - FNV1A and Murmur2 are removed
 - 64-bit xxHash3 was imported with few simplifications from xxhash_clean project and without workarounds for old compilers
 - Particular hash algorithm is considered implementation detail, one should not bother about this. Few low-level functions are provided: hash itself, hash avalanche and hash combining
 - On top of that some useful hash boilerplate was added. Since C++ standard committee is still bikeshedding the particular better hashing interface implementation (see https://gist.github.com/dietmarkuehl/b0767e76bc85e29e74f61e994f105ad9?permalink_comment_id=3923250 for some summary), we do not have anything that is even currently under consideration. The present implementation is inspired by N3333, P0029 and P0814 and provides std-compatible implementations of decent quality (on top of low-level functions) that 'just work' with lots of useful sugar on top of that.

This improves runtime of P4CParserUnroll.switch_20160512 by ~5% since we combine hashes directly without filling and hashing an `std::vector` each time inside `StackVariableHash`.

Fixes #4392 