### PR TITLE
Set type for LAnd, LOr, LNot to be Type_Boolean if unknown.

### DIFF
--- a/ir/expression.def
+++ b/ir/expression.def
@@ -134,10 +134,12 @@ class BXor : Operation_Binary {
 class LAnd : Operation_Binary {
     stringOp = "&&";
     precedence = DBPrint::Prec_LAnd;
+    LAnd { if (type->is<Type::Unknown>()) type = IR::Type_Boolean::get(); }
 }
 class LOr : Operation_Binary {
     stringOp = "||";
     precedence = DBPrint::Prec_LOr;
+    LOr { if (type->is<Type::Unknown>()) type = IR::Type_Boolean::get(); }
 }
 
 /// Represents the ... default initializer expression

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -29,6 +29,12 @@ class Cmpl : Operation_Unary {
 
 class LNot : Operation_Unary {
     stringOp = "!";
+    LNot {
+        // This sets the type only when no type is explicitly provided in the constructor.
+        // If a type is provided in the constructor this assignment has no effect
+        // because the type member is shadowed by the type parameter.
+        type = Type::Boolean::get();
+    }
 }
 
 abstract Operation_Binary : Operation {
@@ -53,7 +59,12 @@ abstract Operation_Ternary : Operation {
 }
 
 abstract Operation_Relation : Operation_Binary {
-    Operation_Relation { type = Type::Boolean::get(); }
+    Operation_Relation {
+        // This sets the type only when no type is explicitly provided in the constructor.
+        // If a type is provided in the constructor this assignment has no effect
+        // because the type member is shadowed by the type parameter.
+        type = Type::Boolean::get();
+    }
 }
 
 class Mul : Operation_Binary {
@@ -134,13 +145,22 @@ class BXor : Operation_Binary {
 class LAnd : Operation_Binary {
     stringOp = "&&";
     precedence = DBPrint::Prec_LAnd;
-    LAnd { if (type->is<Type::Unknown>()) type = IR::Type_Boolean::get(); }
+    LAnd {
+        // This sets the type only when no type is explicitly provided in the constructor.
+        // If a type is provided in the constructor this assignment has no effect
+        // because the type member is shadowed by the type parameter.
+        type = Type::Boolean::get();
+    }
 }
 class LOr : Operation_Binary {
     stringOp = "||";
     precedence = DBPrint::Prec_LOr;
-    LOr { if (type->is<Type::Unknown>()) type = IR::Type_Boolean::get(); }
-}
+    LOr {
+        // This sets the type only when no type is explicitly provided in the constructor.
+        // If a type is provided in the constructor this assignment has no effect
+        // because the type member is shadowed by the type parameter.
+        type = Type::Boolean::get();
+    }}
 
 /// Represents the ... default initializer expression
 class Dots : Expression {


### PR DESCRIPTION
I ran into issues where I created a `IR::Land(new IR::BoolLiteral(new IR::Type_Boolean(), false), new IR::BoolLiteral(new IR::Type_Boolean(), false))` and the resulting type of the `IR::LAnd` was `IR::Type_Unknown`. This happens because https://github.com/p4lang/p4c/blob/main/ir/expression.def#L39 is comparing pointers, not the actual type. 

Correct me if I am wrong but I believe the default type for Logical AND and OR should be `Type_Boolean`. Do this only when the type is unknown. 
