### PR TITLE
Refactor Util::Enumerator

### DIFF
--- a/backends/p4tools/common/compiler/reachability.cpp
+++ b/backends/p4tools/common/compiler/reachability.cpp
@@ -216,15 +216,12 @@ bool P4ProgramDCGCreator::preorder(const IR::P4Program *program) {
         if (const auto *pathExpr = expr->template to<IR::PathExpression>()) {
             // Look up the path expression in the declaration map, and expect to find a
             // declaration instance.
-            std::function<bool(const IR::IDeclaration *)> filter =
-                [pathExpr](const IR::IDeclaration *d) {
-                    CHECK_NULL(d);
-                    const auto *decl = d->to<IR::Declaration_Instance>();
-                    if (decl == nullptr) {
-                        return false;
-                    }
+            auto filter = [pathExpr](const IR::IDeclaration *d) {
+                CHECK_NULL(d);
+                if (const auto *decl = d->to<IR::Declaration_Instance>())
                     return pathExpr->path->name == decl->name;
-                };
+                return false;
+            };
             // Convert the declaration instance into a constructor-call expression.
             const auto *decl =
                 program->getDeclarations()->where(filter)->single()->to<IR::Declaration_Instance>();

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/reachability.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/reachability.cpp
@@ -75,11 +75,10 @@ ReturnedInfo loadExampleForReachability(const char *curFile) {
 
 template <class T>
 auto getNodeByType(const IR::P4Program *program) {
-    auto filter = [](const IR::IDeclaration *d) {
+    return program->getDeclarations()->where([](const IR::IDeclaration *d) {
         CHECK_NULL(d);
         return d->is<T>();
-    };
-    return program->getDeclarations()->where(filter);
+    });
 }
 
 template <class Node>

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -63,8 +63,7 @@ std::vector<const IR::IDeclaration *> ResolutionContext::lookup(const IR::INames
 
     if (const auto *gen = current->to<IR::IGeneralNamespace>()) {
         // FIXME: implement range filtering without enumerator wrappers
-        auto *decls =
-            Util::Enumerator<const IR::IDeclaration *>::createEnumerator(getDeclsByName(gen, name));
+        auto *decls = Util::enumerate(getDeclsByName(gen, name));
         switch (type) {
             case P4::ResolutionType::Any:
                 break;
@@ -220,7 +219,7 @@ const IR::IDeclaration *ResolutionContext::resolveUnique(const IR::ID &name,
     // Check overloaded symbols.
     const IR::Vector<IR::Argument> *arguments;
     if (decls.size() > 1 && (arguments = methodArguments(name))) {
-        decls = Util::Enumerator<const IR::IDeclaration *>::createEnumerator(decls)
+        decls = Util::enumerate(decls)
                     ->where([arguments](const IR::IDeclaration *d) {
                         auto func = d->to<IR::IFunctional>();
                         if (func == nullptr) return true;

--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -25,17 +25,15 @@ ResolutionContext::ResolutionContext() { anyOrder = P4CContext::get().options().
 const std::vector<const IR::IDeclaration *> &ResolutionContext::memoizeDeclarations(
     const IR::INamespace *ns) const {
     std::vector<const IR::IDeclaration *> decls;
-    if (auto nest = ns->to<IR::INestedNamespace>()) {
+    if (const auto *nest = ns->to<IR::INestedNamespace>()) {
         for (const auto *nn : nest->getNestedNamespaces()) {
-            auto nnDecls = nn->getDeclarations();
-            // FIXME: should just insert()
-            for (const auto *decl : *nnDecls) decls.push_back(decl);
+            auto *nnDecls = nn->getDeclarations();
+            decls.insert(decls.end(), nnDecls->begin(), nnDecls->end());
         }
     }
 
     auto *nsDecls = ns->getDeclarations();
-    // FIXME: should just insert()
-    for (const auto *decl : *nsDecls) decls.push_back(decl);
+    decls.insert(decls.end(), nsDecls->begin(), nsDecls->end());
 
     return (namespaceDecls[ns] = std::move(decls));
 }

--- a/frontends/p4/parameterSubstitution.h
+++ b/frontends/p4/parameterSubstitution.h
@@ -75,7 +75,7 @@ class ParameterSubstitution : public IHasDbPrint {
 
     /// Returns parameters in the order they were added
     Util::Enumerator<const IR::Parameter *> *getParametersInArgumentOrder() const {
-        return Util::Enumerator<const IR::Parameter *>::createEnumerator(parameters);
+        return Util::enumerate(parameters);
     }
 
     /// Returns parameters in the order of the parameter list.

--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -223,7 +223,7 @@ void IR::P4Control::dbprint(std::ostream &out) const {
 }
 
 void IR::V1Program::dbprint(std::ostream &out) const {
-    for (auto &obj : Values(scope)) out << obj << Log::endl;
+    for (const auto &obj : Values(scope)) out << obj << Log::endl;
 }
 
 void IR::P4Program::dbprint(std::ostream &out) const {

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -103,8 +103,7 @@ class IndexedVector : public Vector<T> {
         return it->second->template to<U>();
     }
     Util::Enumerator<const IDeclaration *> *getDeclarations() const {
-        return Util::Enumerator<const IDeclaration *>::createEnumerator(
-            Values(declarations).begin(), Values(declarations).end());
+        return Util::enumerate(Values(declarations));
     }
     iterator erase(iterator i) {
         removeFromMap(*i);

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -82,7 +82,7 @@ Util::Enumerator<const IDeclaration *> *INestedNamespace::getDeclarations() cons
     for (const auto *nested : getNestedNamespaces()) {
         if (nested == nullptr) continue;
 
-        rv = (rv ? rv->concat(nested->getDeclarations()) : nested->getDeclarations());
+        rv = rv ? rv->concat(nested->getDeclarations()) : nested->getDeclarations();
     }
     return rv ? rv : new Util::EmptyEnumerator<const IDeclaration *>;
 }

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -79,13 +79,10 @@ Util::Enumerator<const IR::IDeclaration *> *IGeneralNamespace::getDeclsByName(cs
 
 Util::Enumerator<const IDeclaration *> *INestedNamespace::getDeclarations() const {
     Util::Enumerator<const IDeclaration *> *rv = nullptr;
-    for (auto nested : getNestedNamespaces()) {
-        if (nested) {
-            if (rv)
-                rv = rv->concat(nested->getDeclarations());
-            else
-                rv = nested->getDeclarations();
-        }
+    for (const auto *nested : getNestedNamespaces()) {
+        if (nested == nullptr) continue;
+
+        rv = (rv ? rv->concat(nested->getDeclarations()) : nested->getDeclarations());
     }
     return rv ? rv : new Util::EmptyEnumerator<const IDeclaration *>;
 }

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -71,11 +71,10 @@ const Type_Method *Type_Package::getConstructorMethodType() const {
 }
 
 Util::Enumerator<const IR::IDeclaration *> *IGeneralNamespace::getDeclsByName(cstring name) const {
-    std::function<bool(const IDeclaration *)> filter = [name](const IDeclaration *d) {
+    return getDeclarations()->where([name](const IDeclaration *d) {
         CHECK_NULL(d);
         return name == d->getName().name;
-    };
-    return getDeclarations()->where(filter);
+    });
 }
 
 Util::Enumerator<const IDeclaration *> *INestedNamespace::getDeclarations() const {

--- a/ir/namemap.h
+++ b/ir/namemap.h
@@ -150,8 +150,7 @@ class NameMap : public Node {
     static NameMap<T, MAP, COMP, ALLOC> *fromJSON(JSONLoader &json);
 
     Util::Enumerator<const T *> *valueEnumerator() const {
-        return Util::Enumerator<const T *>::createEnumerator(Values(symbols).begin(),
-                                                             Values(symbols).end());
+        return Util::enumerate(Values(symbols));
     }
     template <typename S>
     Util::Enumerator<const S *> *only() const {

--- a/ir/namemap.h
+++ b/ir/namemap.h
@@ -155,8 +155,8 @@ class NameMap : public Node {
     }
     template <typename S>
     Util::Enumerator<const S *> *only() const {
-        std::function<bool(const T *)> filter = [](const T *d) { return d->template is<S>(); };
-        return valueEnumerator()->where(filter)->template as<const S *>();
+        return valueEnumerator()->template as<const S *>()->where(
+            [](const T *d) { return d != nullptr; });
     }
 
     DECLARE_TYPEINFO(NameMap, Node);

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -204,8 +204,8 @@ class Vector : public VectorBase {
     }
     template <typename S>
     Util::Enumerator<const S *> *only() const {
-        std::function<bool(const T *)> filter = [](const T *d) { return d->template is<S>(); };
-        return getEnumerator()->where(filter)->template as<const S *>();
+        return getEnumerator()->template as<const S *>()->where(
+            [](const T *d) { return d != nullptr; });
     }
 
     DECLARE_TYPEINFO_WITH_DISCRIMINATOR(Vector<T>, NodeDiscriminator::VectorT, T, VectorBase);

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -199,9 +199,7 @@ class Vector : public VectorBase {
     virtual void parallel_visit_children(Visitor &v);
     virtual void parallel_visit_children(Visitor &v) const;
     void toJSON(JSONGenerator &json) const override;
-    Util::Enumerator<const T *> *getEnumerator() const {
-        return Util::Enumerator<const T *>::createEnumerator(vec);
-    }
+    Util::Enumerator<const T *> *getEnumerator() const { return Util::enumerate(vec); }
     template <typename S>
     Util::Enumerator<const S *> *only() const {
         return getEnumerator()->template as<const S *>()->where(

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -479,8 +479,7 @@ std::vector<T> Enumerator<T>::emptyVector;
 
 template <typename T>
 Enumerator<T> *Enumerator<T>::createEnumerator(const std::vector<T> &data) {
-    return new GenericEnumerator<typename std::vector<T>::const_iterator>(data.begin(), data.end(),
-                                                                          "vector");
+    return new GenericEnumerator(data.begin(), data.end(), "vector");
 }
 
 template <typename T>
@@ -490,20 +489,19 @@ Enumerator<T> *Enumerator<T>::emptyEnumerator() {
 
 template <typename T>
 Enumerator<T> *Enumerator<T>::createEnumerator(const std::list<T> &data) {
-    return new GenericEnumerator<typename std::list<T>::const_iterator>(data.begin(), data.end(),
-                                                                        "list");
+    return new GenericEnumerator(data.begin(), data.end(), "list");
 }
 
 template <typename T>
 template <typename Iter>
 Enumerator<typename Iter::value_type> *Enumerator<T>::createEnumerator(Iter begin, Iter end) {
-    return new GenericEnumerator<Iter>(begin, end, "iterator");
+    return new GenericEnumerator(begin, end, "iterator");
 }
 
 template <typename T>
 template <typename Iter>
 Enumerator<typename Iter::value_type> *Enumerator<T>::createEnumerator(iterator_range<Iter> range) {
-    return new GenericEnumerator<Iter>(range.begin(), range.end(), "range");
+    return new GenericEnumerator(range.begin(), range.end(), "range");
 }
 
 template <typename T>

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -42,7 +42,7 @@ class Enumerator;
 /// for (auto a : *e) ...
 // FIXME: It is not a proper iterator (see reference type above) and should be removed
 // in favor of more standard approach. Note that Enumerator<T>::getCurrent() always
-// returns element by value, so more or less suitable only copyable types that are cheap
+// returns element by value, so more or less suitable only for copyable types that are cheap
 // to copy.
 template <typename T>
 class EnumeratorHandle {

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -162,6 +162,7 @@ class IteratorEnumerator : public Enumerator<typename Iter::value_type> {
     cstring name;
     friend class Enumerator<typename Iter::value_type>;
 
+ public:
     IteratorEnumerator(Iter begin, Iter end, cstring name)
         : Enumerator<typename Iter::value_type>(),
           begin(begin),
@@ -169,7 +170,6 @@ class IteratorEnumerator : public Enumerator<typename Iter::value_type> {
           current(begin),
           name(name) {}
 
- public:
     cstring toString() const { return this->name + ":" + this->stateName(); }
 
     bool moveNext() {

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -256,11 +256,12 @@ class IteratorEnumerator : public Enumerator<typename Iter::value_type> {
 
 /////////////////////////////////////////////////////////////////////
 
-/// Always returns false
+/// Always empty iterator (equivalent to end())
 template <typename T>
 class EmptyEnumerator : public Enumerator<T> {
  public:
     [[nodiscard]] std::string toString() const { return "EmptyEnumerator"; }
+    /// Always returns false
     bool moveNext() { return false; }
     T getCurrent() const {
         throw std::logic_error("You cannot call 'getCurrent' on an EmptyEnumerator");

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -23,7 +23,6 @@ limitations under the License.
 #include <cstdint>
 #include <functional>
 #include <iterator>
-#include <list>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
@@ -107,13 +106,17 @@ class Enumerator {
     }
 
     ////////////////// factories
-    static Enumerator<T> *createEnumerator(const std::vector<T> &data);
-    static Enumerator<T> *createEnumerator(const std::list<T> &data);
+    template <typename Container>
+    [[deprecated(
+        "Use Util::enumerate() instead")]] static Enumerator<typename Container::value_type> *
+    createEnumerator(const Container &data);
     static Enumerator<T> *emptyEnumerator();  // empty data
     template <typename Iter>
-    static Enumerator<typename Iter::value_type> *createEnumerator(Iter begin, Iter end);
+    [[deprecated("Use Util::enumerate() instead")]] static Enumerator<typename Iter::value_type> *
+    createEnumerator(Iter begin, Iter end);
     template <typename Iter>
-    static Enumerator<typename Iter::value_type> *createEnumerator(iterator_range<Iter> range);
+    [[deprecated("Use Util::enumerate() instead")]] static Enumerator<typename Iter::value_type> *
+    createEnumerator(iterator_range<Iter> range);
     // concatenate all these collections into a single one
     static Enumerator<T> *concatAll(Enumerator<Enumerator<T> *> *inputs);
 
@@ -517,18 +520,14 @@ template <typename T>
 std::vector<T> Enumerator<T>::emptyVector;
 
 template <typename T>
-Enumerator<T> *Enumerator<T>::createEnumerator(const std::vector<T> &data) {
-    return new IteratorEnumerator(data.begin(), data.end(), "vector");
+template <typename Container>
+Enumerator<typename Container::value_type> *Enumerator<T>::createEnumerator(const Container &data) {
+    return new IteratorEnumerator(data.begin(), data.end(), typeid(Container).name());
 }
 
 template <typename T>
 Enumerator<T> *Enumerator<T>::emptyEnumerator() {
     return Enumerator<T>::createEnumerator(Enumerator<T>::emptyVector);
-}
-
-template <typename T>
-Enumerator<T> *Enumerator<T>::createEnumerator(const std::list<T> &data) {
-    return new IteratorEnumerator(data.begin(), data.end(), "list");
 }
 
 template <typename T>

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -620,8 +620,20 @@ bool EnumeratorHandle<T>::operator!=(const EnumeratorHandle<T> &other) const {
 }
 
 template <typename Iter>
-auto *enumerate(Iter begin, Iter end) {
-    return Enumerator<typename Iter::value_type>::createEnumerator(begin, end);
+Enumerator<typename Iter::value_type> *enumerate(Iter begin, Iter end) {
+    return new IteratorEnumerator(begin, end, "iterator");
+}
+
+template <typename Iter>
+Enumerator<typename Iter::value_type> *enumerate(iterator_range<Iter> range) {
+    return new IteratorEnumerator(range.begin(), range.end(), "range");
+}
+
+template <typename Container>
+Enumerator<typename Container::value_type> *enumerate(const Container &data) {
+    using std::begin;
+    using std::end;
+    return new IteratorEnumerator(begin(data), end(data), typeid(data).name());
 }
 
 }  // namespace Util

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include <cstdint>
 #include <functional>
+#include <iterator>
 #include <list>
 #include <stdexcept>
 #include <type_traits>
@@ -39,15 +40,25 @@ class Enumerator;
 // This class provides support for C++-style range for loops
 // Enumerator<T>* e;
 // for (auto a : *e) ...
+// FIXME: It is not a proper iterator (see reference type above) and should be removed
+// in favor of more standard approach. Note that Enumerator<T>::getCurrent() always
+// returns element by value, so more or less suitable only copyable types that are cheap
+// to copy.
 template <typename T>
 class EnumeratorHandle {
  private:
-    Enumerator<T> *enumerator;  // when nullptr it represents end()
+    Enumerator<T> *enumerator = nullptr;  // when nullptr it represents end()
     explicit EnumeratorHandle(Enumerator<T> *enumerator) : enumerator(enumerator) {}
     friend class Enumerator<T>;
 
  public:
-    T operator*() const;
+    using iterator_category = std::input_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using reference = T;
+    using pointer = void;
+
+    reference operator*() const;
     const EnumeratorHandle<T> &operator++();
     bool operator!=(const EnumeratorHandle<T> &other) const;
 };
@@ -66,7 +77,7 @@ class Enumerator {
 
  public:
     Enumerator();
-    virtual ~Enumerator() {}
+    virtual ~Enumerator() = default;
 
     /* move to next element in the collection;
        return false if the next element does not exist */

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -154,7 +154,7 @@ class Enumerator {
    C is the container type */
 
 template <typename Iter>
-class GenericEnumerator : public Enumerator<typename Iter::value_type> {
+class IteratorEnumerator : public Enumerator<typename Iter::value_type> {
  protected:
     Iter begin;
     Iter end;
@@ -162,7 +162,7 @@ class GenericEnumerator : public Enumerator<typename Iter::value_type> {
     cstring name;
     friend class Enumerator<typename Iter::value_type>;
 
-    GenericEnumerator(Iter begin, Iter end, cstring name)
+    IteratorEnumerator(Iter begin, Iter end, cstring name)
         : Enumerator<typename Iter::value_type>(),
           begin(begin),
           end(end),
@@ -518,7 +518,7 @@ std::vector<T> Enumerator<T>::emptyVector;
 
 template <typename T>
 Enumerator<T> *Enumerator<T>::createEnumerator(const std::vector<T> &data) {
-    return new GenericEnumerator(data.begin(), data.end(), "vector");
+    return new IteratorEnumerator(data.begin(), data.end(), "vector");
 }
 
 template <typename T>
@@ -528,19 +528,19 @@ Enumerator<T> *Enumerator<T>::emptyEnumerator() {
 
 template <typename T>
 Enumerator<T> *Enumerator<T>::createEnumerator(const std::list<T> &data) {
-    return new GenericEnumerator(data.begin(), data.end(), "list");
+    return new IteratorEnumerator(data.begin(), data.end(), "list");
 }
 
 template <typename T>
 template <typename Iter>
 Enumerator<typename Iter::value_type> *Enumerator<T>::createEnumerator(Iter begin, Iter end) {
-    return new GenericEnumerator(begin, end, "iterator");
+    return new IteratorEnumerator(begin, end, "iterator");
 }
 
 template <typename T>
 template <typename Iter>
 Enumerator<typename Iter::value_type> *Enumerator<T>::createEnumerator(iterator_range<Iter> range) {
-    return new GenericEnumerator(range.begin(), range.end(), "range");
+    return new IteratorEnumerator(range.begin(), range.end(), "range");
 }
 
 template <typename T>

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -447,8 +447,8 @@ class MapEnumerator final : public Enumerator<S> {
 };
 
 template <typename T, typename Mapper>
-MapEnumerator(Enumerator<T> *, Mapper)
-    -> MapEnumerator<T, typename std::invoke_result_t<Mapper, T>, Mapper>;
+MapEnumerator(Enumerator<T> *,
+              Mapper) -> MapEnumerator<T, typename std::invoke_result_t<Mapper, T>, Mapper>;
 
 /////////////////////////////////////////////////////////////////////
 

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -526,9 +526,6 @@ bool Enumerator<T>::any() {
 }
 
 template <typename T>
-std::vector<T> Enumerator<T>::emptyVector;
-
-template <typename T>
 template <typename Container>
 Enumerator<typename Container::value_type> *Enumerator<T>::createEnumerator(const Container &data) {
     return new IteratorEnumerator(data.begin(), data.end(), typeid(Container).name());
@@ -536,7 +533,7 @@ Enumerator<typename Container::value_type> *Enumerator<T>::createEnumerator(cons
 
 template <typename T>
 Enumerator<T> *Enumerator<T>::emptyEnumerator() {
-    return Enumerator<T>::createEnumerator(Enumerator<T>::emptyVector);
+    return new EmptyEnumerator<T>();
 }
 
 template <typename T>

--- a/lib/iterator_range.h
+++ b/lib/iterator_range.h
@@ -21,6 +21,7 @@ limitations under the License.
 namespace Util {
 namespace Detail {
 using std::begin;
+using std::end;
 
 template <typename Container>
 using IterOfContainer = decltype(begin(std::declval<Container &>()));

--- a/lib/map.h
+++ b/lib/map.h
@@ -148,8 +148,8 @@ class IterValues {
         using iterator_category = typename std::iterator_traits<PairIter>::iterator_category;
         using value_type = typename std::iterator_traits<PairIter>::value_type::second_type;
         using difference_type = typename std::iterator_traits<PairIter>::difference_type;
-        using pointer = value_type *;
-        using reference = value_type &;
+        using pointer = decltype(&it->second);
+        using reference = decltype(*&it->second);
 
         explicit iterator(PairIter i) : it(i) {}
         iterator &operator++() {
@@ -172,8 +172,8 @@ class IterValues {
         }
         bool operator==(const iterator &i) const { return it == i.it; }
         bool operator!=(const iterator &i) const { return it != i.it; }
-        auto operator*() const { return it->second; }
-        auto operator->() const { return &it->second; }
+        reference operator*() const { return it->second; }
+        pointer operator->() const { return &it->second; }
     } b, e;
 
  public:

--- a/lib/map.h
+++ b/lib/map.h
@@ -87,8 +87,8 @@ class IterKeys {
         using iterator_category = typename std::iterator_traits<PairIter>::iterator_category;
         using value_type = typename std::iterator_traits<PairIter>::value_type::first_type;
         using difference_type = typename std::iterator_traits<PairIter>::difference_type;
-        using pointer = value_type *;
-        using reference = value_type &;
+        using pointer = decltype(&it->first);
+        using reference = decltype(*&it->first);
 
         explicit iterator(PairIter i) : it(i) {}
         iterator &operator++() {
@@ -216,8 +216,8 @@ class MapForKey {
         using iterator_category = std::forward_iterator_tag;
         using value_type = typename M::value_type;
         using difference_type = typename std::iterator_traits<MapIt>::difference_type;
-        using pointer = value_type *;
-        using reference = value_type &;
+        using pointer = decltype(&it->second);
+        using reference = decltype(*&it->second);
 
         iterator(const MapForKey &s, MapIt i) : self(s), it(std::move(i)) {}
         iterator &operator++() {
@@ -231,8 +231,8 @@ class MapForKey {
         }
         bool operator==(const iterator &i) const { return it == i.it; }
         bool operator!=(const iterator &i) const { return it != i.it; }
-        auto operator*() const { return it->second; }
-        auto operator->() const { return &it->second; }
+        reference operator*() const { return it->second; }
+        pointer operator->() const { return &it->second; }
     };
 
  public:

--- a/lib/map.h
+++ b/lib/map.h
@@ -111,8 +111,8 @@ class IterKeys {
         }
         bool operator==(const iterator &i) const { return it == i.it; }
         bool operator!=(const iterator &i) const { return it != i.it; }
-        auto operator*() const { return it->first; }
-        auto operator->() const { return &it->first; }
+        reference operator*() const { return it->first; }
+        pointer operator->() const { return &it->first; }
     } b, e;
 
  public:

--- a/lib/map.h
+++ b/lib/map.h
@@ -80,15 +80,16 @@ typename Map::mapped_type *getref(Map *m, const Key &key) {
 /* iterate over the keys in a map */
 template <class PairIter>
 class IterKeys {
-    class iterator
-        : public std::iterator<typename std::iterator_traits<PairIter>::iterator_category,
-                               typename std::iterator_traits<PairIter>::value_type::first_type,
-                               typename std::iterator_traits<PairIter>::difference_type,
-                               typename std::iterator_traits<PairIter>::value_type::first_type *,
-                               typename std::iterator_traits<PairIter>::value_type::first_type &> {
+    class iterator {
         PairIter it;
 
      public:
+        using iterator_category = typename std::iterator_traits<PairIter>::iterator_category;
+        using value_type = typename std::iterator_traits<PairIter>::value_type::first_type;
+        using difference_type = typename std::iterator_traits<PairIter>::difference_type;
+        using pointer = value_type *;
+        using reference = value_type &;
+
         explicit iterator(PairIter i) : it(i) {}
         iterator &operator++() {
             ++it;
@@ -110,8 +111,8 @@ class IterKeys {
         }
         bool operator==(const iterator &i) const { return it == i.it; }
         bool operator!=(const iterator &i) const { return it != i.it; }
-        decltype(*&it->first) operator*() const { return it->first; }
-        decltype(&it->first) operator->() const { return &it->first; }
+        auto operator*() const { return it->first; }
+        auto operator->() const { return &it->first; }
     } b, e;
 
  public:
@@ -140,15 +141,16 @@ IterKeys<PairIter> Keys(std::pair<PairIter, PairIter> range) {
 /* iterate over the values in a map */
 template <class PairIter>
 class IterValues {
-    class iterator
-        : public std::iterator<typename std::iterator_traits<PairIter>::iterator_category,
-                               typename std::iterator_traits<PairIter>::value_type::second_type,
-                               typename std::iterator_traits<PairIter>::difference_type,
-                               typename std::iterator_traits<PairIter>::value_type::second_type *,
-                               typename std::iterator_traits<PairIter>::value_type::second_type &> {
+    class iterator {
         PairIter it;
 
      public:
+        using iterator_category = typename std::iterator_traits<PairIter>::iterator_category;
+        using value_type = typename std::iterator_traits<PairIter>::value_type::second_type;
+        using difference_type = typename std::iterator_traits<PairIter>::difference_type;
+        using pointer = value_type *;
+        using reference = value_type &;
+
         explicit iterator(PairIter i) : it(i) {}
         iterator &operator++() {
             ++it;
@@ -170,11 +172,13 @@ class IterValues {
         }
         bool operator==(const iterator &i) const { return it == i.it; }
         bool operator!=(const iterator &i) const { return it != i.it; }
-        decltype(*&it->second) operator*() const { return it->second; }
-        decltype(&it->second) operator->() const { return &it->second; }
+        auto operator*() const { return it->second; }
+        auto operator->() const { return &it->second; }
     } b, e;
 
  public:
+    using value_type = typename std::iterator_traits<PairIter>::value_type::second_type;
+
     template <class U>
     explicit IterValues(U &map) : b(map.begin()), e(map.end()) {}
     IterValues(PairIter b, PairIter e) : b(b), e(e) {}
@@ -202,12 +206,20 @@ template <class M>
 class MapForKey {
     M &map;
     typename M::key_type key;
-    class iterator : public std::iterator<std::forward_iterator_tag, typename M::value_type> {
+    class iterator {
+        using MapIt = decltype(map.begin);
+
         const MapForKey &self;
-        decltype(map.begin()) it;
+        MapIt it;
 
      public:
-        iterator(const MapForKey &s, decltype(map.begin()) i) : self(s), it(i) {}
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = typename M::value_type;
+        using difference_type = typename std::iterator_traits<MapIt>::difference_type;
+        using pointer = value_type *;
+        using reference = value_type &;
+
+        iterator(const MapForKey &s, MapIt i) : self(s), it(std::move(i)) {}
         iterator &operator++() {
             if (++it != self.map.end() && it->first != self.key) it = self.map.end();
             return *this;
@@ -219,8 +231,8 @@ class MapForKey {
         }
         bool operator==(const iterator &i) const { return it == i.it; }
         bool operator!=(const iterator &i) const { return it != i.it; }
-        decltype(*&it->second) operator*() const { return it->second; }
-        decltype(&it->second) operator->() const { return &it->second; }
+        auto operator*() const { return it->second; }
+        auto operator->() const { return &it->second; }
     };
 
  public:

--- a/midend/flattenInterfaceStructs.h
+++ b/midend/flattenInterfaceStructs.h
@@ -105,17 +105,13 @@ struct StructTypeReplacement : public IHasDbPrint {
                  const IR::Annotations *annotations, IR::IndexedVector<IR::StructField> *fields,
                  AnnotationSelectionPolicy *policy) {
         // Drop name annotations
-        IR::Annotations::Filter f = [](const IR::Annotation *a) {
-            return a->name != IR::Annotation::nameAnnotation;
-        };
-        annotations = annotations->where(f);
+        annotations = annotations->where(
+            [](const IR::Annotation *a) { return a->name != IR::Annotation::nameAnnotation; });
         if (auto st = type->to<T>()) {
-            std::function<bool(const IR::Annotation *)> selector =
-                [&policy](const IR::Annotation *annot) {
-                    if (!policy) return false;
-                    return policy->keep(annot);
-                };
-            auto sannotations = st->annotations->where(selector);
+            auto sannotations = st->annotations->where([policy](const IR::Annotation *annot) {
+                if (!policy) return false;
+                return policy->keep(annot);
+            });
             structFieldMap.emplace(prefix, st);
             for (auto f : st->fields) {
                 auto na = new IR::Annotations();

--- a/test/gtest/enumerator_test.cpp
+++ b/test/gtest/enumerator_test.cpp
@@ -40,7 +40,7 @@ class UtilEnumerator : public ::testing::Test {
 };
 
 TEST_F(UtilEnumerator, Simple) {
-    Enumerator<int> *enumerator = Util::Enumerator<int>::createEnumerator(vec);
+    Enumerator<int> *enumerator = Util::enumerate(vec);
 
     bool more = enumerator->moveNext();
     EXPECT_TRUE(more);
@@ -74,7 +74,7 @@ TEST_F(UtilEnumerator, Simple) {
 }
 
 TEST_F(UtilEnumerator, Range) {
-    Enumerator<int> *enumerator = Util::Enumerator<int>::createEnumerator(vec);
+    Enumerator<int> *enumerator = Util::enumerate(vec);
     int sum = 0;
     for (auto a : *enumerator) sum += a;
     EXPECT_EQ(6, sum);
@@ -82,7 +82,7 @@ TEST_F(UtilEnumerator, Range) {
 
 TEST_F(UtilEnumerator, Linq) {
     // where
-    Enumerator<int> *enumerator = Util::Enumerator<int>::createEnumerator(vec);
+    Enumerator<int> *enumerator = Util::enumerate(vec);
 
     auto isEven = [](int x) { return x % 2 == 0; };
     Enumerator<int> *even = enumerator->where(isEven);
@@ -135,16 +135,15 @@ TEST_F(UtilEnumerator, Linq) {
 
     {
         //// concat
-        Enumerator<int> *col1 = Util::Enumerator<int>::createEnumerator(vec);
-        Enumerator<int> *col2 = Util::Enumerator<int>::createEnumerator(vec);
-        Enumerator<int> *col3 = Util::Enumerator<int>::createEnumerator(vec);
+        Enumerator<int> *col1 = Util::enumerate(vec);
+        Enumerator<int> *col2 = Util::enumerate(vec);
+        Enumerator<int> *col3 = Util::enumerate(vec);
         std::vector<Enumerator<int> *> all;
         all.push_back(col1);
         all.push_back(col2);
         all.push_back(col3);
 
-        Enumerator<Enumerator<int> *> *allEnums =
-            Enumerator<Enumerator<int> *>::createEnumerator(all);
+        Enumerator<Enumerator<int> *> *allEnums = Util::enumerate(all);
         Enumerator<int> *concat = Enumerator<int>::concatAll(allEnums);
         uint64_t count = concat->count();
         EXPECT_EQ(9u, count);
@@ -153,8 +152,8 @@ TEST_F(UtilEnumerator, Linq) {
         count = concat->count();
         EXPECT_EQ(9u, count);
 
-        Enumerator<int> *cc1 = Util::Enumerator<int>::createEnumerator(vec);
-        Enumerator<int> *cc2 = Util::Enumerator<int>::createEnumerator(vec);
+        Enumerator<int> *cc1 = Util::enumerate(vec);
+        Enumerator<int> *cc2 = Util::enumerate(vec);
         cc1 = cc1->concat(cc2);
         count = cc1->count();
         EXPECT_EQ(6u, count);
@@ -165,7 +164,7 @@ TEST_F(UtilEnumerator, Linq) {
         std::vector<B *> bs;
         bs.push_back(new B(1));
         bs.push_back(new B(2));
-        Enumerator<B *> *benum = Enumerator<B *>::createEnumerator(bs);
+        Enumerator<B *> *benum = Util::enumerate(bs);
         Enumerator<A *> *aenum = benum->as<A *>();
         more = aenum->moveNext();
         EXPECT_TRUE(more);
@@ -184,7 +183,7 @@ TEST_F(UtilEnumerator, Linq) {
 
     // first & co.
     {
-        Enumerator<int> *vi = Util::Enumerator<int>::createEnumerator(vec);
+        Enumerator<int> *vi = Util::enumerate(vec);
         EXPECT_EQ(1, vi->next());
         EXPECT_EQ(2, vi->nextOrDefault());
         EXPECT_EQ(3, vi->nextOrDefault());
@@ -197,7 +196,7 @@ TEST_F(UtilEnumerator, Linq) {
     {
         std::vector<int> s;
         s.push_back(5);
-        Enumerator<int> *e = Util::Enumerator<int>::createEnumerator(s);
+        Enumerator<int> *e = Util::enumerate(s);
         EXPECT_EQ(5, e->single());
         EXPECT_THROW(e->single(), std::logic_error);
     }

--- a/test/gtest/enumerator_test.cpp
+++ b/test/gtest/enumerator_test.cpp
@@ -138,10 +138,7 @@ TEST_F(UtilEnumerator, Linq) {
         Enumerator<int> *col1 = Util::enumerate(vec);
         Enumerator<int> *col2 = Util::enumerate(vec);
         Enumerator<int> *col3 = Util::enumerate(vec);
-        std::vector<Enumerator<int> *> all;
-        all.push_back(col1);
-        all.push_back(col2);
-        all.push_back(col3);
+        std::vector<Enumerator<int> *> all{col1, col2, col3};
 
         Enumerator<Enumerator<int> *> *allEnums = Util::enumerate(all);
         Enumerator<int> *concat = Enumerator<int>::concatAll(allEnums);
@@ -152,11 +149,30 @@ TEST_F(UtilEnumerator, Linq) {
         count = concat->count();
         EXPECT_EQ(9u, count);
 
+        concat = Util::concat({col1, col2, col3});
+        concat->reset();
+        count = concat->count();
+        EXPECT_EQ(9u, count);
+
+        concat = Util::concat(col1, col2, col3);
+        concat->reset();
+        count = concat->count();
+        EXPECT_EQ(9u, count);
+
         Enumerator<int> *cc1 = Util::enumerate(vec);
         Enumerator<int> *cc2 = Util::enumerate(vec);
         cc1 = cc1->concat(cc2);
         count = cc1->count();
         EXPECT_EQ(6u, count);
+
+        // cc1 is a ConcatEnumerator. Therefore its ->concat returns the object
+        // itself
+        cc1->reset();
+        auto *cc3 = cc1->concat(col3);
+        EXPECT_EQ(cc1, cc3);
+        cc1->reset();
+        count = cc1->count();
+        EXPECT_EQ(9u, count);
     }
 
     {

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -528,11 +528,12 @@ bool IrClass::shouldSkip(cstring feature) const {
     // (except for validate)
     if (feature == "validate") return false;
 
-    bool provided =
-        Util::enumerate(elements)
-            ->where([](IrElement *e) { return e->is<IrMethod>(); })
-            ->where([feature](IrElement *e) { return e->to<IrMethod>()->name == feature; })
-            ->any();
+    bool provided = Util::enumerate(elements)
+                        ->where([feature](IrElement *e) {
+                            const auto *m = e->to<IrMethod>();
+                            return m && m->name == feature;
+                        })
+                        ->any();
     return provided;
 }
 

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -98,9 +98,8 @@ void exit_namespace(std::ostream &out, IrNamespace *ns) {
 ////////////////////////////////////////////////////////////////////////////////////
 
 Util::Enumerator<IrClass *> *IrDefinitions::getClasses() const {
-    return Util::Enumerator<IrElement *>::createEnumerator(elements)
-        ->map<IrClass *>([](IrElement *e) { return dynamic_cast<IrClass *>(e); })
-        ->where([](IrClass *e) { return e != nullptr; });
+    return Util::enumerate(elements)->as<IrClass *>()->where(
+        [](IrClass *e) { return e != nullptr; });
 }
 
 void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &impl) const {
@@ -508,23 +507,20 @@ int IrClass::generateConstructor(const ctor_args_t &arglist, const IrMethod *use
 }
 
 Util::Enumerator<IrField *> *IrClass::getFields() const {
-    return Util::Enumerator<IrElement *>::createEnumerator(elements)
-        ->where([](IrElement *e) { return e->is<IrField>(); })
-        ->map<IrField *>([](IrElement *e) -> IrField * { return e->to<IrField>(); })
-        ->where([](IrField *f) { return !f->isStatic; });
+    return Util::enumerate(elements)->as<IrField *>()->where(
+        [](IrField *f) { return f && !f->isStatic; });
 }
 
 Util::Enumerator<IrMethod *> *IrClass::getUserMethods() const {
-    return Util::Enumerator<IrElement *>::createEnumerator(elements)
-        ->where([](IrElement *e) { return e->is<IrMethod>(); })
-        ->map<IrMethod *>([](IrElement *e) -> IrMethod * { return e->to<IrMethod>(); });
+    return Util::enumerate(elements)->as<IrMethod *>()->where(
+        [](IrElement *e) { return e != nullptr; });
 }
 
 bool IrClass::shouldSkip(cstring feature) const {
     // skip if there is a 'no' directive
-    auto *e = Util::Enumerator<IrElement *>::createEnumerator(elements);
     bool explicitNo =
-        e->where([](IrElement *el) { return el->is<IrNo>(); })
+        Util::enumerate(elements)
+            ->where([](IrElement *el) { return el->is<IrNo>(); })
             ->where([feature](IrElement *el) { return el->to<IrNo>()->text == feature; })
             ->any();
     if (explicitNo) return true;
@@ -532,9 +528,9 @@ bool IrClass::shouldSkip(cstring feature) const {
     // (except for validate)
     if (feature == "validate") return false;
 
-    e = Util::Enumerator<IrElement *>::createEnumerator(elements);
     bool provided =
-        e->where([](IrElement *e) { return e->is<IrMethod>(); })
+        Util::enumerate(elements)
+            ->where([](IrElement *e) { return e->is<IrMethod>(); })
             ->where([feature](IrElement *e) { return e->to<IrMethod>()->name == feature; })
             ->any();
     return provided;

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include "irclass.h"
 #include "lib/algorithm.h"
+#include "lib/enumerator.h"
 
 enum flags {
     // flags that control the creation of auto-created methods
@@ -288,13 +289,13 @@ void IrClass::generateMethods() {
             if (def.second.flags & NOT_DEFAULT) continue;
             if (kind == NodeKind::Nested && !(def.second.flags & INCL_NESTED)) continue;
             if ((def.second.flags & CONCRETE_ONLY) && kind == NodeKind::Abstract) continue;
-            if (Util::Enumerator<IrElement *>::createEnumerator(elements)
+            if (Util::enumerate(elements)
                     ->where([](IrElement *el) { return el->is<IrNo>(); })
                     ->where([&def](IrElement *el) { return el->to<IrNo>()->text == def.first; })
                     ->any())
                 continue;
             IrMethod *exist = dynamic_cast<IrMethod *>(
-                Util::Enumerator<IrElement *>::createEnumerator(elements)
+                Util::enumerate(elements)
                     ->where([](IrElement *el) { return el->is<IrMethod>(); })
                     ->where([&def](IrElement *el) { return el->to<IrMethod>()->name == def.first; })
                     ->nextOrDefault());


### PR DESCRIPTION
 - Simplify interface
 - Introduce special-case for `ICastable` for `AsEnumerator`
 - Remove non-sense `std::function` type-erasure for `FilterEnumerator`, make it less memory hog
 - Make `ConcatEnumerator` sane, do not do tons of memory allocations each time `ConcatEnumerator` is created
 - Some convenient helpers (`enumerate` / `concat`)
 - Make `EnumeratorHandle` behave as `ForwardIterator`, so STL `insert`, etc. are working with `Enumerator`
 - Make sure `Values` and other things from `lib/map.h` could be used with `Enumerator`, improve here const-correctness & remove deprecated `std::iterator` usage in favor of iterator traits
 - Normalize doxygen comments and reorganize code inside `lib/enumerator.h`, make it `cstring`-less