### PR TITLE
Try to speed up the CI build process

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -143,7 +143,7 @@ jobs:
           source ~/.bash_profile
           ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE \
               -DCMAKE_UNITY_BUILD=ON
-          make -Cbuild -j2
+          make -Cbuild -j$((`nproc`+1))
 
     - name: Run tests (MacOS)
       run: |

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -252,8 +252,8 @@ cmake ${CMAKE_FLAGS} ..
 
 # If CMAKE_ONLY is active, only run CMake. Do not build.
 if [ "$CMAKE_ONLY" == "OFF" ]; then
-  make
-  sudo make install
+  make -j$((`nproc`+1))
+  sudo make -j$((`nproc`+1)) install
   # Print ccache statistics after building
   ccache -p -s
 fi

--- a/tools/install_fedora_deps.sh
+++ b/tools/install_fedora_deps.sh
@@ -65,8 +65,8 @@ git clone --recurse-submodules --depth=1 https://github.com/p4lang/PI
 cd PI
 ./autogen.sh
 ./configure --with-proto
-make
-make install
+make -j$((`nproc`+1))
+make -j$((`nproc`+1)) install
 popd
 
 # Install BMv2 from source
@@ -75,8 +75,8 @@ git clone --depth=1 https://github.com/p4lang/behavioral-model
 cd behavioral-model
 ./autogen.sh
 ./configure --with-pdfixed --with-thrift --with-pi --with-stress-tests --enable-debugger CC="ccache gcc" CXX="ccache g++"
-make
-make install-strip
+make -j$((`nproc`+1))
+make -j$((`nproc`+1)) install-strip
 popd
 
 rm -rf "${tmp_dir}"


### PR DESCRIPTION
Runners have 4 cores now: Add ```-j$((`nproc`+1))``` where possible. 

Fixes #4469.