### PR TITLE
[docs] Sync Directory structure of P4tools 

### DIFF
--- a/backends/dpdk/README.md
+++ b/backends/dpdk/README.md
@@ -19,7 +19,7 @@ generates the 'spec' file to configure the DPDK pipeline.
 
 ## How to use it?
 
-A sample P4 program can be found in the `examples` directory.  To
+A sample P4 program can be found in the `examples` [directory](./examples).  To
 generate the 'spec' file:
 ```bash
 p4c-dpdk --arch psa vxlan.p4 -o vxlan.spec

--- a/backends/dpdk/README.md
+++ b/backends/dpdk/README.md
@@ -19,7 +19,7 @@ generates the 'spec' file to configure the DPDK pipeline.
 
 ## How to use it?
 
-A sample P4 program can be found in the `examples` [directory](./examples).  To
+A sample P4 program can be found in the `examples` directory.  To
 generate the 'spec' file:
 ```bash
 p4c-dpdk --arch psa vxlan.p4 -o vxlan.spec

--- a/backends/p4tools/README.md
+++ b/backends/p4tools/README.md
@@ -4,14 +4,14 @@
 
 ```
 p4tools
- ├─ cmake            ── Common CMake modules
- ├─ common           ── C++ source: common code for the various components P4Tools.
- │  └─ compiler      ── 
- │  └─ control_plane ── 
- │  └─ core          ── core functionality of the submodule.
- │  └─ lib           ── supporting data structures for P4Tools modules.  
+ ├─ cmake            ── common P4Tools CMake modules.
+ ├─ common           ── common code for the various P4Tools modules.
+ │  └─ compiler      ── transformation passes for P4 code.
+ │  └─ control_plane ── code concerning P4Tool's control plane semantics.
+ │  └─ core          ── definitions for core parts of the P4Tools modules.
+ │  └─ lib           ── helper functions and utilities for P4Tools modules.  
  └─  modules         ── P4Tools extensions.
-    └─ testgen       ── C++ source: P4Testgen.
+    └─ testgen       ── P4Testgen: a test-case generator for P4 programs.
 
 ```
 

--- a/backends/p4tools/README.md
+++ b/backends/p4tools/README.md
@@ -4,12 +4,15 @@
 
 ```
 p4tools
- ├─ benchmarks  ── General purpose measurements and plot generation scripts.
- ├─ cmake       ── Common CMake modules
- ├─ common      ── C++ source: common code for the various components P4Tools.
- ├─ modules     ── P4Tools extensions.
- │  └─ testgen  ── C++ source: P4Testgen.
- └─ submodules  ── External dependencies.
+ ├─ cmake            ── Common CMake modules
+ ├─ common           ── C++ source: common code for the various components P4Tools.
+ │  └─ compiler      ── 
+ │  └─ control_plane ── 
+ │  └─ core          ── core functionality of the submodule.
+ │  └─ lib           ── supporting data structures for P4Tools modules.  
+ └─  modules         ── P4Tools extensions.
+    └─ testgen       ── C++ source: P4Testgen.
+
 ```
 
 ## P4Tools


### PR DESCRIPTION
- Needs Help for description of `compiler` and `control_plane`
- [x] Sync Directory structure of P4tools 

PS -
Reverted   `Added directory link for examples directory in DPDK backend's Guide` to maintain focus on P4tools and keep the commit history clear.