### PR TITLE
Replace boost string algorithms with their abseil counterparts

### DIFF
--- a/backends/p4tools/modules/testgen/test/small-step/util.cpp
+++ b/backends/p4tools/modules/testgen/test/small-step/util.cpp
@@ -1,9 +1,8 @@
-#include "backends/p4tools/modules/testgen/test/small-step/util.h"
+#include "util.h"
 
 #include <string>
 
-#include <boost/algorithm/string/replace.hpp>
-
+#include "absl/strings/substitute.h"
 #include "test/gtest/helpers.h"
 
 #include "backends/p4tools/modules/testgen/test/gtest_utils.h"
@@ -17,7 +16,7 @@ std::optional<const P4ToolsTestCase> createSmallStepExprTest(const std::string &
                                                              const std::string &expr) {
     auto source = P4_SOURCE(P4Headers::V1MODEL, R"(
 header H {
-  %HEADER_FIELDS%
+  $0
 }
 
 struct Headers {
@@ -40,7 +39,7 @@ extern void m<T>(in T data);
 
 control mau(inout Headers hdr, inout Metadata meta, inout standard_metadata_t sm) {
   apply {
-    m(%EXPR%);
+    m($1);
   }
 }
 
@@ -60,10 +59,7 @@ control computeChecksum(inout Headers hdr, inout Metadata meta) {
 
 V1Switch(parse(), verifyChecksum(), mau(), mau(), computeChecksum(), deparse()) main;)");
 
-    boost::replace_first(source, "%HEADER_FIELDS%", hdrFields);
-    boost::replace_first(source, "%EXPR%", expr);
-
-    return P4ToolsTestCase::create_16("bmv2", "v1model", source);
+    return P4ToolsTestCase::create_16("bmv2", "v1model", absl::Substitute(source, hdrFields, expr));
 }
 
 }  // namespace SmallStepUtil

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -118,6 +118,9 @@ set_source_files_properties(
 )
 
 add_library(controlplane STATIC ${CONTROLPLANE_SRCS})
-target_link_libraries(controlplane PUBLIC ${CMAKE_THREAD_LIBS_INIT} PUBLIC controlplane-gen)
+target_link_libraries(controlplane
+  PUBLIC ${CMAKE_THREAD_LIBS_INIT}
+  PUBLIC controlplane-gen
+  PRIVATE absl::strings)
 
 add_dependencies(controlplane mkP4configdir ir-generated controlplane-gen frontend-parser-gen)

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -259,6 +259,8 @@ if (FLEX_INCLUDE_DIRS)
 endif ()
 add_library (frontend STATIC ${FRONTEND_SOURCES})
 add_dependencies (frontend frontend-parser-gen)
-target_link_libraries (frontend frontend-parser-gen
-  absl::flat_hash_set
-  absl::flat_hash_map)
+target_link_libraries (frontend
+  PRIVATE frontend-parser-gen
+  PRIVATE absl::strings
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::flat_hash_map)

--- a/frontends/p4/typeChecking/typeConstraints.cpp
+++ b/frontends/p4/typeChecking/typeConstraints.cpp
@@ -151,16 +151,15 @@ std::string TypeConstraint::localError(Explain *explainer) const {
     return absl::StrCat(message, explanation);
 }
 
-bool TypeConstraint::reportErrorImpl(const TypeVariableSubstitution *subst, cstring m) const {
+bool TypeConstraint::reportErrorImpl(const TypeVariableSubstitution *subst,
+                                     std::string message) const {
     const auto *o = origin;
     const auto *constraint = this;
 
     Explain explainer(subst);
-    std::string message(m);
     while (constraint) {
-        cstring local = constraint->localError(&explainer);
-        if (!local.isNullOrEmpty())
-            absl::StrAppend(&message, "---- Originating from:\n", local.c_str());
+        std::string local = constraint->localError(&explainer);
+        if (!local.empty()) absl::StrAppend(&message, "---- Originating from:\n", local);
         o = constraint->origin;
         constraint = constraint->derivedFrom;
     }

--- a/frontends/p4/typeChecking/typeConstraints.cpp
+++ b/frontends/p4/typeChecking/typeConstraints.cpp
@@ -16,6 +16,9 @@ limitations under the License.
 
 #include "typeConstraints.h"
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
 #include "typeUnification.h"
 
 namespace P4 {
@@ -109,6 +112,71 @@ void TypeConstraints::dbprint(std::ostream &out) const {
         out << std::endl << "Constraints: ";
         for (auto c : constraints) out << std::endl << c;
     }
+}
+
+std::string TypeConstraint::localError(Explain *explainer) const {
+    if (errFormat.isNullOrEmpty()) return "";
+
+    std::string message, explanation;
+    boost::format fmt = boost::format(errFormat);
+    switch (errArguments.size()) {
+        case 0:
+            message = boost::str(fmt);
+            break;
+        case 1:
+            absl::StrAppend(&explanation, explain(0, explainer));
+            message = ::error_helper(fmt, errArguments.at(0)).toString();
+            break;
+        case 2:
+            absl::StrAppend(&explanation, explain(0, explainer), explain(1, explainer));
+            message = ::error_helper(fmt, errArguments.at(0), errArguments.at(1)).toString();
+            break;
+        case 3:
+            absl::StrAppend(&explanation, explain(0, explainer), explain(1, explainer),
+                            explain(2, explainer));
+            message =
+                ::error_helper(fmt, errArguments.at(0), errArguments.at(1), errArguments.at(2))
+                    .toString();
+            break;
+        case 4:
+            absl::StrAppend(&explanation, explain(0, explainer), explain(1, explainer),
+                            explain(2, explainer), explain(3, explainer));
+            message = ::error_helper(fmt, errArguments.at(0), errArguments.at(1),
+                                     errArguments.at(2), errArguments.at(3))
+                          .toString();
+            break;
+        default:
+            BUG("Unexpected argument count for error message");
+    }
+    return absl::StrCat(message, explanation);
+}
+
+bool TypeConstraint::reportErrorImpl(const TypeVariableSubstitution *subst, cstring m) const {
+    const auto *o = origin;
+    const auto *constraint = this;
+
+    Explain explainer(subst);
+    std::string message(m);
+    while (constraint) {
+        cstring local = constraint->localError(&explainer);
+        if (!local.isNullOrEmpty())
+            absl::StrAppend(&message, "---- Originating from:\n", local.c_str());
+        o = constraint->origin;
+        constraint = constraint->derivedFrom;
+    }
+
+    // Indent each string in the message
+    std::vector<std::string_view> lines = absl::StrSplit(message, '\n');
+    bool lastIsEmpty = lines.back().empty();
+    if (lastIsEmpty)
+        // We don't want to indent an empty line.
+        lines.pop_back();
+    message = absl::StrJoin(lines, "\n  ");
+    if (lastIsEmpty) message += "\n";
+
+    CHECK_NULL(o);
+    ::errorWithSuffix(ErrorType::ERR_TYPE_ERROR, "'%1%'", message.c_str(), o);
+    return false;
 }
 
 }  // namespace P4

--- a/frontends/p4/typeChecking/typeConstraints.h
+++ b/frontends/p4/typeChecking/typeConstraints.h
@@ -17,15 +17,9 @@ limitations under the License.
 #ifndef TYPECHECKING_TYPECONSTRAINTS_H_
 #define TYPECHECKING_TYPECONSTRAINTS_H_
 
-#include <optional>
-#include <sstream>
-
-#include <boost/algorithm/string.hpp>
-
 #include "ir/ir.h"
 #include "lib/castable.h"
 #include "lib/error_helper.h"
-#include "typeConstraints.h"
 #include "typeSubstitution.h"
 #include "typeSubstitutionVisitor.h"
 #include "typeUnification.h"
@@ -66,6 +60,9 @@ class TypeConstraint : public IHasDbPrint, public ICastable {
     cstring errFormat;
     std::vector<const IR::Node *> errArguments;
 
+ private:
+    bool reportErrorImpl(const TypeVariableSubstitution *subst, cstring message) const;
+
  protected:
     /// Constraint which produced this one.  May be nullptr.
     const TypeConstraint *derivedFrom = nullptr;
@@ -80,45 +77,7 @@ class TypeConstraint : public IHasDbPrint, public ICastable {
         node->apply(*explainer);
         return explainer->explanation;
     }
-    cstring localError(Explain *explainer) const {
-        if (errFormat.isNullOrEmpty()) return "";
-        std::string message, explanation;
-        boost::format fmt = boost::format(errFormat);
-        switch (errArguments.size()) {
-            case 0:
-                message = boost::str(fmt);
-                break;
-            case 1:
-                explanation += explain(0, explainer);
-                message = ::error_helper(fmt, errArguments.at(0)).toString();
-                break;
-            case 2:
-                explanation += explain(0, explainer);
-                explanation += explain(1, explainer);
-                message = ::error_helper(fmt, errArguments.at(0), errArguments.at(1)).toString();
-                break;
-            case 3:
-                explanation += explain(0, explainer);
-                explanation += explain(1, explainer);
-                explanation += explain(2, explainer);
-                message =
-                    ::error_helper(fmt, errArguments.at(0), errArguments.at(1), errArguments.at(2))
-                        .toString();
-                break;
-            case 4:
-                explanation += explain(0, explainer);
-                explanation += explain(1, explainer);
-                explanation += explain(2, explainer);
-                explanation += explain(3, explainer);
-                message = ::error_helper(fmt, errArguments.at(0), errArguments.at(1),
-                                         errArguments.at(2), errArguments.at(3))
-                              .toString();
-                break;
-            default:
-                BUG("Unexpected argument count for error message");
-        }
-        return cstring(message) + explanation;
-    }
+    std::string localError(Explain *explainer) const;
 
  public:
     void setError(cstring format, std::initializer_list<const IR::Node *> nodes) {
@@ -136,32 +95,7 @@ class TypeConstraint : public IHasDbPrint, public ICastable {
         boost::format fmt(format);
         cstring message =
             cstring("  ---- Actual error:\n") + ::error_helper(fmt, args...).toString();
-        auto o = origin;
-        auto constraint = this;
-        Explain explainer(subst);
-        while (constraint) {
-            cstring local = constraint->localError(&explainer);
-            if (!local.isNullOrEmpty()) {
-                message += "---- Originating from:\n";
-                message += local;
-            }
-            o = constraint->origin;
-            constraint = constraint->derivedFrom;
-        }
-        // Indent each string in the message
-        std::string s = message.c_str();
-        std::vector<std::string> lines;
-        boost::split(lines, s, [](char c) { return c == '\n'; });
-        bool lastIsEmpty = lines.at(lines.size() - 1) == "";
-        if (lastIsEmpty)
-            // We don't want to indent an empty line.
-            lines.pop_back();
-        message = cstring::join(lines.begin(), lines.end(), "\n  ");
-        if (lastIsEmpty) message += "\n";
-
-        CHECK_NULL(o);
-        ::errorWithSuffix(ErrorType::ERR_TYPE_ERROR, "'%1%'", message.c_str(), o);
-        return false;
+        return reportErrorImpl(subst, message);
     }
     // Default error message; returns 'false'
     virtual bool reportError(const TypeVariableSubstitution *subst) const = 0;

--- a/frontends/parsers/parserDriver.cpp
+++ b/frontends/parsers/parserDriver.cpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <iostream>
 #include <sstream>
+#include <string_view>
 
 #include <boost/format.hpp>
 
@@ -99,7 +100,7 @@ void AbstractParserDriver::onReadIdentifier(cstring id) { lastIdentifier = id; }
 
 void AbstractParserDriver::onParseError(const Util::SourceInfo &location,
                                         const std::string &message) {
-    static const std::string unexpectedIdentifierError = "syntax error, unexpected IDENTIFIER";
+    static const std::string_view unexpectedIdentifierError = "syntax error, unexpected IDENTIFIER";
     auto &context = BaseCompileContext::get();
     if (message == unexpectedIdentifierError) {
         context.errorReporter().parser_error(

--- a/frontends/parsers/parserDriver.cpp
+++ b/frontends/parsers/parserDriver.cpp
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <sstream>
 
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/format.hpp>
 
 #include "frontends/common/constantFolding.h"
@@ -102,7 +101,7 @@ void AbstractParserDriver::onParseError(const Util::SourceInfo &location,
                                         const std::string &message) {
     static const std::string unexpectedIdentifierError = "syntax error, unexpected IDENTIFIER";
     auto &context = BaseCompileContext::get();
-    if (boost::equal(message, unexpectedIdentifierError)) {
+    if (message == unexpectedIdentifierError) {
         context.errorReporter().parser_error(
             location, boost::format("%s \"%s\"") % unexpectedIdentifierError % lastIdentifier);
     } else {

--- a/frontends/parsers/v1/v1lexer.ll
+++ b/frontends/parsers/v1/v1lexer.ll
@@ -3,7 +3,6 @@
 #include "frontends/parsers/parserDriver.h"
 #include "frontends/parsers/v1/v1lexer_internal.hpp"
 #include "frontends/parsers/v1/v1parser.hpp"
-#include "lib/stringref.h"
 
 using Parser = V1::V1Parser;
 
@@ -69,7 +68,7 @@ using Parser = V1::V1Parser;
 
 "@pragma"[ \t]*[A-Za-z_][A-Za-z0-9_]* {
                   BEGIN((driver.saveState = PRAGMA_LINE));
-                  return Parser::make_PRAGMA(StringRef(yytext+7).trim(), driver.yylloc); }
+                  return Parser::make_PRAGMA(V1Lexer::trim(yytext+7), driver.yylloc); }
 "@pragma"[ \t]* { BEGIN((driver.saveState = PRAGMA_LINE));
                   return Parser::make_PRAGMA("pragma", driver.yylloc); }
 

--- a/frontends/parsers/v1/v1lexer.ll
+++ b/frontends/parsers/v1/v1lexer.ll
@@ -68,7 +68,7 @@ using Parser = V1::V1Parser;
 
 "@pragma"[ \t]*[A-Za-z_][A-Za-z0-9_]* {
                   BEGIN((driver.saveState = PRAGMA_LINE));
-                  return Parser::make_PRAGMA(V1Lexer::trim(yytext+7), driver.yylloc); }
+                  return Parser::make_PRAGMA(cstring(V1Lexer::trim(yytext+7)), driver.yylloc); }
 "@pragma"[ \t]* { BEGIN((driver.saveState = PRAGMA_LINE));
                   return Parser::make_PRAGMA("pragma", driver.yylloc); }
 

--- a/frontends/parsers/v1/v1lexer_internal.hpp
+++ b/frontends/parsers/v1/v1lexer_internal.hpp
@@ -1,5 +1,7 @@
-#ifndef FRONTENDS_V1LEXER_INTERNAL_H_
-#define FRONTENDS_V1LEXER_INTERNAL_H_
+#ifndef FRONTENDS_PARSERS_V1_V1LEXER_INTERNAL_HPP_
+#define FRONTENDS_PARSERS_V1_V1LEXER_INTERNAL_HPP_
+
+#include <string_view>
 
 #include "frontends/common/constantParsing.h"
 #include "frontends/parsers/v1/v1parser.hpp"
@@ -13,7 +15,7 @@ class V1Lexer : public v1FlexLexer {
     typedef V1::V1Parser::symbol_type Token;
 
  public:
-    explicit V1Lexer(std::istream& input) : v1FlexLexer(&input) { }
+    explicit V1Lexer(std::istream &input) : v1FlexLexer(&input) {}
 
     /**
      * Invoked by the parser to advance to the next token in the input stream.
@@ -27,7 +29,21 @@ class V1Lexer : public v1FlexLexer {
      *
      * @return the token that was just read.
      */
-    virtual Token yylex(V1::V1ParserDriver& driver);
+    virtual Token yylex(V1::V1ParserDriver &driver);
+
+    static constexpr std::string_view trim(std::string_view in,
+                                           std::string_view white = " \n\r\t\v") {
+        auto left = in.find_first_not_of(white);
+        if (left == std::string_view::npos) return {};
+
+        in.remove_prefix(left);
+
+        auto right = in.find_last_not_of(white);
+        if (right == std::string_view::npos) return {};
+
+        in.remove_suffix(in.size() - right - 1);
+        return in;
+    }
 
  private:
     int yylex() override { return v1FlexLexer::yylex(); }
@@ -35,4 +51,4 @@ class V1Lexer : public v1FlexLexer {
 
 }  // namespace V1
 
-#endif  /* FRONTENDS_V1LEXER_INTERNAL_H_ */
+#endif /* FRONTENDS_PARSERS_V1_V1LEXER_INTERNAL_HPP_ */

--- a/ir/namemap.h
+++ b/ir/namemap.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "lib/enumerator.h"
 #include "lib/error.h"
 #include "lib/exceptions.h"
+#include "lib/map.h"
 
 class JSONLoader;
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -91,10 +91,3 @@ Conversion of various types to strings.
 ##### sourceCodeBuilder.h
 
 Support for emitting programs in source (works for P4 and C).
-
-##### stringref.h
-
-A stringref is really a substring of another string, with a specified
-length, but sharing the same storage.  Since it is just a reference, care needs
-to be taken to ensure that it does not outlive the storage it refers to -- if
-the object owning the memory releases it.

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -105,7 +105,7 @@ class cstring {
 
     // construct cstring from std::string_view. Do not use if possible, this is linear
     // time operation if string not exists in table, because the underlying string must be copied.
-    cstring(std::string_view string) {  // NOLINT(runtime/explicit)
+    explicit cstring(std::string_view string) {  // NOLINT(runtime/explicit)
         construct_from_shared(string.data(), string.length());
     }
 

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -103,6 +103,12 @@ class cstring {
         construct_from_shared(string.data(), string.length());
     }
 
+    // construct cstring from std::string_view. Do not use if possible, this is linear
+    // time operation if string not exists in table, because the underlying string must be copied.
+    cstring(std::string_view string) {  // NOLINT(runtime/explicit)
+        construct_from_shared(string.data(), string.length());
+    }
+
     // TODO (DanilLutsenko): Make special case for r-value std::string?
 
     // Just helper function, for lazies, who do not like to write .str()
@@ -278,6 +284,8 @@ class cstring {
 
 inline bool operator==(const char *a, cstring b) { return b == a; }
 inline bool operator!=(const char *a, cstring b) { return b != a; }
+inline bool operator==(const std::string &a, cstring b) { return b == a; }
+inline bool operator!=(const std::string &a, cstring b) { return b != a; }
 
 inline std::string operator+(cstring a, cstring b) {
     std::string rv(a);

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -311,3 +311,7 @@ cstring SourceFileLine::toString() const {
 }
 
 }  // namespace Util
+
+////////////////////////////////////////////////////////
+
+[[gnu::used]] void dbprint(const IHasDbPrint *o) { o->dbprint(std::cout); }

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -85,50 +85,50 @@ unsigned InputSources::lineCount() const {
 }
 
 // Append this text to the last line
-void InputSources::appendToLastLine(StringRef text) {
+void InputSources::appendToLastLine(std::string_view text) {
     if (sealed) BUG("Appending to sealed InputSources");
     // Text should not contain any newline characters
-    for (size_t i = 0; i < text.len; i++) {
+    for (size_t i = 0; i < text.size(); i++) {
         char c = text[i];
         if (c == '\n') BUG("Text contains newlines");
     }
-    contents.back() += text.toString();
+    contents.back() += toString(text);
 }
 
 // Append a newline and start a new line
-void InputSources::appendNewline(StringRef newline) {
+void InputSources::appendNewline(std::string_view newline) {
     if (sealed) BUG("Appending to sealed InputSources");
-    contents.back() += newline.toString();
+    contents.back() += toString(newline);
     contents.push_back("");  // start a new line
 }
 
 void InputSources::appendText(const char *text) {
     if (text == nullptr) BUG("Null text being appended");
-    StringRef ref = text;
+    std::string_view ref(text);
 
-    while (ref.len > 0) {
-        const char *nl = ref.find("\r\n");
-        if (nl == nullptr) {
+    while (ref.size() > 0) {
+        auto nlPos = ref.find_first_of("\r\n");
+        if (nlPos == std::string_view::npos) {
             appendToLastLine(ref);
             break;
         }
 
-        size_t toCut = nl - ref.p;
+        size_t toCut = nlPos;
         if (toCut != 0) {
-            StringRef nonnl(ref.p, toCut);
+            std::string_view nonnl(ref.data(), toCut);
             appendToLastLine(nonnl);
-            ref += toCut;
+            ref.remove_prefix(toCut);
         } else {
             if (ref[0] == '\n') {
                 appendNewline("\n");
-                ref += 1;
-            } else if (ref.len > 2 && ref[0] == '\r' && ref[1] == '\n') {
+                ref.remove_prefix(1);
+            } else if (ref.size() > 2 && ref[0] == '\r' && ref[1] == '\n') {
                 appendNewline("\r\n");
-                ref += 2;
+                ref.remove_prefix(2);
             } else {
                 // Just \r
                 appendToLastLine(ref.substr(0, 1));
-                ref += 1;
+                ref.remove_prefix(1);
             }
         }
     }

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -314,4 +314,7 @@ cstring SourceFileLine::toString() const {
 
 ////////////////////////////////////////////////////////
 
-[[gnu::used]] void dbprint(const IHasDbPrint *o) { o->dbprint(std::cout); }
+[[gnu::used]]  // ensure linker will not drop function even if unused
+void dbprint(const IHasDbPrint *o) {
+    o->dbprint(std::cout);
+}

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -21,7 +21,6 @@ limitations under the License.
 #ifndef LIB_SOURCE_FILE_H_
 #define LIB_SOURCE_FILE_H_
 
-#include <iostream>
 #include <map>
 #include <vector>
 
@@ -40,7 +39,7 @@ class IHasDbPrint {
  public:
     virtual void dbprint(std::ostream &out) const = 0;
     void print() const;  // useful in the debugger
-    virtual ~IHasDbPrint() {}
+    virtual ~IHasDbPrint() = default;
 };
 
 namespace Util {
@@ -319,7 +318,6 @@ class InputSources final {
 
 }  // namespace Util
 
-// FIXME: Do we really need to have this in header? This pulls the whole iostream header
-inline void dbprint(const IHasDbPrint *o) { o->dbprint(std::cout); }
+void dbprint(const IHasDbPrint *o);
 
 #endif /* LIB_SOURCE_FILE_H_ */

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -21,11 +21,11 @@ limitations under the License.
 #ifndef LIB_SOURCE_FILE_H_
 #define LIB_SOURCE_FILE_H_
 
+#include <iostream>
 #include <map>
 #include <vector>
 
 #include "cstring.h"
-#include "stringref.h"
 
 // GTest
 #ifdef P4C_GTEST_ENABLED
@@ -302,9 +302,9 @@ class InputSources final {
 
  private:
     /// Append this text to the last line; must not contain newlines
-    void appendToLastLine(StringRef text);
+    void appendToLastLine(std::string_view text);
     /// Append a newline and start a new line
-    void appendNewline(StringRef newline);
+    void appendNewline(std::string_view newline);
 
     /// Input program that is being currently compiled; there can be only one.
     bool sealed;
@@ -319,6 +319,7 @@ class InputSources final {
 
 }  // namespace Util
 
+// FIXME: Do we really need to have this in header? This pulls the whole iostream header
 inline void dbprint(const IHasDbPrint *o) { o->dbprint(std::cout); }
 
 #endif /* LIB_SOURCE_FILE_H_ */

--- a/lib/stringify.cpp
+++ b/lib/stringify.cpp
@@ -122,7 +122,7 @@ cstring toString(cstring value) {
     return value;
 }
 
-cstring toString(StringRef value) { return value; }
+cstring toString(std::string_view value) { return value; }
 
 cstring printf_format(const char *fmt_str, ...) {
     if (fmt_str == nullptr) throw std::runtime_error("Null format string");

--- a/lib/stringify.cpp
+++ b/lib/stringify.cpp
@@ -122,7 +122,7 @@ cstring toString(cstring value) {
     return value;
 }
 
-cstring toString(std::string_view value) { return value; }
+cstring toString(std::string_view value) { return cstring(value); }
 
 cstring printf_format(const char *fmt_str, ...) {
     if (fmt_str == nullptr) throw std::runtime_error("Null format string");

--- a/lib/stringify.cpp
+++ b/lib/stringify.cpp
@@ -18,7 +18,9 @@ limitations under the License.
 
 #include <deque>
 #include <sstream>
+#include <string>
 
+#include "cstring.h"
 #include "exceptions.h"
 
 namespace Util {

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -44,28 +44,28 @@ class HasToString final {
     enum { value = sizeof(func<T>(0)) == sizeof(char) };
 };
 
-template <typename T, typename = decltype(std::to_string((T)0))>
+template <typename T, typename = decltype(std::to_string(std::declval<T>()))>
 cstring toString(T value) {
     return std::to_string(value);
 }
 
 template <typename T>
-auto toString(const T &value) -> typename std::enable_if<HasToString<T>::value, cstring>::type {
+auto toString(const T &value) -> typename std::enable_if_t<HasToString<T>::value, cstring> {
     return value.toString();
 }
 
 template <typename T>
-auto toString(T &value) -> typename std::enable_if<HasToString<T>::value, cstring>::type {
+auto toString(T &value) -> typename std::enable_if_t<HasToString<T>::value, cstring> {
     return value.toString();
 }
 
 template <typename T>
-auto toString(const T *value) -> typename std::enable_if<HasToString<T>::value, cstring>::type {
+auto toString(const T *value) -> typename std::enable_if_t<HasToString<T>::value, cstring> {
     return value->toString();
 }
 
 template <typename T>
-auto toString(T *value) -> typename std::enable_if<HasToString<T>::value, cstring>::type {
+auto toString(T *value) -> typename std::enable_if_t<HasToString<T>::value, cstring> {
     return value->toString();
 }
 

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -25,7 +25,6 @@ limitations under the License.
 
 #include "big_int_util.h"
 #include "cstring.h"
-#include "stringref.h"
 
 // convert values to cstrings
 namespace Util {
@@ -74,7 +73,7 @@ cstring toString(bool value);
 cstring toString(std::string value);
 cstring toString(const char *value);
 cstring toString(cstring value);
-cstring toString(StringRef value);
+cstring toString(std::string_view value);
 /// A width of zero indicates that no width should be displayed.
 cstring toString(const big_int value, unsigned width, bool sign, unsigned int base = 10);
 cstring toString(const void *value);

--- a/lib/stringref.h
+++ b/lib/stringref.h
@@ -38,7 +38,7 @@ static inline void *memrchr(const char *s, int c, size_t n) {
  * to be used with care.  StringRefs should in general have short lifetimes, and not be
  * stored in other long-lived objects. */
 
-struct StringRef {
+[[deprecated("Use std::string_view instead")]] struct StringRef {
     const char *p;
     size_t len;
     StringRef() : p(0), len(0) {}

--- a/test/gtest/complex_bitwise.cpp
+++ b/test/gtest/complex_bitwise.cpp
@@ -2,8 +2,7 @@
 
 #include <optional>
 
-#include <boost/algorithm/string/replace.hpp>
-
+#include "absl/strings/substitute.h"
 #include "frontends/common/parseInput.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/toP4/toP4.h"
@@ -11,7 +10,6 @@
 #include "frontends/p4/typeMap.h"
 #include "helpers.h"
 #include "ir/ir.h"
-#include "lib/log.h"
 #include "lib/sourceCodeBuilder.h"
 #include "midend/simplifyBitwise.h"
 
@@ -45,7 +43,7 @@ control verifyChecksum(inout Headers headers, inout Metadata meta) { apply { } }
 control ingress(inout Headers headers, inout Metadata meta,
                 inout standard_metadata_t sm) {
     apply {
-%INGRESS%
+$0
     }
 }
 
@@ -62,8 +60,8 @@ V1Switch(parse(), verifyChecksum(), ingress(), egress(),
     computeChecksum(), deparse()) main;
     )");
 
-    boost::replace_first(source, "%INGRESS%", ingressSource);
-    return FrontendTestCase::create(source, CompilerOptions::FrontendVersion::P4_16);
+    return FrontendTestCase::create(absl::Substitute(source, ingressSource),
+                                    CompilerOptions::FrontendVersion::P4_16);
 }
 
 class CountAssignmentStatements : public Inspector {

--- a/test/gtest/diagnostics.cpp
+++ b/test/gtest/diagnostics.cpp
@@ -17,12 +17,9 @@ limitations under the License.
 #include <gtest/gtest.h>
 
 #include <optional>
-#include <vector>
 
-#include <boost/algorithm/string/replace.hpp>
-
+#include "absl/strings/substitute.h"
 #include "frontends/common/applyOptionsPragmas.h"
-#include "ir/ir.h"
 #include "test/gtest/helpers.h"
 
 namespace Test {
@@ -31,7 +28,7 @@ namespace {
 
 std::optional<FrontendTestCase> createP4_16DiagnosticsTestCase(const std::string &pragmaSource) {
     auto source = P4_SOURCE(P4Headers::V1MODEL, R"(
-%PRAGMA_SOURCE%
+$0
         struct Headers { bit<8> value; }
         struct Metadata { }
         parser parse(packet_in p, out Headers h, inout Metadata m,
@@ -44,14 +41,12 @@ std::optional<FrontendTestCase> createP4_16DiagnosticsTestCase(const std::string
         V1Switch(parse(), checksum(), mau(), mau(), checksum(), deparse()) main;
     )");
 
-    boost::replace_first(source, "%PRAGMA_SOURCE%", pragmaSource);
-
-    return FrontendTestCase::create(source);
+    return FrontendTestCase::create(absl::Substitute(source, pragmaSource));
 }
 
 std::optional<FrontendTestCase> createP4_14DiagnosticsTestCase(const std::string &pragmaSource) {
     auto source = P4_SOURCE(R"(
-%PRAGMA_SOURCE%
+$0
         header_type headers_t { fields { value : 8; } }
         header headers_t headers;
         parser start {
@@ -61,9 +56,8 @@ std::optional<FrontendTestCase> createP4_14DiagnosticsTestCase(const std::string
         control egress { }
     )");
 
-    boost::replace_first(source, "%PRAGMA_SOURCE%", pragmaSource);
-
-    return FrontendTestCase::create(source, CompilerOptions::FrontendVersion::P4_14);
+    return FrontendTestCase::create(absl::Substitute(source, pragmaSource),
+                                    CompilerOptions::FrontendVersion::P4_14);
 }
 
 }  // namespace

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -24,8 +24,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include <boost/algorithm/string/replace.hpp>
-
+#include "absl/strings/substitute.h"
 #include "control-plane/p4/config/v1/p4types.pb.h"
 #include "control-plane/p4/v1/p4runtime.pb.h"
 #include "p4/config/v1/p4info.pb.h"
@@ -1497,12 +1496,11 @@ std::optional<P4::P4RuntimeAPI> P4RuntimePkgInfo::createTestCase(const char *ann
         control deparse(packet_out p, in Headers h) { apply { } }
         control ingress(inout Headers h, inout Metadata m,
                         inout standard_metadata_t sm) { apply { } }
-        %ANNOTATIONS%
+        $0
         V1Switch(parse(), verifyChecksum(), ingress(), egress(),
                  computeChecksum(), deparse()) main;
     )");
-    boost::replace_first(source, "%ANNOTATIONS%", annotations);
-    return createP4RuntimeTestCase(source);
+    return createP4RuntimeTestCase(absl::Substitute(source, annotations));
 }
 
 TEST_F(P4RuntimePkgInfo, NoAnnotations) {

--- a/test/gtest/path_test.cpp
+++ b/test/gtest/path_test.cpp
@@ -18,9 +18,6 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 
-#include "lib/exceptions.h"
-#include "lib/stringref.h"
-
 namespace Util {
 
 TEST(Util, PathName) {
@@ -30,14 +27,14 @@ TEST(Util, PathName) {
 
     {
         PathName path = "/usr/local/bin/file.exe";
-        StringRef ext = path.getExtension();
-        EXPECT_EQ(StringRef("exe"), ext);
+        auto ext = path.getExtension();
+        EXPECT_EQ("exe", ext);
 
         PathName file = path.getFilename();
         EXPECT_EQ("file.exe", file.toString());
 
-        StringRef base = path.getBasename();
-        EXPECT_EQ(StringRef("file"), base);
+        auto base = path.getBasename();
+        EXPECT_EQ("file", base);
 
         PathName folder = path.getFolder();
         EXPECT_EQ("/usr/local/bin", folder.toString());
@@ -45,13 +42,13 @@ TEST(Util, PathName) {
 
     {
         PathName path = "/usr/local/bin/";
-        StringRef ext = path.getExtension();
+        auto ext = path.getExtension();
         EXPECT_EQ("", ext);
 
         PathName file = path.getFilename();
         EXPECT_EQ("", file.toString());
 
-        StringRef base = path.getBasename();
+        auto base = path.getBasename();
         EXPECT_EQ("", base);
 
         PathName folder = path.getFolder();
@@ -60,14 +57,14 @@ TEST(Util, PathName) {
 
     {
         PathName path = "file.exe";
-        StringRef ext = path.getExtension();
-        EXPECT_EQ(StringRef("exe"), ext);
+        auto ext = path.getExtension();
+        EXPECT_EQ("exe", ext);
 
         PathName file = path.getFilename();
         EXPECT_EQ("file.exe", file.toString());
 
-        StringRef base = path.getBasename();
-        EXPECT_EQ(StringRef("file"), base);
+        auto base = path.getBasename();
+        EXPECT_EQ("file", base);
 
         PathName folder = path.getFolder();
         EXPECT_EQ("", folder.toString());

--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -28,7 +28,6 @@ limitations under the License.
 #include <vector>
 
 #include "lib/cstring.h"
-#include "lib/stringref.h"
 #include "lib/source_file.h"
 #include "lib/error.h"
 #include "tools/ir-generator/irclass.h"


### PR DESCRIPTION
Some refactoring and cleanup while there:
 - Code moved from headers down to cpp
 - `StringRef` replaced with `std::string_view` (header is not removed as I do not know how this might affect downstream)