### PR TITLE
Add policy controlling RemoveUnusedDeclarations

### DIFF
--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -281,7 +281,7 @@ void PsaSwitchBackend::convert(const IR::ToplevelBlock *tlb) {
         new P4::RemoveComplexExpressions(refMap, typeMap,
                                          new ProcessControls(&structure.pipeline_controls)),
         new P4::SimplifyControlFlow(refMap, typeMap),
-        new P4::RemoveAllUnusedDeclarations(refMap),
+        new P4::RemoveAllUnusedDeclarations(refMap, P4::RemoveUnusedPolicy()),
         // Converts the DAG into a TREE (at least for expressions)
         // This is important later for conversion to JSON.
         new P4::ClonePathExpressions(),

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -1169,6 +1169,9 @@ void SimpleSwitchBackend::convert(const IR::ToplevelBlock *tlb) {
     simplify.addPasses({
         // Because --fromJSON flag is used, input sources are empty
         // and ParseAnnotations should be skipped
+        // FIXME -- should this refmap clear be in RenameUserMetadata::init_apply instead?
+        // the only test that requires it is gauntlet_action_mux-bmv2.p4
+        [this] { refMap->clear(); },
         new RenameUserMetadata(refMap, userMetaType, userMetaName),
         new P4::ClearTypeMap(typeMap),  // because the user metadata type has changed
         new P4::SynthesizeActions(refMap, typeMap,
@@ -1182,7 +1185,7 @@ void SimpleSwitchBackend::convert(const IR::ToplevelBlock *tlb) {
         new RemoveComplexExpressions(refMap, typeMap,
                                      new ProcessControls(&structure->pipeline_controls)),
         new P4::SimplifyControlFlow(refMap, typeMap),
-        new P4::RemoveAllUnusedDeclarations(refMap),
+        new P4::RemoveAllUnusedDeclarations(refMap, P4::RemoveUnusedPolicy()),
         new P4::FlattenLogMsg(refMap, typeMap),
         // Converts the DAG into a TREE (at least for expressions)
         // This is important later for conversion to JSON.

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -69,7 +69,7 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new P4::ConstantFolding(refMap, typeMap, false),
         new EliminateHeaderCopy(refMap, typeMap),
         new P4::TypeChecking(refMap, typeMap),
-        new P4::RemoveAllUnusedDeclarations(refMap),
+        new P4::RemoveAllUnusedDeclarations(refMap, P4::RemoveUnusedPolicy()),
         new ConvertActionSelectorAndProfile(refMap, typeMap, &structure),
         new CollectTableInfo(&structure),
         new CollectAddOnMissTable(refMap, typeMap, &structure),

--- a/frontends/p4/actionsInlining.h
+++ b/frontends/p4/actionsInlining.h
@@ -68,11 +68,11 @@ class InlineActions : public PassManager {
     ActionsInlineList actionsToInline;
 
  public:
-    InlineActions(ReferenceMap *refMap, TypeMap *typeMap) {
+    InlineActions(ReferenceMap *refMap, TypeMap *typeMap, const RemoveUnusedPolicy &policy) {
         passes.push_back(new TypeChecking(refMap, typeMap));
         passes.push_back(new DiscoverActionsInlining(&actionsToInline, refMap, typeMap));
         passes.push_back(new InlineActionsDriver(&actionsToInline, new ActionsInliner(refMap)));
-        passes.push_back(new RemoveAllUnusedDeclarations(refMap));
+        passes.push_back(new RemoveAllUnusedDeclarations(refMap, policy));
         setName("InlineActions");
     }
 };

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -214,7 +214,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new SimplifyControlFlow(&refMap, &typeMap),
         new SwitchAddDefault,
         new FrontEndDump(),  // used for testing the program at this point
-        new RemoveAllUnusedDeclarations(&refMap, true),
+        new RemoveAllUnusedDeclarations(&refMap, *policy, true),
         new SimplifyParsers(&refMap),
         new ResetHeaders(&refMap, &typeMap),
         new UniqueNames(&refMap),  // Give each local declaration a unique internal name
@@ -227,28 +227,28 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new SimplifyDefUse(&refMap, &typeMap),
         new UniqueParameters(&refMap, &typeMap),
         new SimplifyControlFlow(&refMap, &typeMap),
-        new SpecializeAll(&refMap, &typeMap, constantFoldingPolicy),
+        new SpecializeAll(&refMap, &typeMap, policy),
         new RemoveParserControlFlow(&refMap, &typeMap),
         new RemoveReturns(&refMap),
         new RemoveDontcareArgs(&refMap, &typeMap),
         new MoveConstructors(&refMap),
-        new RemoveAllUnusedDeclarations(&refMap),
-        new RemoveRedundantParsers(&refMap, &typeMap),
+        new RemoveAllUnusedDeclarations(&refMap, *policy),
+        new RemoveRedundantParsers(&refMap, &typeMap, *policy),
         new ClearTypeMap(&typeMap),
         evaluator,
     });
     if (policy->optimize(options))
         passes.addPasses({
-            new Inline(&refMap, &typeMap, evaluator, options.optimizeParserInlining),
-            new InlineActions(&refMap, &typeMap),
-            new LocalizeAllActions(&refMap),
+            new Inline(&refMap, &typeMap, evaluator, *policy, options.optimizeParserInlining),
+            new InlineActions(&refMap, &typeMap, *policy),
+            new LocalizeAllActions(&refMap, *policy),
             new UniqueNames(&refMap),
             new UniqueParameters(&refMap, &typeMap),
             // Must be done before inlining functions, to allow
             // function calls used as action arguments to be inlined
             // in the proper place.
             new RemoveActionParameters(&refMap, &typeMap),
-            new InlineFunctions(&refMap, &typeMap),
+            new InlineFunctions(&refMap, &typeMap, *policy),
             new SetHeaders(&refMap, &typeMap),
             // Check for constants only after inlining
             new CheckConstants(&refMap, &typeMap),
@@ -258,7 +258,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
             new UniqueNames(&refMap),  // needed again after inlining
             new MoveDeclarations(),    // needed again after inlining
             new SimplifyDefUse(&refMap, &typeMap),
-            new RemoveAllUnusedDeclarations(&refMap),
+            new RemoveAllUnusedDeclarations(&refMap, *policy),
             new SimplifyControlFlow(&refMap, &typeMap),
         });
     passes.addPasses({

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "../common/options.h"
 #include "ir/ir.h"
 #include "parseAnnotations.h"
+#include "unusedDeclarations.h"
 
 namespace P4 {
 
@@ -28,7 +29,7 @@ class ConstantFoldingPolicy;  // forward declare to avoid having to include
 /// A customization point for frontend. The each tool can provide their own implementation of the
 /// policy that customizes its behaviour, or use instance of this class directly to provide the
 /// defaults.
-class FrontEndPolicy {
+class FrontEndPolicy : public RemoveUnusedPolicy {
  public:
     virtual ~FrontEndPolicy() = default;
 

--- a/frontends/p4/functionsInlining.h
+++ b/frontends/p4/functionsInlining.h
@@ -107,12 +107,12 @@ class InlineFunctions : public PassManager {
     FunctionsInlineList functionsToInline;
 
  public:
-    InlineFunctions(ReferenceMap *refMap, TypeMap *typeMap) {
+    InlineFunctions(ReferenceMap *refMap, TypeMap *typeMap, const RemoveUnusedPolicy &policy) {
         passes.push_back(new PassRepeated(
             {new TypeChecking(refMap, typeMap),
              new DiscoverFunctionsInlining(&functionsToInline, refMap, typeMap),
              new InlineFunctionsDriver(&functionsToInline, new FunctionsInliner(refMap->isV1())),
-             new RemoveAllUnusedDeclarations(refMap)}));
+             new RemoveAllUnusedDeclarations(refMap, policy)}));
         passes.push_back(new CloneVariableDeclarations());
         setName("InlineFunctions");
     }

--- a/frontends/p4/inlining.h
+++ b/frontends/p4/inlining.h
@@ -431,12 +431,12 @@ class InlinePass : public PassManager {
 
  public:
     InlinePass(ReferenceMap *refMap, TypeMap *typeMap, EvaluatorPass *evaluator,
-               bool optimizeParserInlining)
+               const RemoveUnusedPolicy &policy, bool optimizeParserInlining)
         : PassManager({new TypeChecking(refMap, typeMap),
                        new DiscoverInlining(&toInline, refMap, typeMap, evaluator),
                        new InlineDriver<InlineList, InlineSummary>(
                            &toInline, new GeneralInliner(refMap, optimizeParserInlining)),
-                       new RemoveAllUnusedDeclarations(refMap)}) {
+                       new RemoveAllUnusedDeclarations(refMap, policy)}) {
         setName("InlinePass");
     }
 };
@@ -451,8 +451,8 @@ class Inline : public PassRepeated {
 
  public:
     Inline(ReferenceMap *refMap, TypeMap *typeMap, EvaluatorPass *evaluator,
-           bool optimizeParserInlining)
-        : PassManager({new InlinePass(refMap, typeMap, evaluator, optimizeParserInlining),
+           const RemoveUnusedPolicy &policy, bool optimizeParserInlining)
+        : PassManager({new InlinePass(refMap, typeMap, evaluator, policy, optimizeParserInlining),
                        // After inlining the output of the evaluator changes, so
                        // we have to run it again
                        evaluator}) {

--- a/frontends/p4/localizeActions.h
+++ b/frontends/p4/localizeActions.h
@@ -171,7 +171,7 @@ class LocalizeAllActions : public PassManager {
     ActionReplacement localReplacements;
 
  public:
-    explicit LocalizeAllActions(ReferenceMap *refMap) {
+    explicit LocalizeAllActions(ReferenceMap *refMap, const RemoveUnusedPolicy &policy) {
         passes.emplace_back(new TagGlobalActions());
         passes.emplace_back(new PassRepeated{
             new ResolveReferences(refMap),
@@ -181,7 +181,7 @@ class LocalizeAllActions : public PassManager {
         passes.emplace_back(new ResolveReferences(refMap));
         passes.emplace_back(new FindRepeatedActionUses(refMap, &localReplacements));
         passes.emplace_back(new DuplicateActions(&localReplacements));
-        passes.emplace_back(new RemoveAllUnusedDeclarations(refMap));
+        passes.emplace_back(new RemoveAllUnusedDeclarations(refMap, policy));
         setName("LocalizeAllActions");
     }
 };

--- a/frontends/p4/redundantParsers.h
+++ b/frontends/p4/redundantParsers.h
@@ -54,11 +54,11 @@ class RemoveRedundantParsers : public PassManager {
     std::set<const IR::P4Parser *> redundantParsers;
 
  public:
-    RemoveRedundantParsers(ReferenceMap *refMap, TypeMap *typeMap)
+    RemoveRedundantParsers(ReferenceMap *refMap, TypeMap *typeMap, const RemoveUnusedPolicy &policy)
         : PassManager{new TypeChecking(refMap, typeMap, true),
                       new FindRedundantParsers(redundantParsers),
                       new EliminateSubparserCalls(redundantParsers, refMap, typeMap),
-                      new RemoveAllUnusedDeclarations(refMap)} {
+                      new RemoveAllUnusedDeclarations(refMap, policy)} {
         setName("RemoveRedundantParsers");
     }
 };

--- a/frontends/p4/specialize.h
+++ b/frontends/p4/specialize.h
@@ -24,6 +24,8 @@ limitations under the License.
 
 namespace P4 {
 
+class FrontEndPolicy;  // full definition not needed here
+
 /// Describes how a parser or control is specialized.
 struct SpecializationInfo {
     /// Name to use for specialized object.
@@ -210,8 +212,7 @@ class SpecializeAll : public PassRepeated {
     SpecializationMap specMap;
 
  public:
-    SpecializeAll(ReferenceMap *refMap, TypeMap *typeMap,
-                  ConstantFoldingPolicy *constantFoldingPolicy);
+    SpecializeAll(ReferenceMap *refMap, TypeMap *typeMap, FrontEndPolicy *policy);
 };
 
 }  // namespace P4

--- a/frontends/p4/unusedDeclarations.cpp
+++ b/frontends/p4/unusedDeclarations.cpp
@@ -21,6 +21,11 @@ limitations under the License.
 
 namespace P4 {
 
+RemoveUnusedDeclarations *RemoveUnusedPolicy::getRemoveUnusedDeclarationsPass(
+    const ReferenceMap *refMap, bool warn) const {
+    return new RemoveUnusedDeclarations(refMap, warn);
+}
+
 Visitor::profile_t RemoveUnusedDeclarations::init_apply(const IR::Node *node) {
     LOG4("Reference map " << refMap);
     return Transform::init_apply(node);

--- a/midend/flattenUnions.h
+++ b/midend/flattenUnions.h
@@ -197,12 +197,12 @@ class FlattenHeaderUnion : public PassManager {
             passes.push_back(new P4::ResolveReferences(refMap));
             passes.push_back(new P4::TypeInference(refMap, typeMap, false));
             passes.push_back(new P4::TypeChecking(refMap, typeMap));
-            passes.push_back(new P4::RemoveAllUnusedDeclarations(refMap));
+            passes.push_back(new P4::RemoveAllUnusedDeclarations(refMap, RemoveUnusedPolicy()));
         }
         passes.push_back(new DoFlattenHeaderUnion(refMap, typeMap));
         passes.push_back(new P4::ClearTypeMap(typeMap));
         passes.push_back(new P4::TypeChecking(refMap, typeMap));
-        passes.push_back(new P4::RemoveAllUnusedDeclarations(refMap));
+        passes.push_back(new P4::RemoveAllUnusedDeclarations(refMap, RemoveUnusedPolicy()));
         passes.push_back(new P4::RemoveUnusedHUDeclarations(refMap));
         passes.push_back(new P4::RemoveParserIfs(refMap, typeMap));
     }


### PR DESCRIPTION
This allows the target to define an override of RemoveUnusedDeclarations that changes the what gets removed and what doesn't, by defining a simple subclass of `P4::RemoveUnusedDeclarations` that only overrides one or two methods and is otherwise the same.

- allow removing unused externs when that is apropriate for the target
- allow not removing unused functions when that is appropriate

I tried just defining a hook function that is called for each IDeclaration, but using that ends up doing a whole series or dynamic_casts, which seems ugly and duplicates what Visitor is already doing for the preorder/postorder methods, so this ends up being more efficient and clearer.