### PR TITLE
Call PassManager's debug hook even after a failing pass

### DIFF
--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -490,15 +490,18 @@ void ParserOptions::dumpPass(const char *manager, unsigned seq, const char *pass
             if (filename == "-") filename = "tmp.p4";
 
             cstring fileName = makeFileName(dumpFolder, filename, suffix);
-            auto stream = openFile(fileName, true);
+            std::unique_ptr<std::ostream> stream{openFile(fileName, true)};
             if (stream != nullptr) {
                 if (Log::verbose()) std::cerr << "Writing program to " << fileName << std::endl;
-                P4::ToP4 toP4(stream, Log::verbose(), file);
+                P4::ToP4 toP4(stream.get(), Log::verbose(), file);
                 if (noIncludes) {
                     toP4.setnoIncludesArg(true);
                 }
-                node->apply(toP4);
-                delete stream;  // close the file
+                if (node) {
+                    node->apply(toP4);
+                } else {
+                    *stream << "No P4 program returned by the pass" << std::endl;
+                }
             }
             break;
         }

--- a/ir/pass_manager.cpp
+++ b/ir/pass_manager.cpp
@@ -85,8 +85,8 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
                     LOG3(log_indent << "heap after " << v->name() << ": in use " << n4(mem)
                                     << "B, max " << n4(maxmem) << "B");
                 }
-                if (stop_on_error && ::errorCount() > initial_error_count) break;
-                if ((program = after) == nullptr) break;
+                if (stop_on_error && ::errorCount() > initial_error_count) early_exit_flag = true;
+                if ((program = after) == nullptr) early_exit_flag = true;
             } catch (Backtrack::trigger::type_t &trig_type) {
                 throw Backtrack::trigger(trig_type);
             }

--- a/ir/pass_manager.cpp
+++ b/ir/pass_manager.cpp
@@ -79,14 +79,14 @@ const IR::Node *PassManager::apply_visitor(const IR::Node *program, const char *
         try {
             try {
                 LOG1(log_indent << name() << " invoking " << v->name());
-                auto after = program->apply(**it);
+                program = program->apply(**it);
                 if (LOGGING(3)) {
                     size_t maxmem, mem = gc_mem_inuse(&maxmem);  // triggers gc
                     LOG3(log_indent << "heap after " << v->name() << ": in use " << n4(mem)
                                     << "B, max " << n4(maxmem) << "B");
                 }
                 if (stop_on_error && ::errorCount() > initial_error_count) early_exit_flag = true;
-                if ((program = after) == nullptr) early_exit_flag = true;
+                if (program == nullptr) early_exit_flag = true;
             } catch (Backtrack::trigger::type_t &trig_type) {
                 throw Backtrack::trigger(trig_type);
             }

--- a/ir/pass_manager.h
+++ b/ir/pass_manager.h
@@ -29,6 +29,8 @@ limitations under the License.
 #include "lib/exceptions.h"
 #include "lib/safe_vector.h"
 
+/// A hook called by pass manager after a pass finishes.
+/// @param node a result of the last pass, which can be the (transformed) node, or a nullptr.
 typedef std::function<void(const char *manager, unsigned seqNo, const char *pass,
                            const IR::Node *node)>
     DebugHook;


### PR DESCRIPTION
**breaking change**: Debug hooks in `PassManager` can now be called with the IR::Node being `nullptr`. This indicates that the last executed pass failed and did not return any value.

This allows running a debug hook also after a failing pass too. This can be useful e.g. to check diagnostic counts for the pass in the debug hook.