### PR TITLE
HalfOpenRange/ClosedRange classes

### DIFF
--- a/ir/CMakeLists.txt
+++ b/ir/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 set (IR_SRCS
   base.cpp
+  bitrange.cpp
   dbprint.cpp
   dbprint-expression.cpp
   dbprint-stmt.cpp

--- a/ir/bitrange.cpp
+++ b/ir/bitrange.cpp
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "ir/json_generator.h"
+#include "ir/json_loader.h"
+
+namespace BitRange {
+
+void rangeToJSON(JSONGenerator &json, int lo, int hi) { json.toJSON(std::make_pair(lo, hi)); }
+
+std::pair<int, int> rangeFromJSON(JSONLoader &json) {
+    std::pair<int, int> endpoints;
+    json >> endpoints;
+    return endpoints;
+}
+
+}  // namespace BitRange

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,6 +15,7 @@
 set (LIBP4CTOOLKIT_SRCS
     alloc_trace.cpp
     backtrace_exception.cpp
+    bitrange.cpp
     bitvec.cpp
     compile_context.cpp
     crash.cpp

--- a/lib/bitrange.cpp
+++ b/lib/bitrange.cpp
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "lib/bitrange.h"
+
+#include <iostream>
+#include <utility>
+
+std::ostream &toStream(std::ostream &out, RangeUnit unit, Endian order, int lo, int hi,
+                       bool closed) {
+    if (unit == RangeUnit::Bit)
+        out << "bit";
+    else if (unit == RangeUnit::Byte)
+        out << "byte";
+    else
+        BUG("unknown range unit");
+
+    out << (!closed && order == Endian::Little ? "(" : "[");
+
+    if (order == Endian::Little) std::swap(lo, hi);
+
+    out << std::dec << lo;
+    if (lo != hi) out << ".." << hi;
+
+    out << (!closed && order == Endian::Network ? ")" : "]");
+
+    return out;
+}

--- a/lib/bitrange.h
+++ b/lib/bitrange.h
@@ -17,7 +17,15 @@ limitations under the License.
 #ifndef LIB_BITRANGE_H_
 #define LIB_BITRANGE_H_
 
+#include <algorithm>
+#include <iosfwd>
+#include <limits>
+#include <optional>
+#include <utility>
+
 #include "bitvec.h"
+#include "exceptions.h"
+#include "hash.h"
 
 /* iterate over ranges of contiguous bits in a bitvector */
 class bitranges {
@@ -50,5 +58,737 @@ class bitranges {
     iter begin() const { return iter(bits.begin()); }
     iter end() const { return iter(bits.end()); }
 };
+
+class JSONGenerator;
+class JSONLoader;
+
+namespace BitRange {
+
+namespace Detail {
+/**
+ * @return the result of dividing @dividend by @divisor, rounded towards
+ * negative infinity. This is different than normal C++ integer division, which
+ * rounds towards zero. For example, `-7 / 8 == 0`, but
+ * `divideFloor(-7, 8) == -1`.
+ */
+inline int divideFloor(int dividend, int divisor) {
+    const int quotient = dividend / divisor;
+    const int remainder = dividend % divisor;
+    if ((remainder != 0) && ((remainder < 0) != (divisor < 0))) return quotient - 1;
+    return quotient;
+}
+
+/**
+ * @return @dividend modulo @divisor as distinct from C++'s
+ * `dividend % divisor`. The difference is that the result of
+ * `dividend % divisor` takes its sign from the dividend, but
+ * `modulo(dividend, divisor)` takes its sign from the divisor.
+ * For example, `-7 % 8 == -7`, but `modulo(-7, 8) == 7`.
+ */
+constexpr int modulo(int dividend, int divisor) {
+    return (dividend % divisor) * ((dividend < 0) != (divisor < 0) ? -1 : 1);
+}
+
+/**
+ * @return the remainder of dividing @dividend by @divisor, rounded towards
+ * negative infinity. This is different than the normal C++ `dividend % divisor` in
+ * two respects:
+ *   - As with `modulo(dividend, divisor)`, it takes its sign from the divisor.
+ *   - For all integers `D1`, `D2`, `D3`,
+ *     `divideFloor(D1, D3) == divideFloor(D2, D3) /\ D1 < D2
+ *          ==> moduloFloor(D1, D3) < moduloFloor(D2, D3)`.
+ *     This is not true for `%`, because due to C++'s round-towards-zero
+ *     behavior the remainders grow in different directions for positive
+ *     dividends than for negative dividends.
+ * To make this concrete, `-7 % 8 == -7`, but `moduloFloor(-7, 8) == 1`.
+ */
+inline int moduloFloor(const int dividend, const int divisor) {
+    const int remainder = modulo(dividend, divisor);
+    if (remainder == 0 || dividend >= 0) return remainder;
+    return divisor - remainder;
+}
+}  // namespace Detail
+
+/**
+ * A helper type used to construct a range, specified as the closed interval
+ * between two bit indices. For example, `FromTo(6, 8)` denotes a range
+ * containing three bits: bit 6, bit 7, and bit 8.
+ *
+ * FromTo is only intended to be used as a constructor parameter, to allow
+ * creation of ranges in a more readable manner; use it to construct a
+ * HalfOpenRange or ClosedRange.
+ */
+struct FromTo {
+    FromTo(int from, int to) : from(from), to(to) {}
+    FromTo(const FromTo &) = delete;
+    FromTo &operator=(const FromTo &) = delete;
+    const int from;
+    const int to;
+};
+
+/**
+ * A helper type used to construct a range, specified as the region of a certain
+ * length beginning at a certain bit index. For example, `StartLen(6, 8)`
+ * denotes a range containing eight bits: bit 6, bit 7, bit 8, bit 9, bit 10,
+ * bit 11, bit 12, and bit 13.
+ *
+ * As with FromTo, StartLen is only meant to be used when constructing a
+ * HalfOpenRange or ClosedRange.
+ */
+struct StartLen {
+    StartLen(int start, int len) : start(start), len(len) {}
+    StartLen(const StartLen &) = delete;
+    StartLen &operator=(const StartLen &) = delete;
+    const int start;
+    const int len;
+};
+
+/**
+ * A helper type used to construct a range that starts at zero and ends at the
+ * maximum index that is safely representable without overflow. Only meant to be
+ * used when constructing a HalfOpenRange or ClosedRange.
+ *
+ * ZeroToMax ranges are useful as an identity when intersecting ranges. If you
+ * have a loop where you intersect ranges over and over, you may find ZeroToMax
+ * useful.
+ *
+ * A caveat: "safely representable" above means that basic bitrange getters,
+ * queries, comparisons, and set operations work. It does *not* mean that any
+ * computation you do with the bitrange will be safe; operations that increase
+ * the size of very large bitranges, that shift them, or that change their units
+ * may result in integer overflow.
+ *
+ * It's generally safe to change the endianness of ZeroToMax, as long as the
+ * space it lives inside is safe. If you try to treat it as living in a space
+ * which also has a very large size, you may encounter integer overflow.
+ *
+ * XXX: There's no substitute for checking unsafe conversions before
+ * performing them, but we don't do that right now, so be cautious with very
+ * large ranges, just as you would be with storing very large values into a
+ * primitive type.
+ */
+struct ZeroToMax {};
+
+/**
+ * A helper type used to construct a range that starts at the minimum index that
+ * is safely representable without overflow and ends at the maximum index that
+ * is safely representable without overflow. Only meant to be used when
+ * constructing a HalfOpenRange or ClosedRange.
+ *
+ * MinToMax ranges are useful as an identity when intersecting ranges. If you
+ * have a loop where you intersect ranges over and over, you may find MinToMax
+ * useful. Note that you're less likely to run into overflow issues with
+ * ZeroToMax ranges, so if you're dealing entirely with non-negative numbers,
+ * you're probably better off using ZeroToMax.
+ *
+ * @see ZeroToMax for more discussion about what "safely representable" means.
+ *
+ * Unlike ZeroToMax, it is not safe to change the endianness of MinToMax; doing
+ * so will inevitably result in integer overflow.
+ */
+struct MinToMax {};
+
+/// JSON serialization/deserialization helpers.
+void rangeToJSON(JSONGenerator &json, int lo, int hi);
+std::pair<int, int> rangeFromJSON(JSONLoader &json);
+
+}  // namespace BitRange
+
+/// Units in which a range can be specified.
+enum class RangeUnit : uint8_t {
+    Bit = 0,
+    Byte = 1  /// 8-bit bytes (octets).
+};
+
+/// An ordering for bits or bytes.
+enum class Endian : uint8_t {
+    Network = 0,  /// Most significant bit/byte first.
+    Little = 1,   /// Least significant bit/byte first.
+};
+
+/**
+ * A half-open range of bits or bytes - `[lo, hi)` - specified in terms of a
+ * specific endian order. Half-open ranges include `lo` but do not include `hi`,
+ * so `HalfOpenRange(3, 5)` contains `3` and `4` but not `5`.
+ *
+ * Use a half-open range when you want to allow for the possibility that the
+ * range may be empty, which may be represented by setting `lo` and `hi` to the
+ * same value. Using a half-open range may also make some algorithms more
+ * natural to express, and it may make working with external code easier since
+ * half-open ranges are idiomatic in C++.
+ *
+ * Note that there are many ways to represent an empty range - `(1, 1)` is
+ * empty, for example, but so is `(2, 2)`. Many operations on HalfOpenRanges
+ * will canonicalize the empty range representation, so don't rely on it - just
+ * call `empty()` to determine if a range is empty.
+ *
+ * XXX: Currently, for backwards compatibility, it's possible to construct
+ * ranges where `lo` is greater than `hi`. We should enforce that ranges are
+ * consistent; we'll add the necessary checks after the existing code has been
+ * audited.
+ *
+ * XXX: We should also add checks to avoid integer overflow.
+ */
+template <RangeUnit Unit, Endian Order>
+struct HalfOpenRange {
+    static constexpr RangeUnit unit = Unit;
+    static constexpr Endian order = Order;
+
+    using FromTo = BitRange::FromTo;
+    using StartLen = BitRange::StartLen;
+    using ZeroToMax = BitRange::ZeroToMax;
+    using MinToMax = BitRange::MinToMax;
+
+    HalfOpenRange() : lo(0), hi(0) {}
+    HalfOpenRange(int lo, int hi) : lo(lo), hi(hi) {}
+    HalfOpenRange(FromTo &&fromTo)  // NOLINT(runtime/explicit)
+        : lo(fromTo.from), hi(fromTo.to + 1) {}
+    HalfOpenRange(StartLen &&startLen)  // NOLINT(runtime/explicit)
+        : lo(startLen.start), hi(startLen.start + startLen.len) {}
+    HalfOpenRange(ZeroToMax &&)  // NOLINT(runtime/explicit)
+        : lo(0), hi(std::numeric_limits<int>::max()) {}
+    HalfOpenRange(MinToMax &&)  // NOLINT(runtime/explicit)
+        : lo(std::numeric_limits<int>::min()), hi(std::numeric_limits<int>::max()) {}
+    explicit HalfOpenRange(std::pair<int, int> range) : lo(range.first), hi(range.second) {}
+
+    /// @return the number of elements in this range.
+    ssize_t size() const { return ssize_t(hi) - ssize_t(lo); }
+
+    /// @return a canonicalized version of this range. This only has an effect
+    /// for empty ranges, which will all be mapped to (0, 0).
+    HalfOpenRange canonicalize() const {
+        if (empty()) return HalfOpenRange(0, 0);
+        return *this;
+    }
+
+    /// @return a new range with the same starting index, but expanded or
+    /// contracted so that it has the provided size in bits. The end result is
+    /// always in bits.
+    HalfOpenRange<RangeUnit::Bit, Order> resizedToBits(int size) const {
+        if (empty()) return HalfOpenRange<RangeUnit::Bit, Order>(0, size);
+        auto asBits = toUnit<RangeUnit::Bit>();
+        return {asBits.lo, asBits.lo + size};
+    }
+
+    /// @return a new range with the same starting index, but expanded or
+    /// contracted so that it has the provided size in bytes.
+    HalfOpenRange resizedToBytes(int size) const {
+        const int resizedLo = empty() ? 0 : lo;
+        if (Unit == RangeUnit::Byte) return {resizedLo, resizedLo + size};
+        return {resizedLo, resizedLo + size * 8};
+    }
+
+    /// @return a new range with the same size, but shifted towards the
+    /// high-numbered bits by the provided amount. No rotation or clamping
+    /// to zero is applied. The result is always in bits.
+    HalfOpenRange<RangeUnit::Bit, Order> shiftedByBits(int offset) const {
+        if (empty()) return HalfOpenRange<RangeUnit::Bit, Order>();
+        auto asBits = toUnit<RangeUnit::Bit>();
+        return {asBits.lo + offset, asBits.hi + offset};
+    }
+
+    /// @return a new range with the same size, but shifted towards the
+    /// high-numbered bytes by the provided amount. No rotation or clamping
+    /// to zero is applied.
+    HalfOpenRange<Unit, Order> shiftedByBytes(int offset) const {
+        if (empty()) return HalfOpenRange();
+        if (Unit == RangeUnit::Byte) return {lo + offset, hi + offset};
+        return {lo + offset * 8, hi + offset * 8};
+    }
+
+    /// @return the byte containing the lowest-numbered bit in this interval.
+    int loByte() const {
+        if (empty()) return 0;
+        return Unit == RangeUnit::Byte ? lo : BitRange::Detail::divideFloor(lo, 8);
+    }
+
+    /// @return the byte containing the highest-numbered bit in this interval.
+    int hiByte() const {
+        if (empty()) return 0;
+        return Unit == RangeUnit::Byte ? hi - 1 : BitRange::Detail::divideFloor(hi - 1, 8);
+    }
+
+    /// @return the next byte that starts after the end of this interval. May
+    /// result in integer overflow if used with ZeroToMax or MinToMax-sized
+    /// ranges.
+    int nextByte() const { return empty() ? 0 : hiByte() + 1; }
+
+    /// @return true if the lowest-numbered bit in this range is
+    /// byte-aligned.
+    bool isLoAligned() const {
+        return (empty() || Unit == RangeUnit::Byte) ? true
+                                                    : BitRange::Detail::moduloFloor(lo, 8) == 0;
+    }
+
+    /// @return true if the highest-numbered bit in this range is
+    /// byte-aligned (meaning that this range stops right before the
+    /// beginning of a new byte).
+    bool isHiAligned() const {
+        return (empty() || Unit == RangeUnit::Byte) ? true
+                                                    : BitRange::Detail::moduloFloor(hi, 8) == 0;
+    }
+
+    bool operator==(HalfOpenRange other) const {
+        if (empty()) return other.empty();
+        return other.lo == lo && other.hi == hi;
+    }
+    bool operator!=(HalfOpenRange other) const { return !(*this == other); }
+
+    /// @return true if this range is empty - i.e., it contains no elements.
+    bool empty() const { return lo == hi; }
+
+    /// @return true if this range includes the provided index.
+    bool contains(int index) const { return index >= lo && index < hi; }
+
+    /// @return true if this range includes the provided range - i.e., if this
+    /// range contains a superset of the provided range's bits.
+    bool contains(HalfOpenRange other) const { return intersectWith(other) == other; }
+
+    /// @return true if this range has some bits in common with the provided
+    /// range. Note that an empty range never overlaps with any other range, so
+    /// `rangeA == rangeB` does not imply that `rangeA.overlaps(rangeB)`.
+    bool overlaps(HalfOpenRange a) const { return !intersectWith(a).empty(); }
+    bool overlaps(int l, int h) const { return !intersectWith(l, h).empty(); }
+
+    /// @return a range which contains all the bits which are included in both
+    /// this range and the provided range, or an empty range if there are no bits
+    /// in common.
+    HalfOpenRange intersectWith(HalfOpenRange a) const { return intersectWith(a.lo, a.hi); }
+    HalfOpenRange intersectWith(int l, int h) const {
+        HalfOpenRange rv = {std::max(lo, l), std::min(hi, h)};
+        if (rv.hi <= rv.lo) return {0, 0};
+        return rv;
+    }
+    HalfOpenRange operator&(HalfOpenRange a) const { return intersectWith(a); }
+    HalfOpenRange operator&=(HalfOpenRange a) {
+        *this = intersectWith(a);
+        return *this;
+    }
+
+    /// @return the smallest range that contains all of the bits in both this
+    /// range and the provided range. Note that because ranges are contiguous,
+    /// the result may contain bits that are not in either of the original
+    /// ranges.
+    HalfOpenRange unionWith(HalfOpenRange a) const { return unionWith(a.lo, a.hi); }
+    HalfOpenRange unionWith(int l, int h) const {
+        if (empty()) return {l, h};
+        if (l == h) return *this;
+        return HalfOpenRange(std::min(lo, l), std::max(hi, h));
+    }
+    HalfOpenRange operator|(HalfOpenRange a) const { return unionWith(a); }
+    HalfOpenRange operator|=(HalfOpenRange a) {
+        *this = unionWith(a);
+        return *this;
+    }
+
+    /**
+     * Convert this range to a range with the specified endian order.
+     *
+     * Making this conversion requires specifying the size of the larger space
+     * that this range is embedded in. That's because the place we start
+     * numbering indices from (the origin, in other words) is changing.  For
+     * example, given a space with 10 elements, a range of 3 indices within that
+     * space may be numbered in two ways as follows:
+     *             Space:               [o o o o o o o o o o]
+     *             Big endian range:    --> [2 3 4]
+     *             Little endian range:     [7 6 5] <--------
+     * We couldn't switch between those numberings without knowing that the
+     * space has 10 elements.
+     *
+     * Note that this operation may result in integer overflow when dealing with
+     * very large ranges. It's generally safe for ZeroToMax as long as the space
+     * size is not also near INT_MAX. It's never safe for MinToMax.
+     *
+     * @tparam DestOrder  The endian order to convert to.
+     * @param spaceSize  The size of the space this range is embedded in.
+     * @return this range, but converted to the specified endian ordering.
+     */
+    template <Endian DestOrder>
+    HalfOpenRange<Unit, DestOrder> toOrder(int spaceSize) const {
+        if (DestOrder == Order) return HalfOpenRange<Unit, DestOrder>(lo, hi);
+        switch (DestOrder) {
+            case Endian::Network:
+            case Endian::Little:
+                return HalfOpenRange<Unit, DestOrder>(spaceSize - hi, spaceSize - lo);
+        }
+        BUG("Unexpected ordering");
+    }
+
+    /**
+     * Convert this range to the smallest enclosing range with the specified unit.
+     *
+     * Conversion from bytes to bits is exact, but conversion from bits to bytes
+     * is lossy and may cause the size of the range to grow if the bits aren't
+     * byte-aligned. If that would be problematic, use `isLoAligned()` and
+     * `isHiAligned()` to check before converting, or just check that converting
+     * the result back to bits yields the original range.
+     *
+     * This operation will result in integer overflow when dealing with
+     * ZeroToMax or MinToMax-sized ranges.
+     *
+     * @tparam DestUnit  The unit to convert to.
+     * @return this range, but converted to the specified unit.
+     */
+    template <RangeUnit DestUnit>
+    HalfOpenRange<DestUnit, Order> toUnit() const {
+        if (DestUnit == Unit) return HalfOpenRange<DestUnit, Order>(lo, hi);
+        if (empty()) return HalfOpenRange<DestUnit, Order>();
+        switch (DestUnit) {
+            case RangeUnit::Bit:
+                return HalfOpenRange<DestUnit, Order>(lo * 8, hi * 8);
+            case RangeUnit::Byte:
+                return HalfOpenRange<DestUnit, Order>(loByte(), nextByte());
+        }
+        BUG("Unexpected unit");
+    }
+
+    /// JSON serialization/deserialization.
+    void toJSON(JSONGenerator &json) const { BitRange::rangeToJSON(json, lo, hi); }
+    static HalfOpenRange fromJSON(JSONLoader &json) {
+        return HalfOpenRange(BitRange::rangeFromJSON(json));
+    }
+
+    /// Total ordering, first by lo, then by hi.
+    bool operator<(const HalfOpenRange &other) const {
+        if (lo != other.lo) return lo < other.lo;
+        return hi < other.hi;
+    }
+
+    friend size_t hash_value(const HalfOpenRange &r) { return Util::Hash{}(r.lo, r.hi); }
+
+    /// The lowest numbered index in the range. For Endian::Network, this is the
+    /// most significant bit or byte; for Endian::Little, it's the least
+    /// significant.
+    int lo;
+
+    /// The highest numbered index in the range. For Endian::Network, this is the
+    /// least significant bit or byte; for Endian::Little, it's the most
+    /// significant. Because this is a half-open range, the range element this
+    /// index identifies is not included in the range.
+    int hi;
+};
+
+/**
+ * A closed range of bits or bytes - `[lo, hi]` specified in terms of a specific
+ * endian order. Closed ranges include both `lo` and `hi`, so
+ * `ClosedRange(3, 5)` contains `3`, `4`, and `5`.
+ *
+ * Use a closed range when you want to forbid the possibility of an empty range.
+ * Using a closed range may also make certain algorithms easier to express.
+ *
+ * XXX: ClosedRange's interface is very similar to HalfOpenRange, but they
+ * have almost totally different implementations, and the limitations of C++
+ * templates make sharing the things they do have in common challenging. Most of
+ * the benefit would have come from sharing documentation; as a compromise, most
+ * of the methods in ClosedRange just reference HalfOpenRange's documentation.
+ *
+ * XXX: Currently, for backwards compatibility, it's possible to construct
+ * ranges where `lo` is greater than or equal to `hi`. We should enforce that
+ * ranges are consistent; we'll add the necessary checks after the existing code
+ * has been audited.
+ *
+ * XXX: We should also add checks to avoid integer overflow.
+ */
+template <RangeUnit Unit, Endian Order>
+struct ClosedRange {
+    static constexpr RangeUnit unit = Unit;
+    static constexpr Endian order = Order;
+
+    using FromTo = BitRange::FromTo;
+    using StartLen = BitRange::StartLen;
+    using ZeroToMax = BitRange::ZeroToMax;
+    using MinToMax = BitRange::MinToMax;
+
+    ClosedRange() : lo(0), hi(0) {}  // FIXME: default is [0,0]? This is just wrong ...
+    constexpr ClosedRange(int lo, int hi) : lo(lo), hi(hi) {}
+    ClosedRange(FromTo &&fromTo)  // NOLINT(runtime/explicit)
+        : lo(fromTo.from), hi(fromTo.to) {}
+    ClosedRange(StartLen &&startLen)  // NOLINT(runtime/explicit)
+        : lo(startLen.start), hi(startLen.start + startLen.len - 1) {}
+    ClosedRange(ZeroToMax &&)  // NOLINT(runtime/explicit)
+        : lo(0), hi(std::numeric_limits<int>::max() - 1) {}
+    ClosedRange(MinToMax &&)  // NOLINT(runtime/explicit)
+        : lo(std::numeric_limits<int>::min()), hi(std::numeric_limits<int>::max() - 1) {}
+    explicit ClosedRange(std::pair<int, int> range) : lo(range.first), hi(range.second) {}
+    ClosedRange(const HalfOpenRange<Unit, Order> &r)  // NOLINT(runtime/explicit)
+        : lo(r.lo), hi(r.hi - 1) {
+        BUG_CHECK(!r.empty(), "can't convert empty range to Closed");
+    }
+
+    /// @see HalfOpenRange::size().
+    ssize_t size() const { return ssize_t(hi) - ssize_t(lo) + 1; }
+
+    /// @see HalfOpenRange::resizedToBits().
+    ClosedRange<RangeUnit::Bit, Order> resizedToBits(int size) const {
+        BUG_CHECK(size != 0, "Resizing ClosedRange to zero size");
+        auto asBits = toUnit<RangeUnit::Bit>();
+        return {asBits.lo, asBits.lo + size - 1};
+    }
+
+    /// @see HalfOpenRange::resizedToBytes().
+    ClosedRange resizedToBytes(int size) const {
+        BUG_CHECK(size != 0, "Resizing ClosedRange to zero size");
+        if (Unit == RangeUnit::Byte) return {lo, lo + size - 1};
+        return {lo, lo + size * 8 - 1};
+    }
+
+    /// @see HalfOpenRange::shiftedByBits().
+    ClosedRange<RangeUnit::Bit, Order> shiftedByBits(int offset) const {
+        auto asBits = toUnit<RangeUnit::Bit>();
+        return {asBits.lo + offset, asBits.hi + offset};
+    }
+
+    /// @see HalfOpenRange::shiftedByBytes().
+    ClosedRange shiftedByBytes(int offset) const {
+        if (Unit == RangeUnit::Byte) return {lo + offset, hi + offset};
+        return {lo + offset * 8, hi + offset * 8};
+    }
+
+    /// @see HalfOpenRange::loByte().
+    int loByte() const {
+        return Unit == RangeUnit::Byte ? lo : BitRange::Detail::divideFloor(lo, 8);
+    }
+
+    /// @see HalfOpenRange::hiByte().
+    int hiByte() const {
+        return Unit == RangeUnit::Byte ? hi : BitRange::Detail::divideFloor(hi, 8);
+    }
+
+    /// @see HalfOpenRange::nextByte().
+    int nextByte() const { return hiByte() + 1; }
+
+    /// @see HalfOpenRange::isLoAligned().
+    bool isLoAligned() const {
+        return Unit == RangeUnit::Byte ? true : BitRange::Detail::moduloFloor(lo, 8) == 0;
+    }
+
+    /// @see HalfOpenRange::isHiAligned().
+    bool isHiAligned() const {
+        return Unit == RangeUnit::Byte ? true : BitRange::Detail::moduloFloor(hi + 1, 8) == 0;
+    }
+
+    bool operator==(ClosedRange other) const { return (other.lo == lo) && (other.hi == hi); }
+    bool operator!=(ClosedRange other) const { return !(*this == other); }
+
+    /// @see HalfOpenRange::contains().
+    bool contains(int index) const { return (index >= lo) && (index <= hi); }
+
+    /// @see HalfOpenRange::contains().
+    bool contains(ClosedRange other) const {
+        auto intersection = intersectWith(other);
+        return intersection.lo == other.lo && intersection.size() == other.size();
+    }
+
+    /// @see HalfOpenRange::overlaps().
+    bool overlaps(ClosedRange a) const { return !intersectWith(a).empty(); }
+    bool overlaps(int l, int h) const { return !intersectWith(l, h).empty(); }
+
+    /// @return a range which contains all the bits which are included in both
+    /// this range and the provided range, or an empty range if there are no bits
+    /// in common. Because the resulting range may be empty, this method returns
+    /// a HalfOpenRange.
+    HalfOpenRange<Unit, Order> intersectWith(ClosedRange a) const {
+        return intersectWith(a.lo, a.hi);
+    }
+    HalfOpenRange<Unit, Order> intersectWith(int l, int h) const {
+        return HalfOpenRange<Unit, Order>(lo, hi + 1)
+            .intersectWith(HalfOpenRange<Unit, Order>(l, h + 1));
+    }
+    HalfOpenRange<Unit, Order> operator&(ClosedRange a) const { return intersectWith(a); }
+    HalfOpenRange<Unit, Order> operator&=(ClosedRange a) {
+        *this = intersectWith(a);
+        return *this;
+    }
+
+    /// @see HalfOpenRange::unionWith().
+    ClosedRange unionWith(ClosedRange a) const { return unionWith(a.lo, a.hi); }
+    ClosedRange unionWith(int l, int h) const {
+        return ClosedRange(std::min(lo, l), std::max(hi, h));
+    }
+    ClosedRange operator|(ClosedRange a) const { return unionWith(a); }
+    ClosedRange operator|=(ClosedRange a) {
+        *this = unionWith(a);
+        return *this;
+    }
+
+    /// @see HalfOpenRange::toOrder().
+    template <Endian DestOrder>
+    ClosedRange<Unit, DestOrder> toOrder(int spaceSize) const {
+        BUG_CHECK(spaceSize > 0, "Can't represent an empty range");
+        if (DestOrder == Order) return ClosedRange<Unit, DestOrder>(lo, hi);
+        switch (DestOrder) {
+            case Endian::Network:
+            case Endian::Little:
+                return ClosedRange<Unit, DestOrder>((spaceSize - 1) - hi, (spaceSize - 1) - lo);
+        }
+        BUG("Unexpected ordering");
+    }
+
+    /// @see HalfOpenRange::toUnit().
+    template <RangeUnit DestUnit>
+    ClosedRange<DestUnit, Order> toUnit() const {
+        if (DestUnit == Unit) return ClosedRange<DestUnit, Order>(lo, hi);
+        switch (DestUnit) {
+            case RangeUnit::Bit:
+                return ClosedRange<DestUnit, Order>(lo * 8, hi * 8 + 7);
+            case RangeUnit::Byte:
+                return ClosedRange<DestUnit, Order>(loByte(), hiByte());
+        }
+        BUG("Unexpected unit");
+    }
+
+    /// JSON serialization/deserialization.
+    void toJSON(JSONGenerator &json) const { BitRange::rangeToJSON(json, lo, hi); }
+    static ClosedRange fromJSON(JSONLoader &json) {
+        return ClosedRange(BitRange::rangeFromJSON(json));
+    }
+
+    /// @see HalfOpenRange::operator<.
+    bool operator<(const ClosedRange &other) const {
+        if (lo != other.lo) return lo < other.lo;
+        return hi < other.hi;
+    }
+
+    friend size_t hash_value(const ClosedRange &r) { return Util::Hash{}(r.lo, r.hi); }
+
+    /// Formats this range as P4 syntax by converting to a little-endian range of bits, and
+    /// formatting the result as "[hi:lo]".
+    cstring formatAsSlice(int spaceSize) const {
+        auto r = toOrder<Endian::Little>(spaceSize);
+        auto hi = r.hi;
+        auto lo = r.lo;
+        if (Unit == RangeUnit::Byte) {
+            lo = lo * 8;
+            hi = hi * 8 + 7;
+        } else {
+            BUG_CHECK(Unit == RangeUnit::Bit, "mismatch range units");
+        }
+        std::stringstream out;
+        out << "[" << hi << ":" << lo << "]";
+        return cstring(out.str());
+    }
+
+    /// The lowest numbered index in the range. For Endian::Network, this is the
+    /// most significant bit or byte; for Endian::Little, it's the least
+    /// significant.
+    int lo;
+
+    /// The highest numbered index in the range. For Endian::Network, this is the
+    /// least significant bit or byte; for Endian::Little, it's the most
+    /// significant. Because this is a closed range, the range element this
+    /// index identifies is included in the range.
+    int hi;
+};
+
+/** Implements range subtraction (similar to set subtraction), computing the
+ * upper and lower ranges that result from @left - @right.  For example,
+ * @left - @right = { C.lower, C.upper }:
+ *
+ *   example   (1)          (2)         (3)         (4)
+ *   @left     --------     ----             ----      ----
+ *   @right       ---            ----   ----        ----------
+ *   C.lower   ---          ----        (empty)     (empty)
+ *   C.upper         --     (empty)          ----   (empty)
+ *
+ * XXX: This could produce a bit vector.
+ */
+template <RangeUnit Unit, Endian Order>
+std::pair<HalfOpenRange<Unit, Order>, HalfOpenRange<Unit, Order>> operator-(
+    HalfOpenRange<Unit, Order> left, HalfOpenRange<Unit, Order> right) {
+    HalfOpenRange<Unit, Order> empty = {0, 0};
+    HalfOpenRange<Unit, Order> intersect = left.intersectWith(right);
+    if (intersect.empty())
+        return left.lo < right.lo ? std::make_pair(left, empty) : std::make_pair(empty, left);
+
+    HalfOpenRange<Unit, Order> lower =
+        left.lo == intersect.lo ? empty : BitRange::FromTo(left.lo, intersect.lo - 1);
+    HalfOpenRange<Unit, Order> upper =
+        left.hi == intersect.hi ? empty : BitRange::FromTo(intersect.hi, left.hi - 1);
+
+    return {lower, upper};
+}
+
+/// @see HalfOpenRange subtraction.
+/// @returns a pair of half-open ranges (which may be empty).
+template <RangeUnit Unit, Endian Order>
+std::pair<HalfOpenRange<Unit, Order>, HalfOpenRange<Unit, Order>> operator-(
+    ClosedRange<Unit, Order> left, ClosedRange<Unit, Order> right) {
+    return toHalfOpenRange(left) - toHalfOpenRange(right);
+}
+
+/// @return a half-open range denoting the same elements as the provided closed
+/// range.
+template <RangeUnit Unit, Endian Order>
+HalfOpenRange<Unit, Order> toHalfOpenRange(ClosedRange<Unit, Order> closedRange) {
+    return HalfOpenRange<Unit, Order>(closedRange.lo, closedRange.hi + 1);
+}
+
+/// @return a closed range denoting the same elements as the provided half-open
+/// range, or std::nullopt if the provided range is empty.
+template <RangeUnit Unit, Endian Order>
+std::optional<ClosedRange<Unit, Order>> toClosedRange(HalfOpenRange<Unit, Order> halfOpenRange) {
+    if (halfOpenRange.empty()) return std::nullopt;
+    return ClosedRange<Unit, Order>(halfOpenRange.lo, halfOpenRange.hi - 1);
+}
+
+/// Convenience typedefs for closed ranges in bits.
+using nw_bitrange = ClosedRange<RangeUnit::Bit, Endian::Network>;
+using le_bitrange = ClosedRange<RangeUnit::Bit, Endian::Little>;
+
+/// Convenience typedefs for closed ranges in bytes.
+using nw_byterange = ClosedRange<RangeUnit::Byte, Endian::Network>;
+using le_byterange = ClosedRange<RangeUnit::Byte, Endian::Little>;
+
+/// Convenience typedefs for half-open ranges in bits.
+using nw_bitinterval = HalfOpenRange<RangeUnit::Bit, Endian::Network>;
+using le_bitinterval = HalfOpenRange<RangeUnit::Bit, Endian::Little>;
+
+/// Convenience typedefs for half-open ranges in bytes.
+using nw_byteinterval = HalfOpenRange<RangeUnit::Byte, Endian::Network>;
+using le_byteinterval = HalfOpenRange<RangeUnit::Byte, Endian::Little>;
+
+std::ostream &toStream(std::ostream &out, RangeUnit unit, Endian order, int lo, int hi,
+                       bool closed);
+
+template <RangeUnit Unit, Endian Order>
+std::ostream &operator<<(std::ostream &out, const HalfOpenRange<Unit, Order> &range) {
+    return toStream(out, Unit, Order, range.lo, range.hi, false);
+}
+
+template <RangeUnit Unit, Endian Order>
+std::ostream &operator<<(std::ostream &out, const ClosedRange<Unit, Order> &range) {
+    return toStream(out, Unit, Order, range.lo, range.hi, true);
+}
+
+// Hashing specializations
+namespace std {
+template <RangeUnit Unit, Endian Order>
+struct hash<HalfOpenRange<Unit, Order>> {
+    std::size_t operator()(const HalfOpenRange<Unit, Order> &r) const {
+        return Util::Hash{}(r.lo, r.hi);
+    }
+};
+
+template <RangeUnit Unit, Endian Order>
+struct hash<ClosedRange<Unit, Order>> {
+    std::size_t operator()(const ClosedRange<Unit, Order> &r) const {
+        return Util::Hash{}(r.lo, r.hi);
+    }
+};
+}  // namespace std
+
+namespace Util {
+template <RangeUnit Unit, Endian Order>
+struct Hasher<HalfOpenRange<Unit, Order>> {
+    size_t operator()(const HalfOpenRange<Unit, Order> &r) const {
+        return Util::Hash{}(r.lo, r.hi);
+    }
+};
+
+template <RangeUnit Unit, Endian Order>
+struct Hasher<ClosedRange<Unit, Order>> {
+    size_t operator()(const ClosedRange<Unit, Order> &r) const { return Util::Hash{}(r.lo, r.hi); }
+};
+}  // namespace Util
 
 #endif /* LIB_BITRANGE_H_ */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@
 
 set (GTEST_UNITTEST_SOURCES
   gtest/arch_test.cpp
+  gtest/bitrange.cpp
   gtest/bitvec_test.cpp
   gtest/call_graph_test.cpp
   gtest/complex_bitwise.cpp

--- a/test/gtest/bitrange.cpp
+++ b/test/gtest/bitrange.cpp
@@ -1,0 +1,1479 @@
+/*
+Copyright 2024 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "lib/bitrange.h"
+
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "helpers.h"
+#include "ir/ir.h"
+#include "ir/json_loader.h"
+
+// disable these tests for gcc-4.9, which for some reason
+// do not link with std::optional
+#if (__GNUC__ > 4) || defined(__clang__)
+namespace Test {
+
+using namespace BitRange;
+using namespace BitRange::Detail;
+
+/// A GTest fixture base class for backend targets.
+class BitrangeTestBase : public ::testing::Test {
+ protected:
+    BitrangeTestBase() : autoBFNContext(new GTestContext()) {}
+
+    AutoCompileContext autoBFNContext;
+};
+
+/// A fixture for testing properties that apply to all HalfOpenRange types.
+template <typename T>
+class HalfOpenRangeTest : public BitrangeTestBase {};
+typedef ::testing::Types<nw_bitinterval, nw_byteinterval, le_bitinterval, le_byteinterval>
+    HalfOpenRangeTypes;
+TYPED_TEST_CASE(HalfOpenRangeTest, HalfOpenRangeTypes);
+
+/// A fixture for testing properties that apply to all ClosedRange types.
+template <typename T>
+class ClosedRangeTest : public BitrangeTestBase {};
+typedef ::testing::Types<nw_bitrange, nw_byterange, le_bitrange, le_byterange> ClosedRangeTypes;
+TYPED_TEST_CASE(ClosedRangeTest, ClosedRangeTypes);
+
+/// A fixture for testing properties that apply to all ranges with bit units.
+template <typename T>
+class BitRangeTest : public BitrangeTestBase {};
+typedef ::testing::Types<nw_bitinterval, le_bitinterval, nw_bitrange, le_bitrange> BitRangeTypes;
+TYPED_TEST_CASE(BitRangeTest, BitRangeTypes);
+
+/// A fixture for testing properties that apply to all ranges with byte units.
+template <typename T>
+class ByteRangeTest : public BitrangeTestBase {};
+typedef ::testing::Types<nw_byteinterval, le_byteinterval, nw_byterange, le_byterange>
+    ByteRangeTypes;
+TYPED_TEST_CASE(ByteRangeTest, ByteRangeTypes);
+
+/// A fixture for testing properties that apply to all ranges of any type.
+template <typename T>
+class AnyRangeTest : public BitrangeTestBase {};
+typedef ::testing::Types<nw_bitinterval, le_bitinterval, nw_bitrange, le_bitrange, nw_byteinterval,
+                         le_byteinterval, nw_byterange, le_byterange>
+    AnyRangeTypes;
+TYPED_TEST_CASE(AnyRangeTest, AnyRangeTypes);
+
+TYPED_TEST(HalfOpenRangeTest, EmptyRange) {
+    using HalfOpenRangeType = TypeParam;
+    const HalfOpenRangeType range;
+
+    // There are multiple ways to express an empty range, so we'll want to make
+    // sure that they all behave the same.
+    const std::map<int, HalfOpenRangeType> emptyRanges = {
+        {0, HalfOpenRangeType()},
+        {1, HalfOpenRangeType(0, 0)},
+        {2, HalfOpenRangeType(36, 36)},
+    };
+
+    for (auto &emptyRange : emptyRanges) {
+        SCOPED_TRACE(emptyRange.first);
+        auto range = emptyRange.second;
+
+        // Make sure that this type of empty range is equal to all the other
+        // kinds of empty ranges.
+        for (auto &otherEmptyRange : emptyRanges) {
+            SCOPED_TRACE(otherEmptyRange.first);
+            EXPECT_EQ(otherEmptyRange.second, range);
+        }
+
+        // Check that it's not equal to a non-empty range.
+        EXPECT_NE(HalfOpenRangeType(0, 1), range);
+
+        // Check that "emptiness" has the properties we expect.
+        EXPECT_EQ(range.lo, range.hi);
+        EXPECT_TRUE(range.empty());
+        EXPECT_EQ(0, range.size());
+        EXPECT_EQ(0, range.loByte());
+        EXPECT_EQ(0, range.hiByte());
+        EXPECT_EQ(0, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+
+        // Check that resizing an empty range results in a range of the
+        // appropriate length with the low endpoint at 0.
+        EXPECT_EQ(0, range.resizedToBits(0).lo);
+        EXPECT_EQ(0, range.resizedToBits(0).size());
+        EXPECT_EQ(0, range.resizedToBits(3).lo);
+        EXPECT_EQ(3, range.resizedToBits(3).size());
+        EXPECT_EQ(0, range.resizedToBytes(0).lo);
+        EXPECT_EQ(0, range.resizedToBytes(0).size());
+        EXPECT_EQ(0, range.resizedToBytes(3).lo);
+        if (HalfOpenRangeType::unit == RangeUnit::Bit)
+            EXPECT_EQ(3 * 8, range.resizedToBytes(3).size());
+        else
+            EXPECT_EQ(3, range.resizedToBytes(3).size());
+
+        // Check that a shifted empty range remains empty.
+        EXPECT_TRUE(range.shiftedByBits(10).empty());
+        EXPECT_TRUE(range.shiftedByBytes(10).empty());
+
+        // Check that an empty range doesn't contain any bits.
+        for (int bit : {-2, -1, 0, 1, 2}) {
+            SCOPED_TRACE(bit);
+            EXPECT_FALSE(range.contains(bit));
+            EXPECT_FALSE(range.contains(HalfOpenRangeType(StartLen(bit, 1))));
+        }
+
+        // Check that an empty range doesn't overlap anything.
+        EXPECT_FALSE(range.overlaps(HalfOpenRangeType()));
+        EXPECT_FALSE(range.overlaps(HalfOpenRangeType(0, 1)));
+        EXPECT_FALSE(range.overlaps(HalfOpenRangeType(-2, 2)));
+        EXPECT_FALSE(range.overlaps(HalfOpenRangeType(8, 16)));
+
+        // Check that the intersection of an empty range with any other range is
+        // always empty.
+        EXPECT_EQ(HalfOpenRangeType(), range.intersectWith(HalfOpenRangeType()));
+        EXPECT_EQ(HalfOpenRangeType(), range.intersectWith(HalfOpenRangeType(0, 1)));
+        EXPECT_EQ(HalfOpenRangeType(), range.intersectWith(HalfOpenRangeType(-2, 2)));
+        EXPECT_EQ(HalfOpenRangeType(), range.intersectWith(HalfOpenRangeType(8, 16)));
+
+        // Check that the union of an empty range with any other range is the
+        // identity function.
+        EXPECT_EQ(HalfOpenRangeType(), range.unionWith(HalfOpenRangeType()));
+        EXPECT_EQ(HalfOpenRangeType(0, 1), range.unionWith(HalfOpenRangeType(0, 1)));
+        EXPECT_EQ(HalfOpenRangeType(-2, 2), range.unionWith(HalfOpenRangeType(-2, 2)));
+        EXPECT_EQ(HalfOpenRangeType(8, 16), range.unionWith(HalfOpenRangeType(8, 16)));
+
+        // Check that empty ranges remain empty when their endianness changes.
+        // (The `template` business here is just grossness caused by the fact
+        // that this test is *itself* a template; you wouldn't ordinarily need
+        // that.)
+        EXPECT_TRUE(range.template toOrder<Endian::Little>(10).empty());
+        EXPECT_TRUE(range.template toOrder<Endian::Network>(10).empty());
+
+        // Check that empty ranges remain empty when their unit changes.
+        EXPECT_TRUE(range.template toUnit<RangeUnit::Bit>().empty());
+        EXPECT_TRUE(range.template toUnit<RangeUnit::Byte>().empty());
+
+        // Check that canonicalizing any empty range results in the same form.
+        EXPECT_EQ(HalfOpenRangeType(0, 0), range.canonicalize());
+    }
+}
+
+TYPED_TEST(HalfOpenRangeTest, Constructors) {
+    using HalfOpenRangeType = TypeParam;
+
+    {
+        HalfOpenRangeType range(5, 15);
+        EXPECT_FALSE(range.empty());
+        EXPECT_EQ(5, range.lo);
+        EXPECT_EQ(15, range.hi);
+        EXPECT_EQ(10, range.size());
+    }
+
+    {
+        HalfOpenRangeType range(FromTo(5, 15));
+        EXPECT_FALSE(range.empty());
+        EXPECT_EQ(5, range.lo);
+        EXPECT_EQ(16, range.hi);
+        EXPECT_EQ(11, range.size());
+    }
+
+    {
+        HalfOpenRangeType range(FromTo(-9, 9));
+        EXPECT_FALSE(range.empty());
+        EXPECT_EQ(-9, range.lo);
+        EXPECT_EQ(10, range.hi);
+        EXPECT_EQ(19, range.size());
+    }
+
+    {
+        HalfOpenRangeType range(StartLen(5, 15));
+        EXPECT_FALSE(range.empty());
+        EXPECT_EQ(5, range.lo);
+        EXPECT_EQ(20, range.hi);
+        EXPECT_EQ(15, range.size());
+    }
+
+    {
+        HalfOpenRangeType range(StartLen(-5, 3));
+        EXPECT_FALSE(range.empty());
+        EXPECT_EQ(-5, range.lo);
+        EXPECT_EQ(-2, range.hi);
+        EXPECT_EQ(3, range.size());
+    }
+
+    {
+        HalfOpenRangeType range(std::make_pair(5, 15));
+        EXPECT_FALSE(range.empty());
+        EXPECT_EQ(5, range.lo);
+        EXPECT_EQ(15, range.hi);
+        EXPECT_EQ(10, range.size());
+    }
+
+    // Check FromTo/StartLen equivalences.
+    EXPECT_EQ(HalfOpenRangeType(FromTo(-7, -3)), HalfOpenRangeType(StartLen(-7, 5)));
+    EXPECT_EQ(HalfOpenRangeType(FromTo(-8, 0)), HalfOpenRangeType(StartLen(-8, 9)));
+    EXPECT_EQ(HalfOpenRangeType(FromTo(-5, 5)), HalfOpenRangeType(StartLen(-5, 11)));
+    EXPECT_EQ(HalfOpenRangeType(FromTo(3, 19)), HalfOpenRangeType(StartLen(3, 17)));
+}
+
+TYPED_TEST(ClosedRangeTest, Constructors) {
+    using ClosedRangeType = TypeParam;
+
+    {
+        ClosedRangeType range(5, 15);
+        EXPECT_EQ(5, range.lo);
+        EXPECT_EQ(15, range.hi);
+        EXPECT_EQ(11, range.size());
+    }
+
+    {
+        ClosedRangeType range(FromTo(5, 15));
+        EXPECT_EQ(5, range.lo);
+        EXPECT_EQ(15, range.hi);
+        EXPECT_EQ(11, range.size());
+    }
+
+    {
+        ClosedRangeType range(FromTo(-9, 9));
+        EXPECT_EQ(-9, range.lo);
+        EXPECT_EQ(9, range.hi);
+        EXPECT_EQ(19, range.size());
+    }
+
+    {
+        ClosedRangeType range(StartLen(5, 15));
+        EXPECT_EQ(5, range.lo);
+        EXPECT_EQ(19, range.hi);
+        EXPECT_EQ(15, range.size());
+    }
+
+    {
+        ClosedRangeType range(StartLen(-5, 3));
+        EXPECT_EQ(-5, range.lo);
+        EXPECT_EQ(-3, range.hi);
+        EXPECT_EQ(3, range.size());
+    }
+
+    {
+        ClosedRangeType range(std::make_pair(5, 15));
+        EXPECT_EQ(5, range.lo);
+        EXPECT_EQ(15, range.hi);
+        EXPECT_EQ(11, range.size());
+    }
+
+    // Check FromTo/StartLen equivalences.
+    EXPECT_EQ(ClosedRangeType(FromTo(-7, -3)), ClosedRangeType(StartLen(-7, 5)));
+    EXPECT_EQ(ClosedRangeType(FromTo(-8, 0)), ClosedRangeType(StartLen(-8, 9)));
+    EXPECT_EQ(ClosedRangeType(FromTo(-5, 5)), ClosedRangeType(StartLen(-5, 11)));
+    EXPECT_EQ(ClosedRangeType(FromTo(3, 19)), ClosedRangeType(StartLen(3, 17)));
+}
+
+TYPED_TEST(BitRangeTest, Resize) {
+    using BitRangeType = TypeParam;
+
+    // Check basic functionality.
+    {
+        BitRangeType range(StartLen(5, 11));
+        EXPECT_EQ(BitRangeType(StartLen(5, 4)), range.resizedToBits(4));
+        EXPECT_EQ(BitRangeType(StartLen(5, 16)), range.resizedToBytes(2));
+    }
+
+    // Check that negative endpoints are handled correctly.
+    {
+        BitRangeType range(FromTo(-11, -2));
+        EXPECT_EQ(BitRangeType(FromTo(-11, -8)), range.resizedToBits(4));
+        EXPECT_EQ(BitRangeType(FromTo(-11, 3)), range.resizedToBits(15));
+        EXPECT_EQ(BitRangeType(FromTo(-11, -4)), range.resizedToBytes(1));
+        EXPECT_EQ(BitRangeType(FromTo(-11, 4)), range.resizedToBytes(2));
+    }
+
+    // Resizing to the original size should leave the range unchanged.
+    {
+        BitRangeType range(StartLen(3, 7));
+        EXPECT_EQ(range, range.resizedToBits(7));
+    }
+    {
+        BitRangeType range(StartLen(3, 16));
+        EXPECT_EQ(range, range.resizedToBytes(2));
+    }
+}
+
+TYPED_TEST(ByteRangeTest, Resize) {
+    using ByteRangeType = TypeParam;
+
+    // `resizedToBits()` always produces a range in bit units, even if the
+    // original range was in byte units.
+    using BitRangeType = decltype(ByteRangeType().resizedToBits(1));
+
+    // Check basic functionality.
+    {
+        ByteRangeType range(StartLen(5, 11));
+        EXPECT_EQ(BitRangeType(StartLen(40, 4)), range.resizedToBits(4));
+        EXPECT_EQ(ByteRangeType(StartLen(5, 2)), range.resizedToBytes(2));
+    }
+
+    // Check that negative endpoints are handled correctly.
+    {
+        ByteRangeType range(FromTo(-11, -2));
+        EXPECT_EQ(BitRangeType(FromTo(-88, -85)), range.resizedToBits(4));
+        EXPECT_EQ(BitRangeType(FromTo(-88, 26)), range.resizedToBits(115));
+        EXPECT_EQ(ByteRangeType(FromTo(-11, -11)), range.resizedToBytes(1));
+        EXPECT_EQ(ByteRangeType(FromTo(-11, 18)), range.resizedToBytes(30));
+    }
+
+    // Resizing to the original size should leave the range unchanged.
+    {
+        ByteRangeType range(StartLen(3, 7));
+        EXPECT_EQ(range, range.resizedToBits(56).template toUnit<RangeUnit::Byte>());
+    }
+    {
+        ByteRangeType range(StartLen(3, 16));
+        EXPECT_EQ(range, range.resizedToBytes(16));
+    }
+}
+
+TYPED_TEST(BitRangeTest, Shift) {
+    using BitRangeType = TypeParam;
+
+    // Check basic functionality.
+    {
+        BitRangeType range(StartLen(5, 11));
+        EXPECT_EQ(BitRangeType(StartLen(9, 11)), range.shiftedByBits(4));
+        EXPECT_EQ(BitRangeType(StartLen(1, 11)), range.shiftedByBits(-4));
+        EXPECT_EQ(BitRangeType(StartLen(-3, 11)), range.shiftedByBits(-8));
+        EXPECT_EQ(BitRangeType(StartLen(21, 11)), range.shiftedByBytes(2));
+        EXPECT_EQ(BitRangeType(StartLen(-11, 11)), range.shiftedByBytes(-2));
+    }
+
+    // Shifting by zero should have no effect.
+    {
+        BitRangeType range(StartLen(3, 7));
+        EXPECT_EQ(range, range.shiftedByBits(0));
+        EXPECT_EQ(range, range.shiftedByBytes(0));
+    }
+}
+
+TYPED_TEST(ByteRangeTest, Shift) {
+    using ByteRangeType = TypeParam;
+
+    // `shiftedByBits()` always produces a range in bit units, even if the
+    // original range was in byte units.
+    using BitRangeType = decltype(ByteRangeType().shiftedByBits(1));
+
+    // Check basic functionality.
+    {
+        ByteRangeType range(FromTo(5, 14));
+        EXPECT_EQ(BitRangeType(FromTo(44, 123)), range.shiftedByBits(4));
+        EXPECT_EQ(BitRangeType(FromTo(36, 115)), range.shiftedByBits(-4));
+        EXPECT_EQ(BitRangeType(FromTo(-79, 0)), range.shiftedByBits(-119));
+        EXPECT_EQ(ByteRangeType(FromTo(7, 16)), range.shiftedByBytes(2));
+        EXPECT_EQ(ByteRangeType(FromTo(-2, 7)), range.shiftedByBytes(-7));
+    }
+
+    // Shifting by zero should have no effect.
+    {
+        ByteRangeType range(StartLen(3, 7));
+        EXPECT_EQ(range, range.shiftedByBits(0).template toUnit<RangeUnit::Byte>());
+        EXPECT_EQ(range, range.shiftedByBytes(0));
+    }
+}
+
+TYPED_TEST(BitRangeTest, ByteAlignment) {
+    using BitRangeType = TypeParam;
+
+    {
+        BitRangeType range(StartLen(0, 7));
+        EXPECT_EQ(0, range.loByte());
+        EXPECT_EQ(0, range.hiByte());
+        EXPECT_EQ(1, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_FALSE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(FromTo(0, 7));
+        EXPECT_EQ(0, range.loByte());
+        EXPECT_EQ(0, range.hiByte());
+        EXPECT_EQ(1, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(StartLen(0, 8));
+        EXPECT_EQ(0, range.loByte());
+        EXPECT_EQ(0, range.hiByte());
+        EXPECT_EQ(1, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(FromTo(5, 6));
+        EXPECT_EQ(0, range.loByte());
+        EXPECT_EQ(0, range.hiByte());
+        EXPECT_EQ(1, range.nextByte());
+        EXPECT_FALSE(range.isLoAligned());
+        EXPECT_FALSE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(StartLen(5, 6));
+        EXPECT_EQ(0, range.loByte());
+        EXPECT_EQ(1, range.hiByte());
+        EXPECT_EQ(2, range.nextByte());
+        EXPECT_FALSE(range.isLoAligned());
+        EXPECT_FALSE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(StartLen(11, 33));
+        EXPECT_EQ(1, range.loByte());
+        EXPECT_EQ(5, range.hiByte());
+        EXPECT_EQ(6, range.nextByte());
+        EXPECT_FALSE(range.isLoAligned());
+        EXPECT_FALSE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(StartLen(16, 128));
+        EXPECT_EQ(2, range.loByte());
+        EXPECT_EQ(17, range.hiByte());
+        EXPECT_EQ(18, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(StartLen(-16, 8));
+        EXPECT_EQ(-2, range.loByte());
+        EXPECT_EQ(-2, range.hiByte());
+        EXPECT_EQ(-1, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(StartLen(-11, 4));
+        EXPECT_EQ(-2, range.loByte());
+        EXPECT_EQ(-1, range.hiByte());
+        EXPECT_EQ(0, range.nextByte());
+        EXPECT_FALSE(range.isLoAligned());
+        EXPECT_FALSE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(StartLen(-3, 16));
+        EXPECT_EQ(-1, range.loByte());
+        EXPECT_EQ(1, range.hiByte());
+        EXPECT_EQ(2, range.nextByte());
+        EXPECT_FALSE(range.isLoAligned());
+        EXPECT_FALSE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(FromTo(-6, -1));
+        EXPECT_EQ(-1, range.loByte());
+        EXPECT_EQ(-1, range.hiByte());
+        EXPECT_EQ(0, range.nextByte());
+        EXPECT_FALSE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        BitRangeType range(FromTo(-15, 0));
+        EXPECT_EQ(-2, range.loByte());
+        EXPECT_EQ(0, range.hiByte());
+        EXPECT_EQ(1, range.nextByte());
+        EXPECT_FALSE(range.isLoAligned());
+        EXPECT_FALSE(range.isHiAligned());
+    }
+}
+
+TYPED_TEST(ByteRangeTest, ByteAlignment) {
+    using ByteRangeType = TypeParam;
+
+    {
+        ByteRangeType range(StartLen(0, 7));
+        EXPECT_EQ(0, range.loByte());
+        EXPECT_EQ(6, range.hiByte());
+        EXPECT_EQ(7, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(FromTo(0, 7));
+        EXPECT_EQ(0, range.loByte());
+        EXPECT_EQ(7, range.hiByte());
+        EXPECT_EQ(8, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(StartLen(0, 8));
+        EXPECT_EQ(0, range.loByte());
+        EXPECT_EQ(7, range.hiByte());
+        EXPECT_EQ(8, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(FromTo(5, 6));
+        EXPECT_EQ(5, range.loByte());
+        EXPECT_EQ(6, range.hiByte());
+        EXPECT_EQ(7, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(StartLen(5, 6));
+        EXPECT_EQ(5, range.loByte());
+        EXPECT_EQ(10, range.hiByte());
+        EXPECT_EQ(11, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(StartLen(11, 33));
+        EXPECT_EQ(11, range.loByte());
+        EXPECT_EQ(43, range.hiByte());
+        EXPECT_EQ(44, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(StartLen(16, 128));
+        EXPECT_EQ(16, range.loByte());
+        EXPECT_EQ(143, range.hiByte());
+        EXPECT_EQ(144, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(StartLen(-16, 8));
+        EXPECT_EQ(-16, range.loByte());
+        EXPECT_EQ(-9, range.hiByte());
+        EXPECT_EQ(-8, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(StartLen(-11, 4));
+        EXPECT_EQ(-11, range.loByte());
+        EXPECT_EQ(-8, range.hiByte());
+        EXPECT_EQ(-7, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(StartLen(-3, 16));
+        EXPECT_EQ(-3, range.loByte());
+        EXPECT_EQ(12, range.hiByte());
+        EXPECT_EQ(13, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(FromTo(-6, -1));
+        EXPECT_EQ(-6, range.loByte());
+        EXPECT_EQ(-1, range.hiByte());
+        EXPECT_EQ(0, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+
+    {
+        ByteRangeType range(FromTo(-15, 0));
+        EXPECT_EQ(-15, range.loByte());
+        EXPECT_EQ(0, range.hiByte());
+        EXPECT_EQ(1, range.nextByte());
+        EXPECT_TRUE(range.isLoAligned());
+        EXPECT_TRUE(range.isHiAligned());
+    }
+}
+
+TYPED_TEST(AnyRangeTest, Contains) {
+    using AnyRangeType = TypeParam;
+
+    AnyRangeType range(FromTo(-11, 5));
+    for (auto i = -15; i < -11; i++) {
+        SCOPED_TRACE(i);
+        EXPECT_FALSE(range.contains(i));
+        EXPECT_FALSE(range.contains(AnyRangeType(StartLen(i, 1))));
+    }
+    for (auto i = -11; i <= 5; i++) {
+        SCOPED_TRACE(i);
+        EXPECT_TRUE(range.contains(i));
+        EXPECT_TRUE(range.contains(AnyRangeType(StartLen(i, 1))));
+    }
+    for (auto i = 6; i <= 10; i++) {
+        SCOPED_TRACE(i);
+        EXPECT_FALSE(range.contains(i));
+        EXPECT_FALSE(range.contains(AnyRangeType(StartLen(i, 1))));
+    }
+
+    // Check that our range doesn't contain another range which lies completely
+    // outside it.
+    EXPECT_FALSE(range.contains(AnyRangeType(FromTo(-1000, -12))));
+    EXPECT_FALSE(range.contains(AnyRangeType(FromTo(6, 1000))));
+
+    // Check that our range *does* contain a range which lies completely within
+    // it.
+    EXPECT_TRUE(range.contains(AnyRangeType(FromTo(-11, -3))));
+    EXPECT_TRUE(range.contains(AnyRangeType(FromTo(-11, 5))));
+    EXPECT_TRUE(range.contains(AnyRangeType(FromTo(-1, 1))));
+    EXPECT_TRUE(range.contains(AnyRangeType(FromTo(2, 5))));
+
+    // Check that our range does not contain a range which lies partially within
+    // it and partially outside.
+    EXPECT_FALSE(range.contains(AnyRangeType(FromTo(-1000, -11))));
+    EXPECT_FALSE(range.contains(AnyRangeType(FromTo(-12, -10))));
+    EXPECT_FALSE(range.contains(AnyRangeType(FromTo(-12, 3))));
+    EXPECT_FALSE(range.contains(AnyRangeType(FromTo(-11, 6))));
+    EXPECT_FALSE(range.contains(AnyRangeType(FromTo(-3, 6))));
+    EXPECT_FALSE(range.contains(AnyRangeType(FromTo(4, 6))));
+    EXPECT_FALSE(range.contains(AnyRangeType(FromTo(5, 1000))));
+    EXPECT_FALSE(range.contains(AnyRangeType(FromTo(-1000, 1000))));
+}
+
+TYPED_TEST(AnyRangeTest, Overlaps) {
+    using AnyRangeType = TypeParam;
+
+    {
+        AnyRangeType range(FromTo(0, 7));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(-1, 0))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(-11, 5))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(-22, 37))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(0, 1))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(0, 18))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(5, 6))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(7, 43))));
+        EXPECT_FALSE(range.overlaps(AnyRangeType(FromTo(-18, -1))));
+        EXPECT_FALSE(range.overlaps(AnyRangeType(FromTo(8, 44))));
+    }
+
+    {
+        AnyRangeType range(FromTo(-18, -3));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(-18, -17))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(-18, 1))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(-3, 3))));
+        EXPECT_FALSE(range.overlaps(AnyRangeType(FromTo(-2, -1))));
+        EXPECT_FALSE(range.overlaps(AnyRangeType(FromTo(-2, 13))));
+        EXPECT_FALSE(range.overlaps(AnyRangeType(FromTo(0, 3))));
+        EXPECT_FALSE(range.overlaps(AnyRangeType(FromTo(5, 13))));
+    }
+
+    {
+        AnyRangeType range(FromTo(5, 5));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(5, 5))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(3, 5))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(3, 8))));
+        EXPECT_TRUE(range.overlaps(AnyRangeType(FromTo(5, 16))));
+        EXPECT_FALSE(range.overlaps(AnyRangeType(FromTo(6, 13))));
+        EXPECT_FALSE(range.overlaps(AnyRangeType(FromTo(-5, -5))));
+    }
+}
+
+TYPED_TEST(AnyRangeTest, IntersectWith) {
+    using AnyRangeType = TypeParam;
+
+    // Intersection always produces a half-open range, even if the original
+    // range was closed.
+    using IntersectionType = HalfOpenRange<AnyRangeType::unit, AnyRangeType::order>;
+
+    {
+        AnyRangeType range(FromTo(0, 4));
+        EXPECT_TRUE(range.intersectWith(AnyRangeType(FromTo(-15, -1))).empty());
+        EXPECT_TRUE(range.intersectWith(AnyRangeType(FromTo(5, 7))).empty());
+        EXPECT_EQ(IntersectionType(FromTo(0, 0)),
+                  range.intersectWith(AnyRangeType(FromTo(-11, 0))));
+        EXPECT_EQ(IntersectionType(FromTo(0, 1)), range.intersectWith(AnyRangeType(FromTo(-5, 1))));
+        EXPECT_EQ(IntersectionType(FromTo(0, 4)),
+                  range.intersectWith(AnyRangeType(FromTo(-300, 500))));
+        EXPECT_EQ(IntersectionType(FromTo(2, 4)), range.intersectWith(AnyRangeType(FromTo(2, 19))));
+        EXPECT_EQ(IntersectionType(FromTo(4, 4)), range.intersectWith(AnyRangeType(FromTo(4, 49))));
+    }
+
+    {
+        AnyRangeType range(FromTo(-7, -2));
+        EXPECT_TRUE(range.intersectWith(AnyRangeType(FromTo(-33, -8))).empty());
+        EXPECT_TRUE(range.intersectWith(AnyRangeType(FromTo(-1, 9))).empty());
+        EXPECT_TRUE(range.intersectWith(AnyRangeType(FromTo(0, 97))).empty());
+        EXPECT_EQ(IntersectionType(FromTo(-7, -7)),
+                  range.intersectWith(AnyRangeType(FromTo(-16, -7))));
+        EXPECT_EQ(IntersectionType(FromTo(-7, -6)),
+                  range.intersectWith(AnyRangeType(FromTo(-7, -6))));
+        EXPECT_EQ(IntersectionType(FromTo(-7, -2)),
+                  range.intersectWith(AnyRangeType(FromTo(-99, 43))));
+        EXPECT_EQ(IntersectionType(FromTo(-3, -2)),
+                  range.intersectWith(AnyRangeType(FromTo(-3, 8000))));
+        EXPECT_EQ(IntersectionType(FromTo(-2, -2)),
+                  range.intersectWith(AnyRangeType(FromTo(-2, 0))));
+    }
+
+    {
+        AnyRangeType range(FromTo(-1, 1));
+        EXPECT_TRUE(range.intersectWith(AnyRangeType(FromTo(-7, -2))).empty());
+        EXPECT_TRUE(range.intersectWith(AnyRangeType(FromTo(2, 76))).empty());
+        EXPECT_EQ(IntersectionType(FromTo(-1, -1)),
+                  range.intersectWith(AnyRangeType(FromTo(-5, -1))));
+        EXPECT_EQ(IntersectionType(FromTo(-1, 0)),
+                  range.intersectWith(AnyRangeType(FromTo(-11, 0))));
+        EXPECT_EQ(IntersectionType(FromTo(0, 0)), range.intersectWith(AnyRangeType(FromTo(0, 0))));
+        EXPECT_EQ(IntersectionType(FromTo(0, 1)),
+                  range.intersectWith(AnyRangeType(FromTo(0, 500))));
+    }
+
+    {
+        AnyRangeType range(FromTo(0, 0));
+        EXPECT_TRUE(range.intersectWith(AnyRangeType(FromTo(-22, -1))).empty());
+        EXPECT_TRUE(range.intersectWith(AnyRangeType(FromTo(1, 63))).empty());
+        EXPECT_EQ(IntersectionType(FromTo(0, 0)),
+                  range.intersectWith(AnyRangeType(FromTo(-500, 500))));
+        EXPECT_EQ(IntersectionType(FromTo(0, 0)), range.intersectWith(AnyRangeType(FromTo(0, 0))));
+    }
+}
+
+TYPED_TEST(AnyRangeTest, UnionWith) {
+    using AnyRangeType = TypeParam;
+
+    {
+        AnyRangeType range(FromTo(0, 4));
+        EXPECT_EQ(AnyRangeType(FromTo(0, 4)), range.unionWith(AnyRangeType(FromTo(1, 2))));
+        EXPECT_EQ(AnyRangeType(FromTo(-5, 4)), range.unionWith(AnyRangeType(FromTo(-5, -1))));
+        EXPECT_EQ(AnyRangeType(FromTo(-5, 4)), range.unionWith(AnyRangeType(FromTo(-5, -4))));
+        EXPECT_EQ(AnyRangeType(FromTo(-5, 4)), range.unionWith(AnyRangeType(FromTo(-5, 2))));
+        EXPECT_EQ(AnyRangeType(FromTo(-5, 4)), range.unionWith(AnyRangeType(FromTo(-5, 4))));
+        EXPECT_EQ(AnyRangeType(FromTo(0, 7)), range.unionWith(AnyRangeType(FromTo(0, 7))));
+        EXPECT_EQ(AnyRangeType(FromTo(0, 7)), range.unionWith(AnyRangeType(FromTo(3, 7))));
+        EXPECT_EQ(AnyRangeType(FromTo(0, 7)), range.unionWith(AnyRangeType(FromTo(5, 7))));
+        EXPECT_EQ(AnyRangeType(FromTo(0, 7)), range.unionWith(AnyRangeType(FromTo(7, 7))));
+        EXPECT_EQ(AnyRangeType(FromTo(-100, 100)),
+                  range.unionWith(AnyRangeType(FromTo(-100, 100))));
+    }
+
+    {
+        AnyRangeType range(FromTo(-9, -3));
+        EXPECT_EQ(AnyRangeType(FromTo(-11, -3)), range.unionWith(AnyRangeType(FromTo(-11, -11))));
+        EXPECT_EQ(AnyRangeType(FromTo(-11, -3)), range.unionWith(AnyRangeType(FromTo(-11, -10))));
+        EXPECT_EQ(AnyRangeType(FromTo(-11, -3)), range.unionWith(AnyRangeType(FromTo(-11, -4))));
+        EXPECT_EQ(AnyRangeType(FromTo(-9, -3)), range.unionWith(AnyRangeType(FromTo(-6, -5))));
+        EXPECT_EQ(AnyRangeType(FromTo(-9, 0)), range.unionWith(AnyRangeType(FromTo(-5, 0))));
+        EXPECT_EQ(AnyRangeType(FromTo(-9, 0)), range.unionWith(AnyRangeType(FromTo(-1, 0))));
+        EXPECT_EQ(AnyRangeType(FromTo(-9, 50)), range.unionWith(AnyRangeType(FromTo(35, 50))));
+        EXPECT_EQ(AnyRangeType(FromTo(-100, 100)),
+                  range.unionWith(AnyRangeType(FromTo(-100, 100))));
+    }
+
+    {
+        AnyRangeType range(FromTo(3, 3));
+        EXPECT_EQ(AnyRangeType(FromTo(3, 3)), range.unionWith(AnyRangeType(FromTo(3, 3))));
+        EXPECT_EQ(AnyRangeType(FromTo(0, 3)), range.unionWith(AnyRangeType(FromTo(0, 1))));
+        EXPECT_EQ(AnyRangeType(FromTo(3, 13)), range.unionWith(AnyRangeType(FromTo(3, 13))));
+        EXPECT_EQ(AnyRangeType(FromTo(-27, 3)), range.unionWith(AnyRangeType(FromTo(-27, -26))));
+        EXPECT_EQ(AnyRangeType(FromTo(-100, 100)),
+                  range.unionWith(AnyRangeType(FromTo(-100, 100))));
+    }
+}
+
+TYPED_TEST(AnyRangeTest, ToOrder) {
+    using FromEndianRangeType = TypeParam;
+
+    // Concoct the range type which is the same as FromEndianRangeType except
+    // that it has the opposite endianness.
+    constexpr auto fromEndian = FromEndianRangeType::order;
+    constexpr auto toEndian = fromEndian == Endian::Network ? Endian::Little : Endian::Network;
+    using ToEndianRangeType = decltype(FromEndianRangeType().template toOrder<toEndian>(1));
+
+    struct ExpectedOrderMapping {
+        int index;
+        const FromEndianRangeType from;
+        const ToEndianRangeType to;
+        int spaceSize;
+    };
+
+    const std::vector<ExpectedOrderMapping> orderMappings = {
+        // A range that fills the space it's defined in looks the same in either
+        // endianess.
+        {0, StartLen(0, 5), StartLen(0, 5), 5},
+        {1, StartLen(0, 10), StartLen(0, 10), 10},
+        {2, StartLen(0, 16), StartLen(0, 16), 16},
+
+        // Simple endian changes within a single byte.
+        {3, FromTo(0, 0), FromTo(7, 7), 8},
+        {4, FromTo(1, 2), FromTo(5, 6), 8},
+        {5, FromTo(3, 6), FromTo(1, 4), 8},
+        {6, FromTo(4, 7), FromTo(0, 3), 8},
+        {7, FromTo(7, 7), FromTo(0, 0), 8},
+
+        // Irregularly sized spaces.
+        {8, FromTo(25, 63), FromTo(23, 61), 87},
+        {9, FromTo(1, 12), FromTo(0, 11), 13},
+        {10, FromTo(0, 0), FromTo(1, 1), 2},
+
+        // Indices outside the space.
+        {11, FromTo(1, 1), FromTo(-1, -1), 1},
+        {12, FromTo(22, 45), FromTo(-37, -14), 9},
+        {13, FromTo(-17, 5), FromTo(4, 26), 10},
+        {14, FromTo(3, 4), FromTo(-1, 0), 4},
+        {15, FromTo(-6, 0), FromTo(15, 21), 16},
+        {16, FromTo(-6, -3), FromTo(18, 21), 16},
+        {17, FromTo(-1000, 1000), FromTo(-1000, 1000), 1},
+    };
+
+    // Check that converting between different orders yields the results we
+    // expect above. We check both directions because endian changes should
+    // always be invertible.
+    // (The `template` business below is just grossness caused by the fact that
+    // this test is *itself* a template; you wouldn't ordinarily need that.)
+    for (auto &mapping : orderMappings) {
+        SCOPED_TRACE(mapping.index);
+        EXPECT_EQ(mapping.to, mapping.from.template toOrder<toEndian>(mapping.spaceSize));
+        EXPECT_EQ(mapping.from, mapping.to.template toOrder<fromEndian>(mapping.spaceSize));
+    }
+}
+
+TYPED_TEST(BitRangeTest, ToUnit) {
+    using BitRangeType = TypeParam;
+
+    // Concoct the range type which is the same as BitRangeType except that it's
+    // in byte units.
+    using ByteRangeType = decltype(BitRangeType().template toUnit<RangeUnit::Byte>());
+
+    struct ExpectedByteRange {
+        int index;
+        const BitRangeType from;
+        const ByteRangeType to;
+    };
+
+    const std::vector<ExpectedByteRange> unitMappings = {
+        // Byte-aligned bit ranges.
+        {0, StartLen(0, 8), StartLen(0, 1)},
+        {1, StartLen(16, 16), StartLen(2, 2)},
+        {2, StartLen(24, 32), StartLen(3, 4)},
+        {3, StartLen(72, 264), StartLen(9, 33)},
+
+        // Non-byte-aligned bit ranges.
+        {4, FromTo(0, 0), FromTo(0, 0)},
+        {5, FromTo(1, 2), FromTo(0, 0)},
+        {6, FromTo(0, 9), FromTo(0, 1)},
+        {7, FromTo(16, 36), FromTo(2, 4)},
+        {8, FromTo(15, 15), FromTo(1, 1)},
+        {9, FromTo(67, 321), FromTo(8, 40)},
+
+        // Negative indices.
+        {10, FromTo(-1, 0), FromTo(-1, 0)},
+        {11, FromTo(-1, -1), FromTo(-1, -1)},
+        {12, FromTo(-8, 1), FromTo(-1, 0)},
+        {13, FromTo(-9, 1), FromTo(-2, 0)},
+        {14, FromTo(-27, -23), FromTo(-4, -3)},
+        {15, FromTo(-31, -9), FromTo(-4, -2)},
+        {16, FromTo(-11, 7), FromTo(-2, 0)},
+        {17, FromTo(-76, 112), FromTo(-10, 14)},
+    };
+
+    // Check that converting from bit units to byte units yields the results we
+    // expect above.
+    // (The `template` business below is just grossness caused by the fact that
+    // this test is *itself* a template; you wouldn't ordinarily need that.)
+    for (auto &mapping : unitMappings) {
+        SCOPED_TRACE(mapping.index);
+        EXPECT_EQ(mapping.to, mapping.from.template toUnit<RangeUnit::Byte>());
+    }
+}
+
+TYPED_TEST(ByteRangeTest, ToUnit) {
+    using ByteRangeType = TypeParam;
+
+    // Concoct the range type which is the same as ByteRangeType except that
+    // it's in bit units.
+    using BitRangeType = decltype(ByteRangeType().template toUnit<RangeUnit::Bit>());
+
+    struct ExpectedBitRange {
+        int index;
+        const ByteRangeType from;
+        const BitRangeType to;
+    };
+
+    const std::vector<ExpectedBitRange> unitMappings = {
+        // Basic byte ranges.
+        {0, FromTo(0, 0), FromTo(0, 7)},
+        {1, FromTo(0, 5), FromTo(0, 47)},
+        {2, FromTo(7, 22), FromTo(56, 183)},
+        {3, FromTo(12, 12), StartLen(96, 8)},
+
+        // Byte ranges with negative indices.
+        {4, FromTo(-5, 3), FromTo(-40, 31)},
+        {5, FromTo(-2, -1), StartLen(-16, 16)},
+        {6, FromTo(-30, 0), FromTo(-240, 7)},
+        {7, FromTo(-84, 7), FromTo(-672, 63)},
+    };
+
+    // Check that converting from byte ranges to bit ranges yields the results
+    // we expect above. We check both directions because converts from bytes to
+    // bits should always be invertible. The same is not true for converting bit
+    // ranges to byte ranges, since non-byte-aligned bit ranges will lose
+    // information in the conversion.
+    // (The `template` business below is just grossness caused by the fact that
+    // this test is *itself* a template; you wouldn't ordinarily need that.)
+    for (auto &mapping : unitMappings) {
+        SCOPED_TRACE(mapping.index);
+        EXPECT_EQ(mapping.to, mapping.from.template toUnit<RangeUnit::Bit>());
+        EXPECT_EQ(mapping.from, mapping.to.template toUnit<RangeUnit::Byte>());
+    }
+}
+
+TYPED_TEST(HalfOpenRangeTest, ToClosedRange) {
+    using HalfOpenRangeType = TypeParam;
+
+    // Concoct the range type which is the same as HalfOpenRangeType except that
+    // it's a closed range.
+    using ClosedRangeType = ClosedRange<HalfOpenRangeType::unit, HalfOpenRangeType::order>;
+
+    struct ExpectedClosedRange {
+        int index;
+        const HalfOpenRangeType from;
+        const std::optional<ClosedRangeType> to;
+    };
+
+    const std::vector<ExpectedClosedRange> closedRangeMappings = {
+        {0, HalfOpenRangeType(0, 1), ClosedRangeType(0, 0)},
+        {1, HalfOpenRangeType(15, 36), ClosedRangeType(15, 35)},
+        {2, HalfOpenRangeType(-1, 0), ClosedRangeType(-1, -1)},
+        {3, HalfOpenRangeType(-21, -8), ClosedRangeType(-21, -9)},
+        {4, HalfOpenRangeType(0, 0), std::nullopt},
+        {5, HalfOpenRangeType(-9, -9), std::nullopt},
+        {6, HalfOpenRangeType(17, 17), std::nullopt},
+    };
+
+    // Check that converting from a half-open range to a closed range yields the
+    // results we expect above.
+    for (auto &mapping : closedRangeMappings) {
+        SCOPED_TRACE(mapping.index);
+        EXPECT_EQ(mapping.to, toClosedRange(mapping.from));
+    }
+}
+
+TYPED_TEST(ClosedRangeTest, ToHalfOpenRange) {
+    using ClosedRangeType = TypeParam;
+
+    // Concoct the range type which is the same as ClosedRangeType except that
+    // it's a half-open range.
+    using HalfOpenRangeType = HalfOpenRange<ClosedRangeType::unit, ClosedRangeType::order>;
+
+    struct ExpectedHalfOpenRange {
+        int index;
+        const ClosedRangeType from;
+        const HalfOpenRangeType to;
+    };
+
+    const std::vector<ExpectedHalfOpenRange> halfOpenRangeMappings = {
+        {0, ClosedRangeType(0, 0), HalfOpenRangeType(0, 1)},
+        {1, ClosedRangeType(15, 35), HalfOpenRangeType(15, 36)},
+        {2, ClosedRangeType(-1, -1), HalfOpenRangeType(-1, 0)},
+        {3, ClosedRangeType(-21, -9), HalfOpenRangeType(-21, -8)},
+    };
+
+    // Check that converting a closed range to a half-open range yields the
+    // results we expect above. Any closed range can be converted to a
+    // half-open range and back again without loss of information. The same is
+    // not true in the other direction because an empty range cannot be
+    // represented as a closed range.
+    for (auto &mapping : halfOpenRangeMappings) {
+        SCOPED_TRACE(mapping.index);
+        EXPECT_EQ(mapping.to, toHalfOpenRange(mapping.from));
+
+        auto backToClosedRange = toClosedRange(toHalfOpenRange(mapping.from));
+        EXPECT_TRUE(backToClosedRange != std::nullopt);
+        EXPECT_EQ(mapping.from, *backToClosedRange);
+    }
+}
+
+TYPED_TEST(HalfOpenRangeTest, MaxSizedRanges) {
+    using RangeType = TypeParam;
+    const RangeType zeroToMax = ZeroToMax();
+    const RangeType minToMax = MinToMax();
+
+    // It should be safe to call `size()` on large ranges.
+    EXPECT_EQ(ssize_t(zeroToMax.hi), zeroToMax.size());
+    EXPECT_EQ(ssize_t(std::numeric_limits<unsigned>::max()), minToMax.size());
+
+    // Shrinking without changing units should be safe for large ranges.
+    {
+        using BitRangeType = decltype(RangeType().template toUnit<RangeUnit::Bit>());
+
+        switch (RangeType::unit) {
+            case RangeUnit::Bit:
+                EXPECT_EQ(BitRangeType(StartLen(0, 1)), zeroToMax.resizedToBits(1));
+                EXPECT_EQ(BitRangeType(StartLen(minToMax.lo, 1)), minToMax.resizedToBits(1));
+                break;
+
+            case RangeUnit::Byte:
+                EXPECT_EQ(RangeType(StartLen(0, 1)), zeroToMax.resizedToBytes(1));
+                EXPECT_EQ(RangeType(StartLen(minToMax.lo, 1)), minToMax.resizedToBytes(1));
+                break;
+        }
+    }
+
+    // `loByte()`, `hiByte()`, `isLoAligned()` and `isHiAligned()` should
+    // produce reasonable results. We explicitly don't check `nextByte()`; that
+    // can't be expected to work in general, since the next byte may not even be
+    // representable in the range's underlying type.
+    switch (RangeType::unit) {
+        case RangeUnit::Bit:
+            EXPECT_EQ(0, zeroToMax.loByte());
+            EXPECT_TRUE(zeroToMax.isLoAligned());
+            EXPECT_EQ(ssize_t(zeroToMax.hi) / 8, ssize_t(zeroToMax.hiByte()));
+            EXPECT_FALSE(zeroToMax.isHiAligned());
+
+            EXPECT_EQ(ssize_t(minToMax.lo) / 8, ssize_t(minToMax.loByte()));
+            EXPECT_TRUE(minToMax.isLoAligned());
+            EXPECT_EQ(ssize_t(minToMax.hi) / 8, ssize_t(minToMax.hiByte()));
+            EXPECT_FALSE(minToMax.isHiAligned());
+
+            break;
+
+        case RangeUnit::Byte:
+            EXPECT_EQ(0, zeroToMax.loByte());
+            EXPECT_TRUE(zeroToMax.isLoAligned());
+            EXPECT_EQ(zeroToMax.hi - 1, zeroToMax.hiByte());
+            EXPECT_TRUE(zeroToMax.isHiAligned());
+
+            EXPECT_EQ(minToMax.lo, minToMax.loByte());
+            EXPECT_TRUE(minToMax.isLoAligned());
+            EXPECT_EQ(minToMax.hi - 1, minToMax.hiByte());
+            EXPECT_TRUE(minToMax.isHiAligned());
+
+            break;
+    }
+
+    // Equality should be reflexive, even for large ranges.
+    EXPECT_EQ(RangeType(ZeroToMax()), zeroToMax);
+    EXPECT_EQ(RangeType(MinToMax()), minToMax);
+
+    // We should be able to accurately answer questions about whether a bit or a
+    // range of bits in included in a large range.
+    EXPECT_TRUE(zeroToMax.contains(0));
+    EXPECT_TRUE(zeroToMax.contains(1));
+    EXPECT_TRUE(zeroToMax.contains(1000));
+    EXPECT_TRUE(zeroToMax.contains(zeroToMax.hi - 1));
+    EXPECT_TRUE(zeroToMax.contains(RangeType(FromTo(0, 0))));
+    EXPECT_TRUE(zeroToMax.contains(RangeType(FromTo(0, 1000))));
+    EXPECT_TRUE(zeroToMax.contains(RangeType(ZeroToMax())));
+    EXPECT_FALSE(zeroToMax.contains(-1));
+    EXPECT_FALSE(zeroToMax.contains(-1000));
+    EXPECT_FALSE(zeroToMax.contains(minToMax.lo));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(FromTo(-1, 0))));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(StartLen(-1000, 1))));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(FromTo(-1000, -1))));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(FromTo(-1000, 1000))));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(FromTo(-1, zeroToMax.hi - 1))));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(MinToMax())));
+
+    EXPECT_TRUE(minToMax.contains(0));
+    EXPECT_TRUE(minToMax.contains(1));
+    EXPECT_TRUE(minToMax.contains(1000));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(0, 0))));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(0, 1000))));
+    EXPECT_TRUE(minToMax.contains(RangeType(ZeroToMax())));
+    EXPECT_TRUE(minToMax.contains(minToMax.hi - 1));
+    EXPECT_TRUE(minToMax.contains(-1));
+    EXPECT_TRUE(minToMax.contains(-1000));
+    EXPECT_TRUE(minToMax.contains(minToMax.lo));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(-1, 0))));
+    EXPECT_TRUE(minToMax.contains(RangeType(StartLen(-1000, 1))));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(-1000, -1))));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(-1000, 1000))));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(-1, minToMax.hi - 1))));
+    EXPECT_TRUE(minToMax.contains(RangeType(MinToMax())));
+
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(FromTo(0, 0))));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(FromTo(0, 1))));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(FromTo(-1, 0))));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(FromTo(-1000, 1000))));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(0, zeroToMax.hi)));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(FromTo(minToMax.lo, 0))));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(minToMax.lo, zeroToMax.hi)));
+    EXPECT_FALSE(zeroToMax.overlaps(RangeType(FromTo(-1, -1))));
+    EXPECT_FALSE(zeroToMax.overlaps(RangeType(FromTo(-1000, -1))));
+    EXPECT_FALSE(zeroToMax.overlaps(RangeType(FromTo(minToMax.lo, -1))));
+
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(0, 0))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(0, 1))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(-1, 0))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(-1000, 1000))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(0, zeroToMax.hi)));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(minToMax.lo, 0)));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(minToMax.lo, zeroToMax.hi)));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(-1, -1))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(-1000, -1))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(minToMax.lo, -1))));
+
+    // We should be able to perform intersection or union operations.
+    // (Supporting union might seem surprising, since that could potentially
+    // increase the size of the range, but unioning two ranges that we can
+    // represent without overflow should never produce a range that we can't.)
+    EXPECT_EQ(zeroToMax, zeroToMax.intersectWith(zeroToMax));
+    EXPECT_EQ(zeroToMax, zeroToMax.unionWith(zeroToMax));
+    EXPECT_EQ(zeroToMax, zeroToMax.intersectWith(minToMax));
+    EXPECT_EQ(minToMax, zeroToMax.unionWith(minToMax));
+    EXPECT_EQ(RangeType(FromTo(0, 1)), zeroToMax.intersectWith(RangeType(FromTo(0, 1))));
+    EXPECT_EQ(zeroToMax, zeroToMax.unionWith(RangeType(FromTo(0, 1))));
+    EXPECT_EQ(RangeType(FromTo(0, 1000)), zeroToMax.intersectWith(RangeType(FromTo(-1000, 1000))));
+    EXPECT_EQ(RangeType(-1000, zeroToMax.hi), zeroToMax.unionWith(RangeType(FromTo(-1000, 1000))));
+    EXPECT_EQ(RangeType(), zeroToMax.intersectWith(RangeType(minToMax.lo, -1)));
+    EXPECT_EQ(minToMax, zeroToMax.unionWith(RangeType(minToMax.lo, -1)));
+    EXPECT_EQ(RangeType(1000, zeroToMax.hi),
+              zeroToMax.intersectWith(RangeType(1000, zeroToMax.hi)));
+    EXPECT_EQ(zeroToMax, zeroToMax.unionWith(RangeType(1000, zeroToMax.hi)));
+
+    EXPECT_EQ(minToMax, minToMax.intersectWith(minToMax));
+    EXPECT_EQ(minToMax, minToMax.unionWith(minToMax));
+    EXPECT_EQ(zeroToMax, minToMax.intersectWith(zeroToMax));
+    EXPECT_EQ(minToMax, minToMax.unionWith(zeroToMax));
+    EXPECT_EQ(RangeType(FromTo(0, 1)), minToMax.intersectWith(RangeType(FromTo(0, 1))));
+    EXPECT_EQ(minToMax, minToMax.unionWith(RangeType(FromTo(0, 1))));
+    EXPECT_EQ(RangeType(FromTo(-1000, 1000)),
+              minToMax.intersectWith(RangeType(FromTo(-1000, 1000))));
+    EXPECT_EQ(minToMax, minToMax.unionWith(RangeType(FromTo(-1000, 1000))));
+    EXPECT_EQ(RangeType(minToMax.lo, -1), minToMax.intersectWith(RangeType(minToMax.lo, -1)));
+    EXPECT_EQ(minToMax, minToMax.unionWith(RangeType(minToMax.lo, -1)));
+    EXPECT_EQ(RangeType(1000, zeroToMax.hi), minToMax.intersectWith(RangeType(1000, zeroToMax.hi)));
+    EXPECT_EQ(minToMax, minToMax.unionWith(RangeType(1000, zeroToMax.hi)));
+
+    // We can't support bit order changes for large ranges in general, because
+    // they can overflow, but life is a little easier if we allow reasonable bit
+    // order changes for ZeroToMax.
+    // XXX(seth): Once we start validating ranges when we create them, this will
+    // feel a bit safer...
+    {
+        constexpr auto oppositeOrder =
+            RangeType::order == Endian::Network ? Endian::Little : Endian::Network;
+        const auto asOppositeOrder = zeroToMax.template toOrder<oppositeOrder>(32);
+
+        EXPECT_EQ(ssize_t(32) - zeroToMax.hi, ssize_t(asOppositeOrder.lo));
+        EXPECT_EQ(32, asOppositeOrder.hi);
+        EXPECT_EQ(zeroToMax, asOppositeOrder.template toOrder<RangeType::order>(32));
+    }
+
+    // We should be able to convert a large HalfOpenRange to a ClosedRange and
+    // back again.
+    using ClosedRangeType = ClosedRange<RangeType::unit, RangeType::order>;
+    EXPECT_EQ(ClosedRangeType(ZeroToMax()), toClosedRange(zeroToMax));
+    EXPECT_TRUE(toClosedRange(zeroToMax));
+    EXPECT_EQ(zeroToMax, toHalfOpenRange(*toClosedRange(zeroToMax)));
+}
+
+TYPED_TEST(ClosedRangeTest, MaxSizedRanges) {
+    using RangeType = TypeParam;
+    using HalfOpenRangeType = HalfOpenRange<RangeType::unit, RangeType::order>;
+    const RangeType zeroToMax = ZeroToMax();
+    const RangeType minToMax = MinToMax();
+
+    // It should be safe to call `size()` on large ranges.
+    EXPECT_EQ(ssize_t(zeroToMax.hi) + 1, zeroToMax.size());
+    EXPECT_EQ(ssize_t(std::numeric_limits<unsigned>::max()), minToMax.size());
+
+    // Shrinking without changing units should be safe for large ranges.
+    {
+        using BitRangeType = decltype(RangeType().template toUnit<RangeUnit::Bit>());
+
+        switch (RangeType::unit) {
+            case RangeUnit::Bit:
+                EXPECT_EQ(BitRangeType(StartLen(0, 1)), zeroToMax.resizedToBits(1));
+                EXPECT_EQ(BitRangeType(StartLen(minToMax.lo, 1)), minToMax.resizedToBits(1));
+                break;
+
+            case RangeUnit::Byte:
+                EXPECT_EQ(RangeType(StartLen(0, 1)), zeroToMax.resizedToBytes(1));
+                EXPECT_EQ(RangeType(StartLen(minToMax.lo, 1)), minToMax.resizedToBytes(1));
+                break;
+        }
+    }
+
+    // `loByte()`, `hiByte()`, `isLoAligned()` and `isHiAligned()` should
+    // produce reasonable results. We explicitly don't check `nextByte()`; that
+    // can't be expected to work in general, since the next byte may not even be
+    // representable in the range's underlying type.
+    switch (RangeType::unit) {
+        case RangeUnit::Bit:
+            EXPECT_EQ(0, zeroToMax.loByte());
+            EXPECT_TRUE(zeroToMax.isLoAligned());
+            EXPECT_EQ(ssize_t(zeroToMax.hi) / 8, ssize_t(zeroToMax.hiByte()));
+            EXPECT_FALSE(zeroToMax.isHiAligned());
+
+            EXPECT_EQ(ssize_t(minToMax.lo) / 8, ssize_t(minToMax.loByte()));
+            EXPECT_TRUE(minToMax.isLoAligned());
+            EXPECT_EQ(ssize_t(minToMax.hi) / 8, ssize_t(minToMax.hiByte()));
+            EXPECT_FALSE(minToMax.isHiAligned());
+
+            break;
+
+        case RangeUnit::Byte:
+            EXPECT_EQ(0, zeroToMax.loByte());
+            EXPECT_TRUE(zeroToMax.isLoAligned());
+            EXPECT_EQ(zeroToMax.hi, zeroToMax.hiByte());
+            EXPECT_TRUE(zeroToMax.isHiAligned());
+
+            EXPECT_EQ(minToMax.lo, minToMax.loByte());
+            EXPECT_TRUE(minToMax.isLoAligned());
+            EXPECT_EQ(minToMax.hi, minToMax.hiByte());
+            EXPECT_TRUE(minToMax.isHiAligned());
+
+            break;
+    }
+
+    // Equality should be reflexive, even for large ranges.
+    EXPECT_EQ(RangeType(ZeroToMax()), zeroToMax);
+    EXPECT_EQ(RangeType(MinToMax()), minToMax);
+
+    // We should be able to accurately answer questions about whether a bit or a
+    // range of bits in included in a large range.
+    EXPECT_TRUE(zeroToMax.contains(0));
+    EXPECT_TRUE(zeroToMax.contains(1));
+    EXPECT_TRUE(zeroToMax.contains(1000));
+    EXPECT_TRUE(zeroToMax.contains(zeroToMax.hi - 1));
+    EXPECT_TRUE(zeroToMax.contains(RangeType(FromTo(0, 0))));
+    EXPECT_TRUE(zeroToMax.contains(RangeType(FromTo(0, 1000))));
+    EXPECT_TRUE(zeroToMax.contains(RangeType(ZeroToMax())));
+    EXPECT_FALSE(zeroToMax.contains(-1));
+    EXPECT_FALSE(zeroToMax.contains(-1000));
+    EXPECT_FALSE(zeroToMax.contains(minToMax.lo));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(FromTo(-1, 0))));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(StartLen(-1000, 1))));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(FromTo(-1000, -1))));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(FromTo(-1000, 1000))));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(FromTo(-1, zeroToMax.hi - 1))));
+    EXPECT_FALSE(zeroToMax.contains(RangeType(MinToMax())));
+
+    EXPECT_TRUE(minToMax.contains(0));
+    EXPECT_TRUE(minToMax.contains(1));
+    EXPECT_TRUE(minToMax.contains(1000));
+    EXPECT_TRUE(minToMax.contains(minToMax.hi - 1));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(0, 0))));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(0, 1000))));
+    EXPECT_TRUE(minToMax.contains(RangeType(ZeroToMax())));
+    EXPECT_TRUE(minToMax.contains(-1));
+    EXPECT_TRUE(minToMax.contains(-1000));
+    EXPECT_TRUE(minToMax.contains(minToMax.lo));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(-1, 0))));
+    EXPECT_TRUE(minToMax.contains(RangeType(StartLen(-1000, 1))));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(-1000, -1))));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(-1000, 1000))));
+    EXPECT_TRUE(minToMax.contains(RangeType(FromTo(-1, minToMax.hi - 1))));
+    EXPECT_TRUE(minToMax.contains(RangeType(MinToMax())));
+
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(FromTo(0, 0))));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(FromTo(0, 1))));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(FromTo(-1, 0))));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(FromTo(-1000, 1000))));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(0, zeroToMax.hi)));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(FromTo(minToMax.lo, 0))));
+    EXPECT_TRUE(zeroToMax.overlaps(RangeType(minToMax.lo, zeroToMax.hi)));
+    EXPECT_FALSE(zeroToMax.overlaps(RangeType(FromTo(-1, -1))));
+    EXPECT_FALSE(zeroToMax.overlaps(RangeType(FromTo(-1000, -1))));
+    EXPECT_FALSE(zeroToMax.overlaps(RangeType(FromTo(minToMax.lo, -1))));
+
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(0, 0))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(0, 1))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(-1, 0))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(-1000, 1000))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(0, zeroToMax.hi)));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(minToMax.lo, 0)));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(minToMax.lo, zeroToMax.hi)));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(-1, -1))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(-1000, -1))));
+    EXPECT_TRUE(minToMax.overlaps(RangeType(FromTo(minToMax.lo, -1))));
+
+    // We should be able to perform intersection or union operations.
+    // (Supporting union might seem surprising, since that could potentially
+    // increase the size of the range, but unioning two ranges that we can
+    // represent without overflow should never produce a range that we can't.)
+    auto checkIntersectionEquals = [](const RangeType expected, const HalfOpenRangeType actual) {
+        EXPECT_FALSE(actual.empty());
+        if (actual.empty()) return;
+        EXPECT_EQ(expected, *toClosedRange(actual));
+    };
+
+    checkIntersectionEquals(zeroToMax, zeroToMax.intersectWith(zeroToMax));
+    EXPECT_EQ(zeroToMax, zeroToMax.unionWith(zeroToMax));
+    checkIntersectionEquals(zeroToMax, zeroToMax.intersectWith(minToMax));
+    EXPECT_EQ(minToMax, zeroToMax.unionWith(minToMax));
+    checkIntersectionEquals(RangeType(FromTo(0, 1)),
+                            zeroToMax.intersectWith(RangeType(FromTo(0, 1))));
+    EXPECT_EQ(zeroToMax, zeroToMax.unionWith(RangeType(FromTo(0, 1))));
+    checkIntersectionEquals(RangeType(FromTo(0, 1000)),
+                            zeroToMax.intersectWith(RangeType(FromTo(-1000, 1000))));
+    EXPECT_EQ(RangeType(-1000, zeroToMax.hi), zeroToMax.unionWith(RangeType(FromTo(-1000, 1000))));
+    EXPECT_TRUE(zeroToMax.intersectWith(RangeType(minToMax.lo, -1)).empty());
+    EXPECT_EQ(minToMax, zeroToMax.unionWith(RangeType(minToMax.lo, -1)));
+    checkIntersectionEquals(RangeType(1000, zeroToMax.hi),
+                            zeroToMax.intersectWith(RangeType(1000, zeroToMax.hi)));
+    EXPECT_EQ(zeroToMax, zeroToMax.unionWith(RangeType(1000, zeroToMax.hi)));
+
+    checkIntersectionEquals(minToMax, minToMax.intersectWith(minToMax));
+    EXPECT_EQ(minToMax, minToMax.unionWith(minToMax));
+    checkIntersectionEquals(zeroToMax, minToMax.intersectWith(zeroToMax));
+    EXPECT_EQ(minToMax, minToMax.unionWith(zeroToMax));
+    checkIntersectionEquals(RangeType(FromTo(0, 1)),
+                            minToMax.intersectWith(RangeType(FromTo(0, 1))));
+    EXPECT_EQ(minToMax, minToMax.unionWith(RangeType(FromTo(0, 1))));
+    checkIntersectionEquals(RangeType(FromTo(-1000, 1000)),
+                            minToMax.intersectWith(RangeType(FromTo(-1000, 1000))));
+    EXPECT_EQ(minToMax, minToMax.unionWith(RangeType(FromTo(-1000, 1000))));
+    checkIntersectionEquals(RangeType(minToMax.lo, -1),
+                            minToMax.intersectWith(RangeType(minToMax.lo, -1)));
+    EXPECT_EQ(minToMax, minToMax.unionWith(RangeType(minToMax.lo, -1)));
+    checkIntersectionEquals(RangeType(1000, zeroToMax.hi),
+                            minToMax.intersectWith(RangeType(1000, zeroToMax.hi)));
+    EXPECT_EQ(minToMax, minToMax.unionWith(RangeType(1000, zeroToMax.hi)));
+
+    // We can't support bit order changes for large ranges in general, because
+    // they can overflow, but life is a little easier if we allow reasonable bit
+    // order changes for ZeroToMax.
+    // XXX(seth): Once we start validating ranges when we create them, this will
+    // feel a bit safer...
+    {
+        constexpr auto oppositeOrder =
+            RangeType::order == Endian::Network ? Endian::Little : Endian::Network;
+        const auto asOppositeOrder = zeroToMax.template toOrder<oppositeOrder>(32);
+
+        EXPECT_EQ(ssize_t(31) - zeroToMax.hi, ssize_t(asOppositeOrder.lo));
+        EXPECT_EQ(31, asOppositeOrder.hi);
+        EXPECT_EQ(zeroToMax, asOppositeOrder.template toOrder<RangeType::order>(32));
+    }
+
+    // We should be able to convert a large ClosedRange to a HalfOpenRange and
+    // back again.
+    EXPECT_EQ(HalfOpenRangeType(ZeroToMax()), toHalfOpenRange(zeroToMax));
+    EXPECT_TRUE(toClosedRange(toHalfOpenRange(zeroToMax)));
+    EXPECT_EQ(zeroToMax, *toClosedRange(toHalfOpenRange(zeroToMax)));
+}
+
+TYPED_TEST(BitRangeTest, Subtract) {
+    using RangeType = TypeParam;
+    using HalfOpenRangeType = HalfOpenRange<RangeType::unit, RangeType::order>;
+
+    auto empty = HalfOpenRangeType(StartLen(0, 0));
+    struct ExpectedSubtractionResults {
+        RangeType minuend;
+        RangeType subtrahend;
+        HalfOpenRangeType lower;
+        HalfOpenRangeType upper;
+    };
+    const std::vector<ExpectedSubtractionResults> testCases = {
+        // Subtracting from the middle of the range should result in two ranges.
+        {StartLen(0, 8), StartLen(2, 4), StartLen(0, 2), StartLen(6, 2)},
+        // Subtracting from either end should result in one empty, one non-empty range.
+        {StartLen(0, 8), StartLen(0, 4), empty, StartLen(4, 4)},
+        {StartLen(0, 8), StartLen(4, 4), StartLen(0, 4), empty},
+        // Subtracting non-overlapping ranges should result in one empty, one identity range.
+        {StartLen(0, 8), StartLen(8, 4), StartLen(0, 8), empty},
+        {StartLen(8, 8), StartLen(0, 4), empty, StartLen(8, 8)},
+        // Subtracting a larger set from a smaller set should result in empty ranges.
+        {StartLen(2, 4), StartLen(0, 9), empty, empty},
+        // Subtracting a range from itself should result in empty ranges.
+        {StartLen(0, 8), StartLen(0, 8), empty, empty}};
+
+    for (auto test : testCases) {
+        EXPECT_EQ(std::make_pair(test.lower, test.upper), test.minuend - test.subtrahend);
+    }
+}
+
+class IntegerMathUtilsTest : public BitrangeTestBase {};
+
+TEST_F(IntegerMathUtilsTest, DivideFloor) {
+    struct ExpectedDivisonResult {
+        int index;
+        int dividend;
+        int divisor;
+        int quotient;
+    };
+
+    const std::vector<ExpectedDivisonResult> divisionResults = {
+        {0, -17, 8, -3}, {1, -16, 8, -2}, {2, -15, 8, -2}, {3, -9, 8, -2},  {4, -8, 8, -1},
+        {5, -7, 8, -1},  {6, -1, 8, -1},  {7, 0, 8, 0},    {8, 4, 8, 0},    {9, 7, 8, 0},
+        {10, 8, 8, 1},   {11, 9, 8, 1},   {12, 15, 8, 1},  {13, 16, 8, 2},  {14, 17, 8, 2},
+        {15, -4, 3, -2}, {16, -3, 3, -1}, {17, -2, 3, -1}, {18, 0, 3, 0},   {19, 1, 3, 0},
+        {20, 3, 3, 1},   {21, 4, 3, 1},   {22, -2, 1, -2}, {23, -1, 1, -1}, {24, 0, 1, 0},
+        {25, 1, 1, 1},   {26, 2, 1, 2},
+    };
+
+    for (auto &result : divisionResults) {
+        SCOPED_TRACE(result.index);
+        EXPECT_EQ(result.quotient, divideFloor(result.dividend, result.divisor));
+    }
+}
+
+TEST_F(IntegerMathUtilsTest, Modulo) {
+    struct ExpectedModuloResult {
+        int index;
+        int dividend;
+        int divisor;
+        int remainder;
+    };
+
+    const std::vector<ExpectedModuloResult> moduloResults = {
+        {0, -17, 8, 1}, {1, -16, 8, 0}, {2, -15, 8, 7}, {3, -9, 8, 1},  {4, -8, 8, 0},
+        {5, -7, 8, 7},  {6, -1, 8, 1},  {7, 0, 8, 0},   {8, 4, 8, 4},   {9, 7, 8, 7},
+        {10, 8, 8, 0},  {11, 9, 8, 1},  {12, 15, 8, 7}, {13, 16, 8, 0}, {14, 17, 8, 1},
+        {15, -4, 3, 1}, {16, -3, 3, 0}, {17, -2, 3, 2}, {18, 0, 3, 0},  {19, 1, 3, 1},
+        {20, 3, 3, 0},  {21, 4, 3, 1},  {22, -2, 1, 0}, {23, -1, 1, 0}, {24, 0, 1, 0},
+        {25, 1, 1, 0},  {26, 2, 1, 0},
+    };
+
+    for (auto &result : moduloResults) {
+        SCOPED_TRACE(result.index);
+        EXPECT_EQ(result.remainder, modulo(result.dividend, result.divisor));
+    }
+}
+
+TEST_F(IntegerMathUtilsTest, ModuloFloor) {
+    struct ExpectedModuloFloorResult {
+        int index;
+        int dividend;
+        int divisor;
+        int remainder;
+    };
+
+    const std::vector<ExpectedModuloFloorResult> moduloFloorResults = {
+        {0, -17, 8, 7}, {1, -16, 8, 0}, {2, -15, 8, 1}, {3, -9, 8, 7},  {4, -8, 8, 0},
+        {5, -7, 8, 1},  {6, -1, 8, 7},  {7, 0, 8, 0},   {8, 4, 8, 4},   {9, 7, 8, 7},
+        {10, 8, 8, 0},  {11, 9, 8, 1},  {12, 15, 8, 7}, {13, 16, 8, 0}, {14, 17, 8, 1},
+        {15, -4, 3, 2}, {16, -3, 3, 0}, {17, -2, 3, 1}, {18, 0, 3, 0},  {19, 1, 3, 1},
+        {20, 3, 3, 0},  {21, 4, 3, 1},  {22, -2, 1, 0}, {23, -1, 1, 0}, {24, 0, 1, 0},
+        {25, 1, 1, 0},  {26, 2, 1, 0},
+    };
+
+    for (auto &result : moduloFloorResults) {
+        SCOPED_TRACE(result.index);
+        EXPECT_EQ(result.remainder, moduloFloor(result.dividend, result.divisor));
+    }
+}
+
+}  // namespace Test
+#endif  // (__GNUC__ > 4) || defined(__clang__)


### PR DESCRIPTION
New classes provide useful abstractions, such as le_bitrange/nw_bitrange.

Splitting out from #4489 at @fruffy's request.

@fruffy I've introduced a new helper struct `RangeJsonHelpers` that contains a pair std::function instances for the rangeToJSON/rangeFromJSON functions. The placeholder implementation of these functions call BUG with a message that the functionality is unimplemented. There's a function `ir/bitrange.h:registerRangeJsonHelpers()` that replaces the placeholders with functions that invoke the appropriate JSONGenerator/JSONLoader functions.

~~@ChrisDodd / @vlstill / @fruffy Do any of you have a better suggestion for how to handle JSON serialization/de-serialization. Here's the backstory/summary:~~
* ~~I'm porting the bitrange classes from Tofino to use le_bitrange in the midend def-use pass (#4489).~~
* ~~The open source compiler doesn't use le_bitrange and other HalfOpenRange/ClosedRange derivatives in the IR, so @fruffy suggested we put the code in lib/bitrange.h + cpp.~~
* ~~Tofino _does_ use these classes in backend IR, and so requires the ability to serialize/deserialize the objects.~~
* ~~lib builds before the IR generator runs, and so lib code can't invoke JSONGenerator/JSONLoader functions since their header files indirectly use ir-generated.h.~~
* ~~I've introduced a helper struct with function instances for serialization/deserialization. The default functions are placeholders that call BUG. I've added a `registerRangeJsonHelpers()` in ir that registers real functions that correctly invoke JSONGenerator/JSONLoader if serialization/deserialization is required.~~

Refactored to avoid this ugliness after @vlstil's [suggestion](https://github.com/p4lang/p4c/pull/4496#issuecomment-1976559045).