### PR TITLE
Add a release template to the compiler.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,41 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: P4 Specification Implementation
+      labels:
+        - p4-spec
+    - title: Changes to the Compiler Core
+      labels:
+        - core
+    - title: Changes to the Control Plane
+      labels:
+        - control-plane
+    - title: Changes to the BMv2 Back Ends
+      labels:
+        - bmv2
+        - bmv2-psa
+    - title: Changes to the eBPF Back Ends
+      labels:
+        - ebpf
+        - ebpf-psa
+    - title: Changes to the TC Back End
+      labels:
+        - p4tc
+    - title: Changes to the DPDK Back End
+      labels:
+        - dpdk
+    - title: Changes to the P4Tools Back End
+      labels:
+        - p4tools
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/ci-auto-release.yml
+++ b/.github/workflows/ci-auto-release.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           base: main
           add-paths: Version.txt
-          reviewers: mbudiu-vmw
+          reviewers: fruffy, jafingerhut, jnfoster
           commit-message: ${{ steps.message.outputs.content }}
           signoff: false
           branch: v${{ env.VERSION }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -47,6 +47,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.TAG }}
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This follows the guide listed here: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

I am not sure whether this will work. Fixes #4690.

@AdarshRawat1 We are also trying to improve our release logs. Do you have any ideas or suggestions how to have better information or templates here? We usually release on a monthly cadence. 

@rst0git Do you know whether this will work with the automated release we use? 