### PR TITLE
Use check_include_file_cxx instead of check_include_file to find mm_malloc.h

### DIFF
--- a/.github/workflows/ci-static-build-test.yml
+++ b/.github/workflows/ci-static-build-test.yml
@@ -21,7 +21,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'run-static') }}
     # Note: Actions have no real ternary condition operator, but this hack works because non-empty
     # strings are true.
-    name: "Dynamic ${{ matrix.dynamic.glibc == 'ON' && 'glibc' || 'stdlib' }}"
+    name: Dynamic ${{ matrix.dynamic.glibc == 'ON' && 'glibc' || 'stdlib' }}
     strategy:
       fail-fast: false
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,13 +234,12 @@ p4c_add_library (rt clock_gettime HAVE_CLOCK_GETTIME)
 
 # check includes
 include (CheckIncludeFile)
-check_include_file (execinfo.h HAVE_EXECINFO_H)
-check_include_file (ucontext.h HAVE_UCONTEXT_H)
-check_include_file (backtrace-supported.h HAVE_LIBBACKTRACE)
-check_include_file(mm_malloc.h, HAVE_MM_MALLOC_H)
 include (CheckIncludeFileCXX)
-check_include_file_cxx (cxxabi.h HAVE_CXXABI_H)
-
+check_include_file(execinfo.h HAVE_EXECINFO_H)
+check_include_file(ucontext.h HAVE_UCONTEXT_H)
+check_include_file(backtrace-supported.h HAVE_LIBBACKTRACE)
+check_include_file_cxx(mm_malloc.h HAVE_MM_MALLOC_H)
+check_include_file_cxx(cxxabi.h HAVE_CXXABI_H)
 if (HAVE_LIBBACKTRACE)
 set (P4C_LIB_DEPS "${P4C_LIB_DEPS};-lbacktrace")
 endif ()

--- a/lib/gc.cpp
+++ b/lib/gc.cpp
@@ -20,11 +20,13 @@ limitations under the License.
 // specifier. As we define posix_memalign below in this file we really need to
 // ensure the proper include order to workaround this weirdness.
 // Some systems (e.g., GCC compiling on arm64) do not have mm_malloc.h. We need to skip it.
+
+#include "config.h"
+
 #if HAVE_MM_MALLOC_H
 #include <mm_malloc.h>  // NOLINT(build/include_order)
 #endif
 
-#include "config.h"
 #if HAVE_LIBGC
 #include <gc/gc_cpp.h>
 #include <gc/gc_mark.h>


### PR DESCRIPTION
It looks like the other function never finds `mm_malloc.h`