### PR TITLE
[P4Testgen] Initialize the testgen targets when invoking the library API

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
@@ -35,7 +35,8 @@ TEST(P4TestgenBenchmark, SuccessfullyGenerate1000Tests) {
     // This enables performance printing.
     P4Tools::enablePerformanceLogging();
 
-    P4Tools::P4Testgen::Testgen::generateTests(compilerOptions, testgenOptions);
+    auto testList = P4Tools::P4Testgen::Testgen::generateTests(compilerOptions, testgenOptions);
+    ASSERT_TRUE(testList.has_value());
 
     // Print the report.
     P4Tools::printPerformanceReport();

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -147,6 +147,7 @@ std::optional<AbstractTestList> generateTestsImpl(std::optional<std::string_view
                                                   const CompilerOptions &compilerOptions,
                                                   const TestgenOptions &testgenOptions,
                                                   bool writeTests) {
+    registerTestgenTargets();
     P4Tools::Target::init(compilerOptions.target.c_str(), compilerOptions.arch.c_str());
 
     // Set up the compilation context.


### PR DESCRIPTION
This is a problem that was not caught in testing. 

The failure isn't caught by the tests because of a nasty side effect of static allocation. gtest initializes the target at some point for another tests and it remains initialized for the tests that should fail.

https://github.com/p4lang/p4c/issues/4286 is relevant here.
