### PR TITLE
Facilitate inheritance from RenameSymbols pass, deduplicate code

### DIFF
--- a/frontends/p4/uniqueNames.cpp
+++ b/frontends/p4/uniqueNames.cpp
@@ -104,7 +104,7 @@ const IR::Annotations *RenameSymbols::addNameAnnotation(cstring name,
 }
 
 const IR::Node *RenameSymbols::postorder(IR::Declaration_Variable *decl) {
-    return renameDeclWithNameAnno(decl);
+    return renameDeclWithNameAnnotation(decl);
 }
 
 const IR::Node *RenameSymbols::postorder(IR::Declaration_Constant *decl) {
@@ -114,7 +114,7 @@ const IR::Node *RenameSymbols::postorder(IR::Declaration_Constant *decl) {
 }
 
 const IR::Node *RenameSymbols::postorder(IR::Parameter *param) {
-    return renameDeclWithNameAnno(param);
+    return renameDeclWithNameAnnotation(param);
 }
 
 const IR::Node *RenameSymbols::postorder(IR::PathExpression *expression) {
@@ -131,17 +131,19 @@ const IR::Node *RenameSymbols::postorder(IR::PathExpression *expression) {
 }
 
 const IR::Node *RenameSymbols::postorder(IR::Declaration_Instance *decl) {
-    return renameDeclWithNameAnno(decl);
+    return renameDeclWithNameAnnotation(decl);
 }
 
-const IR::Node *RenameSymbols::postorder(IR::P4Table *decl) { return renameDeclWithNameAnno(decl); }
+const IR::Node *RenameSymbols::postorder(IR::P4Table *decl) {
+    return renameDeclWithNameAnnotation(decl);
+}
 
 const IR::Node *RenameSymbols::postorder(IR::P4Action *decl) {
-    return renameDeclWithNameAnno(decl);
+    return renameDeclWithNameAnnotation(decl);
 }
 
 const IR::Node *RenameSymbols::postorder(IR::P4ValueSet *decl) {
-    return renameDeclWithNameAnno(decl);
+    return renameDeclWithNameAnnotation(decl);
 }
 
 const IR::Node *RenameSymbols::postorder(IR::Argument *arg) {

--- a/frontends/p4/uniqueNames.cpp
+++ b/frontends/p4/uniqueNames.cpp
@@ -64,14 +64,6 @@ class FindActionCalls : public Inspector {
 
 }  // namespace
 
-// Add a @name annotation ONLY if it does not already exist.
-// Otherwise do nothing.
-static const IR::Annotations *addNameAnnotation(cstring name, const IR::Annotations *annos) {
-    if (annos == nullptr) annos = IR::Annotations::empty;
-    return annos->addAnnotationIfNew(IR::Annotation::nameAnnotation, new IR::StringLiteral(name),
-                                     false);
-}
-
 UniqueNames::UniqueNames(ReferenceMap *refMap) : renameMap(new RenameMap) {
     setName("UniqueNames");
     visitDagOnce = false;
@@ -96,21 +88,25 @@ UniqueParameters::UniqueParameters(ReferenceMap *refMap, TypeMap *typeMap)
 /**************************************************************************/
 
 IR::ID *RenameSymbols::getName() const {
-    auto orig = getOriginal<IR::IDeclaration>();
-    auto newName = renameMap->get(orig);
+    return getName(getOriginal<IR::IDeclaration>());
+}
+
+IR::ID *RenameSymbols::getName(const IR::IDeclaration *decl) const {
+    auto newName = renameMap->get(decl);
     if (!newName.has_value()) return nullptr;
-    auto name = new IR::ID(orig->getName().srcInfo, *newName, orig->getName().originalName);
+    auto name = new IR::ID(decl->getName().srcInfo, *newName, decl->getName().originalName);
     return name;
 }
 
+const IR::Annotations *RenameSymbols::addNameAnnotation(cstring name,
+                                                        const IR::Annotations *annos) {
+    if (annos == nullptr) annos = IR::Annotations::empty;
+    return annos->addAnnotationIfNew(IR::Annotation::nameAnnotation, new IR::StringLiteral(name),
+                                     false);
+}
+
 const IR::Node *RenameSymbols::postorder(IR::Declaration_Variable *decl) {
-    auto name = getName();
-    if (name != nullptr && *name != decl->name) {
-        auto annos = addNameAnnotation(decl->name, decl->annotations);
-        decl->name = *name;
-        decl->annotations = annos;
-    }
-    return decl;
+    return renameDeclWithNameAnno(decl);
 }
 
 const IR::Node *RenameSymbols::postorder(IR::Declaration_Constant *decl) {
@@ -120,12 +116,7 @@ const IR::Node *RenameSymbols::postorder(IR::Declaration_Constant *decl) {
 }
 
 const IR::Node *RenameSymbols::postorder(IR::Parameter *param) {
-    auto name = getName();
-    if (name != nullptr && *name != param->name.name) {
-        param->annotations = addNameAnnotation(param->name, param->annotations);
-        param->name = IR::ID(param->name.srcInfo, *name, param->name.originalName);
-    }
-    return param;
+    return renameDeclWithNameAnno(param);
 }
 
 const IR::Node *RenameSymbols::postorder(IR::PathExpression *expression) {
@@ -142,43 +133,19 @@ const IR::Node *RenameSymbols::postorder(IR::PathExpression *expression) {
 }
 
 const IR::Node *RenameSymbols::postorder(IR::Declaration_Instance *decl) {
-    auto name = getName();
-    if (name != nullptr && *name != decl->name) {
-        auto annos = addNameAnnotation(decl->name, decl->annotations);
-        decl->name = *name;
-        decl->annotations = annos;
-    }
-    return decl;
+    return renameDeclWithNameAnno(decl);
 }
 
 const IR::Node *RenameSymbols::postorder(IR::P4Table *decl) {
-    auto name = getName();
-    if (name != nullptr && *name != decl->name) {
-        auto annos = addNameAnnotation(decl->name, decl->annotations);
-        decl->name = *name;
-        decl->annotations = annos;
-    }
-    return decl;
+    return renameDeclWithNameAnno(decl);
 }
 
 const IR::Node *RenameSymbols::postorder(IR::P4Action *decl) {
-    auto name = getName();
-    if (name != nullptr && *name != decl->name) {
-        auto annos = addNameAnnotation(decl->name, decl->annotations);
-        decl->name = *name;
-        decl->annotations = annos;
-    }
-    return decl;
+    return renameDeclWithNameAnno(decl);
 }
 
 const IR::Node *RenameSymbols::postorder(IR::P4ValueSet *decl) {
-    auto name = getName();
-    if (name != nullptr && *name != decl->name) {
-        auto annos = addNameAnnotation(decl->name, decl->annotations);
-        decl->name = *name;
-        decl->annotations = annos;
-    }
-    return decl;
+    return renameDeclWithNameAnno(decl);
 }
 
 const IR::Node *RenameSymbols::postorder(IR::Argument *arg) {

--- a/frontends/p4/uniqueNames.cpp
+++ b/frontends/p4/uniqueNames.cpp
@@ -87,9 +87,7 @@ UniqueParameters::UniqueParameters(ReferenceMap *refMap, TypeMap *typeMap)
 
 /**************************************************************************/
 
-IR::ID *RenameSymbols::getName() const {
-    return getName(getOriginal<IR::IDeclaration>());
-}
+IR::ID *RenameSymbols::getName() const { return getName(getOriginal<IR::IDeclaration>()); }
 
 IR::ID *RenameSymbols::getName(const IR::IDeclaration *decl) const {
     auto newName = renameMap->get(decl);
@@ -136,9 +134,7 @@ const IR::Node *RenameSymbols::postorder(IR::Declaration_Instance *decl) {
     return renameDeclWithNameAnno(decl);
 }
 
-const IR::Node *RenameSymbols::postorder(IR::P4Table *decl) {
-    return renameDeclWithNameAnno(decl);
-}
+const IR::Node *RenameSymbols::postorder(IR::P4Table *decl) { return renameDeclWithNameAnno(decl); }
 
 const IR::Node *RenameSymbols::postorder(IR::P4Action *decl) {
     return renameDeclWithNameAnno(decl);

--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -114,10 +114,31 @@ class FindSymbols : public Inspector {
 };
 
 class RenameSymbols : public Transform {
+ protected:
     ReferenceMap *refMap;
     RenameMap *renameMap;
 
+    /// Get new name of the current declaration or nullptr if the declaration is not to be renamed.
     IR::ID *getName() const;
+    /// Get new name of the given declaration or nullptr if the declaration is not to be renamed.
+    /// @param decl Declaration *in the original/non-transformed* P4 IR.
+    IR::ID *getName(const IR::IDeclaration *decl) const;
+
+    /// Add a @name annotation ONLY if it does not already exist.
+    /// Otherwise do nothing.
+    static const IR::Annotations *addNameAnnotation(cstring name, const IR::Annotations *annos);
+
+    /// Rename any declaration where we want to add @name annotation with the original name.
+    /// Has to be a template as there is no common base for declarations with annotations member.
+    template<typename D>
+    const IR::Node *renameDeclWithNameAnno(D *decl) {
+        auto name = getName();
+        if (name != nullptr && *name != decl->name) {
+            decl->annotations = addNameAnnotation(decl->name, decl->annotations);
+            decl->name = *name;
+        }
+        return decl;
+    }
 
  public:
     RenameSymbols(ReferenceMap *refMap, RenameMap *renameMap)

--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -130,7 +130,7 @@ class RenameSymbols : public Transform {
 
     /// Rename any declaration where we want to add @name annotation with the original name.
     /// Has to be a template as there is no common base for declarations with annotations member.
-    template<typename D>
+    template <typename D>
     const IR::Node *renameDeclWithNameAnno(D *decl) {
         auto name = getName();
         if (name != nullptr && *name != decl->name) {

--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -131,7 +131,7 @@ class RenameSymbols : public Transform {
     /// Rename any declaration where we want to add @name annotation with the original name.
     /// Has to be a template as there is no common base for declarations with annotations member.
     template <typename D>
-    const IR::Node *renameDeclWithNameAnno(D *decl) {
+    const IR::Node *renameDeclWithNameAnnotation(D *decl) {
         auto name = getName();
         if (name != nullptr && *name != decl->name) {
             decl->annotations = addNameAnnotation(decl->name, decl->annotations);


### PR DESCRIPTION
Until this change, passes inheriting from `P4::RenameSymbols` pass could not make use of it because of important `private` members. These are now `protected` and more protected functions were added to avoid code duplication.