### PR TITLE
Pass FrontEndPolicy to unit tests

### DIFF
--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -147,7 +147,6 @@ class SetStrictStruct : public NoVisit {
 
 }  // namespace
 
-// TODO: remove skipSideEffectOrdering flag
 const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4Program *program,
                                    std::ostream *outStream) {
     if (program == nullptr && options.listFrontendPasses == 0) return nullptr;

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -44,6 +44,7 @@ class FrontEndPolicy {
 
     /// Indicates whether the side-effect-ordering pass should be skipped.
     /// @returns Defaults to false.
+    // TODO: This should probably not be allowed to be skipped at all.
     virtual bool skipSideEffectOrdering() const { return false; }
 
     /// Indicates whether the frontend shoud run some optimizations (inlining, action localization,

--- a/test/gtest/helpers.cpp
+++ b/test/gtest/helpers.cpp
@@ -150,23 +150,15 @@ P4CTestEnvironment::P4CTestEnvironment() {
 
 namespace Test {
 
-struct FrontEndAnnoPolicy : P4::FrontEndPolicy {
-    P4::ParseAnnotations *parseAnnotations;
-
-    /// Pass given ParseAnnotations instance to frontend. The parameter can be null to indicate to
-    /// use the default.
-    explicit FrontEndAnnoPolicy(P4::ParseAnnotations *parseAnnotations)
-        : parseAnnotations(parseAnnotations) {}
-
-    P4::ParseAnnotations *getParseAnnotations() const override { return parseAnnotations; }
-};
-
 /* static */ std::optional<FrontendTestCase> FrontendTestCase::create(
     const std::string &source,
     CompilerOptions::FrontendVersion langVersion
     /* = CompilerOptions::FrontendVersion::P4_16 */,
-    P4::ParseAnnotations *parseAnnotations
+    P4::FrontEndPolicy *policy
     /* = nullptr */) {
+    if (policy == nullptr) {
+        policy = new P4::FrontEndPolicy();
+    }
     auto *program = P4::parseP4String(source, langVersion);
     if (program == nullptr) {
         std::cerr << "Couldn't parse test case source" << std::endl;
@@ -188,7 +180,7 @@ struct FrontEndAnnoPolicy : P4::FrontEndPolicy {
 
     CompilerOptions options;
     options.langVersion = langVersion;
-    program = P4::FrontEnd(new FrontEndAnnoPolicy(parseAnnotations)).run(options, program);
+    program = P4::FrontEnd(policy).run(options, program);
     if (program == nullptr) {
         std::cerr << "Frontend failed" << std::endl;
         return std::nullopt;

--- a/test/gtest/helpers.h
+++ b/test/gtest/helpers.h
@@ -29,6 +29,10 @@ namespace IR {
 class P4Program;
 }  // namespace IR
 
+namespace P4 {
+class FrontEndPolicy;
+}  // namespace P4
+
 /// Specifies which standard headers should be included by a GTest.
 enum class P4Headers {
     NONE,     // No headers.
@@ -114,14 +118,15 @@ struct FrontendTestCase {
     static const CompilerOptions::FrontendVersion defaultVersion =
         CompilerOptions::FrontendVersion::P4_16;
 
-    /// Create a test case that only requires the frontend to run.
+    /// Create a test case that only requires the frontend to run. If policy is nullptr the default
+    /// FrontEndPolicy is used.
     static std::optional<FrontendTestCase> create(
         const std::string &source, CompilerOptions::FrontendVersion langVersion = defaultVersion,
-        P4::ParseAnnotations *parseAnnotations = nullptr);
+        P4::FrontEndPolicy *policy = nullptr);
 
     static std::optional<FrontendTestCase> create(const std::string &source,
-                                                  P4::ParseAnnotations *parseAnnotations) {
-        return create(source, defaultVersion, parseAnnotations);
+                                                  P4::FrontEndPolicy *policy) {
+        return create(source, defaultVersion, policy);
     }
 
     /// The output of the frontend.

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -72,12 +72,22 @@ class ParseAnnotations : public P4::ParseAnnotations {
         : P4::ParseAnnotations("FrontendTest", true, {PARSE("my_anno", StringLiteral)}) {}
 };
 
+struct AnnoFEP : P4::FrontEndPolicy {
+    P4::ParseAnnotations *getParseAnnotations() const override { return pars; }
+
+    explicit AnnoFEP(P4::ParseAnnotations *parseAnnotations) : pars(parseAnnotations) {}
+
+ private:
+    P4::ParseAnnotations *pars;
+};
+
 std::optional<P4::P4RuntimeAPI> createP4RuntimeTestCase(
     const std::string &source,
     CompilerOptions::FrontendVersion langVersion = FrontendTestCase::defaultVersion,
     const cstring arch = defaultArch,
     P4::ParseAnnotations *parseAnnotations = new P4::ParseAnnotations()) {
-    auto frontendTestCase = FrontendTestCase::create(source, langVersion, parseAnnotations);
+    auto frontendTestCase =
+        FrontendTestCase::create(source, langVersion, new AnnoFEP(parseAnnotations));
     if (!frontendTestCase) return std::nullopt;
     return P4::generateP4Runtime(frontendTestCase->program, arch);
 }

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -72,10 +72,11 @@ class ParseAnnotations : public P4::ParseAnnotations {
         : P4::ParseAnnotations("FrontendTest", true, {PARSE("my_anno", StringLiteral)}) {}
 };
 
-struct AnnoFEP : P4::FrontEndPolicy {
+struct AnnotationParsingPolicy : P4::FrontEndPolicy {
     P4::ParseAnnotations *getParseAnnotations() const override { return pars; }
 
-    explicit AnnoFEP(P4::ParseAnnotations *parseAnnotations) : pars(parseAnnotations) {}
+    explicit AnnotationParsingPolicy(P4::ParseAnnotations *parseAnnotations)
+        : pars(parseAnnotations) {}
 
  private:
     P4::ParseAnnotations *pars;
@@ -86,8 +87,8 @@ std::optional<P4::P4RuntimeAPI> createP4RuntimeTestCase(
     CompilerOptions::FrontendVersion langVersion = FrontendTestCase::defaultVersion,
     const cstring arch = defaultArch,
     P4::ParseAnnotations *parseAnnotations = new P4::ParseAnnotations()) {
-    auto frontendTestCase =
-        FrontendTestCase::create(source, langVersion, new AnnoFEP(parseAnnotations));
+    auto frontendTestCase = FrontendTestCase::create(source, langVersion,
+                                                     new AnnotationParsingPolicy(parseAnnotations));
     if (!frontendTestCase) return std::nullopt;
     return P4::generateP4Runtime(frontendTestCase->program, arch);
 }


### PR DESCRIPTION
**Breaking change (dev/test)**: Side-effects ordering is enabled in frontend tests (by #4406).

I've accidentally **enabled side-effects ordering in all frontend tests** throughout the code base in https://github.com/p4lang/p4c/pull/4406 😢. I am sorry about this.

Arguably this could be a good thing (that is the indented use of the frotnend), but it could be surprising to downstream projects. Also, as the policy itself was not exposed, it was not possible to change this behaviour in downstream tests. This PR mitigates the second problem, it exposes frontend policy in tests so that tools can set it in any way they desire. **The side-effects ordering is still enabled by default**, which I think is a more reasonable default (it is the default used in frontend after all).

I don't see a way of ensuring downstream action on this without needlessly breaking interface of the tests that don't depend on either side effects ordering or annotation parsing. Therefore I just intend to ping people who I guess could be working on downstream projects here.