### PR TITLE
Test building P4C with `ENABLE_GTESTS=OFF` in CI

### DIFF
--- a/.github/workflows/ci-test-debian.yml
+++ b/.github/workflows/ci-test-debian.yml
@@ -44,15 +44,17 @@ jobs:
 
   # Build with GCC and test P4C on Ubuntu 20.04.
   test-ubuntu20:
-    name: test-ubuntu20 (Unity ${{ matrix.unity }})
+    name: test-ubuntu20 (GTest ${{ matrix.gtest }}, Unity ${{ matrix.unity }})
     strategy:
       fail-fast: false
       matrix:
+        gtest: [ON, OFF]
         unity: [ON, OFF]
     runs-on: ubuntu-20.04
     env:
       CTEST_PARALLEL_LEVEL: 4
       IMAGE_TYPE: test
+      ENABLE_GTESTS: ${{ matrix.gtest }}
       CMAKE_UNITY_BUILD: ${{ matrix.unity }}
       BUILD_GENERATOR: Ninja
     steps:
@@ -75,4 +77,4 @@ jobs:
         # Need to use sudo for the eBPF kernel tests.
         run: sudo -E ctest --output-on-failure --schedule-random
         working-directory: ./build
-        if: matrix.unity == 'ON'
+        if: matrix.gtest == 'ON' && matrix.unity == 'ON'

--- a/.github/workflows/ci-test-debian.yml
+++ b/.github/workflows/ci-test-debian.yml
@@ -44,12 +44,16 @@ jobs:
 
   # Build with GCC and test P4C on Ubuntu 20.04.
   test-ubuntu20:
-    name: test-ubuntu20 (GTest ${{ matrix.gtest }}, Unity ${{ matrix.unity }})
+    name: test-ubuntu20 (Unity ${{ matrix.unity }}, GTest ${{ matrix.gtest }})
     strategy:
       fail-fast: false
       matrix:
-        gtest: [ON, OFF]
         unity: [ON, OFF]
+        include:
+          - unity: ON
+            gtest: ON
+          - unity: OFF
+            gtest: OFF
     runs-on: ubuntu-20.04
     env:
       CTEST_PARALLEL_LEVEL: 4
@@ -77,4 +81,4 @@ jobs:
         # Need to use sudo for the eBPF kernel tests.
         run: sudo -E ctest --output-on-failure --schedule-random
         working-directory: ./build
-        if: matrix.gtest == 'ON' && matrix.unity == 'ON'
+        if: matrix.unity == 'ON' && matrix.gtest == 'ON'

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -31,6 +31,8 @@ P4C_DIR=$(readlink -f ${THIS_DIR}/..)
 : "${DEBIAN_FRONTEND:=noninteractive}"
 # Whether to install dependencies required to run PTF-ebpf tests
 : "${INSTALL_PTF_EBPF_DEPENDENCIES:=OFF}"
+# Whether to build and run GTest unit tests.
+: "${ENABLE_GTESTS:=ON}"
 # Whether to build the P4Tools back end and platform.
 : "${ENABLE_TEST_TOOLS:=OFF}"
 # Whether to treat warnings as errors.
@@ -240,6 +242,8 @@ CMAKE_FLAGS+="-DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} "
 # Toggle static builds.
 CMAKE_FLAGS+="-DSTATIC_BUILD_WITH_DYNAMIC_GLIBC=${STATIC_BUILD_WITH_DYNAMIC_GLIBC} "
 CMAKE_FLAGS+="-DSTATIC_BUILD_WITH_DYNAMIC_STDLIB=${STATIC_BUILD_WITH_DYNAMIC_STDLIB} "
+# Enable GTest.
+CMAKE_FLAGS+="-DENABLE_GTESTS=${ENABLE_GTESTS} "
 # Toggle the installation of the tools back end.
 CMAKE_FLAGS+="-DENABLE_TEST_TOOLS=${ENABLE_TEST_TOOLS} "
 # RELEASE should be default, but we want to make sure.


### PR DESCRIPTION
In #4715, some building issues with `ENABLE_GTESTS=OFF` have been identified. Adding this variation in CI can help catch such issues early on in the future.