### PR TITLE
Miscellaneous cleanups for P4Testgen.

### DIFF
--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -290,7 +290,7 @@ const IR::Literal *Z3Solver::toLiteral(const z3::expr &e, const IR::Type *type) 
     // Handle booleans.
     if (type->is<IR::Type::Boolean>()) {
         BUG_CHECK(e.is_bool(), "Expected a boolean value: %1%", e);
-        return new IR::BoolLiteral(type, e.is_true());
+        return IR::getBoolLiteral(e.is_true());
     }
 
     // Handle bit vectors.

--- a/backends/p4tools/common/lib/gen_eq.cpp
+++ b/backends/p4tools/common/lib/gen_eq.cpp
@@ -36,13 +36,11 @@ const IR::Expression *equateListTypes(const IR::Expression *left, const IR::Expr
               "different.",
               leftElemsSize, rightElemsSize);
 
-    const IR::Expression *result = new IR::BoolLiteral(IR::Type::Boolean::get(), true);
-    bool firstLoop = true;
+    const IR::Expression *result = nullptr;
     for (size_t i = 0; i < leftElems.size(); i++) {
         const auto *conjunct = equate(leftElems.at(i), rightElems.at(i));
-        if (firstLoop) {
+        if (result == nullptr) {
             result = conjunct;
-            firstLoop = false;
         } else {
             result = new IR::LAnd(IR::Type::Boolean::get(), result, conjunct);
         }
@@ -62,7 +60,7 @@ const IR::Expression *equate(const IR::Expression *left, const IR::Expression *r
 
     // A single default expression can be matched with a list expression.
     if (left->is<IR::DefaultExpression>() || right->is<IR::DefaultExpression>()) {
-        return new IR::BoolLiteral(IR::Type::Boolean::get(), true);
+        return IR::getBoolLiteral(true);
     }
 
     // If we still have lists after unrolling, compare them.
@@ -82,9 +80,9 @@ const IR::Expression *equate(const IR::Expression *left, const IR::Expression *r
     }
 
     if (const auto *rangeKey = right->to<IR::Range>()) {
-        const auto *boolType = IR::Type::Boolean::get();
-        return new IR::LAnd(boolType, new IR::Leq(boolType, rangeKey->left, left),
-                            new IR::Leq(boolType, left, rangeKey->right));
+        return new IR::LAnd(IR::Type::Boolean::get(),
+                            new IR::Leq(IR::Type::Boolean::get(), rangeKey->left, left),
+                            new IR::Leq(IR::Type::Boolean::get(), left, rangeKey->right));
     }
 
     return mkEq(left, right);

--- a/backends/p4tools/modules/testgen/core/program_info.cpp
+++ b/backends/p4tools/modules/testgen/core/program_info.cpp
@@ -83,11 +83,12 @@ void ProgramInfo::produceCopyInOutCall(const IR::Parameter *param, size_t paramI
     }
     const auto *archPath = new IR::PathExpression(paramType, new IR::Path(archRef));
     const auto *paramRef = new IR::PathExpression(paramType, new IR::Path(param->name));
-    const auto *paramDir = new IR::StringLiteral(directionToString(param->direction));
+    const auto *paramDir =
+        new IR::StringLiteral(IR::Type_String::get(), directionToString(param->direction));
     if (copyIns != nullptr) {
         // This mimicks the copy-in from the architecture environment.
         const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-            "copy_in", {archPath, paramRef, paramDir, new IR::BoolLiteral(false)}));
+            "copy_in", {archPath, paramRef, paramDir, IR::getBoolLiteral(false)}));
         copyIns->emplace_back(copyInCall);
     }
     if (copyOuts != nullptr) {

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
@@ -192,14 +192,12 @@ bool AbstractStepper::stepGetHeaderValidity(const IR::StateVariable &headerRef) 
             const auto *res = value->to<IR::BoolLiteral>();
             BUG_CHECK(res, "%1%: expected a boolean", value);
             if (res->value) {
-                state.replaceTopBody(
-                    Continuation::Return(new IR::BoolLiteral(IR::Type::Boolean::get(), true)));
+                state.replaceTopBody(Continuation::Return(IR::getBoolLiteral(true)));
                 result->emplace_back(state);
                 return false;
             }
         }
-        state.replaceTopBody(
-            Continuation::Return(new IR::BoolLiteral(IR::Type::Boolean::get(), false)));
+        state.replaceTopBody(Continuation::Return(IR::getBoolLiteral(false)));
         result->emplace_back(state);
         return false;
     }

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -18,7 +18,6 @@
 #include "backends/p4tools/common/lib/variables.h"
 #include "ir/declaration.h"
 #include "ir/indexed_vector.h"
-#include "ir/ir-generated.h"
 #include "ir/irutils.h"
 #include "ir/node.h"
 #include "ir/solver.h"

--- a/backends/p4tools/modules/testgen/targets/ebpf/constants.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/constants.cpp
@@ -3,6 +3,6 @@
 namespace P4Tools::P4Testgen::EBPF {
 
 const IR::PathExpression EBPFConstants::ACCEPT_VAR =
-    IR::PathExpression(new IR::Type_Boolean(), new IR::Path("*accept"));
+    IR::PathExpression(IR::Type_Boolean::get(), new IR::Path("*accept"));
 
 }  // namespace P4Tools::P4Testgen::EBPF

--- a/backends/p4tools/modules/testgen/targets/pna/constants.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/constants.cpp
@@ -6,7 +6,7 @@
 namespace P4Tools::P4Testgen::Pna {
 
 const IR::Member PnaConstants::DROP_VAR =
-    IR::Member(new IR::Type_Boolean(), new IR::PathExpression("*pna_internal"), "drop_var");
+    IR::Member(IR::Type_Boolean::get(), new IR::PathExpression("*pna_internal"), "drop_var");
 const IR::Member PnaConstants::OUTPUT_PORT_VAR = IR::Member(
     new IR::Type_Bits(32, false), new IR::PathExpression("*pna_internal"), "output_port");
 const IR::Member PnaConstants::PARSER_ERROR = IR::Member(

--- a/backends/p4tools/modules/testgen/test/z3-solver/constraints.cpp
+++ b/backends/p4tools/modules/testgen/test/z3-solver/constraints.cpp
@@ -5,7 +5,6 @@
 
 #include "backends/p4tools/common/core/z3_solver.h"
 #include "backends/p4tools/common/lib/variables.h"
-#include "ir/ir-generated.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"
 #include "lib/cstring.h"

--- a/test/gtest/visitor.cpp
+++ b/test/gtest/visitor.cpp
@@ -47,7 +47,7 @@ struct MultiVisitInspector : public Inspector, virtual public P4::ResolutionCont
         }
     }
 
-    bool preorder(const IR::PathExpression *path) {
+    bool preorder(const IR::PathExpression *path) override {
         visit_def(path);
         return true;
     }


### PR DESCRIPTION
- Remove ir-generated includes.
- Use `IR::getBoolLiteral` where possible.
- Reduce the amount of unnecessary `IR::Boolliteral(true)` use.