### PR TITLE
Move CI Mac and Fedora tests to separate test runs.

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -10,8 +10,6 @@ on:
 
 jobs:
   p4c-lint:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-20.04
     env:
       IMAGE_TYPE: test

--- a/.github/workflows/ci-p4tools.yml
+++ b/.github/workflows/ci-p4tools.yml
@@ -16,8 +16,6 @@ concurrency:
 jobs:
   # Build and test p4tools on Ubuntu 22.04.
   build-and-test-tools:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-22.04
     env:
       CTEST_PARALLEL_LEVEL: 4

--- a/.github/workflows/ci-ptf.yml
+++ b/.github/workflows/ci-ptf.yml
@@ -30,8 +30,6 @@ concurrency:
 
 jobs:
   ptf-linux:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-20.04
     env:
       CTEST_PARALLEL_LEVEL: 4

--- a/.github/workflows/ci-static-build-test.yml
+++ b/.github/workflows/ci-static-build-test.yml
@@ -16,8 +16,6 @@ concurrency:
 jobs:
   # Build a p4c release on Ubuntu 20.04.
   build-linux:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-20.04
     env:
       IMAGE_TYPE: test

--- a/.github/workflows/ci-test-debian.yml
+++ b/.github/workflows/ci-test-debian.yml
@@ -1,4 +1,4 @@
-name: "test-p4c"
+name: "test-p4c-debian"
 
 on:
   push:
@@ -10,11 +10,11 @@ on:
 
 # Cancel any preceding run on the pull request.
 concurrency:
-  group: test-p4c-${{ github.event.pull_request.number || github.ref }}
+  group: test-p4c-debian-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  # Build with gcc and test p4c on Ubuntu 22.04.
+  # Build with GCC and test P4C on Ubuntu 22.04.
   test-ubuntu22:
     runs-on: ubuntu-22.04
     env:
@@ -41,7 +41,7 @@ jobs:
       run: sudo -E ctest --output-on-failure --schedule-random
       working-directory: ./build
 
-  # Build with gcc and test p4c on Ubuntu 20.04.
+  # Build with GCC and test P4C on Ubuntu 20.04.
   test-ubuntu20:
     name: test-ubuntu20 (Unity ${{ matrix.unity }})
     strategy:
@@ -74,40 +74,3 @@ jobs:
       run: sudo -E ctest --output-on-failure --schedule-random
       working-directory: ./build
       if: matrix.unity == 'ON'
-
-  # Build and test p4c on Fedora.
-  test-fedora-linux:
-    # This job runs in Fedora container that runs in Ubuntu VM.
-    runs-on: ubuntu-latest
-    container:
-      image: registry.fedoraproject.org/fedora:latest
-      options: --privileged
-    env:
-      CTEST_PARALLEL_LEVEL: 4
-    steps:
-    # We need to install git here because it is not provided out of the box in Fedora container.
-    - name: Install git
-      run: dnf install -y -q git
-
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: Install dependencies (Fedora Linux)
-      run: tools/install_fedora_deps.sh
-
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1
-      with:
-        key: fedora-test-${{ runner.os }}
-        max-size: 1000M
-
-    - name: Build p4c (Fedora Linux)
-      run: |
-        ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_UNITY_BUILD=ON
-        make -j2 -C build
-
-    - name: Run p4c tests (Fedora Linux)
-      # Need to use sudo for the eBPF kernel tests.
-      run: sudo -E ctest --output-on-failure --schedule-random
-      working-directory: ./build

