### PR TITLE
Refactor ReferenceResolver to use native C++-enumerators in some places

### DIFF
--- a/backends/p4tools/common/compiler/reachability.cpp
+++ b/backends/p4tools/common/compiler/reachability.cpp
@@ -225,14 +225,13 @@ bool P4ProgramDCGCreator::preorder(const IR::P4Program *program) {
                     }
                     return pathExpr->path->name == decl->name;
                 };
-            const auto *declVector = program->getDeclarations()->where(filter)->toVector();
-            BUG_CHECK(!declVector->empty(), "Not a declaration instance: %1%", pathExpr);
+            auto declVector = program->getDeclarations()->where(filter)->toVector();
+            BUG_CHECK(!declVector.empty(), "Not a declaration instance: %1%", pathExpr);
 
             // Convert the declaration instance into a constructor-call expression.
-            const auto *decl = declVector->at(0)->to<IR::Declaration_Instance>();
-            auto *ctorCall =
-                new IR::ConstructorCallExpression(decl->srcInfo, decl->type, decl->arguments);
-            v.push_back(ctorCall);
+            const auto *decl = declVector[0]->to<IR::Declaration_Instance>();
+            v.push_back(
+                new IR::ConstructorCallExpression(decl->srcInfo, decl->type, decl->arguments));
             continue;
         }
     }

--- a/backends/p4tools/common/compiler/reachability.cpp
+++ b/backends/p4tools/common/compiler/reachability.cpp
@@ -225,11 +225,9 @@ bool P4ProgramDCGCreator::preorder(const IR::P4Program *program) {
                     }
                     return pathExpr->path->name == decl->name;
                 };
-            auto declVector = program->getDeclarations()->where(filter)->toVector();
-            BUG_CHECK(!declVector.empty(), "Not a declaration instance: %1%", pathExpr);
-
             // Convert the declaration instance into a constructor-call expression.
-            const auto *decl = declVector[0]->to<IR::Declaration_Instance>();
+            const auto *decl =
+                program->getDeclarations()->where(filter)->single()->to<IR::Declaration_Instance>();
             v.push_back(
                 new IR::ConstructorCallExpression(decl->srcInfo, decl->type, decl->arguments));
             continue;

