### PR TITLE
Refactor error_helper and around

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,6 +54,7 @@ cc_library(
         "@boost//:multiprecision",
         "@com_google_absl//absl/numeric:bits",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
+#include "absl/strings/str_format.h"
 #include "ir/ir.h"
 #include "ir/irutils.h"
 #include "ir/json_loader.h"  // IWYU pragma: keep
@@ -31,18 +32,9 @@ namespace P4Tools {
 const char *toString(const z3::expr &e) { return Z3_ast_to_string(e.ctx(), e); }
 
 #ifndef NDEBUG
-template <typename... Args>
-std::string stringFormat(const char *format, Args... args) {
-    size_t size = snprintf(nullptr, 0, format, args...) + 1;
-    BUG_CHECK(size > 0, "Z3Solver: error during formatting.");
-    std::unique_ptr<char[]> buf(new char[size]);
-    snprintf(buf.get(), size, format, args...);
-    return {buf.get(), buf.get() + size - 1};
-}
-
-#define Z3_LOG(FORMAT, ...)                                                                       \
-    LOG1(stringFormat("Z3Solver:%s() in %s, line %i: " FORMAT "\n", __func__, __FILE__, __LINE__, \
-                      __VA_ARGS__))
+#define Z3_LOG(FORMAT, ...)                                                                \
+    LOG1(absl::StrFormat("Z3Solver:%s() in %s, line %i: " FORMAT "\n", __func__, __FILE__, \
+                         __LINE__, __VA_ARGS__))
 
 /// Converts a Z3 model to a string.
 const char *toString(z3::model m) { return Z3_model_to_string(m.ctx(), m); }

--- a/backends/p4tools/modules/testgen/lib/exceptions.h
+++ b/backends/p4tools/modules/testgen/lib/exceptions.h
@@ -8,7 +8,6 @@ namespace P4Tools::P4Testgen {
 
 /// This class indicates a feature that is not implemented in P4Testgen.
 /// Paths with this unimplemented feature should be skipped
-// FIXME: Can we use CompilerUnimplemented instead?
 class TestgenUnimplemented final : public Util::P4CExceptionBase {
  public:
     template <typename... Args>

--- a/backends/p4tools/modules/testgen/lib/exceptions.h
+++ b/backends/p4tools/modules/testgen/lib/exceptions.h
@@ -1,29 +1,31 @@
 #ifndef BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_EXCEPTIONS_H_
 #define BACKENDS_P4TOOLS_MODULES_TESTGEN_LIB_EXCEPTIONS_H_
 
+#include "absl/strings/str_cat.h"
 #include "lib/exceptions.h"
 
 namespace P4Tools::P4Testgen {
 
 /// This class indicates a feature that is not implemented in P4Testgen.
 /// Paths with this unimplemented feature should be skipped
+// FIXME: Can we use CompilerUnimplemented instead?
 class TestgenUnimplemented final : public Util::P4CExceptionBase {
  public:
-    template <typename... T>
-    explicit TestgenUnimplemented(const char *format, T... args)
-        : P4CExceptionBase(format, args...) {
+    template <typename... Args>
+    explicit TestgenUnimplemented(const char *format, Args &&...args)
+        : P4CExceptionBase(format, std::forward<Args>(args)...) {
         // Check if output is redirected and if so, then don't color text so that
         // escape characters are not present
-        message = cstring(Util::cerr_colorize(Util::ANSI_BLUE)) + "Not yet implemented" +
-                  Util::cerr_clear_colors() + ":\n" + message;
+        message = absl::StrCat(Util::cerr_colorize(Util::ANSI_BLUE), "Not yet implemented",
+                               Util::cerr_clear_colors(), ":\n", message);
     }
 
-    template <typename... T>
-    TestgenUnimplemented(int line, const char *file, const char *format, T... args)
-        : P4CExceptionBase(format, args...) {
-        message = cstring("In file: ") + file + ":" + Util::toString(line) + "\n" +
-                  Util::cerr_colorize(Util::ANSI_BLUE) + "Unimplemented compiler support" +
-                  Util::cerr_clear_colors() + ": " + message;
+    template <typename... Args>
+    TestgenUnimplemented(int line, const char *file, const char *format, Args &&...args)
+        : P4CExceptionBase(format, std::forward<Args>(args)...) {
+        message = absl::StrCat(
+            "In file: ", file, ":", line, "\n", Util::cerr_colorize(Util::ANSI_BLUE),
+            "Unimplemented compiler support", Util::cerr_clear_colors(), ": ", message);
     }
 };
 

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -63,9 +63,9 @@ class TypeChecking : public PassManager {
                  bool updateExpressions = false);
 };
 
-template <typename... T>
-void typeError(const char *format, T... args) {
-    ::error(ErrorType::ERR_TYPE_ERROR, format, args...);
+template <typename... Args>
+void typeError(const char *format, Args &&...args) {
+    ::error(ErrorType::ERR_TYPE_ERROR, format, std::forward<Args>(args)...);
 }
 /// True if the type contains any varbit or header_union subtypes
 bool hasVarbitsOrUnions(const TypeMap *typeMap, const IR::Type *type);

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -46,7 +46,8 @@ abstract Operation_Binary : Operation {
             type = left->type; }
     toString {
         std::stringstream tmp;
-        tmp << DBPrint::Prec_Low << *this;
+        tmp << DBPrint::Prec_Low;
+        dbprint(tmp);
         return tmp.str();
     }
 }

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -294,20 +294,18 @@ class Visitor {
     /// Static version of the above function, which can be called
     /// even if not directly in a visitor
     static bool warning_enabled(const Visitor *visitor, int warning_kind);
-    template <
-        class T,
-        typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
-        class... Args>
-    void warn(const int kind, const char *format, const T *node, Args... args) {
+    template <class T,
+              typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
+              class... Args>
+    void warn(const int kind, const char *format, const T *node, Args &&...args) {
         if (warning_enabled(kind)) ::warning(kind, format, node, std::forward<Args>(args)...);
     }
 
     /// The const ref variant of the above
-    template <
-        class T,
-        typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
-        class... Args>
-    void warn(const int kind, const char *format, const T &node, Args... args) {
+    template <class T,
+              typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
+              class... Args>
+    void warn(const int kind, const char *format, const T &node, Args &&...args) {
         if (warning_enabled(kind)) ::warning(kind, format, node, std::forward<Args>(args)...);
     }
 

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -294,17 +294,13 @@ class Visitor {
     /// Static version of the above function, which can be called
     /// even if not directly in a visitor
     static bool warning_enabled(const Visitor *visitor, int warning_kind);
-    template <class T,
-              typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-              class... Args>
+    template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
     void warn(const int kind, const char *format, const T *node, Args &&...args) {
         if (warning_enabled(kind)) ::warning(kind, format, node, std::forward<Args>(args)...);
     }
 
     /// The const ref variant of the above
-    template <class T,
-              typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-              class... Args>
+    template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
     void warn(const int kind, const char *format, const T &node, Args &&...args) {
         if (warning_enabled(kind)) ::warning(kind, format, node, std::forward<Args>(args)...);
     }

--- a/lib/backtrace_exception.h
+++ b/lib/backtrace_exception.h
@@ -37,7 +37,7 @@ class backtrace_exception : public E {
 
  public:
     template <class... Args>
-    explicit backtrace_exception(Args... args) : E(std::forward<Args>(args)...) {
+    explicit backtrace_exception(Args &&...args) : E(std::forward<Args>(args)...) {
 #if HAVE_EXECINFO_H
         backtrace_size = backtrace(backtrace_buffer, buffer_size);
 #else

--- a/lib/big_int_fwd.h
+++ b/lib/big_int_fwd.h
@@ -1,0 +1,24 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef LIB_BIG_INT_FWD_H_
+#define LIB_BIG_INT_FWD_H_
+
+#include <memory>
+
+#include <boost/multiprecision/fwd.hpp>
+
+using big_int = boost::multiprecision::cpp_int;
+
+#endif /* LIB_BIG_INT_FWD_H_ */

--- a/lib/bug_helper.h
+++ b/lib/bug_helper.h
@@ -53,6 +53,8 @@ std::pair<std::string_view, std::string> maybeAddSourceInfo(const T &t, std::str
     if constexpr (Util::has_SourceInfo_v<T>)
         return getPositionTail(t.getSourceInfo(), position, tail);
 
+    (void)position;
+    (void)tail;
     return {"", ""};
 }
 

--- a/lib/error.h
+++ b/lib/error.h
@@ -53,8 +53,7 @@ inline void error(const char *format, Args &&...args) {
 
 /// Report errors of type kind. Requires that the node argument have source info.
 /// The message format is declared in the error catalog.
-template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-          class... Args>
+template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
 void error(const int kind, const char *format, const T *node, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultErrorDiagnosticAction();
@@ -62,8 +61,7 @@ void error(const int kind, const char *format, const T *node, Args &&...args) {
 }
 
 /// This is similar to the above method, but also has a suffix
-template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-          class... Args>
+template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
 void errorWithSuffix(const int kind, const char *format, const char *suffix, const T *node,
                      Args &&...args) {
     auto &context = BaseCompileContext::get();
@@ -73,8 +71,7 @@ void errorWithSuffix(const int kind, const char *format, const char *suffix, con
 }
 
 /// The const ref variant of the above
-template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-          class... Args>
+template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
 void error(const int kind, const char *format, const T &node, Args &&...args) {
     error(kind, format, &node, std::forward<Args>(args)...);
 }
@@ -84,16 +81,14 @@ void error(const int kind, const char *format, const T &node, Args &&...args) {
 /// This allows incremental migration toward minimizing the number of errors and warnings
 /// reported when passes are repeated, as typed errors are filtered.
 // LEGACY: once we transition to error types, this should be deprecated
-template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-          class... Args>
+template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
 void error(const char *format, const T *node, Args &&...args) {
     error(ErrorType::LEGACY_ERROR, format, node, std::forward<Args>(args)...);
 }
 
 /// The const ref variant of the above
 // LEGACY: once we transition to error types, this should be deprecated
-template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-          class... Args>
+template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
 void error(const char *format, const T &node, Args &&...args) {
     error(ErrorType::LEGACY_ERROR, format, node, std::forward<Args>(args)...);
 }
@@ -119,8 +114,7 @@ inline void warning(const char *format, Args &&...args) {
 #endif
 
 /// Report warnings of type kind. Requires that the node argument have source info.
-template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-          class... Args>
+template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
 void warning(const int kind, const char *format, const T *node, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultWarningDiagnosticAction();
@@ -128,8 +122,7 @@ void warning(const int kind, const char *format, const T *node, Args &&...args) 
 }
 
 /// The const ref variant of the above
-template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-          class... Args>
+template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
 void warning(const int kind, const char *format, const T &node, Args &&...args) {
     ::warning(kind, format, &node, std::forward<Args>(args)...);
 }
@@ -144,8 +137,7 @@ void warning(const int kind, const char *format, Args &&...args) {
 }
 
 /// Report info messages of type kind. Requires that the node argument have source info.
-template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-          class... Args>
+template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
 void info(const int kind, const char *format, const T *node, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultInfoDiagnosticAction();
@@ -153,8 +145,7 @@ void info(const int kind, const char *format, const T *node, Args &&...args) {
 }
 
 /// The const ref variant of the above
-template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-          class... Args>
+template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
 void info(const int kind, const char *format, const T &node, Args &&...args) {
     ::info(kind, format, &node, std::forward<Args>(args)...);
 }

--- a/lib/error.h
+++ b/lib/error.h
@@ -43,41 +43,39 @@ inline unsigned diagnosticCount() {
 /// Report an error with the given message.
 // LEGACY: once we transition to error types, this should be deprecated
 #if LEGACY
-template <typename... T>
-inline void error(const char *format, T... args) {
+template <typename... Args>
+inline void error(const char *format, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultErrorDiagnosticAction();
-    context.errorReporter().diagnose(action, nullptr, format, "", args...);
+    context.errorReporter().diagnose(action, nullptr, format, "", std::forward<Args>(args)...);
 }
 #endif
 
 /// Report errors of type kind. Requires that the node argument have source info.
 /// The message format is declared in the error catalog.
-template <class T,
-          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
           class... Args>
-void error(const int kind, const char *format, const T *node, Args... args) {
+void error(const int kind, const char *format, const T *node, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultErrorDiagnosticAction();
-    context.errorReporter().diagnose(action, kind, format, "", node, args...);
+    context.errorReporter().diagnose(action, kind, format, "", node, std::forward<Args>(args)...);
 }
 
 /// This is similar to the above method, but also has a suffix
-template <class T,
-          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
           class... Args>
 void errorWithSuffix(const int kind, const char *format, const char *suffix, const T *node,
-                     Args... args) {
+                     Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultErrorDiagnosticAction();
-    context.errorReporter().diagnose(action, kind, format, suffix, node, args...);
+    context.errorReporter().diagnose(action, kind, format, suffix, node,
+                                     std::forward<Args>(args)...);
 }
 
 /// The const ref variant of the above
-template <class T,
-          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
           class... Args>
-void error(const int kind, const char *format, const T &node, Args... args) {
+void error(const int kind, const char *format, const T &node, Args &&...args) {
     error(kind, format, &node, std::forward<Args>(args)...);
 }
 
@@ -86,19 +84,17 @@ void error(const int kind, const char *format, const T &node, Args... args) {
 /// This allows incremental migration toward minimizing the number of errors and warnings
 /// reported when passes are repeated, as typed errors are filtered.
 // LEGACY: once we transition to error types, this should be deprecated
-template <class T,
-          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
           class... Args>
-void error(const char *format, const T *node, Args... args) {
+void error(const char *format, const T *node, Args &&...args) {
     error(ErrorType::LEGACY_ERROR, format, node, std::forward<Args>(args)...);
 }
 
 /// The const ref variant of the above
 // LEGACY: once we transition to error types, this should be deprecated
-template <class T,
-          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
           class... Args>
-void error(const char *format, const T &node, Args... args) {
+void error(const char *format, const T &node, Args &&...args) {
     error(ErrorType::LEGACY_ERROR, format, node, std::forward<Args>(args)...);
 }
 #endif
@@ -106,7 +102,7 @@ void error(const char *format, const T &node, Args... args) {
 /// Report errors of type kind for messages that do not have a node.
 /// These will not be filtered
 template <typename... Args>
-void error(const int kind, const char *format, Args... args) {
+void error(const int kind, const char *format, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultErrorDiagnosticAction();
     context.errorReporter().diagnose(action, kind, format, "", std::forward<Args>(args)...);
@@ -114,63 +110,59 @@ void error(const int kind, const char *format, Args... args) {
 
 #if LEGACY
 /// Report a warning with the given message.
-template <typename... T>
-inline void warning(const char *format, T... args) {
+template <typename... Args>
+inline void warning(const char *format, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultWarningDiagnosticAction();
-    context.errorReporter().diagnose(action, nullptr, format, "", args...);
+    context.errorReporter().diagnose(action, nullptr, format, "", std::forward<Args>(args)...);
 }
 #endif
 
 /// Report warnings of type kind. Requires that the node argument have source info.
-template <class T,
-          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
           class... Args>
-void warning(const int kind, const char *format, const T *node, Args... args) {
+void warning(const int kind, const char *format, const T *node, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultWarningDiagnosticAction();
-    context.errorReporter().diagnose(action, kind, format, "", node, args...);
+    context.errorReporter().diagnose(action, kind, format, "", node, std::forward<Args>(args)...);
 }
 
 /// The const ref variant of the above
-template <class T,
-          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
           class... Args>
-void warning(const int kind, const char *format, const T &node, Args... args) {
+void warning(const int kind, const char *format, const T &node, Args &&...args) {
     ::warning(kind, format, &node, std::forward<Args>(args)...);
 }
 
 /// Report warnings of type kind, for messages that do not have a node.
 /// These will not be filtered
 template <typename... Args>
-void warning(const int kind, const char *format, Args... args) {
+void warning(const int kind, const char *format, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultWarningDiagnosticAction();
     context.errorReporter().diagnose(action, kind, format, "", std::forward<Args>(args)...);
 }
 
 /// Report info messages of type kind. Requires that the node argument have source info.
-template <class T,
-          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
           class... Args>
-void info(const int kind, const char *format, const T *node, Args... args) {
+void info(const int kind, const char *format, const T *node, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultInfoDiagnosticAction();
-    context.errorReporter().diagnose(action, kind, format, "", node, args...);
+    context.errorReporter().diagnose(action, kind, format, "", node, std::forward<Args>(args)...);
 }
 
 /// The const ref variant of the above
-template <class T,
-          typename = typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value>::type,
+template <class T, typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
           class... Args>
-void info(const int kind, const char *format, const T &node, Args... args) {
+void info(const int kind, const char *format, const T &node, Args &&...args) {
     ::info(kind, format, &node, std::forward<Args>(args)...);
 }
 
 /// Report info messages of type kind, for messages that do not have a node.
 /// These will not be filtered
 template <typename... Args>
-void info(const int kind, const char *format, Args... args) {
+void info(const int kind, const char *format, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDefaultInfoDiagnosticAction();
     context.errorReporter().diagnose(action, kind, format, "", std::forward<Args>(args)...);
@@ -189,12 +181,13 @@ void info(const int kind, const char *format, Args... args) {
  *                '::warning' or '::error'.
  * @param suffix  A message that is appended at the end.
  */
-template <typename... T>
+template <typename... Args>
 inline void diagnose(DiagnosticAction defaultAction, const char *diagnosticName, const char *format,
-                     const char *suffix, T... args) {
+                     const char *suffix, Args &&...args) {
     auto &context = BaseCompileContext::get();
     auto action = context.getDiagnosticAction(diagnosticName, defaultAction);
-    context.errorReporter().diagnose(action, diagnosticName, format, suffix, args...);
+    context.errorReporter().diagnose(action, diagnosticName, format, suffix,
+                                     std::forward<Args>(args)...);
 }
 
 #endif /* LIB_ERROR_H_ */

--- a/lib/error_helper.h
+++ b/lib/error_helper.h
@@ -33,8 +33,24 @@ static inline ErrorMessage error_helper(boost::format &f, ErrorMessage out) {
     return out;
 }
 
+template <class... Args>
+auto error_helper(boost::format &f, ErrorMessage out, const char *t, Args &&...args) {
+    return error_helper(f % t, out, std::forward<Args>(args)...);
+}
+
+template <typename T, class... Args>
+auto error_helper(boost::format &f, ErrorMessage out, const T &t,
+                  Args &&...args) -> std::enable_if_t<Util::has_toString_v<T>, ErrorMessage>;
+
+template <typename T, class... Args>
+auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args &&...args)
+    -> std::enable_if_t<!Util::has_toString_v<T> && !std::is_pointer_v<T>, ErrorMessage>;
+
 template <typename T, class... Args>
 auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args &&...args) {
+    // Contrary to bug_helper we do not want to show raw pointers to users in
+    // ordinary error messages. Therefore we explicitly delegate to
+    // reference-arg implementation here.
     return error_helper(f, out, *t, std::forward<Args>(args)...);
 }
 

--- a/lib/error_helper.h
+++ b/lib/error_helper.h
@@ -35,134 +35,130 @@ static inline ErrorMessage error_helper(boost::format &f, ErrorMessage out) {
 }
 
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage out, const char *t, Args... args);
+ErrorMessage error_helper(boost::format &f, ErrorMessage out, const char *t, Args &&...args);
 
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage out, const cstring &t, Args... args);
+ErrorMessage error_helper(boost::format &f, ErrorMessage out, const cstring &t, Args &&...args);
 
 // use: ir/mau.cpp:805
 template <class... Args>
 ErrorMessage error_helper(boost::format &f, ErrorMessage out, const Util::SourceInfo &info,
-                          Args... args);
+                          Args &&...args);
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args... args) ->
-    typename std::enable_if<Util::HasToString<T>::value &&
-                                !std::is_base_of<Util::IHasSourceInfo, T>::value,
-                            ErrorMessage>::type;
+auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args &&...args) ->
+    typename std::enable_if_t<
+        Util::HasToString<T>::value && !std::is_base_of_v<Util::IHasSourceInfo, T>, ErrorMessage>;
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args... args) ->
-    typename std::enable_if<Util::HasToString<T>::value &&
-                                !std::is_base_of<Util::IHasSourceInfo, T>::value,
-                            ErrorMessage>::type;
+auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args &&...args) ->
+    typename std::enable_if_t<
+        Util::HasToString<T>::value && !std::is_base_of_v<Util::IHasSourceInfo, T>, ErrorMessage>;
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args... args) ->
-    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type;
+auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args &&...args) ->
+    typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>, ErrorMessage>;
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args... args) ->
-    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type;
+auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args &&...args) ->
+    typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>, ErrorMessage>;
 
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage out, const big_int *t, Args... args);
+ErrorMessage error_helper(boost::format &f, ErrorMessage out, const big_int *t, Args &&...args);
 
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage out, const big_int &t, Args... args);
+ErrorMessage error_helper(boost::format &f, ErrorMessage out, const big_int &t, Args &&...args);
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args... args) ->
-    typename std::enable_if<std::is_arithmetic<T>::value, ErrorMessage>::type;
+auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args &&...args) ->
+    typename std::enable_if_t<std::is_arithmetic_v<T>, ErrorMessage>;
 
 // actual implementations
 
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage out, const char *t, Args... args) {
-    return error_helper(f % t, out, std::forward<Args>(args)...);
+ErrorMessage error_helper(boost::format &f, ErrorMessage out, const char *t, Args &&...args) {
+    return error_helper(f % t, std::move(out), std::forward<Args>(args)...);
 }
 
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage out, const cstring &t, Args... args) {
-    return error_helper(f % t.c_str(), out, std::forward<Args>(args)...);
+ErrorMessage error_helper(boost::format &f, ErrorMessage out, const cstring &t, Args &&...args) {
+    return error_helper(f % t.string_view(), std::move(out), std::forward<Args>(args)...);
 }
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args... args) ->
-    typename std::enable_if<Util::HasToString<T>::value &&
-                                !std::is_base_of<Util::IHasSourceInfo, T>::value,
-                            ErrorMessage>::type {
-    return error_helper(f % t.toString(), out, std::forward<Args>(args)...);
+auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args &&...args) ->
+    typename std::enable_if_t<
+        Util::HasToString<T>::value && !std::is_base_of_v<Util::IHasSourceInfo, T>, ErrorMessage> {
+    return error_helper(f % t.toString(), std::move(out), std::forward<Args>(args)...);
 }
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args... args) ->
-    typename std::enable_if<Util::HasToString<T>::value &&
-                                !std::is_base_of<Util::IHasSourceInfo, T>::value,
-                            ErrorMessage>::type {
-    return error_helper(f % t->toString(), out, std::forward<Args>(args)...);
+auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args &&...args) ->
+    typename std::enable_if_t<Util::HasToString<T>::value &&
+                                  !std::is_base_of_v<Util::IHasSourceInfo, T>,
+                              ErrorMessage>::type {
+    return error_helper(f % t->toString(), std::move(out), std::forward<Args>(args)...);
 }
 
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage out, const big_int *t, Args... args) {
-    return error_helper(f % t, out, std::forward<Args>(args)...);
+ErrorMessage error_helper(boost::format &f, ErrorMessage out, const big_int *t, Args &&...args) {
+    return error_helper(f % t, std::move(out), std::forward<Args>(args)...);
 }
 
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage out, const big_int &t, Args... args) {
-    return error_helper(f % t, out, std::forward<Args>(args)...);
+ErrorMessage error_helper(boost::format &f, ErrorMessage out, const big_int &t, Args &&...args) {
+    return error_helper(f % t, std::move(out), std::forward<Args>(args)...);
 }
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args... args) ->
-    typename std::enable_if<std::is_arithmetic<T>::value, ErrorMessage>::type {
-    return error_helper(f % t, out, std::forward<Args>(args)...);
+auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args &&...args) ->
+    typename std::enable_if_t<std::is_arithmetic_v<T>, ErrorMessage> {
+    return error_helper(f % t, std::move(out), std::forward<Args>(args)...);
 }
 
 template <class... Args>
 ErrorMessage error_helper(boost::format &f, ErrorMessage out, const Util::SourceInfo &info,
-                          Args... args) {
+                          Args &&...args) {
     if (info.isValid()) out.locations.push_back(info);
-    return error_helper(f % "", out, std::forward<Args>(args)...);
+    return error_helper(f % "", std::move(out), std::forward<Args>(args)...);
 }
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args... args) ->
-    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type {
+auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args &&...args) ->
+    typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>, ErrorMessage> {
     auto info = t->getSourceInfo();
     if (info.isValid()) out.locations.push_back(info);
-    return error_helper(f % t->toString(), out, std::forward<Args>(args)...);
+    return error_helper(f % t->toString(), std::move(out), std::forward<Args>(args)...);
 }
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args... args) ->
-    typename std::enable_if<std::is_base_of<Util::IHasSourceInfo, T>::value, ErrorMessage>::type {
+auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args &&...args) ->
+    typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>, ErrorMessage> {
     auto info = t.getSourceInfo();
     if (info.isValid()) out.locations.push_back(info);
-    return error_helper(f % t.toString(), out, std::forward<Args>(args)...);
+    return error_helper(f % t.toString(), std::move(out), std::forward<Args>(args)...);
 }
 
 }  // namespace priv
 
 // Most direct invocations of error_helper usually only reduce arguments
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, Args... args) {
+ErrorMessage error_helper(boost::format &f, Args &&...args) {
     ErrorMessage msg;
     return ::priv::error_helper(f, msg, std::forward<Args>(args)...);
 }
 
 // Invoked from ErrorReporter
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage &msg, Args... args) {
-    return ::priv::error_helper(f, msg, std::forward<Args>(args)...);
+ErrorMessage error_helper(boost::format &f, ErrorMessage msg, Args &&...args) {
+    return ::priv::error_helper(f, std::move(msg), std::forward<Args>(args)...);
 }
 
 // This overload exists for backwards compatibility
 template <class... Args>
 ErrorMessage error_helper(boost::format &f, const std::string &prefix, const Util::SourceInfo &info,
-                          const std::string &suffix, Args... args) {
-    ErrorMessage msg(prefix, info, suffix);
-    return ::priv::error_helper(f, msg, std::forward<Args>(args)...);
+                          const std::string &suffix, Args &&...args) {
+    return ::priv::error_helper(f, ErrorMessage(prefix, info, suffix), std::forward<Args>(args)...);
 }
 
 #endif /* LIB_ERROR_HELPER_H_ */

--- a/lib/error_message.h
+++ b/lib/error_message.h
@@ -44,14 +44,18 @@ struct ErrorMessage {
 
     ErrorMessage() {}
     // Invoked from backwards compatible error_helper
-    ErrorMessage(const std::string &prefix, const Util::SourceInfo &info, const std::string &suffix)
-        : prefix(prefix), locations({info}), suffix(suffix) {}
+    ErrorMessage(std::string prefix, const Util::SourceInfo &info, std::string suffix)
+        : prefix(std::move(prefix)), locations({info}), suffix(std::move(suffix)) {}
     // Invoked from error_reporter
-    ErrorMessage(MessageType type, const std::string &prefix, const std::string &suffix)
-        : type(type), prefix(prefix), suffix(suffix) {}
-    ErrorMessage(MessageType type, const std::string &prefix, const std::string &message,
-                 const std::vector<Util::SourceInfo> &locations, const std::string &suffix)
-        : type(type), prefix(prefix), message(message), locations(locations), suffix(suffix) {}
+    ErrorMessage(MessageType type, std::string prefix, std::string suffix)
+        : type(type), prefix(std::move(prefix)), suffix(std::move(suffix)) {}
+    ErrorMessage(MessageType type, std::string prefix, std::string message,
+                 const std::vector<Util::SourceInfo> &locations, std::string suffix)
+        : type(type),
+          prefix(std::move(prefix)),
+          message(std::move(message)),
+          locations(locations),
+          suffix(std::move(suffix)) {}
 
     std::string getPrefix() const;
     std::string toString() const;

--- a/lib/error_message.h
+++ b/lib/error_message.h
@@ -44,7 +44,7 @@ struct ErrorMessage {
 
     ErrorMessage() {}
     // Invoked from backwards compatible error_helper
-    ErrorMessage(std::string prefix, const Util::SourceInfo &info, std::string suffix)
+    ErrorMessage(std::string prefix, Util::SourceInfo info, std::string suffix)
         : prefix(std::move(prefix)), locations({info}), suffix(std::move(suffix)) {}
     // Invoked from error_reporter
     ErrorMessage(MessageType type, std::string prefix, std::string suffix)
@@ -70,7 +70,7 @@ struct ParserErrorMessage {
     std::string message;
 
     ParserErrorMessage(Util::SourceInfo loc, std::string msg)
-        : location(std::move(loc)), message(std::move(msg)) {}
+        : location(loc), message(std::move(msg)) {}
 
     std::string toString() const;
 };

--- a/lib/error_message.h
+++ b/lib/error_message.h
@@ -67,10 +67,10 @@ struct ErrorMessage {
  */
 struct ParserErrorMessage {
     Util::SourceInfo location;
-    cstring message;
+    std::string message;
 
-    ParserErrorMessage(const Util::SourceInfo &loc, const cstring &msg)
-        : location(loc), message(msg) {}
+    ParserErrorMessage(Util::SourceInfo loc, std::string msg)
+        : location(std::move(loc)), message(std::move(msg)) {}
 
     std::string toString() const;
 };

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -26,7 +26,6 @@ limitations under the License.
 #include <boost/format.hpp>
 
 #include "absl/strings/str_format.h"
-
 #include "bug_helper.h"
 #include "error_catalog.h"
 #include "error_helper.h"
@@ -109,9 +108,7 @@ class ErrorReporter {
         return ::error_helper(fmt, std::forward<Args>(args)...).toString();
     }
 
-    template <class T,
-              typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-              typename... Args>
+    template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, typename... Args>
     void diagnose(DiagnosticAction action, const int errorCode, const char *format,
                   const char *suffix, const T *node, Args &&...args) {
         if (node && !error_reported(errorCode, node->getSourceInfo())) {
@@ -124,9 +121,7 @@ class ErrorReporter {
         }
     }
 
-    template <class T,
-              typename = typename std::enable_if_t<std::is_base_of_v<Util::IHasSourceInfo, T>>,
-              typename... Args>
+    template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, typename... Args>
     void diagnose(DiagnosticAction action, const int errorCode, const char *format,
                   const char *suffix, const T &node, Args &&...args) {
         diagnose(action, errorCode, format, suffix, &node, std::forward<Args>(args)...);

--- a/lib/log.h
+++ b/lib/log.h
@@ -25,6 +25,7 @@ limitations under the License.
 
 #include "config.h"
 #include "indent.h"
+#include "stringify.h"
 
 #ifndef __GNUC__
 #define __attribute__(X)
@@ -150,21 +151,6 @@ void increaseVerbosity();
 static inline std::ostream &operator<<(std::ostream &out,
                                        std::function<std::ostream &(std::ostream &)> fn) {
     return fn(out);
-}
-
-template <class T>
-inline auto operator<<(std::ostream &out, const T &obj) -> decltype((void)obj.dbprint(out), out) {
-    obj.dbprint(out);
-    return out;
-}
-
-template <class T>
-inline auto operator<<(std::ostream &out, const T *obj) -> decltype((void)obj->dbprint(out), out) {
-    if (obj)
-        obj->dbprint(out);
-    else
-        out << "<null>";
-    return out;
 }
 
 /// Serializes the @p container into the stream @p out, delimining it by bracketing it with

--- a/lib/options.h
+++ b/lib/options.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define LIB_OPTIONS_H_
 
 #include <functional>
+#include <iostream>
 #include <ostream>
 #include <stdexcept>
 #include <string>

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -49,7 +49,7 @@ SourceInfo::SourceInfo(const InputSources *sources, SourcePosition start, Source
         BUG("SourceInfo position start %1% after end %2%", start.toString(), end.toString());
 }
 
-cstring SourceInfo::toDebugString() const {
+cstring SourceInfo::toString() const {
     return Util::printf_format("(%s)-(%s)", start.toString(), end.toString());
 }
 
@@ -302,7 +302,7 @@ cstring SourceInfo::getSourceFile() const {
 
 cstring SourceInfo::getLineNum() const {
     SourceFileLine sourceLine = sources->getSourceLine(start.getLineNumber());
-    return toString(sourceLine.sourceLine);
+    return Util::toString(sourceLine.sourceLine);
 }
 
 ////////////////////////////////////////////////////////

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include <vector>
 
 #include "cstring.h"
+#include "stringify.h"
 
 // GTest
 #ifdef P4C_GTEST_ENABLED
@@ -34,13 +35,6 @@ limitations under the License.
 namespace Test {
 class UtilSourceFile;
 }
-
-class IHasDbPrint {
- public:
-    virtual void dbprint(std::ostream &out) const = 0;
-    void print() const;  // useful in the debugger
-    virtual ~IHasDbPrint() = default;
-};
 
 namespace Util {
 struct SourceFileLine;
@@ -170,9 +164,9 @@ class SourceInfo final {
 
     bool operator==(const SourceInfo &rhs) const { return start == rhs.start && end == rhs.end; }
 
-    cstring toDebugString() const;
+    cstring toString() const;
 
-    void dbprint(std::ostream &out) const { out << this->toDebugString(); }
+    void dbprint(std::ostream &out) const { out << this->toString(); }
 
     cstring toSourceFragment(bool useMarker = true) const;
     cstring toBriefSourceFragment() const;

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -217,6 +217,9 @@ class IHasSourceInfo {
     virtual ~IHasSourceInfo() {}
 };
 
+template <class T>
+inline constexpr bool has_SourceInfo_v = std::is_base_of_v<Util::IHasSourceInfo, T>;
+
 /** A line in a source file */
 struct SourceFileLine {
     /// an empty filename indicates stdin

--- a/lib/stringify.cpp
+++ b/lib/stringify.cpp
@@ -28,7 +28,7 @@ cstring toString(bool value) {
     return value ? cstring::literal("true") : cstring::literal("false");
 }
 
-cstring toString(std::string value) { return value; }
+cstring toString(const std::string &value) { return value; }
 
 cstring toString(const char *value) {
     if (value == nullptr) return cstring::literal("<nullptr>");

--- a/lib/stringify.cpp
+++ b/lib/stringify.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 #include <sstream>
 #include <string>
 
+#include "big_int.h"
 #include "cstring.h"
 #include "exceptions.h"
 
@@ -82,9 +83,10 @@ char DigitToChar(int digit) {
     BUG("Unexpected digit: %1%", digit);
 }
 
-cstring toString(big_int value, unsigned width, bool sign, unsigned int base) {
+cstring toString(const big_int &v, unsigned width, bool sign, unsigned int base) {
     std::ostringstream oss;
     big_int zero = 0;
+    big_int value = v;
     if (value < zero) {
         oss << "-";
         value = -value;

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -19,11 +19,12 @@ limitations under the License.
 #ifndef LIB_STRINGIFY_H_
 #define LIB_STRINGIFY_H_
 
-#include <stdint.h>
-
 #include <cstdarg>
+#include <string>
+#include <string_view>
+#include <type_traits>
 
-#include "big_int_util.h"
+#include "big_int_fwd.h"
 #include "cstring.h"
 
 // convert values to cstrings
@@ -70,7 +71,7 @@ cstring toString(const char *value);
 cstring toString(cstring value);
 cstring toString(std::string_view value);
 /// A width of zero indicates that no width should be displayed.
-cstring toString(const big_int value, unsigned width, bool sign, unsigned int base = 10);
+cstring toString(const big_int &value, unsigned width, bool sign, unsigned int base = 10);
 cstring toString(const void *value);
 
 // printf into a string

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -65,7 +65,7 @@ auto toString(T *value) -> typename std::enable_if_t<has_toString_v<T>, cstring>
 }
 
 cstring toString(bool value);
-cstring toString(std::string value);
+cstring toString(const std::string &value);
 cstring toString(const char *value);
 cstring toString(cstring value);
 cstring toString(std::string_view value);

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -24,7 +24,8 @@ limitations under the License.
 #include <string_view>
 #include <type_traits>
 
-#include "big_int_fwd.h"
+// FIXME: Replace with big_int_fwd.h with Boost 1.84+
+#include "big_int.h"
 #include "cstring.h"
 
 class IHasDbPrint {

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -27,6 +27,26 @@ limitations under the License.
 #include "big_int_fwd.h"
 #include "cstring.h"
 
+class IHasDbPrint {
+ public:
+    virtual void dbprint(std::ostream &out) const = 0;
+    void print() const;  // useful in the debugger
+    virtual ~IHasDbPrint() = default;
+};
+
+/// SFINAE helper to check if given class has a `dbprint` method. Apparently,
+/// not everything are descendants of IHasDbPrint...
+template <class, class = void>
+struct has_dbprint : std::false_type {};
+
+template <class T>
+struct has_dbprint<T,
+                   std::void_t<decltype(std::declval<T>().dbprint(std::declval<std::ostream &>()))>>
+    : std::true_type {};
+
+template <class T>
+inline constexpr bool has_dbprint_v = has_dbprint<T>::value;
+
 // convert values to cstrings
 namespace Util {
 
@@ -80,4 +100,40 @@ cstring printf_format(const char *fmt_str, ...);
 cstring vprintf_format(const char *fmt_str, va_list ap);
 char DigitToChar(int digit);
 }  // namespace Util
+
+template <typename T>
+auto operator<<(std::ostream &out, const T &value)
+    -> std::enable_if_t<Util::has_toString_v<T> && !has_dbprint_v<T>, std::ostream &> {
+    return out << value.toString();
+}
+
+template <typename T>
+auto operator<<(std::ostream &out, const T *value)
+    -> std::enable_if_t<Util::has_toString_v<T> && !has_dbprint_v<T>, std::ostream &> {
+    if (value == nullptr)
+        out << "<null>";
+    else
+        out << value->toString();
+
+    return out;
+}
+
+// Prefer dbprint() method when both toString() and dbprint() methods are present
+template <class T>
+inline auto operator<<(std::ostream &out,
+                       const T &obj) -> std::enable_if_t<has_dbprint_v<T>, std::ostream &> {
+    obj.dbprint(out);
+    return out;
+}
+
+template <class T>
+inline auto operator<<(std::ostream &out,
+                       const T *obj) -> std::enable_if_t<has_dbprint_v<T>, std::ostream &> {
+    if (obj)
+        obj->dbprint(out);
+    else
+        out << "<null>";
+    return out;
+}
+
 #endif /* LIB_STRINGIFY_H_ */

--- a/midend/def_use.cpp
+++ b/midend/def_use.cpp
@@ -639,7 +639,8 @@ std::ostream &operator<<(
     const std::pair<const IR::Node *, const ordered_set<const ComputeDefUse::loc_t *>> &p) {
     out << Log::endl;
     out << DBPrint::setprec(DBPrint::Prec_Low);
-    out << p.first << '<' << p.first->id << '>';
+    p.first->dbprint(out);
+    out << '<' << p.first->id << '>';
     if (p.first->srcInfo) {
         unsigned line, col;
         out << '(' << p.first->srcInfo.toSourcePositionData(&line, &col);

--- a/test/gtest/source_file_test.cpp
+++ b/test/gtest/source_file_test.cpp
@@ -92,7 +92,7 @@ TEST(UtilSourceFile, SourceInfo) {
     SourceInfo t2 = SourceInfo(&sources, t2_s, t2_e);
 
     SourceInfo span = t1 + t2;
-    cstring str = span.toDebugString();
+    cstring str = span.toString();
     EXPECT_EQ("(1:1)-(2:2)", str);
 
     SourceInfo invalid;

--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -41,7 +41,9 @@ limitations under the License.
     ((Cur) = (N) ? YYRHSLOC(Rhs, 1) + YYRHSLOC(Rhs, N)                  \
                  : Util::SourceInfo(sources, YYRHSLOC(Rhs, 0).getEnd()))
 
-static void yyerror(const char *fmt, ...);
+template<typename... Args>
+void yyerror(const char *fmt, Args&&... args);
+
 static std::vector<IrElement*> global;
 static CommentBlock *currCommentBlock = nullptr;
 
@@ -408,7 +410,8 @@ name: IDENTIFIER
 %%
 }  // end anonymous namespace
 
-void yyerror(const char *fmt, ...) {
+template<typename... Args>
+void yyerror(const char *fmt, Args&&... args) {
     auto& context = BaseCompileContext::get();
     if (!strcmp(fmt, "syntax error, unexpected IDENTIFIER")) {
         context.errorReporter().parser_error(sources,
@@ -416,10 +419,7 @@ void yyerror(const char *fmt, ...) {
                                              yylval.str.c_str());
         return;
     }
-    va_list args;
-    va_start(args, fmt);
-    context.errorReporter().parser_error(sources, fmt, args);
-    va_end(args);
+    context.errorReporter().parser_error(sources, fmt, std::forward<Args>(args)...);
 }
 
 IrDefinitions *parse(char** files, int count) {

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -119,6 +119,7 @@ void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &i
 
     out << "#include <functional>\n"
         << "#include <map>\n\n"
+        << "#include \"lib/big_int.h\"        // IWYU pragma: keep\n"
         << "// Special IR classes and types\n"
         << "#include \"ir/dbprint.h\"         // IWYU pragma: keep\n"
         << "#include \"ir/id.h\"              // IWYU pragma: keep\n"


### PR DESCRIPTION
This is a next step around messages emission refactoring. Essentially:
  - Use C++17 features to reduce code duplication and modernize code, use universal references instead of passing by value
  - Get rid of varargs for parser errors, use variadic templates instead
  - Simplify code here and there getting rid of cstrings
  - Unify object => string conversion

Things are a bit messy for the latter. We are having: `toString`, `dbprint` (that are different) and sometimes explicit `operator<<`. Plus, we define `operator<<` in a global namespace (in `log.g`, and some IR classes depend on this!) and call `dbprint` from there. However, for error messages, etc. we do not want to use `operator<<` (that is default implementation for `boost::format` for user-defined types) and use explicit `toString`.

So, this PR tries to do some consolidation of conversion to strings:
  - Everything is moved to `stringify.h`, so `log.h` is all about logging
  - We define `operator<<` to use `toString`, if available. If not, we try to delegate to `dbprint`