### PR TITLE
[docs] Add Comment Style Guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -121,6 +121,11 @@ XX is a number between 02-99. Currently, 00_revision_history.md
 contains the documentation revision history, and 01_overview.md is the
 overview of the compiler goals and architecture.
 
+## Documentation Comments Style Guide 
+- Use triple slashes `///` for documenting functions and classes in header files.
+- Double slashes `//` should be used for "internal" comments within functions.
+- For rare occasions such as adding comments to multi-line macros, you may use `/* ... */` style comments.
+
 Happy writing! Should you have any questions, please don't hesitate to ask.
 
 ## Git usage

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,7 +122,7 @@ contains the documentation revision history, and 01_overview.md is the
 overview of the compiler goals and architecture.
 
 ## Documentation Comments Style Guide 
-- Use triple slashes `///` for documenting functions and classes in header files.
+- Use triple slashes `///` for documenting functions and classes in files.
 - Double slashes `//` should be used for "internal" comments within functions.
 - For rare occasions such as adding comments to multi-line macros, you may use `/* ... */` style comments.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -253,6 +253,8 @@ To add a new input test with a sample P4 code file (under `testdata/p4_16_sample
 
 * We generally follow the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html). This is partially enforced by `cpplint` and `clang-format` and their respective configuration files. We have customized Google's `cpplint.py` tool for our purposes.  The tool can be invoked with `make cpplint`. To be able to run `clang-format` on Ubuntu 20.04, install it with `pip3 install --user clang-format`. Do not use the Debian package. Both tools run in a git hook and as part of CI.
 
+* Commenting Style is guided by the [following rules](#documentation-comments-style-guide).
+  
 * Watch out for `const`; it is very important.
 
 * Use `override` whenever possible (new gcc versions enforce this).


### PR DESCRIPTION
### Fixes Issue - 
- #4563

Based on discussion 
- https://github.com/p4lang/p4c/pull/4568#discussion_r1542970252

## Task done 

- [x] Added guidelines on the commenting style convention to be used for documenting the codebase
- [x] Linked the commenting style guide with the [coding convention section](https://github.com/p4lang/p4c/tree/main/docs#coding-conventions)

## Follow-up Discussion 
Should wo include this section somewhere around the [Coding Conventions section](https://github.com/p4lang/p4c/tree/main/docs#coding-conventions) 