### PR TITLE
help compiler folding for divideFloor/moduloFloor

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -48,6 +48,7 @@ cc_library(
         ":config_h",
         "@boost//:format",
         "@boost//:multiprecision",
+        "@com_google_absl//absl/numeric:bits",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -93,3 +93,4 @@ add_library(p4ctoolkit STATIC ${LIBP4CTOOLKIT_SRCS})
 
 # Disable libcall (realloc, malloc) optimizations which may cause infinite loops.
 set_target_properties(p4ctoolkit PROPERTIES COMPILE_FLAGS -fno-builtin)
+target_link_libraries(p4ctoolkit absl::bits)


### PR DESCRIPTION
Add additional test to assist compiler folding to perform these replacements when the divisor is a power-of-two compile-time constant:
 - divideFloor -> right-shift
 - moduloFloor -> bitwise and

This is in response to this [PR comment](https://github.com/p4lang/p4c/pull/4496#discussion_r1515132560) from @ChrisDodd:
> Does this get properly folded to a shift when divisor is a constant power of 2? Similarly, moduloFloor should get folded to an and

The proposed solution adds a test that helps the compiler with optimization for a power-of-two compile-time constant:
```
if (__builtin_constant_p(divisor) && isPowerOfTwo(divisor))
```

`__builtin_constant_p()` and `__builtin_clz` are not supported by all compilers and so are protected by #if guards for gcc/clang.

This [Compiler Explorer test](https://godbolt.org/z/EExYboa5b) shows the impact of the extra test on both clang 15.0.0 and gcc 12.3. (These versions match those available on my test system.) The code contains multiple divideFloor/moduloFloor functions:
* divisor = 4 without optimization
* divisor = 4 with optimization above
* divisor = 5 without optimization
* divisor = 5 with optimization above