--- a/.github/workflows/ci-test-fedora.yml
+++ b/.github/workflows/ci-test-fedora.yml
@@ -1,0 +1,52 @@
+name: "test-p4c-fedora"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  merge_group:
+    branches: [ main ]
+
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: test-p4c-fedora-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # Build and test p4c on Fedora.
+  test-fedora-linux:
+    # This job runs in Fedora container that runs in Ubuntu VM.
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
+      options: --privileged
+    env:
+      CTEST_PARALLEL_LEVEL: 4
+    steps:
+    # We need to install git here because it is not provided out of the box in Fedora container.
+    - name: Install git
+      run: dnf install -y -q git
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Install dependencies (Fedora Linux)
+      run: tools/install_fedora_deps.sh
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: fedora-test-${{ runner.os }}
+        max-size: 1000M
+
+    - name: Build p4c (Fedora Linux)
+      run: |
+        ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_UNITY_BUILD=ON
+        make -j2 -C build
+
+    - name: Run p4c tests (Fedora Linux)
+      # Need to use sudo for the eBPF kernel tests.
+      run: sudo -E ctest --output-on-failure --schedule-random
+      working-directory: ./build

--- a/.github/workflows/ci-test-fedora.yml
+++ b/.github/workflows/ci-test-fedora.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Build p4c (Fedora Linux)
       run: |
         ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_UNITY_BUILD=ON
-        make -j2 -C build
+        make -j$((`nproc`+1)) -C build
 
     - name: Run p4c tests (Fedora Linux)
       # Need to use sudo for the eBPF kernel tests.

--- a/.github/workflows/ci-test-mac.yml
+++ b/.github/workflows/ci-test-mac.yml
@@ -1,0 +1,109 @@
+name: "test-p4c-mac"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  merge_group:
+    branches: [ main ]
+
+# Cancel any preceding run on the pull request.
+concurrency:
+  group: test-p4c-mac-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # Build and test p4c on MacOS for M1 Macs.
+  test-mac-os-m1:
+    runs-on: macos-14
+    env:
+      CTEST_PARALLEL_LEVEL: 4
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: test-${{ runner.os }}
+        max-size: 1000M
+
+    - name: Get brew cache dir
+      id: brew-cache
+      run: |
+        echo "dir=$(brew --prefix)" >> $GITHUB_OUTPUT
+
+    - name: Cache Homebrew Packages
+      id: cache-homebrew-packages
+      uses: actions/cache@v4
+      env:
+        cache-name: homebrew-packages
+      with:
+        path: ${{ steps.brew-cache.outputs.dir }}
+        key: ${{ runner.os }}-m1-${{ hashFiles('tools/install_mac_deps.sh') }}
+
+    - name: Install dependencies (MacOS)
+      run: |
+           tools/install_mac_deps.sh
+
+    - name: Build (MacOS)
+      run: |
+          source ~/.bash_profile
+          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE \
+              -DCMAKE_UNITY_BUILD=ON
+          make -Cbuild -j$((`nproc`+1))
+
+    - name: Run tests (MacOS)
+      run: |
+        source ~/.bash_profile
+        ctest --output-on-failure --schedule-random -LE "bpf|ubpf"
+      working-directory: ./build
+
+  # Build and test p4c on MacOS 13 on x86.
+  test-mac-os:
+    runs-on: macos-13
+    env:
+      CTEST_PARALLEL_LEVEL: 4
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: test-${{ runner.os }}
+        max-size: 1000M
+
+    - name: Get brew cache dir
+      id: brew-cache
+      run: |
+        echo "dir=$(brew --prefix)" >> $GITHUB_OUTPUT
+
+    - name: Cache Homebrew Packages
+      id: cache-homebrew-packages
+      uses: actions/cache@v4
+      env:
+        cache-name: homebrew-packages
+      with:
+        path: ${{ steps.brew-cache.outputs.dir }}
+        key: ${{ runner.os }}-${{ hashFiles('tools/install_mac_deps.sh') }}
+
+    - name: Install dependencies (MacOS)
+      run: |
+           tools/install_mac_deps.sh
+
+    - name: Build (MacOS)
+      run: |
+          source ~/.bash_profile
+          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE \
+              -DCMAKE_UNITY_BUILD=ON
+          make -Cbuild -j$((`nproc`+1))
+
+    - name: Run tests (MacOS)
+      run: |
+        source ~/.bash_profile
+        ctest --output-on-failure --schedule-random -LE "bpf|ubpf"
+      working-directory: ./build

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,7 +10,7 @@ on:
 
 # Cancel any preceding run on the pull request.
 concurrency:
