### PR TITLE
Add string_view and string conversion operators and functions to cstring

### DIFF
--- a/lib/cstring.cpp
+++ b/lib/cstring.cpp
@@ -203,8 +203,8 @@ cstring cstring::before(const char *at) const { return substr(0, at - str); }
 
 cstring cstring::substr(size_t start, size_t length) const {
     if (size() <= start) return cstring::empty;
-    std::string s = str;
-    return s.substr(start, length);
+    auto s = string_view();
+    return cstring(s.substr(start, length));
 }
 
 cstring cstring::replace(char c, char with) const {

--- a/lib/cstring.cpp
+++ b/lib/cstring.cpp
@@ -203,8 +203,7 @@ cstring cstring::before(const char *at) const { return substr(0, at - str); }
 
 cstring cstring::substr(size_t start, size_t length) const {
     if (size() <= start) return cstring::empty;
-    auto s = string_view();
-    return cstring(s.substr(start, length));
+    return cstring(string_view().substr(start, length));
 }
 
 cstring cstring::replace(char c, char with) const {

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <functional>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include "hash.h"
 
@@ -164,6 +165,12 @@ class cstring {
     char get(unsigned index) const { return (index < size()) ? str[index] : 0; }
     const char *c_str() const { return str; }
     operator const char *() const { return str; }
+
+    std::string string() const { return std::string(str); }
+    explicit operator std::string() const { return string(); }
+
+    std::string_view string_view() const { return std::string_view(str); }
+    explicit operator std::string_view() const { return string_view(); }
 
     // Size tests. Constant time except for size(), which is linear time.
     size_t size() const {


### PR DESCRIPTION
The `cstring` type is used a lot in the codebase as it is the type of names in the IR. It is, however not a good idea to perform operations on `cstring` unless the result of the operations is intended to be persistent. In these cases, the operations should be rather performed on `std::string` or `std::string_view` (based on what kind of operations is desired). Note that creating a `std::string_view` from a `cstring` is currently always safe as `cstring` is persistent.

This PR adds explicit operators for conversion to both string and string_view as well as functions which serve the same purpose. I've opted to add these too as I find it syntactically more pleasing to do something like `dec->name.name.string()` than `std::string(dec->name.name)`.