### PR TITLE
Allow annotations on functions

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1413,7 +1413,11 @@ initializer
 /**************** Expressions ****************/
 
 functionDeclaration
-    : functionPrototype blockStatement   {
+    : annotations functionPrototype blockStatement   {
+            auto ann = new IR::Annotations(@1, *$1);
+            driver.structure->pop();
+            $$ = new IR::Function($2->srcInfo, $2->name, ann, $2->type, $3); }
+    | functionPrototype blockStatement   {
             driver.structure->pop();
             $$ = new IR::Function($1->srcInfo, $1->name, $1->type, $2); }
     ;

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -500,7 +500,8 @@ class SwitchStatement : Statement {
         split.run_visit(); }
 }
 
-class Function : Declaration, IFunctional, ISimpleNamespace, INestedNamespace {
+class Function : Declaration, IFunctional, IAnnotated, ISimpleNamespace, INestedNamespace {
+    optional Annotations        annotations = Annotations::empty;
     Type_Method    type;
     BlockStatement body;
     ParameterList getParameters() const override {
@@ -512,6 +513,7 @@ class Function : Declaration, IFunctional, ISimpleNamespace, INestedNamespace {
         return type->parameters->getDeclByName(name); }
     std::vector<INamespace> getNestedNamespaces() const override {
         return { type->typeParameters }; }
+    Annotations getAnnotations() const override { return annotations; }
 }
 
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
Probably an oversight that this wasn't allowed before.  Use case is to specify which hardware resource(s) should be used to implement a specific function