### PR TITLE
Clean up P4Tools and control-plane linking.

### DIFF
--- a/backends/p4tools/cmake/common.cmake
+++ b/backends/p4tools/cmake/common.cmake
@@ -13,23 +13,8 @@ find_package(LibGc 7.2.0 REQUIRED)
 # Helper for defining a p4tools executable target.
 function(add_p4tools_executable target source)
   add_executable(${target} ${source} ${ARGN})
-  target_include_directories(
-    ${target}
-    PUBLIC "${CMAKE_SOURCE_DIR}"
-    PUBLIC "${CMAKE_BINARY_DIR}"
-  )
   install(TARGETS ${target} RUNTIME DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})
 endfunction(add_p4tools_executable)
-
-# Helper for defining a p4tools library target.
-function(add_p4tools_library target)
-  add_library(${target} ${ARGN})
-  target_include_directories(
-    ${target}
-    PUBLIC "${CMAKE_SOURCE_DIR}"
-    PUBLIC "${CMAKE_BINARY_DIR}"
-  )
-endfunction(add_p4tools_library)
 
 macro(p4tools_obtain_z3)
   option(TOOLS_USE_PREINSTALLED_Z3 "Look for a preinstalled version of Z3 instead of installing a prebuilt binary using FetchContent." OFF)

--- a/backends/p4tools/common/CMakeLists.txt
+++ b/backends/p4tools/common/CMakeLists.txt
@@ -36,23 +36,20 @@ set(
   lib/variables.cpp
 )
 
-add_p4tools_library(p4tools-common ${P4C_TOOLS_COMMON_SOURCES})
+add_library(p4tools-common OBJECT ${P4C_TOOLS_COMMON_SOURCES})
 
 target_link_libraries(
   p4tools-common
+  # We export Z3' with the common library.
   PUBLIC ${P4TOOLS_Z3_LIB}
+    # For Abseil includes.
   PRIVATE frontend
 )
 
 target_include_directories(
   p4tools-common
+  # We export Z3's includes with the common library.
   SYSTEM BEFORE PUBLIC ${P4TOOLS_Z3_INCLUDE_DIR}
-)
-target_include_directories(
-  p4tools-common
-  PUBLIC "${CMAKE_BINARY_DIR}/common"
-  PUBLIC "${P4C_SOURCE_DIR}"
-  PUBLIC "${P4C_BINARY_DIR}"
 )
 
 # Add control-plane-specific extensions.

--- a/backends/p4tools/common/control_plane/CMakeLists.txt
+++ b/backends/p4tools/common/control_plane/CMakeLists.txt
@@ -4,5 +4,5 @@ set(
   symbolic_variables.cpp
 )
 
-add_p4tools_library(p4tools-control-plane ${P4C_TOOLS_CONTROL_PLANE_SOURCES})
+add_library(p4tools-control-plane STATIC ${P4C_TOOLS_CONTROL_PLANE_SOURCES})
 target_link_libraries(p4tools-control-plane PRIVATE controlplane)

--- a/backends/p4tools/modules/testgen/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/CMakeLists.txt
@@ -73,6 +73,7 @@ set(
   TESTGEN_LIBS
   PRIVATE p4tools-common
   PRIVATE p4tools-control-plane
+  # Make sure the testgen library and anything that links to it see both the Inja includes.
   PUBLIC inja
 )
 set(TESTGEN_INCLUDES)
@@ -104,9 +105,14 @@ set(IR_DEF_FILES ${IR_DEF_FILES} PARENT_SCOPE)
 configure_file(register.h.in register.h)
 
 # The library.
-add_p4tools_library(testgen ${TESTGEN_SOURCES})
-# Make sure the testgen library and anything that links to it see both the Z3 and Inja includes.
-target_link_libraries(testgen ${TESTGEN_LIBS})
+add_library(testgen STATIC ${TESTGEN_SOURCES})
+target_link_libraries(testgen
+  ${TESTGEN_LIBS}
+  # For Abseil includes.
+  PRIVATE frontend
+  # For Protobuf includes.
+  PRIVATE controlplane
+)
 if (TESTGEN_INCLUDES)
   target_include_directories(testgen ${TESTGEN_INCLUDES})
 endif()
