### PR TITLE
Make the new operator protected for some IR types.

### DIFF
--- a/backends/bmv2/common/lower.cpp
+++ b/backends/bmv2/common/lower.cpp
@@ -81,7 +81,7 @@ const IR::Node *LowerExpressions::postorder(IR::Cast *expression) {
     } else if (destType->width_bits() < srcType->width_bits()) {
         // explicitly discard un needed bits from src
         auto one = new IR::Constant(srcType, 1);
-        auto shift_value = new IR::Constant(new IR::Type_InfInt(), destType->width_bits());
+        auto shift_value = new IR::Constant(IR::Type_InfInt::get(), destType->width_bits());
         auto shl = new IR::Shl(one->srcInfo, one, shift_value);
         auto mask = new IR::Sub(shl->srcInfo, shl, one);
         auto and0 = new IR::BAnd(expression->srcInfo, expression->expr, mask);
@@ -115,7 +115,7 @@ const IR::Node *LowerExpressions::postorder(IR::Slice *expression) {
     BUG_CHECK(e0type->is<IR::Type_Bits>(), "%1%: expected a bit<> type", e0type);
     const IR::Expression *expr;
     if (l != 0) {
-        auto one = new IR::Constant(new IR::Type_InfInt(), l);
+        auto one = new IR::Constant(IR::Type_InfInt::get(), l);
         expr = new IR::Shr(expression->e0->srcInfo, expression->e0, one);
         typeMap->setType(expr, e0type);
         typeMap->setType(one, one->type);
@@ -150,7 +150,7 @@ const IR::Node *LowerExpressions::postorder(IR::Concat *expression) {
     unsigned sizeofb = type->to<IR::Type_Bits>()->size;
     auto cast0 = new IR::Cast(expression->left->srcInfo, resulttype, expression->left);
     auto cast1 = new IR::Cast(expression->right->srcInfo, resulttype, expression->right);
-    auto sizefb0 = new IR::Constant(new IR::Type_InfInt(), sizeofb);
+    auto sizefb0 = new IR::Constant(IR::Type_InfInt::get(), sizeofb);
     auto sh = new IR::Shl(cast0->srcInfo, cast0, sizefb0);
     big_int m = Util::maskFromSlice(sizeofb - 1, 0);
     auto mask = new IR::Constant(expression->right->srcInfo, resulttype, m, 16);

--- a/backends/dpdk/dpdkArch.h
+++ b/backends/dpdk/dpdkArch.h
@@ -593,7 +593,7 @@ class InjectInternetChecksumIntermediateValue : public Transform {
                     auto fields = new IR::IndexedVector<IR::StructField>;
                     for (auto fld : *csum_vec) {
                         fields->push_back(
-                            new IR::StructField(IR::ID(fld), new IR::Type_Bits(16, false)));
+                            new IR::StructField(IR::ID(fld), IR::Type::Bits::get(16, false)));
                     }
                     new_objs->push_back(new IR::Type_Header(IR::ID("cksum_state_t"), *fields));
                 }

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -51,7 +51,7 @@ EBPFType *EBPFTypeFactory::create(const IR::Type *type) {
         result = new EBPFScalarType(tv);
     } else if (type->is<IR::Type_Error>()) {
         // Implement error type as scalar of width 8 bits
-        result = new EBPFScalarType(new IR::Type_Bits(8, false));
+        result = new EBPFScalarType(IR::Type_Bits::get(8, false));
     } else {
         ::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET, "Type %1% not supported", type);
     }

--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
@@ -260,8 +260,8 @@ const IR::MethodCallStatement *generateStacksetValid(const IR::Expression *stack
         stackRef->type->checkedTo<IR::Type_Stack>()->elementType, stackRef, index);
     auto name = (isValid) ? IR::Type_Header::setValid : IR::Type_Header::setInvalid;
     return new IR::MethodCallStatement(new IR::MethodCallExpression(
-        new IR::Type_Void(),
-        new IR::Member(new IR::Type_Method(new IR::Type_Void(), new IR::ParameterList(), name),
+        IR::Type_Void::get(),
+        new IR::Member(new IR::Type_Method(IR::Type_Void::get(), new IR::ParameterList(), name),
                        arrayIndex, name)));
 }
 

--- a/backends/p4tools/modules/testgen/targets/pna/constants.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/constants.cpp
@@ -7,13 +7,13 @@ namespace P4Tools::P4Testgen::Pna {
 
 const IR::Member PnaConstants::DROP_VAR =
     IR::Member(IR::Type_Boolean::get(), new IR::PathExpression("*pna_internal"), "drop_var");
-const IR::Member PnaConstants::OUTPUT_PORT_VAR = IR::Member(
-    new IR::Type_Bits(32, false), new IR::PathExpression("*pna_internal"), "output_port");
-const IR::Member PnaConstants::PARSER_ERROR = IR::Member(
-    new IR::Type_Bits(32, false), new IR::PathExpression("*pna_internal"), "parser_error");
+const IR::Member PnaConstants::OUTPUT_PORT_VAR =
+    IR::Member(IR::Type_Bits::get(32), new IR::PathExpression("*pna_internal"), "output_port");
+const IR::Member PnaConstants::PARSER_ERROR =
+    IR::Member(IR::Type_Bits::get(32), new IR::PathExpression("*pna_internal"), "parser_error");
 // TODO: Make this a proper variables variable.
 // We can not use the utilities because of an issue related to the garbage collector.
 const IR::SymbolicVariable PnaSymbolicVars::DIRECTION =
-    IR::SymbolicVariable(new IR::Type_Bits(32, false), "direction");
+    IR::SymbolicVariable(IR::Type_Bits::get(32), "direction");
 
 }  // namespace P4Tools::P4Testgen::Pna

--- a/backends/p4tools/p4tools.def
+++ b/backends/p4tools/p4tools.def
@@ -153,6 +153,10 @@ class SymbolicVariable : Expression {
 
 /// This type replaces Type_Varbits and can store information about the current size
 class Extracted_Varbits : Type_Bits {
+ public:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
     /// The assigned size of this varbit (assigned by extract calls).
     int assignedSize;
 

--- a/control-plane/addMissingIds.cpp
+++ b/control-plane/addMissingIds.cpp
@@ -36,7 +36,7 @@ const IR::Property *MissingIdAssigner::postorder(IR::Property *property) {
             auto *newAnnos = annos->clone();
             IR::Vector<IR::Expression> annoExprs;
             const auto *idConst =
-                new IR::Constant(new IR::Type_Bits(ID_BIT_WIDTH, false), symbolId + 1);
+                new IR::Constant(IR::Type_Bits::get(ID_BIT_WIDTH, false), symbolId + 1);
             annoExprs.push_back(idConst);
             newAnnos->add(new IR::Annotation("id", annoExprs));
             keyElement->annotations = newAnnos;
@@ -60,7 +60,7 @@ const IR::P4Table *MissingIdAssigner::postorder(IR::P4Table *table) {
         auto *newAnnos = annos->clone();
         IR::Vector<IR::Expression> annoExprs;
         auto symbolId = symbols->getId(ControlPlaneAPI::P4RuntimeSymbolType::P4RT_TABLE(), table);
-        const auto *idConst = new IR::Constant(new IR::Type_Bits(ID_BIT_WIDTH, false), symbolId);
+        const auto *idConst = new IR::Constant(IR::Type_Bits::get(ID_BIT_WIDTH, false), symbolId);
         annoExprs.push_back(idConst);
         newAnnos->add(new IR::Annotation("id", annoExprs));
         table->annotations = newAnnos;
@@ -80,7 +80,7 @@ const IR::Type_Header *MissingIdAssigner::postorder(IR::Type_Header *hdr) {
         IR::Vector<IR::Expression> annoExprs;
         auto symbolId =
             symbols->getId(ControlPlaneAPI::P4RuntimeSymbolType::P4RT_CONTROLLER_HEADER(), hdr);
-        const auto *idConst = new IR::Constant(new IR::Type_Bits(ID_BIT_WIDTH, false), symbolId);
+        const auto *idConst = new IR::Constant(IR::Type_Bits::get(ID_BIT_WIDTH, false), symbolId);
         annoExprs.push_back(idConst);
         newAnnos->add(new IR::Annotation("id", annoExprs));
         hdr->annotations = newAnnos;
@@ -101,7 +101,7 @@ const IR::P4ValueSet *MissingIdAssigner::postorder(IR::P4ValueSet *valueSet) {
         IR::Vector<IR::Expression> annoExprs;
         auto symbolId =
             symbols->getId(ControlPlaneAPI::P4RuntimeSymbolType::P4RT_VALUE_SET(), valueSet);
-        const auto *idConst = new IR::Constant(new IR::Type_Bits(ID_BIT_WIDTH, false), symbolId);
+        const auto *idConst = new IR::Constant(IR::Type_Bits::get(ID_BIT_WIDTH, false), symbolId);
         annoExprs.push_back(idConst);
         newAnnos->add(new IR::Annotation("id", annoExprs));
         valueSet->annotations = newAnnos;
@@ -120,7 +120,7 @@ const IR::P4Action *MissingIdAssigner::postorder(IR::P4Action *action) {
         auto *newAnnos = annos->clone();
         IR::Vector<IR::Expression> annoExprs;
         auto symbolId = symbols->getId(ControlPlaneAPI::P4RuntimeSymbolType::P4RT_ACTION(), action);
-        const auto *idConst = new IR::Constant(new IR::Type_Bits(ID_BIT_WIDTH, false), symbolId);
+        const auto *idConst = new IR::Constant(IR::Type_Bits::get(ID_BIT_WIDTH, false), symbolId);
         annoExprs.push_back(idConst);
         newAnnos->add(new IR::Annotation("id", annoExprs));
         action->annotations = newAnnos;
@@ -135,7 +135,7 @@ const IR::P4Action *MissingIdAssigner::postorder(IR::P4Action *action) {
             auto *newAnnos = annos->clone();
             IR::Vector<IR::Expression> annoExprs;
             const auto *idConst =
-                new IR::Constant(new IR::Type_Bits(ID_BIT_WIDTH, false), symbolId + 1);
+                new IR::Constant(IR::Type_Bits::get(ID_BIT_WIDTH, false), symbolId + 1);
             annoExprs.push_back(idConst);
             newAnnos->add(new IR::Annotation("id", annoExprs));
             param->annotations = newAnnos;

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -37,7 +37,7 @@ class CloneConstants : public Transform {
         } else if (auto ii = type->to<IR::Type_InfInt>()) {
             // You can't just clone a InfInt value, because
             // you get the same declid.  We want a new declid.
-            type = new IR::Type_InfInt(ii->srcInfo);
+            type = IR::Type_InfInt::get(ii->srcInfo);
         } else {
             BUG("unexpected type %2% for constant %2%", type, constant);
         }
@@ -163,7 +163,7 @@ const IR::Node *DoConstantFolding::postorder(IR::Declaration_Constant *d) {
             } else {
                 // Destination type is InfInt; we must "erase" the width of the source
                 if (!cst->type->is<IR::Type_InfInt>()) {
-                    init = new IR::Constant(cst->srcInfo, new IR::Type_InfInt(), cst->value,
+                    init = new IR::Constant(cst->srcInfo, IR::Type_InfInt::get(), cst->value,
                                             cst->base);
                 }
             }

--- a/frontends/p4/defaultArguments.cpp
+++ b/frontends/p4/defaultArguments.cpp
@@ -42,7 +42,7 @@ class TypeNameSubstitutionVisitor : public TypeVariableSubstitutionVisitor {
     }
     // When cloning the value of an argument we want to make a fresh
     // copy for each new InfInt type, and not share the same one.
-    const IR::Node *postorder(IR::Type_InfInt *) override { return new IR::Type_InfInt(); }
+    const IR::Node *postorder(IR::Type_InfInt *) override { return IR::Type_InfInt::get(); }
 };
 }  // namespace
 

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1019,12 +1019,12 @@ specializedType
     ;
 
 baseType
-    : BOOL   { $$ = new IR::Type_Boolean(@1); }
-    | MATCH_KIND { $$ = new IR::Type_MatchKind(@1); }
+    : BOOL   { $$ = IR::Type_Boolean::get(@1); }
+    | MATCH_KIND { $$ = IR::Type_MatchKind::get(@1); }
     | ERROR  { $$ = new IR::Type_Name(@1, new IR::Path(IR::ID(@1, "error"))); }
     | BIT    { $$ = IR::Type::Bits::get(@1, 1); }
-    | STRING { $$ = new IR::Type::String(@1); }
-    | INT    { $$ = new IR::Type_InfInt(@1); }
+    | STRING { $$ = IR::Type::String::get(@1); }
+    | INT    { $$ = IR::Type_InfInt::get(@1); }
     | BIT l_angle INTEGER r_angle
       { $$ = IR::Type::Bits::get(@1+@4, parseConstantChecked(@3, $3), false); }
     | INT l_angle INTEGER r_angle
@@ -1033,16 +1033,16 @@ baseType
       { $$ = IR::Type::Varbits::get(@1+@4, parseConstantChecked(@3, $3)); }
 
     | BIT l_angle "(" expression ")" r_angle
-      { $$ = new IR::Type_Bits(@1+@6, $4, false); }
+      { $$ = IR::Type_Bits::get(@1+@6, $4, false); }
     | INT l_angle "(" expression ")" r_angle
-      { $$ = new IR::Type_Bits(@1+@6, $4, true); }
+      { $$ = IR::Type_Bits::get(@1+@6, $4, true); }
     | VARBIT l_angle "(" expression ")" r_angle
-      { $$ = new IR::Type_Varbits(@1+@6, $4); }
+      { $$ = IR::Type_Varbits::get(@1+@6, $4); }
     ;
 
 typeOrVoid
     : typeRef     { $$ = $1; }
-    | VOID        { $$ = new IR::Type_Void(@1); }
+    | VOID        { $$ = IR::Type_Void::get(@1); }
     | IDENTIFIER  { $$ = new IR::Type_Name(@1, new IR::Path(*(new IR::ID(@1, $1)))); }
         // This is necessary because template arguments may introduce the return type
     ;
@@ -1066,8 +1066,8 @@ typeArg
     : typeRef                     { $$ = $1; }
     | nonTypeName                 { $$ = new IR::Type_Name(@1, new IR::Path(*$1)); }
         // This is necessary because template arguments may introduce the return type
-    | VOID                        { $$ = new IR::Type_Void(@1); }
-    | "_"                         { $$ = new IR::Type_Dontcare(@1); }
+    | VOID                        { $$ = IR::Type_Void::get(@1); }
+    | "_"                         { $$ = IR::Type_Dontcare::get(@1); }
     ;
 
 typeArgumentList
@@ -1078,8 +1078,8 @@ typeArgumentList
 
 realTypeArg
     : typeRef                     { $$ = $1; }
-    | VOID                        { $$ = new IR::Type_Void(@1); }
-    | "_"                         { $$ = new IR::Type_Dontcare(@1); }
+    | VOID                        { $$ = IR::Type_Void::get(@1); }
+    | "_"                         { $$ = IR::Type_Dontcare::get(@1); }
     ;
 
 // For use in contexts where the `<` might be a less-than rather than introducing a type

--- a/frontends/parsers/v1/v1parser.ypp
+++ b/frontends/parsers/v1/v1parser.ypp
@@ -356,7 +356,7 @@ type: BIT { $$ = IR::Type::Bits::get(@1, 1); }
     | COUNTER { $$ = IR::Type_Counter::get(); }
     | EXPRESSION { $$ = IR::Type_Expression::get(); }
     | FIELD_LIST_CALCULATION { $$ = IR::Type_FieldListCalculation::get(); }
-    | INT { $$ = new IR::Type_InfInt; }
+    | INT { $$ = IR::Type_InfInt::get(); }
     | INT "<" INTEGER ">"
       { $$ = IR::Type::Bits::get(@3, parseConstant(@3, $3, 0)->asInt(), true); }
     | METER { $$ = IR::Type_Meter::get(); }

--- a/ir/base.def
+++ b/ir/base.def
@@ -120,6 +120,7 @@ abstract Type_Base : Type {
 class Type_Unknown : Type_Base {
 #nodbprint
     static Type_Unknown get();
+    static Type_Unknown get(const Util::SourceInfo &si);
     toString{ return "Unknown type"; }
 }
 

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -169,28 +169,28 @@ class Constant : Literal {
     // 32-bit systems (which ain't long!) and mpz_import is too big a hammer because and it loses
     // the signess of the value.
     Constant(int v, unsigned base = 10) :
-        Literal(new Type_InfInt()), value(v), base(base) {}
+        Literal(Type_InfInt::get()), value(v), base(base) {}
     Constant(unsigned v, unsigned base = 10) :
-        Literal(new Type_InfInt()), value(v), base(base) {}
+        Literal(Type_InfInt::get()), value(v), base(base) {}
 #emit
 #if __WORDSIZE == 64
     Constant(intmax_t v, unsigned base = 10) :
-        Literal(new Type_InfInt()), value(v), base(base) {}
+        Literal(Type_InfInt::get()), value(v), base(base) {}
 #else
     Constant(long v, unsigned base = 10) :
-        Literal(new Type_InfInt()), value(v), base(base) {}
+        Literal(Type_InfInt::get()), value(v), base(base) {}
     Constant(unsigned long v, unsigned base = 10) :
-        Literal(new Type_InfInt()), value(v), base(base) {}
+        Literal(Type_InfInt::get()), value(v), base(base) {}
     Constant(intmax_t v, unsigned base = 10) :
-        Literal(new Type_InfInt()), value(v), base(base) {}
+        Literal(Type_InfInt::get()), value(v), base(base) {}
 #endif
 #end
     Constant(uint64_t v, unsigned base = 10) :
-        Literal(new Type_InfInt()), value(v), base(base) {}
+        Literal(Type_InfInt::get()), value(v), base(base) {}
     Constant(big_int v, unsigned base = 10) :
-        Literal(new Type_InfInt()), value(v), base(base) {}
+        Literal(Type_InfInt::get()), value(v), base(base) {}
     Constant(Util::SourceInfo si, big_int v, unsigned base = 10) :
-        Literal(si, new Type_InfInt()), value(v), base(base) {}
+        Literal(si, Type_InfInt::get()), value(v), base(base) {}
     Constant(const Type *t, big_int v, unsigned base = 10, bool noWarning = false) :
         Literal(t), value(v), base(base) { CHECK_NULL(t); handleOverflow(noWarning); }
     Constant(Util::SourceInfo si, const Type *t, big_int v,

--- a/ir/irutils.cpp
+++ b/ir/irutils.cpp
@@ -47,22 +47,20 @@ const IR::Constant *convertBoolLiteral(const IR::BoolLiteral *lit) {
 const IR::Expression *getDefaultValue(const IR::Type *type, const Util::SourceInfo &srcInfo,
                                       bool valueRequired) {
     if (const auto *tb = type->to<IR::Type_Bits>()) {
-        // TODO: Use getConstant.
-        return new IR::Constant(srcInfo, tb, 0);
+        return IR::Constant::get(tb, 0, srcInfo);
     }
     if (type->is<IR::Type_Boolean>()) {
-        // TODO: Use getBoolLiteral.
-        return new BoolLiteral(srcInfo, Type::Boolean::get(), false);
+        return IR::BoolLiteral::get(false, srcInfo);
     }
     if (type->is<IR::Type_InfInt>()) {
-        return new IR::Constant(srcInfo, 0);
+        return IR::Constant::get(type, 0, srcInfo);
     }
     if (const auto *te = type->to<IR::Type_Enum>()) {
         return new IR::Member(srcInfo, new IR::TypeNameExpression(te->name),
                               te->members.at(0)->getName());
     }
     if (const auto *te = type->to<IR::Type_SerEnum>()) {
-        return new IR::Cast(srcInfo, type->getP4Type(), new IR::Constant(srcInfo, te->type, 0));
+        return new IR::Cast(srcInfo, type->getP4Type(), IR::Constant::get(te->type, 0, srcInfo));
     }
     if (const auto *te = type->to<IR::Type_Error>()) {
         return new IR::Member(srcInfo, new IR::TypeNameExpression(te->name), "NoError");

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "frontends/common/parser_options.h"
 #include "ir/configuration.h"
 #include "ir/id.h"
+#include "ir/ir-generated.h"
 #include "ir/ir.h"
 #include "ir/vector.h"
 #include "lib/cstring.h"
@@ -87,26 +88,8 @@ const Type_Bits *Type_Bits::get(int width, bool isSigned) {
     return result;
 }
 
-const Type::Unknown *Type::Unknown::get() {
-    static const Type::Unknown *singleton = nullptr;
-    if (!singleton) singleton = (new Type::Unknown());
-    return singleton;
-}
-
-const Type::Boolean *Type::Boolean::get() {
-    static const Type::Boolean *singleton = nullptr;
-    if (!singleton) singleton = (new Type::Boolean());
-    return singleton;
-}
-
-const Type_String *Type_String::get() {
-    static const Type_String *singleton = nullptr;
-    if (!singleton) singleton = (new Type_String());
-    return singleton;
-}
-
-const Type::Bits *Type::Bits::get(Util::SourceInfo si, int sz, bool isSigned) {
-    auto result = new IR::Type_Bits(si, sz, isSigned);
+const Type_Bits *Type_Bits::get(const Util::SourceInfo &si, int sz, bool isSigned) {
+    auto *result = new IR::Type_Bits(si, sz, isSigned);
     if (sz < 0) {
         ::error(ErrorType::ERR_INVALID, "%1%: Width of type cannot be negative", result);
         // Return a value that will not cause crashes later on
@@ -120,8 +103,50 @@ const Type::Bits *Type::Bits::get(Util::SourceInfo si, int sz, bool isSigned) {
     return result;
 }
 
-const Type::Varbits *Type::Varbits::get(Util::SourceInfo si, int sz) {
-    auto result = new Type::Varbits(si, sz);
+const Type_Bits *Type_Bits::get(const Util::SourceInfo &si, const IR::Expression *expression,
+                                bool isSigned) {
+    return new IR::Type_Bits(si, expression, isSigned);
+}
+
+const Type_Unknown *Type_Unknown::get() {
+    static const Type_Unknown *singleton = nullptr;
+    if (!singleton) singleton = (new Type_Unknown());
+    return singleton;
+}
+
+const Type_Unknown *Type_Unknown::get(const Util::SourceInfo &si) {
+    // We do not cache types with source info (yet).
+    return new Type_Unknown(si);
+}
+
+const Type_Boolean *Type_Boolean::get() {
+    static const Type_Boolean *singleton = nullptr;
+    if (!singleton) singleton = (new Type_Boolean());
+    return singleton;
+}
+
+const Type_Boolean *Type_Boolean::get(const Util::SourceInfo &si) {
+    // We do not cache types with source info (yet).
+    return new Type_Boolean(si);
+}
+
+const Type_String *Type_String::get() {
+    static const Type_String *singleton = nullptr;
+    if (!singleton) singleton = (new Type_String());
+    return singleton;
+}
+
+const Type_String *Type_String::get(const Util::SourceInfo &si) {
+    // We do not cache types with source info (yet).
+    return new Type_String(si);
+}
+
+const Type_Varbits *Type_Varbits::get(const Util::SourceInfo &si, const IR::Expression *expr) {
+    return new Type_Varbits(si, expr);
+}
+
+const Type_Varbits *Type_Varbits::get(const Util::SourceInfo &si, int sz) {
+    auto result = new Type_Varbits(si, sz);
     if (sz < 0) {
         ::error(ErrorType::ERR_INVALID, "%1%: Width cannot be negative or zero", result);
         // Return a value that will not cause crashes later on
@@ -130,12 +155,29 @@ const Type::Varbits *Type::Varbits::get(Util::SourceInfo si, int sz) {
     return result;
 }
 
-const Type::Varbits *Type::Varbits::get() { return new Type::Varbits(0); }
+const Type_Varbits *Type_Varbits::get(int sz) { return new Type_Varbits(sz); }
+
+const Type_Varbits *Type_Varbits::get() { return new Type_Varbits(0); }
+
+const Type_InfInt *Type_InfInt::get() {
+    // We do not cache types with declaration IDs (yet).
+    return new Type_InfInt();
+}
+
+const Type_InfInt *Type_InfInt::get(const Util::SourceInfo &si) {
+    // We do not cache types with source info and declaration IDs (yet).
+    return new Type_InfInt(si);
+}
 
 const Type_Dontcare *Type_Dontcare::get() {
     static const Type_Dontcare *singleton;
     if (!singleton) singleton = (new Type_Dontcare());
     return singleton;
+}
+
+const Type_Dontcare *Type_Dontcare::get(const Util::SourceInfo &si) {
+    // We do not cache types with source info (yet).
+    return new Type_Dontcare(si);
 }
 
 const Type_State *Type_State::get() {
@@ -144,16 +186,41 @@ const Type_State *Type_State::get() {
     return singleton;
 }
 
+const Type_State *Type_State::get(const Util::SourceInfo &si) {
+    // We do not cache types with source info (yet).
+    return new Type_State(si);
+}
+
 const Type_Void *Type_Void::get() {
     static const Type_Void *singleton;
     if (!singleton) singleton = (new Type_Void());
     return singleton;
 }
 
+const Type_Void *Type_Void::get(const Util::SourceInfo &si) {
+    // We do not cache types with source info (yet).
+    return new Type_Void(si);
+}
+
 const Type_MatchKind *Type_MatchKind::get() {
     static const Type_MatchKind *singleton;
     if (!singleton) singleton = (new Type_MatchKind());
     return singleton;
+}
+
+const Type_MatchKind *Type_MatchKind::get(const Util::SourceInfo &si) {
+    // We do not cache types with source info (yet).
+    return new Type_MatchKind(si);
+}
+
+const Type_Any *Type_Any::get() {
+    // We do not cache types with declaration IDs (yet).
+    return new Type_Any();
+}
+
+const Type_Any *Type_Any::get(const Util::SourceInfo &si) {
+    // We do not cache types with source info and declaration IDs (yet).
+    return new Type_Any(si);
 }
 
 bool Type_ActionEnum::contains(cstring name) const {

--- a/ir/type.cpp
+++ b/ir/type.cpp
@@ -89,18 +89,17 @@ const Type_Bits *Type_Bits::get(int width, bool isSigned) {
 }
 
 const Type_Bits *Type_Bits::get(const Util::SourceInfo &si, int sz, bool isSigned) {
-    auto *result = new IR::Type_Bits(si, sz, isSigned);
     if (sz < 0) {
-        ::error(ErrorType::ERR_INVALID, "%1%: Width of type cannot be negative", result);
+        ::error(ErrorType::ERR_INVALID, "%1%Width %2% of type cannot be negative", si, sz);
         // Return a value that will not cause crashes later on
         return new IR::Type_Bits(si, 1024, isSigned);
     }
     if (sz == 0 && isSigned) {
-        ::error(ErrorType::ERR_INVALID, "%1%: Width of signed type cannot be zero", result);
+        ::error(ErrorType::ERR_INVALID, "%1%Width of signed type cannot be zero", si);
         // Return a value that will not cause crashes later on
         return new IR::Type_Bits(si, 1024, isSigned);
     }
-    return result;
+    return new IR::Type_Bits(si, sz, isSigned);
 }
 
 const Type_Bits *Type_Bits::get(const Util::SourceInfo &si, const IR::Expression *expression,

--- a/ir/type.def
+++ b/ir/type.def
@@ -67,16 +67,20 @@ inline bool operator>>(cstring s, IR::Direction &d) {
 /// There is no syntax to represent this type.
 /// Treated like a type variable so that unification can assign it a value.
 class Type_Any : Type, ITypeVar {
-    long declid = nextId++;
- private:
+ protected:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
     static long nextId;
  public:
+    long declid = nextId++;
     cstring getVarName() const override { return "int_" + Util::toString(declid); }
     int getDeclId() const override { return declid; }
     dbprint { out << "ANYTYPE/" << declid; }
     toString { return "ANYTYPE"; }
     operator== { return declid == a.declid; }
     static Type_Any get();
+    static Type_Any get(const Util::SourceInfo &si);
     const Type* getP4Type() const override { return nullptr; }
     equiv {
         (void)a;  // silence unused warning
@@ -118,7 +122,13 @@ class Type_Type : Type {
 }
 
 class Type_Boolean : Type_Base {
+ protected:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
+ public:
     static Type_Boolean get();
+    static Type_Boolean get(const Util::SourceInfo &si);
     int width_bits() const override { return 1; }
     toString{ return "bool"; }
     dbprint { out << "bool"; }
@@ -126,17 +136,29 @@ class Type_Boolean : Type_Base {
 
 /// The type of a parser state
 class Type_State : Type_Base {
+ protected:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
+ public:
     static Type_State get();
+    static Type_State get(const Util::SourceInfo &si);
     toString{ return "state"; }
     dbprint { out << "state"; }
 }
 
 /// Represents both bit<> and int<> types in P4-14 and P4-16
 class Type_Bits : Type_Base {
+ protected:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
+ public:
     optional int size = 0;      // zero (only) for not-yet evaluated const expression
     NullOK optional Expression expression; // only used temporarily
     bool isSigned;
-    static Type_Bits get(Util::SourceInfo si, int sz, bool isSigned = false);
+    static Type_Bits get(const Util::SourceInfo &si, Expression expression, bool isSigned = false);
+    static Type_Bits get(const Util::SourceInfo &si, int sz, bool isSigned = false);
     static Type_Bits get(int sz, bool isSigned = false);
     cstring baseName() const { return isSigned ? "int" : "bit"; }
     int width_bits() const override { return size; }
@@ -146,9 +168,16 @@ class Type_Bits : Type_Base {
 }
 
 class Type_Varbits : Type_Base {
+ protected:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
+ public:
     optional int         size = 0;   // if zero it means "unknown"
     NullOK optional Expression  expression = nullptr;  // only used temporarily
-    static Type_Varbits get(Util::SourceInfo si, int size = 0);
+    static Type_Varbits get(const Util::SourceInfo &si, Expression expr);
+    static Type_Varbits get(const Util::SourceInfo &si, int size);
+    static Type_Varbits get(int size);
     static Type_Varbits get();
     toString{ return cstring("varbit<") + Util::toString(size) + ">"; }
     dbprint { out << "varbit<" << size << ">"; }
@@ -215,6 +244,10 @@ class Type_Var : Type_Declaration, ITypeVar {
 /// type unification to discover the correct type for the constants
 /// in some contexts.
 class Type_InfInt : Type, ITypeVar {
+ protected:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
     long declid = nextId++;
  private:
     static long nextId;
@@ -224,6 +257,8 @@ class Type_InfInt : Type, ITypeVar {
     dbprint { out << "int/" << declid; }
     toString { return "int"; }
     operator== { return declid == a.declid; }
+    static Type_InfInt get();
+    static Type_InfInt get(const Util::SourceInfo &si);
     equiv {
         (void)a;  // silence unused warning
         return true; /* ignore declid */
@@ -232,20 +267,38 @@ class Type_InfInt : Type, ITypeVar {
 }
 
 class Type_Dontcare : Type_Base {
+ protected:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
+ public:
     toString{ return "_"; }
     static Type_Dontcare get();
+    static Type_Dontcare get(const Util::SourceInfo &si);
     dbprint { out << "_"; }
 }
 
 class Type_Void : Type_Base {
+ protected:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
+ public:
     toString{ return "void"; }
     static Type_Void get();
+    static Type_Void get(const Util::SourceInfo &si);
     dbprint { out << "void"; }
 }
 
 class Type_MatchKind : Type_Base {
+ protected:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
+ public:
     toString{ return "match_kind"; }
     static Type_MatchKind get();
+    static Type_MatchKind get(const Util::SourceInfo &si);
     dbprint { out << "match_kind"; }
 }
 
@@ -567,7 +620,13 @@ class Declaration_ID : Declaration, CompileTimeValue {
 /// The type of a string literal
 class Type_String : Type_Base {
 #nodbprint
+ protected:
+#emit
+    void *operator new(size_t size) { return ::operator new(size); }
+#end
+ public:
     static Type_String get();
+    static Type_String get(const Util::SourceInfo &si);
     toString{ return "string"; }
 }
 

--- a/midend/convertEnums.h
+++ b/midend/convertEnums.h
@@ -48,7 +48,7 @@ class EnumRepresentation {
     const IR::Type_Bits *type;
 
     EnumRepresentation(Util::SourceInfo srcInfo, unsigned width) {
-        type = new IR::Type_Bits(srcInfo, width, false);
+        type = IR::Type_Bits::get(srcInfo, width, false);
     }
     void add(cstring decl) { repr.emplace(decl, repr.size()); }
     unsigned get(cstring decl) const { return ::get(repr, decl); }

--- a/midend/parserUnroll.cpp
+++ b/midend/parserUnroll.cpp
@@ -791,8 +791,8 @@ class ParserSymbolicInterpreter {
         }
         hasOutOfboundState = true;
         newStates.insert(newName);
-        auto *pathExpr =
-            new IR::PathExpression(new IR::Type_State(), new IR::Path(outOfBoundsStateName, false));
+        auto *pathExpr = new IR::PathExpression(IR::Type_State::get(),
+                                                new IR::Path(outOfBoundsStateName, false));
         stateInfo->newState = new IR::ParserState(newName, components, pathExpr);
     }
 

--- a/midend/parserUnroll.h
+++ b/midend/parserUnroll.h
@@ -254,8 +254,7 @@ class RewriteAllParsers : public Transform {
         if (rewriter->hasOutOfboundState) {
             // generating state with verify(false, error.StackOutOfBounds)
             IR::Vector<IR::Argument> *arguments = new IR::Vector<IR::Argument>();
-            arguments->push_back(
-                new IR::Argument(new IR::BoolLiteral(IR::Type::Boolean::get(), false)));
+            arguments->push_back(new IR::Argument(IR::BoolLiteral::get(false)));
             arguments->push_back(new IR::Argument(
                 new IR::Member(new IR::TypeNameExpression(new IR::Type_Name(IR::ID("error"))),
                                IR::ID("StackOutOfBounds"))));
@@ -274,7 +273,7 @@ class RewriteAllParsers : public Transform {
                 arguments)));
             auto *outOfBoundsState = new IR::ParserState(
                 IR::ID(outOfBoundsStateName), components,
-                new IR::PathExpression(new IR::Type_State(),
+                new IR::PathExpression(IR::Type_State::get(),
                                        new IR::Path(IR::ParserState::reject, false)));
             newParser->states.push_back(outOfBoundsState);
         }

--- a/midend/replaceSelectRange.cpp
+++ b/midend/replaceSelectRange.cpp
@@ -91,7 +91,7 @@ std::vector<const IR::Mask *> *DoReplaceSelectRange::rangeToMasks(const IR::Rang
     auto inType = r->left->type->to<IR::Type_Bits>();
     BUG_CHECK(inType != nullptr, "Range type %1% is not fixed-width integer", r->left->type);
     bool isSigned = inType->isSigned;
-    auto maskType = isSigned ? new IR::Type_Bits(inType->srcInfo, inType->size, false) : inType;
+    auto maskType = isSigned ? IR::Type_Bits::get(inType->srcInfo, inType->size, false) : inType;
 
     if (isSigned) {
         signedIndicesToReplace.emplace(keyIndex);
@@ -150,7 +150,7 @@ const IR::Node *DoReplaceSelectRange::postorder(IR::SelectExpression *e) {
                           "Cannot handle select on types other then fixed-width integeral "
                           "types: %1%",
                           expr->type);
-                auto unsignedType = new IR::Type_Bits(eType->srcInfo, eType->size, false);
+                auto unsignedType = IR::Type_Bits::get(eType->srcInfo, eType->size, false);
 
                 newSelectList.push_back(new IR::Cast(expr->srcInfo, unsignedType, expr));
             } else {

--- a/midend/singleArgumentSelect.cpp
+++ b/midend/singleArgumentSelect.cpp
@@ -27,7 +27,7 @@ static const IR::Expression *convertList(const IR::Expression *expression,
                                          const IR::Type *selectListType) {
     if (expression->is<IR::DefaultExpression>()) {
         int width = selectListType->width_bits();
-        auto type = new IR::Type_Bits(width, false);
+        auto type = IR::Type_Bits::get(width, false);
         return new IR::Mask(expression->srcInfo, new IR::Constant(type, 0, 16),
                             new IR::Constant(type, 0, 16));
     }

--- a/test/gtest/p4runtime.cpp
+++ b/test/gtest/p4runtime.cpp
@@ -1682,7 +1682,7 @@ class P4RuntimeDataTypeSpec : public P4Runtime {
 TEST_F(P4RuntimeDataTypeSpec, Bits) {
     int size(9);
     bool isSigned(true);
-    auto *type = new IR::Type_Bits(size, isSigned);
+    auto *type = IR::Type_Bits::get(size, isSigned);
     const auto *typeSpec =
         P4::ControlPlaneAPI::TypeSpecConverter::convert(&refMap, &typeMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_bitstring());
@@ -1693,7 +1693,7 @@ TEST_F(P4RuntimeDataTypeSpec, Bits) {
 
 TEST_F(P4RuntimeDataTypeSpec, Varbits) {
     int size(64);
-    auto *type = new IR::Type_Varbits(size);
+    auto *type = IR::Type_Varbits::get(size);
     const auto *typeSpec =
         P4::ControlPlaneAPI::TypeSpecConverter::convert(&refMap, &typeMap, type, &typeInfo);
     ASSERT_TRUE(typeSpec->has_bitstring());
@@ -1703,15 +1703,15 @@ TEST_F(P4RuntimeDataTypeSpec, Varbits) {
 }
 
 TEST_F(P4RuntimeDataTypeSpec, Boolean) {
-    auto *type = new IR::Type_Boolean();
+    auto *type = IR::Type_Boolean::get();
     const auto *typeSpec =
         P4::ControlPlaneAPI::TypeSpecConverter::convert(&refMap, &typeMap, type, &typeInfo);
     EXPECT_TRUE(typeSpec->has_bool_());
 }
 
 TEST_F(P4RuntimeDataTypeSpec, Tuple) {
-    auto *typeMember1 = new IR::Type_Bits(1, false);
-    auto *typeMember2 = new IR::Type_Bits(2, false);
+    auto *typeMember1 = IR::Type_Bits::get(1, false);
+    auto *typeMember2 = IR::Type_Bits::get(2, false);
     IR::Vector<IR::Type> components = {typeMember1, typeMember2};
     auto *type = new IR::Type_Tuple(std::move(components));
     const auto *typeSpec =

--- a/testdata/p4_16_errors_outputs/issue3285.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3285.p4-stderr
@@ -1,4 +1,4 @@
-issue3285.p4(1): [--Werror=invalid] error: int<0>: Width of signed type cannot be zero
+issue3285.p4(1): [--Werror=invalid] error: Width of signed type cannot be zero
 const int t = 0s0
               ^^^
 [--Werror=overlimit] error: 1 errors encountered, aborting compilation


### PR DESCRIPTION
Addresses some of the points raised in #4612. Note that #4612 is still required. Type pointers can still not be unique because of the source information associated with the type and the `clone` call. 