### PR TITLE
[Added] P4 Naming Conventions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -293,6 +293,20 @@ To add a new input test with a sample P4 code file (under `testdata/p4_16_sample
   * Use `ordered_map` and `ordered_set` when you need to iterate;
     they provide deterministic iterators.
 
+## Naming conventions
+
+P4 provides a rich assortment of types. Base types include bit-strings, numbers, and errors. There are also built-in types for representing constructs such as parsers, pipelines, actions, and tables. Users can construct new types based on these: structures, enumerations, headers, header stacks, header unions, etc.
+
+In this document we adopt the following conventions:
+
+- Built-in types are written with lowercase characters—e.g., `int<20>`,
+- User-defined types are capitalized—e.g., `IPv4Address`,
+- Type variables are always uppercase—e.g., parser `P<H, IH>(...)`,
+- Variables are uncapitalized— e.g., `ipv4header`,
+- Constants are written with uppercase characters—e.g., `CPU_PORT`, and
+- Errors and enumerations are written in camel-case— e.g. `PacketTooShort`.
+    
+
 ## Compiler Driver
 
 **p4c** is a compiler driver. The goal is to provide a consistent user interface


### PR DESCRIPTION
This PR introduces and documents the naming conventions for various elements in P4, including :

- built-in types
- user-defined types
- type variables
- variables
- constants
- errors