### PR TITLE
Move IRUtils Literal get functions to the respective IR members. Add stringliteral get function. 

### DIFF
--- a/backends/p4tools/common/compiler/configuration.h
+++ b/backends/p4tools/common/compiler/configuration.h
@@ -2,7 +2,6 @@
 #define BACKENDS_P4TOOLS_COMMON_COMPILER_CONFIGURATION_H_
 
 #include <climits>
-#include <limits>
 
 #include "ir/configuration.h"
 
@@ -12,7 +11,7 @@ namespace P4Tools {
 /// integer.
 class CompilerConfiguration : public DefaultP4CConfiguration {
  public:
-    int maximumWidthSupported() const override { return INT_MAX; }
+    [[nodiscard]] int maximumWidthSupported() const override { return INT_MAX; }
 
     /// @return the singleton instance.
     static const CompilerConfiguration &get() {

--- a/backends/p4tools/common/compiler/convert_hs_index.cpp
+++ b/backends/p4tools/common/compiler/convert_hs_index.cpp
@@ -18,7 +18,7 @@ const IR::Node *HSIndexToMember::postorder(IR::ArrayIndex *curArrayIndex) {
 const IR::ArrayIndex *HSIndexToMember::produceStackIndex(const IR::Type *type,
                                                          const IR::Expression *expression,
                                                          size_t arrayIndex) {
-    return new IR::ArrayIndex(type, expression, IR::getConstant(IR::getBitType(32), arrayIndex));
+    return new IR::ArrayIndex(type, expression, IR::Constant::get(IR::getBitType(32), arrayIndex));
 }
 
 }  // namespace P4Tools

--- a/backends/p4tools/common/compiler/convert_struct_expr.cpp
+++ b/backends/p4tools/common/compiler/convert_struct_expr.cpp
@@ -13,7 +13,7 @@ const IR::Node *ConvertStructExpr::postorder(IR::StructExpression *structExpr) {
     }
     if (structType->is<IR::Type_Header>()) {
         return new IR::HeaderExpression(structExpr->srcInfo, structType, structExpr->type,
-                                        structExpr->components, IR::getBoolLiteral(true));
+                                        structExpr->components, IR::BoolLiteral::get(true));
     }
     if (resolved) {
         return new IR::StructExpression(structExpr->srcInfo, structType, structExpr->type,

--- a/backends/p4tools/common/core/abstract_execution_state.cpp
+++ b/backends/p4tools/common/core/abstract_execution_state.cpp
@@ -176,7 +176,7 @@ void AbstractExecutionState::initializeStructLike(const Target &target,
     std::vector<IR::StateVariable> flatTargetValids;
     auto flatTargetFields = getFlatFields(targetVar, &flatTargetValids);
     for (const auto &fieldTargetValid : flatTargetValids) {
-        set(fieldTargetValid, IR::getBoolLiteral(false));
+        set(fieldTargetValid, IR::BoolLiteral::get(false));
     }
     for (const auto &flatTargetRef : flatTargetFields) {
         set(flatTargetRef, target.createTargetUninitialized(flatTargetRef->type, forceTaint));

--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -290,7 +290,7 @@ const IR::Literal *Z3Solver::toLiteral(const z3::expr &e, const IR::Type *type) 
     // Handle booleans.
     if (type->is<IR::Type::Boolean>()) {
         BUG_CHECK(e.is_bool(), "Expected a boolean value: %1%", e);
-        return IR::getBoolLiteral(e.is_true());
+        return IR::BoolLiteral::get(e.is_true());
     }
 
     // Handle bit vectors.
@@ -306,7 +306,7 @@ const IR::Literal *Z3Solver::toLiteral(const z3::expr &e, const IR::Type *type) 
         strNum.erase(remove(strNum.begin(), strNum.end(), ' '), strNum.end());
     }
     big_int bigint(strNum.c_str());
-    return IR::getConstant(type, bigint);
+    return IR::Constant::get(type, bigint);
 }
 
 void Z3Solver::toJSON(JSONGenerator &json) const {
@@ -491,7 +491,7 @@ const ShiftType *Z3Translator::rewriteShift(const ShiftType *shift) const {
     // vector.
     const auto *shiftAmount = right->to<IR::Constant>();
     BUG_CHECK(shiftAmount, "Shift amount is not a compile-time known constant: %1%", right);
-    const auto *newShiftAmount = IR::getConstant(left->type, shiftAmount->value);
+    const auto *newShiftAmount = IR::Constant::get(left->type, shiftAmount->value);
 
     return new ShiftType(shift->type, left, newShiftAmount);
 }

--- a/backends/p4tools/common/lib/gen_eq.cpp
+++ b/backends/p4tools/common/lib/gen_eq.cpp
@@ -60,7 +60,7 @@ const IR::Expression *equate(const IR::Expression *left, const IR::Expression *r
 
     // A single default expression can be matched with a list expression.
     if (left->is<IR::DefaultExpression>() || right->is<IR::DefaultExpression>()) {
-        return IR::getBoolLiteral(true);
+        return IR::BoolLiteral::get(true);
     }
 
     // If we still have lists after unrolling, compare them.

--- a/backends/p4tools/common/lib/table_utils.cpp
+++ b/backends/p4tools/common/lib/table_utils.cpp
@@ -89,11 +89,11 @@ const IR::Expression *computeEntryMatch(const IR::P4Table &table, const IR::Entr
     auto numKeys = key.keyElements.size();
     // If there are no entries or keys, there is nothing we can match against.
     if (numKeys == 0) {
-        return IR::getBoolLiteral(false);
+        return IR::BoolLiteral::get(false);
     }
     BUG_CHECK(key.keyElements.size() == entry.keys->size(),
               "The entry key list and key match list must be equal in size.");
-    const IR::Expression *entryMatchCondition = IR::getBoolLiteral(true);
+    const IR::Expression *entryMatchCondition = IR::BoolLiteral::get(true);
     for (size_t idx = 0; idx < numKeys; ++idx) {
         const auto *keyElement = key.keyElements.at(idx);
         const auto *keyExpr = keyElement->expression;

--- a/backends/p4tools/common/lib/taint.cpp
+++ b/backends/p4tools/common/lib/taint.cpp
@@ -215,7 +215,7 @@ class TaintPropagator : public Transform {
         }
         // Otherwise we convert the expression to a constant of the sliced type.
         // Ultimately, the value here does not matter.
-        return IR::getConstant(sliceTb, 0);
+        return IR::Constant::get(sliceTb, 0);
     }
 
  public:
@@ -231,7 +231,7 @@ class MaskBuilder : public Transform {
 
     const IR::Node *preorder(IR::PathExpression *path) override {
         // Non-tainted members just return the max value, which corresponds to a mask of all zeroes.
-        return IR::getConstant(path->type, IR::getMaxBvVal(path->type));
+        return IR::Constant::get(path->type, IR::getMaxBvVal(path->type));
     }
 
     const IR::Node *preorder(IR::TaintExpression *taintExpr) override {

--- a/backends/p4tools/common/lib/util.cpp
+++ b/backends/p4tools/common/lib/util.cpp
@@ -76,13 +76,13 @@ const IR::Constant *Utils::getRandConstantForWidth(int bitWidth) {
     auto maxVal = IR::getMaxBvVal(bitWidth);
     auto randInt = Utils::getRandBigInt(maxVal);
     const auto *constType = IR::getBitType(bitWidth);
-    return IR::getConstant(constType, randInt);
+    return IR::Constant::get(constType, randInt);
 }
 
 const IR::Constant *Utils::getRandConstantForType(const IR::Type_Bits *type) {
     auto maxVal = IR::getMaxBvVal(type->width_bits());
     auto randInt = Utils::getRandBigInt(maxVal);
-    return IR::getConstant(type, randInt);
+    return IR::Constant::get(type, randInt);
 }
 
 /* =========================================================================================

--- a/backends/p4tools/modules/testgen/core/program_info.cpp
+++ b/backends/p4tools/modules/testgen/core/program_info.cpp
@@ -83,8 +83,7 @@ void ProgramInfo::produceCopyInOutCall(const IR::Parameter *param, size_t paramI
     }
     const auto *archPath = new IR::PathExpression(paramType, new IR::Path(archRef));
     const auto *paramRef = new IR::PathExpression(paramType, new IR::Path(param->name));
-    const auto *paramDir =
-        new IR::StringLiteral(IR::Type_String::get(), directionToString(param->direction));
+    const auto *paramDir = IR::getStringLiteral(directionToString(param->direction));
     if (copyIns != nullptr) {
         // This mimicks the copy-in from the architecture environment.
         const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(

--- a/backends/p4tools/modules/testgen/core/program_info.cpp
+++ b/backends/p4tools/modules/testgen/core/program_info.cpp
@@ -83,11 +83,11 @@ void ProgramInfo::produceCopyInOutCall(const IR::Parameter *param, size_t paramI
     }
     const auto *archPath = new IR::PathExpression(paramType, new IR::Path(archRef));
     const auto *paramRef = new IR::PathExpression(paramType, new IR::Path(param->name));
-    const auto *paramDir = IR::getStringLiteral(directionToString(param->direction));
+    const auto *paramDir = IR::StringLiteral::get(directionToString(param->direction));
     if (copyIns != nullptr) {
         // This mimicks the copy-in from the architecture environment.
         const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-            "copy_in", {archPath, paramRef, paramDir, IR::getBoolLiteral(false)}));
+            "copy_in", {archPath, paramRef, paramDir, IR::BoolLiteral::get(false)}));
         copyIns->emplace_back(copyInCall);
     }
     if (copyOuts != nullptr) {

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
@@ -192,12 +192,12 @@ bool AbstractStepper::stepGetHeaderValidity(const IR::StateVariable &headerRef) 
             const auto *res = value->to<IR::BoolLiteral>();
             BUG_CHECK(res, "%1%: expected a boolean", value);
             if (res->value) {
-                state.replaceTopBody(Continuation::Return(IR::getBoolLiteral(true)));
+                state.replaceTopBody(Continuation::Return(IR::BoolLiteral::get(true)));
                 result->emplace_back(state);
                 return false;
             }
         }
-        state.replaceTopBody(Continuation::Return(IR::getBoolLiteral(false)));
+        state.replaceTopBody(Continuation::Return(IR::BoolLiteral::get(false)));
         result->emplace_back(state);
         return false;
     }
@@ -212,7 +212,7 @@ bool AbstractStepper::stepGetHeaderValidity(const IR::StateVariable &headerRef) 
 void AbstractStepper::setHeaderValidity(const IR::StateVariable &headerRef, bool validity,
                                         ExecutionState &nextState) {
     const auto &headerRefValidity = ToolsVariables::getHeaderValidity(headerRef);
-    nextState.set(headerRefValidity, IR::getBoolLiteral(validity));
+    nextState.set(headerRefValidity, IR::BoolLiteral::get(validity));
 
     // In some cases, the header may be `part of a union.
     if (validity) {
@@ -351,7 +351,7 @@ void AbstractStepper::setTargetUninitialized(ExecutionState &nextState,
         auto fields = nextState.getFlatFields(ref, &validFields);
         // We also need to initialize the validity bits of the headers. These are false.
         for (const auto &validField : validFields) {
-            nextState.set(validField, IR::getBoolLiteral(false));
+            nextState.set(validField, IR::BoolLiteral::get(false));
         }
         // For each field in the undefined struct, we create a new symbolic variable.
         // If the variable does not have an initializer we need to create a new variable for it.
@@ -373,7 +373,7 @@ void AbstractStepper::declareStructLike(ExecutionState &nextState,
     auto fields = nextState.getFlatFields(parentExpr, &validFields);
     // We also need to initialize the validity bits of the headers. These are false.
     for (const auto &validField : validFields) {
-        nextState.set(validField, IR::getBoolLiteral(false));
+        nextState.set(validField, IR::BoolLiteral::get(false));
     }
     // For each field in the undefined struct, we create a new symbolic variable.
     // If the variable does not have an initializer we need to create a new variable for it.

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -284,8 +284,8 @@ bool CmdStepper::preorder(const IR::P4Program * /*program*/) {
         std::optional<const Constraint *> portRangeCond = std::nullopt;
         const auto &inputPortVar = programInfo.getTargetInputPortVar();
         for (auto portRange : options.permittedPortRanges) {
-            const auto *loVarIn = IR::getConstant(inputPortVar->type, portRange.first);
-            const auto *hiVarIn = IR::getConstant(inputPortVar->type, portRange.second);
+            const auto *loVarIn = IR::Constant::get(inputPortVar->type, portRange.first);
+            const auto *hiVarIn = IR::Constant::get(inputPortVar->type, portRange.second);
             if (portRangeCond.has_value()) {
                 portRangeCond = new IR::LOr(portRangeCond.value(),
                                             new IR::LAnd(new IR::Leq(loVarIn, inputPortVar),
@@ -308,7 +308,7 @@ bool CmdStepper::preorder(const IR::P4Program * /*program*/) {
     if (pktSize != 0) {
         const auto *fixedSizeEqu =
             new IR::Geq(ExecutionState::getInputPacketSizeVar(),
-                        IR::getConstant(&PacketVars::PACKET_SIZE_VAR_TYPE, pktSize));
+                        IR::Constant::get(&PacketVars::PACKET_SIZE_VAR_TYPE, pktSize));
         if (cond == std::nullopt) {
             cond = fixedSizeEqu;
         } else {
@@ -446,7 +446,7 @@ const Constraint *CmdStepper::startParser(const IR::P4Parser *parser, ExecutionS
     const auto *boolType = IR::Type::Boolean::get();
     const Constraint *result =
         new IR::Leq(boolType, ExecutionState::getInputPacketSizeVar(),
-                    IR::getConstant(parserCursorVarType, ExecutionState::getMaxPacketLength()));
+                    IR::Constant::get(parserCursorVarType, ExecutionState::getMaxPacketLength()));
 
     // Constrain the input packet size to be a multiple of 8 bits. Do this by constraining the
     // lowest three bits of the packet size to 0.
@@ -455,9 +455,9 @@ const Constraint *CmdStepper::startParser(const IR::P4Parser *parser, ExecutionS
         boolType, result,
         new IR::Equ(boolType,
                     new IR::Slice(threeBitType, ExecutionState::getInputPacketSizeVar(),
-                                  IR::getConstant(parserCursorVarType, 2),
-                                  IR::getConstant(parserCursorVarType, 0)),
-                    IR::getConstant(threeBitType, 0)));
+                                  IR::Constant::get(parserCursorVarType, 2),
+                                  IR::Constant::get(parserCursorVarType, 0)),
+                    IR::Constant::get(threeBitType, 0)));
 
     // Call the implementation for the specific target.
     // If we get a constraint back, add it to the result.

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -303,7 +303,7 @@ bool ExprStepper::preorder(const IR::PathExpression *pathExpression) {
     // If the path expression is a Type_MatchKind, convert it to a StringLiteral.
     if (pathExpression->type->is<IR::Type_MatchKind>()) {
         state.replaceTopBody(Continuation::Return(
-            new IR::StringLiteral(IR::Type_MatchKind::get(), pathExpression->path->name)));
+            IR::getStringLiteral(pathExpression->path->name, IR::Type_MatchKind::get())));
         result->emplace_back(state);
         return false;
     }

--- a/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/expr_stepper.cpp
@@ -303,7 +303,7 @@ bool ExprStepper::preorder(const IR::PathExpression *pathExpression) {
     // If the path expression is a Type_MatchKind, convert it to a StringLiteral.
     if (pathExpression->type->is<IR::Type_MatchKind>()) {
         state.replaceTopBody(Continuation::Return(
-            IR::getStringLiteral(pathExpression->path->name, IR::Type_MatchKind::get())));
+            IR::StringLiteral::get(pathExpression->path->name, IR::Type_MatchKind::get())));
         result->emplace_back(state);
         return false;
     }
@@ -423,7 +423,7 @@ bool ExprStepper::preorder(const IR::SelectExpression *selectExpression) {
         }
     }
 
-    const IR::Expression *missCondition = IR::getBoolLiteral(true);
+    const IR::Expression *missCondition = IR::BoolLiteral::get(true);
     bool hasDefault = false;
     for (const auto *selectCase : selectCases) {
         auto &nextState = state.clone();

--- a/backends/p4tools/modules/testgen/core/small_step/small_step.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/small_step.cpp
@@ -31,11 +31,11 @@
 namespace P4Tools::P4Testgen {
 
 SmallStepEvaluator::Branch::Branch(ExecutionState &nextState)
-    : constraint(IR::getBoolLiteral(true)), nextState(nextState) {}
+    : constraint(IR::BoolLiteral::get(true)), nextState(nextState) {}
 
 SmallStepEvaluator::Branch::Branch(std::optional<const Constraint *> c,
                                    const ExecutionState &prevState, ExecutionState &nextState)
-    : constraint(IR::getBoolLiteral(true)), nextState(nextState) {
+    : constraint(IR::BoolLiteral::get(true)), nextState(nextState) {
     if (c) {
         // Evaluate the branch constraint in the current state of symbolic environment.
         // Substitutes all variables to their symbolic value (expression on the program's initial
@@ -51,7 +51,7 @@ SmallStepEvaluator::Branch::Branch(std::optional<const Constraint *> c,
 SmallStepEvaluator::Branch::Branch(std::optional<const Constraint *> c,
                                    const ExecutionState &prevState, ExecutionState &nextState,
                                    P4::Coverage::CoverageSet potentialNodes)
-    : constraint(IR::getBoolLiteral(true)),
+    : constraint(IR::BoolLiteral::get(true)),
       nextState(nextState),
       potentialNodes(std::move(potentialNodes)) {
     if (c) {
@@ -223,7 +223,7 @@ class CommandVisitor {
                 " Incrementing number of guard violations.",
                 condStream.str().c_str());
             self.get().violatedGuardConditions++;
-            return new std::vector<Branch>({{IR::getBoolLiteral(false), state, nextState}});
+            return new std::vector<Branch>({{IR::BoolLiteral::get(false), state, nextState}});
         }
         // Otherwise, we proceed as usual.
         return new std::vector<Branch>({{cond, state, nextState}});

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -148,8 +148,7 @@ const IR::Expression *TableStepper::computeHit(TableMatchMap *matches) {
 
 const IR::StringLiteral *TableStepper::getTableActionString(
     const IR::MethodCallExpression *actionCall) {
-    cstring actionName = actionCall->method->toString();
-    return new IR::StringLiteral(IR::Type_String::get(), actionName);
+    return IR::getStringLiteral(actionCall->method->toString());
 }
 
 const IR::Expression *TableStepper::evalTableConstEntries() {

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.cpp
@@ -96,7 +96,7 @@ const IR::Expression *TableStepper::computeTargetMatchType(
         const IR::Expression *ternaryMask = nullptr;
         // We can recover from taint by inserting a ternary match that is 0.
         if (keyProperties.isTainted) {
-            ternaryMask = IR::getConstant(keyExpr->type, 0);
+            ternaryMask = IR::Constant::get(keyExpr->type, 0);
             keyExpr = ternaryMask;
         } else {
             ternaryMask = ControlPlaneState::getTableTernaryMask(properties.tableName,
@@ -115,22 +115,22 @@ const IR::Expression *TableStepper::computeTargetMatchType(
         // The maxReturn is the maximum vale for the given bit width. This value is shifted by
         // the mask variable to create a mask (and with that, a prefix).
         auto maxReturn = IR::getMaxBvVal(keyWidth);
-        auto *prefix = new IR::Sub(IR::getConstant(keyType, keyWidth), maskVar);
+        auto *prefix = new IR::Sub(IR::Constant::get(keyType, keyWidth), maskVar);
         const IR::Expression *lpmMask = nullptr;
         // We can recover from taint by inserting a ternary match that is 0.
         if (keyProperties.isTainted) {
-            lpmMask = IR::getConstant(keyExpr->type, 0);
+            lpmMask = IR::Constant::get(keyExpr->type, 0);
             maskVar = lpmMask;
             keyExpr = lpmMask;
         } else {
-            lpmMask = new IR::Shl(IR::getConstant(keyType, maxReturn), prefix);
+            lpmMask = new IR::Shl(IR::Constant::get(keyType, maxReturn), prefix);
         }
         matches->emplace(keyProperties.name, new LPM(keyProperties.key, ctrlPlaneKey, maskVar));
         return new IR::LAnd(
             hitCondition,
             new IR::LAnd(
                 // This is the actual LPM match under the shifted mask (the prefix).
-                new IR::Leq(maskVar, IR::getConstant(keyType, keyWidth)),
+                new IR::Leq(maskVar, IR::Constant::get(keyType, keyWidth)),
                 // The mask variable shift should not be larger than the key width.
                 new IR::Equ(new IR::BAnd(keyExpr, lpmMask), new IR::BAnd(ctrlPlaneKey, lpmMask))));
     }
@@ -139,7 +139,7 @@ const IR::Expression *TableStepper::computeTargetMatchType(
 }
 
 const IR::Expression *TableStepper::computeHit(TableMatchMap *matches) {
-    const IR::Expression *hitCondition = IR::getBoolLiteral(!properties.resolvedKeys.empty());
+    const IR::Expression *hitCondition = IR::BoolLiteral::get(!properties.resolvedKeys.empty());
     for (auto keyProperties : properties.resolvedKeys) {
         hitCondition = computeTargetMatchType(keyProperties, matches, hitCondition);
     }
@@ -148,11 +148,11 @@ const IR::Expression *TableStepper::computeHit(TableMatchMap *matches) {
 
 const IR::StringLiteral *TableStepper::getTableActionString(
     const IR::MethodCallExpression *actionCall) {
-    return IR::getStringLiteral(actionCall->method->toString());
+    return IR::StringLiteral::get(actionCall->method->toString());
 }
 
 const IR::Expression *TableStepper::evalTableConstEntries() {
-    const IR::Expression *tableMissCondition = IR::getBoolLiteral(true);
+    const IR::Expression *tableMissCondition = IR::BoolLiteral::get(true);
 
     const auto *key = table->getKey();
     BUG_CHECK(key != nullptr, "An empty key list should have been handled earlier.");
@@ -189,7 +189,7 @@ const IR::Expression *TableStepper::evalTableConstEntries() {
         // Update all the tracking variables for tables.
         std::vector<Continuation::Command> replacements;
         replacements.emplace_back(new IR::MethodCallStatement(Util::SourceInfo(), tableAction));
-        nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
+        nextState.set(getTableHitVar(table), IR::BoolLiteral::get(true));
         nextState.set(getTableActionVar(table), getTableActionString(tableAction));
 
         // Some path selection strategies depend on looking ahead and collecting potential
@@ -286,7 +286,7 @@ void TableStepper::setTableDefaultEntries(
             auto collector = CoverableNodesScanner(stepper->state);
             collector.updateNodeCoverage(actionType, coveredNodes);
         }
-        nextState.set(getTableHitVar(table), IR::getBoolLiteral(false));
+        nextState.set(getTableHitVar(table), IR::BoolLiteral::get(false));
         nextState.set(getTableActionVar(table), getTableActionString(tableAction));
         std::stringstream tableStream;
         tableStream << "Table Branch: " << properties.tableName;
@@ -354,7 +354,7 @@ void TableStepper::evalTableControlEntries(
             collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
-        nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
+        nextState.set(getTableHitVar(table), IR::BoolLiteral::get(true));
         nextState.set(getTableActionVar(table), getTableActionString(tableAction));
 
         std::stringstream tableStream;
@@ -509,7 +509,7 @@ void TableStepper::addDefaultAction(std::optional<const IR::Expression *> tableM
         auto collector = CoverableNodesScanner(stepper->state);
         collector.updateNodeCoverage(actionType, coveredNodes);
     }
-    nextState.set(getTableHitVar(table), IR::getBoolLiteral(false));
+    nextState.set(getTableHitVar(table), IR::BoolLiteral::get(false));
     nextState.set(getTableActionVar(table), getTableActionString(tableAction));
 
     nextState.replaceTopBody(&replacements);

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
@@ -73,7 +73,8 @@ class TableStepper {
 
     /// Sets the action taken by the given table. The arguments in the given MethodCallExpression
     /// are assumed to be symbolic values.
-    const IR::StringLiteral *getTableActionString(const IR::MethodCallExpression *actionCall);
+    static const IR::StringLiteral *getTableActionString(
+        const IR::MethodCallExpression *actionCall);
 
     /// A helper function to iteratively resolve table keys into symbolic values.
     /// This function returns false, if no key needs to be resolved.

--- a/backends/p4tools/modules/testgen/lib/execution_state.cpp
+++ b/backends/p4tools/modules/testgen/lib/execution_state.cpp
@@ -67,8 +67,8 @@ ExecutionState::ExecutionState(const IR::P4Program *program)
     : AbstractExecutionState(program),
       body({program}),
       stack(*(new std::stack<std::reference_wrapper<const StackFrame>>())) {
-    env.set(&PacketVars::INPUT_PACKET_LABEL, IR::getConstant(IR::getBitType(0), 0));
-    env.set(&PacketVars::PACKET_BUFFER_LABEL, IR::getConstant(IR::getBitType(0), 0));
+    env.set(&PacketVars::INPUT_PACKET_LABEL, IR::Constant::get(IR::getBitType(0), 0));
+    env.set(&PacketVars::PACKET_BUFFER_LABEL, IR::Constant::get(IR::getBitType(0), 0));
     // We also add the taint property and set it to false.
     setProperty("inUndefinedState", false);
     // Drop is initialized to false, too.
@@ -507,7 +507,7 @@ void ExecutionState::prependToPacketBuffer(const IR::Expression *expr) {
 }
 
 void ExecutionState::resetPacketBuffer() {
-    env.set(&PacketVars::PACKET_BUFFER_LABEL, IR::getConstant(IR::getBitType(0), 0));
+    env.set(&PacketVars::PACKET_BUFFER_LABEL, IR::Constant::get(IR::getBitType(0), 0));
 }
 
 const IR::Expression *ExecutionState::getEmitBuffer() const {
@@ -515,7 +515,7 @@ const IR::Expression *ExecutionState::getEmitBuffer() const {
 }
 
 void ExecutionState::resetEmitBuffer() {
-    env.set(&PacketVars::EMIT_BUFFER_LABEL, IR::getConstant(IR::getBitType(0), 0));
+    env.set(&PacketVars::EMIT_BUFFER_LABEL, IR::Constant::get(IR::getBitType(0), 0));
 }
 
 void ExecutionState::appendToEmitBuffer(const IR::Expression *expr) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/cmd_stepper.cpp
@@ -82,22 +82,22 @@ void Bmv2V1ModelCmdStepper::initializeTargetEnvironment(ExecutionState &nextStat
     nextState.set(programInfo.getTargetInputPortVar(),
                   ToolsVariables::getSymbolicVariable(nineBitType, "bmv2_ingress_port"));
     // BMv2 implicitly sets the output port to 0.
-    nextState.set(programInfo.getTargetOutputPortVar(), IR::getConstant(nineBitType, 0));
+    nextState.set(programInfo.getTargetOutputPortVar(), IR::Constant::get(nineBitType, 0));
     // Initialize parser_err with no error.
     const auto *parserErrVar =
         new IR::Member(programInfo.getParserErrorType(),
                        new IR::PathExpression("*standard_metadata"), "parser_error");
-    nextState.set(parserErrVar, IR::getConstant(parserErrVar->type, 0));
+    nextState.set(parserErrVar, IR::Constant::get(parserErrVar->type, 0));
     // Initialize checksum_error with no error.
     const auto *checksumErrVar =
         new IR::Member(oneBitType, new IR::PathExpression("*standard_metadata"), "checksum_error");
-    nextState.set(checksumErrVar, IR::getConstant(checksumErrVar->type, 0));
+    nextState.set(checksumErrVar, IR::Constant::get(checksumErrVar->type, 0));
     // The packet size meta data is the testgen packet length variable divided by 8.
     const auto *pktSizeType = &PacketVars::PACKET_SIZE_VAR_TYPE;
     const auto *packetSizeVar =
         new IR::Member(pktSizeType, new IR::PathExpression("*standard_metadata"), "packet_length");
     const auto *packetSizeConst = new IR::Div(pktSizeType, ExecutionState::getInputPacketSizeVar(),
-                                              IR::getConstant(pktSizeType, 8));
+                                              IR::Constant::get(pktSizeType, 8));
     nextState.set(packetSizeVar, packetSizeConst);
 }
 
@@ -135,7 +135,7 @@ std::map<Continuation::Exception, Continuation> Bmv2V1ModelCmdStepper::getExcept
                 Continuation::Exception::PacketTooShort,
                 Continuation::Body({new IR::AssignmentStatement(
                     errVar,
-                    IR::getConstant(errVar->type, P4Constants::PARSER_ERROR_PACKET_TOO_SHORT))}));
+                    IR::Constant::get(errVar->type, P4Constants::PARSER_ERROR_PACKET_TOO_SHORT))}));
             // NoMatch will transition to the next block.
             result.emplace(Continuation::Exception::NoMatch, Continuation::Body({}));
             break;

--- a/backends/p4tools/modules/testgen/targets/bmv2/concolic.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/concolic.cpp
@@ -71,7 +71,7 @@ big_int Bmv2Concolic::computeChecksum(const std::vector<const IR::Expression *> 
         if (remainder != 0) {
             auto fillWidth = CHUNK_SIZE - remainder;
             concatWidth += fillWidth;
-            const auto *remainderExpr = IR::getConstant(IR::getBitType(fillWidth), 0);
+            const auto *remainderExpr = IR::Constant::get(IR::getBitType(fillWidth), 0);
             concatExpr = new IR::Concat(IR::getBitType(concatWidth), concatExpr, remainderExpr);
         }
         auto dataInt =
@@ -141,7 +141,8 @@ const ConcolicMethodImpls::ImplList Bmv2Concolic::BMV2_CONCOLIC_METHOD_IMPLS{
          // Assign a value to the @param result using the computed result
          if (const auto *checksumVarType = checksumVar->type->to<IR::Type_Bits>()) {
              // Overwrite any previous assignment or result.
-             (*resolvedConcolicVariables)[*var] = IR::getConstant(checksumVarType, computedResult);
+             (*resolvedConcolicVariables)[*var] =
+                 IR::Constant::get(checksumVarType, computedResult);
 
          } else {
              TESTGEN_UNIMPLEMENTED("Checksum output %1% of type %2% not supported", checksumVar,
@@ -194,7 +195,8 @@ const ConcolicMethodImpls::ImplList Bmv2Concolic::BMV2_CONCOLIC_METHOD_IMPLS{
          // Assign a value to the @param result using the computed result
          if (checksumVarType->is<IR::Type_Bits>()) {
              // Overwrite any previous assignment or result.
-             (*resolvedConcolicVariables)[*var] = IR::getConstant(checksumVarType, computedResult);
+             (*resolvedConcolicVariables)[*var] =
+                 IR::Constant::get(checksumVarType, computedResult);
          } else {
              TESTGEN_UNIMPLEMENTED("Checksum output %1% of type %2% not supported", checksumVar,
                                    checksumVarType);
@@ -248,7 +250,8 @@ const ConcolicMethodImpls::ImplList Bmv2Concolic::BMV2_CONCOLIC_METHOD_IMPLS{
          // Assign a value to the @param result using the computed result
          if (checksumVarType->is<IR::Type_Bits>()) {
              // Overwrite any previous assignment or result.
-             (*resolvedConcolicVariables)[*var] = IR::getConstant(checksumVarType, computedResult);
+             (*resolvedConcolicVariables)[*var] =
+                 IR::Constant::get(checksumVarType, computedResult);
          } else {
              TESTGEN_UNIMPLEMENTED("Checksum output %1% of type %2% not supported", checksumVar,
                                    checksumVarType);

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
@@ -147,9 +147,9 @@ const IR::Expression *makeConstant(Token input, const IdenitifierTypeMap &typeMa
     }
     if (input.is(Token::Kind::Number)) {
         if (leftType == nullptr) {
-            return IR::getConstant(IR::Type_Bits::get(32), big_int(std::string(inputStr)));
+            return IR::Constant::get(IR::Type_Bits::get(32), big_int(std::string(inputStr)));
         }
-        return IR::getConstant(leftType, big_int(std::string(inputStr)));
+        return IR::Constant::get(leftType, big_int(std::string(inputStr)));
     }
     // TODO: Is this the right solution for priorities?
     if (input.is(Token::Kind::Priority)) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -120,7 +120,7 @@ std::vector<Continuation::Command> Bmv2V1ModelProgramInfo::processDeclaration(
     std::vector<Continuation::Command> cmds;
     // Copy-in.
     const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_in", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_in", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyInCall);
@@ -128,7 +128,7 @@ std::vector<Continuation::Command> Bmv2V1ModelProgramInfo::processDeclaration(
     cmds.emplace_back(typeDecl);
     // Copy-out.
     const auto *copyOutCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_out", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_out", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyOutCall);

--- a/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/program_info.cpp
@@ -73,7 +73,7 @@ Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(
     }
     const IR::Expression *constraint =
         new IR::Grt(IR::Type::Boolean::get(), ExecutionState::getInputPacketSizeVar(),
-                    IR::getConstant(&PacketVars::PACKET_SIZE_VAR_TYPE, minPktSize));
+                    IR::Constant::get(&PacketVars::PACKET_SIZE_VAR_TYPE, minPktSize));
 
     for (const auto &restriction : compilerResult.getP4ConstraintsRestrictions()) {
         constraint = new IR::LAnd(constraint, restriction);
@@ -120,7 +120,7 @@ std::vector<Continuation::Command> Bmv2V1ModelProgramInfo::processDeclaration(
     std::vector<Continuation::Command> cmds;
     // Copy-in.
     const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_in", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_in", {IR::StringLiteral::get(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyInCall);
@@ -128,7 +128,7 @@ std::vector<Continuation::Command> Bmv2V1ModelProgramInfo::processDeclaration(
     cmds.emplace_back(typeDecl);
     // Copy-out.
     const auto *copyOutCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_out", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_out", {IR::StringLiteral::get(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyOutCall);
@@ -152,8 +152,8 @@ std::vector<Continuation::Command> Bmv2V1ModelProgramInfo::processDeclaration(
             const IR::Expression *cond = new IR::Equ(
                 outPortVar, new IR::Constant(outPortVar->type, BMv2Constants::DROP_PORT));
             for (auto portRange : options.permittedPortRanges) {
-                const auto *loVarOut = IR::getConstant(outPortVar->type, portRange.first);
-                const auto *hiVarOut = IR::getConstant(outPortVar->type, portRange.second);
+                const auto *loVarOut = IR::Constant::get(outPortVar->type, portRange.first);
+                const auto *hiVarOut = IR::Constant::get(outPortVar->type, portRange.second);
                 cond = new IR::LOr(cond, new IR::LAnd(new IR::Leq(loVarOut, outPortVar),
                                                       new IR::Leq(outPortVar, hiVarOut)));
             }
@@ -163,7 +163,7 @@ std::vector<Continuation::Command> Bmv2V1ModelProgramInfo::processDeclaration(
         // Drop the packet if the multicast group is set.
         const IR::Expression *mcastGroupVar = new IR::Member(
             IR::getBitType(16), new IR::PathExpression("*standard_metadata"), "mcast_grp");
-        mcastGroupVar = new IR::Neq(mcastGroupVar, IR::getConstant(IR::getBitType(16), 0));
+        mcastGroupVar = new IR::Neq(mcastGroupVar, IR::Constant::get(IR::getBitType(16), 0));
         auto *mcastStmt = new IR::IfStatement(mcastGroupVar, dropStmt, nullptr);
         cmds.emplace_back(mcastStmt);
     }
@@ -197,7 +197,7 @@ const IR::StateVariable &Bmv2V1ModelProgramInfo::getTargetOutputPortVar() const 
 
 const IR::Expression *Bmv2V1ModelProgramInfo::dropIsActive() const {
     const auto &egressPortVar = getTargetOutputPortVar();
-    return new IR::Equ(IR::getConstant(egressPortVar->type, BMv2Constants::DROP_PORT),
+    return new IR::Equ(IR::Constant::get(egressPortVar->type, BMv2Constants::DROP_PORT),
                        egressPortVar);
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/table_stepper.cpp
@@ -47,7 +47,7 @@ const IR::Expression *Bmv2V1ModelTableStepper::computeTargetMatchType(
         // We can recover from taint by simply not adding the optional match.
         // Create a new symbolic variable that corresponds to the key expression.
         // We can recover from taint by inserting a ternary match that is 0.
-        const auto *wildCard = IR::getConstant(keyExpr->type, 0);
+        const auto *wildCard = IR::Constant::get(keyExpr->type, 0);
         if (keyProperties.isTainted) {
             matches->emplace(keyProperties.name,
                              new Ternary(keyProperties.key, ctrlPlaneKey, wildCard));
@@ -87,8 +87,8 @@ const IR::Expression *Bmv2V1ModelTableStepper::computeTargetMatchType(
         const IR::Expression *minKey = nullptr;
         const IR::Expression *maxKey = nullptr;
         if (keyProperties.isTainted) {
-            minKey = IR::getConstant(keyExpr->type, 0);
-            maxKey = IR::getConstant(keyExpr->type, IR::getMaxBvVal(keyExpr->type));
+            minKey = IR::Constant::get(keyExpr->type, 0);
+            maxKey = IR::Constant::get(keyExpr->type, IR::getMaxBvVal(keyExpr->type));
             keyExpr = minKey;
         } else {
             std::tie(minKey, maxKey) = Bmv2ControlPlaneState::getTableRange(
@@ -169,7 +169,7 @@ void Bmv2V1ModelTableStepper::evalTableActionProfile(
             collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
-        nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
+        nextState.set(getTableHitVar(table), IR::BoolLiteral::get(true));
         nextState.set(getTableActionVar(table), getTableActionString(tableAction));
         std::stringstream tableStream;
         tableStream << "Table Branch: " << properties.tableName;
@@ -255,7 +255,7 @@ void Bmv2V1ModelTableStepper::evalTableActionSelector(
             collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
-        nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
+        nextState.set(getTableHitVar(table), IR::BoolLiteral::get(true));
         nextState.set(getTableActionVar(table), getTableActionString(tableAction));
         std::stringstream tableStream;
         tableStream << "Table Branch: " << properties.tableName;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/p4_asserts_parser_test.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/small-step/p4_asserts_parser_test.cpp
@@ -101,8 +101,8 @@ TEST_F(P4AssertsParserTest, Restrictions) {
             IR::Type_Bits::get(8), "ingress.ternary_table_mask_h.h.a1");
         const auto &expr2 = P4Tools::ToolsVariables::getSymbolicVariable(
             IR::Type_Bits::get(8), "ingress.ternary_table_lpm_prefix_h.h.a1");
-        const auto *const1 = IR::getConstant(IR::Type_Bits::get(8), 0);
-        const auto *const2 = IR::getConstant(IR::Type_Bits::get(8), 64);
+        const auto *const1 = IR::Constant::get(IR::Type_Bits::get(8), 0);
+        const auto *const2 = IR::Constant::get(IR::Type_Bits::get(8), 64);
         const auto *operation =
             new IR::LAnd(new IR::Neq(expr1, const1), new IR::Neq(expr2, const2));
         ASSERT_TRUE(parsingResult[0]->equiv(*operation));
@@ -110,14 +110,14 @@ TEST_F(P4AssertsParserTest, Restrictions) {
     {
         const auto &expr1 = P4Tools::ToolsVariables::getSymbolicVariable(
             IR::Type_Bits::get(8), "ingress.ternary_table_key_h.h.a1");
-        const auto *const1 = IR::getConstant(IR::Type_Bits::get(8), 0);
+        const auto *const1 = IR::Constant::get(IR::Type_Bits::get(8), 0);
         const auto *operation1 = new IR::Neq(expr1, const1);
         ASSERT_TRUE(parsingResult[1]->equiv(*operation1));
     }
     {
         const auto &expr1 = P4Tools::ToolsVariables::getSymbolicVariable(
             IR::Type_Bits::get(8), "ingress.ternary_table_key_h.h.a");
-        const auto *const2 = IR::getConstant(IR::Type_Bits::get(8), 255);
+        const auto *const2 = IR::Constant::get(IR::Type_Bits::get(8), 255);
         const auto *operation2 = new IR::Neq(expr1, const2);
         ASSERT_TRUE(parsingResult[2]->equiv(*operation2));
     }

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/test_backend/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/test_backend/ptf.cpp
@@ -19,7 +19,7 @@ using ::testing::HasSubstr;
 
 TableConfig PTFTest::getForwardTableConfig() {
     ActionArg port(new IR::Parameter("port", IR::Direction::None, IR::getBitType(9)),
-                   IR::getConstant(IR::getBitType(9), big_int("0x2")));
+                   IR::Constant::get(IR::getBitType(9), big_int("0x2")));
     std::vector<ActionArg> args({port});
     const auto hit = ActionCall(
         "SwitchIngress.hit",
@@ -27,7 +27,7 @@ TableConfig PTFTest::getForwardTableConfig() {
 
     auto const *exactMatch = new Exact(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("exact")),
-        IR::getConstant(IR::getBitType(48), big_int("0x222222222222")));
+        IR::Constant::get(IR::getBitType(48), big_int("0x222222222222")));
     auto matches = TableMatchMap({{"hdr.ethernet.dst_addr", exactMatch}});
 
     return TableConfig(new IR::P4Table("table", new IR::TableProperties()),
@@ -37,13 +37,13 @@ TableConfig PTFTest::getForwardTableConfig() {
 TableConfig PTFTest::getIPRouteTableConfig() {
     const auto srcAddr =
         ActionArg(new IR::Parameter("srcAddr", IR::Direction::None, IR::getBitType(32)),
-                  IR::getConstant(IR::getBitType(32), big_int("0xF81096F")));
+                  IR::Constant::get(IR::getBitType(32), big_int("0xF81096F")));
     const auto dstAddr =
         ActionArg(new IR::Parameter("dstAddr", IR::Direction::None, IR::getBitType(48)),
-                  IR::getConstant(IR::getBitType(48), big_int("0x12176CD3")));
+                  IR::Constant::get(IR::getBitType(48), big_int("0x12176CD3")));
     const auto dstPort =
         ActionArg(new IR::Parameter("dst_port", IR::Direction::None, IR::getBitType(9)),
-                  IR::getConstant(IR::getBitType(9), big_int("0x2")));
+                  IR::Constant::get(IR::getBitType(9), big_int("0x2")));
     const auto args = std::vector<ActionArg>({srcAddr, dstAddr, dstPort});
     const auto nat = ActionCall(
         "SwitchIngress.nat",
@@ -51,11 +51,11 @@ TableConfig PTFTest::getIPRouteTableConfig() {
 
     const auto *dipExactMatch = new Exact(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("exact")),
-        IR::getConstant(IR::getBitType(32), big_int("0xA612895D")));
+        IR::Constant::get(IR::getBitType(32), big_int("0xA612895D")));
 
     const auto *vrfExactMatch = new Exact(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("exact")),
-        IR::getConstant(IR::getBitType(16), big_int("0x0")));
+        IR::Constant::get(IR::getBitType(16), big_int("0x0")));
 
     TableMatchMap matches({{"vrf", vrfExactMatch}, {"hdr.ipv4.dst_addr", dipExactMatch}});
 
@@ -65,11 +65,11 @@ TableConfig PTFTest::getIPRouteTableConfig() {
 
 /// Create a test spec with an Exact match and print an ptf test.
 TEST_F(PTFTest, Ptf01) {
-    const auto *pld = IR::getConstant(
+    const auto *pld = IR::Constant::get(
         IR::getBitType(512), big_int("0x22222222222200060708090a080045000056000100004006f94dc0a8"
                                      "0001c0a8000204d200500000000000000000500220000d2c0000000102"
                                      "03040506070809"));
-    const auto *pldIgnMask = IR::getConstant(
+    const auto *pldIgnMask = IR::Constant::get(
         IR::getBitType(512), big_int("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f01"
                                      "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f010"
                                      "f0f0f0f0f0f0f0f0f0f0f0f0f0f0"));
@@ -90,15 +90,15 @@ TEST_F(PTFTest, Ptf01) {
 TEST_F(PTFTest, Ptf02) {
     /// TODO: If payload starts with leading 0s, they are truncated causing ptf to fail with
     /// malformed packet, need to pad to account for leading zeros.
-    const auto *pldIngress = IR::getConstant(
+    const auto *pldIngress = IR::Constant::get(
         IR::getBitType(512), big_int("0x22210203040500060708090a0800450000560001000040068"
                                      "a88c0a80001a612895d04d20050000000000000000050022000"
                                      "0000000000010203040506070809"));
-    const auto *pldEgress = IR::getConstant(
+    const auto *pldEgress = IR::Constant::get(
         IR::getBitType(512), big_int("0x22210203040500060708090a080045000056000100004006e"
                                      "2c70f81096f12176cd304d20050000000000000000050022000"
                                      "0000000000010203040506070809"));
-    const auto *pldIgnMask = IR::getConstant(
+    const auto *pldIgnMask = IR::Constant::get(
         IR::getBitType(512), big_int("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f01"
                                      "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f010"
                                      "f0f0f0f0f0f0f0f0f0f0f0f0f0f0"));
@@ -119,9 +119,9 @@ TEST_F(PTFTest, Ptf02) {
 
 TableConfig PTFTest::gettest1TableConfig() {
     const auto val = ActionArg(new IR::Parameter("val", IR::Direction::None, IR::getBitType(8)),
-                               IR::getConstant(IR::getBitType(8), big_int("0x7F")));
+                               IR::Constant::get(IR::getBitType(8), big_int("0x7F")));
     const auto port = ActionArg(new IR::Parameter("port", IR::Direction::None, IR::getBitType(9)),
-                                IR::getConstant(IR::getBitType(9), big_int("0x2")));
+                                IR::Constant::get(IR::getBitType(9), big_int("0x2")));
     const auto args = std::vector<ActionArg>({val, port});
     const auto setb1 = ActionCall(
         "setb1", new IR::P4Action("dummy", new IR::ParameterList({}, {}), new IR::BlockStatement()),
@@ -129,8 +129,8 @@ TableConfig PTFTest::gettest1TableConfig() {
 
     const auto *f1TernaryMatch = new Ternary(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("ternary")),
-        IR::getConstant(IR::getBitType(32), big_int("0xABCD0101")),
-        IR::getConstant(IR::getBitType(32), big_int("0xFFFF0000")));
+        IR::Constant::get(IR::getBitType(32), big_int("0xABCD0101")),
+        IR::Constant::get(IR::getBitType(32), big_int("0xFFFF0000")));
 
     TableMatchMap matches({{"data.f1", f1TernaryMatch}});
 
@@ -141,13 +141,13 @@ TableConfig PTFTest::gettest1TableConfig() {
 /// Create a test spec with a Ternary match and print an ptf test.
 TEST_F(PTFTest, Ptf03) {
     const auto *pldIngress =
-        IR::getConstant(IR::getBitType(112), big_int("0x0000010100000202030355667788"));
+        IR::Constant::get(IR::getBitType(112), big_int("0x0000010100000202030355667788"));
     const auto *pldIngIgnMask =
-        IR::getConstant(IR::getBitType(112), big_int("0x0000000000000000000000000000"));
+        IR::Constant::get(IR::getBitType(112), big_int("0x0000000000000000000000000000"));
     const auto *pldEgress =
-        IR::getConstant(IR::getBitType(96), big_int("0x00000101deadd00dbeef7f66"));
+        IR::Constant::get(IR::getBitType(96), big_int("0x00000101deadd00dbeef7f66"));
     const auto *pldEgIgnMask =
-        IR::getConstant(IR::getBitType(96), big_int("0x00000000ffffffffffff0000"));
+        IR::Constant::get(IR::getBitType(96), big_int("0x00000000ffffffffffff0000"));
 
     const auto ingressPacket = Packet(0, pldIngress, pldIngIgnMask);
     const auto egressPacket = Packet(2, pldEgress, pldEgIgnMask);
@@ -168,9 +168,9 @@ TEST_F(PTFTest, Ptf03) {
 
 TableConfig PTFTest::gettest1TableConfig2() {
     const auto val = ActionArg(new IR::Parameter("val", IR::Direction::None, IR::getBitType(8)),
-                               IR::getConstant(IR::getBitType(8), big_int("0x7F")));
+                               IR::Constant::get(IR::getBitType(8), big_int("0x7F")));
     const auto port = ActionArg(new IR::Parameter("port", IR::Direction::None, IR::getBitType(9)),
-                                IR::getConstant(IR::getBitType(9), big_int("0x2")));
+                                IR::Constant::get(IR::getBitType(9), big_int("0x2")));
     const auto args = std::vector<ActionArg>({val, port});
     const auto setb1 = ActionCall(
         "setb1", new IR::P4Action("dummy", new IR::ParameterList({}, {}), new IR::BlockStatement()),
@@ -178,21 +178,21 @@ TableConfig PTFTest::gettest1TableConfig2() {
 
     const auto *h1ExactMatch = new Exact(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("exact")),
-        IR::getConstant(IR::getBitType(16), big_int("0x3")));
+        IR::Constant::get(IR::getBitType(16), big_int("0x3")));
 
     const auto *f1TernaryMatch = new Ternary(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("ternary")),
-        IR::getConstant(IR::getBitType(32), big_int("0xABCD0101")),
-        IR::getConstant(IR::getBitType(32), big_int("0xFFFF0000")));
+        IR::Constant::get(IR::getBitType(32), big_int("0xABCD0101")),
+        IR::Constant::get(IR::getBitType(32), big_int("0xFFFF0000")));
 
     const auto *b1ExactMatch = new Exact(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("exact")),
-        IR::getConstant(IR::getBitType(8), big_int("0x1")));
+        IR::Constant::get(IR::getBitType(8), big_int("0x1")));
 
     const auto *f2TernaryMatch = new Ternary(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("ternary")),
-        IR::getConstant(IR::getBitType(32), big_int("0xABCDD00D")),
-        IR::getConstant(IR::getBitType(32), big_int("0x0000FFFF")));
+        IR::Constant::get(IR::getBitType(32), big_int("0xABCDD00D")),
+        IR::Constant::get(IR::getBitType(32), big_int("0x0000FFFF")));
 
     TableMatchMap matches1({{"data.f1", f1TernaryMatch}});
 
@@ -209,13 +209,13 @@ TableConfig PTFTest::gettest1TableConfig2() {
 /// Create a test spec with one Exact match and one Ternary match and print an ptf test.
 TEST_F(PTFTest, Ptf04) {
     const auto *pldIngress =
-        IR::getConstant(IR::getBitType(112), big_int("0x0000010100000202030355667788"));
+        IR::Constant::get(IR::getBitType(112), big_int("0x0000010100000202030355667788"));
     const auto *pldIngIgnMask =
-        IR::getConstant(IR::getBitType(112), big_int("0x0000000000000000000000000000"));
+        IR::Constant::get(IR::getBitType(112), big_int("0x0000000000000000000000000000"));
     const auto *pldEgress =
-        IR::getConstant(IR::getBitType(96), big_int("0x00000101deadd00dbeef7f66"));
+        IR::Constant::get(IR::getBitType(96), big_int("0x00000101deadd00dbeef7f66"));
     const auto *pldEgIgnMask =
-        IR::getConstant(IR::getBitType(96), big_int("0x00000000ffffffffffff0000"));
+        IR::Constant::get(IR::getBitType(96), big_int("0x00000000ffffffffffff0000"));
 
     const auto ingressPacket = Packet(0, pldIngress, pldIngIgnMask);
     const auto egressPacket = Packet(2, pldEgress, pldEgIgnMask);

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/test_backend/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/test_backend/stf.cpp
@@ -19,7 +19,7 @@ using ::testing::HasSubstr;
 
 TableConfig STFTest::getForwardTableConfig() {
     ActionArg port(new IR::Parameter("port", IR::Direction::None, IR::getBitType(9)),
-                   IR::getConstant(IR::getBitType(9), big_int("0x2")));
+                   IR::Constant::get(IR::getBitType(9), big_int("0x2")));
     std::vector<ActionArg> args({port});
     const auto hit = ActionCall(
         "SwitchIngress.hit",
@@ -27,7 +27,7 @@ TableConfig STFTest::getForwardTableConfig() {
 
     auto const *exactMatch = new Exact(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("exact")),
-        IR::getConstant(IR::getBitType(48), big_int("0x222222222222")));
+        IR::Constant::get(IR::getBitType(48), big_int("0x222222222222")));
     auto matches = TableMatchMap({{"hdr.ethernet.dst_addr", exactMatch}});
 
     return TableConfig(new IR::P4Table("table", new IR::TableProperties()),
@@ -37,13 +37,13 @@ TableConfig STFTest::getForwardTableConfig() {
 TableConfig STFTest::getIPRouteTableConfig() {
     const auto srcAddr =
         ActionArg(new IR::Parameter("srcAddr", IR::Direction::None, IR::getBitType(32)),
-                  IR::getConstant(IR::getBitType(32), big_int("0xF81096F")));
+                  IR::Constant::get(IR::getBitType(32), big_int("0xF81096F")));
     const auto dstAddr =
         ActionArg(new IR::Parameter("dstAddr", IR::Direction::None, IR::getBitType(48)),
-                  IR::getConstant(IR::getBitType(48), big_int("0x12176CD3")));
+                  IR::Constant::get(IR::getBitType(48), big_int("0x12176CD3")));
     const auto dstPort =
         ActionArg(new IR::Parameter("dst_port", IR::Direction::None, IR::getBitType(9)),
-                  IR::getConstant(IR::getBitType(9), big_int("0x2")));
+                  IR::Constant::get(IR::getBitType(9), big_int("0x2")));
     const auto args = std::vector<ActionArg>({srcAddr, dstAddr, dstPort});
     const auto nat = ActionCall(
         "SwitchIngress.nat",
@@ -51,11 +51,11 @@ TableConfig STFTest::getIPRouteTableConfig() {
 
     const auto *dipExactMatch = new Exact(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("exact")),
-        IR::getConstant(IR::getBitType(32), big_int("0xA612895D")));
+        IR::Constant::get(IR::getBitType(32), big_int("0xA612895D")));
 
     const auto *vrfExactMatch = new Exact(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("exact")),
-        IR::getConstant(IR::getBitType(16), big_int("0x0")));
+        IR::Constant::get(IR::getBitType(16), big_int("0x0")));
 
     TableMatchMap matches({{"vrf", vrfExactMatch}, {"hdr.ipv4.dst_addr", dipExactMatch}});
 
@@ -65,11 +65,11 @@ TableConfig STFTest::getIPRouteTableConfig() {
 
 /// Create a test spec with an Exact match and print an stf test.
 TEST_F(STFTest, Stf01) {
-    const auto *pld = IR::getConstant(
+    const auto *pld = IR::Constant::get(
         IR::getBitType(512), big_int("0x22222222222200060708090a080045000056000100004006f94dc0a8"
                                      "0001c0a8000204d200500000000000000000500220000d2c0000000102"
                                      "03040506070809"));
-    const auto *pldIgnMask = IR::getConstant(
+    const auto *pldIgnMask = IR::Constant::get(
         IR::getBitType(512), big_int("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f01"
                                      "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f010"
                                      "f0f0f0f0f0f0f0f0f0f0f0f0f0f0"));
@@ -90,15 +90,15 @@ TEST_F(STFTest, Stf01) {
 TEST_F(STFTest, Stf02) {
     /// TODO: If payload starts with leading 0s, they are truncated causing stf to fail with
     /// malformed packet, need to pad to account for leading zeros.
-    const auto *pldIngress = IR::getConstant(
+    const auto *pldIngress = IR::Constant::get(
         IR::getBitType(512), big_int("0x22210203040500060708090a0800450000560001000040068"
                                      "a88c0a80001a612895d04d20050000000000000000050022000"
                                      "0000000000010203040506070809"));
-    const auto *pldEgress = IR::getConstant(
+    const auto *pldEgress = IR::Constant::get(
         IR::getBitType(512), big_int("0x22210203040500060708090a080045000056000100004006e"
                                      "2c70f81096f12176cd304d20050000000000000000050022000"
                                      "0000000000010203040506070809"));
-    const auto *pldIgnMask = IR::getConstant(
+    const auto *pldIgnMask = IR::Constant::get(
         IR::getBitType(512), big_int("0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f01"
                                      "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f010"
                                      "f0f0f0f0f0f0f0f0f0f0f0f0f0f0"));
@@ -119,9 +119,9 @@ TEST_F(STFTest, Stf02) {
 
 TableConfig STFTest::gettest1TableConfig() {
     const auto val = ActionArg(new IR::Parameter("val", IR::Direction::None, IR::getBitType(8)),
-                               IR::getConstant(IR::getBitType(8), big_int("0x7F")));
+                               IR::Constant::get(IR::getBitType(8), big_int("0x7F")));
     const auto port = ActionArg(new IR::Parameter("port", IR::Direction::None, IR::getBitType(9)),
-                                IR::getConstant(IR::getBitType(9), big_int("0x2")));
+                                IR::Constant::get(IR::getBitType(9), big_int("0x2")));
     const auto args = std::vector<ActionArg>({val, port});
     const auto setb1 = ActionCall(
         "setb1", new IR::P4Action("dummy", new IR::ParameterList({}, {}), new IR::BlockStatement()),
@@ -129,8 +129,8 @@ TableConfig STFTest::gettest1TableConfig() {
 
     const auto *f1TernaryMatch = new Ternary(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("ternary")),
-        IR::getConstant(IR::getBitType(32), big_int("0xABCD0101")),
-        IR::getConstant(IR::getBitType(32), big_int("0xFFFF0000")));
+        IR::Constant::get(IR::getBitType(32), big_int("0xABCD0101")),
+        IR::Constant::get(IR::getBitType(32), big_int("0xFFFF0000")));
 
     TableMatchMap matches({{"data.f1", f1TernaryMatch}});
 
@@ -141,13 +141,13 @@ TableConfig STFTest::gettest1TableConfig() {
 /// Create a test spec with a Ternary match and print an stf test.
 TEST_F(STFTest, Stf03) {
     const auto *pldIngress =
-        IR::getConstant(IR::getBitType(112), big_int("0x0000010100000202030355667788"));
+        IR::Constant::get(IR::getBitType(112), big_int("0x0000010100000202030355667788"));
     const auto *pldIngIgnMask =
-        IR::getConstant(IR::getBitType(112), big_int("0x0000000000000000000000000000"));
+        IR::Constant::get(IR::getBitType(112), big_int("0x0000000000000000000000000000"));
     const auto *pldEgress =
-        IR::getConstant(IR::getBitType(96), big_int("0x00000101deadd00dbeef7f66"));
+        IR::Constant::get(IR::getBitType(96), big_int("0x00000101deadd00dbeef7f66"));
     const auto *pldEgIgnMask =
-        IR::getConstant(IR::getBitType(96), big_int("0x00000000ffffffffffff0000"));
+        IR::Constant::get(IR::getBitType(96), big_int("0x00000000ffffffffffff0000"));
 
     const auto ingressPacket = Packet(0, pldIngress, pldIngIgnMask);
     const auto egressPacket = Packet(2, pldEgress, pldEgIgnMask);
@@ -168,9 +168,9 @@ TEST_F(STFTest, Stf03) {
 
 TableConfig STFTest::gettest1TableConfig2() {
     const auto val = ActionArg(new IR::Parameter("val", IR::Direction::None, IR::getBitType(8)),
-                               IR::getConstant(IR::getBitType(8), big_int("0x7F")));
+                               IR::Constant::get(IR::getBitType(8), big_int("0x7F")));
     const auto port = ActionArg(new IR::Parameter("port", IR::Direction::None, IR::getBitType(9)),
-                                IR::getConstant(IR::getBitType(9), big_int("0x2")));
+                                IR::Constant::get(IR::getBitType(9), big_int("0x2")));
     const auto args = std::vector<ActionArg>({val, port});
     const auto setb1 = ActionCall(
         "setb1", new IR::P4Action("dummy", new IR::ParameterList({}, {}), new IR::BlockStatement()),
@@ -178,21 +178,21 @@ TableConfig STFTest::gettest1TableConfig2() {
 
     const auto *h1ExactMatch = new Exact(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("exact")),
-        IR::getConstant(IR::getBitType(16), big_int("0x3")));
+        IR::Constant::get(IR::getBitType(16), big_int("0x3")));
 
     const auto *f1TernaryMatch = new Ternary(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("ternary")),
-        IR::getConstant(IR::getBitType(32), big_int("0xABCD0101")),
-        IR::getConstant(IR::getBitType(32), big_int("0xFFFF0000")));
+        IR::Constant::get(IR::getBitType(32), big_int("0xABCD0101")),
+        IR::Constant::get(IR::getBitType(32), big_int("0xFFFF0000")));
 
     const auto *b1ExactMatch = new Exact(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("exact")),
-        IR::getConstant(IR::getBitType(8), big_int("0x1")));
+        IR::Constant::get(IR::getBitType(8), big_int("0x1")));
 
     const auto *f2TernaryMatch = new Ternary(
         new IR::KeyElement(new IR::PathExpression("key"), new IR::PathExpression("ternary")),
-        IR::getConstant(IR::getBitType(32), big_int("0xABCDD00D")),
-        IR::getConstant(IR::getBitType(32), big_int("0x0000FFFF")));
+        IR::Constant::get(IR::getBitType(32), big_int("0xABCDD00D")),
+        IR::Constant::get(IR::getBitType(32), big_int("0x0000FFFF")));
 
     TableMatchMap matches1({{"data.f1", f1TernaryMatch}});
 
@@ -209,13 +209,13 @@ TableConfig STFTest::gettest1TableConfig2() {
 /// Create a test spec with one Exact match and one Ternary match and print an stf test.
 TEST_F(STFTest, Stf04) {
     const auto *pldIngress =
-        IR::getConstant(IR::getBitType(112), big_int("0x0000010100000202030355667788"));
+        IR::Constant::get(IR::getBitType(112), big_int("0x0000010100000202030355667788"));
     const auto *pldIngIgnMask =
-        IR::getConstant(IR::getBitType(112), big_int("0x0000000000000000000000000000"));
+        IR::Constant::get(IR::getBitType(112), big_int("0x0000000000000000000000000000"));
     const auto *pldEgress =
-        IR::getConstant(IR::getBitType(96), big_int("0x00000101deadd00dbeef7f66"));
+        IR::Constant::get(IR::getBitType(96), big_int("0x00000101deadd00dbeef7f66"));
     const auto *pldEgIgnMask =
-        IR::getConstant(IR::getBitType(96), big_int("0x00000000ffffffffffff0000"));
+        IR::Constant::get(IR::getBitType(96), big_int("0x00000000ffffffffffff0000"));
 
     const auto ingressPacket = Packet(0, pldIngress, pldIngIgnMask);
     const auto egressPacket = Packet(2, pldEgress, pldEgIgnMask);

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
@@ -78,9 +78,9 @@ TestBackEnd::TestInfo Bmv2TestBackend::produceTestInfo(
     if (testInfo.outputPacket->type->width_bits() == 0) {
         int outPktSize = ZERO_PKT_WIDTH;
         testInfo.outputPacket =
-            IR::getConstant(IR::getBitType(outPktSize), Bmv2TestBackend::ZERO_PKT_VAL);
+            IR::Constant::get(IR::getBitType(outPktSize), Bmv2TestBackend::ZERO_PKT_VAL);
         testInfo.packetTaintMask =
-            IR::getConstant(IR::getBitType(outPktSize), Bmv2TestBackend::ZERO_PKT_MAX);
+            IR::Constant::get(IR::getBitType(outPktSize), Bmv2TestBackend::ZERO_PKT_MAX);
     }
     return testInfo;
 }
@@ -88,7 +88,7 @@ TestBackEnd::TestInfo Bmv2TestBackend::produceTestInfo(
 const TestSpec *Bmv2TestBackend::createTestSpec(const ExecutionState *executionState,
                                                 const Model *finalModel, const TestInfo &testInfo) {
     const auto *ingressPayload = testInfo.inputPacket;
-    const auto *ingressPayloadMask = IR::getConstant(IR::getBitType(1), 1);
+    const auto *ingressPayloadMask = IR::Constant::get(IR::getBitType(1), 1);
     const auto ingressPacket = Packet(testInfo.inputPort, ingressPayload, ingressPayloadMask);
 
     std::optional<Packet> egressPacket = std::nullopt;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/stf.cpp
@@ -111,7 +111,7 @@ inja::json STF::getControlPlaneForTable(const TableMatchMap &matches,
             auto fieldWidth = dataValue->type->width_bits();
             auto maxVal = IR::getMaxBvVal(prefixLen);
             const auto *maskField =
-                IR::getConstant(dataValue->type, maxVal << (fieldWidth - prefixLen));
+                IR::Constant::get(dataValue->type, maxVal << (fieldWidth - prefixLen));
             BUG_CHECK(dataValue->type->width_bits() == maskField->type->width_bits(),
                       "Data value and its mask should have the same bit width.");
             // Using the width from mask - should be same as data

--- a/backends/p4tools/modules/testgen/targets/ebpf/backend/stf/stf.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/backend/stf/stf.cpp
@@ -117,7 +117,7 @@ inja::json STF::getControlPlaneForTable(const TableMatchMap &matches,
             auto fieldWidth = dataValue->type->width_bits();
             auto maxVal = IR::getMaxBvVal(prefixLen);
             const auto *maskField =
-                IR::getConstant(dataValue->type, maxVal << (fieldWidth - prefixLen));
+                IR::Constant::get(dataValue->type, maxVal << (fieldWidth - prefixLen));
             BUG_CHECK(dataValue->type->width_bits() == maskField->type->width_bits(),
                       "Data value and its mask should have the same bit width.");
             // Using the width from mask - should be same as data

--- a/backends/p4tools/modules/testgen/targets/ebpf/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/cmd_stepper.cpp
@@ -51,9 +51,9 @@ void EBPFCmdStepper::initializeTargetEnvironment(ExecutionState &nextState) cons
 
     const auto *nineBitType = IR::getBitType(9);
     // Set the input ingress port to 0.
-    nextState.set(programInfo.getTargetInputPortVar(), IR::getConstant(nineBitType, 0));
+    nextState.set(programInfo.getTargetInputPortVar(), IR::Constant::get(nineBitType, 0));
     // eBPF implicitly sets the output port to 0. In reality, there is no output port.
-    nextState.set(programInfo.getTargetOutputPortVar(), IR::getConstant(nineBitType, 0));
+    nextState.set(programInfo.getTargetOutputPortVar(), IR::Constant::get(nineBitType, 0));
     // We need to explicitly set the parser error. There is no eBPF metadata.
     const auto *errVar = new IR::Member(new IR::PathExpression("*"), "parser_err");
     nextState.setParserErrorLabel(errVar);

--- a/backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/expr_stepper.cpp
@@ -104,7 +104,7 @@ void EBPFExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
              auto emitIsTainted = Taint::hasTaint(validVar);
              if (emitIsTainted || !validVar->checkedTo<IR::BoolLiteral>()->value) {
                  auto &nextState = state.clone();
-                 nextState.replaceTopBody(Continuation::Return(IR::getBoolLiteral(false)));
+                 nextState.replaceTopBody(Continuation::Return(IR::BoolLiteral::get(false)));
                  result->emplace_back(nextState);
                  return;
              }
@@ -148,7 +148,7 @@ void EBPFExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
              checksum =
                  new IR::Add(bt16, new IR::Slice(checksum, 31, 16), new IR::Slice(checksum, 15, 0));
              const auto *calcResult = new IR::Cmpl(bt16, checksum);
-             const auto *comparison = new IR::Equ(calcResult, IR::getConstant(bt16, 0));
+             const auto *comparison = new IR::Equ(calcResult, IR::Constant::get(bt16, 0));
              auto &nextState = state.clone();
              nextState.replaceTopBody(Continuation::Return(comparison));
              result->emplace_back(nextState);
@@ -184,8 +184,8 @@ void EBPFExprStepper::evalExternMethodCall(const IR::MethodCallExpression *call,
              // TODO: We need custom test objects to implement richer, stateful testing here.
              auto &nextState = state.clone();
              const auto *cond =
-                 new IR::LAnd(new IR::Equ(synExpr, IR::getConstant(synExpr->type, 1)),
-                              new IR::Equ(ackExpr, IR::getConstant(ackExpr->type, 0)));
+                 new IR::LAnd(new IR::Equ(synExpr, IR::Constant::get(synExpr->type, 1)),
+                              new IR::Equ(ackExpr, IR::Constant::get(ackExpr->type, 0)));
              nextState.replaceTopBody(Continuation::Return(cond));
              result->emplace_back(nextState);
          }},

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
@@ -60,7 +60,7 @@ EBPFProgramInfo::EBPFProgramInfo(const TestgenCompilerResult &compilerResult,
     // The input packet should be larger than 0.
     targetConstraints =
         new IR::Grt(IR::Type::Boolean::get(), ExecutionState::getInputPacketSizeVar(),
-                    IR::getConstant(&PacketVars::PACKET_SIZE_VAR_TYPE, 0));
+                    IR::Constant::get(&PacketVars::PACKET_SIZE_VAR_TYPE, 0));
 }
 
 const ArchSpec &EBPFProgramInfo::getArchSpec() const { return ARCH_SPEC; }
@@ -85,7 +85,7 @@ std::vector<Continuation::Command> EBPFProgramInfo::processDeclaration(
 
     // Copy-in.
     const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_in", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_in", {IR::StringLiteral::get(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyInCall);
@@ -93,7 +93,7 @@ std::vector<Continuation::Command> EBPFProgramInfo::processDeclaration(
     cmds.emplace_back(typeDecl);
     // Copy-out.
     const auto *copyOutCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_out", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_out", {IR::StringLiteral::get(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyOutCall);

--- a/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/program_info.cpp
@@ -85,7 +85,7 @@ std::vector<Continuation::Command> EBPFProgramInfo::processDeclaration(
 
     // Copy-in.
     const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_in", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_in", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyInCall);
@@ -93,7 +93,7 @@ std::vector<Continuation::Command> EBPFProgramInfo::processDeclaration(
     cmds.emplace_back(typeDecl);
     // Copy-out.
     const auto *copyOutCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_out", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_out", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyOutCall);

--- a/backends/p4tools/modules/testgen/targets/ebpf/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/ebpf/test_backend.cpp
@@ -64,15 +64,15 @@ TestBackEnd::TestInfo EBPFTestBackend::produceTestInfo(
     if (testInfo.outputPacket->type->width_bits() == 0) {
         int outPktSize = ZERO_PKT_WIDTH;
         testInfo.outputPacket =
-            IR::getConstant(IR::getBitType(outPktSize), EBPFTestBackend::ZERO_PKT_VAL);
+            IR::Constant::get(IR::getBitType(outPktSize), EBPFTestBackend::ZERO_PKT_VAL);
         testInfo.packetTaintMask =
-            IR::getConstant(IR::getBitType(outPktSize), EBPFTestBackend::ZERO_PKT_MAX);
+            IR::Constant::get(IR::getBitType(outPktSize), EBPFTestBackend::ZERO_PKT_MAX);
     } else {
         // eBPF actually can not modify the input packet. It can only filter. Thus we reuse our
         // input packet here.
         testInfo.outputPacket = testInfo.inputPacket;
-        testInfo.packetTaintMask = IR::getConstant(testInfo.inputPacket->type,
-                                                   IR::getMaxBvVal(testInfo.inputPacket->type));
+        testInfo.packetTaintMask = IR::Constant::get(testInfo.inputPacket->type,
+                                                     IR::getMaxBvVal(testInfo.inputPacket->type));
     }
     return testInfo;
 }
@@ -83,7 +83,7 @@ const TestSpec *EBPFTestBackend::createTestSpec(const ExecutionState *executionS
     TestSpec *testSpec = nullptr;
 
     const auto *ingressPayload = testInfo.inputPacket;
-    const auto *ingressPayloadMask = IR::getConstant(IR::getBitType(1), 1);
+    const auto *ingressPayloadMask = IR::Constant::get(IR::getBitType(1), 1);
     const auto ingressPacket = Packet(testInfo.inputPort, ingressPayload, ingressPayloadMask);
 
     std::optional<Packet> egressPacket = std::nullopt;

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/cmd_stepper.cpp
@@ -50,9 +50,9 @@ void PnaDpdkCmdStepper::initializeTargetEnvironment(ExecutionState &nextState) c
         blockIdx++;
     }
     const auto *thirtytwoBitType = IR::getBitType(32);
-    nextState.set(&PnaConstants::DROP_VAR, IR::getBoolLiteral(false));
+    nextState.set(&PnaConstants::DROP_VAR, IR::BoolLiteral::get(false));
     // PNA implicitly sets the output port to 0.
-    nextState.set(&PnaConstants::OUTPUT_PORT_VAR, IR::getConstant(thirtytwoBitType, 0));
+    nextState.set(&PnaConstants::OUTPUT_PORT_VAR, IR::Constant::get(thirtytwoBitType, 0));
     // Initialize the direction metadata variables.
     nextState.set(
         new IR::Member(thirtytwoBitType, new IR::PathExpression("*pre_istd"), "direction"),
@@ -71,7 +71,7 @@ std::optional<const Constraint *> PnaDpdkCmdStepper::startParserImpl(
     nextState.setParserErrorLabel(&PnaConstants::PARSER_ERROR);
     // Initialize the parser error to 0.
     nextState.set(&PnaConstants::PARSER_ERROR,
-                  IR::getConstant(programInfo.getParserErrorType(), 0));
+                  IR::Constant::get(programInfo.getParserErrorType(), 0));
     return std::nullopt;
 }
 
@@ -83,7 +83,7 @@ std::map<Continuation::Exception, Continuation> PnaDpdkCmdStepper::getExceptionH
     result.emplace(
         Continuation::Exception::PacketTooShort,
         Continuation::Body({new IR::AssignmentStatement(
-            &PnaConstants::PARSER_ERROR, IR::getConstant(programInfo.getParserErrorType(), 1))}));
+            &PnaConstants::PARSER_ERROR, IR::Constant::get(programInfo.getParserErrorType(), 1))}));
     // NoMatch will transition to the next block.
     result.emplace(Continuation::Exception::NoMatch, Continuation::Body({}));
 

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
@@ -9,6 +9,7 @@
 #include "backends/p4tools/common/lib/util.h"
 #include "ir/id.h"
 #include "ir/ir.h"
+#include "ir/irutils.h"
 #include "lib/cstring.h"
 #include "lib/exceptions.h"
 
@@ -69,7 +70,7 @@ std::vector<Continuation::Command> PnaDpdkProgramInfo::processDeclaration(
     std::vector<Continuation::Command> cmds;
     // Copy-in.
     const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_in", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_in", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyInCall);
@@ -77,7 +78,7 @@ std::vector<Continuation::Command> PnaDpdkProgramInfo::processDeclaration(
     cmds.emplace_back(typeDecl);
     // Copy-out.
     const auto *copyOutCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_out", {new IR::StringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_out", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyOutCall);

--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/program_info.cpp
@@ -70,7 +70,7 @@ std::vector<Continuation::Command> PnaDpdkProgramInfo::processDeclaration(
     std::vector<Continuation::Command> cmds;
     // Copy-in.
     const auto *copyInCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_in", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_in", {IR::StringLiteral::get(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyInCall);
@@ -78,7 +78,7 @@ std::vector<Continuation::Command> PnaDpdkProgramInfo::processDeclaration(
     cmds.emplace_back(typeDecl);
     // Copy-out.
     const auto *copyOutCall = new IR::MethodCallStatement(Utils::generateInternalMethodCall(
-        "copy_out", {IR::getStringLiteral(typeDecl->name)}, IR::Type_Void::get(),
+        "copy_out", {IR::StringLiteral::get(typeDecl->name)}, IR::Type_Void::get(),
         new IR::ParameterList(
             {new IR::Parameter("blockRef", IR::Direction::In, IR::Type_Unknown::get())})));
     cmds.emplace_back(copyOutCall);

--- a/backends/p4tools/modules/testgen/targets/pna/shared_expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_expr_stepper.cpp
@@ -45,7 +45,7 @@ const ExternMethodImpls SharedPnaExprStepper::PNA_EXTERN_METHOD_IMPLS({
          auto &nextState = state.clone();
          // Use an assignment to set drop variable to true.
          // This variable will be processed in the deparser.
-         nextState.set(&PnaConstants::DROP_VAR, IR::getBoolLiteral(true));
+         nextState.set(&PnaConstants::DROP_VAR, IR::BoolLiteral::get(true));
          nextState.add(*new TraceEvents::Generic("drop_packet executed"));
          nextState.popBody();
          result->emplace_back(nextState);
@@ -142,7 +142,7 @@ const ExternMethodImpls SharedPnaExprStepper::PNA_EXTERN_METHOD_IMPLS({
              return;
          };
          auto *cond = new IR::Equ(
-             directionVar, IR::getConstant(directionVar->type, PacketDirection::NET_TO_HOST));
+             directionVar, IR::Constant::get(directionVar->type, PacketDirection::NET_TO_HOST));
 
          // Return the NET_TO_HOST value.
          auto &netToHostState = state.clone();
@@ -168,7 +168,7 @@ const ExternMethodImpls SharedPnaExprStepper::PNA_EXTERN_METHOD_IMPLS({
         const ExecutionState &state, SmallStepEvaluator::Result &result) {
          auto &nextState = state.clone();
          nextState.add(*new TraceEvents::Generic("add_entry executed. Currently a no-op."));
-         nextState.replaceTopBody(Continuation::Return(IR::getBoolLiteral(true)));
+         nextState.replaceTopBody(Continuation::Return(IR::BoolLiteral::get(true)));
          result->emplace_back(nextState);
      }},
 });

--- a/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/shared_table_stepper.cpp
@@ -66,8 +66,8 @@ const IR::Expression *SharedPnaTableStepper::computeTargetMatchType(
         const IR::Expression *minKey = nullptr;
         const IR::Expression *maxKey = nullptr;
         if (keyProperties.isTainted) {
-            minKey = IR::getConstant(keyExpr->type, 0);
-            maxKey = IR::getConstant(keyExpr->type, IR::getMaxBvVal(keyExpr->type));
+            minKey = IR::Constant::get(keyExpr->type, 0);
+            maxKey = IR::Constant::get(keyExpr->type, IR::getMaxBvVal(keyExpr->type));
             keyExpr = minKey;
         } else {
             std::tie(minKey, maxKey) = Bmv2ControlPlaneState::getTableRange(
@@ -148,7 +148,7 @@ void SharedPnaTableStepper::evalTableActionProfile(
             collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
-        nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
+        nextState.set(getTableHitVar(table), IR::BoolLiteral::get(true));
         nextState.set(getTableActionVar(table), getTableActionString(tableAction));
         std::stringstream tableStream;
         tableStream << "Table Branch: " << properties.tableName;
@@ -235,7 +235,7 @@ void SharedPnaTableStepper::evalTableActionSelector(
             collector.updateNodeCoverage(actionType, coveredNodes);
         }
 
-        nextState.set(getTableHitVar(table), IR::getBoolLiteral(true));
+        nextState.set(getTableHitVar(table), IR::BoolLiteral::get(true));
         nextState.set(getTableActionVar(table), getTableActionString(tableAction));
 
         std::stringstream tableStream;

--- a/backends/p4tools/modules/testgen/targets/pna/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/test_backend.cpp
@@ -70,7 +70,7 @@ const TestSpec *PnaTestBackend::createTestSpec(const ExecutionState *executionSt
     TestSpec *testSpec = nullptr;
 
     const auto *ingressPayload = testInfo.inputPacket;
-    const auto *ingressPayloadMask = IR::getConstant(IR::getBitType(1), 1);
+    const auto *ingressPayloadMask = IR::Constant::get(IR::getBitType(1), 1);
     const auto ingressPacket = Packet(testInfo.inputPort, ingressPayload, ingressPayloadMask);
 
     std::optional<Packet> egressPacket = std::nullopt;

--- a/backends/p4tools/modules/testgen/test/lib/format_int.cpp
+++ b/backends/p4tools/modules/testgen/test/lib/format_int.cpp
@@ -31,7 +31,7 @@ using P4Tools::insertSeparators;
 TEST_F(FormatTest, Format01) {
     {
         const auto *typeBits = IR::getBitType(16);
-        const auto *sixteenBits = IR::getConstant(typeBits, 0x10);
+        const auto *sixteenBits = IR::Constant::get(typeBits, 0x10);
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, false}).c_str(), "10");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, true}).c_str(), "0x10");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, true, false}).c_str(), "0010");
@@ -43,7 +43,7 @@ TEST_F(FormatTest, Format01) {
     }
     {
         const auto *typeBits = IR::getBitType(64);
-        const auto *sixteenBits = IR::getConstant(typeBits, 0x060000);
+        const auto *sixteenBits = IR::Constant::get(typeBits, 0x060000);
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, false}).c_str(), "60000");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, true}).c_str(), "0x60000");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, true, false}).c_str(), "0000000000060000");
@@ -57,7 +57,7 @@ TEST_F(FormatTest, Format01) {
     }
     {
         const auto *typeBits = IR::getBitType(62);
-        const auto *sixteenBits = IR::getConstant(typeBits, 0x060000);
+        const auto *sixteenBits = IR::Constant::get(typeBits, 0x060000);
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, false}).c_str(), "60000");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, true}).c_str(), "0x60000");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, true, false}).c_str(), "0000000000060000");
@@ -71,7 +71,7 @@ TEST_F(FormatTest, Format01) {
     }
     {
         const auto *typeBits = IR::getBitType(1);
-        const auto *sixteenBits = IR::getConstant(typeBits, 0x1);
+        const auto *sixteenBits = IR::Constant::get(typeBits, 0x1);
         ASSERT_STREQ(formatHexExpr(sixteenBits).c_str(), "0x1");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, false}).c_str(), "1");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, true}).c_str(), "0x1");
@@ -84,7 +84,7 @@ TEST_F(FormatTest, Format01) {
     }
     {
         const auto *typeBits = IR::getBitType(16, true);
-        const auto *sixteenBits = IR::getConstant(typeBits, -1);
+        const auto *sixteenBits = IR::Constant::get(typeBits, -1);
         ASSERT_EQ(static_cast<uint16_t>(sixteenBits->asInt64()), 0xFFFF);
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, false}).c_str(), "FFFF");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, true}).c_str(), "0xFFFF");
@@ -97,7 +97,7 @@ TEST_F(FormatTest, Format01) {
     }
     {
         const auto *typeBits = IR::getBitType(16, true);
-        const auto *sixteenBits = IR::getConstant(typeBits, -1);
+        const auto *sixteenBits = IR::Constant::get(typeBits, -1);
         ASSERT_EQ(static_cast<uint16_t>(sixteenBits->asInt64()), 0xFFFF);
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, false, false}).c_str(), "ffff");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, true, false}).c_str(), "0xffff");
@@ -110,7 +110,7 @@ TEST_F(FormatTest, Format01) {
     }
     {
         const auto *typeBits = IR::getBitType(16, true);
-        const auto *sixteenBits = IR::getConstant(typeBits, -32767);
+        const auto *sixteenBits = IR::Constant::get(typeBits, -32767);
         ASSERT_EQ(static_cast<uint16_t>(sixteenBits->asInt64()), 0x8001);
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, false}).c_str(), "8001");
         ASSERT_STREQ(formatHexExpr(sixteenBits, {false, false, true}).c_str(), "0x8001");
@@ -127,7 +127,7 @@ TEST_F(FormatTest, Format01) {
 TEST_F(FormatTest, Format02) {
     {
         const auto *typeBits = IR::getBitType(8);
-        const auto *sixteenBits = IR::getConstant(typeBits, 012);
+        const auto *sixteenBits = IR::Constant::get(typeBits, 012);
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, false}).c_str(), "12");
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, true}).c_str(), "012");
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, true, false}).c_str(), "0012");
@@ -139,7 +139,7 @@ TEST_F(FormatTest, Format02) {
     }
     {
         const auto *typeBits = IR::getBitType(8, true);
-        const auto *sixteenBits = IR::getConstant(typeBits, -012);
+        const auto *sixteenBits = IR::Constant::get(typeBits, -012);
         ASSERT_EQ(static_cast<uint8_t>(sixteenBits->asInt64()), 0366);
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, false}).c_str(), "366");
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, true}).c_str(), "0366");
@@ -152,7 +152,7 @@ TEST_F(FormatTest, Format02) {
     }
     {
         const auto *typeBits = IR::getBitType(16);
-        const auto *sixteenBits = IR::getConstant(typeBits, 020);
+        const auto *sixteenBits = IR::Constant::get(typeBits, 020);
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, false}).c_str(), "20");
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, true}).c_str(), "020");
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, true, false}).c_str(), "00000020");
@@ -164,7 +164,7 @@ TEST_F(FormatTest, Format02) {
     }
     {
         const auto *typeBits = IR::getBitType(16, true);
-        const auto *sixteenBits = IR::getConstant(typeBits, -020);
+        const auto *sixteenBits = IR::Constant::get(typeBits, -020);
         ASSERT_EQ(static_cast<uint16_t>(sixteenBits->asInt64()), 0177760);
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, false}).c_str(), "177760");
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, true}).c_str(), "0177760");
@@ -177,7 +177,7 @@ TEST_F(FormatTest, Format02) {
     }
     {
         const auto *typeBits = IR::getBitType(8);
-        const auto *sixteenBits = IR::getConstant(typeBits, 010);
+        const auto *sixteenBits = IR::Constant::get(typeBits, 010);
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, false}).c_str(), "10");
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, true}).c_str(), "010");
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, true, false}).c_str(), "0010");
@@ -189,7 +189,7 @@ TEST_F(FormatTest, Format02) {
     }
     {
         const auto *typeBits = IR::getBitType(8, true);
-        const auto *sixteenBits = IR::getConstant(typeBits, -010);
+        const auto *sixteenBits = IR::Constant::get(typeBits, -010);
         ASSERT_EQ(static_cast<uint8_t>(sixteenBits->asInt64()), 0370);
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, false}).c_str(), "370");
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {false, false, true}).c_str(), "0370");
@@ -206,7 +206,7 @@ TEST_F(FormatTest, Format02) {
 TEST_F(FormatTest, Format03) {
     {
         const auto *typeBits = IR::getBitType(8);
-        const auto *sixteenBits = IR::getConstant(typeBits, 0b11);
+        const auto *sixteenBits = IR::Constant::get(typeBits, 0b11);
         ASSERT_STREQ(formatBinExpr(sixteenBits, {false, false, false}).c_str(), "11");
         ASSERT_STREQ(formatBinExpr(sixteenBits, {false, false, true}).c_str(), "0b11");
         ASSERT_STREQ(formatBinExpr(sixteenBits, {false, true, false}).c_str(), "00000011");
@@ -218,7 +218,7 @@ TEST_F(FormatTest, Format03) {
     }
     {
         const auto *typeBits = IR::getBitType(8, true);
-        const auto *sixteenBits = IR::getConstant(typeBits, -0b00111111);
+        const auto *sixteenBits = IR::Constant::get(typeBits, -0b00111111);
         ASSERT_EQ(static_cast<uint8_t>(sixteenBits->asInt64()), 0b11000001);
         ASSERT_STREQ(formatBinExpr(sixteenBits, {false, false, false}).c_str(), "11000001");
         ASSERT_STREQ(formatBinExpr(sixteenBits, {false, false, true}).c_str(), "0b11000001");
@@ -231,7 +231,7 @@ TEST_F(FormatTest, Format03) {
     }
     {
         const auto *typeBits = IR::getBitType(16);
-        const auto *sixteenBits = IR::getConstant(typeBits, 0b10000);
+        const auto *sixteenBits = IR::Constant::get(typeBits, 0b10000);
         ASSERT_STREQ(formatBinExpr(sixteenBits, {false, false, false}).c_str(), "10000");
         ASSERT_STREQ(formatBinExpr(sixteenBits, {false, false, true}).c_str(), "0b10000");
         ASSERT_STREQ(formatBinExpr(sixteenBits, {false, true, false}).c_str(), "0000000000010000");
@@ -245,7 +245,7 @@ TEST_F(FormatTest, Format03) {
     }
     {
         const auto *typeBits = IR::getBitType(16, true);
-        const auto *sixteenBits = IR::getConstant(typeBits, -0b0000000000010000);
+        const auto *sixteenBits = IR::Constant::get(typeBits, -0b0000000000010000);
         ASSERT_EQ(static_cast<uint16_t>(sixteenBits->asInt64()), 0b1111111111110000);
         ASSERT_STREQ(formatBinExpr(sixteenBits, {false, false, false}).c_str(), "1111111111110000");
         ASSERT_STREQ(formatBinExpr(sixteenBits, {false, false, true}).c_str(),

--- a/backends/p4tools/modules/testgen/test/lib/taint.cpp
+++ b/backends/p4tools/modules/testgen/test/lib/taint.cpp
@@ -33,18 +33,18 @@ TEST_F(TaintTest, Taint01) {
     // Create a base state with a parameter continuation to apply the value on.
     {
         const auto *taintExpression = P4Tools::ToolsVariables::getTaintExpression(typeBits);
-        const auto *constantVar = IR::getConstant(typeBits, 2);
+        const auto *constantVar = IR::Constant::get(typeBits, 2);
         const auto *expr = new IR::Add(constantVar, taintExpression);
         const auto *taintedExpr = Taint::propagateTaint(expr);
         const auto *expectedExpr = taintExpression;
         ASSERT_TRUE(taintedExpr->equiv(*expectedExpr));
     }
     {
-        const auto *constantVar1 = IR::getConstant(typeBits, 2);
-        const auto *constantVar2 = IR::getConstant(typeBits, 2);
+        const auto *constantVar1 = IR::Constant::get(typeBits, 2);
+        const auto *constantVar2 = IR::Constant::get(typeBits, 2);
         const auto *expr = new IR::Add(constantVar1, constantVar2);
         const auto *taintedExpr = Taint::propagateTaint(expr);
-        const auto *expectedExpr = IR::getConstant(typeBits, 2);
+        const auto *expectedExpr = IR::Constant::get(typeBits, 2);
         ASSERT_TRUE(taintedExpr->equiv(*expectedExpr));
     }
     {
@@ -65,18 +65,18 @@ TEST_F(TaintTest, Taint02) {
     const auto *taintExpression = P4Tools::ToolsVariables::getTaintExpression(typeBits);
     {
         const auto *expr =
-            new IR::Concat(IR::getBitType(16), IR::getConstant(typeBits, 2), taintExpression);
+            new IR::Concat(IR::getBitType(16), IR::Constant::get(typeBits, 2), taintExpression);
         const auto *slicedExpr = new IR::Slice(expr, 15, 8);
         const auto *taintedExpr = Taint::propagateTaint(slicedExpr);
-        const auto *expectedExpr = IR::getConstant(typeBits, 0);
+        const auto *expectedExpr = IR::Constant::get(typeBits, 0);
         ASSERT_TRUE(taintedExpr->equiv(*expectedExpr));
     }
     {
         const auto *expr =
-            new IR::Concat(IR::getBitType(16), taintExpression, IR::getConstant(typeBits, 2));
+            new IR::Concat(IR::getBitType(16), taintExpression, IR::Constant::get(typeBits, 2));
         const auto *slicedExpr = new IR::Slice(expr, 7, 0);
         const auto *taintedExpr = Taint::propagateTaint(slicedExpr);
-        const auto *expectedExpr = IR::getConstant(typeBits, 0);
+        const auto *expectedExpr = IR::Constant::get(typeBits, 0);
         ASSERT_TRUE(taintedExpr->equiv(*expectedExpr));
     }
 }
@@ -92,7 +92,7 @@ TEST_F(TaintTest, Taint03) {
     const auto *taintExpression = P4Tools::ToolsVariables::getTaintExpression(typeBits);
     {
         const auto *expr =
-            new IR::Concat(IR::getBitType(16), IR::getConstant(typeBits, 2), taintExpression);
+            new IR::Concat(IR::getBitType(16), IR::Constant::get(typeBits, 2), taintExpression);
         const auto *slicedExpr = new IR::Slice(expr, 7, 0);
         const auto *taintedExpr = Taint::propagateTaint(slicedExpr);
         const auto *expectedExpr = taintExpression;
@@ -100,7 +100,7 @@ TEST_F(TaintTest, Taint03) {
     }
     {
         const auto *expr =
-            new IR::Concat(IR::getBitType(16), taintExpression, IR::getConstant(typeBits, 2));
+            new IR::Concat(IR::getBitType(16), taintExpression, IR::Constant::get(typeBits, 2));
         const auto *slicedExpr = new IR::Slice(expr, 15, 8);
         const auto *taintedExpr = Taint::propagateTaint(slicedExpr);
         const auto *expectedExpr = taintExpression;
@@ -119,7 +119,7 @@ TEST_F(TaintTest, Taint04) {
     const auto *taintExpression = P4Tools::ToolsVariables::getTaintExpression(typeBits);
     {
         const auto *expr =
-            new IR::Concat(IR::getBitType(16), IR::getConstant(typeBits, 2), taintExpression);
+            new IR::Concat(IR::getBitType(16), IR::Constant::get(typeBits, 2), taintExpression);
         const auto *slicedExpr = new IR::Slice(expr, 11, 4);
         const auto *taintedExpr = Taint::propagateTaint(slicedExpr);
         const auto *expectedExpr = taintExpression;
@@ -127,7 +127,7 @@ TEST_F(TaintTest, Taint04) {
     }
     {
         const auto *expr =
-            new IR::Concat(IR::getBitType(16), taintExpression, IR::getConstant(typeBits, 2));
+            new IR::Concat(IR::getBitType(16), taintExpression, IR::Constant::get(typeBits, 2));
         const auto *slicedExpr = new IR::Slice(expr, 11, 4);
         const auto *taintedExpr = Taint::propagateTaint(slicedExpr);
         const auto *expectedExpr = taintExpression;
@@ -144,7 +144,7 @@ TEST_F(TaintTest, Taint05) {
     // Create a base state with a parameter continuation to apply the value on.
     const auto *typeBits = IR::getBitType(8);
     const auto *taintExpression = P4Tools::ToolsVariables::getTaintExpression(typeBits);
-    const auto *constantVar = IR::getConstant(typeBits, 2);
+    const auto *constantVar = IR::Constant::get(typeBits, 2);
     {
         const auto *expr = new IR::Concat(IR::getBitType(16), taintExpression, constantVar);
         expr = new IR::Concat(IR::getBitType(24), taintExpression, expr);
@@ -172,7 +172,7 @@ TEST_F(TaintTest, Taint06) {
     // Create a base state with a parameter continuation to apply the value on.
     const auto *typeBits = IR::getBitType(8);
     const auto *taintExpression = P4Tools::ToolsVariables::getTaintExpression(typeBits);
-    const auto *constantVar = IR::getConstant(typeBits, 2);
+    const auto *constantVar = IR::Constant::get(typeBits, 2);
     {
         const auto *expr = new IR::Concat(IR::getBitType(16), constantVar, taintExpression);
         expr = new IR::Concat(IR::getBitType(24), expr, constantVar);
@@ -200,7 +200,7 @@ TEST_F(TaintTest, Taint07) {
     // Create a base state with a parameter continuation to apply the value on.
     const auto *typeBits = IR::getBitType(8);
     const auto *taintExpression = P4Tools::ToolsVariables::getTaintExpression(typeBits);
-    const auto *constantVar = IR::getConstant(typeBits, 2);
+    const auto *constantVar = IR::Constant::get(typeBits, 2);
 
     {
         const auto *expr = new IR::Concat(IR::getBitType(16), taintExpression, constantVar);
@@ -208,7 +208,7 @@ TEST_F(TaintTest, Taint07) {
         const auto *slicedExpr = new IR::Slice(expr, 11, 4);
         slicedExpr = new IR::Slice(slicedExpr, 9, 8);
         const auto *taintedExpr = Taint::propagateTaint(slicedExpr);
-        const auto *expectedExpr = IR::getConstant(IR::getBitType(2), 0);
+        const auto *expectedExpr = IR::Constant::get(IR::getBitType(2), 0);
         ASSERT_TRUE(taintedExpr->equiv(*expectedExpr));
     }
     {
@@ -217,7 +217,7 @@ TEST_F(TaintTest, Taint07) {
         const auto *slicedExpr = new IR::Slice(expr, 19, 12);
         slicedExpr = new IR::Slice(slicedExpr, 7, 5);
         const auto *taintedExpr = Taint::propagateTaint(slicedExpr);
-        const auto *expectedExpr = IR::getConstant(IR::getBitType(3), 0);
+        const auto *expectedExpr = IR::Constant::get(IR::getBitType(3), 0);
         ASSERT_TRUE(taintedExpr->equiv(*expectedExpr));
     }
 }
@@ -230,7 +230,7 @@ TEST_F(TaintTest, Taint08) {
     // Create a base state with a parameter continuation to apply the value on.
     const auto *typeBits = IR::getBitType(8);
     const auto *taintExpression = P4Tools::ToolsVariables::getTaintExpression(typeBits);
-    const auto *constantVar = IR::getConstant(typeBits, 2);
+    const auto *constantVar = IR::Constant::get(typeBits, 2);
 
     {
         const auto *expr = new IR::Concat(IR::getBitType(16), taintExpression, constantVar);
@@ -296,11 +296,11 @@ TEST_F(TaintTest, Taint10) {
     const auto *typeBits = IR::getBitType(8);
     // Create a base state with a parameter continuation to apply the value on.
     {
-        const auto *constantVar1 = IR::getConstant(typeBits, 2);
-        const auto *constantVar2 = IR::getConstant(typeBits, 2);
+        const auto *constantVar1 = IR::Constant::get(typeBits, 2);
+        const auto *constantVar2 = IR::Constant::get(typeBits, 2);
         const auto *expr = new IR::Slice(new IR::Add(constantVar1, constantVar2), 3, 0);
         const auto *taintedExpr = Taint::propagateTaint(expr);
-        const auto *expectedExpr = IR::getConstant(IR::getBitType(4), 0);
+        const auto *expectedExpr = IR::Constant::get(IR::getBitType(4), 0);
         ASSERT_TRUE(taintedExpr->equiv(*expectedExpr));
     }
 }

--- a/backends/p4tools/modules/testgen/test/z3-solver/constraints.cpp
+++ b/backends/p4tools/modules/testgen/test/z3-solver/constraints.cpp
@@ -84,51 +84,49 @@ TEST_F(Z3SolverSatisfiabilityChecks, Strings) {
     const auto *fooVar = P4Tools::ToolsVariables::getSymbolicVariable(stringType, "foo");
     const auto *barVar = P4Tools::ToolsVariables::getSymbolicVariable(stringType, "bar");
     {
-        auto *expression = new IR::Equ(new IR::StringLiteral(stringType, "dead"),
-                                       new IR::StringLiteral(stringType, "dead"));
+        auto *expression = new IR::Equ(IR::getStringLiteral("dead"), IR::getStringLiteral("dead"));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(new IR::StringLiteral(stringType, "dead"),
-                                       new IR::StringLiteral(stringType, "beef"));
+        auto *expression = new IR::Equ(IR::getStringLiteral("dead"), IR::getStringLiteral("beef"));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, false);
     }
     {
-        auto *expression = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        auto *expression = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
-        auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        auto *expression = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
+        auto *constraint1 = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, true);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
+        auto *constraint1 = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, true);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
-        auto *constraint2 = new IR::Equ(barVar, new IR::StringLiteral(stringType, "dead"));
+        auto *constraint1 = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
+        auto *constraint2 = new IR::Equ(barVar, IR::getStringLiteral("dead"));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
-        auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "beef"));
+        auto *expression = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
+        auto *constraint1 = new IR::Equ(fooVar, IR::getStringLiteral("beef"));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, false);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, new IR::StringLiteral(stringType, "dead"));
-        auto *constraint2 = new IR::Equ(barVar, new IR::StringLiteral(stringType, "beef"));
+        auto *constraint1 = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
+        auto *constraint2 = new IR::Equ(barVar, IR::getStringLiteral("beef"));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, false);
     }

--- a/backends/p4tools/modules/testgen/test/z3-solver/constraints.cpp
+++ b/backends/p4tools/modules/testgen/test/z3-solver/constraints.cpp
@@ -30,50 +30,50 @@ TEST_F(Z3SolverSatisfiabilityChecks, BitVectors) {
     const auto *barVar = P4Tools::ToolsVariables::getSymbolicVariable(eightBitType, "bar");
     {
         auto *expression =
-            new IR::Equ(IR::getConstant(eightBitType, 1), IR::getConstant(eightBitType, 1));
+            new IR::Equ(IR::Constant::get(eightBitType, 1), IR::Constant::get(eightBitType, 1));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, true);
     }
     {
         auto *expression =
-            new IR::Equ(IR::getConstant(eightBitType, 1), IR::getConstant(eightBitType, 2));
+            new IR::Equ(IR::Constant::get(eightBitType, 1), IR::Constant::get(eightBitType, 2));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, false);
     }
     {
-        auto *expression = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        auto *expression = new IR::Equ(fooVar, IR::Constant::get(eightBitType, 1));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
-        auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        auto *expression = new IR::Equ(fooVar, IR::Constant::get(eightBitType, 1));
+        auto *constraint1 = new IR::Equ(fooVar, IR::Constant::get(eightBitType, 1));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, true);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
+        auto *constraint1 = new IR::Equ(fooVar, IR::Constant::get(eightBitType, 1));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, true);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
-        auto *constraint2 = new IR::Equ(barVar, IR::getConstant(eightBitType, 1));
+        auto *constraint1 = new IR::Equ(fooVar, IR::Constant::get(eightBitType, 1));
+        auto *constraint2 = new IR::Equ(barVar, IR::Constant::get(eightBitType, 1));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
-        auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 2));
+        auto *expression = new IR::Equ(fooVar, IR::Constant::get(eightBitType, 1));
+        auto *constraint1 = new IR::Equ(fooVar, IR::Constant::get(eightBitType, 2));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, false);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, IR::getConstant(eightBitType, 1));
-        auto *constraint2 = new IR::Equ(barVar, IR::getConstant(eightBitType, 2));
+        auto *constraint1 = new IR::Equ(fooVar, IR::Constant::get(eightBitType, 1));
+        auto *constraint2 = new IR::Equ(barVar, IR::Constant::get(eightBitType, 2));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, false);
     }
@@ -84,49 +84,51 @@ TEST_F(Z3SolverSatisfiabilityChecks, Strings) {
     const auto *fooVar = P4Tools::ToolsVariables::getSymbolicVariable(stringType, "foo");
     const auto *barVar = P4Tools::ToolsVariables::getSymbolicVariable(stringType, "bar");
     {
-        auto *expression = new IR::Equ(IR::getStringLiteral("dead"), IR::getStringLiteral("dead"));
+        auto *expression =
+            new IR::Equ(IR::StringLiteral::get("dead"), IR::StringLiteral::get("dead"));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(IR::getStringLiteral("dead"), IR::getStringLiteral("beef"));
+        auto *expression =
+            new IR::Equ(IR::StringLiteral::get("dead"), IR::StringLiteral::get("beef"));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, false);
     }
     {
-        auto *expression = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
+        auto *expression = new IR::Equ(fooVar, IR::StringLiteral::get("dead"));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
-        auto *constraint1 = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
+        auto *expression = new IR::Equ(fooVar, IR::StringLiteral::get("dead"));
+        auto *constraint1 = new IR::Equ(fooVar, IR::StringLiteral::get("dead"));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, true);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
+        auto *constraint1 = new IR::Equ(fooVar, IR::StringLiteral::get("dead"));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, true);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
-        auto *constraint2 = new IR::Equ(barVar, IR::getStringLiteral("dead"));
+        auto *constraint1 = new IR::Equ(fooVar, IR::StringLiteral::get("dead"));
+        auto *constraint2 = new IR::Equ(barVar, IR::StringLiteral::get("dead"));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
-        auto *constraint1 = new IR::Equ(fooVar, IR::getStringLiteral("beef"));
+        auto *expression = new IR::Equ(fooVar, IR::StringLiteral::get("dead"));
+        auto *constraint1 = new IR::Equ(fooVar, IR::StringLiteral::get("beef"));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, false);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, IR::getStringLiteral("dead"));
-        auto *constraint2 = new IR::Equ(barVar, IR::getStringLiteral("beef"));
+        auto *constraint1 = new IR::Equ(fooVar, IR::StringLiteral::get("dead"));
+        auto *constraint2 = new IR::Equ(barVar, IR::StringLiteral::get("beef"));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, false);
     }
@@ -137,49 +139,49 @@ TEST_F(Z3SolverSatisfiabilityChecks, Bools) {
     const auto *fooVar = P4Tools::ToolsVariables::getSymbolicVariable(boolType, "foo");
     const auto *barVar = P4Tools::ToolsVariables::getSymbolicVariable(boolType, "bar");
     {
-        auto *expression = new IR::Equ(IR::getBoolLiteral(true), IR::getBoolLiteral(true));
+        auto *expression = new IR::Equ(IR::BoolLiteral::get(true), IR::BoolLiteral::get(true));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(IR::getBoolLiteral(true), IR::getBoolLiteral(false));
+        auto *expression = new IR::Equ(IR::BoolLiteral::get(true), IR::BoolLiteral::get(false));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, false);
     }
     {
-        auto *expression = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        auto *expression = new IR::Equ(fooVar, IR::BoolLiteral::get(true));
         ConstraintVector inputExpression = {expression};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(fooVar, IR::getBoolLiteral(true));
-        auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        auto *expression = new IR::Equ(fooVar, IR::BoolLiteral::get(true));
+        auto *constraint1 = new IR::Equ(fooVar, IR::BoolLiteral::get(true));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, true);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
+        auto *constraint1 = new IR::Equ(fooVar, IR::BoolLiteral::get(true));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, true);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
-        auto *constraint2 = new IR::Equ(barVar, IR::getBoolLiteral(true));
+        auto *constraint1 = new IR::Equ(fooVar, IR::BoolLiteral::get(true));
+        auto *constraint2 = new IR::Equ(barVar, IR::BoolLiteral::get(true));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, true);
     }
     {
-        auto *expression = new IR::Equ(fooVar, IR::getBoolLiteral(true));
-        auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(false));
+        auto *expression = new IR::Equ(fooVar, IR::BoolLiteral::get(true));
+        auto *constraint1 = new IR::Equ(fooVar, IR::BoolLiteral::get(false));
         ConstraintVector inputExpression = {expression, constraint1};
         testCheckSat(inputExpression, false);
     }
     {
         auto *expression = new IR::Equ(fooVar, barVar);
-        auto *constraint1 = new IR::Equ(fooVar, IR::getBoolLiteral(true));
-        auto *constraint2 = new IR::Equ(barVar, IR::getBoolLiteral(false));
+        auto *constraint1 = new IR::Equ(fooVar, IR::BoolLiteral::get(true));
+        auto *constraint2 = new IR::Equ(barVar, IR::BoolLiteral::get(false));
         ConstraintVector inputExpression = {expression, constraint1, constraint2};
         testCheckSat(inputExpression, false);
     }

