### PR TITLE
Workaround for gcc-11.4/draft 2x spec flaw

### DIFF
--- a/ir/id.h
+++ b/ir/id.h
@@ -47,6 +47,10 @@ struct ID : Util::IHasSourceInfo {
     }
     bool operator==(const ID &a) const { return name == a.name; }
     bool operator!=(const ID &a) const { return name != a.name; }
+    bool operator==(cstring a) const { return name == a; }
+    bool operator!=(cstring a) const { return name != a; }
+    bool operator==(const char *a) const { return name == a; }
+    bool operator!=(const char *a) const { return name != a; }
     explicit operator bool() const { return name; }
     operator cstring() const { return name; }
     bool isDontCare() const { return name == "_"; }

--- a/ir/namemap.h
+++ b/ir/namemap.h
@@ -130,7 +130,7 @@ class NameMap : public Node {
     }
 
     IRNODE_SUBCLASS(NameMap)
-    bool operator==(const Node &a) const override { return a == *this; }
+    bool operator==(const Node &a) const override { return a.operator==(*this); }
     bool operator==(const NameMap &a) const { return symbols == a.symbols; }
     bool equiv(const Node &a_) const override {
         if (static_cast<const Node *>(this) == &a_) return true;

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -190,6 +190,9 @@ class cstring {
     bool operator==(cstring a) const { return str == a.str; }
     bool operator!=(cstring a) const { return str != a.str; }
 
+    bool operator==(std::nullptr_t) const { return str == nullptr; }
+    bool operator!=(std::nullptr_t) const { return str != nullptr; }
+
     // Other comparisons and tests. Linear time.
     bool operator==(const char *a) const { return str ? a && !strcmp(str, a) : !a; }
     bool operator!=(const char *a) const { return str ? !a || !!strcmp(str, a) : !!a; }


### PR DESCRIPTION
TLDR: workaround for problems compiling p4c with gcc 11.4 (and probably others) with `-std=c++2x`

A late draft of the C++2x spec introduced a non-backwards compatible change in the way overloading for operator ==/!= is handled; this was considered a defect and was fixed in the final C++20 spec.  However, the default version of gcc on Ubuntu 22.04 (gcc 11.4) happens to implement that spec draft, so gives errors with our code.

More recent versions of gcc (and older versions too!) don't have this problem.  So this change isn't really necessary, but is pretty small and may help others who run into this specific problem.