### PR TITLE
added the prettyprinter binary

### DIFF
--- a/pretty-printer/example.p4
+++ b/pretty-printer/example.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+#include <v1model.p4>
+struct metadata {}
+struct headers {}
+parser MyParser(packet_in packet,
+ out headers hdr,
+ inout metadata meta,
+ inout standard_metadata_t standard_metadata) {
+ state start { transition accept; }
+}
+control MyVerifyChecksum(inout headers hdr, inout metadata
+meta) { apply { } }
+control MyIngress(inout headers hdr,
+ inout metadata meta,
+ inout standard_metadata_t standard_metadata) {
+apply {
+ if (standard_metadata.ingress_port == 1) {
+ standard_metadata.egress_spec = 2;
+ } else if (standard_metadata.ingress_port == 2) {
+ standard_metadata.egress_spec = 1;
+ }
+ }
+}
+control MyEgress(inout headers hdr,
+ inout metadata meta,
+ inout standard_metadata_t standard_metadata) {
+ apply { }
+}
+control MyComputeChecksum(inout headers hdr, inout metadata
+meta) {
+ apply { }
+}
+control MyDeparser(packet_out packet, in headers hdr) {
+ apply { }
+}
+V1Switch(
+ MyParser(),
+ MyVerifyChecksum(),
+ MyIngress(),
+ MyEgress(),
+ MyComputeChecksum(),
+ MyDeparser()
+) main;

--- a/pretty-printer/p4fmt
+++ b/pretty-printer/p4fmt
@@ -1,0 +1,1 @@
+/home/sanket-teli/gsoc/p4c/build/extensions/p4fmt/p4fmt


### PR DESCRIPTION
This PR is the demonstration of simple p4c backend with minimal frontend passes, printing the formatted p4c program using the pretty-printer. Use can pass a `.p4` file to this `./p4fmt` binary and it will print the formatted p4 program for you.

to use pretty-printer clone this repo
` git clone github.com/Sanket-0510/p4c`

`cd pretty-printer`

`./p4fmt ./example.p4`

I have added a sample p4 program in example.p4 but you can pass any p4 file to this binary and it will format the code for you.