### PR TITLE
Invalid include fix in `p4fmt.cpp`

### DIFF
--- a/backends/p4fmt/p4fmt.cpp
+++ b/backends/p4fmt/p4fmt.cpp
@@ -9,7 +9,6 @@
 #include "lib/error.h"
 #include "lib/nullstream.h"
 #include "options.h"
-#include "test/gtest/helpers.h"
 
 int main(int argc, char *const argv[]) {
     AutoCompileContext autoP4FmtContext(new P4Fmt::P4FmtContext);


### PR DESCRIPTION
Fixes: #4715