### PR TITLE
Add missing Bazel targets.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -231,12 +231,14 @@ cc_library(
     deps = [
         ":config_h",
         ":lib",
+        ":p4info_dpdk_cc_proto",
         "@boost//:algorithm",
         "@boost//:functional",
         "@boost//:iostreams",
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_github_p4lang_p4runtime//:p4types_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_protobuf//:protobuf",
     ],
 )


### PR DESCRIPTION
There is no build cleaner available open-source as far as I can tell. We have to keep track of this manually. 