### PR TITLE
Add 2 more CRC checksum variants to lib/nethash

### DIFF
--- a/lib/nethash.cpp
+++ b/lib/nethash.cpp
@@ -159,8 +159,16 @@ uint16_t crc16(const uint8_t *buf, size_t len) {
     return crcGeneric<uint16_t, 0, 0, table_crc16, Reflect>(buf, len);
 }
 
+uint16_t crc16ANSI(const uint8_t *buf, size_t len) {
+    return crcGeneric<uint16_t, 0, 0, table_crc16, Identity>(buf, len);
+}
+
 uint32_t crc32(const uint8_t *buf, size_t len) {
     return crcGeneric<uint32_t, 0xffffffff, 0xffffffff, table_crc32, Reflect>(buf, len);
+}
+
+uint32_t crc32FCS(const uint8_t *buf, size_t len) {
+    return crcGeneric<uint32_t, 0xffffffff, 0xffffffff, table_crc32, Identity>(buf, len);
 }
 
 uint16_t crcCCITT(const uint8_t *buf, size_t len) {

--- a/lib/nethash.h
+++ b/lib/nethash.h
@@ -8,15 +8,23 @@
 /// A collection of hashing functions commonly used in network protocols.
 namespace NetHash {
 
-/// CRC-16/CRC-16-IBM/CRC-16-ANSI (parameters: bit-reflection, polynomial 0x8005, init = 0 and
-/// xor_out = 0).
+/// CRC-16 used in BMv2 (parameters: bit-reflection, polynomial 0x8005, init = 0 and xor_out = 0).
 uint16_t crc16(const uint8_t *buf, size_t len);
+
+/// CRC-16-ANSI/CRC-16-IBM (parameters: NO bit-reflection, polynomial 0x8005, init = 0 and
+/// xor_out = 0).
+uint16_t crc16ANSI(const uint8_t *buf, size_t len);
 
 /// CRC16-CCITT (parameters: NO bit-reflection, polynomial 0x1021, init = ~0 and xor_out = 0).
 uint16_t crcCCITT(const uint8_t *buf, size_t len);
 
-/// CRC-32 (parameters: bit-reflection, polynomial 0x04C11DB7, init = ~0 and xor_out = ~0).
+/// CRC-32, used in BMv2 (parameters: bit-reflection, polynomial 0x04C11DB7, init = ~0 and
+/// xor_out = ~0).
 uint32_t crc32(const uint8_t *buf, size_t len);
+
+/// CRC-32 used for Ethernet FCS (parameters: NO bit-reflection, polynomial 0x04C11DB7, init = ~0
+/// and xor_out = ~0).
+uint32_t crc32FCS(const uint8_t *buf, size_t len);
 
 /// 16-bit ones' complement checksum (used in IP, TCP, UDP, ...).
 uint16_t csum16(const uint8_t *buf, size_t len);

--- a/test/gtest/nethash.cpp
+++ b/test/gtest/nethash.cpp
@@ -48,6 +48,17 @@ TEST(NetHash, crc32) {
     EXPECT_EQ(apply<crc32>("foobar%142qrs"), 0x95E1D00B_u32);
 }
 
+TEST(NetHash, crc32FCS) {
+    EXPECT_EQ(apply<crc32FCS>({}), 0x00000000_u32);
+    EXPECT_EQ(apply<crc32FCS>({0}), 0xB1F7404B_u32);
+    EXPECT_EQ(apply<crc32FCS>({0, 0, 0, 0, 0}), 0xB8EF4463_u32);
+    EXPECT_EQ(apply<crc32FCS>({0x0b, 0xb8, 0x1f, 0x90}), 0xEDA1EA6D_u32);
+    EXPECT_EQ(apply<crc32FCS>("fooo"), 0xCD961E19_u32);
+    EXPECT_EQ(apply<crc32FCS>("a"), 0x19939B6B_u32);
+    EXPECT_EQ(apply<crc32FCS>("foobar"), 0x52C03DC1_u32);
+    EXPECT_EQ(apply<crc32FCS>("foobar%142qrs"), 0xF3630DE4_u32);
+}
+
 TEST(NetHash, crc16) {
     EXPECT_EQ(apply<crc16>({}), 0x0000_u16);
     EXPECT_EQ(apply<crc16>({0}), 0x0000_u16);
@@ -57,6 +68,17 @@ TEST(NetHash, crc16) {
     EXPECT_EQ(apply<crc16>("a"), 0xE8C1_u16);
     EXPECT_EQ(apply<crc16>("foobar"), 0xB0C8_u16);
     EXPECT_EQ(apply<crc16>("foobar%142qrs"), 0x3DA9_u16);
+}
+
+TEST(NetHash, crc16ANSI) {
+    EXPECT_EQ(apply<crc16ANSI>({}), 0x0000_u16);
+    EXPECT_EQ(apply<crc16ANSI>({0}), 0x0000_u16);
+    EXPECT_EQ(apply<crc16ANSI>({0, 0, 0, 0, 0}), 0x0000_u16);
+    EXPECT_EQ(apply<crc16ANSI>({0x0b, 0xb8, 0x1f, 0x90}), 0xD400_u16);
+    EXPECT_EQ(apply<crc16ANSI>("fooo"), 0x9C3A_u16);
+    EXPECT_EQ(apply<crc16ANSI>("a"), 0x8145_u16);
+    EXPECT_EQ(apply<crc16ANSI>("foobar"), 0x8F5B_u16);
+    EXPECT_EQ(apply<crc16ANSI>("foobar%142qrs"), 0x5A5E_u16);
 }
 
 TEST(NetHash, crcCCITT) {


### PR DESCRIPTION
I am not sure what was the motivation for choice of the exact CRC variants for BMv2, but some targets use different variants, this PR adds some. These particular variants are similar to those in BMv2, but they lack bit reflection.

I am not super happy about the naming, but I did not find any good catalog of variants.