### PR TITLE
Build P4Testgen on MacOS.

### DIFF
--- a/.github/workflows/ci-test-mac.yml
+++ b/.github/workflows/ci-test-mac.yml
@@ -52,13 +52,13 @@ jobs:
       run: |
           source ~/.bash_profile
           ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE \
-              -DCMAKE_UNITY_BUILD=ON
+              -DCMAKE_UNITY_BUILD=ON -DENABLE_TEST_TOOLS=ON
           make -Cbuild -j$((`nproc`+1))
 
     - name: Run tests (MacOS)
       run: |
         source ~/.bash_profile
-        ctest --output-on-failure --schedule-random -LE "bpf|ubpf"
+        ctest --output-on-failure --schedule-random -LE "bpf|ubpf|testgen"
       working-directory: ./build
 
   # Build and test p4c on MacOS 13 on x86.
@@ -99,11 +99,11 @@ jobs:
       run: |
           source ~/.bash_profile
           ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE \
-              -DCMAKE_UNITY_BUILD=ON
+              -DCMAKE_UNITY_BUILD=ON -DENABLE_TEST_TOOLS=ON
           make -Cbuild -j$((`nproc`+1))
 
     - name: Run tests (MacOS)
       run: |
         source ~/.bash_profile
-        ctest --output-on-failure --schedule-random -LE "bpf|ubpf"
+        ctest --output-on-failure --schedule-random -LE "bpf|ubpf|testgen"
       working-directory: ./build


### PR DESCRIPTION
Make sure we can also build P4Testgen on MacOS. This does not run tests. We still need to enable BMv2 support for that. 