### PR TITLE
Add 4 digit uid to dump file names

### DIFF
--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -483,7 +483,9 @@ void ParserOptions::dumpPass(const char *manager, unsigned seq, const char *pass
             exit(1);
         }
         if (match) {
-            cstring suffix = cstring("-") + name;
+            char buf[16];
+            snprintf(buf, sizeof(buf), "-%04zu-", ++dump_uid);
+            cstring suffix = cstring(buf) + name;
             cstring filename = file;
             if (filename == "-") filename = "tmp.p4";
 

--- a/frontends/common/parser_options.h
+++ b/frontends/common/parser_options.h
@@ -43,6 +43,9 @@ class ParserOptions : public Util::Options {
     // annotation names that are to be ignored by the compiler
     std::set<cstring> disabledAnnotations;
 
+    // used to generate dump file names
+    mutable size_t dump_uid = 0;
+
  protected:
     // Function that is returned by getDebugHook.
     void dumpPass(const char *manager, unsigned seq, const char *pass, const IR::Node *node) const;


### PR DESCRIPTION
I noticed an issue with dumping passes that get called more than once, generally in a `PassRepeated` -- the filename generated is the same, so the dumps overwrite and you end up with only the last iteration of the pass.  This change adds a unique index number so you get mulitple files, and as a bonus, the files will be sorted in order in `ls`