### PR TITLE
Ensure we take compiler-provided declaration of posix_memalign

### DIFF
--- a/.github/workflows/ci-test-debian.yml
+++ b/.github/workflows/ci-test-debian.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       CTEST_PARALLEL_LEVEL: 4
+      COMPILE_WITH_CLANG: ON
       IMAGE_TYPE: test
       BUILD_GENERATOR: Ninja
     steps:
@@ -52,6 +53,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       CTEST_PARALLEL_LEVEL: 4
+      COMPILE_WITH_CLANG: ON
       IMAGE_TYPE: test
       CMAKE_UNITY_BUILD: ${{ matrix.unity }}
       BUILD_GENERATOR: Ninja

--- a/.github/workflows/ci-test-debian.yml
+++ b/.github/workflows/ci-test-debian.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       CTEST_PARALLEL_LEVEL: 4
-      COMPILE_WITH_CLANG: ON
       IMAGE_TYPE: test
       BUILD_GENERATOR: Ninja
     steps:
@@ -53,7 +52,6 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       CTEST_PARALLEL_LEVEL: 4
-      COMPILE_WITH_CLANG: ON
       IMAGE_TYPE: test
       CMAKE_UNITY_BUILD: ${{ matrix.unity }}
       BUILD_GENERATOR: Ninja

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -263,7 +263,7 @@ void *calloc(size_t size, size_t elsize) {
     return rv;
 }
 int posix_memalign(void **memptr, size_t alignment, size_t size)
-#ifndef __APPLE__
+#ifdef __GLIBC__
     noexcept
 #endif
 {

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -14,6 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Some systems (e.g. those with GNU libc) declare posix_memalign with an
+// exception specifier. Compilers (clang including) might have special handling
+// of this to allow posix_memalign redeclaration with / without exception
+// specifier. As we define posix_memalign below in this file we really need to
+// ensure the proper include order to workaround this this weirdness.
+#include <mm_malloc.h>  // NOLINT(build/include_order)
+
 #include "config.h"
 #if HAVE_LIBGC
 #include <gc/gc_cpp.h>
@@ -264,7 +271,7 @@ void *calloc(size_t size, size_t elsize) {
 }
 int posix_memalign(void **memptr, size_t alignment, size_t size)
 #ifdef __GLIBC__
-    noexcept
+    __THROW
 #endif
 {
     maybe_initialize_gc();

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 // exception specifier. Compilers (clang including) might have special handling
 // of this to allow posix_memalign redeclaration with / without exception
 // specifier. As we define posix_memalign below in this file we really need to
-// ensure the proper include order to workaround this this weirdness.
+// ensure the proper include order to workaround this weirdness.
 #include <mm_malloc.h>  // NOLINT(build/include_order)
 
 #include "config.h"


### PR DESCRIPTION
Some systems (e.g. those with GNU libc) declare posix_memalign with an exception specifier. Compilers (clang including) might have special handling of this to allow posix_memalign redeclaration with / without exception specifier. As we override posix_memalign for GC purposes we really need to ensure the proper include order to workaround this weirdness.