### PR TITLE
Explicitly instantiate (Indexed)Vector with types used in IR to speedup compilation

### DIFF
--- a/ir/CMakeLists.txt
+++ b/ir/CMakeLists.txt
@@ -24,6 +24,7 @@ set (IR_SRCS
   expression.cpp
   ir.cpp
   irutils.cpp
+  indexed_vector.cpp
   json_parser.cpp
   loop-visitor.cpp
   node.cpp
@@ -32,6 +33,7 @@ set (IR_SRCS
   type.cpp
   v1.cpp
   visitor.cpp
+  vector.cpp
   write_context.cpp
 )
 

--- a/ir/indexed_vector.cpp
+++ b/ir/indexed_vector.cpp
@@ -1,0 +1,37 @@
+/*
+Copyright 2024-present Intel Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "indexed_vector.h"
+
+#include "ir.h"
+#include "json_loader.h"  // implements JSON construction/fromJSON
+
+namespace IR {
+
+template class IndexedVector<ActionListElement>;
+template class IndexedVector<Declaration>;
+template class IndexedVector<Declaration_ID>;
+template class IndexedVector<NamedExpression>;
+template class IndexedVector<Node>;
+template class IndexedVector<Parameter>;
+template class IndexedVector<ParserState>;
+template class IndexedVector<Property>;
+template class IndexedVector<SerEnumMember>;
+template class IndexedVector<StatOrDecl>;
+template class IndexedVector<StructField>;
+template class IndexedVector<Type_Var>;
+
+}  // namespace IR

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -215,6 +215,21 @@ class IndexedVector : public Vector<T> {
                                         Vector<T>);
 };
 
+/// These instantiations of Vector are created in ir-generated. Therefore we instantiate them
+/// explicitly to speed up compilation.
+extern template class IndexedVector<ActionListElement>;
+extern template class IndexedVector<Declaration>;
+extern template class IndexedVector<Declaration_ID>;
+extern template class IndexedVector<NamedExpression>;
+extern template class IndexedVector<Node>;
+extern template class IndexedVector<Parameter>;
+extern template class IndexedVector<ParserState>;
+extern template class IndexedVector<Property>;
+extern template class IndexedVector<SerEnumMember>;
+extern template class IndexedVector<StatOrDecl>;
+extern template class IndexedVector<StructField>;
+extern template class IndexedVector<Type_Var>;
+
 }  // namespace IR
 
 #endif /* IR_INDEXED_VECTOR_H_ */

--- a/ir/vector.cpp
+++ b/ir/vector.cpp
@@ -1,0 +1,40 @@
+/*
+Copyright 2024-present Intel Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "vector.h"
+
+#include "ir.h"
+#include "json_loader.h"  // implements JSON construction/fromJSON
+
+namespace IR {
+
+template class Vector<Annotation>;
+template class Vector<AnnotationToken>;
+template class Vector<Argument>;
+template class Vector<ArgumentInfo>;
+template class Vector<CaseEntry>;
+template class Vector<Entry>;
+template class Vector<Expression>;
+template class Vector<KeyElement>;
+template class Vector<Method>;
+template class Vector<NamedExpression>;
+template class Vector<Node>;
+template class Vector<Primitive>;
+template class Vector<SelectCase>;
+template class Vector<SwitchCase>;
+template class Vector<Type>;
+
+}  // namespace IR

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -209,6 +209,24 @@ class Vector : public VectorBase {
     DECLARE_TYPEINFO_WITH_DISCRIMINATOR(Vector<T>, NodeDiscriminator::VectorT, T, VectorBase);
 };
 
+/// These instantiations of Vector are created in ir-generated. Therefore we instantiate them
+/// explicitly to speed up compilation.
+extern template class Vector<Annotation>;
+extern template class Vector<AnnotationToken>;
+extern template class Vector<Argument>;
+extern template class Vector<ArgumentInfo>;
+extern template class Vector<CaseEntry>;
+extern template class Vector<Entry>;
+extern template class Vector<Expression>;
+extern template class Vector<KeyElement>;
+extern template class Vector<Method>;
+extern template class Vector<NamedExpression>;
+extern template class Vector<Node>;
+extern template class Vector<Primitive>;
+extern template class Vector<SelectCase>;
+extern template class Vector<SwitchCase>;
+extern template class Vector<Type>;
+
 }  // namespace IR
 
 // XXX(seth): We use this namespace to hide our get() overloads from ADL. GCC


### PR DESCRIPTION
This speeds up compilation **of P4C** by about 7-9 % in my measurements, see https://github.com/p4lang/p4c/issues/4674#issuecomment-2130013132. We should double check that this does not slow down the compilation **with P4C** (as it prevents no-LTO inlining), but I would expect it to be OK as a lot of work with `Vector`/`IndexedVector` is though virtual functions anyway. I'll try to benchmark this later today, but if anyone has a nice big benchmark and some time at hand, please compare it too.