### PR TITLE
Improve error message when shifting int by non-const

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -2684,8 +2684,13 @@ const IR::Node *TypeInference::shift(const IR::Operation_Binary *expression) {
         return expression;
     }
 
-    if (ltype->is<IR::Type_InfInt>() && !rtype->is<IR::Type_InfInt>()) {
-        typeError("%1%: width of left operand of shift needs to be specified", expression);
+    if (ltype->is<IR::Type_InfInt>() && !rtype->is<IR::Type_InfInt>() &&
+        !isCompileTimeConstant(expression->right)) {
+        typeError(
+            "%1%: shift result type is arbitrary-precision int, but right operand is not constant; "
+            "width of left operand of shift needs to be specified or both operands need to be "
+            "constant",
+            expression);
         return expression;
     }
 

--- a/testdata/p4_16_errors/shift-int-non-const.p4
+++ b/testdata/p4_16_errors/shift-int-non-const.p4
@@ -1,0 +1,15 @@
+header hdr_t {
+  bit<8> v;
+}
+
+control c(inout hdr_t hdr, inout bit<4> b) {
+  apply {
+    const int a = 5;
+    hdr.v = (bit<8>)(a >> b);
+  }
+}
+
+control C(inout hdr_t hdr, inout bit<4> b);
+package P(C c);
+
+P(c()) main;

--- a/testdata/p4_16_errors_outputs/issue2206.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2206.p4-stderr
@@ -1,3 +1,3 @@
-issue2206.p4(27): [--Werror=type-error] error: 1 << h.h.c: width of left operand of shift needs to be specified
+issue2206.p4(27): [--Werror=type-error] error: 1 << h.h.c: shift result type is arbitrary-precision int, but right operand is not constant; width of left operand of shift needs to be specified or both operands need to be constant
         h.h.a = (1 << h.h.c) + 8w2;
                  ^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/shift-int-non-const.p4
+++ b/testdata/p4_16_errors_outputs/shift-int-non-const.p4
@@ -1,0 +1,14 @@
+header hdr_t {
+    bit<8> v;
+}
+
+control c(inout hdr_t hdr, inout bit<4> b) {
+    apply {
+        const int a = 5;
+        hdr.v = (bit<8>)(a >> b);
+    }
+}
+
+control C(inout hdr_t hdr, inout bit<4> b);
+package P(C c);
+P(c()) main;

--- a/testdata/p4_16_errors_outputs/shift-int-non-const.p4-stderr
+++ b/testdata/p4_16_errors_outputs/shift-int-non-const.p4-stderr
@@ -1,0 +1,3 @@
+shift-int-non-const.p4(8): [--Werror=type-error] error: 5 >> b: shift result type is arbitrary-precision int, but right operand is not constant; width of left operand of shift needs to be specified or both operands need to be constant
+    hdr.v = (bit<8>)(a >> b);
+                     ^^^^^^

--- a/testdata/p4_16_samples/shift-int-const.p4
+++ b/testdata/p4_16_samples/shift-int-const.p4
@@ -1,0 +1,16 @@
+header hdr_t {
+  bit<8> v;
+}
+
+control c(inout hdr_t hdr) {
+  apply {
+    const int a = 5;
+    const bit<4> b = 2;
+    hdr.v = (bit<8>)(a >> b);
+  }
+}
+
+control C(inout hdr_t hdr);
+package P(C c);
+
+P(c()) main;

--- a/testdata/p4_16_samples_outputs/shift-int-const-first.p4
+++ b/testdata/p4_16_samples_outputs/shift-int-const-first.p4
@@ -1,0 +1,15 @@
+header hdr_t {
+    bit<8> v;
+}
+
+control c(inout hdr_t hdr) {
+    apply {
+        const int a = 5;
+        const bit<4> b = 4w2;
+        hdr.v = 8w1;
+    }
+}
+
+control C(inout hdr_t hdr);
+package P(C c);
+P(c()) main;

--- a/testdata/p4_16_samples_outputs/shift-int-const-frontend.p4
+++ b/testdata/p4_16_samples_outputs/shift-int-const-frontend.p4
@@ -1,0 +1,13 @@
+header hdr_t {
+    bit<8> v;
+}
+
+control c(inout hdr_t hdr) {
+    apply {
+        hdr.v = 8w1;
+    }
+}
+
+control C(inout hdr_t hdr);
+package P(C c);
+P(c()) main;

--- a/testdata/p4_16_samples_outputs/shift-int-const-midend.p4
+++ b/testdata/p4_16_samples_outputs/shift-int-const-midend.p4
@@ -1,0 +1,22 @@
+header hdr_t {
+    bit<8> v;
+}
+
+control c(inout hdr_t hdr) {
+    @hidden action shiftintconst9() {
+        hdr.v = 8w1;
+    }
+    @hidden table tbl_shiftintconst9 {
+        actions = {
+            shiftintconst9();
+        }
+        const default_action = shiftintconst9();
+    }
+    apply {
+        tbl_shiftintconst9.apply();
+    }
+}
+
+control C(inout hdr_t hdr);
+package P(C c);
+P(c()) main;

--- a/testdata/p4_16_samples_outputs/shift-int-const.p4
+++ b/testdata/p4_16_samples_outputs/shift-int-const.p4
@@ -1,0 +1,15 @@
+header hdr_t {
+    bit<8> v;
+}
+
+control c(inout hdr_t hdr) {
+    apply {
+        const int a = 5;
+        const bit<4> b = 2;
+        hdr.v = (bit<8>)(a >> b);
+    }
+}
+
+control C(inout hdr_t hdr);
+package P(C c);
+P(c()) main;


### PR DESCRIPTION
Fixes #4652. Note that besides changing the error I've also allowed the case when the right operand is `bit<N>`/`int<N>` but it is also constant. This case should be allowed and it does actually work in most cases in practice, it is just covered by constant folding.

---

BTW: I did not realize until now that the type checker actually *does constant folding* too! This will make any "small frontend" quite hard to do if it was to not do constant folding.