### PR TITLE
warn on unused controls/parsers

### DIFF
--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -54,6 +54,8 @@ const IR::Node *RemoveUnusedDeclarations::preorder(IR::Type_SerEnum *type) {
 const IR::Node *RemoveUnusedDeclarations::preorder(IR::P4Control *cont) {
     auto orig = getOriginal<IR::P4Control>();
     if (!refMap->isUsed(orig)) {
+        if (giveWarning(orig))
+            warn(ErrorType::WARN_UNUSED, "Control %1% is not used; removing", cont);
         LOG3("Removing " << cont << dbp(orig));
         prune();
         return nullptr;
@@ -68,6 +70,8 @@ const IR::Node *RemoveUnusedDeclarations::preorder(IR::P4Control *cont) {
 const IR::Node *RemoveUnusedDeclarations::preorder(IR::P4Parser *parser) {
     auto orig = getOriginal<IR::P4Parser>();
     if (!refMap->isUsed(orig)) {
+        if (giveWarning(orig))
+            warn(ErrorType::WARN_UNUSED, "Parser %1% is not used; removing", parser);
         LOG3("Removing " << parser << dbp(orig));
         prune();
         return nullptr;

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -55,7 +55,8 @@ const IR::Node *RemoveUnusedDeclarations::preorder(IR::P4Control *cont) {
     auto orig = getOriginal<IR::P4Control>();
     if (!refMap->isUsed(orig)) {
         if (giveWarning(orig))
-            warn(ErrorType::WARN_UNUSED, "Control %1% is not used; removing", cont);
+            warn(ErrorType::WARN_UNUSED, "Control %2% is not used; removing", cont,
+                 cont->externalName());
         LOG3("Removing " << cont << dbp(orig));
         prune();
         return nullptr;
@@ -71,7 +72,8 @@ const IR::Node *RemoveUnusedDeclarations::preorder(IR::P4Parser *parser) {
     auto orig = getOriginal<IR::P4Parser>();
     if (!refMap->isUsed(orig)) {
         if (giveWarning(orig))
-            warn(ErrorType::WARN_UNUSED, "Parser %1% is not used; removing", parser);
+            warn(ErrorType::WARN_UNUSED, "Parser %2% is not used; removing", parser,
+                 parser->externalName());
         LOG3("Removing " << parser << dbp(orig));
         prune();
         return nullptr;

--- a/testdata/p4_16_samples_outputs/actionAnnotations.p4-stderr
+++ b/testdata/p4_16_samples_outputs/actionAnnotations.p4-stderr
@@ -1,1 +1,4 @@
+actionAnnotations.p4(17): [--Wwarn=unused] warning: Control test is not used; removing
+control test()
+        ^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/alias.p4-stderr
+++ b/testdata/p4_16_samples_outputs/alias.p4-stderr
@@ -1,1 +1,4 @@
+alias.p4(38): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/annotations.p4-stderr
+++ b/testdata/p4_16_samples_outputs/annotations.p4-stderr
@@ -1,1 +1,4 @@
+annotations.p4(30): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/apply-cf.p4-stderr
+++ b/testdata/p4_16_samples_outputs/apply-cf.p4-stderr
@@ -1,1 +1,4 @@
+apply-cf.p4(19): [--Wwarn=unused] warning: Control x is not used; removing
+control x()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/assign.p4-stderr
+++ b/testdata/p4_16_samples_outputs/assign.p4-stderr
@@ -1,1 +1,4 @@
+assign.p4(21): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/bfd_offload.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bfd_offload.p4-stderr
@@ -1,3 +1,9 @@
+bfd_offload.p4(44): [--Wwarn=unused] warning: Control for_rx_bfd_packets is not used; removing
+control for_rx_bfd_packets() {
+        ^^^^^^^^^^^^^^^^^^
+bfd_offload.p4(50): [--Wwarn=unused] warning: Control for_tx_bfd_packets is not used; removing
+control for_tx_bfd_packets() {
+        ^^^^^^^^^^^^^^^^^^
 bfd_offload.p4(29): [--Wwarn=unused] warning: bfd_session_liveness_tracker: unused instance
 BFD_Offload(32768) bfd_session_liveness_tracker = {
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/bitwise-and.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bitwise-and.p4-stderr
@@ -1,3 +1,6 @@
+bitwise-and.p4(21): [--Wwarn=unused] warning: Control C is not used; removing
+control C(bit<1> meta) {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module
 [--Wwarn=missing] warning: Program does not contain a main module, so P4Info's 'pkg_info' field will not be set
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/bitwise-cast.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bitwise-cast.p4-stderr
@@ -1,1 +1,4 @@
+bitwise-cast.p4(19): [--Wwarn=unused] warning: Control p is not used; removing
+control p() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/bool_cast.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bool_cast.p4-stderr
@@ -1,1 +1,4 @@
+bool_cast.p4(17): [--Wwarn=unused] warning: Control SetAndFwd is not used; removing
+control SetAndFwd()
+        ^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/bool_double_cast.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bool_double_cast.p4-stderr
@@ -1,1 +1,4 @@
+bool_double_cast.p4(17): [--Wwarn=unused] warning: Control SetAndFwd is not used; removing
+control SetAndFwd()
+        ^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/bool_to_bit_cast.p4-stderr
+++ b/testdata/p4_16_samples_outputs/bool_to_bit_cast.p4-stderr
@@ -1,0 +1,3 @@
+bool_to_bit_cast.p4(45): [--Wwarn=unused] warning: Control C is not used; removing
+control C() {
+        ^

--- a/testdata/p4_16_samples_outputs/call.p4-stderr
+++ b/testdata/p4_16_samples_outputs/call.p4-stderr
@@ -1,1 +1,7 @@
+call.p4(17): [--Wwarn=unused] warning: Control qp is not used; removing
+control qp()
+        ^^
+call.p4(42): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/cases.p4-stderr
+++ b/testdata/p4_16_samples_outputs/cases.p4-stderr
@@ -1,4 +1,7 @@
 cases.p4(31): [--Wwarn=missing] warning: SwitchCase: fallthrough with no statement
             c:
             ^
+cases.p4(17): [--Wwarn=unused] warning: Control ctrl is not used; removing
+control ctrl() {
+        ^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/cast.p4-stderr
+++ b/testdata/p4_16_samples_outputs/cast.p4-stderr
@@ -1,1 +1,4 @@
+cast.p4(17): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/constants.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constants.p4-stderr
@@ -1,1 +1,4 @@
+constants.p4(17): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/constructor_cast.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constructor_cast.p4-stderr
@@ -1,1 +1,4 @@
+constructor_cast.p4(21): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/crash-typechecker.p4-stderr
+++ b/testdata/p4_16_samples_outputs/crash-typechecker.p4-stderr
@@ -1,1 +1,4 @@
+crash-typechecker.p4(11): [--Wwarn=unused] warning: Control x is not used; removing
+control x() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/decl.p4-stderr
+++ b/testdata/p4_16_samples_outputs/decl.p4-stderr
@@ -10,4 +10,7 @@ decl.p4(37): [--Wwarn=shadow] warning: 'y' shadows 'y'
 decl.p4(33)
                 bit y;
                 ^^^^^^
+decl.p4(17): [--Wwarn=unused] warning: Control p is not used; removing
+control p(in bit y_0)
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/default-switch.p4-stderr
+++ b/testdata/p4_16_samples_outputs/default-switch.p4-stderr
@@ -4,4 +4,7 @@ default-switch.p4(13): [--Wwarn=ordering] warning: b: label following 'default' 
 default-switch.p4(12)
             default:
             ^^^^^^^
+default-switch.p4(1): [--Wwarn=unused] warning: Control ctrl is not used; removing
+control ctrl() {
+        ^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/direct-call.p4-stderr
+++ b/testdata/p4_16_samples_outputs/direct-call.p4-stderr
@@ -1,1 +1,7 @@
+direct-call.p4(20): [--Wwarn=unused] warning: Control d is not used; removing
+control d() {
+        ^
+direct-call.p4(16): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/direct-call1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/direct-call1.p4-stderr
@@ -1,1 +1,7 @@
+direct-call1.p4(7): [--Wwarn=unused] warning: Parser q is not used; removing
+parser q() {
+       ^
+direct-call1.p4(1): [--Wwarn=unused] warning: Parser p is not used; removing
+parser p() {
+       ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/direct-call2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/direct-call2.p4-stderr
@@ -1,1 +1,7 @@
+direct-call2.p4(7): [--Wwarn=unused] warning: Parser q is not used; removing
+parser q() {
+       ^
+direct-call2.p4(1): [--Wwarn=unused] warning: Parser p is not used; removing
+parser p() {
+       ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/entries-prio.p4-stderr
+++ b/testdata/p4_16_samples_outputs/entries-prio.p4-stderr
@@ -1,1 +1,4 @@
+entries-prio.p4(12): [--Wwarn=unused] warning: Control c is not used; removing
+control c(in Headers h) {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/enum.p4-stderr
+++ b/testdata/p4_16_samples_outputs/enum.p4-stderr
@@ -1,1 +1,4 @@
+enum.p4(24): [--Wwarn=unused] warning: Control c is not used; removing
+control c()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/expression.p4-stderr
+++ b/testdata/p4_16_samples_outputs/expression.p4-stderr
@@ -1,1 +1,4 @@
+expression.p4(17): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/extern2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/extern2.p4-stderr
@@ -1,1 +1,4 @@
+extern2.p4(22): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/extern3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/extern3.p4-stderr
@@ -1,1 +1,4 @@
+extern3.p4(23): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/fold_match.p4-stderr
+++ b/testdata/p4_16_samples_outputs/fold_match.p4-stderr
@@ -46,4 +46,7 @@ fold_match.p4(105): [--Wwarn=parser-transition] warning: SelectCase: unreachable
 fold_match.p4(111): [--Wwarn=parser-transition] warning: SelectExpression: no case matches
         transition select(32w0)
                    ^
+fold_match.p4(17): [--Wwarn=unused] warning: Parser p is not used; removing
+parser p()
+       ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/generic.p4-stderr
+++ b/testdata/p4_16_samples_outputs/generic.p4-stderr
@@ -1,4 +1,10 @@
 generic.p4(17): [--Wwarn=unused] warning: 'T' is unused
 extern Crc16<T>
              ^
+generic.p4(27): [--Wwarn=unused] warning: Control q is not used; removing
+control q<S>(in S dt)
+        ^
+generic.p4(41): [--Wwarn=unused] warning: Control z is not used; removing
+control z<D1, T1>(X<D1> x, in D1 v, in T1 t)
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/hashext.p4-stderr
+++ b/testdata/p4_16_samples_outputs/hashext.p4-stderr
@@ -1,1 +1,4 @@
+hashext.p4(36): [--Wwarn=unused] warning: Control test is not used; removing
+control test(inout hdrs hdr) {
+        ^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/hashext2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/hashext2.p4-stderr
@@ -1,1 +1,4 @@
+hashext2.p4(33): [--Wwarn=unused] warning: Control test is not used; removing
+control test(inout hdrs hdr) {
+        ^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/header.p4-stderr
+++ b/testdata/p4_16_samples_outputs/header.p4-stderr
@@ -1,1 +1,4 @@
+header.p4(42): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/initializer.p4-stderr
+++ b/testdata/p4_16_samples_outputs/initializer.p4-stderr
@@ -1,1 +1,4 @@
+initializer.p4(19): [--Wwarn=unused] warning: Control ingress is not used; removing
+control ingress(out bit<32> field_d_32) {
+        ^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/interface2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/interface2.p4-stderr
@@ -1,1 +1,4 @@
+interface2.p4(21): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue1304.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1304.p4-stderr
@@ -1,0 +1,6 @@
+issue1304.p4(32): [--Wwarn=unused] warning: Control MyVerifyChecksum is not used; removing
+control MyVerifyChecksum(inout my_packet hdr, inout my_metadata meta) {
+        ^^^^^^^^^^^^^^^^
+issue1304.p4(54): [--Wwarn=unused] warning: Control MyComputeChecksum is not used; removing
+control MyComputeChecksum(inout my_packet p, inout my_metadata m) {
+        ^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue1334.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1334.p4-stderr
@@ -1,0 +1,3 @@
+issue1334.p4(14): [--Wwarn=unused] warning: Control d is not used; removing
+control d(out bit<32> x)(bit<32> a) {
+        ^

--- a/testdata/p4_16_samples_outputs/issue1524.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1524.p4-stderr
@@ -1,3 +1,9 @@
+issue1524.p4(36): [--Wwarn=unused] warning: Parser ParserImpl is not used; removing
+parser ParserImpl(packet_in packet,
+       ^^^^^^^^^^
+issue1524.p4(50): [--Wwarn=unused] warning: Control bar is not used; removing
+control bar() {
+        ^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module
 [--Wwarn=missing] warning: Program does not contain a main module, so P4Info's 'pkg_info' field will not be set
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue1586.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1586.p4-stderr
@@ -1,1 +1,4 @@
+issue1586.p4(3): [--Wwarn=unused] warning: Control cIngress is not used; removing
+control cIngress()
+        ^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue1914-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1914-1.p4-stderr
@@ -1,0 +1,3 @@
+issue1914-1.p4(83): [--Wwarn=unused] warning: Control verifyChecksum is not used; removing
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+        ^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue1914-2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1914-2.p4-stderr
@@ -1,0 +1,3 @@
+issue1914-2.p4(83): [--Wwarn=unused] warning: Control verifyChecksum is not used; removing
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+        ^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue1914.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1914.p4-stderr
@@ -1,0 +1,3 @@
+issue1914.p4(83): [--Wwarn=unused] warning: Control verifyChecksum is not used; removing
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+        ^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue1989-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1989-bmv2.p4-stderr
@@ -1,0 +1,3 @@
+issue1989-bmv2.p4(38): [--Wwarn=unused] warning: Control ingress_stub is not used; removing
+control ingress_stub(inout headers hdr, inout test_metadata_t meta,
+        ^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue1997.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1997.p4-stderr
@@ -1,1 +1,4 @@
+issue1997.p4(23): [--Wwarn=unused] warning: Control c is not used; removing
+control c(in hdr h, inout standard_metadata_t standard_meta) {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue2036-3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2036-3.p4-stderr
@@ -1,1 +1,4 @@
+issue2036-3.p4(7): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue2037.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2037.p4-stderr
@@ -1,1 +1,4 @@
+issue2037.p4(2): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue2090.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2090.p4-stderr
@@ -1,0 +1,3 @@
+spec-ex09.p4(24): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^

--- a/testdata/p4_16_samples_outputs/issue2126.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2126.p4-stderr
@@ -1,1 +1,4 @@
+issue2126.p4(1): [--Wwarn=unused] warning: Parser p is not used; removing
+parser p() {
+       ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue2265-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2265-1.p4-stderr
@@ -1,1 +1,4 @@
+issue2265-1.p4(3): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue2265.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2265.p4-stderr
@@ -1,1 +1,4 @@
+issue2265.p4(7): [--Wwarn=unused] warning: Control c is not used; removing
+control c<T>(inout T data) {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue2514.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2514.p4-stderr
@@ -1,0 +1,3 @@
+issue2514.p4(23): [--Wwarn=unused] warning: Parser prs is not used; removing
+parser prs(inout my_headers_t hdr) {
+       ^^^

--- a/testdata/p4_16_samples_outputs/issue2735.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2735.p4-stderr
@@ -1,3 +1,6 @@
+issue2735.p4(8): [--Wwarn=unused] warning: Control SnvsIngress is not used; removing
+control SnvsIngress(out Mac_entry b0) {
+        ^^^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module
 [--Wwarn=missing] warning: Program does not contain a main module, so P4Info's 'pkg_info' field will not be set
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue2905.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2905.p4-stderr
@@ -1,1 +1,4 @@
+issue2905.p4(3): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3056.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3056.p4-stderr
@@ -1,1 +1,4 @@
+issue3056.p4(6): [--Wwarn=unused] warning: Control compute is not used; removing
+control compute() {
+        ^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3246-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3246-1.p4-stderr
@@ -1,1 +1,4 @@
+issue3246-1.p4(8): [--Wwarn=unused] warning: Control c is not used; removing
+control c(out bit<8> result) {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3307.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3307.p4-stderr
@@ -1,1 +1,4 @@
+issue3307.p4(6): [--Wwarn=unused] warning: Parser MyParser is not used; removing
+parser MyParser(t tt) {
+       ^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3333.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3333.p4-stderr
@@ -1,1 +1,4 @@
+issue3333.p4(2): [--Wwarn=unused] warning: Parser MyParser1 is not used; removing
+parser MyParser1(in myenum a) {
+       ^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3343.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3343.p4-stderr
@@ -1,1 +1,4 @@
+issue3343.p4(1): [--Wwarn=unused] warning: Parser MyParser1 is not used; removing
+parser MyParser1(in bit<6> ttt) {
+       ^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3379-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3379-1.p4-stderr
@@ -1,4 +1,7 @@
 issue3379-1.p4(14): [--Wwarn=unused] warning: t4: unused instance
 mypackaget<bit>(MyParser1()) t4;
                              ^^
+issue3379-1.p4(3): [--Wwarn=unused] warning: Parser MyParser1 is not used; removing
+parser MyParser1(in bit tt) {
+       ^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3379.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3379.p4-stderr
@@ -1,4 +1,7 @@
 issue3379.p4(15): [--Wwarn=unused] warning: t4: unused instance
 mypackaget(MyParser1()) t4;
                         ^^
+issue3379.p4(3): [--Wwarn=unused] warning: Parser MyParser1 is not used; removing
+parser MyParser1(in bit tt) {
+       ^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue344.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue344.p4-stderr
@@ -1,4 +1,7 @@
 issue344.p4(24): [--Wwarn=unused] warning: c: unused instance
 top(C<_>()) c;
             ^
+issue344.p4(17): [--Wwarn=unused] warning: Control C is not used; removing
+control C<H>() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue361-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2.p4-stderr
@@ -1,1 +1,4 @@
+issue361-bmv2.p4(46): [--Wwarn=unused] warning: Control C is not used; removing
+control C() {
+        ^
 [--Wwarn=parser-transition] warning: SelectCase: unreachable case

--- a/testdata/p4_16_samples_outputs/issue3619.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3619.p4-stderr
@@ -1,4 +1,7 @@
 issue3619.p4(4): [--Wwarn=missing] warning: SwitchCase: fallthrough with no statement
             default:
             ^^^^^^^
+issue3619.p4(1): [--Wwarn=unused] warning: Control c is not used; removing
+control c(in bit<4> v) {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3623-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3623-1.p4-stderr
@@ -1,1 +1,4 @@
+issue3623-1.p4(5): [--Wwarn=unused] warning: Control c is not used; removing
+control c(in e v)
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3623.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3623.p4-stderr
@@ -1,1 +1,4 @@
+issue3623.p4(5): [--Wwarn=unused] warning: Control c is not used; removing
+control c(in bit<4> v) {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3671-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3671-1.p4-stderr
@@ -1,1 +1,4 @@
+issue3671-1.p4(10): [--Wwarn=unused] warning: Control c is not used; removing
+control c()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3671.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3671.p4-stderr
@@ -1,1 +1,4 @@
+issue3671.p4(11): [--Wwarn=unused] warning: Control c is not used; removing
+control c()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue3672.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3672.p4-stderr
@@ -1,1 +1,4 @@
+issue3672.p4(7): [--Wwarn=unused] warning: Control c is not used; removing
+control c()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue414-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2.p4-stderr
@@ -1,3 +1,6 @@
 issue414-bmv2.p4(64): [--Wwarn=unused] warning: cbar_inst2: unused instance
     cBar() cbar_inst2;
            ^^^^^^^^^^
+issue414-bmv2.p4(42): [--Wwarn=unused] warning: Control cBar is not used; removing
+control cBar(inout mystruct1 meta) {
+        ^^^^

--- a/testdata/p4_16_samples_outputs/issue529.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue529.p4-stderr
@@ -1,1 +1,4 @@
+issue529.p4(25): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue638-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue638-1.p4-stderr
@@ -1,1 +1,4 @@
+issue638-1.p4(18): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue940.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue940.p4-stderr
@@ -13,4 +13,7 @@ extern bit<6> wrong();
 issue940.p4(9): [--Wwarn=unused] warning: instance: unused instance
 Checksum16() instance;
              ^^^^^^^^
+issue940.p4(11): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/line.p4-stderr
+++ b/testdata/p4_16_samples_outputs/line.p4-stderr
@@ -1,1 +1,7 @@
+file.p4(4): [--Wwarn=unused] warning: Control x is not used; removing
+control x()
+        ^
+file1.p4(6): [--Wwarn=unused] warning: Control y is not used; removing
+control y() { apply {} }
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/mask.p4-stderr
+++ b/testdata/p4_16_samples_outputs/mask.p4-stderr
@@ -1,0 +1,3 @@
+mask.p4(26): [--Wwarn=unused] warning: Parser Parser is not used; removing
+parser Parser(packet_in b, out Parsed_Packet p) {
+       ^^^^^^

--- a/testdata/p4_16_samples_outputs/match.p4-stderr
+++ b/testdata/p4_16_samples_outputs/match.p4-stderr
@@ -1,1 +1,4 @@
+match.p4(51): [--Wwarn=unused] warning: Parser Top is not used; removing
+parser Top(packet_in b, out Parsed_headers headers) {
+       ^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/module.p4-stderr
+++ b/testdata/p4_16_samples_outputs/module.p4-stderr
@@ -19,4 +19,10 @@ switch1(f()) main2;
 module.p4(44): [--Wwarn=unused] warning: main7: unused instance
 switch4(f2()) main7;
               ^^^^^
+module.p4(23): [--Wwarn=unused] warning: Parser f is not used; removing
+parser f(out bool x)
+       ^
+module.p4(26): [--Wwarn=unused] warning: Parser f2 is not used; removing
+parser f2(out bool x, out bool y)
+       ^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/names.p4-stderr
+++ b/testdata/p4_16_samples_outputs/names.p4-stderr
@@ -1,1 +1,4 @@
+names.p4(20): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/parse.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parse.p4-stderr
@@ -1,1 +1,4 @@
+parse.p4(19): [--Wwarn=unused] warning: Parser p is not used; removing
+parser p(in bs b, out bool matches)
+       ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/parser-unroll-issue3537-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-unroll-issue3537-1.p4-stderr
@@ -1,0 +1,3 @@
+parser-unroll-issue3537-1.p4(43): [--Wwarn=unused] warning: Control Aux is not used; removing
+control Aux(inout M meta) {
+        ^^^

--- a/testdata/p4_16_samples_outputs/parser-unroll-issue3537.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-unroll-issue3537.p4-stderr
@@ -1,0 +1,3 @@
+parser-unroll-issue3537.p4(71): [--Wwarn=unused] warning: Control Aux is not used; removing
+control Aux(inout M meta) {
+        ^^^

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue3537-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue3537-1.p4-stderr
@@ -1,3 +1,6 @@
+parser-unroll-issue3537-1.p4(43): [--Wwarn=unused] warning: Control Aux is not used; removing
+control Aux(inout M meta) {
+        ^^^
 [--Wwarn=invalid] warning: Parser cycle can't be unrolled, because ParserUnroll can't detect the number of loop iterations:
 Parser ParserI state chain: start, s1, s2, s2
 [--Wwarn=invalid] warning: Parser cycle can't be unrolled, because ParserUnroll can't detect the number of loop iterations:

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue3537.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue3537.p4-stderr
@@ -1,0 +1,3 @@
+parser-unroll-issue3537.p4(71): [--Wwarn=unused] warning: Control Aux is not used; removing
+control Aux(inout M meta) {
+        ^^^

--- a/testdata/p4_16_samples_outputs/pr1363.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pr1363.p4-stderr
@@ -4,4 +4,7 @@ pr1363.p4(12): [--Wwarn=shadow] warning: 'implementation' shadows 'implementatio
 pr1363.p4(3)
 typedef bit implementation;
             ^^^^^^^^^^^^^^
+pr1363.p4(9): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/pragma-action.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pragma-action.p4-stderr
@@ -1,1 +1,4 @@
+pragma-action.p4(17): [--Wwarn=unused] warning: Control test is not used; removing
+control test()
+        ^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/pragma-deprecated.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pragma-deprecated.p4-stderr
@@ -13,4 +13,7 @@ extern bit<6> wrong();
 pragma-deprecated.p4(9): [--Wwarn=unused] warning: instance: unused instance
 Checksum16() instance;
              ^^^^^^^^
+pragma-deprecated.p4(11): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/pragmas.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pragmas.p4-stderr
@@ -1,1 +1,4 @@
+pragmas.p4(31): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/precedence-lt.p4-stderr
+++ b/testdata/p4_16_samples_outputs/precedence-lt.p4-stderr
@@ -1,1 +1,4 @@
+precedence-lt.p4(11): [--Wwarn=unused] warning: Control C is not used; removing
+control C(inout data d, inout bit<16> foo, Object o) {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/select-type.p4-stderr
+++ b/testdata/p4_16_samples_outputs/select-type.p4-stderr
@@ -1,1 +1,4 @@
+select-type.p4(17): [--Wwarn=unused] warning: Parser p is not used; removing
+parser p() {
+       ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/shadow.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow.p4-stderr
@@ -4,4 +4,7 @@ shadow.p4(22): [--Wwarn=shadow] warning: 'x' shadows 'x'
 shadow.p4(20)
         bit x;
         ^^^^^^
+shadow.p4(17): [--Wwarn=unused] warning: Control c is not used; removing
+control c()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/shadow1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow1.p4-stderr
@@ -4,4 +4,7 @@ shadow1.p4(20): [--Wwarn=shadow] warning: 'counter' shadows 'counter'
 shadow1.p4(17)
 extern counter {}
        ^^^^^^^
+shadow1.p4(19): [--Wwarn=unused] warning: Parser p is not used; removing
+parser p() {
+       ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/shadow3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/shadow3.p4-stderr
@@ -4,4 +4,7 @@ shadow3.p4(20): [--Wwarn=shadow] warning: 'p' shadows 'p'
 shadow3.p4(19)
 control MyIngress(inout H p) {
                           ^
+shadow3.p4(19): [--Wwarn=unused] warning: Control MyIngress is not used; removing
+control MyIngress(inout H p) {
+        ^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex03.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex03.p4-stderr
@@ -1,1 +1,4 @@
+spec-ex03.p4(19): [--Wwarn=unused] warning: Control dp is not used; removing
+control dp()
+        ^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex06.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex06.p4-stderr
@@ -1,1 +1,4 @@
+spec-ex06.p4(19): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex08.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex08.p4-stderr
@@ -1,1 +1,4 @@
+spec-ex08.p4(25): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex09.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex09.p4-stderr
@@ -1,1 +1,4 @@
+spec-ex09.p4(24): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex16.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex16.p4-stderr
@@ -1,3 +1,6 @@
+spec-ex16.p4(26): [--Wwarn=unused] warning: Control Map2 is not used; removing
+control Map2(in bit<8> d) { apply {} }
+        ^^^^
 spec-ex16.p4(32): [--Wwarn=unused] warning: main1: unused instance
                 Map1()) main1;
                         ^^^^^

--- a/testdata/p4_16_samples_outputs/spec-ex18.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex18.p4-stderr
@@ -1,1 +1,4 @@
+spec-ex18.p4(51): [--Wwarn=unused] warning: Parser Top is not used; removing
+parser Top(packet_in b, out Parsed_headers headers) {
+       ^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex19.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex19.p4-stderr
@@ -1,0 +1,3 @@
+spec-ex09.p4(24): [--Wwarn=unused] warning: Control p is not used; removing
+control p()
+        ^

--- a/testdata/p4_16_samples_outputs/spec-ex20.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex20.p4-stderr
@@ -1,1 +1,4 @@
+spec-ex20.p4(37): [--Wwarn=unused] warning: Parser X is not used; removing
+parser X(packet_in b, out Pkthdr p)
+       ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex22.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex22.p4-stderr
@@ -1,1 +1,4 @@
+spec-ex22.p4(17): [--Wwarn=unused] warning: Control c is not used; removing
+control c()
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex25.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex25.p4-stderr
@@ -1,4 +1,7 @@
 spec-ex25.p4(31): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
         key = { x : exact; }
                 ^
+spec-ex25.p4(23): [--Wwarn=unused] warning: Control c is not used; removing
+control c(bit<32> x)
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex29.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex29.p4-stderr
@@ -1,1 +1,7 @@
+spec-ex29.p4(47): [--Wwarn=unused] warning: Parser top is not used; removing
+parser top(packet_in b, out Parsed_packet p) {
+       ^^^
+spec-ex29.p4(70): [--Wwarn=unused] warning: Control Automatic is not used; removing
+control Automatic(packet_out b, in Parsed_packet p) {
+        ^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-ex31.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-ex31.p4-stderr
@@ -1,1 +1,7 @@
+spec-ex31.p4(30): [--Wwarn=unused] warning: Parser GenericParser is not used; removing
+parser GenericParser(packet_in b,
+       ^^^^^^^^^^^^^
+spec-ex31.p4(26): [--Wwarn=unused] warning: Parser EthernetParser is not used; removing
+parser EthernetParser(packet_in b,
+       ^^^^^^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/spec-issue1068.p4-stderr
+++ b/testdata/p4_16_samples_outputs/spec-issue1068.p4-stderr
@@ -1,1 +1,7 @@
+spec-issue1068.p4(7): [--Wwarn=unused] warning: Parser MyParser1 is not used; removing
+parser MyParser1() {
+       ^^^^^^^^^
+spec-issue1068.p4(1): [--Wwarn=unused] warning: Parser MyParser is not used; removing
+parser MyParser<t>(t tt) {
+       ^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/strength.p4-stderr
+++ b/testdata/p4_16_samples_outputs/strength.p4-stderr
@@ -4,4 +4,7 @@ strength.p4(50): [--Wwarn=overflow] warning: 4s0xf: signed value does not fit in
 strength.p4(38): [--Wwarn=mismatch] warning: 4w16: value does not fit in 4 bits
         y = y * 16;
                 ^^
+strength.p4(17): [--Wwarn=unused] warning: Control strength is not used; removing
+control strength() {
+        ^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/strength2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/strength2.p4-stderr
@@ -1,1 +1,4 @@
+strength2.p4(17): [--Wwarn=unused] warning: Control strength is not used; removing
+control strength() {
+        ^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/structured-annotation.p4-stderr
+++ b/testdata/p4_16_samples_outputs/structured-annotation.p4-stderr
@@ -1,1 +1,4 @@
+structured-annotation.p4(10): [--Wwarn=unused] warning: Control c is not used; removing
+control c() {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/useless-cast.p4-stderr
+++ b/testdata/p4_16_samples_outputs/useless-cast.p4-stderr
@@ -1,1 +1,4 @@
+useless-cast.p4(1): [--Wwarn=unused] warning: Control c is not used; removing
+control c(out bit<32> y) {
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/valid.p4-stderr
+++ b/testdata/p4_16_samples_outputs/valid.p4-stderr
@@ -1,1 +1,4 @@
+valid.p4(21): [--Wwarn=unused] warning: Control c is not used; removing
+control c(inout h hdr)
+        ^
 [--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
Add warnings for unused P4Control and P4Parser objects to match P4Table warnings. Addresses issue #4439.