### PR TITLE
Remove obsolete `output_to_genfiles = True`.

### DIFF
--- a/bazel/bison.bzl
+++ b/bazel/bison.bzl
@@ -61,5 +61,4 @@ genyacc = rule(
                   "subject to $(location ...) expansion.",
         ),
     },
-    output_to_genfiles = True,
 )


### PR DESCRIPTION
This is a no-op for Bazel, which enables `--incompatible_merge_genfiles_directory` by default.