@@ -117,9 +123,8 @@ target_link_libraries(
   p4testgen
   PRIVATE testgen
   ${TESTGEN_LIBS}
-  ${P4C_LIBRARIES}
-  ${P4C_LIB_DEPS}
-  ${CMAKE_THREAD_LIBS_INIT}
+  PRIVATE ${P4C_LIBRARIES}
+  PRIVATE ${P4C_LIB_DEPS}
 )
 
 add_custom_target(
@@ -141,9 +146,9 @@ if(ENABLE_GTESTS)
     testgen-gtest
     PRIVATE testgen
     PRIVATE gtest
-    ${TESTGEN_LIBS}
-    ${P4C_LIBRARIES}
-    ${P4C_LIB_DEPS}
+    PRIVATE ${TESTGEN_LIBS}
+    PRIVATE ${P4C_LIBRARIES}
+    PRIVATE ${P4C_LIB_DEPS}
   )
 
   if(ENABLE_TESTING)

--- a/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
+++ b/backends/p4tools/modules/testgen/targets/bmv2/CMakeLists.txt
@@ -56,7 +56,6 @@ execute_process(COMMAND ln -sfn ${P4C_SOURCE_DIR}/backends/bmv2/run-bmv2-test.py
 
 set(
   TESTGEN_LIBS ${TESTGEN_LIBS}
-  PRIVATE controlplane
   PARENT_SCOPE
 )
 

--- a/control-plane/CMakeLists.txt
+++ b/control-plane/CMakeLists.txt
@@ -96,19 +96,17 @@ set (CONTROLPLANE_HDRS
 )
 
 add_library(controlplane-gen OBJECT ${P4RUNTIME_GEN_SRCS})
-# TODO(https://github.com/p4lang/p4c/issues/4477):
-# We should not need this, but because of the way managed includes and
-# libraries for Protobuf we need to explicitly add the include directories here.
-target_include_directories(
-  controlplane-gen SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIRS} SYSTEM BEFORE
-  PUBLIC ${ABSL_COMMON_INCLUDE_DIRS}
+
+target_include_directories(controlplane-gen
+  # TODO(https://github.com/p4lang/p4c/issues/4477):
+  # We should not need this, but because of the way managed includes and
+  # libraries for Protobuf we need to explicitly add the include directories here.
+  SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIRS}
+  # Needed for the correct import of google/status.pb.cc
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(controlplane-gen PUBLIC ${Protobuf_LIBRARY} PRIVATE absl::log)
-# Needed for the correct import of google/status.pb.cc
-target_include_directories(
-  controlplane-gen PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
-)
 
 # Silence various warnings as the root issue is out of our control, example
 # https://github.com/protocolbuffers/protobuf/issues/7140
@@ -119,8 +117,11 @@ set_source_files_properties(
 
 add_library(controlplane STATIC ${CONTROLPLANE_SRCS})
 target_link_libraries(controlplane
-  PUBLIC ${CMAKE_THREAD_LIBS_INIT}
+  # Export Protobuf includes with controlplane-gen.
   PUBLIC controlplane-gen
-  PRIVATE absl::strings)
+  # Required for the generated parser and the Abseil includes.
+  PRIVATE frontend
+  PRIVATE absl::strings
+)
 
-add_dependencies(controlplane mkP4configdir ir-generated controlplane-gen frontend-parser-gen)
+add_dependencies(controlplane mkP4configdir)

--- a/frontends/CMakeLists.txt
+++ b/frontends/CMakeLists.txt
@@ -258,7 +258,6 @@ if (FLEX_INCLUDE_DIRS)
   include_directories (${FLEX_INCLUDE_DIRS})
 endif ()
 add_library (frontend STATIC ${FRONTEND_SOURCES})
-add_dependencies (frontend frontend-parser-gen)
 target_link_libraries (frontend
   PRIVATE frontend-parser-gen
   PRIVATE absl::strings

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -114,5 +114,8 @@ set (MIDEND_HDRS
 
 
 add_library (midend STATIC ${MIDEND_SRCS})
-target_link_libraries(midend frontend) # For TypeMap / RefMap
+target_link_libraries(midend
+  # For TypeMap / RefMap
+  PRIVATE frontend
+)
 add_dependencies(midend genIR ir-generated)


### PR DESCRIPTION
Make sure we only export what is necessary and link most libraries privately. Also remove the `add_p4tools_library` function, it is too inflexible and `add_library` works just fine. 