### PR TITLE
Update formatters (clang-format, isort, black)

### DIFF
--- a/backends/bmv2/common/parser.cpp
+++ b/backends/bmv2/common/parser.cpp
@@ -413,9 +413,8 @@ unsigned ParserConverter::combine(const IR::Expression *keySet, const IR::ListEx
                 mask_value = Util::mask(width);
             }
             mask = Util::shift_left(mask, w) + mask_value;
-            LOG3("Shifting "
-                 << " into key " << key_value << " &&& " << mask_value << " result is " << value
-                 << " &&& " << mask);
+            LOG3("Shifting " << " into key " << key_value << " &&& " << mask_value << " result is "
+                             << value << " &&& " << mask);
             index++;
         }
 

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -665,8 +665,7 @@ void ExternConverter_Hash::convertExternInstance(ConversionContext *ctxt, const 
 void ExternConverter_Checksum::convertExternInstance(UNUSED ConversionContext *ctxt,
                                                      UNUSED const IR::Declaration *c,
                                                      UNUSED const IR::ExternBlock *eb,
-                                                     UNUSED const bool &emitExterns) { /* TODO */
-}
+                                                     UNUSED const bool &emitExterns) { /* TODO */ }
 
 void ExternConverter_InternetChecksum::convertExternInstance(UNUSED ConversionContext *ctxt,
                                                              UNUSED const IR::Declaration *c,
@@ -972,8 +971,7 @@ void ExternConverter_Register::convertExternInstance(UNUSED ConversionContext *c
 void ExternConverter_Random::convertExternInstance(UNUSED ConversionContext *ctxt,
                                                    UNUSED const IR::Declaration *c,
                                                    UNUSED const IR::ExternBlock *eb,
-                                                   UNUSED const bool &emitExterns) { /* TODO */
-}
+                                                   UNUSED const bool &emitExterns) { /* TODO */ }
 
 void ExternConverter_ActionProfile::convertExternInstance(UNUSED ConversionContext *ctxt,
                                                           UNUSED const IR::Declaration *c,
@@ -1056,7 +1054,6 @@ void ExternConverter_ActionSelector::convertExternInstance(UNUSED ConversionCont
 void ExternConverter_Digest::convertExternInstance(UNUSED ConversionContext *ctxt,
                                                    UNUSED const IR::Declaration *c,
                                                    UNUSED const IR::ExternBlock *eb,
-                                                   UNUSED const bool &emitExterns) { /* TODO */
-}
+                                                   UNUSED const bool &emitExterns) { /* TODO */ }
 
 }  // namespace BMV2

--- a/backends/dpdk/spec.cpp
+++ b/backends/dpdk/spec.cpp
@@ -540,21 +540,17 @@ std::ostream &IR::DpdkAction::toSpec(std::ostream &out) const {
 }
 
 std::ostream &IR::DpdkChecksumAddStatement::toSpec(std::ostream &out) const {
-    out << "ckadd "
-        << "h.cksum_state." << intermediate_value << " " << DPDK::toStr(field);
+    out << "ckadd " << "h.cksum_state." << intermediate_value << " " << DPDK::toStr(field);
     return out;
 }
 
 std::ostream &IR::DpdkChecksumSubStatement::toSpec(std::ostream &out) const {
-    out << "cksub "
-        << "h.cksum_state." << intermediate_value << " " << DPDK::toStr(field);
+    out << "cksub " << "h.cksum_state." << intermediate_value << " " << DPDK::toStr(field);
     return out;
 }
 
 std::ostream &IR::DpdkChecksumClearStatement::toSpec(std::ostream &out) const {
-    out << "mov "
-        << "h.cksum_state." << intermediate_value << " "
-        << "0x0";
+    out << "mov " << "h.cksum_state." << intermediate_value << " " << "0x0";
     return out;
 }
 
@@ -581,8 +577,7 @@ std::ostream &IR::DpdkGetHashStatement::toSpec(std::ostream &out) const {
 }
 
 std::ostream &IR::DpdkGetChecksumStatement::toSpec(std::ostream &out) const {
-    out << "mov " << DPDK::toStr(dst) << " "
-        << "h.cksum_state." << intermediate_value;
+    out << "mov " << DPDK::toStr(dst) << " " << "h.cksum_state." << intermediate_value;
     return out;
 }
 

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -224,10 +224,10 @@ class XdpTarget : public KernelSamplesTarget {
 class BccTarget : public Target {
  public:
     BccTarget() : Target("BCC") {}
-    void emitLicense(Util::SourceCodeBuilder *, cstring) const override{};
+    void emitLicense(Util::SourceCodeBuilder *, cstring) const override {};
     void emitCodeSection(Util::SourceCodeBuilder *, cstring) const override {}
     void emitIncludes(Util::SourceCodeBuilder *builder) const override;
-    void emitResizeBuffer(Util::SourceCodeBuilder *, cstring, cstring) const override{};
+    void emitResizeBuffer(Util::SourceCodeBuilder *, cstring, cstring) const override {};
     void emitTableLookup(Util::SourceCodeBuilder *builder, cstring tblName, cstring key,
                          cstring value) const override;
     void emitTableUpdate(Util::SourceCodeBuilder *builder, cstring tblName, cstring key,
@@ -256,7 +256,7 @@ class TestTarget : public EBPF::KernelSamplesTarget {
  public:
     TestTarget() : KernelSamplesTarget(false, "Userspace Test") {}
 
-    void emitResizeBuffer(Util::SourceCodeBuilder *, cstring, cstring) const override{};
+    void emitResizeBuffer(Util::SourceCodeBuilder *, cstring, cstring) const override {};
     void emitIncludes(Util::SourceCodeBuilder *builder) const override;
     void emitTableDecl(Util::SourceCodeBuilder *builder, cstring tblName, TableKind tableKind,
                        cstring keyType, cstring valueType, unsigned size) const override;

--- a/backends/p4tools/common/version.cpp
+++ b/backends/p4tools/common/version.cpp
@@ -4,7 +4,6 @@
 
 void printVersion(const char *binaryName) {
     std::cout << binaryName << std::endl
-              << "Version"
-              << " " << P4TOOLS_VERSION_MAJOR << "." << P4TOOLS_VERSION_MINOR << "."
+              << "Version" << " " << P4TOOLS_VERSION_MAJOR << "." << P4TOOLS_VERSION_MINOR << "."
               << P4TOOLS_VERSION_PATCH << P4TOOLS_VERSION_HASH << std::endl;
 }

--- a/backends/p4tools/modules/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/execution_state.cpp
@@ -220,8 +220,8 @@ const std::vector<std::reference_wrapper<const TraceEvent>> &ExecutionState::get
 
 const Continuation::Body &ExecutionState::getBody() const { return body; }
 
-const std::stack<std::reference_wrapper<const ExecutionState::StackFrame>>
-    &ExecutionState::getStack() const {
+const std::stack<std::reference_wrapper<const ExecutionState::StackFrame>> &
+ExecutionState::getStack() const {
     return stack;
 }
 

--- a/backends/p4tools/modules/testgen/main.cpp
+++ b/backends/p4tools/modules/testgen/main.cpp
@@ -34,8 +34,7 @@ int main(int argc, char **argv) {
         result = P4Tools::P4Testgen::Testgen().main(args);
     } catch (const Util::CompilerBug &e) {
         std::cerr << "Internal error: " << updateErrorMsg(e.what()) << "\n";
-        std::cerr << "Please submit a bug report with your code."
-                  << "\n";
+        std::cerr << "Please submit a bug report with your code." << "\n";
         result = EXIT_FAILURE;
     } catch (const Util::CompilerUnimplemented &e) {
         std::cerr << updateErrorMsg(e.what()) << "\n";
@@ -45,12 +44,10 @@ int main(int argc, char **argv) {
         result = EXIT_FAILURE;
     } catch (const std::exception &e) {
         std::cerr << "Internal error: " << updateErrorMsg(e.what()) << "\n";
-        std::cerr << "Please submit a bug report with your code."
-                  << "\n";
+        std::cerr << "Please submit a bug report with your code." << "\n";
         result = EXIT_FAILURE;
     } catch (...) {
-        std::cerr << "Internal error. Please submit a bug report with your code."
-                  << "\n";
+        std::cerr << "Internal error. Please submit a bug report with your code." << "\n";
         result = EXIT_FAILURE;
     }
     P4Tools::printPerformanceReport();

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -96,8 +96,8 @@ const IR::P4Table *Bmv2V1ModelProgramInfo::getTableofDirectExtern(
 
 const ArchSpec &Bmv2V1ModelProgramInfo::getArchSpec() const { return ARCH_SPEC; }
 
-const ordered_map<cstring, const IR::Type_Declaration *>
-    *Bmv2V1ModelProgramInfo::getProgrammableBlocks() const {
+const ordered_map<cstring, const IR::Type_Declaration *> *
+Bmv2V1ModelProgramInfo::getProgrammableBlocks() const {
     return &programmableBlocks;
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_spec.cpp
@@ -130,8 +130,8 @@ bool Bmv2V1ModelMeterValue::isDirectMeter() const { return isDirect; }
  *  Bmv2V1ModelActionProfile
  * ========================================================================================= */
 
-const std::vector<std::pair<cstring, std::vector<ActionArg>>>
-    *Bmv2V1ModelActionProfile::getActions() const {
+const std::vector<std::pair<cstring, std::vector<ActionArg>>> *
+Bmv2V1ModelActionProfile::getActions() const {
     return &actions;
 }
 

--- a/backends/p4tools/modules/testgen/targets/pna/shared_program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_program_info.cpp
@@ -27,8 +27,8 @@ SharedPnaProgramInfo::SharedPnaProgramInfo(
     concolicMethodImpls.add(*PnaDpdkConcolic::getPnaDpdkConcolicMethodImpls());
 }
 
-const ordered_map<cstring, const IR::Type_Declaration *>
-    *SharedPnaProgramInfo::getProgrammableBlocks() const {
+const ordered_map<cstring, const IR::Type_Declaration *> *
+SharedPnaProgramInfo::getProgrammableBlocks() const {
     return &programmableBlocks;
 }
 

--- a/backends/ubpf/target.h
+++ b/backends/ubpf/target.h
@@ -29,8 +29,8 @@ class UbpfTarget : public EBPF::Target {
  public:
     UbpfTarget() : EBPF::Target("UBPF") {}
 
-    void emitLicense(Util::SourceCodeBuilder *, cstring) const override{};
-    void emitCodeSection(Util::SourceCodeBuilder *, cstring) const override{};
+    void emitLicense(Util::SourceCodeBuilder *, cstring) const override {};
+    void emitCodeSection(Util::SourceCodeBuilder *, cstring) const override {};
     void emitIncludes(Util::SourceCodeBuilder *builder) const override;
     void emitResizeBuffer(Util::SourceCodeBuilder *builder, cstring buffer,
                           cstring offsetVar) const override;
@@ -42,11 +42,11 @@ class UbpfTarget : public EBPF::Target {
     void emitGetFromStandardMetadata(Util::SourceCodeBuilder *builder, cstring stdMetadataVar,
                                      cstring metadataField) const;
     void emitUserTableUpdate(UNUSED Util::SourceCodeBuilder *builder, UNUSED cstring tblName,
-                             UNUSED cstring key, UNUSED cstring value) const override{};
+                             UNUSED cstring key, UNUSED cstring value) const override {};
     void emitTableDecl(Util::SourceCodeBuilder *builder, cstring tblName, EBPF::TableKind tableKind,
                        cstring keyType, cstring valueType, unsigned size) const override;
     void emitMain(UNUSED Util::SourceCodeBuilder *builder, UNUSED cstring functionName,
-                  UNUSED cstring argName) const override{};
+                  UNUSED cstring argName) const override {};
     void emitMain(Util::SourceCodeBuilder *builder, cstring functionName, cstring argName,
                   cstring standardMetadata) const;
     void emitUbpfHelpers(EBPF::CodeBuilder *builder) const;

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -308,8 +308,7 @@ const IR::Node *DoConstantFolding::postorder(IR::Add *e) {
 }
 
 const IR::Node *DoConstantFolding::postorder(IR::AddSat *e) {
-    return binary(
-        e, [](big_int a, big_int b) -> big_int { return a + b; }, true);
+    return binary(e, [](big_int a, big_int b) -> big_int { return a + b; }, true);
 }
 
 const IR::Node *DoConstantFolding::postorder(IR::Sub *e) {
@@ -317,8 +316,7 @@ const IR::Node *DoConstantFolding::postorder(IR::Sub *e) {
 }
 
 const IR::Node *DoConstantFolding::postorder(IR::SubSat *e) {
-    return binary(
-        e, [](big_int a, big_int b) -> big_int { return a - b; }, true);
+    return binary(e, [](big_int a, big_int b) -> big_int { return a - b; }, true);
 }
 
 const IR::Node *DoConstantFolding::postorder(IR::Mul *e) {

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -845,8 +845,8 @@ std::ostream &operator<<(std::ostream &out, const ControlFlowVisitor::flow_join_
     out << Brief;
     for (auto &i : info.parents) {
         out << Log::endl
-            << "  " << *i.first << " [" << i.first->id << "] "
-            << "exist=" << i.second.exist << " visited=" << i.second.visited;
+            << "  " << *i.first << " [" << i.first->id << "] " << "exist=" << i.second.exist
+            << " visited=" << i.second.visited;
     }
     dbsetflags(out, flags);
 #endif

--- a/lib/algorithm.h
+++ b/lib/algorithm.h
@@ -21,7 +21,7 @@ limitations under the License.
 #include <set>
 
 // Round up x/y, for integers
-#define ROUNDUP(x, y) (((x) + (y)-1) / (y))
+#define ROUNDUP(x, y) (((x) + (y) - 1) / (y))
 // Elements in an array
 #define ELEMENTS(a) (sizeof(a) / sizeof(a[0]))
 

--- a/lib/hashvec.cpp
+++ b/lib/hashvec.cpp
@@ -314,11 +314,12 @@ void hash_vector_base::redo_hash() {
         if (erased[i]) continue;
         const void *k = getkey(i);
         if (find(k, &cache)) {
-            if (info->ismulti)
-                while (find_next(k, &cache))
-                    ;
-            else
+            if (info->ismulti) {
+                while (find_next(k, &cache)) {
+                }
+            } else {
                 BUG("dupliacte keys in hash_vector_base::redo_hash");
+            }
         }
         if (j != i) {
             moveentry(j, i);
@@ -336,16 +337,16 @@ size_t hash_vector_base::hv_insert(const void *key, lookup_cache *cache) {
     if (cache) {
 #ifndef NDEBUG
         if (find(key, &local) && info->ismulti)
-            while (find_next(key, &local))
-                ;
+            while (find_next(key, &local)) {
+            }
         BUG_CHECK(local.slot == cache->slot && local.collisions == cache->collisions,
                   "invalid cache in hash_vector_base::hv_insert");
 #endif
     } else {
         cache = &local;
         if (find(key, cache) && info->ismulti)
-            while (find_next(key, cache))
-                ;
+            while (find_next(key, cache)) {
+            }
     }
     if ((collisions += cache->collisions) > hashsize / 2) {
         /* Too many collisions -- redo hash table */
@@ -372,8 +373,8 @@ size_t hash_vector_base::hv_insert(const void *key, lookup_cache *cache) {
         }
         redo_hash();
         if (find(key, cache) && info->ismulti)
-            while (find_next(key, cache))
-                ;
+            while (find_next(key, cache)) {
+            }
     }
     if ((idx = info->gethash(this, cache->slot)) == 0) {
         bool need_redo = false;
@@ -395,8 +396,8 @@ size_t hash_vector_base::hv_insert(const void *key, lookup_cache *cache) {
             allochash();
             redo_hash();
             if (find(key, cache) && info->ismulti)
-                while (find_next(key, cache))
-                    ;
+                while (find_next(key, cache)) {
+                }
         }
         info->sethash(this, cache->slot, limit() + 1);
         inuse++;
@@ -413,8 +414,8 @@ size_t hash_vector_base::remove(const void *key, lookup_cache *cache) {
     if (cache) {
 #ifndef NDEBUG
         if (find(key, &local) && info->ismulti)
-            while (local.slot != cache->slot && find_next(key, cache))
-                ;
+            while (local.slot != cache->slot && find_next(key, cache)) {
+            }
         BUG_CHECK(local.slot == cache->slot && local.collisions == cache->collisions,
                   "invalid cache in hash_vector_base::remove");
 #endif

--- a/lib/json.cpp
+++ b/lib/json.cpp
@@ -149,8 +149,7 @@ void JsonObject::serialize(std::ostream &out) const {
         if (!first) out << ",";
         first = false;
         out << IndentCtl::endl;
-        out << "\"" << it.first << "\""
-            << " : ";
+        out << "\"" << it.first << "\"" << " : ";
         if (it.second == nullptr)
             out << "null";
         else

--- a/midend/convertEnums.cpp
+++ b/midend/convertEnums.cpp
@@ -9,8 +9,7 @@ const IR::Node *DoConvertEnums::preorder(IR::Type_Enum *type) {
     if (!convert) return type;
     unsigned long long count = type->members.size();
     unsigned long long width = policy->enumSize(count);
-    LOG2("Converting enum " << type->name << " to "
-                            << "bit<" << width << ">");
+    LOG2("Converting enum " << type->name << " to " << "bit<" << width << ">");
     BUG_CHECK(count <= (1ULL << width), "%1%: not enough bits to represent %2%", width, type);
     auto r = new EnumRepresentation(type->srcInfo, width);
     auto canontype = typeMap->getTypeType(getOriginal(), true);

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ pyroute2==0.7.3
 ply==3.11
 ptf==0.9.4
 scapy==2.5.0
-clang-format==15.0.6
-black==22.3.0
-isort==5.10.0
+clang-format==18.1.0
+black==24.2.0
+isort==5.13.2
 protobuf==3.20.2; python_version > '3.6'
 grpcio==1.59.3; python_version > '3.6'
 googleapis-common-protos==1.53.0; python_version > '3.6'

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -113,8 +113,8 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
                       buf << f->name << ".equiv(a." << f->name << ")";
                   } else {
                       buf << "(" << f->name << " ? a." << f->name << " ? " << f->name
-                          << "->equiv(*a." << f->name << ")"
-                          << " : false : a." << f->name << " == nullptr)";
+                          << "->equiv(*a." << f->name << ")" << " : false : a." << f->name
+                          << " == nullptr)";
                   }
               }
               if (first) {  // no fields?
@@ -241,8 +241,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
               if (!f->isInline && f->nullOK)
                   buf << cl->indent << "if (" << f->name << " != nullptr) ";
               buf << cl->indent << "json << \",\" << std::endl << json.indent << \"\\\"" << f->name
-                  << "\\\" : \" << "
-                  << "this->" << f->name << ";" << std::endl;
+                  << "\\\" : \" << " << "this->" << f->name << ";" << std::endl;
           }
           buf << "}";
           return buf.str();


### PR DESCRIPTION
It's been a while since we have last updated the formatters. clang-format in particular has implemented a variety of changes. 