--- a/ir/expression.cpp
+++ b/ir/expression.cpp
@@ -168,7 +168,7 @@ const IR::BoolLiteral *IR::BoolLiteral::get(bool value, const Util::SourceInfo &
     return value ? &TRUE_BOOLLITERAL : &FALSE_BOOLLITERAL;
 }
 
-const IR::StringLiteral *IR::StringLiteral::get(const IR::Type *t, cstring value,
+const IR::StringLiteral *IR::StringLiteral::get(cstring value, const IR::Type *t,
                                                 const Util::SourceInfo &si) {
     // Do not cache values with a non-empty source info (yet).
     if (si.isValid()) {

--- a/ir/expression.cpp
+++ b/ir/expression.cpp
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <ostream>
 
+#include "absl/container/flat_hash_map.h"
 #include "ir/id.h"
 #include "ir/indexed_vector.h"
 #include "ir/ir.h"
@@ -147,7 +148,7 @@ const IR::Constant *IR::Constant::get(const IR::Type *t, big_int v, Util::Source
     }
     // Constants are interned. Keys in the intern map are pairs of types and values.
     using key_t = std::tuple<int, RTTI::TypeId, bool, big_int>;
-    static std::map<key_t, const Constant *> CONSTANTS;
+    static absl::flat_hash_map<key_t, const Constant *, Util::Hash> CONSTANTS;
 
     auto *&result = CONSTANTS[{tb->width_bits(), t->typeId(), tb->isSigned, v}];
     if (result == nullptr) {
@@ -176,7 +177,7 @@ const IR::StringLiteral *IR::StringLiteral::get(cstring value, const IR::Type *t
     }
     // String literals are interned.
     using key_t = std::pair<cstring, const IR::Type *>;
-    static std::map<key_t, const IR::StringLiteral *> STRINGS;
+    static absl::flat_hash_map<key_t, const IR::StringLiteral *, Util::Hash> STRINGS;
 
     auto *&result = STRINGS[{value, t}];
     if (result == nullptr) {

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -198,10 +198,10 @@ class Constant : Literal {
         Literal(si, t), value(v), base(base) { CHECK_NULL(t); handleOverflow(noWarning); }
 #emit
     static Constant GetMask(unsigned width);
+#end
 
     /// @return a constant. Any constant returned here is interned. Base is always 10.
     static const Constant *get(const Type *t, big_int v, Util::SourceInfo si = {});
-#end
 
     bool fitsInt() const { return value >= INT_MIN && value <= INT_MAX; }
     bool fitsLong() const { return value >= LONG_MIN && value <= LONG_MAX; }
@@ -262,10 +262,8 @@ class BoolLiteral : Literal {
     bool value;
     toString{ return value ? "true" : "false"; }
 
-#emit
     /// @return a bool literal. Both booleans are interned.
     static const BoolLiteral *get(bool value, const Util::SourceInfo &si = {});
-#end
 }
 
 class StringLiteral : Literal {
@@ -275,10 +273,10 @@ class StringLiteral : Literal {
     StringLiteral(ID v) : Literal(v.srcInfo), value(v.name) {}
 #emit
     operator IR::ID() const { return IR::ID(srcInfo, value); }
+#end
 
     /// @returns a string literal. The value is cached.
     static const StringLiteral *get(cstring value, const Type *t = Type_String::get(), const Util::SourceInfo &si = {});
-#end
 }
 
 class PathExpression : Expression {

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -198,7 +198,11 @@ class Constant : Literal {
         Literal(si, t), value(v), base(base) { CHECK_NULL(t); handleOverflow(noWarning); }
 #emit
     static Constant GetMask(unsigned width);
+
+    /// @return a constant. Any constant returned here is interned. Base is always 10.
+    static const Constant *get(const Type *t, big_int v, Util::SourceInfo si = {});
 #end
+
     bool fitsInt() const { return value >= INT_MIN && value <= INT_MAX; }
     bool fitsLong() const { return value >= LONG_MIN && value <= LONG_MAX; }
     bool fitsUint() const { return value >= 0 && value <= UINT_MAX; }
@@ -257,6 +261,11 @@ class Constant : Literal {
 class BoolLiteral : Literal {
     bool value;
     toString{ return value ? "true" : "false"; }
+
+#emit
+    /// @return a bool literal. Both booleans are interned.
+    static const BoolLiteral *get(bool value, const Util::SourceInfo &si = {});
+#end
 }
 
 class StringLiteral : Literal {
@@ -266,6 +275,9 @@ class StringLiteral : Literal {
     StringLiteral(ID v) : Literal(v.srcInfo), value(v.name) {}
 #emit
     operator IR::ID() const { return IR::ID(srcInfo, value); }
+
+    /// @returns a string literal. The value is cached.
+    static const StringLiteral *get(cstring value, const Type *t = Type_String::get(), const Util::SourceInfo &si = {});
 #end
 }
 

--- a/ir/irutils.cpp
+++ b/ir/irutils.cpp
@@ -1,8 +1,6 @@
 #include "ir/irutils.h"
 
 #include <cmath>
-#include <map>
-#include <tuple>
 #include <vector>
 
 #include "ir/indexed_vector.h"
@@ -10,7 +8,6 @@
 #include "ir/vector.h"
 #include "ir/visitor.h"
 #include "lib/exceptions.h"
-#include "lib/rtti.h"
 
 namespace IR {
 
@@ -33,63 +30,18 @@ const Type_Bits *getBitTypeToFit(int value) {
  *  Expressions
  * ============================================================================================= */
 
-const Constant *getConstant(const Type *type, big_int v, const Util::SourceInfo &srcInfo) {
-    // Only cache bits with width lower than 16 bit to restrict the size of the cache.
-    const auto *tb = type->to<Type_Bits>();
-    if (type->width_bits() > 16 || tb == nullptr) {
-        return new Constant(srcInfo, type, v);
-    }
-    // Constants are interned. Keys in the intern map are pairs of types and values.
-    using key_t = std::tuple<int, RTTI::TypeId, bool, big_int>;
-    static std::map<key_t, const Constant *> CONSTANTS;
-
-    auto *&result = CONSTANTS[{tb->width_bits(), type->typeId(), tb->isSigned, v}];
-    if (result == nullptr) {
-        result = new Constant(srcInfo, tb, v);
-    }
-
-    return result;
-}
-
 const IR::Constant *getMaxValueConstant(const Type *t, const Util::SourceInfo &srcInfo) {
     if (t->is<Type_Bits>()) {
-        return IR::getConstant(t, IR::getMaxBvVal(t), srcInfo);
+        return IR::Constant::get(t, IR::getMaxBvVal(t), srcInfo);
     }
     if (t->is<Type_Boolean>()) {
-        return IR::getConstant(IR::getBitType(1), 1, srcInfo);
+        return IR::Constant::get(IR::getBitType(1), 1, srcInfo);
     }
     P4C_UNIMPLEMENTED("Maximum value calculation for type %1% not implemented.", t);
 }
 
-const BoolLiteral *getBoolLiteral(bool value, const Util::SourceInfo &srcInfo) {
-    // Boolean literals are interned.
-    static std::map<bool, const BoolLiteral *> LITERALS;
-
-    auto *&result = LITERALS[value];
-    if (result == nullptr) {
-        result = new BoolLiteral(srcInfo, Type::Boolean::get(), value);
-    }
-    return result;
-}
-
-const IR::StringLiteral *getStringLiteral(cstring value, const IR::Type *type,
-                                          const Util::SourceInfo &srcInfo) {
-    if (type == nullptr) {
-        type = Type::String::get();
-    }
-    // String literals are interned.
-    using key_t = std::pair<cstring, const IR::Type *>;
-    static std::map<key_t, const IR::StringLiteral *> STRINGS;
-
-    auto *&result = STRINGS[{value, type}];
-    if (result == nullptr) {
-        result = new IR::StringLiteral(srcInfo, type, value);
-    }
-    return result;
-}
-
 const IR::Constant *convertBoolLiteral(const IR::BoolLiteral *lit) {
-    return IR::getConstant(IR::getBitType(1), lit->value ? 1 : 0, lit->getSourceInfo());
+    return IR::Constant::get(IR::getBitType(1), lit->value ? 1 : 0, lit->getSourceInfo());
 }
 
 const IR::Expression *getDefaultValue(const IR::Type *type, const Util::SourceInfo &srcInfo,

--- a/ir/irutils.cpp
+++ b/ir/irutils.cpp
@@ -72,6 +72,22 @@ const BoolLiteral *getBoolLiteral(bool value, const Util::SourceInfo &srcInfo) {
     return result;
 }
 
+const IR::StringLiteral *getStringLiteral(cstring value, const IR::Type *type,
+                                          const Util::SourceInfo &srcInfo) {
+    if (type == nullptr) {
+        type = Type::String::get();
+    }
+    // String literals are interned.
+    using key_t = std::pair<cstring, const IR::Type *>;
+    static std::map<key_t, const IR::StringLiteral *> STRINGS;
+
+    auto *&result = STRINGS[{value, type}];
+    if (result == nullptr) {
+        result = new IR::StringLiteral(srcInfo, type, value);
+    }
+    return result;
+}
+
 const IR::Constant *convertBoolLiteral(const IR::BoolLiteral *lit) {
     return IR::getConstant(IR::getBitType(1), lit->value ? 1 : 0, lit->getSourceInfo());
 }

--- a/ir/irutils.h
+++ b/ir/irutils.h
@@ -45,16 +45,6 @@ const Type_Bits *getBitTypeToFit(int value);
  *  Expressions
  * ========================================================================================= */
 
-/// @returns a constant. The value is cached.
-const Constant *getConstant(const Type *type, big_int v, const Util::SourceInfo &srcInfo = {});
-
-/// @returns a bool literal. The value is cached.
-const BoolLiteral *getBoolLiteral(bool value, const Util::SourceInfo &srcInfo = {});
-
-/// @returns a string literal. If @param type is nullptr, Type_String is used. The value is cached.
-const StringLiteral *getStringLiteral(cstring value, const Type *type = nullptr,
-                                      const Util::SourceInfo &srcInfo = {});
-
 /// @returns a constant with the maximum big_int value that can fit into this bit width.
 /// Implicitly converts boolean types to a bit vector of width one with value 1.
 const IR::Constant *getMaxValueConstant(const Type *t, const Util::SourceInfo &srcInfo = {});

--- a/ir/irutils.h
+++ b/ir/irutils.h
@@ -13,6 +13,7 @@ namespace IR {
 
 // Forward-declare some IR classes that are used in function declarations.
 class BoolLiteral;
+class StringLiteral;
 class Constant;
 class Expression;
 class BaseListExpression;
@@ -49,6 +50,10 @@ const Constant *getConstant(const Type *type, big_int v, const Util::SourceInfo 
 
 /// @returns a bool literal. The value is cached.
 const BoolLiteral *getBoolLiteral(bool value, const Util::SourceInfo &srcInfo = {});
+
+/// @returns a string literal. If @param type is nullptr, Type_String is used. The value is cached.
+const StringLiteral *getStringLiteral(cstring value, const Type *type = nullptr,
+                                      const Util::SourceInfo &srcInfo = {});
 
 /// @returns a constant with the maximum big_int value that can fit into this bit width.
 /// Implicitly converts boolean types to a bit vector of width one with value 1.

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -11,6 +11,8 @@
 #include <tuple>
 #include <type_traits>
 
+#include "lib/big_int_util.h"
+
 namespace Util {
 
 namespace Detail {
@@ -175,6 +177,9 @@ struct Hasher<signed char> : Detail::IntegerHasher<signed char> {};
 
 template <>
 struct Hasher<char> : Detail::IntegerHasher<char> {};
+
+template <>
+struct Hasher<big_int> : Detail::StdHasher {};
 
 template <>
 struct Hasher<float> : Detail::FloatHasher<float> {};

--- a/midend/booleanKeys.cpp
+++ b/midend/booleanKeys.cpp
@@ -21,7 +21,7 @@ const IR::Node *CastBooleanTableKeys::postorder(IR::Entry *entry) {
         const auto *keyExpr = keyExprs->components.at(idx);
         if (const auto *boolLiteral = keyExpr->to<IR::BoolLiteral>()) {
             int v = boolLiteral->value ? 1 : 0;
-            keyExprs->components[idx] = IR::getConstant(IR::getBitType(1), v);
+            keyExprs->components[idx] = IR::Constant::get(IR::getBitType(1), v);
         }
     }
     entry->keys = keyExprs;

--- a/midend/saturationElim.cpp
+++ b/midend/saturationElim.cpp
@@ -20,14 +20,14 @@ const IR::Mux *SaturationElim::eliminate(const IR::Operation_Binary *binary) {
 
     // overflowNumber is the largest value that can be represented before overflowing.
     // This is 2^(bits->size) - 1 for unsigned and 2^(bits->size - 1) - 1 for signed.
-    const auto *overflowNumber = IR::getConstant(bitType, IR::getMaxBvVal(bitType));
+    const auto *overflowNumber = IR::Constant::get(bitType, IR::getMaxBvVal(bitType));
 
-    const IR::Constant *zero = IR::getConstant(bitType, 0);
+    const IR::Constant *zero = IR::Constant::get(bitType, 0);
 
     // underflowNumber is the smallest value that can be represented before underflowing.
     // This is 0 for unsigned and -(2^(bits->size - 1)) for signed.
     const auto *underflowNumber =
-        (bitType->isSigned) ? IR::getConstant(bitType, IR::getMinBvVal(bitType)) : zero;
+        (bitType->isSigned) ? IR::Constant::get(bitType, IR::getMinBvVal(bitType)) : zero;
 
     const auto *boolType = IR::Type::Boolean::get();
     const IR::Expression *expr = nullptr;
@@ -70,7 +70,7 @@ const IR::Mux *SaturationElim::eliminate(const IR::Operation_Binary *binary) {
                                             new IR::Sub(bitType, overflowNumber, binary->right));
 
             // Unsigned addition never underflows.
-            underflowCondition = IR::getBoolLiteral(false);
+            underflowCondition = IR::BoolLiteral::get(false);
         }
     } else if (binary->is<IR::SubSat>()) {
         expr = new IR::Sub(bitType, binary->left, binary->right);
@@ -101,7 +101,7 @@ const IR::Mux *SaturationElim::eliminate(const IR::Operation_Binary *binary) {
                 boolType, leftNegative, new IR::LAnd(boolType, rightNonNegative, exprNonNegative));
         } else {
             // Unsigned subtraction never overflows.
-            overflowCondition = IR::getBoolLiteral(false);
+            overflowCondition = IR::BoolLiteral::get(false);
 
             // An unsigned subtraction, x - y, underflows exactly when x < y.
             underflowCondition = new IR::Lss(boolType, binary->left, binary->right);

--- a/test/gtest/transforms.cpp
+++ b/test/gtest/transforms.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 
 #include "helpers.h"
+#include "ir/ir-generated.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"
 #include "ir/visitor.h"
@@ -62,7 +63,7 @@ TEST_F(P4C_IR, InlineBlock) {
     const auto *pe = new IR::PathExpression(new IR::Path("foo"));
     const auto *stmt = new IR::BlockStatement(IR::IndexedVector<IR::StatOrDecl>({
         new IR::AssignmentStatement(pe, c2),
-        new IR::IfStatement(IR::getBoolLiteral(true), new IR::AssignmentStatement(pe, c2),
+        new IR::IfStatement(IR::BoolLiteral::get(true), new IR::AssignmentStatement(pe, c2),
                             new IR::BlockStatement(IR::IndexedVector<IR::StatOrDecl>({
                                 new IR::AssignmentStatement(pe, c2),
                             }))),


### PR DESCRIPTION
I have been doing this a lot lately, so might as well contribute a utility function. Maybe all of these "get" functions should be static class members? 