### PR TITLE
[P4Testgen] Add a rudimentary P4Testgen benchmark with via GTest.

### DIFF
--- a/backends/p4tools/modules/testgen/lib/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/lib/test_backend.cpp
@@ -104,7 +104,6 @@ bool TestBackEnd::run(const FinalState &state) {
         auto concolicOptState = state.computeConcolicState(*resolvedConcolicVariables);
         if (!concolicOptState.has_value()) {
             testCount++;
-            printPerformanceReport(std::nullopt);
             return needsToTerminate(testCount);
         }
         auto replacedState = concolicOptState.value().get();
@@ -125,7 +124,6 @@ bool TestBackEnd::run(const FinalState &state) {
         abort = printTestInfo(executionState, testInfo, outputPortExpr);
         if (abort) {
             testCount++;
-            printPerformanceReport(std::nullopt);
             return needsToTerminate(testCount);
         }
         const auto *testSpec = createTestSpec(executionState, &finalModel, testInfo);
@@ -175,12 +173,14 @@ bool TestBackEnd::run(const FinalState &state) {
 
         printTraces("============ End Test %1% ============\n", testCount);
         P4::Coverage::printCoverageReport(coverableNodes, visitedNodes);
-        printPerformanceReport(std::nullopt);
 
         // If MAX_NODE_COVERAGE is enabled, terminate early if we hit max node coverage already.
         if (testgenOptions.stopMetric == "MAX_NODE_COVERAGE" && coverage == 1.0) {
             return true;
         }
+#ifdef P4TESTGEN_PRINT_PERFORMANCE_PER_TEST
+        printPerformanceReport(std::nullopt);
+#endif
         return needsToTerminate(testCount);
     }
 }

--- a/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
@@ -33,9 +33,10 @@ set(TESTGEN_SOURCES
 
 set(TESTGEN_GTEST_SOURCES
   ${TESTGEN_GTEST_SOURCES}
-  ${CMAKE_CURRENT_SOURCE_DIR}/test/testgen_api/output_option_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test/testgen_api/api_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test/testgen_api/benchmark.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test/testgen_api/control_plane_filter_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test/testgen_api/output_option_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test/test_backend/ptf.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test/test_backend/stf.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test/small-step/binary.cpp

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include "backends/p4tools/common/lib/logging.h"
+#include "test/gtest/helpers.h"
 
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/path_selection.h"
 #include "backends/p4tools/modules/testgen/options.h"
@@ -10,11 +11,13 @@
 namespace Test {
 
 TEST(P4TestgenBenchmark, SuccessfullyGenerate1000Tests) {
-    auto compilerOptions = CompilerOptions();
+    auto compilerOptions = P4CContextWithOptions<CompilerOptions>::get().options();
     compilerOptions.target = "bmv2";
     compilerOptions.arch = "v1model";
-    auto fabricFile = std::filesystem::path(__FILE__).replace_filename(
-        "../../../../../../../../testdata/p4_16_samples/fabric_20190420/fabric.p4");
+    auto includePath = P4CTestEnvironment::getProjectRoot() / "p4include";
+    compilerOptions.preprocessor_options = "-I" + includePath.string();
+    auto fabricFile =
+        P4CTestEnvironment::getProjectRoot() / "testdata/p4_16_samples/fabric_20190420/fabric.p4";
     compilerOptions.file = fabricFile.string();
     auto &testgenOptions = P4Tools::P4Testgen::TestgenOptions::get();
     testgenOptions.testBackend = "PROTOBUF_IR";

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
@@ -1,0 +1,38 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "backends/p4tools/common/lib/logging.h"
+
+#include "backends/p4tools/modules/testgen/core/symbolic_executor/path_selection.h"
+#include "backends/p4tools/modules/testgen/options.h"
+#include "backends/p4tools/modules/testgen/testgen.h"
+
+namespace Test {
+
+TEST(P4TestgenBenchmark, SuccessfullyGenerate1000Tests) {
+    auto compilerOptions = CompilerOptions();
+    compilerOptions.target = "bmv2";
+    compilerOptions.arch = "v1model";
+    auto fabricFile = std::filesystem::path(__FILE__).replace_filename(
+        "../../../../../../../../testdata/p4_16_samples/fabric_20190420/fabric.p4");
+    compilerOptions.file = fabricFile.string();
+    auto &testgenOptions = P4Tools::P4Testgen::TestgenOptions::get();
+    testgenOptions.testBackend = "PROTOBUF_IR";
+    testgenOptions.testBaseName = "dummy";
+    testgenOptions.seed = 1;
+    // Fix the packet size.
+    testgenOptions.minPktSize = 512;
+    testgenOptions.maxPktSize = 512;
+    // Select a random path for each test.
+    testgenOptions.pathSelectionPolicy = P4Tools::P4Testgen::PathSelectionPolicy::RandomBacktrack;
+    // Generate 2000 tests.
+    testgenOptions.maxTests = 2000;
+    // This enables performance printing.
+    P4Tools::enablePerformanceLogging();
+
+    P4Tools::P4Testgen::Testgen::generateTests(compilerOptions, testgenOptions);
+
+    // Print the report.
+    P4Tools::printPerformanceReport();
+}
+}  // namespace Test

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -163,7 +163,7 @@ std::optional<AbstractTestList> generateTestsImpl(std::optional<std::string_view
         // Run the compiler to get an IR and invoke the tool.
         compilerResultOpt = P4Tools::CompilerTarget::runCompiler(std::string(program.value()));
     } else {
-        if (!compilerOptions.file.isNullOrEmpty()) {
+        if (compilerOptions.file.isNullOrEmpty()) {
             ::error("Expected a file input.");
             return std::nullopt;
         }

--- a/test/gtest/helpers.cpp
+++ b/test/gtest/helpers.cpp
@@ -148,6 +148,10 @@ P4CTestEnvironment::P4CTestEnvironment() {
     _psaP4 = readHeader(psaPath.c_str(), true);
 }
 
+std::filesystem::path P4CTestEnvironment::getProjectRoot() {
+    return std::filesystem::path(__FILE__).parent_path().parent_path().parent_path();
+}
+
 namespace Test {
 
 /* static */ std::optional<FrontendTestCase> FrontendTestCase::create(

--- a/test/gtest/helpers.h
+++ b/test/gtest/helpers.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
 #include <optional>
 #include <string>
 
@@ -91,6 +92,9 @@ class P4CTestEnvironment {
 
     /// @return a string containing the "psa.p4" P4 standard header.
     const std::string &psaP4() const { return _psaP4; }
+
+    /// @return the path to the P4C project root.
+    static std::filesystem::path getProjectRoot();
 
  private:
     P4CTestEnvironment();


### PR DESCRIPTION
Generate 1000 P4Testgen tests for the fabric P4 program. This should take around 30 seconds. 
GTest is not really intended for this but it seems to work well enough. 