### PR TITLE
Use better maps to store visitor state

### DIFF
--- a/ir/CMakeLists.txt
+++ b/ir/CMakeLists.txt
@@ -64,7 +64,8 @@ set (BASE_IR_DEF_FILES
 set (IR_DEF_FILES ${IR_DEF_FILES} ${BASE_IR_DEF_FILES} PARENT_SCOPE)
 
 add_library (ir STATIC ${IR_SRCS})
-target_link_libraries(ir absl::flat_hash_map)
+target_link_libraries(ir
+  PRIVATE absl::flat_hash_map)
 add_dependencies(ir genIR)
 
 

--- a/ir/CMakeLists.txt
+++ b/ir/CMakeLists.txt
@@ -64,6 +64,7 @@ set (BASE_IR_DEF_FILES
 set (IR_DEF_FILES ${IR_DEF_FILES} ${BASE_IR_DEF_FILES} PARENT_SCOPE)
 
 add_library (ir STATIC ${IR_SRCS})
+target_link_libraries(ir absl::flat_hash_map)
 add_dependencies(ir genIR)
 
 

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -19,8 +19,8 @@ limitations under the License.
 #include <stdlib.h>
 #include <time.h>
 
+#include "absl/container/flat_hash_map.h"
 #include "ir/ir-generated.h"
-#include "lib/source_file.h"
 
 #if HAVE_LIBGC
 #include <gc/gc.h>
@@ -54,7 +54,7 @@ class Visitor::ChangeTracker {
         bool visitOnce;
         const IR::Node *result;
     };
-    typedef std::unordered_map<const IR::Node *, visit_info_t> visited_t;
+    using visited_t = absl::flat_hash_map<const IR::Node *, visit_info_t>;
     visited_t visited;
 
  public:
@@ -130,7 +130,7 @@ class Visitor::ChangeTracker {
     void revisit_visited() {
         for (auto it = visited.begin(); it != visited.end();) {
             if (!it->second.visit_in_progress)
-                it = visited.erase(it);
+                visited.erase(it++);
             else
                 ++it;
         }
@@ -195,7 +195,7 @@ class Visitor::Tracker {
     struct info_t {
         bool done, visitOnce;
     };
-    typedef std::unordered_map<const IR::Node *, info_t> visited_t;
+    using visited_t = absl::flat_hash_map<const IR::Node *, info_t>;
     visited_t visited;
 
  public:
@@ -204,7 +204,7 @@ class Visitor::Tracker {
     void revisit_visited() {
         for (auto it = visited.begin(); it != visited.end();) {
             if (it->second.done)
-                it = visited.erase(it);
+                visited.erase(it++);
             else
                 ++it;
         }

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -179,13 +179,13 @@ class Visitor::ChangeTracker {
 
     /** Produce the final result of visiting @n.
      *
-     * @return The ultimate result of visiting @n, or @n if `finish(@n)` has not
+     * @return The ultimate result of visiting @n, or `nullptr` if `finish(@n)` has not
      * been invoked.
      */
     const IR::Node *finalResult(const IR::Node *n) const {
         auto it = visited.find(n);
         bool done = it != visited.end() && !it->second.visit_in_progress && it->second.visitOnce;
-        return done ? it->second.result : n;
+        return done ? it->second.result : nullptr;
     }
 
     void visitOnce(const IR::Node *n) {
@@ -459,7 +459,8 @@ namespace {
 class ForwardChildren : public Visitor {
     const ChangeTracker &visited;
     const IR::Node *apply_visitor(const IR::Node *n, const char * = 0) {
-        return visited.finalResult(n);
+        if (const auto *result = visited.finalResult(n)) return result;
+        return n;
     }
 
  public:

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -173,6 +173,17 @@ class Visitor::ChangeTracker {
         return it->second.result;
     }
 
+    /** Produce the final result of visiting @n.
+     *
+     * @return The ultimate result of visiting @n, or @n `finish(@n)` has not
+     * been invoked.
+     */
+    const IR::Node *finalResult(const IR::Node *n) const {
+        auto it = visited.find(n);
+        bool done = it != visited.end() && !it->second.visit_in_progress && it->second.visitOnce;
+        return done ? it->second.result : n;
+    }
+
     void visitOnce(const IR::Node *n) {
         auto it = visited.find(n);
         if (it == visited.end()) BUG("visitor state tracker corrupted");
@@ -440,8 +451,7 @@ namespace {
 class ForwardChildren : public Visitor {
     const ChangeTracker &visited;
     const IR::Node *apply_visitor(const IR::Node *n, const char * = 0) {
-        if (visited.done(n)) return visited.result(n);
-        return n;
+        return visited.finalResult(n);
     }
 
  public:

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -58,6 +58,8 @@ class Visitor::ChangeTracker {
     visited_t visited;
 
  public:
+    ChangeTracker() : visited(16) {}
+
     /** Begin tracking @n during a visiting pass.  Use `finish(@n)` to mark @n as
      * visited once the pass completes.
      *
@@ -199,6 +201,8 @@ class Visitor::Tracker {
     visited_t visited;
 
  public:
+    Tracker() : visited(16) {}
+
     /** Forget nodes that have already been visited, allowing them to be visited
      * again. */
     void revisit_visited() {

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -135,6 +135,8 @@ class Visitor::ChangeTracker {
     void revisit_visited() {
         for (auto it = visited.begin(); it != visited.end();) {
             if (!it->second.visit_in_progress)
+                // `visited` is abseil map, therefore erase does not return iterator, use
+                // post-increment
                 visited.erase(it++);
             else
                 ++it;
@@ -224,6 +226,8 @@ class Visitor::Tracker {
     void revisit_visited() {
         for (auto it = visited.begin(); it != visited.end();) {
             if (it->second.done)
+                // `visited` is abseil map, therefore erase does not return iterator, use
+                // post-increment
                 visited.erase(it++);
             else
                 ++it;

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -177,7 +177,7 @@ class Visitor::ChangeTracker {
 
     /** Produce the final result of visiting @n.
      *
-     * @return The ultimate result of visiting @n, or @n `finish(@n)` has not
+     * @return The ultimate result of visiting @n, or @n if `finish(@n)` has not
      * been invoked.
      */
     const IR::Node *finalResult(const IR::Node *n) const {

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -59,7 +59,9 @@ class Visitor::ChangeTracker {
     visited_t visited;
 
  public:
-    ChangeTracker() : visited(16) {}
+    ChangeTracker()
+        : visited(16) {}  // Pre-allocate 16 slots as usually these maps are small, but we do create
+                          // lots of them. This saves quite some time for rehashes
 
     /** Begin tracking @n during a visiting pass.  Use `finish(@n)` to mark @n as
      * visited once the pass completes.
@@ -213,7 +215,9 @@ class Visitor::Tracker {
     visited_t visited;
 
  public:
-    Tracker() : visited(16) {}
+    Tracker()
+        : visited(16) {}  // Pre-allocate 16 slots as usually these maps are small, but we do create
+                          // lots of them. This saves quite some time for rehashes
 
     /** Forget nodes that have already been visited, allowing them to be visited
      * again. */

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 
 #include "absl/container/flat_hash_map.h"
 #include "ir/ir-generated.h"
+#include "lib/hash.h"
 
 #if HAVE_LIBGC
 #include <gc/gc.h>
@@ -54,7 +55,7 @@ class Visitor::ChangeTracker {
         bool visitOnce;
         const IR::Node *result;
     };
-    using visited_t = absl::flat_hash_map<const IR::Node *, visit_info_t>;
+    using visited_t = absl::flat_hash_map<const IR::Node *, visit_info_t, Util::Hash>;
     visited_t visited;
 
  public:
@@ -197,7 +198,7 @@ class Visitor::Tracker {
     struct info_t {
         bool done, visitOnce;
     };
-    using visited_t = absl::flat_hash_map<const IR::Node *, info_t>;
+    using visited_t = absl::flat_hash_map<const IR::Node *, info_t, Util::Hash>;
     visited_t visited;
 
  public:


### PR DESCRIPTION
This PR imports modern hash map implementation from https://github.com/greg7mdp/parallel-hashmap Essentially it's a hash map extracted from Abseil plus some additional stuff on top of that. Note that while it is a drop-in replacement of `std::unordered_map` it has different guarantees wrt iterator invalidation as it uses open-addressing scheme.

Advantages of this map is:
 - Much faster lookups
 - Much less malloc traffic
 - Better memory usage

On our downstream codebase just this switch alone yields ~2.1x compile time reduction on some large P4C apps.

The PR contains several commits to measure effects:
 - Use of map itself (`gtestp4c-phmap` below)
 - Preallocation of 16 slots (we know that in majority of cases this would be enough) (`gtestp4c-phmap-16` below)
 - Switch from `std::hash` to `Utils::Hash` (`gtestp4c-phmap-16-hash` below)

To compare with `hvec_map` I also benchmarked wrt it (`gtestp4c-hmap`). The benchmarking results are:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `gtestp4c-baseline --gtest_filter=P4CParserUnroll.switch_20160512` | 8.375 ± 0.177 | 8.118 | 8.648 | 1.25 ± 0.04 |
| `gtestp4c-phmap --gtest_filter=P4CParserUnroll.switch_20160512` | 6.886 ± 0.173 | 6.563 | 7.061 | 1.03 ± 0.03 |
| `gtestp4c-phmap-16 --gtest_filter=P4CParserUnroll.switch_20160512` | 6.722 ± 0.118 | 6.539 | 6.900 | 1.00 ± 0.03 |
| `gtestp4c-phmap-16-hash --gtest_filter=P4CParserUnroll.switch_20160512` | 6.705 ± 0.147 | 6.546 | 7.038 | 1.00 |
| `gtestp4c-hmap --gtest_filter=P4CParserUnroll.switch_20160512` | 7.547 ± 0.099 | 7.356 | 7.689 | 1.13 ± 0.03 |

To summarize: it yields 25% improvements against the baseline `std::unordered_map` and 13% improvements towards `hvec_map`. As I already said, for some of our downstream apps the difference is more than two-fold, the compilation time reduced from 5m 14s down to 2m 29s (`hvec_map` was not that attractive there sadly). I also saw some marginal reduction of peak RSS from 15.3 GiB down to 14.87 GiB.

To give more benchmarking results, here are the whole gtest times (here the proportion of `Visitor` code is much less):

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `gtestp4c-baseline` | 14.398 ± 0.310 | 13.920 | 14.923 | 1.17 ± 0.03 |
| `gtestp4c-hmap` | 13.083 ± 0.280 | 12.683 | 13.496 | 1.06 ± 0.03 |
| `gtestp4c-phmap-16-hash` | 12.338 ± 0.256 | 12.003 | 12.877 | 1.00 |