### PR TITLE
Midend def-use pass

### DIFF
--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -25,12 +25,14 @@ limitations under the License.
 #include "frontends/p4/simplifyParsers.h"
 #include "frontends/p4/strengthReduction.h"
 #include "frontends/p4/toP4/toP4.h"
+#include "frontends/p4/typeChecking/typeChecker.h"
 #include "frontends/p4/typeMap.h"
 #include "frontends/p4/unusedDeclarations.h"
 #include "midend/actionSynthesis.h"
 #include "midend/compileTimeOps.h"
 #include "midend/complexComparison.h"
 #include "midend/copyStructures.h"
+#include "midend/def_use.h"
 #include "midend/eliminateInvalidHeaders.h"
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateSerEnums.h"
@@ -121,6 +123,9 @@ MidEnd::MidEnd(CompilerOptions &options, std::ostream *outStream) {
          new P4::CompileTimeOperations(),
          new P4::TableHit(&refMap, &typeMap),
          new P4::EliminateSwitch(&refMap, &typeMap),
+         new P4::ResolveReferences(&refMap),
+         new P4::TypeChecking(&refMap, &typeMap, true),  // update types before ComputeDefUse
+         new P4::ComputeDefUse,                          // present for testing
          evaluator,
          [v1controls, evaluator](const IR::Node *root) -> const IR::Node * {
              auto toplevel = evaluator->getToplevelBlock();

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -20,6 +20,7 @@ set (MIDEND_SRCS
   convertErrors.cpp
   copyStructures.cpp
   coverage.cpp
+  def_use.cpp
   eliminateInvalidHeaders.cpp
   eliminateNewtype.cpp
   eliminateSerEnums.cpp
@@ -71,6 +72,7 @@ set (MIDEND_HDRS
   convertErrors.h
   copyStructures.h
   coverage.h
+  def_use.h
   eliminateInvalidHeaders.h
   eliminateNewtype.h
   eliminateSerEnums.h

--- a/midend/def_use.cpp
+++ b/midend/def_use.cpp
@@ -1,0 +1,576 @@
+/*
+Copyright 2024 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "def_use.h"
+
+#include "frontends/p4/methodInstance.h"
+
+namespace P4 {
+
+const ordered_set<const ComputeDefUse::loc_t *> ComputeDefUse::empty = {};
+
+void ComputeDefUse::flow_merge(Visitor &a_) {
+    ComputeDefUse &a = dynamic_cast<ComputeDefUse &>(a_);
+    for (auto &di : a.def_info) def_info[di.first].flow_merge(di.second);
+}
+void ComputeDefUse::flow_copy(ControlFlowVisitor &a_) {
+    ComputeDefUse &a = dynamic_cast<ComputeDefUse &>(a_);
+    BUG_CHECK(state == a.state, "inconsistent state in ComputeDefUse::flow_copy");
+    def_info = a.def_info;
+}
+
+ComputeDefUse::def_info_t::def_info_t(const def_info_t &a)
+    : defs(a.defs),
+      live(a.live),
+      parent(a.parent),
+      valid_bit_defs(a.valid_bit_defs),
+      fields(a.fields),
+      slices(a.slices) {
+    for (auto &v : Values(fields)) v.parent = this;
+    for (auto &v : Values(slices)) v.parent = this;
+}
+
+ComputeDefUse::def_info_t::def_info_t(def_info_t &&a)
+    : defs(std::move(a.defs)),
+      live(std::move(a.live)),
+      parent(std::move(a.parent)),
+      valid_bit_defs(std::move(a.valid_bit_defs)),
+      fields(std::move(a.fields)),
+      slices(std::move(a.slices)) {
+    for (auto &v : Values(fields)) v.parent = this;
+    for (auto &v : Values(slices)) v.parent = this;
+}
+
+void ComputeDefUse::def_info_t::flow_merge(def_info_t &a) {
+    defs.insert(a.defs.begin(), a.defs.end());
+    live |= a.live;
+    valid_bit_defs.insert(a.valid_bit_defs.begin(), a.valid_bit_defs.end());
+    for (auto &f : a.fields) fields[f.first].flow_merge(f.second);
+    for (auto &s : a.slices) {
+        split_slice(s.first);
+        for (auto it = slices_overlap_begin(s.first);
+             it != slices.end() && it->first.overlaps(s.first); ++it) {
+            BUG_CHECK(s.first.contains(it->first), "slice_split failed to work");
+            it->second.flow_merge(s.second);
+        }
+    }
+    slices_sanity();
+}
+
+class ComputeDefUse::SetupJoinPoints : public ControlFlowVisitor::SetupJoinPoints,
+                                       public P4::ResolutionContext {
+    bool preorder(const IR::ParserState *n) override {
+        LOG6("SetupJoinPoints(ParserState " << n->name << ")" << Log::indent);
+        return true;
+    }
+    void revisit(const IR::ParserState *n) override {
+        if (n->isBuiltin() && n->components.empty() && !n->selectExpression) {
+            // FIXME -- P4-14->16 conversion uses a single accept and reject state for
+            // both ingress and egress, which will cause problems, so we avoid it.
+            // Perhaps we should ignore/not revisit all states with components.empty()
+            // as they by definition don't do anything?
+            return;
+        }
+        ++join_points[n].count;
+        LOG6("SetupJoinPoints::revisit(ParserState " << n->name << ") [" << join_points[n].count
+                                                     << "]");
+    }
+    void loop_revisit(const IR::ParserState *n) override { LOG6("  * loop into " << n->name); }
+    void postorder(const IR::ParserState *) override { LOG6_UNINDENT; }
+    void revisit(const IR::Node *) override {}
+    bool preorder(const IR::PathExpression *pe) override {
+        if (pe->type->is<IR::Type_State>()) {
+            auto *d = resolveUnique(pe->path->name, P4::ResolutionType::Any);
+            BUG_CHECK(d, "failed to resolve %s", pe);
+            auto ps = d->to<IR::ParserState>();
+            BUG_CHECK(ps, "%s is not a parser state", d);
+            visit(ps, "transition");
+        }
+        return false;
+    }
+    bool preorder(const IR::P4Parser *p) override {
+        IndentCtl::TempIndent indent;
+        LOG6("SetupJoinPoints(P4Parser " << p->name << ")" << indent);
+        LOG8("    " << Log::indent << Log::indent << *p << Log::unindent << Log::unindent);
+        if (auto start = p->states.getDeclaration<IR::ParserState>("start")) visit(start, "start");
+        return false;
+    }
+    bool preorder(const IR::P4Control *) override { return false; }
+    bool preorder(const IR::Type *) override { return false; }
+
+ public:
+    explicit SetupJoinPoints(decltype(join_points) &fjp)
+        : ControlFlowVisitor::SetupJoinPoints(fjp) {}
+};
+
+void ComputeDefUse::applySetupJoinPoints(const IR::Node *root) {
+    root->apply(SetupJoinPoints(*flow_join_points));
+}
+
+bool ComputeDefUse::filter_join_point(const IR::Node *n) {
+    LOG6("init_join_flows " << n->to<IR::ParserState>()->name << " = "
+                            << flow_join_points->at(n).count);
+    return false;
+}
+
+const ComputeDefUse::loc_t *ComputeDefUse::getLoc(const Visitor::Context *ctxt) {
+    if (!ctxt) return nullptr;
+    loc_t tmp{ctxt->node, getLoc(ctxt->parent)};
+    return &*cached_locs.insert(tmp).first;
+}
+
+const ComputeDefUse::loc_t *ComputeDefUse::getLoc(const IR::Node *n, const Visitor::Context *ctxt) {
+    for (auto *p = ctxt; p; p = p->parent)
+        if (p->node == n) return getLoc(p);
+    auto rv = getLoc(ctxt);
+    loc_t tmp{n, rv};
+    return &*cached_locs.insert(tmp).first;
+}
+
+/* sanity check on slices -- make sure keys do not overlap */
+void ComputeDefUse::def_info_t::slices_sanity() {
+    auto prev = slices.end();
+    for (auto it = slices.begin(); it != slices.end(); ++it) {
+        if (prev != slices.end()) BUG_CHECK(!prev->first.overlaps(it->first), "Overlapping slices");
+        prev = it;
+    }
+    BUG_CHECK(fields.empty() || slices.empty(), "Both fields and slices present");
+}
+
+/// return an iterator to the first element of 'slices' that overlaps the given range,
+/// or slices.end() if none do
+std::map<le_bitrange, ComputeDefUse::def_info_t>::iterator
+ComputeDefUse::def_info_t::slices_overlap_begin(le_bitrange range) {
+    auto rv = slices.lower_bound(range);
+    if (rv != slices.begin()) {
+        auto p = std::prev(rv);
+        if (range.overlaps(p->first)) rv = p;
+    }
+    return rv;
+}
+
+/* erase parts of the slices that overlap the specified range.  So if we have [7:0] and [15:8],
+ * erase_slice([11:4]) will leave [3:0] and [15:12]
+ */
+void ComputeDefUse::def_info_t::erase_slice(le_bitrange range) {
+    for (auto it = slices_overlap_begin(range); it != slices.end() && it->first.overlaps(range);) {
+        if (!range.contains(it->first)) {
+            if (it->first.lo < range.lo) {
+                bool i = slices.emplace(le_bitrange(it->first.lo, range.lo - 1), it->second).second;
+                BUG_CHECK(i, "inserting already present range?");
+            }
+            if (it->first.hi > range.hi) {
+                bool i =
+                    slices.emplace(le_bitrange(range.hi + 1, it->first.hi), std::move(it->second))
+                        .second;
+                BUG_CHECK(i, "inserting already present range?");
+            }
+        }
+        it = slices.erase(it);
+    }
+    slices_sanity();
+}
+
+/* split slices such that any slice that overlaps with the given range is completely contained
+ * with that range.  So if we have the slices [7:0] and [15:8] split_slice([11:4]) will
+ * split the slices into [3:0], [7:4], [11:8], and [15:12]
+ */
+void ComputeDefUse::def_info_t::split_slice(le_bitrange range) {
+    for (auto it = slices_overlap_begin(range); it != slices.end() && it->first.overlaps(range);) {
+        if (!range.contains(it->first)) {
+            // first, insert the pieces of it->first that do not overlap range
+            if (it->first.lo < range.lo) {
+                bool i = slices.emplace(le_bitrange(it->first.lo, range.lo - 1), it->second).second;
+                BUG_CHECK(i, "inserting already present range?"); }
+            if (it->first.hi > range.hi) {
+                bool i = slices.emplace(le_bitrange(range.hi + 1, it->first.hi), it->second).second;
+                BUG_CHECK(i, "inserting already present range?"); }
+            // then insert the intersecion of range and it->first
+            bool i = slices.emplace(range.intersectWith(it->first), std::move(it->second)).second;
+            BUG_CHECK(i, "inserting already present range?");
+            it = slices.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    slices_sanity();
+}
+
+bool ComputeDefUse::preorder(const IR::P4Control *c) {
+    BUG_CHECK(state == SKIPPING, "Nested %s not supported in ComputeDefUse", c);
+    IndentCtl::TempIndent indent;
+    LOG5("ComputeDefUse(P4Control " << c->name << ")" << indent);
+    for (auto *p : c->getApplyParameters()->parameters)
+        if (p->direction == IR::Direction::In || p->direction == IR::Direction::InOut)
+            def_info[p].defs.insert(getLoc(p));
+    state = NORMAL;
+    visit(c->body, "body");  // just visit the body; tables/actions will be visited when applied
+    for (auto *p : c->getApplyParameters()->parameters)
+        if (p->direction == IR::Direction::Out || p->direction == IR::Direction::InOut)
+            add_uses(getLoc(p), def_info[p]);
+    def_info.clear();
+    state = SKIPPING;
+    return false;
+}
+
+bool ComputeDefUse::preorder(const IR::P4Table *tbl) {
+    if (state == SKIPPING) return false;
+    IndentCtl::TempIndent indent;
+    LOG5("ComputeDefUse(P4Table " << tbl->name << ")" << indent);
+    if (auto key = tbl->getKey()) visit(key, "key");
+    if (auto actions = tbl->getActionList()) {
+        parallel_visit(actions->actionList, "actions");
+    } else {
+        BUG("No actions in %s", tbl);
+    }
+    return false;
+}
+
+bool ComputeDefUse::preorder(const IR::P4Action *act) {
+    if (state == SKIPPING) return false;
+    for (auto *p : *act->parameters) def_info[p].defs.insert(getLoc(p));
+    IndentCtl::TempIndent indent;
+    LOG5("ComputeDefUse(P4Action " << act->name << ")" << indent);
+    visit(act->body, "body");
+    return false;
+}
+
+bool ComputeDefUse::preorder(const IR::P4Parser *p) {
+    BUG_CHECK(state == SKIPPING, "Nested %s not supported in ComputeDefUse", p);
+    IndentCtl::TempIndent indent;
+    LOG5("ComputeDefUse(P4Parser " << p->name << ")" << indent);
+    for (auto *a : p->getApplyParameters()->parameters)
+        if (a->direction == IR::Direction::In || a->direction == IR::Direction::InOut)
+            def_info[a].defs.insert(getLoc(a));
+    state = NORMAL;
+    if (auto start = p->states.getDeclaration<IR::ParserState>("start")) {
+        visit(start, "start");
+    } else {
+        BUG("No start state in %s", p);
+    }
+    for (auto *a : p->getApplyParameters()->parameters)
+        if (a->direction == IR::Direction::Out || a->direction == IR::Direction::InOut)
+            add_uses(getLoc(a), def_info[a]);
+    def_info.clear();
+    state = SKIPPING;
+    return false;
+}
+bool ComputeDefUse::preorder(const IR::ParserState *p) {
+    LOG5("ComputeDefUse(ParserState " << p->name << ")" << Log::indent);
+    return true;
+}
+void ComputeDefUse::revisit(const IR::ParserState *p) { LOG5("  * revisit " << p->name); }
+void ComputeDefUse::loop_revisit(const IR::ParserState *p) { LOG5("  * loop into " << p->name); }
+void ComputeDefUse::postorder(const IR::ParserState *) { LOG5_UNINDENT; }
+
+bool ComputeDefUse::preorder(const IR::KeyElement *ke) {
+    visit(ke->expression, "expression");
+    return false;
+}
+
+// Add all definitions in the given def_info_t (whole and partial) as defs that reach
+// a use at the specified location
+void ComputeDefUse::add_uses(const loc_t *loc, def_info_t &di) {
+    for (auto *l : di.defs) {
+        defuse.uses[l->node].insert(loc);
+        defuse.defs[loc->node].insert(l);
+    }
+    for (auto &f : Values(di.fields)) add_uses(loc, f);
+    for (auto &sl : Values(di.slices)) add_uses(loc, sl);
+}
+
+static const IR::Expression *get_primary(const IR::Expression *e, const Visitor::Context *ctxt) {
+    if (ctxt && (ctxt->node->is<IR::Member>() || ctxt->node->is<IR::Slice>() ||
+                 ctxt->node->is<IR::ArrayIndex>())) {
+        return get_primary(ctxt->node->to<IR::Expression>(), ctxt->parent);
+    } else {
+        return e;
+    }
+}
+
+static const IR::Expression *isValid(const IR::Member *m, const Visitor::Context *ctxt) {
+    if (m->member.name == "$valid") return m;
+    if (!ctxt || !ctxt->node->is<IR::MethodCallExpression>()) return nullptr;
+    if (m->member.name == "isValid" || m->member.name == "setValid" ||
+        m->member.name == "setInvalid")
+        return ctxt->node->to<IR::Expression>();
+    return nullptr;
+}
+
+const IR::Expression *ComputeDefUse::do_read(def_info_t &di, const IR::Expression *e,
+                                             const Context *ctxt) {
+    if (!ctxt) {
+    } else if (auto *m = ctxt->node->to<IR::Member>()) {
+        if (auto *t = isValid(m, ctxt->parent)) {
+            auto loc = getLoc(t);
+            for (auto *l : di.valid_bit_defs) {
+                defuse.uses[l->node].insert(loc);
+                defuse.defs[loc->node].insert(l);
+            }
+            return t;
+        } else if (auto *str = m->expr->type->to<IR::Type_StructLike>()) {
+            int fi = str->getFieldIndex(m->member.name);
+            BUG_CHECK(fi >= 0, "%s: no field %s found", m, m->member.name);
+            if (di.fields.count(m->member.name))
+                e = do_read(di.fields.at(m->member.name), m, ctxt->parent);
+            else
+                e = get_primary(m, ctxt->parent);
+            if (!di.live[fi]) return e;
+        } else if (m->expr->type->to<IR::Type_Stack>()) {
+            if (m->member.name == "lastIndex") {
+                // this depends on how much has been written to the header stack, but not
+                // on any data that has been written.  So what should the defs be?  For now,
+                // amything that writes to the stack as a whole is considered
+                e = m;
+            } else if (m->member.name == "next" || m->member.name == "last") {
+                for (auto &el : di.slices) add_uses(getLoc(m), el.second);
+                e = m;
+            } else {
+                BUG("invalid read of header stack: %s", m);
+            }
+        } else {
+            BUG("%s: Member of unexpected type %s", m, m->expr->type);
+        }
+    } else if (auto *sl = ctxt->node->to<IR::Slice>()) {
+        le_bitrange range(sl->getL(), sl->getH());
+        for (auto it = di.slices_overlap_begin(range);
+             it != di.slices.end() && range.overlaps(it->first); ++it) {
+            e = do_read(it->second, sl, ctxt->parent);
+            BUG_CHECK(e == sl, "slice %s is not primary in ComputeDefUse::do_read", sl);
+        }
+        e = sl;
+        if (!di.live.getrange(range.lo, range.size())) return e;
+    } else if (auto *ai = ctxt->node->to<IR::ArrayIndex>()) {
+        if (auto idx = ai->right->to<IR::Constant>()) {
+            int i = idx->asInt();
+            le_bitrange range(i, i);
+            if (di.slices.count(range))
+                e = do_read(di.slices.at(range), ai, ctxt->parent);
+            else
+                e = get_primary(ai, ctxt->parent);
+            if (!di.live[i]) return e;
+        } else {
+            for (auto &sl : Values(di.slices)) do_read(sl, ai, ctxt->parent);
+            e = get_primary(ai, ctxt->parent);
+        }
+    }
+    auto loc = getLoc(e);
+    for (auto *l : di.defs) {
+        defuse.uses[l->node].insert(loc);
+        defuse.defs[loc->node].insert(l);
+    }
+    return e;
+}
+
+// get the single constant integer argument of a push_front or pop_front call
+static int constIntMethodArg(const Visitor::Context *ctxt) {
+    BUG_CHECK(ctxt, "null context");
+    auto *mc = ctxt->node->to<IR::MethodCallExpression>();
+    BUG_CHECK(mc && mc->arguments->size() == 1, "%s wrong number of arguments", mc);
+    auto *arg = mc->arguments->at(0)->expression->to<IR::Constant>();
+    BUG_CHECK(arg && arg->value > 0, "%s argument is not a positive constant", mc);
+    return arg->asInt();
+}
+
+const IR::Expression *ComputeDefUse::do_write(def_info_t &di, const IR::Expression *e,
+                                              const Context *ctxt) {
+    if (!ctxt) {
+    } else if (auto *m = ctxt->node->to<IR::Member>()) {
+        if (auto *t = isValid(m, ctxt->parent)) {
+            di.valid_bit_defs.clear();
+            di.valid_bit_defs.insert(getLoc(t));
+            return t;
+        } else if (auto *str = m->expr->type->to<IR::Type_StructLike>()) {
+            int fi = str->getFieldIndex(m->member.name);
+            BUG_CHECK(fi >= 0, "%s: no field %s found", m, m->member.name);
+            e = do_write(di.fields[m->member.name], m, ctxt->parent);
+            di.live[fi] = 0;
+            if (!di.live) di.defs.clear();
+            return e;
+        } else if (auto *ts = m->expr->type->to<IR::Type_Stack>()) {
+            if (m->member.name == "next" || m->member.name == "last") {
+                di.defs.insert(getLoc(m));
+                di.live.setrange(0, ts->getSize());
+            } else if (m->member.name == "push_front" || m->member.name == "pop_front") {
+                int cnt = constIntMethodArg(ctxt->parent);
+                if (m->member.name == "push_front") {
+                    di.live <<= cnt;
+                    di.live.clrrange(ts->getSize(), cnt);
+                } else {
+                    di.live >>= cnt;
+                    cnt = -cnt;
+                }
+                if (!di.live) di.defs.clear();
+                decltype(di.slices) tmp;
+                for (auto &sl : di.slices) {
+                    int ni = sl.first.lo + cnt;
+                    if (size_t(ni) < ts->getSize())
+                        tmp.emplace(le_bitrange(ni, ni), std::move(sl.second));
+                }
+                di.slices = std::move(tmp);
+            } else {
+                BUG("invalid write to header stack: %s", m);
+            }
+        } else {
+            BUG("%s: Member of unexpected type %s", m, m->expr->type);
+        }
+    } else if (auto *sl = ctxt->node->to<IR::Slice>()) {
+        le_bitrange range(sl->getL(), sl->getH());
+        di.live.clrrange(range.lo, range.size());
+        if (!di.live) di.defs.clear();
+        di.erase_slice(range);
+        e = do_write(di.slices[range], sl, ctxt->parent);
+        return e;
+    } else if (auto *ai = ctxt->node->to<IR::ArrayIndex>()) {
+        if (auto idx = ai->right->to<IR::Constant>()) {
+            int i = idx->asInt();
+            di.live[i] = 0;
+            if (!di.live) di.defs.clear();
+            e = do_write(di.slices[le_bitrange(i, i)], ai, ctxt->parent);
+        } else {
+            di.defs.insert(getLoc(ai));
+            di.live.setrange(0, ai->left->type->to<IR::Type_Indexed>()->getSize());
+            e = ai;
+        }
+        return e;
+    }
+    di.defs.clear();
+    di.defs.insert(getLoc(e));
+    di.fields.clear();
+    di.slices.clear();
+    if (auto *s = e->type->to<IR::Type_StructLike>()) {
+        di.live.setrange(0, s->fields.size());
+    } else if (auto *i = e->type->to<IR::Type_Indexed>()) {
+        di.live.setrange(0, i->getSize());
+    } else if (auto *b = e->type->to<IR::Type::Bits>()) {
+        di.live.setrange(0, b->width_bits());
+    } else if (auto *b = e->type->to<IR::Type::Varbits>()) {
+        di.live.setrange(0, b->size);
+    } else if (e->type->is<IR::Type::Boolean>()) {
+        di.live.setrange(0, 1);
+    } else if (e->type->is<IR::Type_Enum>() || e->type->is<IR::Type_Error>()) {
+        di.live.setrange(0, 1);
+    } else if (auto *se = e->type->to<IR::Type_SerEnum>()) {
+        di.live.setrange(0, se->type->width_bits());
+    } else {
+        BUG("Unexpected type %s in ComputeDefUse::do_write", e->type);
+    }
+    return e;
+}
+
+bool ComputeDefUse::preorder(const IR::PathExpression *pe) {
+    LOG7("ComputeDefUse(PathExpression " << *pe << ")");
+    if (pe->type->is<IR::Type_State>()) {
+        auto *d = resolveUnique(pe->path->name, P4::ResolutionType::Any);
+        BUG_CHECK(d, "failed to resolve %s", pe);
+        auto ps = d->to<IR::ParserState>();
+        BUG_CHECK(ps, "%s is not a parser state", d);
+        visit(ps, "transition");
+        return false;
+    }
+    if (state == SKIPPING) return false;
+    auto *d = resolveUnique(pe->path->name, P4::ResolutionType::Any);
+    BUG_CHECK(d, "failed to resolve %s", pe);
+    if (isRead() && state != WRITE_ONLY) do_read(def_info[d], pe, getContext());
+    if (isWrite() && state != READ_ONLY) do_write(def_info[d], pe, getContext());
+    return false;
+}
+void ComputeDefUse::loop_revisit(const IR::PathExpression *pe) {
+    LOG5("  * not visiting PathExpresion " << pe->path->name << " to avoid loop!");
+}
+
+bool ComputeDefUse::preorder(const IR::MethodCallExpression *mc) {
+    auto *mi = P4::MethodInstance::resolve(mc, this);
+    if (state == WRITE_ONLY) {
+        BUG_CHECK(!isWrite(), "Method call in out or inout arg should have failed typechecking");
+        return false;
+    } else if (state == READ_ONLY) {
+        if (!isRead()) return false;
+    }
+    auto saved_state = state;
+    state = READ_ONLY;
+    visit(mc->arguments, "arguments");
+    state = NORMAL;
+    if (auto *ac = mi->to<P4::ActionCall>()) {
+        visit(ac->action, "action");
+    } else if (auto *bi = mi->to<P4::BuiltInMethod>()) {
+        if (bi->name == "isValid") {
+            state = READ_ONLY;
+        } else if (bi->name == "setValid" || bi->name == "setInvalid") {
+            state = WRITE_ONLY;
+        } else if (bi->name == "push_front" || bi->name == "pop_front") {
+            // push/pop we deal with as writes (in do_write)
+            state = WRITE_ONLY;
+        } else {
+            BUG("unknown BuiltInMethod: %s", mc);
+        }
+        visit(mc->method, "method");
+    } else {
+        if (mi->object) {
+            auto obj = mi->object->getNode();  // FIXME -- should be able to visit an INode
+            if (!isInContext(obj)) visit(obj, "object");
+        }
+    }
+    state = WRITE_ONLY;
+    visit(mc->arguments, "arguments");
+    state = saved_state;
+    return false;
+}
+
+void ComputeDefUse::end_apply() { LOG5(defuse); }
+
+// Debugging
+std::ostream &operator<<(std::ostream &out, const ComputeDefUse::loc_t &loc) {
+    out << '<' << loc.node->id << '>';
+    if (loc.node->srcInfo) {
+        unsigned line, col;
+        out << '(' << loc.node->srcInfo.toSourcePositionData(&line, &col);
+        out << ':' << line << ':' << (col + 1) << ')';
+    }
+    return out;
+}
+
+std::ostream &operator<<(
+    std::ostream &out,
+    const std::pair<const IR::Node *, const ordered_set<const ComputeDefUse::loc_t *>> &p) {
+    out << Log::endl;
+    out << DBPrint::setprec(DBPrint::Prec_Low);
+    out << p.first << '<' << p.first->id << '>';
+    if (p.first->srcInfo) {
+        unsigned line, col;
+        out << '(' << p.first->srcInfo.toSourcePositionData(&line, &col);
+        out << ':' << line << ':' << (col + 1) << ')';
+    }
+    out << ": {";
+    const char *sep = " ";
+    for (auto *l : p.second) {
+        out << sep << *l;
+        sep = ", ";
+    }
+    out << (sep + 1) << "}";
+    return out;
+}
+
+std::ostream &operator<<(std::ostream &out, const ComputeDefUse::defuse_t &du) {
+    out << "defs:" << Log::indent;
+    for (auto &p : du.defs) out << p;
+    out << Log::unindent << Log::endl << "uses:" << Log::indent;
+    for (auto &p : du.uses) out << p;
+    out << Log::unindent;
+    return out;
+}
+
+}  // namespace P4

--- a/midend/def_use.cpp
+++ b/midend/def_use.cpp
@@ -224,15 +224,18 @@ bool ComputeDefUse::preorder(const IR::P4Control *c) {
     BUG_CHECK(state == SKIPPING, "Nested %s not supported in ComputeDefUse", c);
     IndentCtl::TempIndent indent;
     LOG5("ComputeDefUse(P4Control " << c->name << ")" << indent);
+    bool is_type_declaration = !c->getTypeParameters()->empty();
     for (auto *p : c->getApplyParameters()->parameters)
         if (p->direction == IR::Direction::In || p->direction == IR::Direction::InOut) {
             def_info[p].defs.insert(getLoc(p));
             // Assume that all components of input parameters are live: we don't currently
             // propagate liveness innformation across parser/control block boundaries.
-            if (auto *tn = p->type->to<IR::Type_Name>()) {
-                auto *d = resolveUnique(tn->path->name, P4::ResolutionType::Any);
-                if (auto *type = d->to<IR::Type>()) {
-                    set_live_from_type(def_info[p], type);
+            if (!is_type_declaration) {
+                if (auto *tn = p->type->to<IR::Type_Name>()) {
+                    auto *d = resolveUnique(tn->path->name, P4::ResolutionType::Any);
+                    if (auto *type = d->to<IR::Type>()) {
+                        set_live_from_type(def_info[p], type);
+                    }
                 }
             }
         }

--- a/midend/def_use.h
+++ b/midend/def_use.h
@@ -101,6 +101,7 @@ class ComputeDefUse : public Inspector,
     };
     ordered_map<const IR::IDeclaration *, def_info_t> def_info;
     void add_uses(const loc_t *, def_info_t &);
+    void set_live_from_type(def_info_t &di, const IR::Type *type);
 
     // computed defuse info for all uses and defs in the program
     struct defuse_t {
@@ -162,6 +163,7 @@ class ComputeDefUse : public Inspector,
     }
 
     // for debugging
+    friend std::ostream &operator<<(std::ostream &, const loc_t &);
     friend std::ostream &operator<<(std::ostream &, const defuse_t &);
     friend std::ostream &operator<<(std::ostream &out, const ComputeDefUse &cdu) {
         return out << cdu.defuse;

--- a/midend/def_use.h
+++ b/midend/def_use.h
@@ -1,0 +1,173 @@
+/*
+Copyright 2024 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef MIDEND_DEF_USE_H_
+#define MIDEND_DEF_USE_H_
+
+#include "frontends/common/resolveReferences/resolveReferences.h"
+#include "ir/ir.h"
+#include "lib/bitrange.h"
+
+namespace P4 {
+
+/**
+ * @brief Compute defuse info within P4Parser and P4Control blocks in the midend.
+ *
+ * This pass finds all uses and definitions of field/slice values in all controls
+ * and parsers in the program and stores maps of which defs reach which uses.
+ * After the pass runs, getDefs(use) will return all the definitions in the program
+ * that reach the argument use while getUses(def) will return all the uses of the
+ * given def.  The returned values are sets of ComputeUseDef::loc_t objects which
+ * contain both the node that is def or use as well as the context path from the root
+ * of the IR to that node -- actions that are used by mulitple tables or parser states
+ * reachable via multiple paths may have mulitple entries as a result
+ *
+ * @pre Currently the code does not consider calls between controls or parsers, as it is
+ * expected to run after inlining when all such calls have been flattened.
+ * It could be extended to deal with the before inlining case.
+ */
+class ComputeDefUse : public Inspector,
+                      public ControlFlowVisitor,
+                      public P4WriteContext,
+                      public P4::ResolutionContext {
+    ComputeDefUse *clone() const { return new ComputeDefUse(*this); }
+    void flow_merge(Visitor &) override;
+    void flow_copy(ControlFlowVisitor &) override;
+    enum { SKIPPING, NORMAL, READ_ONLY, WRITE_ONLY } state = SKIPPING;
+
+ public:
+    // a location in the program.  Includes the context from the visitor, which needs to
+    // be copied out of the Visitor::Context objects, as they are allocated on the stack and
+    // will become invalid as the IR traversal continues
+    struct loc_t {
+        const IR::Node *node;
+        const loc_t *parent;
+        bool operator<(const loc_t &a) const {
+            if (node != a.node) return node->id < a.node->id;
+            if (!a.parent) return parent != nullptr;
+            return *parent < *a.parent;
+        }
+        template <class T>
+        const T *find() const {
+            for (auto *p = this; p; p = p->parent) {
+                if (auto *t = p->node->to<T>()) return t;
+            }
+            return nullptr;
+        }
+    };
+
+ private:
+    std::set<loc_t> &cached_locs;
+    const loc_t *getLoc(const Visitor::Context *ctxt);
+    const loc_t *getLoc() { return getLoc(getChildContext()); }
+    const loc_t *getLoc(const IR::Node *, const Visitor::Context *);
+    const loc_t *getLoc(const IR::Node *n) { return getLoc(n, getChildContext()); }
+
+    // flow tracking info about defs live at the point we are currently visiting
+    struct def_info_t {
+        // definitions of a symbol (or part of a symbol) visible at this point in the
+        // program.  `defs` will be empty if `live` is; if not those defs are visible only
+        // for those bits/elements/fields where live is set.
+        ordered_set<const loc_t *> defs;
+        bitvec live;
+        def_info_t *parent = nullptr;
+        // track valid bit access for headers separate from the rest of the header
+        ordered_set<const loc_t *> valid_bit_defs;
+        // one of these maps will always be empty.
+        std::map<cstring, def_info_t> fields;
+        std::map<le_bitrange, def_info_t> slices;  // also used for arrays
+        // keys in slices are always non-overlapping (checked by slices_sanity)
+        void slices_sanity();
+        std::map<le_bitrange, def_info_t>::iterator slices_overlap_begin(le_bitrange);
+        void erase_slice(le_bitrange);
+        void split_slice(le_bitrange);
+        void flow_merge(def_info_t &);
+        def_info_t() = default;
+        def_info_t(const def_info_t &);
+        def_info_t(def_info_t &&);
+    };
+    ordered_map<const IR::IDeclaration *, def_info_t> def_info;
+    void add_uses(const loc_t *, def_info_t &);
+
+    // computed defuse info for all uses and defs in the program
+    struct defuse_t {
+        // defs maps from all uses to their definitions
+        // uses maps from all definitions to their uses
+        // uses/defs are lvalue expressions, or param declarations.
+        ordered_map<const IR::Node *, ordered_set<const loc_t *>> defs;
+        ordered_map<const IR::Node *, ordered_set<const loc_t *>> uses;
+    } & defuse;
+    static const ordered_set<const loc_t *> empty;
+
+    profile_t init_apply(const IR::Node *root) override {
+        auto rv = Inspector::init_apply(root);
+        state = SKIPPING;
+        clear();
+        return rv;
+    }
+    bool preorder(const IR::P4Control *) override;
+    bool preorder(const IR::P4Table *) override;
+    bool preorder(const IR::P4Action *) override;
+    bool preorder(const IR::P4Parser *) override;
+    bool preorder(const IR::ParserState *) override;
+    void revisit(const IR::ParserState *) override;
+    void loop_revisit(const IR::ParserState *) override;
+    void postorder(const IR::ParserState *) override;
+    bool preorder(const IR::Type *) override { return false; }
+    bool preorder(const IR::Annotations *) override { return false; }
+    bool preorder(const IR::KeyElement *) override;
+    const IR::Expression *do_read(def_info_t &, const IR::Expression *, const Context *);
+    const IR::Expression *do_write(def_info_t &, const IR::Expression *, const Context *);
+    bool preorder(const IR::PathExpression *) override;
+    void loop_revisit(const IR::PathExpression *) override;
+    bool preorder(const IR::MethodCallExpression *) override;
+    void end_apply() override;
+
+    class SetupJoinPoints;
+    void applySetupJoinPoints(const IR::Node *root) override;
+    bool filter_join_point(const IR::Node *) override;
+
+ public:
+    ComputeDefUse()
+        : ResolutionContext(true), cached_locs(*new std::set<loc_t>), defuse(*new defuse_t) {
+        joinFlows = true;
+    }
+    void clear() {
+        cached_locs.clear();
+        def_info.clear();
+        defuse.defs.clear();
+        defuse.uses.clear();
+    }
+
+    const ordered_set<const loc_t *> &getDefs(const IR::Node *n) const {
+        auto it = defuse.defs.find(n);
+        return it == defuse.defs.end() ? empty : it->second;
+    }
+    const ordered_set<const loc_t *> &getUses(const IR::Node *n) const {
+        auto it = defuse.uses.find(n);
+        return it == defuse.uses.end() ? empty : it->second;
+    }
+
+    // for debugging
+    friend std::ostream &operator<<(std::ostream &, const defuse_t &);
+    friend std::ostream &operator<<(std::ostream &out, const ComputeDefUse &cdu) {
+        return out << cdu.defuse;
+    }
+};
+
+}  // namespace P4
+
+#endif /* MIDEND_DEF_USE_H_ */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,8 @@ set (GTEST_UNITTEST_SOURCES
   gtest/hvec_map.cpp
   gtest/indexed_vector.cpp
   gtest/json_test.cpp
+  gtest/midend_def_use.cpp
+  gtest/midend_pass.cpp
   gtest/midend_test.cpp
   gtest/frontend_test.cpp
   gtest/opeq_test.cpp

--- a/test/gtest/midend_def_use.cpp
+++ b/test/gtest/midend_def_use.cpp
@@ -1,0 +1,415 @@
+/*
+Copyright 2024 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+
+#include <regex>
+#include <string>
+
+#include "frontends/common/parseInput.h"
+#include "helpers.h"
+#include "midend/def_use.h"
+#include "midend_pass.h"
+
+using namespace P4;
+
+namespace Test {
+
+using P4TestContext = P4CContextWithOptions<CompilerOptions>;
+
+class P4CMidendDefUse : public P4CTest {};
+
+/// Run the midend and return the ComputeDefUse object
+P4::ComputeDefUse *computeDefUse(std::string source, CompilerOptions::FrontendVersion langVersion =
+                                                         CompilerOptions::FrontendVersion::P4_16) {
+    AutoCompileContext autoP4TestContext(new P4TestContext);
+
+    auto *program = P4::parseP4String(source, langVersion);
+    CHECK_NULL(program);
+    BUG_CHECK(::errorCount() == 0, "Unexpected errors");
+
+    auto &options = P4TestContext::get().options();
+    const char *argv = "./gtestp4c";
+    options.process(1, (char *const *)&argv);
+    options.langVersion = CompilerOptions::FrontendVersion::P4_16;
+
+    P4::FrontEnd frontend;
+    program = frontend.run(options, program);
+    CHECK_NULL(program);
+
+    MidEnd midEnd(options);
+    const IR::P4Program *res = program;
+    midEnd.process(res);
+
+    return midEnd.defuse;
+}
+
+/// Get two vectors of strings: one corresponding to the defs and one corresponding to the uses of
+/// the defuse oject.
+std::pair<std::vector<std::string>, std::vector<std::string>> get_defs_uses(
+    const P4::ComputeDefUse *defuse, bool dump = false) {
+    std::vector<std::string> defs;
+    std::vector<std::string> uses;
+
+    std::stringstream defuse_ss;
+    defuse_ss << *defuse;
+
+    std::vector<std::string> *target = &defs;
+    std::string line;
+    while (std::getline(defuse_ss, line)) {
+        if (line == "defs:") {
+            target = &defs;
+        } else if (line == "uses:") {
+            target = &uses;
+        } else {
+            target->push_back(line);
+        }
+    }
+
+    // Debug output
+    if (dump) {
+        std::cerr << "defs:" << std::endl;
+        for (auto &line : defs) std::cerr << line << std::endl;
+        std::cerr << "uses:" << std::endl;
+        for (auto &line : uses) std::cerr << line << std::endl;
+    }
+
+    return std::make_pair(defs, uses);
+}
+
+/// Check whether a corresponding def-use line exists in the defuse output
+///
+/// Def/use lines are of the form:
+///     h.h1.f1[31:31]<200396>(control:3:21): { <129206>(control:0:47) }
+///
+/// @param lines      The string dump from the defuse object.
+/// @param lhs        The "left-hand side" term to search for (`h.h1.f1[31:31]` in the example).
+/// @param lhs_line   The line number for the @p lhs parameter (3 in the example).
+/// @param rhs_lines  A set of line numbers to expect on the "right-hand side" of the expression
+/// ({ 0 } in the example).
+///
+/// @return boolean indicating if any of the def-use lines match.
+bool check_def_use(const std::vector<std::string> &lines, std::string lhs, unsigned lhs_line,
+                   std::set<unsigned> rhs_lines) {
+    // Regex to apply to the whole line
+    const std::regex line_regex(R"((\w[^<]*)<\d+>\([^)]+:(\d+):[^)]+\): \{ (.*) \})");
+
+    // Regex to apply to elements on the "right-hand side" -- the elements within the braces in the
+    // line
+    const std::regex element_regex(R"(<\d+>\([^)]+:(\d+):[^)]+\))");
+
+    for (auto &line : lines) {
+        std::smatch match;
+        if (std::regex_search(line, match, line_regex)) {
+            // Check if the line corresponds to the lhs + lhs_line
+            if (match[1] == lhs && std::stoul(match[2]) == lhs_line) {
+                // auto target_lines = rhs_lines;
+
+                // Split the right-hand side into the component elements
+                size_t pos = 0;
+                std::string rhs = match[3];
+                std::vector<std::string> elements;
+                while ((pos = rhs.find(", ")) != std::string::npos) {
+                    elements.push_back(rhs.substr(0, pos));
+                    rhs.erase(0, pos + 2);
+                }
+                elements.push_back(rhs);
+
+                // Verify that the elements match the rhs_lines
+                std::set<unsigned> target_lines;
+                for (auto &element : elements) {
+                    if (std::regex_match(element, match, element_regex)) {
+                        // if (!target_lines.erase(std::stoul(match[1]))) miss = true;
+                        target_lines.emplace(std::stoul(match[1]));
+                    }
+                }
+                if (target_lines == rhs_lines) return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+/// Trim any leading whitespace from a string
+/// @returns Trimmed version of the string
+std::string ltrim(const std::string &str) {
+    const std::string whitespace = " \n\r\t";
+
+    auto pos = str.find_first_not_of(whitespace);
+    return (pos == std::string::npos) ? "" : str.substr(pos);
+}
+
+/// Construct a program string, substituting in sections for the header definitions, parser body,
+/// main control body, and deparser body.
+///
+/// The body parameters should exclude the section declaration and opening/closing braces. For
+/// example, the parser body should consist of only the state definitions (and any prededing
+/// declarations) -- it should not include `parser ParserName(parameters)`.
+///
+/// The resulting string contains pre-processor declarations the name each of the sections:
+/// "header", "parser", "control", and "deparser". This is helpful when checking the def-use
+/// results: line numbers are relative to the section beginning. The `parser`/`control` declarations
+/// (including parameters) are line 0; the body always starts at line 1.
+///
+/// Note: leading whitespace is stripped from the headers and body definitions.
+std::string make_program(const std::string &headers, const std::string &parser_body,
+                         const std::string &control_body, const std::string &deparser_body) {
+    std::string program = R"(
+        // simplified core.p4
+        error {
+            NoError,           /// No error.
+            PacketTooShort,    /// Not enough bits in packet for 'extract'.
+            NoMatch,           /// 'select' expression has no matches.
+            StackOutOfBounds,  /// Reference to invalid element of a header stack.
+            HeaderTooShort,    /// Extracting too many bits into a varbit field.
+            ParserTimeout,     /// Parser execution time limit exceeded.
+            ParserInvalidArgument  /// Parser operation was called with a value
+                                   /// not supported by the implementation.
+        }
+        extern void verify(in bool check, in error toSignal);
+        extern packet_in {
+            void extract<T> (out T hdr);
+        }
+        extern packet_out {
+            void emit<T> (in T hdr);
+        }
+
+        // simplified v1model.p4
+        parser Parser<H, M> (packet_in b, 
+                          out H parsedHdr,
+                          out M meta);
+        control Ingress<H, M> (inout H hdr, inout M meta);
+        control Deparser<H> (packet_out b, in H hdr);
+        package PSA<H, M> (Parser<H, M> p, Ingress<H, M> ig, Deparser<H> dp);
+
+        // user program
+# 1 "headers" 1
+        )" + ltrim(headers) +
+                          R"(
+# 0 "parser" 1
+        parser MyParser(packet_in pkt, out ParsedHeaders h, out Metadata m) {
+        )" + ltrim(parser_body) +
+                          R"(
+        }
+# 0 "control" 1
+        control MyIngress(inout ParsedHeaders h, inout Metadata m) {
+        )" + ltrim(control_body) +
+                          R"(
+        }
+# 0 "deparser" 1
+        control MyDeparser(packet_out b, in ParsedHeaders h) {
+        )" + ltrim(deparser_body) +
+                          R"(
+        }
+        PSA(MyParser(), MyIngress(), MyDeparser()) main;
+    )";
+
+    return P4_SOURCE(program.c_str());
+}
+
+TEST_F(P4CMidendDefUse, whole_field_1) {
+    std::string headers = R"(
+        header hdr_h_t {
+            bit<16> f1;
+            bit<16> f2;
+        }
+        header hdr_b_t {
+            bit<8> f1;
+            bit<8> f2;
+        }
+        struct ParsedHeaders {
+            hdr_h_t h1;
+            hdr_b_t h2;
+        }
+        struct Metadata {
+            bit<32> hdr;
+        }
+    )";
+    std::string parser_body = R"(
+        state start {
+            pkt.extract(h.h1);
+            m.hdr = 0;
+            transition accept;
+        }
+    )";
+    std::string control_body = R"(
+        apply {
+            h.h1.f2 = 16w0x1234;
+
+            if (h.h1.f1 == h.h1.f2) {
+                h.h1.f1 = 0;
+            }
+        }
+    )";
+    std::string deparser_body = R"(
+        apply {
+            b.emit(h);
+        }
+    )";
+
+    auto program = make_program(headers, parser_body, control_body, deparser_body);
+    auto *defuse = computeDefUse(program, CompilerOptions::FrontendVersion::P4_16);
+    ASSERT_TRUE(defuse);
+
+    auto [defs, uses] = get_defs_uses(defuse);
+
+    EXPECT_TRUE(check_def_use(defs, "h.h1.f1", 4, {0}));
+    // Note: no def for h.h1.f2 as the use on line 4 is replaced by a constant
+    EXPECT_TRUE(check_def_use(defs, "inout ParsedHeaders h", 0, {0, 2, 5}));
+
+    EXPECT_TRUE(check_def_use(uses, "h.h1.f1", 5, {0}));
+    EXPECT_TRUE(check_def_use(uses, "h.h1.f2", 2, {0}));
+    EXPECT_TRUE(check_def_use(uses, "inout ParsedHeaders h", 0, {0, 4}));
+}
+
+TEST_F(P4CMidendDefUse, whole_field_2) {
+    std::string headers = R"(
+        header hdr_h_t {
+            bit<16> f1;
+            bit<16> f2;
+        }
+        header hdr_b_t {
+            bit<8> f1;
+            bit<8> f2;
+        }
+        struct ParsedHeaders {
+            hdr_h_t h1;
+            hdr_b_t h2;
+        }
+        struct Metadata {
+            bit<32> hdr;
+        }
+    )";
+    std::string parser_body = R"(
+        state start {
+            pkt.extract(h.h1);
+            m.hdr = 0;
+            transition accept;
+        }
+    )";
+    std::string control_body = R"(
+        apply {
+            if (h.h1.f1 == 0x1234) {
+                h.h2.setValid();
+                h.h2.f1 = 0x01;
+                h.h2.f2 = 0x23;
+            }
+        }
+    )";
+    std::string deparser_body = R"(
+        apply {
+            b.emit(h);
+        }
+    )";
+
+    auto program = make_program(headers, parser_body, control_body, deparser_body);
+    auto *defuse = computeDefUse(program, CompilerOptions::FrontendVersion::P4_16);
+    ASSERT_TRUE(defuse);
+
+    auto [defs, uses] = get_defs_uses(defuse);
+
+    EXPECT_TRUE(check_def_use(defs, "h.h1.f1", 2, {0}));
+    EXPECT_TRUE(check_def_use(defs, "inout ParsedHeaders h", 0, {0, 4, 5}));
+
+    EXPECT_TRUE(check_def_use(uses, "h.h2.f1", 4, {0}));
+    EXPECT_TRUE(check_def_use(uses, "h.h2.f2", 5, {0}));
+    EXPECT_TRUE(check_def_use(uses, "inout ParsedHeaders h", 0, {0, 2}));
+}
+
+TEST_F(P4CMidendDefUse, slice_1) {
+    std::string headers = R"(
+        header hw_t {
+            bit<32> f1;
+        }
+        header hb_t {
+            bit<8> f1;
+        }
+        struct ParsedHeaders {
+            hw_t h1;
+            hb_t h2;
+            hb_t h3;
+        }
+        struct Metadata {
+            bit<32> hdr;
+        }
+    )";
+    std::string parser_body = R"(
+        state start {
+            pkt.extract(h.h1);
+            m.hdr = 0;
+            transition select (h.h1.f1[0:0]) {
+                0 : parse_h2;
+                1 : parse_h3;
+            }
+        }
+        state parse_h2 {
+            pkt.extract(h.h2);
+            transition accept;
+        }
+        state parse_h3 {
+            pkt.extract(h.h3);
+            transition accept;
+        }
+    )";
+    std::string control_body = R"(
+        apply {
+            if (h.h2.isValid()) {
+                if (h.h1.f1[31:31] == 1) {
+                    h.h2.f1 = 8w0x12;
+                }
+            } else {
+                h.h1.f1 = 32w0x12345678;
+            }
+
+            if (h.h2.isValid()) {
+                if (h.h1.f1[31:24] == h.h2.f1)
+                    h.h2.f1 = 0;
+            } else {
+                if (h.h1.f1[7:0] == h.h3.f1)
+                    h.h1.f1[7:0] = 8w0xff;
+            }
+        }
+    )";
+    std::string deparser_body = R"(
+        apply {
+            b.emit(h);
+        }
+    )";
+
+    auto program = make_program(headers, parser_body, control_body, deparser_body);
+    auto *defuse = computeDefUse(program, CompilerOptions::FrontendVersion::P4_16);
+    ASSERT_TRUE(defuse);
+
+    auto [defs, uses] = get_defs_uses(defuse);
+
+    EXPECT_TRUE(check_def_use(defs, "h.h2.isValid", 2, {0}));
+    EXPECT_TRUE(check_def_use(defs, "h.h1.f1[31:31]", 3, {0}));
+    EXPECT_TRUE(check_def_use(defs, "h.h2.isValid()", 10, {0}));
+    EXPECT_TRUE(check_def_use(defs, "h.h1.f1[31:24]", 11, {0, 7}));
+    EXPECT_TRUE(check_def_use(defs, "h.h2.f1", 11, {0, 4}));
+    EXPECT_TRUE(check_def_use(defs, "h.h1.f1[7:0]", 14, {0, 7}));
+    EXPECT_TRUE(check_def_use(defs, "h.h3.f1", 14, {0}));
+    EXPECT_TRUE(check_def_use(defs, "inout ParsedHeaders h", 0, {0, 4, 7, 12, 15}));
+
+    EXPECT_TRUE(check_def_use(uses, "h.h1.f1", 7, {0, 11, 14}));
+    EXPECT_TRUE(check_def_use(uses, "h.h2.f1", 4, {0, 11}));
+    EXPECT_TRUE(check_def_use(uses, "h.h1.f1[7:0]", 15, {0}));
+    EXPECT_TRUE(check_def_use(uses, "h.h2.f1", 12, {0}));
+    EXPECT_TRUE(check_def_use(uses, "inout ParsedHeaders h", 0, {0, 2, 3, 10, 11, 14}));
+}
+
+}  // namespace Test

--- a/test/gtest/midend_pass.cpp
+++ b/test/gtest/midend_pass.cpp
@@ -1,0 +1,154 @@
+/*
+Copyright 2024 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "midend_pass.h"
+
+#include "frontends/common/constantFolding.h"
+#include "frontends/common/options.h"
+#include "frontends/p4/evaluator/evaluator.h"
+#include "frontends/p4/fromv1.0/v1model.h"
+#include "frontends/p4/moveDeclarations.h"
+#include "frontends/p4/simplify.h"
+#include "frontends/p4/simplifyParsers.h"
+#include "frontends/p4/strengthReduction.h"
+#include "midend/compileTimeOps.h"
+#include "midend/complexComparison.h"
+#include "midend/copyStructures.h"
+#include "midend/def_use.h"
+#include "midend/eliminateInvalidHeaders.h"
+#include "midend/eliminateNewtype.h"
+#include "midend/eliminateSerEnums.h"
+#include "midend/eliminateSwitch.h"
+#include "midend/eliminateTuples.h"
+#include "midend/eliminateTypedefs.h"
+#include "midend/expandEmit.h"
+#include "midend/expandLookahead.h"
+#include "midend/flattenHeaders.h"
+#include "midend/flattenInterfaceStructs.h"
+#include "midend/local_copyprop.h"
+#include "midend/midEndLast.h"
+#include "midend/nestedStructs.h"
+#include "midend/noMatch.h"
+#include "midend/parserUnroll.h"
+#include "midend/predication.h"
+#include "midend/removeAssertAssume.h"
+#include "midend/removeExits.h"
+#include "midend/removeMiss.h"
+#include "midend/removeSelectBooleans.h"
+#include "midend/replaceSelectRange.h"
+#include "midend/simplifyKey.h"
+#include "midend/simplifySelectCases.h"
+#include "midend/simplifySelectList.h"
+#include "midend/tableHit.h"
+
+namespace Test {
+
+MidEnd::MidEnd(CompilerOptions &options, std::ostream *outStream) {
+    bool isv1 = options.langVersion == CompilerOptions::FrontendVersion::P4_14;
+    refMap.setIsV1(isv1);
+    auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
+    setName("MidEnd");
+
+    auto v1controls = new std::set<cstring>();
+    defuse = new P4::ComputeDefUse;
+
+    addPasses(
+        {options.ndebug ? new P4::RemoveAssertAssume(&refMap, &typeMap) : nullptr,
+         new P4::RemoveMiss(&refMap, &typeMap),
+         new P4::EliminateNewtype(&refMap, &typeMap),
+         new P4::EliminateInvalidHeaders(&refMap, &typeMap),
+         new P4::EliminateSerEnums(&refMap, &typeMap),
+         new P4::SimplifyKey(
+             &refMap, &typeMap,
+             new P4::OrPolicy(new P4::IsValid(&refMap, &typeMap), new P4::IsLikeLeftValue())),
+         new P4::RemoveExits(&refMap, &typeMap),
+         new P4::ConstantFolding(&refMap, &typeMap),
+         new P4::SimplifySelectCases(&refMap, &typeMap, false),  // non-constant keysets
+         new P4::ExpandLookahead(&refMap, &typeMap),
+         new P4::ExpandEmit(&refMap, &typeMap),
+         new P4::HandleNoMatch(&refMap),
+         new P4::SimplifyParsers(&refMap),
+         new P4::StrengthReduction(&refMap, &typeMap),
+         new P4::EliminateTuples(&refMap, &typeMap),
+         new P4::SimplifyComparisons(&refMap, &typeMap),
+         new P4::CopyStructures(&refMap, &typeMap),
+         new P4::NestedStructs(&refMap, &typeMap),
+         new P4::StrengthReduction(&refMap, &typeMap),
+         new P4::SimplifySelectList(&refMap, &typeMap),
+         new P4::RemoveSelectBooleans(&refMap, &typeMap),
+         new P4::FlattenHeaders(&refMap, &typeMap),
+         new P4::FlattenInterfaceStructs(&refMap, &typeMap),
+         new P4::EliminateTypedef(&refMap, &typeMap),
+         new P4::ReplaceSelectRange(&refMap, &typeMap),
+         new P4::Predication(&refMap),
+         new P4::MoveDeclarations(),  // more may have been introduced
+         new P4::ConstantFolding(&refMap, &typeMap),
+         new P4::LocalCopyPropagation(&refMap, &typeMap),
+         new P4::ConstantFolding(&refMap, &typeMap),
+         new P4::StrengthReduction(&refMap, &typeMap),
+         new P4::MoveDeclarations(),  // more may have been introduced
+         new P4::SimplifyControlFlow(&refMap, &typeMap),
+         new P4::CompileTimeOperations(),
+         new P4::TableHit(&refMap, &typeMap),
+         new P4::EliminateSwitch(&refMap, &typeMap),
+         defuse,
+         evaluator,
+         [v1controls, evaluator](const IR::Node *root) -> const IR::Node * {
+             auto toplevel = evaluator->getToplevelBlock();
+             auto main = toplevel->getMain();
+             if (main == nullptr)
+                 // nothing further to do
+                 return nullptr;
+             // Special handling when compiling for v1model.p4
+             if (main->type->name == P4V1::V1Model::instance.sw.name) {
+                 if (main->getConstructorParameters()->size() != 6) return root;
+                 auto verify = main->getParameterValue(P4V1::V1Model::instance.sw.verify.name);
+                 auto update = main->getParameterValue(P4V1::V1Model::instance.sw.compute.name);
+                 auto deparser = main->getParameterValue(P4V1::V1Model::instance.sw.deparser.name);
+                 if (verify == nullptr || update == nullptr || deparser == nullptr ||
+                     !verify->is<IR::ControlBlock>() || !update->is<IR::ControlBlock>() ||
+                     !deparser->is<IR::ControlBlock>()) {
+                     return root;
+                 }
+                 v1controls->emplace(verify->to<IR::ControlBlock>()->container->name);
+                 v1controls->emplace(update->to<IR::ControlBlock>()->container->name);
+                 v1controls->emplace(deparser->to<IR::ControlBlock>()->container->name);
+             }
+             return root;
+         },
+         new P4::SynthesizeActions(&refMap, &typeMap, new SkipControls(v1controls)),
+         new P4::MoveActionsToTables(&refMap, &typeMap),
+         options.loopsUnrolling ? new P4::ParsersUnroll(true, &refMap, &typeMap) : nullptr,
+         evaluator,
+         [this, evaluator]() { toplevel = evaluator->getToplevelBlock(); },
+         new P4::MidEndLast()});
+    if (options.listMidendPasses) {
+        listPasses(*outStream, "\n");
+        *outStream << std::endl;
+        return;
+    }
+    if (options.excludeMidendPasses) {
+        removePasses(options.passesToExcludeMidend);
+    }
+    toplevel = evaluator->getToplevelBlock();
+}
+
+IR::ToplevelBlock *MidEnd::process(const IR::P4Program *&program) {
+    program = program->apply(*this);
+    return toplevel;
+}
+
+}  // namespace Test

--- a/test/gtest/midend_pass.h
+++ b/test/gtest/midend_pass.h
@@ -1,0 +1,64 @@
+/*
+Copyright 2024 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef TEST_GTEST_MIDEND_PASS_H_
+#define TEST_GTEST_MIDEND_PASS_H_
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+
+#include "ir/ir.h"
+#include "midend/actionSynthesis.h"
+
+namespace P4 {
+class ReferenceMap;
+class TypeMap;
+class ComputeDefUse;
+class ToplevelBlock;
+}  // namespace P4
+
+class CompilerOptions;
+
+namespace Test {
+
+class SkipControls : public P4::ActionSynthesisPolicy {
+    const std::set<cstring> *skip;
+
+ public:
+    explicit SkipControls(const std::set<cstring> *skip) : skip(skip) { CHECK_NULL(skip); }
+    bool convert(const Visitor::Context *, const IR::P4Control *control) override {
+        if (skip->find(control->name) != skip->end()) return false;
+        return true;
+    }
+};
+
+/// Collection of midend passes for tests to use
+class MidEnd : public PassManager {
+ public:
+    P4::ReferenceMap refMap;
+    P4::TypeMap typeMap;
+    P4::ComputeDefUse *defuse;
+    IR::ToplevelBlock *toplevel = nullptr;
+
+    explicit MidEnd(CompilerOptions &options, std::ostream *outStream = nullptr);
+    IR::ToplevelBlock *process(const IR::P4Program *&program);
+};
+
+}  // namespace Test
+
+#endif /* TEST_GTEST_MIDEND_PASS_H_ */

--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -3,173 +3,20 @@
 #include <cstdlib>
 #include <fstream>
 
-#include "frontends/common/constantFolding.h"
 #include "frontends/common/parseInput.h"
-#include "frontends/common/resolveReferences/resolveReferences.h"
-#include "frontends/p4/createBuiltins.h"
-#include "frontends/p4/evaluator/evaluator.h"
-#include "frontends/p4/fromv1.0/v1model.h"
-#include "frontends/p4/moveDeclarations.h"
-#include "frontends/p4/simplify.h"
-#include "frontends/p4/simplifyParsers.h"
-#include "frontends/p4/strengthReduction.h"
-#include "frontends/p4/toP4/toP4.h"
-#include "frontends/p4/typeChecking/typeChecker.h"
-#include "frontends/p4/typeMap.h"
-#include "frontends/p4/uniqueNames.h"
-#include "frontends/p4/unusedDeclarations.h"
 #include "ir/ir.h"
 #include "lib/log.h"
-#include "midend/actionSynthesis.h"
-#include "midend/compileTimeOps.h"
-#include "midend/complexComparison.h"
-#include "midend/copyStructures.h"
-#include "midend/eliminateNewtype.h"
-#include "midend/eliminateSerEnums.h"
-#include "midend/eliminateSwitch.h"
-#include "midend/eliminateTuples.h"
-#include "midend/expandEmit.h"
-#include "midend/expandLookahead.h"
-#include "midend/flattenHeaders.h"
-#include "midend/flattenInterfaceStructs.h"
-#include "midend/local_copyprop.h"
-#include "midend/midEndLast.h"
-#include "midend/nestedStructs.h"
-#include "midend/noMatch.h"
-#include "midend/parserUnroll.h"
-#include "midend/predication.h"
-#include "midend/removeAssertAssume.h"
-#include "midend/removeExits.h"
-#include "midend/removeMiss.h"
-#include "midend/removeSelectBooleans.h"
-#include "midend/replaceSelectRange.h"
-#include "midend/simplifyKey.h"
-#include "midend/simplifySelectCases.h"
-#include "midend/simplifySelectList.h"
-#include "midend/tableHit.h"
 #include "test/gtest/env.h"
 #include "test/gtest/helpers.h"
+#include "test/gtest/midend_pass.h"
 
 using namespace P4;
 
 namespace Test {
 
-class P4TestOptions : public CompilerOptions {
- public:
-    P4TestOptions() {}
-};
-
-using P4TestContext = P4CContextWithOptions<P4TestOptions>;
+using P4TestContext = P4CContextWithOptions<CompilerOptions>;
 
 class P4CParserUnroll : public P4CTest {};
-
-class SkipControls : public P4::ActionSynthesisPolicy {
-    const std::set<cstring> *skip;
-
- public:
-    explicit SkipControls(const std::set<cstring> *skip) : skip(skip) { CHECK_NULL(skip); }
-    bool convert(const Visitor::Context *, const IR::P4Control *control) override {
-        if (skip->find(control->name) != skip->end()) return false;
-        return true;
-    }
-};
-
-class MidEnd : public PassManager {
- public:
-    P4::ReferenceMap refMap;
-    P4::TypeMap typeMap;
-    IR::ToplevelBlock *toplevel = nullptr;
-
-    explicit MidEnd(CompilerOptions &options, std::ostream *outStream = nullptr) {
-        bool isv1 = options.langVersion == CompilerOptions::FrontendVersion::P4_14;
-        refMap.setIsV1(isv1);
-        auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
-        setName("MidEnd");
-
-        auto v1controls = new std::set<cstring>();
-
-        addPasses(
-            {options.ndebug ? new P4::RemoveAssertAssume(&refMap, &typeMap) : nullptr,
-             new P4::RemoveMiss(&refMap, &typeMap),
-             new P4::EliminateNewtype(&refMap, &typeMap),
-             new P4::EliminateSerEnums(&refMap, &typeMap),
-             new P4::SimplifyKey(
-                 &refMap, &typeMap,
-                 new P4::OrPolicy(new P4::IsValid(&refMap, &typeMap), new P4::IsLikeLeftValue())),
-             new P4::RemoveExits(&refMap, &typeMap),
-             new P4::ConstantFolding(&refMap, &typeMap),
-             new P4::SimplifySelectCases(&refMap, &typeMap, false),  // non-constant keysets
-             new P4::ExpandLookahead(&refMap, &typeMap),
-             new P4::ExpandEmit(&refMap, &typeMap),
-             new P4::HandleNoMatch(&refMap),
-             new P4::SimplifyParsers(&refMap),
-             new P4::StrengthReduction(&refMap, &typeMap),
-             new P4::EliminateTuples(&refMap, &typeMap),
-             new P4::SimplifyComparisons(&refMap, &typeMap),
-             new P4::CopyStructures(&refMap, &typeMap),
-             new P4::NestedStructs(&refMap, &typeMap),
-             new P4::SimplifySelectList(&refMap, &typeMap),
-             new P4::RemoveSelectBooleans(&refMap, &typeMap),
-             new P4::FlattenHeaders(&refMap, &typeMap),
-             new P4::FlattenInterfaceStructs(&refMap, &typeMap),
-             new P4::ReplaceSelectRange(&refMap, &typeMap),
-             new P4::Predication(&refMap),
-             new P4::MoveDeclarations(),  // more may have been introduced
-             new P4::ConstantFolding(&refMap, &typeMap),
-             new P4::LocalCopyPropagation(&refMap, &typeMap),
-             new P4::ConstantFolding(&refMap, &typeMap),
-             new P4::StrengthReduction(&refMap, &typeMap),
-             new P4::MoveDeclarations(),  // more may have been introduced
-             new P4::SimplifyControlFlow(&refMap, &typeMap),
-             new P4::CompileTimeOperations(),
-             new P4::TableHit(&refMap, &typeMap),
-             new P4::EliminateSwitch(&refMap, &typeMap),
-             evaluator,
-             [v1controls, evaluator](const IR::Node *root) -> const IR::Node * {
-                 auto toplevel = evaluator->getToplevelBlock();
-                 auto main = toplevel->getMain();
-                 if (main == nullptr)
-                     // nothing further to do
-                     return nullptr;
-                 // Special handling when compiling for v1model.p4
-                 if (main->type->name == P4V1::V1Model::instance.sw.name) {
-                     if (main->getConstructorParameters()->size() != 6) return root;
-                     auto verify = main->getParameterValue(P4V1::V1Model::instance.sw.verify.name);
-                     auto update = main->getParameterValue(P4V1::V1Model::instance.sw.compute.name);
-                     auto deparser =
-                         main->getParameterValue(P4V1::V1Model::instance.sw.deparser.name);
-                     if (verify == nullptr || update == nullptr || deparser == nullptr ||
-                         !verify->is<IR::ControlBlock>() || !update->is<IR::ControlBlock>() ||
-                         !deparser->is<IR::ControlBlock>()) {
-                         return root;
-                     }
-                     v1controls->emplace(verify->to<IR::ControlBlock>()->container->name);
-                     v1controls->emplace(update->to<IR::ControlBlock>()->container->name);
-                     v1controls->emplace(deparser->to<IR::ControlBlock>()->container->name);
-                 }
-                 return root;
-             },
-             new P4::SynthesizeActions(&refMap, &typeMap, new SkipControls(v1controls)),
-             new P4::MoveActionsToTables(&refMap, &typeMap),
-             options.loopsUnrolling ? new ParsersUnroll(true, &refMap, &typeMap) : nullptr,
-             evaluator,
-             [this, evaluator]() { toplevel = evaluator->getToplevelBlock(); },
-             new P4::MidEndLast()});
-        if (options.listMidendPasses) {
-            listPasses(*outStream, "\n");
-            *outStream << std::endl;
-            return;
-        }
-        if (options.excludeMidendPasses) {
-            removePasses(options.passesToExcludeMidend);
-        }
-        toplevel = evaluator->getToplevelBlock();
-    }
-    IR::ToplevelBlock *process(const IR::P4Program *&program) {
-        program = program->apply(*this);
-        return toplevel;
-    }
-};
 
 // #define PARSER_UNROLL_TIME_CHECKING
 


### PR DESCRIPTION
Contributing a midend def-use analysis pass.

The pass is an inspector named ComputeDefUse. The pass populates a private attribute named `defuse`. This defuse information is queried via one of two functions: `getDefs` and `getUses`. Both functions take a `const IR::Node*` parameter and return the defs or uses for that node.

There is also a ostream operator that takes a ComputeDefUse object and prints the defuse information in human-readable form. For example:
```
defs:
  h.h1.f1<146088>(control:4:17): { <93152>(control:0:47) }
  inout ParsedHeaders h<93152>(control:0:47): { <93152>(control:0:47), <146097>(control:5:17), <146080>(control:2:13) }
  inout Metadata m<93156>(control:0:65): { <93156>(control:0:65) }
uses:
  inout ParsedHeaders h<93152>(control:0:47): { <146088>(control:4:17), <93152>(control:0:47) }
  h.h1.f1<146097>(control:5:17): { <93152>(control:0:47) }
  h.h1.f2<146080>(control:2:13): { <93152>(control:0:47) }
  inout Metadata m<93156>(control:0:65): { <93156>(control:0:65) }
```
The `defs` sections show for each element what the corresponding defs are (e.g., the use `h.h1.f1` on line 4 of control has a corresponding def on line 0 of control). Similarly, the `uses` section shows for each element what the corresponding uses are.

This pass has _not_ been extensively tested.

@ChrisDodd The second, third, and fourth commits are changes on top of the original def-use code: they fix a few issues that were uncovered while testing:
* The second fixes an issue where split_slice is passed a range that doesn't correspond to any existing slices.
* The third sets liveness from the input of a control block, and propagates liveness in do_write while drilling down into structlike types.
* The fourth attempts to distinguish between control blocks that are "type declarations" vs actual block instantiations and doesn't attempt to set field liveness for type declarations.

The test issue1914-1.p4 provides an example of a control block type declaration:
```
control EmptyVerifyChecksum<H, M>(inout H hdr, inout M meta) {
    apply { }
}
```
The midend def-use pass sees this as:
```
  [96958] P4Control name=EmptyVerifyChecksum declid=17
    type: [250] Type_Control name=EmptyVerifyChecksum declid=16
      annotations: [5] Annotations
      typeParameters: [238] TypeParameters
        [235] Type_Var name=H declid=14
        [236] Type_Var name=M declid=15
      applyParams: [248] ParameterList
        [242] Parameter name=hdr declid=37 direction=inout
          annotations: [5] Annotations
          type: [241] Type_Name
            path: [240] Path name=H absolute=0
        [246] Parameter name=meta declid=38 direction=inout
          annotations: [5] Annotations
          type: [245] Type_Name
            path: [244] Path name=M absolute=0
    constructorParams: [258] ParameterList
    body: [96979] BlockStatement
      annotations: [5] Annotations
```
Without the protection in the fourth commit, the pass would call resolveUnique on H and M which both fail.