### PR TITLE
Use abseil maps even more

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -239,6 +239,8 @@ cc_library(
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_github_p4lang_p4runtime//:p4types_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/container:inlined_vector",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,15 +203,17 @@ endif()
 # we require -pthread to make std::call_once work, even if we're not using threads...
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
-set (P4C_LIB_DEPS "${P4C_LIB_DEPS};${CMAKE_THREAD_LIBS_INIT}")
+list (APPEND P4C_LIB_DEPS ${CMAKE_THREAD_LIBS_INIT})
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 include_directories(SYSTEM ${PROTOBUF_INCLUDE_DIRS})
 include_directories(SYSTEM ${LIBGC_INCLUDE_DIR})
 set (HAVE_LIBBOOST_IOSTREAMS 1)
-set (P4C_LIB_DEPS "${P4C_LIB_DEPS};${Boost_LIBRARIES}")
+list (APPEND P4C_LIB_DEPS ${Boost_LIBRARIES})
 if (ENABLE_GC)
-  set (P4C_LIB_DEPS "${P4C_LIB_DEPS};${LIBGC_LIBRARIES}")
+  list (APPEND P4C_LIB_DEPS ${LIBGC_LIBRARIES})
 endif ()
+set (P4C_ABSL_LIBRARIES absl::flat_hash_map absl::flat_hash_set)
+list (APPEND P4C_LIB_DEPS ${P4C_ABSL_LIBRARIES})
 
 # other required libraries
 p4c_add_library (rt clock_gettime HAVE_CLOCK_GETTIME)
@@ -507,6 +509,7 @@ add_custom_target(genIR DEPENDS ${IR_GENERATED_SRCS})
 set_source_files_properties(${IR_GENERATOR} PROPERTIES GENERATED TRUE)
 add_library(ir-generated OBJECT ${IR_GENERATED_SRCS} ${EXTENSION_IR_SOURCES})
 add_dependencies(ir-generated ir genIR)
+target_link_libraries(ir-generated ${P4C_LIB_DEPS})
 
 ######################################## IR Generation End ########################################
 

--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -83,7 +83,7 @@ set (BMV2_BACKEND_COMMON_HDRS
 set (IR_DEF_FILES ${IR_DEF_FILES} ${CMAKE_CURRENT_SOURCE_DIR}/bmv2.def PARENT_SCOPE)
 
 add_library(bmv2backend STATIC ${BMV2_BACKEND_COMMON_SRCS})
-add_dependencies(bmv2backend ir-generated frontend)
+target_link_libraries(bmv2backend ir-generated frontend)
 
 add_executable(p4c-bm2-ss ${BMV2_SIMPLE_SWITCH_SRCS})
 target_link_libraries (p4c-bm2-ss bmv2backend ${P4C_LIBRARIES} ${P4C_LIB_DEPS})

--- a/backends/dpdk/CMakeLists.txt
+++ b/backends/dpdk/CMakeLists.txt
@@ -99,8 +99,7 @@ endforeach()
 set(EXTENSION_IR_SOURCES ${EXTENSION_IR_SOURCES} ${QUAL_DPDK_IR_SRCS} PARENT_SCOPE)
 
 add_executable(p4c-dpdk ${P4C_DPDK_SOURCES})
-target_link_libraries (p4c-dpdk dpdk_runtime ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
-add_dependencies(p4c-dpdk dpdk_runtime frontend)
+target_link_libraries (p4c-dpdk dpdk_runtime frontend ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
 
 install (TARGETS p4c-dpdk
         RUNTIME DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})

--- a/backends/graphs/CMakeLists.txt
+++ b/backends/graphs/CMakeLists.txt
@@ -30,11 +30,10 @@ set (GRAPHS_HDRS
 )
 
 add_library(p4cgraphs STATIC ${GRAPHS_SRCS} ${EXTENSION_P4_14_CONV_SOURCES})
-add_dependencies(p4cgraphs ir-generated frontend)
+target_link_libraries(p4cgraphs ir-generated frontend)
 
 add_executable(p4c-graphs p4c-graphs.cpp)
-target_link_libraries (p4c-graphs p4cgraphs ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
-add_dependencies(p4c-graphs ir-generated frontend)
+target_link_libraries (p4c-graphs p4cgraphs ir-generated frontend ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
 
 install (TARGETS p4c-graphs
   RUNTIME DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})

--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -41,6 +41,8 @@ add_p4tools_library(p4tools-common ${P4C_TOOLS_COMMON_SOURCES})
 target_link_libraries(
   p4tools-common
   PUBLIC ${P4TOOLS_Z3_LIB}
+  PRIVATE frontend
+  PRIVATE ir-generated
 )
 
 target_include_directories(
@@ -54,9 +56,5 @@ target_include_directories(
   PUBLIC "${P4C_BINARY_DIR}"
 )
 
-add_dependencies(p4tools-common ir-generated frontend)
-
 # Add control-plane-specific extensions.
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/control_plane)
-
-

--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -42,7 +42,6 @@ target_link_libraries(
   p4tools-common
   PUBLIC ${P4TOOLS_Z3_LIB}
   PRIVATE frontend
-  PRIVATE ir-generated
 )
 
 target_include_directories(

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -259,4 +259,6 @@ if (FLEX_INCLUDE_DIRS)
 endif ()
 add_library (frontend STATIC ${FRONTEND_SOURCES})
 add_dependencies (frontend frontend-parser-gen)
-target_link_libraries (frontend frontend-parser-gen)
+target_link_libraries (frontend frontend-parser-gen
+  absl::flat_hash_set
+  absl::flat_hash_map)

--- a/frontends/common/resolveReferences/referenceMap.cpp
+++ b/frontends/common/resolveReferences/referenceMap.cpp
@@ -43,8 +43,7 @@ void ReferenceMap::setDeclaration(const IR::Path *path, const IR::IDeclaration *
     CHECK_NULL(path);
     CHECK_NULL(decl);
     LOG3("Resolved " << dbp(path) << " to " << dbp(decl));
-    auto it = pathToDeclaration.find(path);
-    auto previous = it != pathToDeclaration.end() ? it->second : nullptr;
+    const auto *previous = get(pathToDeclaration, path);
     if (previous != nullptr && previous != decl)
         BUG("%1% already resolved to %2% instead of %3%", dbp(path), dbp(previous),
             dbp(decl->getNode()));
@@ -57,8 +56,7 @@ void ReferenceMap::setDeclaration(const IR::This *pointer, const IR::IDeclaratio
     CHECK_NULL(pointer);
     CHECK_NULL(decl);
     LOG3("Resolved " << dbp(pointer) << " to " << dbp(decl));
-    auto it = thisToDeclaration.find(pointer);
-    auto previous = it != thisToDeclaration.end() ? it->second : nullptr;
+    const auto *previous = get(thisToDeclaration, pointer);
     if (previous != nullptr && previous != decl)
         BUG("%1% already resolved to %2% instead of %3%", dbp(pointer), dbp(previous), dbp(decl));
     thisToDeclaration.emplace(pointer, decl);
@@ -66,8 +64,7 @@ void ReferenceMap::setDeclaration(const IR::This *pointer, const IR::IDeclaratio
 
 const IR::IDeclaration *ReferenceMap::getDeclaration(const IR::This *pointer, bool notNull) const {
     CHECK_NULL(pointer);
-    auto it = thisToDeclaration.find(pointer);
-    auto result = it != thisToDeclaration.end() ? it->second : nullptr;
+    const auto *result = get(thisToDeclaration, pointer);
 
     if (result)
         LOG3("Looking up " << dbp(pointer) << " found " << dbp(result));
@@ -80,8 +77,7 @@ const IR::IDeclaration *ReferenceMap::getDeclaration(const IR::This *pointer, bo
 
 const IR::IDeclaration *ReferenceMap::getDeclaration(const IR::Path *path, bool notNull) const {
     CHECK_NULL(path);
-    auto it = pathToDeclaration.find(path);
-    auto result = it != pathToDeclaration.end() ? it->second : nullptr;
+    const auto *result = get(pathToDeclaration, path);
 
     if (result)
         LOG3("Looking up " << dbp(path) << " found " << dbp(result));

--- a/frontends/common/resolveReferences/referenceMap.cpp
+++ b/frontends/common/resolveReferences/referenceMap.cpp
@@ -35,7 +35,7 @@ void ReferenceMap::clear() {
     program = nullptr;
     used.clear();
     thisToDeclaration.clear();
-    for (auto &reserved : P4::reservedWords) usedNames.insert({reserved, 0});
+    for (auto &reserved : P4::reservedWords) usedNames.emplace(reserved, 0);
     ProgramMap::clear();
 }
 
@@ -43,7 +43,8 @@ void ReferenceMap::setDeclaration(const IR::Path *path, const IR::IDeclaration *
     CHECK_NULL(path);
     CHECK_NULL(decl);
     LOG3("Resolved " << dbp(path) << " to " << dbp(decl));
-    auto previous = get(pathToDeclaration, path);
+    auto it = pathToDeclaration.find(path);
+    auto previous = it != pathToDeclaration.end() ? it->second : nullptr;
     if (previous != nullptr && previous != decl)
         BUG("%1% already resolved to %2% instead of %3%", dbp(path), dbp(previous),
             dbp(decl->getNode()));
@@ -56,7 +57,8 @@ void ReferenceMap::setDeclaration(const IR::This *pointer, const IR::IDeclaratio
     CHECK_NULL(pointer);
     CHECK_NULL(decl);
     LOG3("Resolved " << dbp(pointer) << " to " << dbp(decl));
-    auto previous = get(thisToDeclaration, pointer);
+    auto it = thisToDeclaration.find(pointer);
+    auto previous = it != thisToDeclaration.end() ? it->second : nullptr;
     if (previous != nullptr && previous != decl)
         BUG("%1% already resolved to %2% instead of %3%", dbp(pointer), dbp(previous), dbp(decl));
     thisToDeclaration.emplace(pointer, decl);
@@ -64,7 +66,8 @@ void ReferenceMap::setDeclaration(const IR::This *pointer, const IR::IDeclaratio
 
 const IR::IDeclaration *ReferenceMap::getDeclaration(const IR::This *pointer, bool notNull) const {
     CHECK_NULL(pointer);
-    auto result = get(thisToDeclaration, pointer);
+    auto it = thisToDeclaration.find(pointer);
+    auto result = it != thisToDeclaration.end() ? it->second : nullptr;
 
     if (result)
         LOG3("Looking up " << dbp(pointer) << " found " << dbp(result));
@@ -77,7 +80,8 @@ const IR::IDeclaration *ReferenceMap::getDeclaration(const IR::This *pointer, bo
 
 const IR::IDeclaration *ReferenceMap::getDeclaration(const IR::Path *path, bool notNull) const {
     CHECK_NULL(path);
-    auto result = get(pathToDeclaration, path);
+    auto it = pathToDeclaration.find(path);
+    auto result = it != pathToDeclaration.end() ? it->second : nullptr;
 
     if (result)
         LOG3("Looking up " << dbp(path) << " found " << dbp(result));
@@ -108,7 +112,7 @@ cstring ReferenceMap::newName(cstring base) {
 
     cstring name = base;
     if (usedNames.count(name)) name = cstring::make_unique(usedNames, name, usedNames[base], '_');
-    usedNames.insert({name, 0});
+    usedNames.emplace(name, 0);
     return name;
 }
 
@@ -127,7 +131,7 @@ cstring MinimalNameGenerator::newName(cstring base) {
 
     cstring name = base;
     if (usedNames.count(name)) name = cstring::make_unique(usedNames, name, usedNames[base], '_');
-    usedNames.insert({name, 0});
+    usedNames.emplace(name, 0);
     return name;
 }
 

--- a/frontends/common/resolveReferences/referenceMap.h
+++ b/frontends/common/resolveReferences/referenceMap.h
@@ -17,11 +17,12 @@ limitations under the License.
 #ifndef COMMON_RESOLVEREFERENCES_REFERENCEMAP_H_
 #define COMMON_RESOLVEREFERENCES_REFERENCEMAP_H_
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "frontends/common/programMap.h"
 #include "ir/ir.h"
 #include "ir/visitor.h"
 #include "lib/cstring.h"
-#include "lib/map.h"
 
 namespace P4 {
 
@@ -34,7 +35,7 @@ class NameGenerator {
 class MinimalNameGenerator : public NameGenerator, public Inspector {
     /// All names used in the program. Key is a name, value represents how many times
     /// this name was used as a base for newly generated unique names.
-    std::unordered_map<cstring, int> usedNames;
+    absl::flat_hash_map<cstring, int, Util::Hash> usedNames;
     void postorder(const IR::Path *p) override { usedName(p->name.name); }
     void postorder(const IR::Type_Declaration *t) override { usedName(t->name.name); }
     void postorder(const IR::Declaration *d) override { usedName(d->name.name); }
@@ -67,17 +68,17 @@ class ReferenceMap final : public ProgramMap, public NameGenerator, public Decla
     bool isv1;
 
     /// Maps paths in the program to declarations.
-    ordered_map<const IR::Path *, const IR::IDeclaration *> pathToDeclaration;
+    absl::flat_hash_map<const IR::Path *, const IR::IDeclaration *, Util::Hash> pathToDeclaration;
 
     /// Set containing all declarations in the program.
-    std::set<const IR::IDeclaration *> used;
+    absl::flat_hash_set<const IR::IDeclaration *, Util::Hash> used;
 
     /// Map from `This` to declarations (an experimental feature).
-    std::map<const IR::This *, const IR::IDeclaration *> thisToDeclaration;
+    absl::flat_hash_map<const IR::This *, const IR::IDeclaration *, Util::Hash> thisToDeclaration;
 
     /// All names used in the program. Key is a name, value represents how many times
     /// this name was used as a base for newly generated unique names.
-    std::unordered_map<cstring, int> usedNames;
+    absl::flat_hash_map<cstring, int, Util::Hash> usedNames;
 
  public:
     ReferenceMap();
@@ -116,7 +117,7 @@ class ReferenceMap final : public ProgramMap, public NameGenerator, public Decla
     bool isUsed(const IR::IDeclaration *decl) const { return used.count(decl) > 0; }
 
     /// Indicate that @p name is used in the program.
-    void usedName(cstring name) { usedNames.insert({name, 0}); }
+    void usedName(cstring name) { usedNames.emplace(name, 0); }
 };
 
 }  // namespace P4

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -17,9 +17,9 @@ limitations under the License.
 #ifndef COMMON_RESOLVEREFERENCES_RESOLVEREFERENCES_H_
 #define COMMON_RESOLVEREFERENCES_RESOLVEREFERENCES_H_
 
+#include "absl/container/flat_hash_map.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
-#include "lib/exceptions.h"
 #include "lib/iterator_range.h"
 #include "referenceMap.h"
 
@@ -41,10 +41,12 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
     std::unordered_multimap<cstring, const IR::IDeclaration *> &memoizeDeclsByName(
         const IR::INamespace *ns) const;
 
-    mutable std::unordered_map<const IR::INamespace *, std::vector<const IR::IDeclaration *>>
+    mutable absl::flat_hash_map<const IR::INamespace *, std::vector<const IR::IDeclaration *>,
+                                Util::Hash>
         namespaceDecls;
-    mutable std::unordered_map<const IR::INamespace *,
-                               std::unordered_multimap<cstring, const IR::IDeclaration *>>
+    mutable absl::flat_hash_map<const IR::INamespace *,
+                                std::unordered_multimap<cstring, const IR::IDeclaration *>,
+                                Util::Hash>
         namespaceDeclNames;
 
  protected:

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -258,8 +258,8 @@ void ProgramPoints::add(const ProgramPoints *from) {
 }
 
 const ProgramPoints *ProgramPoints::merge(const ProgramPoints *with) const {
-    auto result = new ProgramPoints(points);
-    for (auto p : with->points) result->points.emplace(p);
+    auto *result = new ProgramPoints(points);
+    result->points.insert(with->points.begin(), with->points.end());
     return result;
 }
 

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -253,6 +253,10 @@ bool LocationSet::overlaps(const LocationSet *other) const {
     return false;
 }
 
+void ProgramPoints::add(const ProgramPoints *from) {
+    points.insert(from->points.begin(), from->points.end());
+}
+
 const ProgramPoints *ProgramPoints::merge(const ProgramPoints *with) const {
     auto result = new ProgramPoints(points);
     for (auto p : with->points) result->points.emplace(p);
@@ -329,10 +333,10 @@ void Definitions::removeLocation(const StorageLocation *location) {
 }
 
 const ProgramPoints *Definitions::getPoints(const LocationSet *locations) const {
-    const ProgramPoints *result = new ProgramPoints();
-    for (auto sl : *locations->canonicalize()) {
-        auto points = getPoints(sl->to<BaseLocation>());
-        result = result->merge(points);
+    ProgramPoints *result = new ProgramPoints();
+    for (const auto *sl : *locations->canonicalize()) {
+        const auto *points = getPoints(sl->to<BaseLocation>());
+        result->add(points);
     }
     return result;
 }

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -260,7 +260,11 @@ const ProgramPoints *ProgramPoints::merge(const ProgramPoints *with) const {
 }
 
 ProgramPoint::ProgramPoint(const ProgramPoint &context, const IR::Node *node) {
-    for (auto e : context.stack) stack.push_back(e);
+    assign(context, node);
+}
+
+void ProgramPoint::assign(const ProgramPoint &context, const IR::Node *node) {
+    stack.assign(context.stack.begin(), context.stack.end());
     stack.push_back(node);
 }
 

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "frontends/p4/sideEffects.h"
 #include "frontends/p4/tableApply.h"
 #include "frontends/p4/ternaryBool.h"
+#include "lib/hash.h"
 
 namespace P4 {
 
@@ -31,10 +32,9 @@ namespace {
 class HasUses {
     // Set of program points whose left-hand sides are used elsewhere
     // in the program together with their use count
-    absl::flat_hash_set<const IR::Node *> used;
+    absl::flat_hash_set<const IR::Node *, Util::Hash> used;
 
     class SliceTracker {
-        // FIXME: Can squeeze this bool into lower bit of pointer
         const IR::Slice *trackedSlice = nullptr;
         bool active = false;
         bool overwritesPrevious(const IR::Slice *previous) {

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -371,7 +371,7 @@ class FindUninitialized : public Inspector {
     ProgramPoint currentPoint;  // context of the current expression/statement
     /// For some simple expresssions keep here the read location sets.
     /// This does not include location sets read by subexpressions.
-    absl::flat_hash_map<const IR::Expression *, const LocationSet *> readLocations;
+    absl::flat_hash_map<const IR::Expression *, const LocationSet *, Util::Hash> readLocations;
     HasUses *hasUses;  // output
     /// If true the current statement is unreachable
     bool unreachable = false;
@@ -381,10 +381,9 @@ class FindUninitialized : public Inspector {
     bool reportInvalidHeaders = true;
 
     const LocationSet *getReads(const IR::Expression *expression, bool nonNull = false) const {
-        auto it = readLocations.find(expression);
-        if (nonNull)
-            BUG_CHECK(it != readLocations.end(), "no locations known for %1%", dbp(expression));
-        return (it == readLocations.end() ? nullptr : it->second);
+        const auto *result = ::get(readLocations, expression);
+        if (nonNull) BUG_CHECK(result != nullptr, "no locations known for %1%", dbp(expression));
+        return result;
     }
     /// 'expression' is reading the 'loc' location set
     void reads(const IR::Expression *expression, const LocationSet *loc) {

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -112,8 +112,7 @@ void TypeMap::setType(const IR::Node *element, const IR::Type *type) {
 
 const IR::Type *TypeMap::getType(const IR::Node *element, bool notNull) const {
     CHECK_NULL(element);
-    auto it = typeMap.find(element);
-    auto result = it != typeMap.end() ? it->second : nullptr;
+    const auto *result = get(typeMap, element);
     LOG4("Looking up type for " << dbp(element) << " => " << dbp(result));
     if (notNull && result == nullptr)
         BUG_CHECK(errorCount() > 0, "Could not find type for %1%", dbp(element));

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -16,8 +16,6 @@ limitations under the License.
 
 #include "typeMap.h"
 
-#include "lib/map.h"
-
 namespace P4 {
 
 bool TypeMap::typeIsEmpty(const IR::Type *type) const {
@@ -101,8 +99,8 @@ void TypeMap::checkPrecondition(const IR::Node *element, const IR::Type *type) c
 
 void TypeMap::setType(const IR::Node *element, const IR::Type *type) {
     checkPrecondition(element, type);
-    auto it = typeMap.find(element);
-    if (it != typeMap.end()) {
+    auto [it, inserted] = typeMap.emplace(element, type);
+    if (!inserted) {
         const IR::Type *existingType = it->second;
         if (!implicitlyConvertibleTo(type, existingType))
             BUG("Changing type of %1% in type map from %2% to %3%", dbp(element), dbp(existingType),
@@ -110,12 +108,12 @@ void TypeMap::setType(const IR::Node *element, const IR::Type *type) {
         return;
     }
     LOG3("setType " << dbp(element) << " => " << dbp(type));
-    typeMap.emplace(element, type);
 }
 
 const IR::Type *TypeMap::getType(const IR::Node *element, bool notNull) const {
     CHECK_NULL(element);
-    auto result = get(typeMap, element);
+    auto it = typeMap.find(element);
+    auto result = it != typeMap.end() ? it->second : nullptr;
     LOG4("Looking up type for " << dbp(element) << " => " << dbp(result));
     if (notNull && result == nullptr)
         BUG_CHECK(errorCount() > 0, "Could not find type for %1%", dbp(element));
@@ -126,8 +124,9 @@ const IR::Type *TypeMap::getType(const IR::Node *element, bool notNull) const {
 const IR::Type *TypeMap::getTypeType(const IR::Node *element, bool notNull) const {
     CHECK_NULL(element);
     auto result = getType(element, notNull);
-    BUG_CHECK(result->is<IR::Type_Type>(), "%1%: expected a TypeType", result);
-    return result->to<IR::Type_Type>()->type;
+    auto typeType = result->to<IR::Type_Type>();
+    BUG_CHECK(typeType, "%1%: expected a TypeType", result);
+    return typeType->type;
 }
 
 void TypeMap::addSubstitutions(const TypeVariableSubstitution *tvs) {

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -17,9 +17,10 @@ limitations under the License.
 #ifndef FRONTENDS_P4_TYPEMAP_H_
 #define FRONTENDS_P4_TYPEMAP_H_
 
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "frontends/common/programMap.h"
 #include "frontends/p4/typeChecking/typeSubstitution.h"
-#include "lib/ordered_set.h"
 
 namespace P4 {
 /**
@@ -38,7 +39,6 @@ Objects that have a type in the map:
 - type declarations - map name to the actual type
 */
 class TypeMap final : public ProgramMap {
- protected:
     // We want to have the same canonical type for two
     // different tuples, lists, stacks, or p4lists with the same signature.
     std::vector<const IR::Type *> canonicalTuples;
@@ -47,13 +47,13 @@ class TypeMap final : public ProgramMap {
     std::vector<const IR::Type *> canonicalLists;
 
     // Map each node to its canonical type
-    ordered_map<const IR::Node *, const IR::Type *> typeMap;
+    absl::flat_hash_map<const IR::Node *, const IR::Type *, Util::Hash> typeMap;
     // All left-values in the program.
-    ordered_set<const IR::Expression *> leftValues;
+    absl::flat_hash_set<const IR::Expression *, Util::Hash> leftValues;
     // All compile-time constants.  A compile-time constant
     // is not necessarily a constant - it could be a directionless
     // parameter as well.
-    ordered_set<const IR::Expression *> constants;
+    absl::flat_hash_set<const IR::Expression *, Util::Hash> constants;
     // For each type variable in the program the actual
     // type that is substituted for it.
     TypeVariableSubstitution allTypeVariables;

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -114,4 +114,5 @@ set (MIDEND_HDRS
 
 
 add_library (midend STATIC ${MIDEND_SRCS})
+target_link_libraries(midend frontend) # For TypeMap / RefMap
 add_dependencies(midend genIR ir-generated)


### PR DESCRIPTION
This is PR on top of https://github.com/p4lang/p4c/pull/4459 to show how we can improve the things even more with better data structures.

Essentially, this uses more efficient data structures on some hot code paths:
 - abseil hash maps / sets in reference resolver and type map
 - abseil maps / sets & pre-allocated vector in use-def analisys
 - remove some useless allocations and memory traffic in use def

Here are results:
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `gtestp4c-abseil --gtest_filter=P4CParserUnroll.switch_20160512` | 6.056 ± 0.232 | 5.773 | 6.465 | 1.29 ± 0.05 |
| `gtestp4c --gtest_filter=P4CParserUnroll.switch_20160512` | 4.701 ± 0.061 | 4.600 | 4.783 | 1.00 |

`gtestp4c-abseil` is https://github.com/p4lang/p4c/pull/4459 (so yes 78% faster a total compared to `main`).