### PR TITLE
Allow constructing an IR::ID from a std::string

### DIFF
--- a/ir/id.h
+++ b/ir/id.h
@@ -39,6 +39,7 @@ struct ID : Util::IHasSourceInfo {
     }
     ID(const char *n) : ID(Util::SourceInfo(), n) {}  // NOLINT(runtime/explicit)
     ID(cstring n) : ID(Util::SourceInfo(), n) {}      // NOLINT(runtime/explicit)
+    ID(std::string n) : ID(Util::SourceInfo(), n) {}  // NOLINT(runtime/explicit)
     ID(cstring n, cstring old) : ID(Util::SourceInfo(), n, old) {}
     void dbprint(std::ostream &out) const {
         out << name;

--- a/midend/def_use.h
+++ b/midend/def_use.h
@@ -43,7 +43,7 @@ class ComputeDefUse : public Inspector,
                       public ControlFlowVisitor,
                       public P4WriteContext,
                       public P4::ResolutionContext {
-    ComputeDefUse *clone() const { return new ComputeDefUse(*this); }
+    ComputeDefUse *clone() const override { return new ComputeDefUse(*this); }
     void flow_merge(Visitor &) override;
     void flow_copy(ControlFlowVisitor &) override;
     enum { SKIPPING, NORMAL, READ_ONLY, WRITE_ONLY } state = SKIPPING;


### PR DESCRIPTION
- also add missing `override` (fix warning)