### PR TITLE
Fixes to lib/hash and lib/big_int_util.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,6 +41,7 @@ cc_library(
     name = "config_h",
     hdrs = ["config.h"],
     include_prefix = ".",
+    deps = [":sed_config_h"],
 )
 
 cc_library(

--- a/backends/p4tools/common/lib/symbolic_env.cpp
+++ b/backends/p4tools/common/lib/symbolic_env.cpp
@@ -1,9 +1,7 @@
 #include "backends/p4tools/common/lib/symbolic_env.h"
 
 #include <algorithm>
-#include <string>
 #include <utility>
-#include <vector>
 
 #include <boost/container/vector.hpp>
 
@@ -11,7 +9,6 @@
 #include "ir/indexed_vector.h"
 #include "ir/vector.h"
 #include "ir/visitor.h"
-#include "lib/cstring.h"
 #include "lib/exceptions.h"
 
 namespace P4Tools {
@@ -28,7 +25,8 @@ bool SymbolicEnv::exists(const IR::StateVariable &var) const { return map.find(v
 
 void SymbolicEnv::set(const IR::StateVariable &var, const IR::Expression *value) {
     BUG_CHECK(value->type && !value->type->is<IR::Type_Unknown>(),
-              "Cannot set value with unspecified type: %1%", value);
+              "Cannot set value for node %1% with unspecified type: %2%", value->node_type_name(),
+              value);
     map[var] = value;
 }
 

--- a/ir/expression.cpp
+++ b/ir/expression.cpp
@@ -161,7 +161,7 @@ const IR::Constant *IR::Constant::get(const IR::Type *t, big_int v, Util::Source
 const IR::BoolLiteral *IR::BoolLiteral::get(bool value, const Util::SourceInfo &si) {
     // Do not cache values with a non-empty source info (yet).
     if (si.isValid()) {
-        return new IR::BoolLiteral(si, value);
+        return new IR::BoolLiteral(si, IR::Type_Boolean::get(), value);
     }
     // Boolean literals are interned.
     static IR::BoolLiteral TRUE_BOOLLITERAL(si, IR::Type_Boolean::get(), true);

--- a/lib/alloc_trace.cpp
+++ b/lib/alloc_trace.cpp
@@ -64,6 +64,9 @@ void AllocTrace::count(void **bt, size_t sz) {
 }
 
 std::ostream &operator<<(std::ostream &out, const AllocTrace &at) {
+#if HAVE_LIBGC
+    PauseTrace temp_pause;
+#endif
     typedef decltype(at.data)::value_type data_t;
     std::vector<std::pair<size_t, const data_t *>> sorted;
     size_t total_total = 0;

--- a/lib/alloc_trace.cpp
+++ b/lib/alloc_trace.cpp
@@ -64,9 +64,6 @@ void AllocTrace::count(void **bt, size_t sz) {
 }
 
 std::ostream &operator<<(std::ostream &out, const AllocTrace &at) {
-#if HAVE_LIBGC
-    PauseTrace temp_pause;
-#endif
     typedef decltype(at.data)::value_type data_t;
     std::vector<std::pair<size_t, const data_t *>> sorted;
     size_t total_total = 0;

--- a/lib/alloc_trace.h
+++ b/lib/alloc_trace.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <map>
 #include <ostream>
 
+#include "config.h"
 #include "exceptions.h"
 #include "gc.h"
 

--- a/lib/big_int.h
+++ b/lib/big_int.h
@@ -1,0 +1,24 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef LIB_BIG_INT_H_
+#define LIB_BIG_INT_H_
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+using big_int = boost::multiprecision::cpp_int;
+
+#endif /* LIB_BIG_INT_H_ */

--- a/lib/big_int_util.h
+++ b/lib/big_int_util.h
@@ -17,10 +17,8 @@ limitations under the License.
 #ifndef LIB_BIG_INT_UTIL_H_
 #define LIB_BIG_INT_UTIL_H_
 
-#include <boost/multiprecision/cpp_int.hpp>
-
-#include "config.h"
-typedef boost::multiprecision::cpp_int big_int;
+#include "big_int.h"
+#include "hash.h"
 
 namespace Util {
 
@@ -92,5 +90,8 @@ static inline int floor_log2(big_int v) {
 }
 
 static inline int ceil_log2(big_int v) { return v ? floor_log2(v - 1) + 1 : -1; }
+
+template <>
+struct Util::Hasher<big_int> : Detail::StdHasher {};
 
 #endif /* LIB_BIG_INT_UTIL_H_ */

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -11,8 +11,6 @@
 #include <tuple>
 #include <type_traits>
 
-#include "lib/big_int_util.h"
-
 namespace Util {
 
 namespace Detail {
@@ -177,9 +175,6 @@ struct Hasher<signed char> : Detail::IntegerHasher<signed char> {};
 
 template <>
 struct Hasher<char> : Detail::IntegerHasher<char> {};
-
-template <>
-struct Hasher<big_int> : Detail::StdHasher {};
 
 template <>
 struct Hasher<float> : Detail::FloatHasher<float> {};


### PR DESCRIPTION
A couple fixes after #4623 has been merged.

- Move the boost definition of `boost::multiprecision::cpp_int` into its own header file.
- Fix missing of typing for BoolLiterals with SourceInfo.
- Move `big_int` hashing to `big_int_utils`.
