### PR TITLE
[Docs]  capitalize "GCC" acronym in docs and comment

### DIFF
--- a/.github/workflows/ci-ubuntu-18-nightly.yml
+++ b/.github/workflows/ci-ubuntu-18-nightly.yml
@@ -10,7 +10,7 @@ on:
     branches: [main]
 
 jobs:
-  # Build with gcc and test p4c on Ubuntu 18.04.
+  # Build with GCC and test p4c on Ubuntu 18.04.
   test-ubuntu18:
     # Only run on pull requests with the "run-ubuntu18" label.
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-ubuntu18') }}

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ On some platforms Docker limits the memory usage of any container, even
 containers used during the `docker build` process. On macOS in particular the
 default is 2GB, which is not enough to build P4C. Increase the memory limit to
 at least 4GB via Docker preferences or you are likely to see "internal compiler
-errors" from gcc which are caused by low memory.
+errors" from GCC which are caused by low memory.
 
 # Bazel
 [![Bazel Build](https://github.com/p4lang/p4c/actions/workflows/ci-bazel.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-bazel.yml)

--- a/backends/bmv2/common/helpers.h
+++ b/backends/bmv2/common/helpers.h
@@ -165,7 +165,7 @@ struct CounterlikeTraits;
 /// be a definition. If the declaration is not a definition, the specialization
 /// may be defined later (7.3.1.2).
 ///
-/// gcc reports an error when trying so specialize CounterlikeTraits<> for
+/// GCC reports an error when trying so specialize CounterlikeTraits<> for
 /// Standard::CounterExtern & Standard::MeterExtern outside of the Helpers
 /// namespace, even when qualifying CounterlikeTraits<> with Helpers::. It seems
 /// to be related to this bug:

--- a/backends/ebpf/runtime/contrib/uthash.h
+++ b/backends/ebpf/runtime/contrib/uthash.h
@@ -749,7 +749,7 @@ do {                                                                            
  *
  * Note the preprocessor built-in defines can be emitted using:
  *
- *   gcc -m64 -dM -E - < /dev/null                  (on gcc)
+ *   gcc -m64 -dM -E - < /dev/null                  (on GCC)
  *   cc -## a.c (where a.c is a simple test file)   (Sun Studio)
  */
 #if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))

--- a/backends/ebpf/runtime/contrib/uthash.h
+++ b/backends/ebpf/runtime/contrib/uthash.h
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>   /* exit */
 
 /* These macros use decltype or the earlier __typeof GNU extension.
-   As decltype is only available in newer compilers (VS2010 or gcc 4.3+
+   As decltype is only available in newer compilers (VS2010 or GCC 4.3+
    when compiling c++ source) this code uses whatever method is needed
    or, for VS2008 where neither is available, uses casting workarounds. */
 #if !defined(DECLTYPE) && !defined(NO_DECLTYPE)

--- a/control-plane/p4RuntimeArchStandard.h
+++ b/control-plane/p4RuntimeArchStandard.h
@@ -63,7 +63,7 @@ namespace Helpers {
 // be a definition. If the declaration is not a definition, the specialization
 // may be defined later (7.3.1.2).
 //
-// gcc reports an error when trying so specialize CounterlikeTraits<> for
+// GCC reports an error when trying so specialize CounterlikeTraits<> for
 // Standard::CounterExtern & Standard::MeterExtern outside of the Helpers
 // namespace, even when qualifying CounterlikeTraits<> with Helpers::. It seems
 // to be related to this bug:

--- a/docs/README.md
+++ b/docs/README.md
@@ -251,7 +251,7 @@ To add a new input test with a sample P4 code file (under `testdata/p4_16_sample
   
 * Watch out for `const`; it is very important.
 
-* Use `override` whenever possible (new gcc versions enforce this).
+* Use `override` whenever possible (new GCC versions enforce this).
 
 * Never use `const_cast` and `reinterpret_cast`.
 

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -96,7 +96,7 @@ class Vector : public VectorBase {
     iterator erase(iterator s, iterator e) { return vec.erase(s, e); }
     template <typename ForwardIter>
     iterator insert(iterator i, ForwardIter b, ForwardIter e) {
-        /* FIXME -- gcc prior to 4.9 is broken and the insert routine returns void
+        /* FIXME -- GCC prior to 4.9 is broken and the insert routine returns void
          * FIXME -- rather than an iterator.  So we recalculate it from an index */
         int index = i - vec.begin();
         vec.insert(i, b, e);
@@ -129,14 +129,14 @@ class Vector : public VectorBase {
     }
 
     iterator insert(iterator i, const T *v) {
-        /* FIXME -- gcc prior to 4.9 is broken and the insert routine returns void
+        /* FIXME -- GCC prior to 4.9 is broken and the insert routine returns void
          * FIXME -- rather than an iterator.  So we recalculate it from an index */
         int index = i - vec.begin();
         vec.insert(i, v);
         return vec.begin() + index;
     }
     iterator insert(iterator i, size_t n, const T *v) {
-        /* FIXME -- gcc prior to 4.9 is broken and the insert routine returns void
+        /* FIXME -- GCC prior to 4.9 is broken and the insert routine returns void
          * FIXME -- rather than an iterator.  So we recalculate it from an index */
         int index = i - vec.begin();
         vec.insert(i, n, v);

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -800,7 +800,7 @@ cstring Visitor::demangle(const char *str) { return str; }
 #endif
 
 #if HAVE_LIBGC
-/** There's a bad interaction between the garbage collector and gcc's exception handling --
+/** There's a bad interaction between the garbage collector and GCC's exception handling --
  * the exception support code in glibstdc++ (specifically __cxa_allocate_exception) allocates
  * space for exceptions being throw with malloc (NOT with ::operrator new for some reason),
  * and the garbage collector does not scan the malloc heap for roots when garbage collecting

--- a/lib/log.cpp
+++ b/lib/log.cpp
@@ -268,7 +268,7 @@ std::ostream &uncachedFileLogOutput(const char *file) {
             if (!end) end = spec + strlen(spec);
             std::string logname(spec, end - spec);
             if (!logfiles.count(logname)) {
-                // FIXME: can't emplace a unique_ptr in some versions of gcc -- need
+                // FIXME: can't emplace a unique_ptr in some versions of GCC -- need
                 // explicit reset call.
                 logfiles[logname].reset(new std::ofstream(logname, mode));
             }

--- a/lib/rtti.h
+++ b/lib/rtti.h
@@ -59,7 +59,7 @@ limitations under the License.
 ///  inlined and therefore is again series of typeid ranged checks interleaved
 ///  with `this` adjustment.
 ///  The code relies on C++17 features. Care was taken to ensure that `constexpr`
-///  functions are compiled down to compile-time constants for gcc >= 9 and recent
+///  functions are compiled down to compile-time constants for GCC >= 9 and recent
 ///  of clang. Some of them likely would need to be marked as `consteval` when C++20
 ///  would be used across the codebase.
 
@@ -73,7 +73,7 @@ static constexpr uint64_t kHashDiscriminator = UINT64_C(0xFF);
 
 namespace detail {
 // Apparently string_view does not optimize properly in constexpr context
-// for gcc < 13
+// for GCC < 13
 struct TypeNameHolder {
     template <size_t N>
     constexpr TypeNameHolder(const char (&str)[N]) : str(&str[0]), length(N - 1) {}  // NOLINT

--- a/test/gtest/bitrange.cpp
+++ b/test/gtest/bitrange.cpp
@@ -25,7 +25,7 @@ limitations under the License.
 #include "ir/ir.h"
 #include "ir/json_loader.h"
 
-// disable these tests for gcc-4.9, which for some reason
+// disable these tests for GCC-4.9, which for some reason
 // do not link with std::optional
 #if (__GNUC__ > 4) || defined(__clang__)
 namespace Test {

--- a/test/gtest/bitvec_test.cpp
+++ b/test/gtest/bitvec_test.cpp
@@ -40,7 +40,7 @@ TEST(Bitvec, bigval) {
     EXPECT_EQ(bv.getbit(110), true);
 // older clang (<= 3.8) does not understand 'std::enable_if' in template function.
 // anyone trying to use setraw() on a large int will run into compilation error with
-// older clang, not a problem for gcc though.
+// older clang, not a problem for GCC though.
 #if (defined(__GNUC__) && !defined(__clang__)) || \
     (defined(__clang__) && (__clang_major__ >= 3) && (__clang_minor__ > 8))
     bv.setraw(val, 2);

--- a/testdata/p4_16_samples/op_bin.p4
+++ b/testdata/p4_16_samples/op_bin.p4
@@ -83,12 +83,12 @@ control pipe(inout Headers_t headers, out bool xout) {
         filter_tbl.apply();
 
         // If-statement below tests if appropriate parenthesis are
-        // added because, if not, gcc compling fails with emitted C code.
+        // added because, if not, GCC compling fails with emitted C code.
         if (headers.ipv6.isValid() && ((headers.ethernet.etherType == 0x86dd)
 	    || (headers.ipv6.hop_limit == 255)))
             headers.ipv6.protocol = 17;
         // If-statement below tests if duplicate parenthesis
-        // are not added in emitted C code causing gcc compiling failure.
+        // are not added in emitted C code causing GCC compiling failure.
         if (headers.ethernet.etherType == 0x0800)
             headers.ipv6.protocol = 10;
     }

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -2013,7 +2013,7 @@ class CleansedLines(object):
         # the integer/fractional/exponent parts would all be parsed
         # correctly as long as there are digits on both sides of the
         # separator.  So we are fine as long as we don't see something
-        # like "0.'3" (gcc 4.9.0 will not allow this literal).
+        # like "0.'3" (GCC 4.9.0 will not allow this literal).
         if Search(r'\b(?:0[bBxX]?|[1-9])[0-9a-fA-F]*$', head):
           match_literal = Match(r'^((?:\'?[0-9a-zA-Z_])*)(.*)$', "'" + tail)
           collapsed += head + match_literal.group(1).replace("'", '')

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -5965,7 +5965,7 @@ _HEADERS_CONTAINING_TEMPLATES = (
     ('<utility>', ('pair',)),
     ('<vector>', ('vector',)),
 
-    # gcc extensions.
+    # GCC extensions.
     # Note: std::hash is their hash, ::hash is our hash
     ('<hash_map>', ('hash_map', 'hash_multimap',)),
     ('<hash_set>', ('hash_set', 'hash_multiset',)),


### PR DESCRIPTION
# Changes

`GCC` acronym Capitalized to keep documentation consistent. 

## Reference 
 Based on this review on PR 
- https://github.com/p4lang/p4c/pull/4624#discussion_r1570860358 
