### PR TITLE
Fix a compilation error with unity builds and clang.

### DIFF
--- a/.github/workflows/ci-test-debian.yml
+++ b/.github/workflows/ci-test-debian.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       CTEST_PARALLEL_LEVEL: 4
       IMAGE_TYPE: test
+      COMPILE_WITH_CLANG: ON
       BUILD_GENERATOR: Ninja
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +52,7 @@ jobs:
         unity: [ON, OFF]
     runs-on: ubuntu-20.04
     env:
+      COMPILE_WITH_CLANG: ON
       CTEST_PARALLEL_LEVEL: 4
       IMAGE_TYPE: test
       CMAKE_UNITY_BUILD: ${{ matrix.unity }}

--- a/.github/workflows/ci-test-debian.yml
+++ b/.github/workflows/ci-test-debian.yml
@@ -20,7 +20,6 @@ jobs:
     env:
       CTEST_PARALLEL_LEVEL: 4
       IMAGE_TYPE: test
-      COMPILE_WITH_CLANG: ON
       BUILD_GENERATOR: Ninja
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +51,6 @@ jobs:
         unity: [ON, OFF]
     runs-on: ubuntu-20.04
     env:
-      COMPILE_WITH_CLANG: ON
       CTEST_PARALLEL_LEVEL: 4
       IMAGE_TYPE: test
       CMAKE_UNITY_BUILD: ${{ matrix.unity }}

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -14,6 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// This include is necessary to prevent this error from happening:
+// "error: 'posix_memalign' is missing exception specification 'noexcept'"
+// This error is possible when compiling with clang and including "mm_malloc.h" after the definition
+// of posix_memalign. This can easily happen in unity builds.
+#if defined(__clang__)
+#include <mm_malloc.h>
+#endif
+
 #include "config.h"
 #if HAVE_LIBGC
 #include <gc/gc_cpp.h>

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -14,6 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// This include is necessary to prevent this error from happening:
+// "error: 'posix_memalign' is missing exception specification 'noexcept'"
+// This error is possible when compiling with clang and including "mm_malloc.h" after the definition
+// of posix_memalign. This can easily happen in unity builds.
+#if defined(__clang__)
+#include <mm_malloc.h>
+#endif
+
 #include "config.h"
 #if HAVE_LIBGC
 #include <gc/gc_cpp.h>
@@ -263,8 +271,8 @@ void *calloc(size_t size, size_t elsize) {
     return rv;
 }
 int posix_memalign(void **memptr, size_t alignment, size_t size)
-#ifdef __GLIBC__
-    __THROW
+#ifndef __APPLE__
+    noexcept
 #endif
 {
     maybe_initialize_gc();
@@ -321,4 +329,3 @@ size_t gc_mem_inuse(size_t *max) {
     return 0;
 #endif
 }
-#include <mm_malloc.h>

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -14,14 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This include is necessary to prevent this error from happening:
-// "error: 'posix_memalign' is missing exception specification 'noexcept'"
-// This error is possible when compiling with clang and including "mm_malloc.h" after the definition
-// of posix_memalign. This can easily happen in unity builds.
-#if defined(__clang__)
-#include <mm_malloc.h>
-#endif
-
 #include "config.h"
 #if HAVE_LIBGC
 #include <gc/gc_cpp.h>
@@ -271,8 +263,8 @@ void *calloc(size_t size, size_t elsize) {
     return rv;
 }
 int posix_memalign(void **memptr, size_t alignment, size_t size)
-#ifndef __APPLE__
-    noexcept
+#ifdef __GLIBC__
+    __THROW
 #endif
 {
     maybe_initialize_gc();
@@ -329,3 +321,4 @@ size_t gc_mem_inuse(size_t *max) {
     return 0;
 #endif
 }
+#include <mm_malloc.h>


### PR DESCRIPTION
This is an esoteric issue that only happens when you compile a unity build with clang.
For the following code
```cpp
int posix_memalign(void **memptr, size_t alignment, size_t size)
#ifndef __APPLE__
    noexcept
#endif
{
    maybe_initialize_gc();

    TRACE_ALLOC(size)
    return GC_posix_memalign(memptr, alignment, size);
}
```
you get this exception:

```
In file included from p4c/lib/big_int_util.cpp:17:                                                                                   
In file included from p4c/lib/big_int_util.h:20:                                                                                     
In file included from /usr/include/boost/multiprecision/cpp_int.hpp:12:               
In file included from /usr/include/boost/multiprecision/number.hpp:26:                
In file included from /usr/include/boost/multiprecision/detail/generic_interconvert.hpp:9:                                                                                  
In file included from /usr/include/boost/multiprecision/detail/default_ops.hpp:12:    
In file included from /usr/include/boost/math/special_functions/next.hpp:23:          
In file included from /usr/lib/llvm-19/lib/clang/19/include/xmmintrin.h:31:           
/usr/lib/llvm-19/lib/clang/19/include/mm_malloc.h:25:16: error: 'posix_memalign' is missing exception specification 'throw()'
```

The reason is that the definition in `mm_malloc.h`:
`extern int posix_memalign(void **__memptr, size_t __alignment, size_t __size);`
clashes with the definition in `stdlib.h`
`
extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
     __THROW __nonnull ((1)) __wur;
`

@asl Do you maybe have a better approach here? 




