### PR TITLE
Fix Resource links in Doxygen documentation.

### DIFF
--- a/docs/doxygen/01_overview.md
+++ b/docs/doxygen/01_overview.md
@@ -14,13 +14,10 @@ The P4C compiler is a compiler infrastructure for the P4 compiler designed with 
 
 ## Additional documentation
 
-* the P4_14 (P4 v1.0) language is described in the [P4 spec](http://p4.org/wp-content/uploads/2015/04/p4-latest.pdf)
-
-* the [P4_16 draft language](http://p4.org/wp-content/uploads/2016/12/P4_16-prerelease-Dec_16.pdf)
-  specification is still under revision.
+* The documentation for P4_16 and P4Runtime is available [here](https://p4.org/specs/)
 
 * the core design of the compiler intermediate representation (IR) and
-  the visitor patterns are briefly described in [IR](IR.md)
+  the visitor patterns are briefly described in [IR](../IR.md)
 
-* The [migration guide](migration-guide.pptx) describes how P4_14 (v1.0)
+* The [migration guide](../migration-guide.pptx) describes how P4_14 (v1.0)
   programs are translated into P4_16 programs


### PR DESCRIPTION
## Issue 
Resource links within the "Additional Documentation" section are not correctly pointing to their intended locations.

## fix
Updated the resource links 