--- a/backends/p4tools/common/lib/namespace_context.cpp
+++ b/backends/p4tools/common/lib/namespace_context.cpp
@@ -37,13 +37,8 @@ const IR::IDeclaration *NamespaceContext::findNestedDecl(
         // Handle case where current namespace is an IGeneralNamespace.
         // If there is no match, we fall through.
         if (const auto *ns = subNamespace->to<IR::IGeneralNamespace>()) {
-            auto decls = ns->getDeclsByName(name)->toVector();
-            if (!decls.empty()) {
-                // TODO: Figure out what to do with multiple results. Maybe return all of them and
-                // let the caller sort it out?
-                BUG_CHECK(decls.size() == 1, "Handling of overloaded names not implemented");
-                return decls.front();
-            }
+            auto *decl = ns->getDeclsByName(name)->singleOrDefault();
+            if (decl != nullptr) return decl;
         }
 
         // As last resort, fall through to a NestedNamespace check.
@@ -82,13 +77,8 @@ const IR::IDeclaration *NamespaceContext::findDecl(const IR::Path *path) const {
     // Handle case where current namespace is an IGeneralNamespace.
     // If there is no match, we fall through.
     if (const auto *ns = curNamespace->to<IR::IGeneralNamespace>()) {
-        auto decls = ns->getDeclsByName(name)->toVector();
-        if (!decls.empty()) {
-            // TODO: Figure out what to do with multiple results. Maybe return all of them and let
-            // the caller sort it out?
-            BUG_CHECK(decls.size() == 1, "Handling of overloaded names not implemented");
-            return decls.front();
-        }
+        auto *decl = ns->getDeclsByName(name)->singleOrDefault();
+        if (decl != nullptr) return decl;
     }
     // As last resort, check if the NestedNamespace contains the declaration.
     if (const auto *ns = curNamespace->to<IR::INestedNamespace>()) {

--- a/backends/p4tools/common/lib/namespace_context.cpp
+++ b/backends/p4tools/common/lib/namespace_context.cpp
@@ -37,12 +37,12 @@ const IR::IDeclaration *NamespaceContext::findNestedDecl(
         // Handle case where current namespace is an IGeneralNamespace.
         // If there is no match, we fall through.
         if (const auto *ns = subNamespace->to<IR::IGeneralNamespace>()) {
-            const auto *decls = ns->getDeclsByName(name)->toVector();
-            if (!decls->empty()) {
+            auto decls = ns->getDeclsByName(name)->toVector();
+            if (!decls.empty()) {
                 // TODO: Figure out what to do with multiple results. Maybe return all of them and
                 // let the caller sort it out?
-                BUG_CHECK(decls->size() == 1, "Handling of overloaded names not implemented");
-                return decls->at(0);
+                BUG_CHECK(decls.size() == 1, "Handling of overloaded names not implemented");
+                return decls.front();
             }
         }
 
@@ -82,12 +82,12 @@ const IR::IDeclaration *NamespaceContext::findDecl(const IR::Path *path) const {
     // Handle case where current namespace is an IGeneralNamespace.
     // If there is no match, we fall through.
     if (const auto *ns = curNamespace->to<IR::IGeneralNamespace>()) {
-        const auto *decls = ns->getDeclsByName(name)->toVector();
-        if (!decls->empty()) {
+        auto decls = ns->getDeclsByName(name)->toVector();
+        if (!decls.empty()) {
             // TODO: Figure out what to do with multiple results. Maybe return all of them and let
             // the caller sort it out?
-            BUG_CHECK(decls->size() == 1, "Handling of overloaded names not implemented");
-            return decls->at(0);
+            BUG_CHECK(decls.size() == 1, "Handling of overloaded names not implemented");
+            return decls.front();
         }
     }
     // As last resort, check if the NestedNamespace contains the declaration.

--- a/backends/p4tools/common/lib/util.cpp
+++ b/backends/p4tools/common/lib/util.cpp
@@ -145,12 +145,12 @@ std::vector<const IR::Type_Declaration *> argumentsToTypeDeclarations(
 
 const IR::IDeclaration *findProgramDecl(const IR::IGeneralNamespace *ns, const IR::Path *path) {
     auto name = path->name.name;
-    const auto *decls = ns->getDeclsByName(name)->toVector();
-    if (!decls->empty()) {
+    auto decls = ns->getDeclsByName(name)->toVector();
+    if (!decls.empty()) {
         // TODO: Figure out what to do with multiple results. Maybe return all of them and
         // let the caller sort it out?
-        BUG_CHECK(decls->size() == 1, "Handling of overloaded names not implemented");
-        return decls->at(0);
+        BUG_CHECK(decls.size() == 1, "Handling of overloaded names not implemented");
+        return decls.front();
     }
     BUG("Variable %1% not found in the available namespaces.", path);
 }

--- a/backends/p4tools/common/lib/util.cpp
+++ b/backends/p4tools/common/lib/util.cpp
@@ -145,13 +145,8 @@ std::vector<const IR::Type_Declaration *> argumentsToTypeDeclarations(
 
 const IR::IDeclaration *findProgramDecl(const IR::IGeneralNamespace *ns, const IR::Path *path) {
     auto name = path->name.name;
-    auto decls = ns->getDeclsByName(name)->toVector();
-    if (!decls.empty()) {
-        // TODO: Figure out what to do with multiple results. Maybe return all of them and
-        // let the caller sort it out?
-        BUG_CHECK(decls.size() == 1, "Handling of overloaded names not implemented");
-        return decls.front();
-    }
+    auto *decl = ns->getDeclsByName(name)->singleOrDefault();
+    if (decl != nullptr) return decl;
     BUG("Variable %1% not found in the available namespaces.", path);
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/reachability.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/reachability.cpp
@@ -39,7 +39,7 @@ using P4ReachabilityContext = P4CContextWithOptions<P4ReachabilityOptions>;
 class P4CReachability : public ::testing::Test {};
 
 template <class T>
-std::vector<const IR::IDeclaration *> *getNodeByType(const IR::P4Program *program) {
+std::vector<const IR::IDeclaration *> getNodeByType(const IR::P4Program *program) {
     std::function<bool(const IR::IDeclaration *)> filter = [](const IR::IDeclaration *d) {
         CHECK_NULL(d);
         return d->is<T>();
@@ -83,9 +83,8 @@ ReturnedInfo loadExampleForReachability(const char *curFile) {
 }
 
 template <class T>
-const IR::Node *getSpecificNode(std::vector<const IR::IDeclaration *> *v, cstring name) {
-    CHECK_NULL(v);
-    for (const auto *i : *v) {
+const IR::Node *getSpecificNode(const std::vector<const IR::IDeclaration *> &v, cstring name) {
+    for (const auto *i : v) {
         auto element = i->to<T>();
         if (element->name.name == name) {
             return element;
@@ -109,13 +108,12 @@ TEST_F(P4CReachability, testParserStatesAndAnnotations) {
     const auto *program = std::get<0>(result);
     ASSERT_TRUE(program);
     const auto *dcg = std::get<1>(result);
-    auto *parserVector = getNodeByType<IR::P4Parser>(program);
-    ASSERT_TRUE(parserVector);
+    auto parserVector = getNodeByType<IR::P4Parser>(program);
     const auto *parser = getSpecificNode<IR::P4Parser>(parserVector, "ParserI");
     ASSERT_TRUE(parser);
     // Parser ParserI is reachable.
     ASSERT_TRUE(dcg->isReachable(program, parser));
-    auto *controlsVector = getNodeByType<IR::P4Control>(program);
+    auto controlsVector = getNodeByType<IR::P4Control>(program);
     const auto *ingress = getSpecificNode<IR::P4Control>(controlsVector, "IngressI");
     ASSERT_TRUE(ingress);
     const auto *engress = getSpecificNode<IR::P4Control>(controlsVector, "EgressI");

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/reachability.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/reachability.cpp
@@ -90,7 +90,9 @@ const Node *getSpecificNode(const IR::P4Program *program, cstring name) {
 
         return false;
     };
-    return program->getDeclarations()->where(filter)->singleOrDefault()->template to<Node>();
+    if (auto *node = program->getDeclarations()->where(filter)->singleOrDefault())
+        return node->template to<Node>();
+    return nullptr;
 }
 
 template <class T>

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/transformations/saturation_arithm.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/transformations/saturation_arithm.cpp
@@ -88,8 +88,7 @@ class Z3SolverSatTests : public ::testing::Test {
         }
 
         // Extract the binary operation from the P4Program
-        auto declVector = test->getProgram().getDeclsByName("mau")->toVector();
-        const auto *decl = declVector.at(0);
+        const auto *decl = test->getProgram().getDeclsByName("mau")->single();
         const auto *control = decl->to<IR::P4Control>();
         for (const auto *st : control->body->components) {
             if (const auto *as = st->to<IR::IfStatement>()) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/transformations/saturation_arithm.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/transformations/saturation_arithm.cpp
@@ -88,8 +88,8 @@ class Z3SolverSatTests : public ::testing::Test {
         }
 
         // Extract the binary operation from the P4Program
-        auto *const declVector = test->getProgram().getDeclsByName("mau")->toVector();
-        const auto *decl = (*declVector)[0];
+        auto declVector = test->getProgram().getDeclsByName("mau")->toVector();
+        const auto *decl = declVector.at(0);
         const auto *control = decl->to<IR::P4Control>();
         for (const auto *st : control->body->components) {
             if (const auto *as = st->to<IR::IfStatement>()) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/asrt_model.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/asrt_model.cpp
@@ -93,8 +93,7 @@ class Z3SolverTest : public P4ToolsTest {
         }
 
         // Extract the binary operation from the P4Program
-        auto declVector = test->getProgram().getDeclsByName("mau")->toVector();
-        const auto *decl = declVector.at(0);
+        const auto *decl = test->getProgram().getDeclsByName("mau")->single();
         const auto *control = decl->to<IR::P4Control>();
         SymbolicConverter converter;
         for (const auto *st : control->body->components) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/asrt_model.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/asrt_model.cpp
@@ -93,8 +93,8 @@ class Z3SolverTest : public P4ToolsTest {
         }
 
         // Extract the binary operation from the P4Program
-        auto *const declVector = test->getProgram().getDeclsByName("mau")->toVector();
-        const auto *decl = (*declVector)[0];
+        auto declVector = test->getProgram().getDeclsByName("mau")->toVector();
+        const auto *decl = declVector.at(0);
         const auto *control = decl->to<IR::P4Control>();
         SymbolicConverter converter;
         for (const auto *st : control->body->components) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/expressions.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/expressions.cpp
@@ -87,8 +87,8 @@ class Z3SolverTests : public ::testing::Test {
         }
 
         // Extract the binary operation from the P4Program
-        auto *const declVector = test->getProgram().getDeclsByName("mau")->toVector();
-        const auto *decl = (*declVector)[0];
+        auto declVector = test->getProgram().getDeclsByName("mau")->toVector();
+        const auto *decl = declVector.at(0);
         const auto *control = decl->to<IR::P4Control>();
         for (const auto *st : control->body->components) {
             if (const auto *as = st->to<IR::IfStatement>()) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/expressions.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/z3-solver/expressions.cpp
@@ -87,8 +87,7 @@ class Z3SolverTests : public ::testing::Test {
         }
 
         // Extract the binary operation from the P4Program
-        auto declVector = test->getProgram().getDeclsByName("mau")->toVector();
-        const auto *decl = declVector.at(0);
+        const auto *decl = test->getProgram().getDeclsByName("mau")->single();
         const auto *control = decl->to<IR::P4Control>();
         for (const auto *st : control->body->components) {
             if (const auto *as = st->to<IR::IfStatement>()) {

--- a/backends/p4tools/modules/testgen/test/small-step/util.h
+++ b/backends/p4tools/modules/testgen/test/small-step/util.h
@@ -55,14 +55,11 @@ std::optional<const P4ToolsTestCase> createSmallStepExprTest(const std::string &
 template <class T>
 const T *extractExpr(const IR::P4Program &program) {
     // Get the mau declarations in the P4Program.
-    auto decls = program.getDeclsByName("mau")->toVector();
-    if (decls.size() != 1) {
-        return nullptr;
-    }
+    auto *decl = program.getDeclsByName("mau")->single();
 
     // Convert the mau declaration to a control and ensure that
     // there is a single statement in the body.
-    const auto *control = decls.front()->to<IR::P4Control>();
+    const auto *control = decl->checkedTo<IR::P4Control>();
     if (control->body->components.size() != 1) {
         return nullptr;
     }

--- a/backends/p4tools/modules/testgen/test/small-step/util.h
+++ b/backends/p4tools/modules/testgen/test/small-step/util.h
@@ -55,14 +55,14 @@ std::optional<const P4ToolsTestCase> createSmallStepExprTest(const std::string &
 template <class T>
 const T *extractExpr(const IR::P4Program &program) {
     // Get the mau declarations in the P4Program.
-    const auto *decls = program.getDeclsByName("mau")->toVector();
-    if (decls->size() != 1) {
+    auto decls = program.getDeclsByName("mau")->toVector();
+    if (decls.size() != 1) {
         return nullptr;
     }
 
     // Convert the mau declaration to a control and ensure that
     // there is a single statement in the body.
-    const auto *control = (*decls)[0]->to<IR::P4Control>();
+    const auto *control = decls.front()->to<IR::P4Control>();
     if (control->body->components.size() != 1) {
         return nullptr;
     }

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -314,7 +314,8 @@ const IR::IDeclaration *ResolveReferences::resolvePath(const IR::Path *path, boo
 
 void ResolveReferences::checkShadowing(const IR::INamespace *ns) const {
     if (!checkShadow) return;
-    std::map<cstring, const IR::Node *> prev_in_scope;  // check for shadowing within a scope
+    // FIXME: Likely the map is small, can use flat_map or something similar
+    std::unordered_map<cstring, const IR::Node *> prev_in_scope;  // check for shadowing within a scope
     auto decls = getDeclarations(ns);
     for (const auto *decl : decls) {
         const IR::Node *node = decl->getNode();

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -18,8 +18,6 @@ limitations under the License.
 
 namespace P4 {
 
-static const std::vector<const IR::IDeclaration *> empty;
-
 ResolutionContext::ResolutionContext() { anyOrder = P4CContext::get().options().isv1(); }
 
 const std::vector<const IR::IDeclaration *> &ResolutionContext::memoizeDeclarations(

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -173,7 +173,6 @@ std::vector<const IR::IDeclaration *> ResolutionContext::lookup(const IR::INames
             auto rv = lookup(nn, name, type);
             if (!rv.empty()) return rv;
         }
-
     }
     return {};
 }

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -168,11 +168,12 @@ std::vector<const IR::IDeclaration *> ResolutionContext::lookup(const IR::INames
                   current->node_type_name());
     }
     if (const auto *nested = current->to<IR::INestedNamespace>()) {
-        auto temp = nested->getNestedNamespaces();
-        for (auto it = temp.rbegin(); it != temp.rend(); ++it) {
-            auto rv = lookup(*it, name, type);
+        auto nestedNamespaces = nested->getNestedNamespaces();
+        for (const auto *nn : Util::iterator_range(nestedNamespaces).reverse()) {
+            auto rv = lookup(nn, name, type);
             if (!rv.empty()) return rv;
         }
+
     }
     return {};
 }

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -315,7 +315,8 @@ const IR::IDeclaration *ResolveReferences::resolvePath(const IR::Path *path, boo
 void ResolveReferences::checkShadowing(const IR::INamespace *ns) const {
     if (!checkShadow) return;
     // FIXME: Likely the map is small, can use flat_map or something similar
-    std::unordered_map<cstring, const IR::Node *> prev_in_scope;  // check for shadowing within a scope
+    std::unordered_map<cstring, const IR::Node *>
+        prev_in_scope;  // check for shadowing within a scope
     auto decls = getDeclarations(ns);
     for (const auto *decl : decls) {
         const IR::Node *node = decl->getNode();

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -16,6 +16,8 @@ limitations under the License.
 
 #include "resolveReferences.h"
 
+#include "frontends/common/parser_options.h"
+
 namespace P4 {
 
 ResolutionContext::ResolutionContext() { anyOrder = P4CContext::get().options().isv1(); }

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -102,7 +102,7 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
             nsIt != namespaceDeclNames.end() ? nsIt->second : memoizeDeclsByName(ns);
 
         auto decls = Values(namesToDecls.equal_range(name));
-        return Util::make_range(decls.begin(), decls.end());
+        return Util::iterator_range(decls.begin(), decls.end());
     }
 };
 

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -50,14 +50,13 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
  protected:
     // Note that all errors have been merged by the parser into
     // a single error { } namespace.
-
-    const std::vector<const IR::IDeclaration *> *lookup(const IR::INamespace *ns, IR::ID name,
-                                                        ResolutionType type) const;
+    std::vector<const IR::IDeclaration *> lookup(const IR::INamespace *ns, const IR::ID &name,
+                                                 ResolutionType type) const;
 
     // match kinds exist in their own special namespace, made from all the match_kind
     // declarations in the global scope.  Unlike errors, we don't merge those scopes in
     // the parser, so we have to find them and scan them here.
-    const std::vector<const IR::IDeclaration *> *lookupMatchKind(IR::ID name) const;
+    std::vector<const IR::IDeclaration *> lookupMatchKind(const IR::ID &name) const;
 
     // P4_14 allows things to be used before their declaration while P4_16 (generally)
     // does not, so we will resolve names to things declared later only when translating
@@ -73,10 +72,10 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
 
  public:
     /// Resolve references for @p name, restricted to @p type declarations.
-    const std::vector<const IR::IDeclaration *> *resolve(IR::ID name, ResolutionType type) const;
+    std::vector<const IR::IDeclaration *> resolve(const IR::ID &name, ResolutionType type) const;
 
     /// Resolve reference for @p name, restricted to @p type declarations, and expect one result.
-    const IR::IDeclaration *resolveUnique(IR::ID name, ResolutionType type,
+    const IR::IDeclaration *resolveUnique(const IR::ID &name, ResolutionType type,
                                           const IR::INamespace * = nullptr) const;
 
     /// Resolve @p path; if @p isType is `true` then resolution will

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -32,14 +32,15 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
  private:
     // Returns a vector of the decls that exist in the given namespace, and caches the result
     // for future lookups.
-    std::vector<const IR::IDeclaration *> *memoizeDeclarations(const IR::INamespace *ns) const;
+    const std::vector<const IR::IDeclaration *> &memoizeDeclarations(
+        const IR::INamespace *ns) const;
 
     // Returns a mapping from name -> decl for the given namespace, and caches the result for
     // future lookups.
     std::unordered_multimap<cstring, const IR::IDeclaration *> &memoizeDeclsByName(
         const IR::INamespace *ns) const;
 
-    mutable std::unordered_map<const IR::INamespace *, std::vector<const IR::IDeclaration *> *>
+    mutable std::unordered_map<const IR::INamespace *, std::vector<const IR::IDeclaration *>>
         namespaceDecls;
     mutable std::unordered_map<const IR::INamespace *,
                                std::unordered_multimap<cstring, const IR::IDeclaration *>>

--- a/frontends/p4/createBuiltins.cpp
+++ b/frontends/p4/createBuiltins.cpp
@@ -25,12 +25,12 @@ namespace P4 {
 const IR::Node *CreateBuiltins::preorder(IR::P4Program *program) {
     auto decls = program->getDeclsByName(P4::P4CoreLibrary::instance().noAction.str());
     auto vec = decls->toVector();
-    if (vec->empty()) return program;
-    if (vec->size() > 1) {
+    if (vec.empty()) return program;
+    if (vec.size() > 1) {
         ::error(ErrorType::ERR_MODEL, "Multiple declarations of %1%: %2% %3%",
-                P4::P4CoreLibrary::instance().noAction.str(), vec->at(0), vec->at(1));
+                P4::P4CoreLibrary::instance().noAction.str(), vec[0], vec[1]);
     }
-    globalNoAction = vec->at(0);
+    globalNoAction = vec[0];
     return program;
 }
 

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -268,15 +268,15 @@ Util::Enumerator<const IDeclaration *> *P4Program::getDeclarations() const {
 const IR::PackageBlock *ToplevelBlock::getMain() const {
     auto program = getProgram();
     auto mainDecls = program->getDeclsByName(IR::P4Program::main)->toVector();
-    if (mainDecls->size() == 0) {
+    if (mainDecls.empty()) {
         ::warning(ErrorType::WARN_MISSING, "Program does not contain a `%s' module",
                   IR::P4Program::main);
         return nullptr;
     }
-    auto main = mainDecls->at(0);
-    if (mainDecls->size() > 1) {
+    auto main = mainDecls[0];
+    if (mainDecls.size() > 1) {
         ::error(ErrorType::ERR_DUPLICATE, "Program has multiple `%s' instances: %1%, %2%",
-                IR::P4Program::main, main->getNode(), mainDecls->at(1)->getNode());
+                IR::P4Program::main, main->getNode(), mainDecls[1]->getNode());
         return nullptr;
     }
     if (!main->is<IR::Declaration_Instance>()) {

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -122,6 +122,9 @@ class Enumerator {
     bool any();
     // The only next element; throws if the enumerator does not have exactly 1 element
     T single();
+    // The only next element or default value if none exists; throws if the
+    // enumerator does not have exactly 0 or 1 element
+    T singleOrDefault();
     // Next element, or the default value if none exists
     T nextOrDefault();
     // Next element; throws if there are no elements
@@ -535,6 +538,16 @@ template <typename T>
 T Enumerator<T>::single() {
     bool next = moveNext();
     if (!next) throw std::logic_error("There is no element for `single()'");
+    T result = getCurrent();
+    next = moveNext();
+    if (next) throw std::logic_error("There are multiple elements when calling `single()'");
+    return result;
+}
+
+template <typename T>
+T Enumerator<T>::singleOrDefault() {
+    bool next = moveNext();
+    if (!next) return T{};
     T result = getCurrent();
     next = moveNext();
     if (next) throw std::logic_error("There are multiple elements when calling `single()'");

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include <vector>
 
 #include "lib/cstring.h"
+#include "lib/iterator_range.h"
 
 namespace Util {
 enum class EnumeratorState { NotStarted, Valid, PastEnd };
@@ -99,6 +100,8 @@ class Enumerator {
     static Enumerator<T> *emptyEnumerator();  // empty data
     template <typename Iter>
     static Enumerator<typename Iter::value_type> *createEnumerator(Iter begin, Iter end);
+    template <typename Iter>
+    static Enumerator<typename Iter::value_type> *createEnumerator(iterator_range<Iter> range);
     // concatenate all these collections into a single one
     static Enumerator<T> *concatAll(Enumerator<Enumerator<T> *> *inputs);
 
@@ -492,6 +495,12 @@ template <typename T>
 template <typename Iter>
 Enumerator<typename Iter::value_type> *Enumerator<T>::createEnumerator(Iter begin, Iter end) {
     return new GenericEnumerator<Iter>(begin, end, "iterator");
+}
+
+template <typename T>
+template <typename Iter>
+Enumerator<typename Iter::value_type> *Enumerator<T>::createEnumerator(iterator_range<Iter> range) {
+    return new GenericEnumerator<Iter>(range.begin(), range.end(), "range");
 }
 
 template <typename T>

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -105,7 +105,7 @@ class Enumerator {
     // concatenate all these collections into a single one
     static Enumerator<T> *concatAll(Enumerator<Enumerator<T> *> *inputs);
 
-    std::vector<T> *toVector();
+    std::vector<T> toVector();
     /* Return an enumerator returning all elements that pass the filter */
     Enumerator<T> *where(std::function<bool(const T &)> filter);
     /* Apply specified function to all elements of this enumerator */
@@ -504,9 +504,9 @@ Enumerator<typename Iter::value_type> *Enumerator<T>::createEnumerator(iterator_
 }
 
 template <typename T>
-std::vector<T> *Enumerator<T>::toVector() {
-    auto result = new std::vector<T>();
-    while (moveNext()) result->push_back(getCurrent());
+std::vector<T> Enumerator<T>::toVector() {
+    std::vector<T> result;
+    while (moveNext()) result.push_back(getCurrent());
     return result;
 }
 

--- a/lib/iterator_range.h
+++ b/lib/iterator_range.h
@@ -15,6 +15,7 @@ limitations under the License.
 #ifndef LIB_ITERATOR_RANGE_H_
 #define LIB_ITERATOR_RANGE_H_
 
+#include <iterator>
 #include <utility>
 
 namespace Util {
@@ -24,33 +25,31 @@ template <typename Container>
 using IterOfContainer = decltype(std::begin(std::declval<Container &>()));
 }  // namespace Detail
 
-template <typename Iter>
+template <typename Iter, typename Sentinel = Iter>
 class iterator_range {
+    using reverse_iterator = std::reverse_iterator<Iter>;
+
     Iter beginIt, endIt;
 
  public:
     template <typename Container>
     explicit iterator_range(Container &&c) : beginIt(c.begin()), endIt(c.end()) {}
+
     iterator_range(Iter beginIt, Iter endIt)
         : beginIt(std::move(beginIt)), endIt(std::move(endIt)) {}
 
-    Iter begin() const { return beginIt; }
-    Iter end() const { return endIt; }
+    auto reverse() const { return iterator_range<reverse_iterator>(rbegin(), rend()); }
+
+    auto begin() const { return beginIt; }
+    auto end() const { return endIt; }
+    auto rbegin() const { return reverse_iterator{endIt}; }
+    auto rend() const { return reverse_iterator{beginIt}; }
+
     bool empty() const { return beginIt == endIt; }
 };
 
 template <typename Container>
 iterator_range(Container &&) -> iterator_range<typename Detail::IterOfContainer<Container>>;
-
-template <class T>
-iterator_range<T> make_range(T x, T y) {
-    return iterator_range<T>(std::move(x), std::move(y));
-}
-
-template <typename T>
-iterator_range<T> make_range(std::pair<T, T> p) {
-    return iterator_range<T>(std::move(p.first), std::move(p.second));
-}
 
 }  // namespace Util
 

--- a/lib/iterator_range.h
+++ b/lib/iterator_range.h
@@ -1,0 +1,57 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef LIB_ITERATOR_RANGE_H_
+#define LIB_ITERATOR_RANGE_H_
+
+#include <utility>
+
+namespace Util {
+namespace Detail {
+// FIXME: We might have begin() found via ADL, support it as well
+template <typename Container>
+using IterOfContainer = decltype(std::begin(std::declval<Container &>()));
+}  // namespace Detail
+
+template <typename Iter>
+class iterator_range {
+    Iter beginIt, endIt;
+
+ public:
+    template <typename Container>
+    iterator_range(Container &&c) : beginIt(c.begin()), endIt(c.end()) {}
+    iterator_range(Iter beginIt, Iter endIt)
+        : beginIt(std::move(beginIt)), endIt(std::move(endIt)) {}
+
+    Iter begin() const { return beginIt; }
+    Iter end() const { return endIt; }
+    bool empty() const { return beginIt == endIt; }
+};
+
+template <typename Container>
+iterator_range(Container &&) -> iterator_range<typename Detail::IterOfContainer<Container>>;
+
+template <class T>
+iterator_range<T> make_range(T x, T y) {
+    return iterator_range<T>(std::move(x), std::move(y));
+}
+
+template <typename T>
+iterator_range<T> make_range(std::pair<T, T> p) {
+    return iterator_range<T>(std::move(p.first), std::move(p.second));
+}
+
+}  // namespace Util
+
+#endif /*  LIB_ITERATOR_RANGE_H_ */

--- a/lib/iterator_range.h
+++ b/lib/iterator_range.h
@@ -30,7 +30,7 @@ class iterator_range {
 
  public:
     template <typename Container>
-    iterator_range(Container &&c) : beginIt(c.begin()), endIt(c.end()) {}
+    explicit iterator_range(Container &&c) : beginIt(c.begin()), endIt(c.end()) {}
     iterator_range(Iter beginIt, Iter endIt)
         : beginIt(std::move(beginIt)), endIt(std::move(endIt)) {}
 

--- a/lib/iterator_range.h
+++ b/lib/iterator_range.h
@@ -20,11 +20,25 @@ limitations under the License.
 
 namespace Util {
 namespace Detail {
-// FIXME: We might have begin() found via ADL, support it as well
+using std::begin;
+
 template <typename Container>
-using IterOfContainer = decltype(std::begin(std::declval<Container &>()));
+using IterOfContainer = decltype(begin(std::declval<Container &>()));
+
+template <typename Range>
+constexpr auto begin_impl(Range &&range) {
+    return begin(std::forward<Range>(range));
+}
+
+template <typename Range>
+constexpr auto end_impl(Range &&range) {
+    return end(std::forward<Range>(range));
+}
+
 }  // namespace Detail
 
+// This is a lightweight alternative for C++20 std::range. Should be replaced
+// with ranges as soon as C++20 would be implemented.
 template <typename Iter, typename Sentinel = Iter>
 class iterator_range {
     using reverse_iterator = std::reverse_iterator<Iter>;
@@ -33,7 +47,8 @@ class iterator_range {
 
  public:
     template <typename Container>
-    explicit iterator_range(Container &&c) : beginIt(c.begin()), endIt(c.end()) {}
+    explicit iterator_range(Container &&c)
+        : beginIt(Detail::begin_impl(c)), endIt(Detail::end_impl(c)) {}
 
     iterator_range(Iter beginIt, Iter endIt)
         : beginIt(std::move(beginIt)), endIt(std::move(endIt)) {}

--- a/midend/noMatch.cpp
+++ b/midend/noMatch.cpp
@@ -56,15 +56,15 @@ const IR::Node *DoHandleNoMatch::postorder(IR::P4Program *program) {
     // Check if 'verify' exists.
     auto decls = program->getDeclsByName(IR::ParserState::verify);
     auto vec = decls->toVector();
-    if (vec->empty()) {
+    if (vec.empty()) {
         ::error(ErrorType::ERR_MODEL,
                 "Declaration of function '%1%' not found; did you include core.p4?",
                 IR::ParserState::verify);
         return program;
     }
-    if (vec->size() > 1) {
+    if (vec.size() > 1) {
         ::error(ErrorType::ERR_MODEL, "Multiple declarations of %1%: %2% %3%",
-                IR::ParserState::verify, vec->at(0), vec->at(1));
+                IR::ParserState::verify, vec[0], vec[1]);
     }
     return program;
 }

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -178,12 +178,12 @@ class MidEnd : public PassManager {
 #endif
 
 const IR::P4Parser *getParser(const IR::P4Program *program) {
+    // FIXME: This certainly should be improved
     std::function<bool(const IR::IDeclaration *)> filter = [](const IR::IDeclaration *d) {
         CHECK_NULL(d);
         return d->is<IR::P4Parser>();
     };
-    auto newDeclVector = program->getDeclarations()->where(filter)->toVector();
-    return newDeclVector.at(0)->to<IR::P4Parser>();
+    return program->getDeclarations()->where(filter)->single()->to<IR::P4Parser>();
 }
 
 /// Rewrites parser

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -178,12 +178,12 @@ class MidEnd : public PassManager {
 #endif
 
 const IR::P4Parser *getParser(const IR::P4Program *program) {
-    // FIXME: This certainly should be improved
-    std::function<bool(const IR::IDeclaration *)> filter = [](const IR::IDeclaration *d) {
-        CHECK_NULL(d);
-        return d->is<IR::P4Parser>();
-    };
-    return program->getDeclarations()->where(filter)->single()->to<IR::P4Parser>();
+    // FIXME: This certainly should be improved, it should be possible to check
+    // and cast at the same time
+    return program->getDeclarations()
+        ->where([](const IR::IDeclaration *d) { return d->is<IR::P4Parser>(); })
+        ->single()
+        ->to<IR::P4Parser>();
 }
 
 /// Rewrites parser

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -182,8 +182,8 @@ const IR::P4Parser *getParser(const IR::P4Program *program) {
         CHECK_NULL(d);
         return d->is<IR::P4Parser>();
     };
-    const auto *newDeclVector = program->getDeclarations()->where(filter)->toVector();
-    return (*newDeclVector)[0]->to<IR::P4Parser>();
+    auto newDeclVector = program->getDeclarations()->where(filter)->toVector();
+    return newDeclVector.at(0)->to<IR::P4Parser>();
 }
 
 /// Rewrites parser


### PR DESCRIPTION
Refactor ReferenceResolver to get rid of majority of unnecessary heap allocations due to obsessive `Enumerator<>` usage:
  - Use iterators and iterator ranges where possible
  - Ensure we do not allocate on heap temporary objects and exploit move semantics as much as possible returning vectors by value
  - Do some refactoring around `Enumerator<>->toVector()`: make it return result by value. It seems that the use in the tree is always about creating some temporaries. And it does not make any sense to allocate vectors on heap then
  - Few small improvements here and there, e.g. removing dependence from boost adapters here
 
Partially addresses https://github.com/p4lang/p4c/issues/4412

Ideally, we'd switch from memory allocation at `getDeclarations` / `getDeclsByName`, but it's a bit long way to go for now.