### PR TITLE
Change minimum key struct alignment to 8

### DIFF
--- a/backends/tc/ebpfCodeGen.cpp
+++ b/backends/tc/ebpfCodeGen.cpp
@@ -661,7 +661,7 @@ void EBPFTablePNA::emitKeyType(EBPF::CodeBuilder *builder) {
     EBPF::CodeGenInspector commentGen(program->refMap, program->typeMap);
     commentGen.setBuilder(builder);
 
-    unsigned int structAlignment = 4;  // 4 by default
+    unsigned int structAlignment = 8;  // by default
 
     builder->emitIndent();
     builder->appendLine("u32 keysz;");

--- a/testdata/p4tc_samples_outputs/calculator_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/calculator_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_calculate_key {
     u32 keysz;
     u32 maskid;
     u8 field0; /* hdr.p4calc.op */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_CALCULATE_ACT_MAINCONTROLIMPL_OPERATION_ADD 1
 #define MAINCONTROLIMPL_CALCULATE_ACT_MAINCONTROLIMPL_OPERATION_SUB 2
 #define MAINCONTROLIMPL_CALCULATE_ACT_MAINCONTROLIMPL_OPERATION_AND 3

--- a/testdata/p4tc_samples_outputs/checksum_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/checksum_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) ingress_nh_table_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.srcAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH 1
 #define INGRESS_NH_TABLE_ACT_INGRESS_DROP 2
 struct __attribute__((__packed__)) ingress_nh_table_value {

--- a/testdata/p4tc_samples_outputs/const_entries_range_mask_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/const_entries_range_mask_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_t_range_key {
     u32 keysz;
     u32 maskid;
     u8 field0; /* h.h.r */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_T_RANGE_ACT_MAINCONTROLIMPL_A 1
 #define MAINCONTROLIMPL_T_RANGE_ACT_MAINCONTROLIMPL_A_WITH_CONTROL_PARAMS 2
 struct __attribute__((__packed__)) MainControlImpl_t_range_value {

--- a/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
@@ -8,7 +8,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* istd.input_port */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_value {
@@ -29,7 +29,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_DROP 3
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {

--- a/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
@@ -7,11 +7,11 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_key {
     u32 keysz;
     u32 maskid;
     u8 field0; /* hdr.tcp.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAX_MAINCONTROLIMPL_SET_CT_OPTIONS_KEY_MASKS 128
 struct MainControlImpl_set_ct_options_key_mask {
     __u8 mask[sizeof(struct MainControlImpl_set_ct_options_key)];
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_SYN_PACKET 1
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_FIN_OR_RST_PACKET 2
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_OTHER_PACKETS 3

--- a/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_value {

--- a/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) ingress_nh_table2_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.srcAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define INGRESS_NH_TABLE2_ACT_INGRESS_SEND_NH 2
 #define INGRESS_NH_TABLE2_ACT_INGRESS_DROP 3
 struct __attribute__((__packed__)) ingress_nh_table2_value {
@@ -27,7 +27,7 @@ struct __attribute__((__packed__)) ingress_nh_table_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.srcAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define INGRESS_NH_TABLE_ACT__SEND_NH 1
 #define INGRESS_NH_TABLE_ACT_INGRESS_DROP 3
 struct __attribute__((__packed__)) ingress_nh_table_value {

--- a/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) ingress_nh_table2_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.srcAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define INGRESS_NH_TABLE2_ACT_INGRESS_SEND_NH 2
 #define INGRESS_NH_TABLE2_ACT_INGRESS_DROP 3
 struct __attribute__((__packed__)) ingress_nh_table2_value {
@@ -28,7 +28,7 @@ struct __attribute__((__packed__)) ingress_nh_table_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.srcAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH 2
 #define INGRESS_NH_TABLE_ACT__DROP 1
 struct __attribute__((__packed__)) ingress_nh_table_value {

--- a/testdata/p4tc_samples_outputs/ipip_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/ipip_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) Main_fwd_table_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* istd.input_port */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAIN_FWD_TABLE_ACT_MAIN_SET_IPIP 1
 #define MAIN_FWD_TABLE_ACT_MAIN_SET_NH 2
 #define MAIN_FWD_TABLE_ACT_MAIN_DROP 3

--- a/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_value {
@@ -28,11 +28,11 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAX_MAINCONTROLIMPL_IPV4_TBL_2_KEY_MASKS 128
 struct MainControlImpl_ipv4_tbl_2_key_mask {
     __u8 mask[sizeof(struct MainControlImpl_ipv4_tbl_2_key)];
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_DROP 3
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
@@ -52,7 +52,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_3_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.srcAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_3_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_3_ACT_MAINCONTROLIMPL_DROP 3
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_3_value {
@@ -73,7 +73,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_4_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_4_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_4_ACT_MAINCONTROLIMPL_DROP 3
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_4_value {

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_value {
@@ -28,11 +28,11 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAX_MAINCONTROLIMPL_IPV4_TBL_2_KEY_MASKS 128
 struct MainControlImpl_ipv4_tbl_2_key_mask {
     __u8 mask[sizeof(struct MainControlImpl_ipv4_tbl_2_key)];
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_DROP 3
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
@@ -53,11 +53,11 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_3_key {
     u32 maskid;
     u32 field0; /* hdr.ipv4.srcAddr */
     u8 field1; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAX_MAINCONTROLIMPL_IPV4_TBL_3_KEY_MASKS 128
 struct MainControlImpl_ipv4_tbl_3_key_mask {
     __u8 mask[sizeof(struct MainControlImpl_ipv4_tbl_3_key)];
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_3_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_3_ACT_MAINCONTROLIMPL_DROP 3
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_3_value {
@@ -79,7 +79,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_4_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_4_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_4_ACT_MAINCONTROLIMPL_DROP 3
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_4_value {

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_value {
@@ -28,7 +28,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_DROP 4
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
@@ -49,7 +49,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_3_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_3_ACT_MAINCONTROLIMPL_SENDTOPORT 3
 #define MAINCONTROLIMPL_IPV4_TBL_3_ACT_MAINCONTROLIMPL_DROP 4
 #define MAINCONTROLIMPL_IPV4_TBL_3_ACT__NOACTION 0
@@ -71,7 +71,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_4_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u16 field2; /* hdr.ipv4.fragOffset */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_4_ACT_MAINCONTROLIMPL_SENDTOPORT 3
 #define MAINCONTROLIMPL_IPV4_TBL_4_ACT_MAINCONTROLIMPL_DROP 4
 #define MAINCONTROLIMPL_IPV4_TBL_4_ACT__NOACTION 0
@@ -91,7 +91,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_5_key {
     u32 keysz;
     u32 maskid;
     u16 field0; /* hdr.ipv4.fragOffset */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_5_ACT__NOACTION 0
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_5_value {
     unsigned int action;
@@ -107,7 +107,7 @@ struct __attribute__((__packed__)) MainControlImpl_set_all_options_key {
     u16 field1; /* hdr.tcp.srcPort */
     u16 field2; /* hdr.ipv4.fragOffset */
     u8 field3; /* hdr.ipv4.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_SET_ALL_OPTIONS_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_SET_ALL_OPTIONS_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 #define MAINCONTROLIMPL_SET_ALL_OPTIONS_ACT_MAINCONTROLIMPL_TCP_SYN_PACKET 5
@@ -143,11 +143,11 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_key {
     u32 keysz;
     u32 maskid;
     u8 field0; /* hdr.tcp.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAX_MAINCONTROLIMPL_SET_CT_OPTIONS_KEY_MASKS 128
 struct MainControlImpl_set_ct_options_key_mask {
     __u8 mask[sizeof(struct MainControlImpl_set_ct_options_key)];
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_SYN_PACKET 5
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_FIN_OR_RST_PACKET 6
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_OTHER_PACKETS 7

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_value {
@@ -28,7 +28,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_DROP 4
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
@@ -49,7 +49,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_3_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_3_ACT_MAINCONTROLIMPL_SENDTOPORT 3
 #define MAINCONTROLIMPL_IPV4_TBL_3_ACT_MAINCONTROLIMPL_DROP 4
 #define MAINCONTROLIMPL_IPV4_TBL_3_ACT__NOACTION 0
@@ -70,7 +70,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_4_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u16 field2; /* hdr.ipv4.fragOffset */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_4_ACT_MAINCONTROLIMPL_SENDTOPORT 3
 #define MAINCONTROLIMPL_IPV4_TBL_4_ACT_MAINCONTROLIMPL_DROP 4
 #define MAINCONTROLIMPL_IPV4_TBL_4_ACT__NOACTION 0
@@ -89,7 +89,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_5_key {
     u32 keysz;
     u32 maskid;
     u16 field0; /* hdr.ipv4.fragOffset */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_5_ACT__NOACTION 0
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_5_value {
     unsigned int action;
@@ -105,7 +105,7 @@ struct __attribute__((__packed__)) MainControlImpl_set_all_options_key {
     u16 field1; /* hdr.tcp.srcPort */
     u16 field2; /* hdr.ipv4.fragOffset */
     u8 field3; /* hdr.ipv4.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_SET_ALL_OPTIONS_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_SET_ALL_OPTIONS_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 #define MAINCONTROLIMPL_SET_ALL_OPTIONS_ACT_MAINCONTROLIMPL_TCP_SYN_PACKET 5
@@ -140,11 +140,11 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_key {
     u32 keysz;
     u32 maskid;
     u8 field0; /* hdr.tcp.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAX_MAINCONTROLIMPL_SET_CT_OPTIONS_KEY_MASKS 128
 struct MainControlImpl_set_ct_options_key_mask {
     __u8 mask[sizeof(struct MainControlImpl_set_ct_options_key)];
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_SYN_PACKET 5
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_FIN_OR_RST_PACKET 6
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_OTHER_PACKETS 7

--- a/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_value {
@@ -28,7 +28,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_DROP 3
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {

--- a/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_value {
@@ -28,7 +28,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_SENDTOPORT 3
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_DROP 4
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT__NOACTION 0

--- a/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_value {
@@ -26,7 +26,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 keysz;
     u32 maskid;
     u8 field0; /* hdr.ipv4.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT__NOACTION 0
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     unsigned int action;

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_key {
     u32 keysz;
     u32 maskid;
     u8 field0; /* hdr.tcp.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_SYN_PACKET 1
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_FIN_OR_RST_PACKET 2
 #define MAINCONTROLIMPL_SET_CT_OPTIONS_ACT_MAINCONTROLIMPL_TCP_OTHER_PACKETS 3

--- a/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
@@ -9,7 +9,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_value {

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
@@ -8,7 +8,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* istd.input_port */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_value {
@@ -28,7 +28,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.protocol */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_DROP 3
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {

--- a/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) ingress_nh_table_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.srcAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH 1
 #define INGRESS_NH_TABLE_ACT_INGRESS_DROP 2
 struct __attribute__((__packed__)) ingress_nh_table_value {

--- a/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) ingress_nh_table_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.srcAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH 1
 #define INGRESS_NH_TABLE_ACT_INGRESS_DROP 2
 struct __attribute__((__packed__)) ingress_nh_table_value {

--- a/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
@@ -8,11 +8,11 @@ struct __attribute__((__packed__)) ingress_nh_table_key {
     u32 maskid;
     u32 field0; /* hdr.ipv4.srcAddr */
     u32 field1; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAX_INGRESS_NH_TABLE_KEY_MASKS 128
 struct ingress_nh_table_key_mask {
     __u8 mask[sizeof(struct ingress_nh_table_key)];
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH 1
 #define INGRESS_NH_TABLE_ACT_INGRESS_DROP 2
 struct __attribute__((__packed__)) ingress_nh_table_value {

--- a/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_value {
@@ -28,7 +28,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 field0; /* hdr.ipv4.dstAddr */
     u32 field1; /* hdr.ipv4.srcAddr */
     u8 field2; /* hdr.ipv4.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_SENDTOPORT 3
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT_MAINCONTROLIMPL_DROP 4
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {

--- a/testdata/p4tc_samples_outputs/tc_type_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_type_annotation_example_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_1_key {
     u32 keysz;
     u32 maskid;
     u32 field0; /* hdr.ipv4.dstAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_NEXT_HOP 1
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT_MAINCONTROLIMPL_DEFAULT_ROUTE_DROP 2
 #define MAINCONTROLIMPL_IPV4_TBL_1_ACT__NOACTION 0
@@ -28,7 +28,7 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_key {
     u32 keysz;
     u32 maskid;
     u8 field0; /* hdr.ipv4.flags */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_IPV4_TBL_2_ACT__NOACTION 0
 struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     unsigned int action;

--- a/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
@@ -7,7 +7,7 @@ struct __attribute__((__packed__)) MainControlImpl_tbl_default_key {
     u32 keysz;
     u32 maskid;
     u8 field0[16]; /* hdr.ipv6.srcAddr */
-} __attribute__((aligned(4)));
+} __attribute__((aligned(8)));
 #define MAINCONTROLIMPL_TBL_DEFAULT_ACT_MAINCONTROLIMPL_SET_DST 1
 #define MAINCONTROLIMPL_TBL_DEFAULT_ACT__NOACTION 0
 struct __attribute__((__packed__)) MainControlImpl_tbl_default_value {


### PR DESCRIPTION
Change minimum key struct alignment to 8 to better fit with the P4TC subsystem.