### PR TITLE
More compilation fixes for C++20: hvec_map and copy_bitref 

### DIFF
--- a/lib/bitvec.h
+++ b/lib/bitvec.h
@@ -653,7 +653,9 @@ class bitvec::copy_bitref : public bitvec::bitref<const bitvec> {
     copy_bitref(const copy_bitref &a) = default;
     copy_bitref(copy_bitref &&a) = default;
     bool operator==(const bitref &a) const { return idx == a.idx && self == a.self; }
+    bool operator==(const copy_bitref &a) const { return idx == a.idx && self == a.self; }
     bool operator!=(const bitref &a) const { return idx != a.idx || self != a.self; }
+    bool operator!=(const copy_bitref &a) const { return idx != a.idx || self != a.self; }
 };
 inline bitvec::copy_bitref bitvec::min() && { return copy_bitref(*this, ffs()); }
 inline bitvec::copy_bitref bitvec::max() && { return --copy_bitref(*this, size * bits_per_unit); }

--- a/lib/hvec_map.h
+++ b/lib/hvec_map.h
@@ -146,14 +146,14 @@ class hvec_map : hash_vector_base {
     bool empty() const { return inuse == 0; }
     size_t size() const { return inuse; }
     size_t max_size() const { return UINT32_MAX; }
-    bool operator==(const hvec_map &a) {
+    bool operator==(const hvec_map &a) const {
         if (inuse != a.inuse) return false;
         auto it = begin();
         for (auto &el : a)
             if (el != *it++) return false;
         return true;
     }
-    bool operator!=(const hvec_map &a) { return !(*this == a); }
+    bool operator!=(const hvec_map &a) const { return !(*this == a); }
     void clear() {
         hash_vector_base::clear();
         data.clear();


### PR DESCRIPTION
Two more small fixes for C++20 support. Add the equality comparison operators to `copy_bitref` and make the equality operator const for `hvec_map`.