### PR TITLE
[P4Testgen] Clean up the direct extern map implementation for BMv2.

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/bmv2.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/bmv2.cpp
@@ -113,7 +113,7 @@ CompilerResultOrError Bmv2V1ModelCompilerTarget::runCompilerImpl(
 
     return {*new BMv2V1ModelCompilerResult{
         TestgenCompilerResult(CompilerResult(*program), coverage.getCoverableNodes(), dcg),
-        p4runtimeApi, directExternMapper.getdirectExternMap(), p4ConstraintsRestrictions}};
+        p4runtimeApi, directExternMapper.getDirectExternMap(), p4ConstraintsRestrictions}};
 }
 
 MidEnd Bmv2V1ModelCompilerTarget::mkMidEnd(const CompilerOptions &options) const {

--- a/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.cpp
@@ -54,10 +54,9 @@ bool MapDirectExterns::preorder(const IR::P4Table *table) {
         const auto *impl = table->properties->getProperty(tableProperty);
         if (impl != nullptr) {
             auto declInstanceOpt = getExternFromTableImplementation(impl);
-            if (!declInstanceOpt.has_value()) {
-                return false;
+            if (declInstanceOpt.has_value()) {
+                directExternMap.emplace(declInstanceOpt.value()->controlPlaneName(), table);
             }
-            directExternMap.emplace(declInstanceOpt.value()->controlPlaneName(), table);
         }
     }
     return false;

--- a/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h
@@ -11,7 +11,11 @@
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
-/// A map of direct extern declarations which are attached to a table.
+/// A mapping of the control plane name of extern declarations which are associated with a table.
+/// Such an extern is referred to as direct extern. There can only be one extern associated with a
+/// table in BMv2.
+/// We are using the cstring name and not an IR::Declaration pointer for the mapping because other
+/// passes may clone or transform the IR::Declaration node, invalidating this mapping.
 using DirectExternMap = std::map<cstring, const IR::P4Table *>;
 
 /// A lightweight visitor, which collects all the declarations in the program then checks whether a

--- a/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/map_direct_externs.h
@@ -1,34 +1,44 @@
 #ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_MAP_DIRECT_EXTERNS_H_
 #define BACKENDS_P4TOOLS_MODULES_TESTGEN_TARGETS_BMV2_MAP_DIRECT_EXTERNS_H_
 
+#include <array>
 #include <map>
+#include <optional>
 
 #include "ir/ir.h"
 #include "ir/visitor.h"
+#include "lib/cstring.h"
 
 namespace P4Tools::P4Testgen::Bmv2 {
 
 /// A map of direct extern declarations which are attached to a table.
-using DirectExternMap = std::map<const IR::IDeclaration *, const IR::P4Table *>;
+using DirectExternMap = std::map<cstring, const IR::P4Table *>;
 
 /// A lightweight visitor, which collects all the declarations in the program then checks whether a
 /// table is referencing the declaration as an direct extern. The direct externs are collected in a
 /// map. Currently checks for "counters" or "meters" properties in the table.
 class MapDirectExterns : public Inspector {
  private:
+    /// The table property labels which are associated with an extern declaration.
+    static constexpr std::array kTableExternProperties = {"meters", "counters"};
+
     /// List of the declared instances in the program.
     std::map<cstring, const IR::Declaration_Instance *> declaredExterns;
 
     /// Maps direct extern declarations to the table they are attached to.
     DirectExternMap directExternMap;
 
- public:
-    bool preorder(const IR::Declaration_Instance *declInstance) override;
+    /// Tries to lookup the associated extern declaration from a table implementation property.
+    /// @returns std::nullopt if the declaration can not be found.
+    std::optional<const IR::Declaration_Instance *> getExternFromTableImplementation(
+        const IR::Property *tableImplementation);
 
+    bool preorder(const IR::Declaration_Instance *declInstance) override;
     bool preorder(const IR::P4Table *table) override;
 
+ public:
     /// @returns the list of direct externs and their corresponding table.
-    const std::map<const IR::IDeclaration *, const IR::P4Table *> &getdirectExternMap();
+    const DirectExternMap &getDirectExternMap();
 };
 
 }  // namespace P4Tools::P4Testgen::Bmv2

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -86,7 +86,7 @@ Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(
 const IR::P4Table *Bmv2V1ModelProgramInfo::getTableofDirectExtern(
     const IR::IDeclaration *directExternDecl) const {
     const auto &directExternMap = getCompilerResult().getDirectExternMap();
-    auto it = directExternMap.find(directExternDecl);
+    auto it = directExternMap.find(directExternDecl->controlPlaneName());
     if (it == directExternMap.end()) {
         BUG("No table associated with this direct extern %1%. The extern should have been removed.",
             directExternDecl);

--- a/lib/bitrange.h
+++ b/lib/bitrange.h
@@ -17,13 +17,14 @@ limitations under the License.
 #ifndef LIB_BITRANGE_H_
 #define LIB_BITRANGE_H_
 
+#include <absl/numeric/bits.h>
+
 #include <algorithm>
 #include <iosfwd>
 #include <limits>
 #include <optional>
 #include <utility>
 
-#include "absl/numeric/bits.h"
 #include "bitvec.h"
 #include "exceptions.h"
 #include "hash.h"


### PR DESCRIPTION
- Use cstring instead of the declaration pointer in the direct extern map.
- Check for all implementations.
- Create an explicit static array of implementations. 