### PR TITLE
[P4Testgen] Add more API options to the P4Testgen api.

### DIFF
--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -2,6 +2,7 @@
 #define BACKENDS_P4TOOLS_MODULES_TESTGEN_OPTIONS_H_
 
 #include <cstdint>
+#include <filesystem>
 #include <optional>
 #include <set>
 #include <string>
@@ -36,7 +37,7 @@ class TestgenOptions : public AbstractP4cToolOptions {
     static TestgenOptions &get();
 
     /// Directory for generated tests. Defaults to PWD.
-    cstring outputDir = nullptr;
+    std::optional<std::filesystem::path> outputDir = std::nullopt;
 
     /// Fail on unimplemented features instead of trying the next branch
     bool strict = false;

--- a/backends/p4tools/modules/testgen/testgen.h
+++ b/backends/p4tools/modules/testgen/testgen.h
@@ -16,10 +16,34 @@ class Testgen : public AbstractP4cTool<TestgenOptions> {
     int mainImpl(const CompilerResult &compilerResult) override;
 
  public:
-    ///
-    static std::optional<AbstractTestList> generateTests(const std::string &program,
+    /// Invokes P4Testgen and returns a list of abstract tests which are generated based on the
+    /// input TestgenOptions. The abstract tests can be further specialized depending on the select
+    /// test back end. CompilerOptions is required to invoke the correct preprocessor and P4
+    /// compiler. It is assumed that `.file` in the compiler options is set.
+    static std::optional<AbstractTestList> generateTests(const CompilerOptions &options,
+                                                         const TestgenOptions &testgenOptions);
+    /// Invokes P4Testgen and returns a list of abstract tests which are generated based on the
+    /// input TestgenOptions. The abstract tests can be further specialized depending on the select
+    /// test back end. CompilerOptions is required to invoke the correct P4 compiler. This function
+    /// assumes that @param program is already preprocessed. P4Testgen will directly parse the input
+    /// program.
+    static std::optional<AbstractTestList> generateTests(std::string_view program,
                                                          const CompilerOptions &options,
                                                          const TestgenOptions &testgenOptions);
+
+    /// Invokes P4Testgen and writes a list of abstract tests to a specified output directory which
+    /// are generated based on the input TestgenOptions. The abstract tests can be further
+    /// specialized depending on the select test back end. CompilerOptions is required to invoke the
+    /// correct preprocessor and P4 compiler. It is assumed that `.file` in the compiler options is
+    /// set.
+    static int writeTests(const CompilerOptions &options, const TestgenOptions &testgenOptions);
+
+    /// Invokes P4Testgen and writes a list of abstract tests to a specified output directory which
+    /// are generated based on the input TestgenOptions. CompilerOptions is required to invoke the
+    /// correct P4 compiler. This function assumes that @param program is already preprocessed.
+    /// P4Testgen will directly parse the input program.
+    static int writeTests(std::string_view program, const CompilerOptions &options,
+                          const TestgenOptions &testgenOptions);
 
     virtual ~Testgen() = default;
 };


### PR DESCRIPTION
- Make it possible to write tests using the API.
- Also make it possible to read in a program from a file instead of directly passing in the program string. 