### PR TITLE
Only emit the warning on EXPORT_COMPILE_COMMANDS when there are clang-tidy files to lint.

### DIFF
--- a/cmake/Linters.cmake
+++ b/cmake/Linters.cmake
@@ -95,12 +95,12 @@ endif()
 find_program(CLANG_TIDY_CMD clang-tidy)
 
 if(CLANG_TIDY_CMD)
-  if (NOT CMAKE_EXPORT_COMPILE_COMMANDS)
-    message(WARNING "CMAKE_EXPORT_COMPILE_COMMANDS is not set ON, clang-tidy remains disabled.")
-  endif()
-
   # Retrieve the global clang-tidy property.
   get_property(CLANG_TIDY_FILES GLOBAL PROPERTY CLANG_TIDY-files)
+
+  if (DEFINED CLANG_TIDY_FILES AND NOT CMAKE_EXPORT_COMPILE_COMMANDS)
+    message(WARNING "CMAKE_EXPORT_COMPILE_COMMANDS is not set ON, clang-tidy remains disabled.")
+  endif()
   if(DEFINED CLANG_TIDY_FILES AND CMAKE_EXPORT_COMPILE_COMMANDS)
 
     # Write the list to a file.


### PR DESCRIPTION
Fix a warning that was caused by adding the clang-tidy linter. It pops ups because `EXPORT_COMPILE_COMMANDS` is disabled but we do not need it when there is nothing to lint. 