### PR TITLE
[P4Testgen] Move seed logging to toplevel.

### DIFF
--- a/backends/p4tools/common/p4ctool.h
+++ b/backends/p4tools/common/p4ctool.h
@@ -49,6 +49,11 @@ class AbstractP4cTool {
             enableInformationLogging();
         }
 
+        // Print the seed if it has been set.
+        if (toolOptions.seed) {
+            printInfo("============ Program seed %1% =============\n", *toolOptions.seed);
+        }
+
         // Run the compiler to get an IR and invoke the tool.
         const auto compilerResult = P4Tools::CompilerTarget::runCompiler();
         if (!compilerResult.has_value()) {

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -199,11 +199,6 @@ int Testgen::mainImpl(const CompilerResult &compilerResult) {
         ::error("P4Testgen encountered errors during preprocessing.");
         return EXIT_FAILURE;
     }
-    // Get the options and the seed.
-    auto seed = Utils::getCurrentSeed();
-    if (seed) {
-        printFeature("test_info", 4, "============ Prograam seed %1% =============\n", *seed);
-    }
 
     const auto &testgenOptions = TestgenOptions::get();
     return generateAndWriteAbstractTests(testgenOptions, *programInfo);


### PR DESCRIPTION
The seed is a top-level option. Move logging information to the top-level. 