### PR TITLE
Introduce guard for aarch64 GCC compilation.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,7 +29,10 @@ genrule(
     cmd = " | ".join([
         "sed 's|cmakedefine|define|g' < $(SRCS)",
         "sed 's|define HAVE_LIBGC 1|undef HAVE_LIBGC|g'",
+        # TODO: We should actually check these properly instead of just #undefing them.
+        # Maybe select() can help here?
         "sed 's|define HAVE_LIBBACKTRACE 1|undef HAVE_LIBBACKTRACE|g' > $(OUTS)",
+        "sed 's|define HAVE_MM_MALLOC_H 1|undef HAVE_MM_MALLOC_H|g' > $(OUTS)",
     ]),
     visibility = ["//visibility:private"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,11 +26,11 @@ genrule(
     name = "sed_config_h",
     srcs = ["cmake/config.h.cmake"],
     outs = ["config.h"],
+    # TODO: We should actually check these properly instead of just #undefing them.
+    # Maybe select() can help here?
     cmd = " | ".join([
         "sed 's|cmakedefine|define|g' < $(SRCS)",
         "sed 's|define HAVE_LIBGC 1|undef HAVE_LIBGC|g'",
-        # TODO: We should actually check these properly instead of just #undefing them.
-        # Maybe select() can help here?
         "sed 's|define HAVE_LIBBACKTRACE 1|undef HAVE_LIBBACKTRACE|g' > $(OUTS)",
         "sed 's|define HAVE_MM_MALLOC_H 1|undef HAVE_MM_MALLOC_H|g' > $(OUTS)",
     ]),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ include (CheckIncludeFile)
 check_include_file (execinfo.h HAVE_EXECINFO_H)
 check_include_file (ucontext.h HAVE_UCONTEXT_H)
 check_include_file (backtrace-supported.h HAVE_LIBBACKTRACE)
+check_include_file(mm_malloc.h, HAVE_MM_MALLOC_H)
 include (CheckIncludeFileCXX)
 check_include_file_cxx (cxxabi.h HAVE_CXXABI_H)
 

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -33,3 +33,6 @@
 
 /* Define to 1 if you have the cxxabi.h header */
 #cmakedefine HAVE_CXXABI_H 1
+
+/* Define to 1 if you have the mm_malloc.h header */
+#cmakedefine HAVE_MM_MALLOC_H 1

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -19,7 +19,10 @@ limitations under the License.
 // of this to allow posix_memalign redeclaration with / without exception
 // specifier. As we define posix_memalign below in this file we really need to
 // ensure the proper include order to workaround this weirdness.
+// GCC compiling on arm64 can not find mm_malloc.h. We need to skip this include.
+#if defined(__clang__) || !defined(__aarch64__)
 #include <mm_malloc.h>  // NOLINT(build/include_order)
+#endif
 
 #include "config.h"
 #if HAVE_LIBGC

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -19,8 +19,8 @@ limitations under the License.
 // of this to allow posix_memalign redeclaration with / without exception
 // specifier. As we define posix_memalign below in this file we really need to
 // ensure the proper include order to workaround this weirdness.
-// GCC compiling on arm64 can not find mm_malloc.h. We need to skip this include.
-#if defined(__clang__) || !defined(__aarch64__)
+// Some systems (e.g., GCC compiling on arm64) do not have mm_malloc.h. We need to skip it.
+#if HAVE_MM_MALLOC_H
 #include <mm_malloc.h>  // NOLINT(build/include_order)
 #endif
 


### PR DESCRIPTION
Fixes #4639.

