### PR TITLE
Fixes from static analysis

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -896,6 +896,7 @@ DoConstantFolding::Result DoConstantFolding::setContains(const IR::Expression *k
             return Result::No;
         }
         auto sel = getConstant(select);
+        BUG_CHECK(sel, "%1%: expected a constant expression", select);
         // For Enum and SerEnum instances we can just use expression equivalence.
         // This assumes that type checking does not allow us to compare constants to SerEnums.
         if (key->equiv(*sel)) return Result::Yes;

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -3074,7 +3074,7 @@ const IR::Node *TypeInference::postorder(IR::Slice *expression) {
     }
 
     auto e1type = getType(expression->e1);
-    if (e1type->is<IR::Type_SerEnum>()) {
+    if (e1type && e1type->is<IR::Type_SerEnum>()) {
         auto ei = EnumInstance::resolve(expression->e1, typeMap);
         CHECK_NULL(ei);
         auto sei = ei->to<SerEnumInstance>();
@@ -3085,7 +3085,7 @@ const IR::Node *TypeInference::postorder(IR::Slice *expression) {
         expression->e1 = sei->value;
     }
     auto e2type = getType(expression->e2);
-    if (e2type->is<IR::Type_SerEnum>()) {
+    if (e2type && e2type->is<IR::Type_SerEnum>()) {
         auto ei = EnumInstance::resolve(expression->e2, typeMap);
         CHECK_NULL(ei);
         auto sei = ei->to<SerEnumInstance>();

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -3430,7 +3430,7 @@ const IR::Expression *TypeInference::actionCall(bool inActionList,
     }
     auto method = actionCall->method;
     auto methodType = getType(method);
-    if (!methodType) return actionCall; // error emitted in getType
+    if (!methodType) return actionCall;  // error emitted in getType
     auto baseType = methodType->to<IR::Type_Action>();
     if (!baseType) {
         typeError("%1%: must be an action", method);

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -3326,8 +3326,10 @@ const IR::Node *TypeInference::postorder(IR::Member *expression) {
     }
 
     if (auto *apply = type->to<IR::IApply>(); apply && member == IR::IApply::applyMethodName) {
-        auto methodType = apply->getApplyMethodType();
-        methodType = canonicalize(methodType)->to<IR::Type_Method>();
+        auto *methodType = apply->getApplyMethodType();
+        auto *canon = canonicalize(methodType);
+        if (!canon) return expression;
+        methodType = canon->to<IR::Type_Method>();
         if (methodType == nullptr) return expression;
         learn(methodType, this);
         setType(getOriginal(), methodType);
@@ -3428,6 +3430,7 @@ const IR::Expression *TypeInference::actionCall(bool inActionList,
     }
     auto method = actionCall->method;
     auto methodType = getType(method);
+    if (!methodType) return actionCall; // error emitted in getType
     auto baseType = methodType->to<IR::Type_Action>();
     if (!baseType) {
         typeError("%1%: must be an action", method);

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -626,6 +626,7 @@ const IR::Node *TypeInference::postorder(IR::P4Action *action) {
     bool foundDirectionless = false;
     for (auto p : action->parameters->parameters) {
         auto ptype = getType(p);
+        BUG_CHECK(ptype, "%1%: parameter type missing when it was found previously", p);
         if (ptype->is<IR::Type_Extern>())
             typeError("%1%: Action parameters cannot have extern types", p->type);
         if (p->direction == IR::Direction::None)

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -391,7 +391,7 @@ class ParserSymbolicInterpreter {
             }
 
             if (value == nullptr) value = factory->create(type, true);
-            if (value->is<SymbolicError>()) {
+            if (value && value->is<SymbolicError>()) {
                 ::warning(ErrorType::ERR_EXPRESSION, "%1%: %2%", d,
                           value->to<SymbolicError>()->message());
                 return nullptr;

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -251,7 +251,7 @@ void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &i
 }
 
 void IrClass::generateTreeMacro(std::ostream &out) const {
-    for (auto p = this; p != nodeClass(); p = p->getParent()) out << "  ";
+    for (auto p = this; p && p != nodeClass(); p = p->getParent()) out << "  ";
     out << "M(";
     const char *sep = "";
     for (auto p = this; p; p = p->getParent()) {

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -251,14 +251,14 @@ void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &i
 }
 
 void IrClass::generateTreeMacro(std::ostream &out) const {
-    {
-        auto *p = this;
-        for (; p && p != nodeClass(); p = p->getParent()) out << "  ";
-        BUG_CHECK(p != nullptr, "Falled out of the class hierarchy");
+    auto *p = this;
+    for (; p && p != nodeClass(); p = p->getParent()) {
+        out << "  ";
     }
+    BUG_CHECK(p != nullptr, "Falled out of the class hierarchy");
     out << "M(";
     const char *sep = "";
-    for (auto *p = this; p; p = p->getParent()) {
+    for (p = this; p; p = p->getParent()) {
         out << sep << p->containedIn << p->name;
         sep = *sep ? ") B(" : ", D(";
     }

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -251,10 +251,14 @@ void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &i
 }
 
 void IrClass::generateTreeMacro(std::ostream &out) const {
-    for (auto p = this; p && p != nodeClass(); p = p->getParent()) out << "  ";
+    {
+        auto *p = this;
+        for (; p && p != nodeClass(); p = p->getParent()) out << "  ";
+        BUG_CHECK(p != nullptr, "Falled out of the class hierarchy");
+    }
     out << "M(";
     const char *sep = "";
-    for (auto p = this; p; p = p->getParent()) {
+    for (auto *p = this; p; p = p->getParent()) {
         out << sep << p->containedIn << p->name;
         sep = *sep ? ") B(" : ", D(";
     }


### PR DESCRIPTION
- Add a BUG_CHECK
- constantFolding: Be a bit more defensive
- ir-generator: Make sure we don't dereference null when exploring class hierarchy
- Permit AutoCompileContext to throw in destructor if context is inconsistent
- typeChecker: Hanlde possible nullptr
- parserUnroll: Account for SymbolicValueFactory::create returning nullptr
- typeChecker: Avoid dereferencing null type after getType failure
