### PR TITLE
Allow implicit conversion of brace-lists to type list

### DIFF
--- a/testdata/p4_16_samples/listinit.p4
+++ b/testdata/p4_16_samples/listinit.p4
@@ -1,0 +1,14 @@
+
+extern test<T1, T2> {
+  test(list<tuple<T1, T2>> pairs);
+}
+
+test<bit<16>, _>({
+    { 16w0, "foo" },
+    { 16w1, "bar" },
+    { 16w2, "baz" }
+}) obj;
+
+test<bit<16>, _>({}) o2;
+
+test<bit<16>, bit<8>>({ { 0, 10}, { 1, 12 }, { 2, 15 } }) o3;

--- a/testdata/p4_16_samples_outputs/listinit-first.p4
+++ b/testdata/p4_16_samples_outputs/listinit-first.p4
@@ -1,0 +1,7 @@
+extern test<T1, T2> {
+    test(list<tuple<T1, T2>> pairs);
+}
+
+test<bit<16>, _>({ { 16w0, "foo" }, { 16w1, "bar" }, { 16w2, "baz" } }) obj;
+test<bit<16>, _>({  }) o2;
+test<bit<16>, bit<8>>({ { 0, 10 }, { 1, 12 }, { 2, 15 } }) o3;

--- a/testdata/p4_16_samples_outputs/listinit-frontend.p4
+++ b/testdata/p4_16_samples_outputs/listinit-frontend.p4
@@ -1,0 +1,7 @@
+extern test<T1, T2> {
+    test(list<tuple<T1, T2>> pairs);
+}
+
+test<bit<16>, _>({ { 16w0, "foo" }, { 16w1, "bar" }, { 16w2, "baz" } }) obj;
+test<bit<16>, _>({  }) o2;
+test<bit<16>, bit<8>>({ { 0, 10 }, { 1, 12 }, { 2, 15 } }) o3;

--- a/testdata/p4_16_samples_outputs/listinit.p4
+++ b/testdata/p4_16_samples_outputs/listinit.p4
@@ -1,0 +1,7 @@
+extern test<T1, T2> {
+    test(list<tuple<T1, T2>> pairs);
+}
+
+test<bit<16>, _>({ { 16w0, "foo" }, { 16w1, "bar" }, { 16w2, "baz" } }) obj;
+test<bit<16>, _>({  }) o2;
+test<bit<16>, bit<8>>({ { 0, 10 }, { 1, 12 }, { 2, 15 } }) o3;

--- a/testdata/p4_16_samples_outputs/listinit.p4-stderr
+++ b/testdata/p4_16_samples_outputs/listinit.p4-stderr
@@ -1,0 +1,10 @@
+listinit.p4(10): [--Wwarn=unused] warning: obj: unused instance
+}) obj;
+   ^^^
+listinit.p4(12): [--Wwarn=unused] warning: o2: unused instance
+test<bit<16>, _>({}) o2;
+                     ^^
+listinit.p4(14): [--Wwarn=unused] warning: o3: unused instance
+test<bit<16>, bit<8>>({ { 0, 10}, { 1, 12 }, { 2, 15 } }) o3;
+                                                          ^^
+[--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
An explicit list type has been in the spec for awhile, but p4c was requiring explicit casts on `{}`-lists to match them to list typed thing in type unification.

This small change allow unification of `{}` lists with type `list` without an explicit cast.