-  group: test-${{ github.event.pull_request.number || github.ref }}
+  group: test-p4c-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
@@ -110,98 +110,4 @@ jobs:
     - name: Run p4c tests (Fedora Linux)
       # Need to use sudo for the eBPF kernel tests.
       run: sudo -E ctest --output-on-failure --schedule-random
-      working-directory: ./build
-
-  # Build and test p4c on MacOS for M1 Macs.
-  test-mac-os-m1:
-    runs-on: macos-14
-    env:
-      CTEST_PARALLEL_LEVEL: 4
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1
-      with:
-        key: test-${{ runner.os }}
-        max-size: 1000M
-
-    - name: Get brew cache dir
-      id: brew-cache
-      run: |
-        echo "dir=$(brew --prefix)" >> $GITHUB_OUTPUT
-
-    - name: Cache Homebrew Packages
-      id: cache-homebrew-packages
-      uses: actions/cache@v4
-      env:
-        cache-name: homebrew-packages
-      with:
-        path: ${{ steps.brew-cache.outputs.dir }}
-        key: ${{ runner.os }}-m1-${{ hashFiles('tools/install_mac_deps.sh') }}
-
-    - name: Install dependencies (MacOS)
-      run: |
-           tools/install_mac_deps.sh
-
-    - name: Build (MacOS)
-      run: |
-          source ~/.bash_profile
-          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE \
-              -DCMAKE_UNITY_BUILD=ON
-          make -Cbuild -j$((`nproc`+1))
-
-    - name: Run tests (MacOS)
-      run: |
-        source ~/.bash_profile
-        ctest --output-on-failure --schedule-random -LE "bpf|ubpf"
-      working-directory: ./build
-
-  # Build and test p4c on MacOS 13 on x86.
-  test-mac-os:
-    runs-on: macos-13
-    env:
-      CTEST_PARALLEL_LEVEL: 4
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1
-      with:
-        key: test-${{ runner.os }}
-        max-size: 1000M
-
-    - name: Get brew cache dir
-      id: brew-cache
-      run: |
-        echo "dir=$(brew --prefix)" >> $GITHUB_OUTPUT
-
-    - name: Cache Homebrew Packages
-      id: cache-homebrew-packages
-      uses: actions/cache@v4
-      env:
-        cache-name: homebrew-packages
-      with:
-        path: ${{ steps.brew-cache.outputs.dir }}
-        key: ${{ runner.os }}-${{ hashFiles('tools/install_mac_deps.sh') }}
-
-    - name: Install dependencies (MacOS)
-      run: |
-           tools/install_mac_deps.sh
-
-    - name: Build (MacOS)
-      run: |
-          source ~/.bash_profile
-          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE \
-              -DCMAKE_UNITY_BUILD=ON
-          make -Cbuild -j$((`nproc`+1))
-
-    - name: Run tests (MacOS)
-      run: |
-        source ~/.bash_profile
-        ctest --output-on-failure --schedule-random -LE "bpf|ubpf"
       working-directory: ./build

--- a/.github/workflows/ci-ubuntu-18-nightly.yml
+++ b/.github/workflows/ci-ubuntu-18-nightly.yml
@@ -14,8 +14,6 @@ jobs:
   test-ubuntu18:
     # Only run on pull requests with the "run-ubuntu18" label.
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-ubuntu18') }}
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
     env:
       CTEST_PARALLEL_LEVEL: 4

--- a/.github/workflows/ci-ubuntu-20-sanitizer-nightly.yml
+++ b/.github/workflows/ci-ubuntu-20-sanitizer-nightly.yml
@@ -14,8 +14,6 @@ jobs:
   test-ubuntu20-clang-sanitizers:
     # Only run on pull requests with the "run-sanitizer" label.
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-sanitizer') }}
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-20.04
     env:
       CTEST_PARALLEL_LEVEL: 2


### PR DESCRIPTION
We are bundling too many tests in one job. Factor out the MacOS and Fedora tests into a separate file. They are functionally different enough in workflow. 