### PR TITLE
[documentation] Add hyperlinks to the actual directory in the README file.

### DIFF
--- a/backends/dpdk/README.md
+++ b/backends/dpdk/README.md
@@ -19,7 +19,7 @@ generates the 'spec' file to configure the DPDK pipeline.
 
 ## How to use it?
 
-A sample P4 program can be found in the `examples` [directory](./examples).  To
+A sample P4 program can be found in the [`examples` directory](./examples).  To
 generate the 'spec' file:
 ```bash
 p4c-dpdk --arch psa vxlan.p4 -o vxlan.spec

--- a/backends/dpdk/README.md
+++ b/backends/dpdk/README.md
@@ -19,7 +19,7 @@ generates the 'spec' file to configure the DPDK pipeline.
 
 ## How to use it?
 
-A sample P4 program can be found in the `examples` directory.  To
+A sample P4 program can be found in the `examples` [directory](./examples).  To
 generate the 'spec' file:
 ```bash
 p4c-dpdk --arch psa vxlan.p4 -o vxlan.spec

--- a/backends/tc/README.md
+++ b/backends/tc/README.md
@@ -19,7 +19,7 @@ The backend for TC reuses code from the p4c-ebpf for generating c file.
 
 ## How to use it?
 
-The sample p4 programs are located in the "testdata/p4tc_samples" directory.
+The sample p4 programs are located in the "testdata/p4tc_samples" [directory](../../testdata/p4tc_samples).
 
 To generate the 'template' file, 'c' file and 'json' file:
 

--- a/backends/tc/README.md
+++ b/backends/tc/README.md
@@ -19,7 +19,7 @@ The backend for TC reuses code from the p4c-ebpf for generating c file.
 
 ## How to use it?
 
-The sample p4 programs are located in the ["testdata/p4tc_samples" directory](../../testdata/p4tc_samples).
+The sample p4 programs are located in the [`testdata/p4tc_samples` directory](../../testdata/p4tc_samples).
 
 To generate the 'template' file, 'c' file and 'json' file:
 

--- a/backends/tc/README.md
+++ b/backends/tc/README.md
@@ -19,7 +19,7 @@ The backend for TC reuses code from the p4c-ebpf for generating c file.
 
 ## How to use it?
 
-The sample p4 programs are located in the "testdata/p4tc_samples" [directory](../../testdata/p4tc_samples).
+The sample p4 programs are located in the ["testdata/p4tc_samples" directory](../../testdata/p4tc_samples).
 
 To generate the 'template' file, 'c' file and 'json' file:
 

--- a/backends/ubpf/README.md
+++ b/backends/ubpf/README.md
@@ -55,7 +55,7 @@ However, we introduced some modifications, which are listed below:
 
 ### How to use?
 
-The sample P4 programs are located in [`examples/` directory](./examples). We have tested them with the [P4rt-OVS](https://github.com/Orange-OpenSource/p4rt-ovs) switch - 
+The sample P4 programs are located in the [`examples/` directory](./examples). We have tested them with the [P4rt-OVS](https://github.com/Orange-OpenSource/p4rt-ovs) switch - 
 the Open vSwitch that can be extended with BPF programs at runtime. See [the detailed tutorial](./docs/EXAMPLES.md) on how to run and test those examples.
 
 In order to generate the C code use the following command:

--- a/backends/ubpf/README.md
+++ b/backends/ubpf/README.md
@@ -55,7 +55,7 @@ However, we introduced some modifications, which are listed below:
 
 ### How to use?
 
-The sample P4 programs are located in `examples/` directory. We have tested them with the [P4rt-OVS](https://github.com/Orange-OpenSource/p4rt-ovs) switch - 
+The sample P4 programs are located in [`examples/` directory](./examples). We have tested them with the [P4rt-OVS](https://github.com/Orange-OpenSource/p4rt-ovs) switch - 
 the Open vSwitch that can be extended with BPF programs at runtime. See [the detailed tutorial](./docs/EXAMPLES.md) on how to run and test those examples.
 
 In order to generate the C code use the following command:


### PR DESCRIPTION
## Changes 
 - Added directory link for examples directory in DPDK backend's Guide.
 - Added Directory link for "testdata/p4tc_samples" in Guide of "tc" Backend.
 - Added directory link for "examples" directory in "ubpf" backend's Guide.