### PR TITLE
Generalization & minor refactoring in RenameMap

### DIFF
--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -31,17 +31,33 @@ class RenameMap {
     std::map<const IR::MethodCallExpression *, const IR::P4Action *> actionCall;
 
  public:
-    void setNewName(const IR::IDeclaration *decl, cstring name);
+    /// @brief Add rename entry for the declaration to be named with the given name.
+    /// @param allowOverride If set to true, don't fail if a new name was already set but replace it
+    /// instead.
+    void setNewName(const IR::IDeclaration *decl, cstring name, bool allowOverride = false);
+
+    /// Get new name for the declaration, fails if none exists.
     cstring getName(const IR::IDeclaration *decl) const {
-        CHECK_NULL(decl);
-        BUG_CHECK(newName.find(decl) != newName.end(), "%1%: no new name", decl);
-        auto result = ::get(newName, decl);
-        return result;
+        auto n = get(decl);
+        BUG_CHECK(n.has_value(), "%1%: no new name", decl);
+        return *n;
     }
+
+    /// @returns true if there is a new name for the declaration, false otherwise.
     bool toRename(const IR::IDeclaration *decl) const {
         CHECK_NULL(decl);
         return newName.find(decl) != newName.end();
     }
+
+    /// Get new name for the declaration (wrapped in optional), or std::nullopt if there is none.
+    std::optional<cstring> get(const IR::IDeclaration *decl) const {
+        CHECK_NULL(decl);
+        if (auto it = newName.find(decl); it != newName.end()) {
+            return it->second;
+        }
+        return {};
+    }
+
     void foundInTable(const IR::P4Action *action);
     void markActionCall(const IR::P4Action *action, const IR::MethodCallExpression *call);
     const IR::P4Action *actionCalled(const IR::MethodCallExpression *expression) const;


### PR DESCRIPTION
This is a slight generalization and refactor of `P4::RenameMap`. The existing interface stays the same, but there are two more ways to use it:

- `setNewName` can now accept an optional `bool` argument. If set to `true`, the bug check for the case an an existing renaming is going to be replaced is disabled.
- `get` member function that returns `std::optional<cstring>` was added. If the name has no mapping, this will return `std::nullopt`, while in `getName` there was a failure. This allows the user of the map to skip double searching the map.