### PR TITLE
Extend parser to allow parentheses in lvalues

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1464,6 +1464,7 @@ lvalue
     | lvalue dot_name %prec DOT          { $$ = new IR::Member(@1 + @2, $1, *$2); }
     | lvalue "[" expression "]"          { $$ = new IR::ArrayIndex(@1 + @4, $1, $3); }
     | lvalue "[" expression ":" expression "]" { $$ = new IR::Slice(@1 + @6, $1, $3, $5); }
+    | "(" lvalue ")"                     { $$ = $2; }
     ;
 
 expression

--- a/testdata/p4_16_samples/lvalue-parens.p4
+++ b/testdata/p4_16_samples/lvalue-parens.p4
@@ -1,0 +1,11 @@
+control C();
+package P(C c);
+
+control MyC() {
+  bit<8> x;
+  apply {
+    (x) = 1;
+  }
+}
+
+P(MyC()) main;

--- a/testdata/p4_16_samples_outputs/lvalue-parens-first.p4
+++ b/testdata/p4_16_samples_outputs/lvalue-parens-first.p4
@@ -1,0 +1,10 @@
+control C();
+package P(C c);
+control MyC() {
+    bit<8> x;
+    apply {
+        x = 8w1;
+    }
+}
+
+P(MyC()) main;

--- a/testdata/p4_16_samples_outputs/lvalue-parens-frontend.p4
+++ b/testdata/p4_16_samples_outputs/lvalue-parens-frontend.p4
@@ -1,0 +1,8 @@
+control C();
+package P(C c);
+control MyC() {
+    apply {
+    }
+}
+
+P(MyC()) main;

--- a/testdata/p4_16_samples_outputs/lvalue-parens-midend.p4
+++ b/testdata/p4_16_samples_outputs/lvalue-parens-midend.p4
@@ -1,0 +1,8 @@
+control C();
+package P(C c);
+control MyC() {
+    apply {
+    }
+}
+
+P(MyC()) main;

--- a/testdata/p4_16_samples_outputs/lvalue-parens.p4
+++ b/testdata/p4_16_samples_outputs/lvalue-parens.p4
@@ -1,0 +1,10 @@
+control C();
+package P(C c);
+control MyC() {
+    bit<8> x;
+    apply {
+        x = 1;
+    }
+}
+
+P(MyC()) main;


### PR DESCRIPTION
Fixes p4lang/p4-spec#1273