### PR TITLE
Depend on Boost using FetchContent instead of relying on system-provided boost

### DIFF
--- a/.github/workflows/ci-test-debian.yml
+++ b/.github/workflows/ci-test-debian.yml
@@ -98,7 +98,6 @@ jobs:
       ENABLE_P4TC: OFF
       ENABLE_P4FMT: OFF
       ENABLE_P4TEST: OFF
-      ENABLE_P4C_GRAPHS: OFF
     steps:
       - uses: actions/checkout@v7
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ CMAKE_DEPENDENT_OPTION (ENABLE_TOFINO "Build the TOFINO backend (required for th
 CMAKE_DEPENDENT_OPTION (ENABLE_P4TC "Build the P4TC backend" ON ENABLE_CONTROL_PLANE OFF)
 OPTION (ENABLE_P4FMT "Build the P4FMT backend" ON)
 CMAKE_DEPENDENT_OPTION (ENABLE_P4TEST "Build the P4Test backend (required for the full test suite)" ON ENABLE_CONTROL_PLANE OFF)
-OPTION (ENABLE_TEST_TOOLS "Build the P4Tools development platform" OFF)
+CMAKE_DEPENDENT_OPTION (ENABLE_TEST_TOOLS "Build the P4Tools development platform" OFF ENABLE_CONTROL_PLANE OFF)
 OPTION (ENABLE_P4C_GRAPHS "Build the p4c-graphs backend" ON)
 OPTION (ENABLE_GC "Compile with the Boehm-Demers-Weiser garbage collector." ON)
 OPTION (ENABLE_WERROR "Treat warnings as errors" OFF)
@@ -54,6 +54,7 @@ likely depend on the standard libary anyway. If you have some non-static C++ dep
 STATIC_BUILD_WITH_DYNAMIC_STDLIB." OFF)
 OPTION (STATIC_BUILD_WITH_DYNAMIC_STDLIB "Build a (mostly) statically linked release binary. \
 Glibc and C++ standard library is linked dynamically." OFF)
+set(ADDITIONAL_P4C_BOOST_MODULES "" CACHE STRING "Build and make these additional boost modules available. Modules are separated with semicolons.")
 
 if (STATIC_BUILD_WITH_DYNAMIC_GLIBC OR STATIC_BUILD_WITH_DYNAMIC_STDLIB)
     # We want to optimize the binary size for a static release binary by default.
@@ -156,10 +157,6 @@ if(STATIC_BUILD_WITH_DYNAMIC_GLIBC OR STATIC_BUILD_WITH_DYNAMIC_STDLIB)
   endif()
   set(BUILD_SHARED_LIBS OFF)
   set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
-  # Link Boost statically
-  # See https://cmake.org/cmake/help/latest/module/FindBoost.html for details
-  set(Boost_USE_STATIC_LIBS ON)
-  set(Boost_USE_STATIC_RUNTIME OFF)
   # Set the static variable
   set(P4C_STATIC_BUILD STATIC)
   # TODO: We can not use -static here because of compilation and portability problems:
@@ -173,6 +170,11 @@ if(STATIC_BUILD_WITH_DYNAMIC_GLIBC OR STATIC_BUILD_WITH_DYNAMIC_STDLIB)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")
   endif()
   add_definitions("-DP4C_STATIC_BUILD")
+endif()
+
+# Enable P4C_GRAPHS if TOFINO is enabled.
+if (ENABLE_TOFINO)
+  set(ENABLE_P4C_GRAPHS ON)
 endif()
 
 # Ensure we enable sanitizers before fetching dependencies so the correct flags
@@ -223,19 +225,24 @@ if (ENABLE_GTESTS)
 endif ()
 include(Abseil)
 p4c_obtain_abseil()
+# The boost graph module is optional and only required by the graphs back end.
+if(ENABLE_P4C_GRAPHS AND NOT P4C_USE_PREINSTALLED_BOOST)
+  list(APPEND ADDITIONAL_P4C_BOOST_MODULES graph)
+  list(APPEND P4C_BOOST_LIBRARIES Boost::graph)
+endif()
+if (ENABLE_TOFINO AND NOT P4C_USE_PREINSTALLED_BOOST)
+    # Tofino core.
+    list(APPEND ADDITIONAL_P4C_BOOST_MODULES algorithm uuid)
+    list(APPEND P4C_BOOST_LIBRARIES Boost::algorithm Boost::uuid)
+    # BF-ASM.
+    # list(APPEND ADDITIONAL_P4C_BOOST_MODULES)
+endif()
+include(Boost)
+p4c_obtain_boost()
 
 # We require -pthread to make std::call_once work, even if we're not using threads...
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
-
-# The boost graph headers are optional and only required by the graphs back end.
-find_package (Boost QUIET COMPONENTS graph)
-if (Boost_FOUND)
-  set (HAVE_LIBBOOST_GRAPH 1)
-else ()
-  message (WARNING "Boost graph headers not found, will not build 'graphs' backend")
-endif ()
-find_package (Boost REQUIRED COMPONENTS iostreams)
 
 # Compile with the Boehm garbage collector (https://github.com/ivmai/bdwgc), if requested.
 # One can disable the GC, e.g., to run under Valgrind, by editing config.h.
@@ -247,9 +254,6 @@ if (ENABLE_MULTITHREAD)
   add_definitions("-DMULTITHREAD")
 endif()
 list (APPEND P4C_LIB_DEPS ${CMAKE_THREAD_LIBS_INIT})
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-set (HAVE_LIBBOOST_IOSTREAMS 1)
-list (APPEND P4C_LIB_DEPS ${Boost_LIBRARIES})
 if (ENABLE_GC)
   list (APPEND P4C_LIB_DEPS ${LIBGC_LIBRARIES})
 endif ()
@@ -499,7 +503,7 @@ endif ()
 if (ENABLE_EBPF)
     add_subdirectory (backends/ebpf)
 endif ()
-if (ENABLE_P4C_GRAPHS AND HAVE_LIBBOOST_GRAPH EQUAL 1)
+if (ENABLE_P4C_GRAPHS)
   add_subdirectory (backends/graphs)
 endif ()
 if (ENABLE_P4TC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,10 @@ CMAKE_DEPENDENT_OPTION (ENABLE_P4TC "Build the P4TC backend" ON ENABLE_CONTROL_P
 OPTION (ENABLE_P4FMT "Build the P4FMT backend" ON)
 CMAKE_DEPENDENT_OPTION (ENABLE_P4TEST "Build the P4Test backend (required for the full test suite)" ON ENABLE_CONTROL_PLANE OFF)
 CMAKE_DEPENDENT_OPTION (ENABLE_TEST_TOOLS "Build the P4Tools development platform" OFF ENABLE_CONTROL_PLANE OFF)
-OPTION (ENABLE_P4C_GRAPHS "Build the p4c-graphs backend" ON)
+OPTION (ENABLE_P4C_GRAPHS "Build the p4c-graphs backend" OFF)
+if (ENABLE_TOFINO)
+  set(ENABLE_P4C_GRAPHS ON)
+endif()
 OPTION (ENABLE_GC "Compile with the Boehm-Demers-Weiser garbage collector." ON)
 OPTION (ENABLE_WERROR "Treat warnings as errors" OFF)
 OPTION (ENABLE_SANITIZERS "Enable sanitizers" OFF)
@@ -54,7 +57,7 @@ likely depend on the standard libary anyway. If you have some non-static C++ dep
 STATIC_BUILD_WITH_DYNAMIC_STDLIB." OFF)
 OPTION (STATIC_BUILD_WITH_DYNAMIC_STDLIB "Build a (mostly) statically linked release binary. \
 Glibc and C++ standard library is linked dynamically." OFF)
-set(ADDITIONAL_P4C_BOOST_MODULES "" CACHE STRING "Build and make these additional boost modules available. Modules are separated with semicolons.")
+set(ADDITIONAL_P4C_BOOST_MODULES "" CACHE STRING "Additional Boost modules to build, e.g. for custom backends. Modules are separated with semicolons.")
 
 if (STATIC_BUILD_WITH_DYNAMIC_GLIBC OR STATIC_BUILD_WITH_DYNAMIC_STDLIB)
     # We want to optimize the binary size for a static release binary by default.
@@ -172,11 +175,6 @@ if(STATIC_BUILD_WITH_DYNAMIC_GLIBC OR STATIC_BUILD_WITH_DYNAMIC_STDLIB)
   add_definitions("-DP4C_STATIC_BUILD")
 endif()
 
-# Enable P4C_GRAPHS if TOFINO is enabled.
-if (ENABLE_TOFINO)
-  set(ENABLE_P4C_GRAPHS ON)
-endif()
-
 # Ensure we enable sanitizers before fetching dependencies so the correct flags
 # are propagated below
 if (ENABLE_SANITIZERS)
@@ -225,19 +223,38 @@ if (ENABLE_GTESTS)
 endif ()
 include(Abseil)
 p4c_obtain_abseil()
-# The boost graph module is optional and only required by the graphs back end.
-if(ENABLE_P4C_GRAPHS AND NOT P4C_USE_PREINSTALLED_BOOST)
-  list(APPEND ADDITIONAL_P4C_BOOST_MODULES graph)
-  list(APPEND P4C_BOOST_LIBRARIES Boost::graph)
-endif()
-if (ENABLE_TOFINO AND NOT P4C_USE_PREINSTALLED_BOOST)
-    # Tofino core.
-    list(APPEND ADDITIONAL_P4C_BOOST_MODULES algorithm uuid)
-    list(APPEND P4C_BOOST_LIBRARIES Boost::algorithm Boost::uuid)
-    # BF-ASM.
-    # list(APPEND ADDITIONAL_P4C_BOOST_MODULES)
-endif()
+
+# Collect Boost module requirements before the Boost module is set up. To make this
+# work we need to look ahead. Backends and extensions declare their requirements
+# in a small boost.cmake file; extensions are discovered automatically.
+# FIXME: This is a bit of a hack, but only required because the boost cmake module is
+# a monolithic block, just like the framework...
+set(P4C_BOOST_MODULES ${ADDITIONAL_P4C_BOOST_MODULES})
 include(Boost)
+if (ENABLE_P4C_GRAPHS)
+  include(backends/graphs/boost.cmake)
+endif()
+if (ENABLE_TOFINO)
+  include(backends/tofino/boost.cmake)
+endif()
+file (GLOB p4c_extensions RELATIVE ${P4C_SOURCE_DIR}/extensions ${P4C_SOURCE_DIR}/extensions/*)
+MESSAGE ("-- Available extensions ${p4c_extensions}")
+set (P4C_ENABLED_EXTENSIONS)
+foreach (ext ${p4c_extensions})
+  if (EXISTS ${P4C_SOURCE_DIR}/extensions/${ext}/CMakeLists.txt)
+    # Generate an option that makes it possible to disable this extension.
+    string(MAKE_C_IDENTIFIER ${ext} EXT_AS_IDENTIFIER)
+    string(TOUPPER ${EXT_AS_IDENTIFIER} EXT_AS_OPTION_NAME)
+    string(CONCAT ENABLE_EXT_OPTION "ENABLE_" ${EXT_AS_OPTION_NAME})
+    OPTION (${ENABLE_EXT_OPTION} "Build the ${ext} backend" ON)
+    if (${ENABLE_EXT_OPTION})
+      list (APPEND P4C_ENABLED_EXTENSIONS ${ext})
+      if (EXISTS ${P4C_SOURCE_DIR}/extensions/${ext}/boost.cmake)
+        include (${P4C_SOURCE_DIR}/extensions/${ext}/boost.cmake)
+      endif()
+    endif()
+  endif()
+endforeach(ext)
 p4c_obtain_boost()
 
 # We require -pthread to make std::call_once work, even if we're not using threads...
@@ -471,21 +488,8 @@ if (ENABLE_CONTROL_PLANE)
     add_subdirectory (control-plane)
 endif()
 
-file (GLOB p4c_extensions RELATIVE ${P4C_SOURCE_DIR}/extensions ${P4C_SOURCE_DIR}/extensions/*)
-MESSAGE ("-- Available extensions ${p4c_extensions}")
-foreach (ext ${p4c_extensions})
-  if (EXISTS ${P4C_SOURCE_DIR}/extensions/${ext}/CMakeLists.txt)
-    # Generate an option that makes it possible to disable this extension.
-    string(MAKE_C_IDENTIFIER ${ext} EXT_AS_IDENTIFIER)
-    string(TOUPPER ${EXT_AS_IDENTIFIER} EXT_AS_OPTION_NAME)
-    string(CONCAT ENABLE_EXT_OPTION "ENABLE_" ${EXT_AS_OPTION_NAME})
-    string(CONCAT EXT_HELP_TEXT "Build the " ${ext} " backend")
-    OPTION (${ENABLE_EXT_OPTION} ${EXT_HELP_TEXT} ON)
-
-    if (${ENABLE_EXT_OPTION})
-        add_subdirectory (extensions/${ext})
-    endif()
-  endif()
+foreach (ext IN LISTS P4C_ENABLED_EXTENSIONS)
+  add_subdirectory (extensions/${ext})
 endforeach(ext)
 
 # With the current implementation of ir-generator, all targets share the

--- a/backends/graphs/CMakeLists.txt
+++ b/backends/graphs/CMakeLists.txt
@@ -3,6 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if (P4C_USE_PREINSTALLED_BOOST)
+  find_package(Boost REQUIRED COMPONENTS graph)
+  set(HAVE_LIBBOOST_GRAPH 1)
+endif()
+
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/version.h.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/version.h" @ONLY)
 
@@ -21,7 +26,10 @@ set (GRAPHS_HDRS
 )
 
 add_library(p4cgraphs STATIC ${GRAPHS_SRCS} ${EXTENSION_P4_14_CONV_SOURCES})
-target_link_libraries(p4cgraphs ir-generated frontend)
+target_link_libraries(p4cgraphs
+  PRIVATE ir-generated frontend
+  PUBLIC Boost::graph
+)
 
 add_executable(p4c-graphs p4c-graphs.cpp)
 target_link_libraries (p4c-graphs p4cgraphs ir-generated frontend ${P4C_LIBRARIES} ${P4C_LIB_DEPS})

--- a/backends/graphs/CMakeLists.txt
+++ b/backends/graphs/CMakeLists.txt
@@ -3,11 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if (P4C_USE_PREINSTALLED_BOOST)
-  find_package(Boost REQUIRED COMPONENTS graph)
-  set(HAVE_LIBBOOST_GRAPH 1)
-endif()
-
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/version.h.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/version.h" @ONLY)
 
@@ -28,7 +23,7 @@ set (GRAPHS_HDRS
 add_library(p4cgraphs STATIC ${GRAPHS_SRCS} ${EXTENSION_P4_14_CONV_SOURCES})
 target_link_libraries(p4cgraphs
   PRIVATE ir-generated frontend
-  PUBLIC Boost::graph
+  PUBLIC ${P4C_BOOST_LIBRARIES}
 )
 
 add_executable(p4c-graphs p4c-graphs.cpp)

--- a/backends/graphs/boost.cmake
+++ b/backends/graphs/boost.cmake
@@ -1,0 +1,3 @@
+# Boost module requirements of the graphs backend. Included by the top-level
+# CMakeLists.txt before p4c_obtain_boost() runs.
+p4c_require_boost(graph)

--- a/backends/graphs/graphs.h
+++ b/backends/graphs/graphs.h
@@ -8,15 +8,6 @@
 #ifndef BACKENDS_GRAPHS_GRAPHS_H_
 #define BACKENDS_GRAPHS_GRAPHS_H_
 
-#include "config.h"
-#include "lib/cstring.h"
-
-/// Shouldn't happen as cmake will not try to build this backend if the boost
-/// graph headers couldn't be found.
-#ifndef HAVE_LIBBOOST_GRAPH
-#error "This backend requires the boost graph headers, which could not be found"
-#endif
-
 #include <map>
 #include <optional>
 #include <utility>  // std::pair
@@ -26,9 +17,11 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/graphviz.hpp>
 
+#include "config.h"
 #include "frontends/p4/parserCallGraph.h"
 #include "ir/ir.h"
 #include "ir/visitor.h"
+#include "lib/cstring.h"
 
 namespace P4 {
 

--- a/backends/p4tools/modules/testgen/targets/tofino/target.h
+++ b/backends/p4tools/modules/testgen/targets/tofino/target.h
@@ -22,8 +22,6 @@
 
 #include <string>
 
-#include <boost/filesystem.hpp>
-
 #include "ir/ir.h"
 #include "ir/solver.h"
 

--- a/backends/p4tools/modules/testgen/targets/tofino/test_backend.h
+++ b/backends/p4tools/modules/testgen/targets/tofino/test_backend.h
@@ -25,8 +25,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem.hpp>
-
 #include "backends/p4tools/common/lib/model.h"
 #include "backends/p4tools/common/lib/trace_event.h"
 #include "ir/ir.h"

--- a/backends/tofino/CMakeLists.txt
+++ b/backends/tofino/CMakeLists.txt
@@ -54,9 +54,6 @@ if (ENABLE_TESTING)
   enable_testing()
 endif()
 
-set(BOOST_MIN_VERSION "1.58.0")
-find_package(Boost ${BOOST_MIN_VERSION} REQUIRED)
-
 set(INTERFACES_DIR ${BFN_P4C_SOURCE_DIR}/compiler_interfaces)
 
 # Get the version from bf-p4c/version.h

--- a/backends/tofino/bf-asm/CMakeLists.txt
+++ b/backends/tofino/bf-asm/CMakeLists.txt
@@ -22,7 +22,7 @@ MESSAGE("-- Adding bf-asm")
 
 OPTION(ASAN_ENABLED "Enable ASAN checks" OFF)
 
-set (BFASM_LIB_DEPS p4ctoolkit ${P4C_LIB_DEPS})
+set (BFASM_LIB_DEPS p4ctoolkit ${P4C_LIB_DEPS} ${P4C_BOOST_LIBRARIES})
 set (BFASM_GEN_DIR ${BFASM_BINARY_DIR}/gen)
 
 # other required libraries

--- a/backends/tofino/bf-asm/deparser.h
+++ b/backends/tofino/bf-asm/deparser.h
@@ -20,8 +20,6 @@
 
 #include <vector>
 
-#include <boost/optional.hpp>
-
 #include "constants.h"
 #include "lib/bitops.h"
 #include "lib/ordered_set.h"

--- a/backends/tofino/bf-asm/salu_inst.cpp
+++ b/backends/tofino/bf-asm/salu_inst.cpp
@@ -17,8 +17,6 @@
 
 #include <cstring>
 
-#include <boost/optional.hpp>
-
 #include "backends/tofino/bf-asm/config.h"
 #include "backends/tofino/bf-asm/stage.h"
 #include "backends/tofino/bf-asm/tables.h"

--- a/backends/tofino/bf-p4c/CMakeLists.txt
+++ b/backends/tofino/bf-p4c/CMakeLists.txt
@@ -23,7 +23,6 @@ MESSAGE("-- Adding p4c-barefoot")
 set(BF_P4C_UNIFIED_SOURCE_CHUNK_SIZE "5" CACHE STRING
     "Target unified compilation chunk size for bf-p4c (an integer or ALL)")
 
-find_package (Boost REQUIRED COMPONENTS graph)
 if (ENABLE_BAREFOOT_INTERNAL)
   add_definitions("-DBAREFOOT_INTERNAL=1")
 endif()
@@ -82,11 +81,6 @@ add_definitions("-DSOURCE_INFO_SCHEMA_VERSION=\"${SOURCE_INFO_SCHEMA_VERSION}\""
 get_schema_version(resources_schema RESOURCES_SCHEMA_VERSION)
 MESSAGE(STATUS "Found source info schema version ${RESOURCES_SCHEMA_VERSION}")
 add_definitions("-DRESOURCES_SCHEMA_VERSION=\"${RESOURCES_SCHEMA_VERSION}\"")
-
-set (HAVE_LIBBOOST_GRAPH 1)
-
-set (P4C_LIB_DEPS "${P4C_LIB_DEPS};${Boost_GRAPH_LIBRARY};${Z3_LIB}")
-set (P4C_LIB_DEPS ${P4C_LIB_DEPS} PARENT_SCOPE)
 
 add_subdirectory(logging)
 
@@ -467,13 +461,6 @@ set (BF_P4C_IR_DEF_FILES
 # publish IR_DEF_FILES upstream
 set (IR_DEF_FILES ${IR_DEF_FILES} ${BF_P4C_IR_DEF_FILES} PARENT_SCOPE)
 
-set (BF_P4C_GRAPHS_SRCS
-  ${P4C_SOURCE_DIR}/backends/graphs/controls.cpp
-  ${P4C_SOURCE_DIR}/backends/graphs/graphs.cpp
-  ${P4C_SOURCE_DIR}/backends/graphs/parsers.cpp
-  ${P4C_SOURCE_DIR}/backends/graphs/graph_visitor.cpp
-  )
-
 set (p4include_HEADERS
   p4include/tofino1_specs.p4
   p4include/tofino1_base.p4
@@ -530,7 +517,6 @@ set (BF_P4C_SOURCES
 set (P4C_BAREFOOT_SRCS
   frontend.cpp
   ${BF_P4C_BACKEND_CONV_SRCS}
-  ${BF_P4C_GRAPHS_SRCS}
   )
 
 if(BUILD_STATIC_BFP4C_LIBS)
@@ -538,7 +524,8 @@ if(BUILD_STATIC_BFP4C_LIBS)
 else()
   add_library(tofinobackend OBJECT ${BF_P4C_SOURCES})
 endif()
-target_link_libraries(tofinobackend PRIVATE absl::prefetch ${P4C_LIB_DEPS} controlplane-gen ir)
+target_link_libraries(tofinobackend PRIVATE absl::prefetch
+  PUBLIC ${P4C_LIB_DEPS} ${Z3_LIB} controlplane-gen ir p4cgraphs)
 target_include_directories(
   tofinobackend
   # We also export Z3's includes with the common library.
@@ -556,8 +543,7 @@ else()
   # $<TARGET_OBJECTS:tofinobackend> $<TARGET_OBJECTS:bfn_p4runtime> to sources does not work)
   add_library(bfp4c OBJECT ${P4C_BAREFOOT_SRCS})
 endif()
-target_link_libraries (bfp4c tofinobackend bfn_p4runtime
-  ${P4C_LIBRARIES} ${P4C_LIB_DEPS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries (bfp4c PUBLIC tofinobackend bfn_p4runtime ${CMAKE_THREAD_LIBS_INIT})
 # XXX These compile definitions and include directories should be inherited
 # XXX from bfp4c's dependencies, but these CMake files aren't very modular.
 target_compile_definitions(bfp4c
@@ -596,7 +582,7 @@ else()
   # here explictly as well as their dependencies
   add_executable(p4c-barefoot p4c-barefoot.cpp $<TARGET_OBJECTS:bfp4c>
                                 $<TARGET_OBJECTS:tofinobackend> $<TARGET_OBJECTS:bfn_p4runtime>)
-  target_link_libraries(p4c-barefoot ${P4C_LIBRARIES} ${P4C_LIB_DEPS} ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(p4c-barefoot ${P4C_LIBRARIES} ${P4C_LIB_DEPS} ${Z3_LIB} p4cgraphs ${CMAKE_THREAD_LIBS_INIT})
   # FIXME: These includes should be exported by earlier libraries.
   target_include_directories(
       p4c-barefoot
@@ -928,7 +914,7 @@ if (ENABLE_GTESTS)
                                 "${CMAKE_CURRENT_SOURCE_DIR}/test/gtest/tofino_gtest_utils.cpp")
   # test_bf_gtest_helpers should be in its own testlib - & requies 'whole_archive' hack!
   # Leave it in GTEST_BF_P4C_SOURCES for now.
-  target_link_libraries (bf_gtest_support PRIVATE absl::flat_hash_map PRIVATE absl::flat_hash_set PRIVATE ir ${P4C_LIB_DEPS})
+  target_link_libraries (bf_gtest_support PRIVATE absl::flat_hash_map PRIVATE absl::flat_hash_set PRIVATE ir ${P4C_LIB_DEPS} ${Z3_LIB} p4cgraphs)
   target_include_directories(
     bf_gtest_support
     # We also export Z3's includes with the common library.
@@ -1036,7 +1022,6 @@ if (ENABLE_GTESTS)
     ${CMAKE_CURRENT_SOURCE_DIR}/test/gtest/union_find.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/gtest/v1model_translate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/utils/super_cluster_builder.cpp
-    ${BF_P4C_GRAPHS_SRCS}
     )
   if (NOT BUILD_STATIC_BFP4C_LIBS)
     # objlibs cannot be linked, need to add objects here explicitly

--- a/backends/tofino/bf-p4c/common/extract_maupipe.cpp
+++ b/backends/tofino/bf-p4c/common/extract_maupipe.cpp
@@ -22,9 +22,6 @@
 
 #include <optional>
 
-#include <boost/none.hpp>
-#include <boost/optional/optional.hpp>
-
 #include "backends/tofino/bf-p4c/arch/bridge_metadata.h"
 #include "backends/tofino/bf-p4c/arch/helpers.h"
 #include "backends/tofino/bf-p4c/common/bridged_packing.h"

--- a/backends/tofino/bf-p4c/logging/CMakeLists.txt
+++ b/backends/tofino/bf-p4c/logging/CMakeLists.txt
@@ -50,6 +50,6 @@ add_custom_target(genLogging
 
 add_executable(test_phv_logging test_phv.cpp ${BFN_P4C_SOURCE_DIR}/bf-p4c/common/run_id.cpp)
 add_dependencies(test_phv_logging genLogging)
-target_link_libraries(test_phv_logging PRIVATE absl::strings)
+target_link_libraries(test_phv_logging PRIVATE absl::strings ${P4C_BOOST_LIBRARIES})
 
 add_test(NAME test_phv_logging COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_phv_logging)

--- a/backends/tofino/bf-p4c/mau/table_dependency_graph.cpp
+++ b/backends/tofino/bf-p4c/mau/table_dependency_graph.cpp
@@ -24,10 +24,10 @@
 #include <numeric>
 #include <sstream>
 
+#include <boost/format.hpp>
 #include <boost/graph/breadth_first_search.hpp>
 #include <boost/graph/depth_first_search.hpp>
 #include <boost/graph/lookup_edge.hpp>
-#include <boost/optional/optional_io.hpp>
 
 #include "backends/tofino/bf-p4c/common/run_id.h"
 #include "backends/tofino/bf-p4c/ir/table_tree.h"

--- a/backends/tofino/bf-p4c/mau/table_summary.cpp
+++ b/backends/tofino/bf-p4c/mau/table_summary.cpp
@@ -67,8 +67,6 @@
 #include <numeric>
 #include <sstream>
 
-#include <boost/optional/optional_io.hpp>
-
 #include "backends/tofino/bf-p4c/bf-p4c-options.h"
 #include "backends/tofino/bf-p4c/common/table_printer.h"
 #include "backends/tofino/bf-p4c/common/utils.h"

--- a/backends/tofino/bf-p4c/midend/fold_constant_hashes.cpp
+++ b/backends/tofino/bf-p4c/midend/fold_constant_hashes.cpp
@@ -19,7 +19,7 @@
 /* clang-format off */
 
 #include "backends/tofino/bf-p4c/midend/fold_constant_hashes.h"
-#include <boost/optional/optional_io.hpp>
+#include <boost/format.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include "frontends/p4/externInstance.h"
 #include "frontends/p4/methodInstance.h"

--- a/backends/tofino/bf-p4c/parde/lower_parser.cpp
+++ b/backends/tofino/bf-p4c/parde/lower_parser.cpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-#include <boost/optional/optional_io.hpp>
+#include <boost/format.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 
 #include "backends/tofino/bf-p4c/arch/bridge_metadata.h"

--- a/backends/tofino/bf-p4c/parde/parser_output.cpp
+++ b/backends/tofino/bf-p4c/parde/parser_output.cpp
@@ -18,7 +18,7 @@
 
 #include <algorithm>
 
-#include <boost/optional/optional_io.hpp>
+#include <boost/format.hpp>
 
 #include "backends/tofino/bf-p4c/common/asm_output.h"
 #include "backends/tofino/bf-p4c/common/autoindent.h"

--- a/backends/tofino/bf-p4c/phv/action_phv_constraints.cpp
+++ b/backends/tofino/bf-p4c/phv/action_phv_constraints.cpp
@@ -22,7 +22,7 @@
 #include <sstream>
 #include <tuple>
 
-#include <boost/optional/optional_io.hpp>
+#include <boost/format.hpp>
 
 #include "backends/tofino/bf-p4c/common/asm_output.h"
 #include "backends/tofino/bf-p4c/common/scc_toposort.h"

--- a/backends/tofino/bf-p4c/phv/add_initialization.cpp
+++ b/backends/tofino/bf-p4c/phv/add_initialization.cpp
@@ -18,7 +18,7 @@
 
 #include "backends/tofino/bf-p4c/phv/add_initialization.h"
 
-#include "boost/optional/optional_io.hpp"
+#include <boost/format.hpp>
 
 bool MapFieldToExpr::preorder(const IR::Expression *expr) {
     if (expr->is<IR::Cast>() || expr->is<IR::Slice>() || expr->is<IR::Neg>()) return true;

--- a/backends/tofino/bf-p4c/phv/allocate_phv.cpp
+++ b/backends/tofino/bf-p4c/phv/allocate_phv.cpp
@@ -23,7 +23,6 @@
 
 #include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
-#include <boost/optional/optional_io.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 
 #include "backends/tofino/bf-p4c/bf-p4c-options.h"

--- a/backends/tofino/bf-p4c/phv/utils/slice_alloc.cpp
+++ b/backends/tofino/bf-p4c/phv/utils/slice_alloc.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <sstream>
 
-#include <boost/optional/optional_io.hpp>
+#include <boost/format.hpp>
 
 #include "backends/tofino/bf-p4c/mau/table_summary.h"
 #include "backends/tofino/bf-p4c/phv/phv_fields.h"

--- a/backends/tofino/bf-p4c/phv/utils/utils.cpp
+++ b/backends/tofino/bf-p4c/phv/utils/utils.cpp
@@ -23,7 +23,7 @@
 #include <numeric>
 #include <optional>
 
-#include <boost/optional/optional_io.hpp>
+#include <boost/format.hpp>
 
 #include "backends/tofino/bf-p4c/common/table_printer.h"
 #include "backends/tofino/bf-p4c/ir/bitrange.h"

--- a/backends/tofino/bf-p4c/specs/gress.cpp
+++ b/backends/tofino/bf-p4c/specs/gress.cpp
@@ -21,7 +21,7 @@
 #include <lib/cstring.h>
 #include <lib/exceptions.h>
 
-#include <boost/optional/optional_io.hpp>
+#include <boost/format.hpp>
 
 using namespace P4::literals;
 

--- a/backends/tofino/boost.cmake
+++ b/backends/tofino/boost.cmake
@@ -1,0 +1,3 @@
+# Boost module requirements of the Tofino backend. Included by the top-level
+# CMakeLists.txt before p4c_obtain_boost() runs.
+p4c_require_boost(algorithm uuid)

--- a/cmake/Boost.cmake
+++ b/cmake/Boost.cmake
@@ -1,0 +1,78 @@
+macro(p4c_obtain_boost)
+  option(
+    P4C_USE_PREINSTALLED_BOOST
+    "Look for a preinstalled version of Boost in the system instead of installing the library using FetchContent."
+    OFF
+  )
+
+  # If P4C_USE_PREINSTALLED_BOOST is ON just try to find a preinstalled version of Boost.
+  if(P4C_USE_PREINSTALLED_BOOST)
+    if(NOT BUILD_SHARED_LIBS)
+      # Link Boost statically.
+      # See https://cmake.org/cmake/help/latest/module/FindBoost.html for details.
+      set(Boost_USE_STATIC_LIBS ON)
+      set(Boost_USE_STATIC_RUNTIME OFF)
+    endif()
+    find_package(Boost REQUIRED COMPONENTS iostreams)
+    list(APPEND P4C_BOOST_LIBRARIES Boost::iostreams)
+  else()
+    set(P4C_BOOST_VERSION "1.86.0")
+    set(P4C_BOOST_HASH "2c5ec5edcdff47ff55e27ed9560b0a0b94b07bd07ed9928b476150e16b0efc57")
+    message(STATUS "Fetching Boost version ${P4C_BOOST_VERSION} for P4C...")
+    # Print out download state while setting up Boost.
+    set(FETCHCONTENT_QUIET_PREV ${FETCHCONTENT_QUIET})
+    set(FETCHCONTENT_QUIET OFF)
+    # Unity builds do not work for Boost...
+    set(CMAKE_UNITY_BUILD_PREV ${CMAKE_UNITY_BUILD})
+    set(CMAKE_UNITY_BUILD OFF)
+
+    # Add boost modules.
+    # format, multiprecision, and iostreams are needed by P4C core.
+    set(BOOST_INCLUDE_LIBRARIES format multiprecision iostreams)
+    list(APPEND BOOST_INCLUDE_LIBRARIES ${ADDITIONAL_P4C_BOOST_MODULES})
+    set(BOOST_ENABLE_CMAKE ON)
+
+    # Always link local Boost statically.
+    set(Boost_USE_STATIC_LIBS ON)
+    set(Boost_USE_STATIC_RUNTIME OFF)
+
+    # Download and extract Boost from GitHub.
+    message(STATUS "Downloading and extracting boost library sources. This may take some time...")
+    FetchContent_Declare(
+        Boost
+        URL https://github.com/boostorg/boost/releases/download/boost-${P4C_BOOST_VERSION}/boost-${P4C_BOOST_VERSION}-cmake.tar.xz
+        URL_HASH SHA256=${P4C_BOOST_HASH}
+        USES_TERMINAL_DOWNLOAD TRUE
+        GIT_PROGRESS TRUE
+    )
+    FetchContent_MakeAvailable(Boost)
+
+    # Suppress warnings for all Boost targets.
+    get_all_targets(BOOST_BUILD_TARGETS ${Boost_SOURCE_DIR})
+    set(boost_target_includes "")
+    foreach(target in ${BOOST_BUILD_TARGETS})
+      if(target MATCHES "boost_*")
+        # Do not suppress warnings for Boost library targets that are aliased.
+        get_target_property(target_type ${target} TYPE)
+        if(NOT ${target_type} STREQUAL "INTERFACE_LIBRARY")
+          target_compile_options(${target} PRIVATE "-Wno-error" "-w")
+        endif()
+        # Force inclusion of the Boost headers as system headers.
+        # This is necessary because users may have their own system boost headers
+        # which can be in conflict. Also ensures that linters don't complain.
+        get_target_property(target_includes ${target} INTERFACE_INCLUDE_DIRECTORIES)
+        set_target_properties(${target} PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${target_includes}")
+      endif()
+    endforeach()
+    # Reset temporary variable modifications.
+    set(CMAKE_UNITY_BUILD ${CMAKE_UNITY_BUILD_PREV})
+    set(FETCHCONTENT_QUIET ${FETCHCONTENT_QUIET_PREV})
+    list(APPEND P4C_BOOST_LIBRARIES Boost::iostreams Boost::format Boost::multiprecision)
+  endif()
+
+  include_directories(BEFORE SYSTEM ${Boost_INCLUDE_DIRS})
+  set(HAVE_LIBBOOST_IOSTREAMS TRUE)
+  list(APPEND P4C_LIB_DEPS ${P4C_BOOST_LIBRARIES})
+
+  message(STATUS "Done with setting up Boost for P4C.")
+endmacro(p4c_obtain_boost)

--- a/cmake/Boost.cmake
+++ b/cmake/Boost.cmake
@@ -1,3 +1,9 @@
+# Registers additional Boost modules required by a backend or extension.
+# Called from a backend's boost.cmake before p4c_obtain_boost() runs.
+macro(p4c_require_boost)
+  list(APPEND P4C_BOOST_MODULES ${ARGN})
+endmacro()
+
 macro(p4c_obtain_boost)
   option(
     P4C_USE_PREINSTALLED_BOOST
@@ -29,12 +35,8 @@ macro(p4c_obtain_boost)
     # Add boost modules.
     # format, multiprecision, and iostreams are needed by P4C core.
     set(BOOST_INCLUDE_LIBRARIES format multiprecision iostreams)
-    list(APPEND BOOST_INCLUDE_LIBRARIES ${ADDITIONAL_P4C_BOOST_MODULES})
+    list(APPEND BOOST_INCLUDE_LIBRARIES ${P4C_BOOST_MODULES})
     set(BOOST_ENABLE_CMAKE ON)
-
-    # Always link local Boost statically.
-    set(Boost_USE_STATIC_LIBS ON)
-    set(Boost_USE_STATIC_RUNTIME OFF)
 
     # Download and extract Boost from GitHub.
     message(STATUS "Downloading and extracting boost library sources. This may take some time...")
@@ -43,14 +45,12 @@ macro(p4c_obtain_boost)
         URL https://github.com/boostorg/boost/releases/download/boost-${P4C_BOOST_VERSION}/boost-${P4C_BOOST_VERSION}-cmake.tar.xz
         URL_HASH SHA256=${P4C_BOOST_HASH}
         USES_TERMINAL_DOWNLOAD TRUE
-        GIT_PROGRESS TRUE
     )
     FetchContent_MakeAvailable(Boost)
 
     # Suppress warnings for all Boost targets.
     get_all_targets(BOOST_BUILD_TARGETS ${Boost_SOURCE_DIR})
-    set(boost_target_includes "")
-    foreach(target in ${BOOST_BUILD_TARGETS})
+    foreach(target IN LISTS BOOST_BUILD_TARGETS)
       if(target MATCHES "boost_*")
         # Do not suppress warnings for Boost library targets that are aliased.
         get_target_property(target_type ${target} TYPE)
@@ -67,10 +67,13 @@ macro(p4c_obtain_boost)
     # Reset temporary variable modifications.
     set(CMAKE_UNITY_BUILD ${CMAKE_UNITY_BUILD_PREV})
     set(FETCHCONTENT_QUIET ${FETCHCONTENT_QUIET_PREV})
-    list(APPEND P4C_BOOST_LIBRARIES Boost::iostreams Boost::format Boost::multiprecision)
+    # Map every requested module to its Boost:: target.
+    list(APPEND P4C_BOOST_LIBRARIES Boost::format Boost::multiprecision Boost::iostreams)
+    foreach(module IN LISTS P4C_BOOST_MODULES)
+      list(APPEND P4C_BOOST_LIBRARIES Boost::${module})
+    endforeach()
   endif()
 
-  include_directories(BEFORE SYSTEM ${Boost_INCLUDE_DIRS})
   set(HAVE_LIBBOOST_IOSTREAMS TRUE)
   list(APPEND P4C_LIB_DEPS ${P4C_BOOST_LIBRARIES})
 

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -7,9 +7,6 @@
 /* Define to 1 if you have the boost iostreams library */
 #cmakedefine HAVE_LIBBOOST_IOSTREAMS 1
 
-/* Define to 1 if you have the boost graph headers */
-#cmakedefine HAVE_LIBBOOST_GRAPH 1
-
 /* Define to 1 if you have libbacktrace */
 #cmakedefine HAVE_LIBBACKTRACE 1
 

--- a/ir/CMakeLists.txt
+++ b/ir/CMakeLists.txt
@@ -62,7 +62,7 @@ set (BASE_IR_DEF_FILES
 set (IR_DEF_FILES ${IR_DEF_FILES} ${BASE_IR_DEF_FILES} PARENT_SCOPE)
 
 add_library (ir STATIC ${IR_SRCS})
-target_link_libraries(ir PRIVATE absl::flat_hash_map ${LIBGC_LIBRARIES})
+target_link_libraries(ir PRIVATE absl::flat_hash_map ${LIBGC_LIBRARIES} ${P4C_BOOST_LIBRARIES})
 
 
 add_dependencies(ir genIR)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -91,4 +91,5 @@ target_link_libraries(p4ctoolkit
   PUBLIC absl::bits
   PUBLIC absl::strings
   PUBLIC ${LIBGC_LIBRARIES}
+  PUBLIC ${P4C_BOOST_LIBRARIES}
 )

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -52,7 +52,7 @@ P4C_DIR=$(readlink -f ${THIS_DIR}/..)
 # Build with -ftrivial-auto-var-init=pattern to catch more bugs caused by
 # uninitialized variables.
 : "${BUILD_AUTO_VAR_INIT_PATTERN:=OFF}"
-# BMv2 is enable by default.
+# BMv2 is enabled by default.
 : "${ENABLE_BMV2:=ON}"
 # eBPF is enabled by default.
 : "${ENABLE_EBPF:=ON}"
@@ -104,9 +104,6 @@ P4C_DEPS="bison \
           g++ \
           git \
           lld \
-          libboost-dev \
-          libboost-graph-dev \
-          libboost-iostreams-dev \
           libfl-dev \
           pkg-config \
           python3 \

--- a/tools/install_mac_deps.sh
+++ b/tools/install_mac_deps.sh
@@ -42,21 +42,16 @@ HOMEBREW_PREFIX=$(brew --prefix)
 # Fetch the latest formulae
 brew update
 
-BOOST_LIB="boost@1.85"
 REQUIRED_PACKAGES=(
     autoconf automake ccache cmake jsoncpp libtool
     openssl coreutils bison grep ninja virtualenv uv
     libevent nanomsg thrift xxhash
-    ${BOOST_LIB}
+    # Only required for BMv2
+    boost
 )
 for package in "${REQUIRED_PACKAGES[@]}"; do
   brew_install ${package}
 done
-
-# Check if linking is needed.
-if ! brew ls --linked --formula ${BOOST_LIB} > /dev/null 2>&1; then
-  brew link ${BOOST_LIB}
-fi
 
 # Check if PATH modification is needed.
 if ! grep -q "$(brew --prefix bison)/bin" ~/.bash_profile; then


### PR DESCRIPTION
This PR sets up boost to be installed via FetchContent instead of depending on the system-provided version. Because a lot of Boost is header-only this is a little tricky. 

Recent versions of boost have improved their CMake support significantly. I pushed a version which only requires downloading boost and linking the appropriate targets. The required boost headers are exported with each target, comparable to Abseil. To make sure that the linked headers are included as system headers I had to do some patching, but that is fairly straightforward.

If one desires to add additional boost targets, they can do so by setting P4C_TARGET_BOOST_LIBRARIES at command line or before invoking boost.

#### Dependencies

We currently depend on multiprecision and format as part of our core. iostreams for [one particular optimization](https://github.com/p4lang/p4c/blob/main/frontends/parsers/parserDriver.cpp#L20) in the parser and graphs for the graphs backend.

graphs alone has an egregious amount of dependencies: https://github.com/boostorg/graph/blob/develop/CMakeLists.txt#L18
iostreams dependencies https://github.com/boostorg/iostreams/blob/develop/CMakeLists.txt#L79
format dependencies https://github.com/boostorg/format/blob/develop/CMakeLists.txt#L17
multiprecision dependencies https://github.com/boostorg/multiprecision/blob/develop/CMakeLists.txt#L30

The only project out of those that is currently standalone is multiprecision.

~~Because of this dependency problem we need to add almost all the different boost modules to the include path to make sure that we are including the local boost header first. We do this by globbing for the `include` folder and adding it to the include path.~~



