### PR TITLE
Fix spurious failure when two tests try to remove `ptf.log` at the same time.

### DIFF
--- a/backends/bmv2/run-bmv2-ptf-test.py
+++ b/backends/bmv2/run-bmv2-ptf-test.py
@@ -256,7 +256,11 @@ class VethEnv(PTFTestEnv):
         # Add the tools PTF folder to the python path, it contains the base test.
         pypath = ROOT_DIR.joinpath("tools/ptf")
         # Show list of the tests
-        test_list_cmd = f"ptf --pypath {pypath} --test-dir {self.options.testdir} --list"
+        test_list_cmd = (
+            f"ptf --pypath {pypath} "
+            f"--log-file {self.options.testdir.joinpath('ptf.log')} "
+            f"--test-dir {self.options.testdir} --list"
+        )
         returncode = self.bridge.ns_exec(test_list_cmd)
         if returncode != testutils.SUCCESS:
             return returncode


### PR DESCRIPTION
It can happen that test A deletes `ptf.log` and then test B tries to delete the log a second later. This will cause the following error: 
```
WARNING: Traceback (most recent call last):
WARNING:   File "/usr/local/bin/ptf", line 684, in <module>
WARNING:     logging_setup(config)
WARNING:   File "/usr/local/bin/ptf", line 449, in logging_setup
WARNING:     os.remove(config["log_file"])
WARNING: FileNotFoundError: [Errno 2] No such file or directory: 'ptf.log'
```
To avoid that from happening we make sure the log is saved in the unique temporary directory instead. We already did this for the actual PTF test, but not for the initial PTF check. 

Ideally, we would fix this error from occurring at all in PTF.
