### PR TITLE
Contribute DiagnosticCountInPassHook

### DIFF
--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -26,6 +26,7 @@ limitations under the License.
 #include "frontends/p4/toP4/toP4.h"
 #include "ir/ir.h"
 #include "ir/json_loader.h"
+#include "ir/pass_utils.h"
 #include "lib/crash.h"
 #include "lib/error.h"
 #include "lib/exceptions.h"
@@ -137,6 +138,9 @@ int main(int argc, char *const argv[]) {
                 try {
                     P4::FrontEnd fe;
                     fe.addDebugHook(hook);
+                    // use -TdiagnosticCountInPass:1 / -TdiagnosticCountInPass:4 to get output of
+                    // this hook
+                    fe.addDebugHook(P4::getDiagnosticCountInPassHook());
                     program = fe.run(options, program);
                 } catch (const std::exception &bug) {
                     std::cerr << bug.what() << std::endl;

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -128,11 +128,14 @@ int main(int argc, char *const argv[]) {
             error(ErrorType::ERR_IO, "Can't open %s", options.file);
         }
     } else {
+        P4::DiagnosticCountInfo info;
         program = P4::parseP4File(options);
+        info.emitInfo("PARSER");
 
         if (program != nullptr && ::errorCount() == 0) {
             P4::P4COptionPragmaParser optionsPragmaParser;
             program->apply(P4::ApplyOptionsPragmas(optionsPragmaParser));
+            info.emitInfo("PASS P4COptionPragmaParser");
 
             if (!options.parseOnly) {
                 try {
@@ -140,7 +143,7 @@ int main(int argc, char *const argv[]) {
                     fe.addDebugHook(hook);
                     // use -TdiagnosticCountInPass:1 / -TdiagnosticCountInPass:4 to get output of
                     // this hook
-                    fe.addDebugHook(P4::getDiagnosticCountInPassHook());
+                    fe.addDebugHook(info.getPassManagerHook());
                     program = fe.run(options, program);
                 } catch (const std::exception &bug) {
                     std::cerr << bug.what() << std::endl;

--- a/ir/CMakeLists.txt
+++ b/ir/CMakeLists.txt
@@ -27,6 +27,7 @@ set (IR_SRCS
   json_parser.cpp
   node.cpp
   pass_manager.cpp
+  pass_utils.cpp
   type.cpp
   v1.cpp
   visitor.cpp
@@ -50,6 +51,7 @@ set (IR_HDRS
   node.h
   nodemap.h
   pass_manager.h
+  pass_utils.h
   vector.h
   visitor.h
 )

--- a/ir/pass_utils.cpp
+++ b/ir/pass_utils.cpp
@@ -44,7 +44,7 @@ DebugHook getDiagnosticCountInPassHook(BaseCompileContext &ctxt) {
                 }
             }
 
-            // if the log level is high enough, emit also pass count
+            // If the log level is high enough, emit also pass count.
             if (Log::fileLogLevelIsAtLeast(DIAGNOSTIC_COUNT_IN_PASS_TAG, 4)) {
                 LOG_FEATURE(DIAGNOSTIC_COUNT_IN_PASS_TAG, 4,
                             "PASS " << manager << "[" << seqNo << "] ~> " << pass << " emitted "

--- a/ir/pass_utils.cpp
+++ b/ir/pass_utils.cpp
@@ -1,0 +1,64 @@
+#include "ir/pass_utils.h"
+
+#include <initializer_list>
+#include <tuple>
+
+#include "lib/log.h"
+
+/// @file
+/// @authors Vladimír Štill
+/// @brief Utilities for passes and pass managers.
+
+namespace P4 {
+
+// The state needs to be shared between all hook copies as the hook is copied in the pass manager.
+struct DiagnosticCountInPassHookState {
+    explicit DiagnosticCountInPassHookState(BaseCompileContext &ctxt)
+        : lastDiagCount(ctxt.errorReporter().getDiagnosticCount()),
+          lastErrorCount(ctxt.errorReporter().getErrorCount()),
+          lastWarningCount(ctxt.errorReporter().getWarningCount()),
+          lastInfoCount(ctxt.errorReporter().getInfoCount()) {}
+
+    unsigned lastDiagCount, lastErrorCount, lastWarningCount, lastInfoCount;
+};
+
+DebugHook getDiagnosticCountInPassHook(BaseCompileContext &ctxt) {
+    return [state = std::make_shared<DiagnosticCountInPassHookState>(ctxt), &ctxt](
+               const char *manager, unsigned seqNo, const char *pass, const IR::Node *) mutable {
+        unsigned diag = ctxt.errorReporter().getDiagnosticCount();
+
+        if (diag != state->lastDiagCount) {
+            unsigned errs = ctxt.errorReporter().getErrorCount(),
+                     warns = ctxt.errorReporter().getWarningCount(),
+                     infos = ctxt.errorReporter().getInfoCount();
+            std::stringstream summary;
+            const char *sep = "";
+            for (auto [newCnt, oldCnt, kind] :
+                 {std::tuple(errs, state->lastErrorCount, "error"),
+                  std::tuple(warns, state->lastWarningCount, "warning"),
+                  std::tuple(infos, state->lastInfoCount, "info")}) {
+                if (newCnt > oldCnt) {
+                    auto diff = newCnt - oldCnt;
+                    summary << sep << diff << " " << kind << (diff > 1 ? "s" : "");
+                    sep = ", ";
+                }
+            }
+
+            // if the log level is high enough, emit also pass count
+            if (Log::fileLogLevelIsAtLeast(DIAGNOSTIC_COUNT_IN_PASS_TAG, 4)) {
+                LOG_FEATURE(DIAGNOSTIC_COUNT_IN_PASS_TAG, 4,
+                            "PASS " << manager << "[" << seqNo << "] ~> " << pass << " emitted "
+                                    << summary.str());
+            } else {
+                LOG_FEATURE(DIAGNOSTIC_COUNT_IN_PASS_TAG, 1,
+                            "PASS " << manager << " ~> " << pass << " emitted " << summary.str());
+            }
+            state->lastDiagCount = diag;
+            state->lastErrorCount = errs;
+            state->lastWarningCount = warns;
+            state->lastInfoCount = infos;
+        }
+    };
+}
+
+}  // namespace P4

--- a/ir/pass_utils.cpp
+++ b/ir/pass_utils.cpp
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #include "ir/pass_utils.h"
 
 #include <initializer_list>

--- a/ir/pass_utils.cpp
+++ b/ir/pass_utils.cpp
@@ -8,7 +8,6 @@
 #include "pass_utils.h"
 
 /// @file
-/// @authors Vladimír Štill
 /// @brief Utilities for passes and pass managers.
 
 namespace P4 {

--- a/ir/pass_utils.h
+++ b/ir/pass_utils.h
@@ -5,7 +5,6 @@
 #include "lib/compile_context.h"
 
 /// @file
-/// @authors Vladimír Štill
 /// @brief Utilities for passes and pass managers.
 
 namespace P4 {

--- a/ir/pass_utils.h
+++ b/ir/pass_utils.h
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 Intel Corp.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #ifndef IR_PASS_UTILS_H_
 #define IR_PASS_UTILS_H_
 

--- a/ir/pass_utils.h
+++ b/ir/pass_utils.h
@@ -16,10 +16,11 @@ inline const char *DIAGNOSTIC_COUNT_IN_PASS_TAG = "diagnosticCountInPass";
 /// different levels (error, warning, info) printed by each of the pass after it ended. This is
 /// intended to help in debuggig and testing.
 ///
-/// NOTE: You either need to create one pass and use its copies in all the pass managers in the
-/// compilation, or create each of the following hooks only after the previous compilations teps had
-/// already run. Otherwise, you can get spurious logs for a first pass of a pass manager running
-/// after some diagnostics were emitted.
+/// NOTE: You either need to use one \ref DiagnosticCountInfo object (and its \ref
+/// getPassManagerHook) for the entire compilation, create one pass and use its copies in all the
+/// pass managers in the compilation, or create each of the following hooks only after the previous
+/// compilations steps had already run. Otherwise, you can get spurious logs for a first pass of a
+/// pass manager running after some diagnostics were emitted.
 ///
 /// It logs the messages if the log level for "diagnosticCountInPass" is at least 1. If the log
 /// level is at least 4, the logs also include the sequence number of the pass that printed the
@@ -29,6 +30,55 @@ inline const char *DIAGNOSTIC_COUNT_IN_PASS_TAG = "diagnosticCountInPass";
 /// from. If not provied BaseCompileContext::get() is used.
 /// @return A debug hook suitable for using in pass managers.
 DebugHook getDiagnosticCountInPassHook(BaseCompileContext &ctxt = BaseCompileContext::get());
+
+struct DiagnosticCountInfoState;  // forward declaration
+
+/// A guard useful for emitting diagnostic info about non-passes.
+/// \see DiagnosticCountInfo::getInfoGuard.
+struct DiagnosticCountInfoGuard {
+    ~DiagnosticCountInfoGuard();
+
+    /// avoid creating moved-from object and copies that could emit spurious logs.
+    DiagnosticCountInfoGuard(DiagnosticCountInfoGuard &&) = delete;
+
+    friend struct DiagnosticCountInfo;
+
+ private:
+    DiagnosticCountInfoGuard(std::string_view componentInfo,
+                             std::shared_ptr<DiagnosticCountInfoState> state)
+        : componentInfo(componentInfo), state(state) {}
+    std::string_view componentInfo;
+    std::shared_ptr<DiagnosticCountInfoState> state;
+};
+
+/// An alternative interface to the diagnostic count info that allows using it outside of pass
+/// manager (but can also generate a pass manager hook).
+/// All copies of one object and all hooks and guards derived from it share the same diagnostic
+/// message counts so they can provide consistent logs.
+///
+/// \see getDiagnosticCountInPassHook
+struct DiagnosticCountInfo {
+    /// @param ctxt Optionally, you can provide a compilation context to take the diagnostic counts
+    /// from. If not provied BaseCompileContext::get() is used.
+    DiagnosticCountInfo(BaseCompileContext &ctxt = BaseCompileContext::get());
+
+    /// Very similar to \ref getDiagnosticCountInPassHook, but the state is tied with this instance
+    /// so that calling the hook and the \ref emitInfo/\ref getInfoGuard during one compilation will
+    /// produce the correct counts.
+    DebugHook getPassManagerHook();
+
+    /// Emits the information like printed by the debug hook, except using componentInfo as the info
+    /// at the beginning of the line: the line will be in form "<componentInfo> emitted <counts>".
+    /// This is useful e.g. for printing info about diagnostics in parser.
+    void emitInfo(std::string_view componentInfo);
+
+    /// Similar to \ref emitInfo, but prints the info at the moment the returned guard is
+    /// destructed.
+    DiagnosticCountInfoGuard getInfoGuard(std::string_view componentInfo);
+
+ private:
+    std::shared_ptr<DiagnosticCountInfoState> state;
+};
 
 }  // namespace P4
 

--- a/ir/pass_utils.h
+++ b/ir/pass_utils.h
@@ -1,0 +1,35 @@
+#ifndef IR_PASS_UTILS_H_
+#define IR_PASS_UTILS_H_
+
+#include "ir/pass_manager.h"
+#include "lib/compile_context.h"
+
+/// @file
+/// @authors Vladimír Štill
+/// @brief Utilities for passes and pass managers.
+
+namespace P4 {
+
+inline const char *DIAGNOSTIC_COUNT_IN_PASS_TAG = "diagnosticCountInPass";
+
+/// @brief This creates a debug hook that prints information about the number of diagnostics of
+/// different levels (error, warning, info) printed by each of the pass after it ended. This is
+/// intended to help in debuggig and testing.
+///
+/// NOTE: You either need to create one pass and use its copies in all the pass managers in the
+/// compilation, or create each of the following hooks only after the previous compilations teps had
+/// already run. Otherwise, you can get spurious logs for a first pass of a pass manager running
+/// after some diagnostics were emitted.
+///
+/// It logs the messages if the log level for "diagnosticCountInPass" is at least 1. If the log
+/// level is at least 4, the logs also include the sequence number of the pass that printed the
+/// message in the pass manager.
+///
+/// @param ctxt Optionally, you can provide a compilation context to take the diagnostic counts
+/// from. If not provied BaseCompileContext::get() is used.
+/// @return A debug hook suitable for using in pass managers.
+DebugHook getDiagnosticCountInPassHook(BaseCompileContext &ctxt = BaseCompileContext::get());
+
+}  // namespace P4
+
+#endif  // IR_PASS_UTILS_H_

--- a/ir/pass_utils.h
+++ b/ir/pass_utils.h
@@ -60,7 +60,7 @@ struct DiagnosticCountInfoGuard {
 struct DiagnosticCountInfo {
     /// @param ctxt Optionally, you can provide a compilation context to take the diagnostic counts
     /// from. If not provied BaseCompileContext::get() is used.
-    DiagnosticCountInfo(BaseCompileContext &ctxt = BaseCompileContext::get());
+    explicit DiagnosticCountInfo(BaseCompileContext &ctxt = BaseCompileContext::get());
 
     /// Very similar to \ref getDiagnosticCountInPassHook, but the state is tied with this instance
     /// so that calling the hook and the \ref emitInfo/\ref getInfoGuard during one compilation will


### PR DESCRIPTION
This is the reason behind #4626. A pass manager hook that is useful for testing (p4test-like) the compiler output or just for the developers to see what passes emit diagnostic messages.

Example output (with the hook in driver added and running with `-TdiagnosticCountInPass:1`):

```
main.p4(65): [--Wwarn=parser-transition] warning: sub_parser: implicit transition to `reject'
           state sub_parser{
                 ^^^^^^^^^^
PASS FrontEnd ~> CreateBuiltins emitted 1 warning
[--Wwarn=parser-transition] warning: SelectCase: unreachable case
PASS MidEnd ~> PassRepeated emitted 1 warning
```