### PR TITLE
Refactor some visitor internals

### DIFF
--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -28,7 +28,6 @@ limitations under the License.
 
 #include "dbprint.h"
 #include "ir/id.h"
-#include "ir/indexed_vector.h"
 #include "ir/ir.h"
 #include "ir/vector.h"
 #include "lib/algorithm.h"
@@ -47,6 +46,8 @@ limitations under the License.
  */
 class Visitor::ChangeTracker {
     struct visit_info_t {
+        // FIXME: We should be able to put these two bools into low 2 bits of
+        // result saving 8 bytes per record
         bool visit_in_progress;
         bool visitOnce;
         const IR::Node *result;
@@ -60,10 +61,8 @@ class Visitor::ChangeTracker {
      */
     void start(const IR::Node *n, bool defaultVisitOnce) {
         // Initialization
-        visited_t::iterator visited_it;
-        bool inserted;
         bool visit_in_progress = true;
-        std::tie(visited_it, inserted) =
+        auto [visited_it, inserted] =
             visited.emplace(n, visit_info_t{visit_in_progress, defaultVisitOnce, n});
 
         // Sanity check for IR loops
@@ -176,6 +175,104 @@ class Visitor::ChangeTracker {
     }
 };
 
+/** @class Visitor::Tracker
+ *  @brief Assists visitors in traversing the IR.
+
+ *  A Tracker object assists visitors traversing the IR by tracking each
+ *  node.  The `start` method begins tracking, and `finish` ends it.  The
+ *  `done` method determines whether the node has been visited.
+ */
+class Visitor::Tracker {
+    // FIXME: We can squeeze these into low 2 bits of key, eliminating the value entirely
+    struct info_t {
+        bool done, visitOnce;
+    };
+    typedef std::unordered_map<const IR::Node *, info_t> visited_t;
+    visited_t visited;
+
+ public:
+    /** Forget nodes that have already been visited, allowing them to be visited
+     * again. */
+    void revisit_visited() {
+        for (auto it = visited.begin(); it != visited.end();) {
+            if (it->second.done)
+                it = visited.erase(it);
+            else
+                ++it;
+        }
+    }
+
+    /** Begin tracking @n during a visiting pass.  Use `finish(@n)` to mark @n as
+     * visited once the pass completes.
+     */
+    void start(const IR::Node *n, bool defaultVisitOnce) {
+        // Initialization
+        auto [it, inserted] = visited.emplace(n, info_t{false, defaultVisitOnce});
+
+        // Sanity check for IR loops
+        if (!inserted && !it->second.done) BUG("IR loop detected ");
+    }
+
+    /** Mark the process of visiting @n as finished, with @final being the
+     * final state of the node, or nullptr if the node was removed from the
+     * tree.  `done(@n)` will return true, and `result(@n)` will return
+     * the resulting node, if any.
+     *
+     * If @final is a new node, that node is marked as finished as well, as if
+     * `start(@final); finish(@final);` were invoked.
+     *
+     * @exception Util::CompilerBug This method fails if `start(@n)` has not
+     * previously been invoked.
+     */
+    void finish(const IR::Node *n) {
+        auto it = visited.find(n);
+        if (it == visited.end()) BUG("visitor state tracker corrupted");
+
+        it->second.done = true;
+    }
+
+    /** Determine whether @n is currently being visited and the visitor has not finished
+     * That is, `start(@n)` has been invoked, and `finish(@n)` has not,
+     *
+     * @return true if @n is being visited and has not finished
+     */
+    bool busy(const IR::Node *n) const {
+        auto it = visited.find(n);
+        return it != visited.end() && !it->second.done;
+    }
+
+    /** Determine whether @n has been visited and the visitor has finished
+     *  and we don't want to visit @n again the next time we see it.
+     * That is, `start(@n)` has been invoked, followed by `finish(@n)`,
+     * and the visitOnce field is true.
+     *
+     * @return true if @n has been visited and the visitor is finished and visitOnce is true
+     */
+    bool done(const IR::Node *n) const {
+        auto it = visited.find(n);
+        return it != visited.end() && it->second.done && it->second.visitOnce;
+    }
+
+    /** Return a visitOnce flag for node @n */
+    bool shouldVisitOnce(const IR::Node *n) {
+        auto it = visited.find(n);
+        if (it == visited.end()) BUG("visitor state tracker corrupted");
+        return it->second.visitOnce;
+    }
+
+    void visitOnce(const IR::Node *n) {
+        auto it = visited.find(n);
+        if (it == visited.end()) BUG("visitor state tracker corrupted");
+        it->second.visitOnce = true;
+    }
+
+    void visitAgain(const IR::Node *n) {
+        auto it = visited.find(n);
+        if (it == visited.end()) BUG("visitor state tracker corrupted");
+        it->second.visitOnce = false;
+    }
+};
+
 // static
 bool Visitor::warning_enabled(const Visitor *visitor, int warning_kind) {
     auto errorString = ErrorCatalog::getCatalog().getName(warning_kind);
@@ -214,7 +311,7 @@ Visitor::profile_t Modifier::init_apply(const IR::Node *root) {
 }
 Visitor::profile_t Inspector::init_apply(const IR::Node *root) {
     auto rv = Visitor::init_apply(root);
-    visited = std::make_shared<visited_t>();
+    visited = std::make_shared<Tracker>();
     return rv;
 }
 Visitor::profile_t Transform::init_apply(const IR::Node *root) {
@@ -260,19 +357,11 @@ Visitor::profile_t::~profile_t() {
     }
 }
 
-void Inspector::visitOnce() const {
-    auto it = visited->find(getOriginal());
-    if (it == visited->end()) BUG("visitor state tracker corrupted");
-    it->second.visitOnce = true;
-}
+void Inspector::visitOnce() const { visited->visitOnce(getOriginal()); }
 void Modifier::visitOnce() const { visited->visitOnce(getOriginal()); }
 void Transform::visitOnce() const { visited->visitOnce(getOriginal()); }
 
-void Inspector::visitAgain() const {
-    auto it = visited->find(getOriginal());
-    if (it == visited->end()) BUG("visitor state tracker corrupted");
-    it->second.visitOnce = false;
-}
+void Inspector::visitAgain() const { visited->visitAgain(getOriginal()); }
 void Modifier::visitAgain() const { visited->visitAgain(getOriginal()); }
 void Transform::visitAgain() const { visited->visitAgain(getOriginal()); }
 
@@ -373,22 +462,17 @@ const IR::Node *Inspector::apply_visitor(const IR::Node *n, const char *name) {
     if (ctxt) ctxt->child_name = name;
     if (n && !join_flows(n)) {
         PushContext local(ctxt, n);
-        auto [it, inserted] = visited->emplace(n, info_t{false, visitDagOnce});
-        if (!inserted && !it->second.done) {
+        if (visited->busy(n)) {
             n->apply_visitor_loop_revisit(*this);
-        } else if (!inserted && it->second.visitOnce) {
+        } else if (visited->done(n)) {
             n->apply_visitor_revisit(*this);
         } else {
-            it->second.done = false;
+            visited->start(n, visitDagOnce);
             if (n->apply_visitor_preorder(*this)) {
                 n->visit_children(*this);
                 n->apply_visitor_postorder(*this);
             }
-            // `it` is not valid here as there might be rehash during the insertion,
-            // perform another lookup
-            auto doneIt = visited->find(n);
-            if (doneIt == visited->end()) BUG("visitor state tracker corrupted");
-            doneIt->second.done = true;
+            visited->finish(n);
         }
         post_join_flows(n, n);
     }
@@ -459,14 +543,8 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
     return n;
 }
 
-void Inspector::revisit_visited() {
-    for (auto it = visited->begin(); it != visited->end();) {
-        if (it->second.done)
-            it = visited->erase(it);
-        else
-            ++it;
-    }
-}
+void Inspector::revisit_visited() { visited->revisit_visited(); }
+bool Inspector::visit_in_progress(const IR::Node *n) const { return visited->busy(n); }
 void Modifier::revisit_visited() { visited->revisit_visited(); }
 bool Modifier::visit_in_progress(const IR::Node *n) const { return visited->busy(n); }
 void Transform::revisit_visited() { visited->revisit_visited(); }

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -61,14 +61,11 @@ class Visitor::ChangeTracker {
      */
     void start(const IR::Node *n, bool defaultVisitOnce) {
         // Initialization
-        bool visit_in_progress = true;
-        auto [visited_it, inserted] =
-            visited.emplace(n, visit_info_t{visit_in_progress, defaultVisitOnce, n});
+        auto [it, inserted] =
+            visited.emplace(n, visit_info_t{true, defaultVisitOnce, n});
 
         // Sanity check for IR loops
-        bool already_present = !inserted;
-        visit_info_t *visit_info = &(visited_it->second);
-        if (already_present && visit_info->visit_in_progress) BUG("IR loop detected ");
+        if (!inserted && it->second.visit_in_progress) BUG("IR loop detected ");
     }
 
     /** Mark the process of visiting @orig as finished, with @final being the

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -48,8 +48,8 @@ struct Visitor_Context {
     // context via getContext/findContext
     const Visitor_Context *parent;
     const IR::Node *node, *original;
-    mutable int child_index;
     mutable const char *child_name;
+    mutable int child_index;
     int depth;
     template <class T>
     inline const T *findContext(const Visitor_Context *&c) const {

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -351,6 +351,7 @@ class Visitor {
     virtual void post_join_flows(const IR::Node *, const IR::Node *) {}
 
     void visit_children(const IR::Node *, std::function<void()> fn) { fn(); }
+    class Tracker;        // used by Inspector -- private to it
     class ChangeTracker;  // used by Modifier and Transform -- private to them
     // This overrides visitDagOnce for a single node -- can only be called from
     // preorder and postorder functions
@@ -393,11 +394,7 @@ class Modifier : public virtual Visitor {
 };
 
 class Inspector : public virtual Visitor {
-    struct info_t {
-        bool done, visitOnce;
-    };
-    typedef std::unordered_map<const IR::Node *, info_t> visited_t;
-    std::shared_ptr<visited_t> visited;
+    std::shared_ptr<Tracker> visited;
     bool check_clone(const Visitor *) override;
 
  public:
@@ -415,10 +412,7 @@ class Inspector : public virtual Visitor {
     IRNODE_ALL_SUBCLASSES(DECLARE_VISIT_FUNCTIONS)
 #undef DECLARE_VISIT_FUNCTIONS
     void revisit_visited();
-    bool visit_in_progress(const IR::Node *n) const {
-        if (visited->count(n)) return !visited->at(n).done;
-        return false;
-    }
+    bool visit_in_progress(const IR::Node *n) const;
     void visitOnce() const override;
     void visitAgain() const override;
 };

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -354,13 +354,13 @@ class Visitor {
     class ChangeTracker;  // used by Modifier and Transform -- private to them
     // This overrides visitDagOnce for a single node -- can only be called from
     // preorder and postorder functions
-    void visitOnce() const { *visitCurrentOnce = true; }
-    void visitAgain() const { *visitCurrentOnce = false; }
+    // FIXME: It would be better named visitCurrentOnce() / visitCurrenAgain()
+    virtual void visitOnce() const { BUG("do not know how to handle request"); }
+    virtual void visitAgain() const { BUG("do not know how to handle request"); }
 
  private:
     virtual void visitor_const_error();
     const Context *ctxt = nullptr;  // should be readonly to subclasses
-    bool *visitCurrentOnce = nullptr;
     friend class Inspector;
     friend class Modifier;
     friend class Transform;
@@ -388,6 +388,8 @@ class Modifier : public virtual Visitor {
 #undef DECLARE_VISIT_FUNCTIONS
     void revisit_visited();
     bool visit_in_progress(const IR::Node *) const;
+    void visitOnce() const override;
+    void visitAgain() const override;
 };
 
 class Inspector : public virtual Visitor {
@@ -417,6 +419,8 @@ class Inspector : public virtual Visitor {
         if (visited->count(n)) return !visited->at(n).done;
         return false;
     }
+    void visitOnce() const override;
+    void visitAgain() const override;
 };
 
 class Transform : public virtual Visitor {
@@ -441,6 +445,8 @@ class Transform : public virtual Visitor {
 #undef DECLARE_VISIT_FUNCTIONS
     void revisit_visited();
     bool visit_in_progress(const IR::Node *) const;
+    void visitOnce() const override;
+    void visitAgain() const override;
     // can only be called usefully from a 'preorder' function (directly or indirectly)
     void prune() { prune_flag = true; }
 


### PR DESCRIPTION
This is a first step towards #4418

The particular set of changes includes:
 - Refactor `Inspector`'s visiting tracking to be similar to `ChangeTracker` of `Modifier` / `Transform`. Albeit very similar, there are important differences here and there
 - Fixed subtle iterator invalidation bug in `Inspector::apply_visitor`. It was not exposed due to way `std::unordered_map` is implemented in libc++ / libstdc++. Long story short: iterator was kept across possible insertion. It will be invalidated in case of rehash
 - Ensured no internal guts of visiting process is exposed for the purposes of `visitOnce` / `visitAgain`. Previously we had a pointer to a field inside map's value stored in `Visitor`. So we risked a lot to obtain some dangling pointer to freed memory. It worked due to guarantees we had from `std::unordered_map`, but would stop to work with maps with less strong guarantees. And in general, it looks like an escaping pointer complicating code clarity.
 - Reduced size of `Visitor::Context` via rearranging fields to reduce alignment padding waste
 - Removed extraneous map lookups from hot code paths

As a result we are having ~5% speedup on `P4CParserUnroll.switch_20160512` testcase:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `gtestp4c-baseline --gtest_filter=P4CParserUnroll.switch_20160512` | 8.620 ± 0.113 | 8.413 | 8.749 | 1.05 ± 0.02 |
| `gtestp4c --gtest_filter=P4CParserUnroll.switch_20160512` | 8.200 ± 0.098 | 8.059 | 8.362 | 1.00 |

(benchmarking by hyperfine with 10 iterations and warm-up)