### PR TITLE
Move out of place comment in gc.cpp

### DIFF
--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -34,7 +34,8 @@ limitations under the License.
 #include "log.h"
 #include "n4.h"
 
-// One can disable the GC, e.g., to run under Valgrind, by editing config.h
+// One can disable the GC, e.g., to run under Valgrind, by editing config.h or toggling
+// -DENABLE_GC=OFF in CMake.
 #if HAVE_LIBGC
 static bool done_init, started_init;
 // emergency pool to allow a few extra allocations after a bad_alloc is thrown so we

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -34,6 +34,7 @@ limitations under the License.
 #include "log.h"
 #include "n4.h"
 
+// One can disable the GC, e.g., to run under Valgrind, by editing config.h
 #if HAVE_LIBGC
 static bool done_init, started_init;
 // emergency pool to allow a few extra allocations after a bad_alloc is thrown so we
@@ -63,7 +64,6 @@ static void maybe_initialize_gc() {
     }
 }
 
-// One can disable the GC, e.g., to run under Valgrind, by editing config.h
 void *operator new(std::size_t size) {
     TRACE_ALLOC(size)
 


### PR DESCRIPTION
Based on the git history (https://github.com/p4lang/p4c/commit/27ab2c796672383d0d8388ed2e1e9d6d677b9818#diff-3f329039fda7acd3a6dfa342bcf5181e5aeca86642c0c96bb8ccf1086a887028R13), it seems like it belongs somewhere around `#ifdef HAVE_LIBGC`, which has already been moved