### PR TITLE
Try to clean up the Protobuf includes.

### DIFF
--- a/backends/dpdk/CMakeLists.txt
+++ b/backends/dpdk/CMakeLists.txt
@@ -40,7 +40,7 @@ add_custom_command(
 add_dependencies(dpdk_runtime_dir controlplane)
 
 add_library(dpdk_runtime STATIC ${DPDK_P4RUNTIME_INFO_GEN_SRCS})
-target_link_libraries(dpdk_runtime controlplane)
+target_link_libraries(dpdk_runtime PRIVATE controlplane)
 
 # Silence various warnings as the root issue is out of our control, example https://github.com/protocolbuffers/protobuf/issues/7140
 set_source_files_properties(${DPDK_P4RUNTIME_INFO_GEN_SRCS} {$DPDK_P4RUNTIME_INFO_GEN_HDRS} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds -Wno-error")
@@ -61,7 +61,7 @@ set(P4C_DPDK_SOURCES
     options.cpp
     control-plane/bfruntime_ext.cpp
     tdiConf.cpp
-    )
+)
 
 set(P4C_DPDK_HEADERS
     ../bmv2/common/lower.h
@@ -82,7 +82,7 @@ set(P4C_DPDK_HEADERS
     control-plane/bfruntime_ext.h
     control-plane/bfruntime_arch_handler.h
     tdiConf.h
-    )
+)
 
 set (IR_DEF_FILES ${IR_DEF_FILES} ${CMAKE_CURRENT_SOURCE_DIR}/dpdk.def PARENT_SCOPE)
 

--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -59,5 +59,4 @@ add_dependencies(p4tools-common ir-generated frontend)
 # Add control-plane-specific extensions.
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/control_plane)
 
-target_link_libraries(p4tools-control-plane controlplane)
 

--- a/backends/p4tools/common/control_plane/CMakeLists.txt
+++ b/backends/p4tools/common/control_plane/CMakeLists.txt
@@ -5,8 +5,4 @@ set(
 )
 
 add_p4tools_library(p4tools-control-plane ${P4C_TOOLS_CONTROL_PLANE_SOURCES})
-
-target_include_directories(
-  p4tools-control-plane
-  SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIRS}
-)
+target_link_libraries(p4tools-control-plane PRIVATE controlplane)

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -106,7 +106,7 @@ configure_file(register.h.in register.h)
 # The library.
 add_p4tools_library(testgen ${TESTGEN_SOURCES})
 # Make sure the testgen library and anything that links to it see both the Z3 and Inja includes.
-target_link_libraries(testgen PUBLIC p4tools-common ${Protobuf_LIBRARY} inja)
+target_link_libraries(testgen ${TESTGEN_LIBS})
 if (TESTGEN_INCLUDES)
   target_include_directories(testgen ${TESTGEN_INCLUDES})
 endif()

--- a/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
@@ -54,11 +54,7 @@ execute_process(COMMAND ln -sfn ${P4C_SOURCE_DIR}/backends/bmv2/run-bmv2-test.py
 
 set(
   TESTGEN_LIBS ${TESTGEN_LIBS}
+  PRIVATE controlplane
   PARENT_SCOPE
 )
 
-set(
-  TESTGEN_INCLUDES ${TESTGEN_INCLUDES}
-  SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIRS}
-  PARENT_SCOPE
-)

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -79,7 +79,7 @@ set (CONTROLPLANE_SRCS
   p4RuntimeSymbolTable.cpp
   typeSpecConverter.cpp
   bfruntime.cpp
-  )
+)
 
 set (CONTROLPLANE_HDRS
   addMissingIds.h
@@ -93,22 +93,28 @@ set (CONTROLPLANE_HDRS
   p4RuntimeTypes.h
   typeSpecConverter.h
   bfruntime.h
-  )
+)
 
 add_library(controlplane-gen OBJECT ${P4RUNTIME_GEN_SRCS})
-target_include_directories(controlplane-gen
-  SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIRS}
+target_include_directories(
+  controlplane-gen SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIRS} SYSTEM BEFORE
+  PUBLIC ${ABSL_COMMON_INCLUDE_DIRS}
 )
-target_link_libraries (controlplane-gen PUBLIC ${Protobuf_LIBRARY})
+
+target_link_libraries(controlplane-gen PUBLIC ${Protobuf_LIBRARY} PRIVATE absl::log)
 # Needed for the correct import of google/status.pb.cc
 target_include_directories(
-  controlplane-gen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+  controlplane-gen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-
-# Silence various warnings as the root issue is out of our control, example https://github.com/protocolbuffers/protobuf/issues/7140
-set_source_files_properties (${P4RUNTIME_GEN_SRCS} {$P4RUNTIME_GEN_HDRS} PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds -Wno-error")
+# Silence various warnings as the root issue is out of our control, example
+# https://github.com/protocolbuffers/protobuf/issues/7140
+set_source_files_properties(
+  ${P4RUNTIME_GEN_SRCS} {$P4RUNTIME_GEN_HDRS}
+  PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter -Wno-array-bounds -Wno-error"
+)
 
 add_library(controlplane STATIC ${CONTROLPLANE_SRCS})
-target_link_libraries(controlplane ${CMAKE_THREAD_LIBS_INIT} controlplane-gen)
+target_link_libraries(controlplane PUBLIC ${CMAKE_THREAD_LIBS_INIT} PUBLIC controlplane-gen)
+
 add_dependencies(controlplane mkP4configdir ir-generated controlplane-gen frontend-parser-gen)

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -96,6 +96,9 @@ set (CONTROLPLANE_HDRS
 )
 
 add_library(controlplane-gen OBJECT ${P4RUNTIME_GEN_SRCS})
+# TODO(https://github.com/p4lang/p4c/issues/4477):
+# We should not need this, but because of the way managed includes and
+# libraries for Protobuf we need to explicitly add the include directories here.
 target_include_directories(
   controlplane-gen SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIRS} SYSTEM BEFORE
   PUBLIC ${ABSL_COMMON_INCLUDE_DIRS}


### PR DESCRIPTION
The control plane target depends on Protobuf and Abseil. At least for Protobuf, it should export this dependency such that other downstream targets do not need to include the Protobuf include directories all the time. 

Unclear what to do about Abseil. It is more or less a core compiler dependency and libraries should be linked by each target individually. 

This is tangentially related to https://github.com/p4lang/p4c/issues/4420. Because the control plane pulls in all this stuff, it should be optional. 
