### PR TITLE
Force black to use the pytoml file as configuration.

### DIFF
--- a/cmake/Linters.cmake
+++ b/cmake/Linters.cmake
@@ -117,13 +117,13 @@ if(NOT ${BLACK_CMD} OR NOT (NOT ${ISORT_CMD}))
     set(BLACK_CMD black)
     add_custom_target(
       black
-      COMMAND xargs -a ${BLACK_TXT_FILE} -r -d '\;' ${BLACK_CMD} --check --diff -- || (echo ${RED}black failed. Run \"make black-fix-errors\" to fix the complaints.${COLOURRESET} && false)
+      COMMAND xargs -a ${BLACK_TXT_FILE} -r -d '\;' ${BLACK_CMD} --config ${P4C_SOURCE_DIR}/pyproject.toml --check --diff -- || (echo ${RED}black failed. Run \"make black-fix-errors\" to fix the complaints.${COLOURRESET} && false)
       WORKING_DIRECTORY ${P4C_SOURCE_DIR}
       COMMENT "Checking files for correct black formatting."
     )
     add_custom_target(
       black-fix-errors
-      COMMAND xargs -a ${BLACK_TXT_FILE} -r -d '\;' ${BLACK_CMD} --
+      COMMAND xargs -a ${BLACK_TXT_FILE} -r -d '\;' ${BLACK_CMD} --config ${P4C_SOURCE_DIR}/pyproject.toml --
       WORKING_DIRECTORY ${P4C_SOURCE_DIR}
       COMMENT "Formatting files using black."
     )


### PR DESCRIPTION
Some downstream repositories do not seem to pick up the right black configuration. This can happen with out-of-tree builds. Unclear why for me. 

Forcing the configuration path fixes this problem. 