### PR TITLE
[#4006] Remove confusing warning when the same header is extracted multiple times in a parse path

### DIFF
--- a/frontends/p4/coreLibrary.h
+++ b/frontends/p4/coreLibrary.h
@@ -27,7 +27,6 @@ enum class StandardExceptions {
     PacketTooShort,
     NoMatch,
     StackOutOfBounds,
-    OverwritingHeader,
     HeaderTooShort,
     ParserTimeout,
 };
@@ -46,9 +45,6 @@ inline std::ostream &operator<<(std::ostream &out, P4::StandardExceptions e) {
             break;
         case P4::StandardExceptions::StackOutOfBounds:
             out << "StackOutOfBounds";
-            break;
-        case P4::StandardExceptions::OverwritingHeader:
-            out << "OverwritingHeader";
             break;
         case P4::StandardExceptions::HeaderTooShort:
             out << "HeaderTooShort";
@@ -111,7 +107,6 @@ class P4CoreLibrary : public ::Model::Model {
           packetTooShort(StandardExceptions::PacketTooShort),
           noMatch(StandardExceptions::NoMatch),
           stackOutOfBounds(StandardExceptions::StackOutOfBounds),
-          overwritingHeader(StandardExceptions::OverwritingHeader),
           headerTooShort(StandardExceptions::HeaderTooShort) {}
     // NOLINTEND(bugprone-throw-keyword-missing)
 
@@ -133,7 +128,6 @@ class P4CoreLibrary : public ::Model::Model {
     P4Exception_Model packetTooShort;
     P4Exception_Model noMatch;
     P4Exception_Model stackOutOfBounds;
-    P4Exception_Model overwritingHeader;
     P4Exception_Model headerTooShort;
 };
 

--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -66,6 +66,7 @@ const int ErrorType::WARN_UNINITIALIZED_USE = 1019;
 const int ErrorType::WARN_INVALID_HEADER = 1020;
 const int ErrorType::WARN_DUPLICATE_PRIORITIES = 1021;
 const int ErrorType::WARN_ENTRIES_OUT_OF_ORDER = 1022;
+const int ErrorType::WARN_MULTI_HDR_EXTRACT = 1023;
 
 // ------ Info messages -----------
 const int ErrorType::INFO_INFERRED = WARN_MAX + 1;
@@ -116,6 +117,7 @@ std::map<int, cstring> ErrorCatalog::errorCatalog = {
     {ErrorType::WARN_INVALID_HEADER, "invalid_header"_cs},
     {ErrorType::WARN_DUPLICATE_PRIORITIES, "duplicate_priorities"_cs},
     {ErrorType::WARN_ENTRIES_OUT_OF_ORDER, "entries_out_of_priority_order"_cs},
+    {ErrorType::WARN_MULTI_HDR_EXTRACT, "multi_header_extract"_cs},
 
     // Info messages
     {ErrorType::INFO_INFERRED, "inferred"_cs},

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -80,6 +80,7 @@ class ErrorType {
     static const int WARN_INVALID_HEADER;           // access to fields of an invalid header
     static const int WARN_DUPLICATE_PRIORITIES;     // two entries with the same priority
     static const int WARN_ENTRIES_OUT_OF_ORDER;     // entries with priorities out of order
+    static const int WARN_MULTI_HDR_EXTRACT;        // same header may be extracted more than once
     // Backends should extend this class with additional warnings in the range 1500-2141.
     static const int WARN_MIN_BACKEND = 1500;  // first allowed backend warning code
     static const int WARN_MAX = 2141;          // last allowed warning code

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -1140,12 +1140,6 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression *expression) 
 
                 BUG_CHECK(hdr->is<SymbolicHeader>(), "%1%: Not a header?", hdr);
                 auto sh = hdr->to<SymbolicHeader>();
-                if (sh->valid->isKnown() && sh->valid->value) {
-                    auto result = new SymbolicException(expression,
-                                                        P4::StandardExceptions::OverwritingHeader);
-                    set(expression, result);
-                    return;
-                }
                 sh->setAllUnknown();
                 sh->setValid(true);
                 set(expression, SymbolicVoid::get());

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -1146,7 +1146,8 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression *expression) 
                         "%1%: Performing an extraction more than once on the same header will "
                         "nearly always cause all but the last extracted header to be deleted "
                         "from the packet. It may be preferable to replace previous extractions "
-                        "with lookaheads instead.", expression);
+                        "with lookaheads instead.",
+                        expression);
                 }
                 sh->setAllUnknown();
                 sh->setValid(true);

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -1140,6 +1140,12 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression *expression) 
 
                 BUG_CHECK(hdr->is<SymbolicHeader>(), "%1%: Not a header?", hdr);
                 auto sh = hdr->to<SymbolicHeader>();
+                if (sh->valid->isKnown() && sh->valid->value) {
+                    ::warning(ErrorType::WARN_MULTI_HDR_EXTRACT, "%1%: Performing an extraction "
+                    "more than once on the same header will nearly always cause all but the last "
+                    "extracted header to be deleted from the packet. It may be preferable to "
+                    "replace previous extractions with lookaheads instead.", expression);
+                }
                 sh->setAllUnknown();
                 sh->setValid(true);
                 set(expression, SymbolicVoid::get());

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -1141,10 +1141,12 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression *expression) 
                 BUG_CHECK(hdr->is<SymbolicHeader>(), "%1%: Not a header?", hdr);
                 auto sh = hdr->to<SymbolicHeader>();
                 if (sh->valid->isKnown() && sh->valid->value) {
-                    ::warning(ErrorType::WARN_MULTI_HDR_EXTRACT, "%1%: Performing an extraction "
-                    "more than once on the same header will nearly always cause all but the last "
-                    "extracted header to be deleted from the packet. It may be preferable to "
-                    "replace previous extractions with lookaheads instead.", expression);
+                    ::warning(
+                        ErrorType::WARN_MULTI_HDR_EXTRACT,
+                        "%1%: Performing an extraction more than once on the same header will "
+                        "nearly always cause all but the last extracted header to be deleted "
+                        "from the packet. It may be preferable to replace previous extractions "
+                        "with lookaheads instead.", expression);
                 }
                 sh->setAllUnknown();
                 sh->setValid(true);

--- a/testdata/p4_16_samples/parser-unroll-issue4006_twice_extracted_header.p4
+++ b/testdata/p4_16_samples/parser-unroll-issue4006_twice_extracted_header.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> eth_addr_t;
+
+header ethernet_h {
+    eth_addr_t dstAddr;
+    eth_addr_t srcAddr;
+    bit<16>    etherType;
+}
+
+header vlan_h {
+    bit<16> tpid;
+    bit<16> etherType;
+}
+
+struct empty_t { }
+
+struct headers_t {
+    ethernet_h ethernet;
+    vlan_h     vlan;
+}
+
+parser in_parser(packet_in pkt, out headers_t hdr, inout empty_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x8100: parse_vlan1;
+            0x88A8: parse_vlan2;
+            default: accept;
+        }
+    }
+
+    state parse_vlan2 {
+        pkt.extract(hdr.vlan);
+        hdr.ethernet.etherType = 0x8100;
+        transition select(hdr.vlan.etherType) {
+            0x8100: parse_vlan1;
+            default: reject;
+        }
+    }
+
+    state parse_vlan1 {
+        pkt.extract(hdr.vlan);
+        transition accept;
+    }
+}
+
+control in_cntrl(inout headers_t hdr, inout empty_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply { }
+}
+
+control in_deparser(packet_out packet, out empty_t clone_i2e_meta, out empty_t resubmit_meta, out empty_t normal_meta, inout headers_t hdr, in empty_t meta, in psa_ingress_output_metadata_t istd) {
+    apply { packet.emit(hdr); }
+}
+
+parser e_parser(packet_in buffer, out empty_t hdr, inout empty_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control e_cntrl(inout empty_t hdr, inout empty_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd ) {
+    apply { }
+}
+
+
+control e_deparser(packet_out packet, out empty_t clone_e2e_meta, out empty_t recirculate_meta, inout empty_t hdr, in empty_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply { }
+}
+
+
+PSA_Switch(IngressPipeline(in_parser(), in_cntrl(), in_deparser()),PacketReplicationEngine(), EgressPipeline(e_parser(), e_cntrl(), e_deparser()), BufferingQueueingEngine()) main;
+

--- a/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header-first.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> eth_addr_t;
+header ethernet_h {
+    eth_addr_t dstAddr;
+    eth_addr_t srcAddr;
+    bit<16>    etherType;
+}
+
+header vlan_h {
+    bit<16> tpid;
+    bit<16> etherType;
+}
+
+struct empty_t {
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    vlan_h     vlan;
+}
+
+parser in_parser(packet_in pkt, out headers_t hdr, inout empty_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x8100: parse_vlan1;
+            16w0x88a8: parse_vlan2;
+            default: accept;
+        }
+    }
+    state parse_vlan2 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        hdr.ethernet.etherType = 16w0x8100;
+        transition select(hdr.vlan.etherType) {
+            16w0x8100: parse_vlan1;
+            default: reject;
+        }
+    }
+    state parse_vlan1 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        transition accept;
+    }
+}
+
+control in_cntrl(inout headers_t hdr, inout empty_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control in_deparser(packet_out packet, out empty_t clone_i2e_meta, out empty_t resubmit_meta, out empty_t normal_meta, inout headers_t hdr, in empty_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<headers_t>(hdr);
+    }
+}
+
+parser e_parser(packet_in buffer, out empty_t hdr, inout empty_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control e_cntrl(inout empty_t hdr, inout empty_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control e_deparser(packet_out packet, out empty_t clone_e2e_meta, out empty_t recirculate_meta, inout empty_t hdr, in empty_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+PSA_Switch<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(IngressPipeline<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t>(in_parser(), in_cntrl(), in_deparser()), PacketReplicationEngine(), EgressPipeline<empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(e_parser(), e_cntrl(), e_deparser()), BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header-frontend.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> eth_addr_t;
+header ethernet_h {
+    eth_addr_t dstAddr;
+    eth_addr_t srcAddr;
+    bit<16>    etherType;
+}
+
+header vlan_h {
+    bit<16> tpid;
+    bit<16> etherType;
+}
+
+struct empty_t {
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    vlan_h     vlan;
+}
+
+parser in_parser(packet_in pkt, out headers_t hdr, inout empty_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x8100: parse_vlan1;
+            16w0x88a8: parse_vlan2;
+            default: accept;
+        }
+    }
+    state parse_vlan2 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        hdr.ethernet.etherType = 16w0x8100;
+        transition select(hdr.vlan.etherType) {
+            16w0x8100: parse_vlan1;
+            default: reject;
+        }
+    }
+    state parse_vlan1 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        transition accept;
+    }
+}
+
+control in_cntrl(inout headers_t hdr, inout empty_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control in_deparser(packet_out packet, out empty_t clone_i2e_meta, out empty_t resubmit_meta, out empty_t normal_meta, inout headers_t hdr, in empty_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<headers_t>(hdr);
+    }
+}
+
+parser e_parser(packet_in buffer, out empty_t hdr, inout empty_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control e_cntrl(inout empty_t hdr, inout empty_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control e_deparser(packet_out packet, out empty_t clone_e2e_meta, out empty_t recirculate_meta, inout empty_t hdr, in empty_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+PSA_Switch<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(IngressPipeline<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t>(in_parser(), in_cntrl(), in_deparser()), PacketReplicationEngine(), EgressPipeline<empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(e_parser(), e_cntrl(), e_deparser()), BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header-midend.p4
@@ -1,0 +1,83 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+header ethernet_h {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header vlan_h {
+    bit<16> tpid;
+    bit<16> etherType;
+}
+
+struct empty_t {
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    vlan_h     vlan;
+}
+
+parser in_parser(packet_in pkt, out headers_t hdr, inout empty_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x8100: parse_vlan1;
+            16w0x88a8: parse_vlan2;
+            default: accept;
+        }
+    }
+    state parse_vlan2 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        hdr.ethernet.etherType = 16w0x8100;
+        transition select(hdr.vlan.etherType) {
+            16w0x8100: parse_vlan1;
+            default: reject;
+        }
+    }
+    state parse_vlan1 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        transition accept;
+    }
+}
+
+control in_cntrl(inout headers_t hdr, inout empty_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control in_deparser(packet_out packet, out empty_t clone_i2e_meta, out empty_t resubmit_meta, out empty_t normal_meta, inout headers_t hdr, in empty_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action parserunrollissue4006_twice_extracted_header54() {
+        packet.emit<ethernet_h>(hdr.ethernet);
+        packet.emit<vlan_h>(hdr.vlan);
+    }
+    @hidden table tbl_parserunrollissue4006_twice_extracted_header54 {
+        actions = {
+            parserunrollissue4006_twice_extracted_header54();
+        }
+        const default_action = parserunrollissue4006_twice_extracted_header54();
+    }
+    apply {
+        tbl_parserunrollissue4006_twice_extracted_header54.apply();
+    }
+}
+
+parser e_parser(packet_in buffer, out empty_t hdr, inout empty_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control e_cntrl(inout empty_t hdr, inout empty_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control e_deparser(packet_out packet, out empty_t clone_e2e_meta, out empty_t recirculate_meta, inout empty_t hdr, in empty_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+PSA_Switch<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(IngressPipeline<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t>(in_parser(), in_cntrl(), in_deparser()), PacketReplicationEngine(), EgressPipeline<empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(e_parser(), e_cntrl(), e_deparser()), BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> eth_addr_t;
+header ethernet_h {
+    eth_addr_t dstAddr;
+    eth_addr_t srcAddr;
+    bit<16>    etherType;
+}
+
+header vlan_h {
+    bit<16> tpid;
+    bit<16> etherType;
+}
+
+struct empty_t {
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    vlan_h     vlan;
+}
+
+parser in_parser(packet_in pkt, out headers_t hdr, inout empty_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x8100: parse_vlan1;
+            0x88a8: parse_vlan2;
+            default: accept;
+        }
+    }
+    state parse_vlan2 {
+        pkt.extract(hdr.vlan);
+        hdr.ethernet.etherType = 0x8100;
+        transition select(hdr.vlan.etherType) {
+            0x8100: parse_vlan1;
+            default: reject;
+        }
+    }
+    state parse_vlan1 {
+        pkt.extract(hdr.vlan);
+        transition accept;
+    }
+}
+
+control in_cntrl(inout headers_t hdr, inout empty_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control in_deparser(packet_out packet, out empty_t clone_i2e_meta, out empty_t resubmit_meta, out empty_t normal_meta, inout headers_t hdr, in empty_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr);
+    }
+}
+
+parser e_parser(packet_in buffer, out empty_t hdr, inout empty_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control e_cntrl(inout empty_t hdr, inout empty_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control e_deparser(packet_out packet, out empty_t clone_e2e_meta, out empty_t recirculate_meta, inout empty_t hdr, in empty_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+PSA_Switch(IngressPipeline(in_parser(), in_cntrl(), in_deparser()), PacketReplicationEngine(), EgressPipeline(e_parser(), e_cntrl(), e_deparser()), BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header.p4-stderr
@@ -1,3 +1,0 @@
-parser-unroll-issue4006_twice_extracted_header.p4(44): [--Wwarn=multi_header_extract] warning: pkt.extract(hdr.vlan): Performing an extraction more than once on the same header will nearly always cause all but the last extracted header to be deleted from the packet. It may be preferable to replace previous extractions with lookaheads instead.
-        pkt.extract(hdr.vlan);
-        ^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header.p4-stderr
@@ -1,0 +1,3 @@
+parser-unroll-issue4006_twice_extracted_header.p4(44): [--Wwarn=multi_header_extract] warning: pkt.extract(hdr.vlan): Performing an extraction more than once on the same header will nearly always cause all but the last extracted header to be deleted from the packet. It may be preferable to replace previous extractions with lookaheads instead.
+        pkt.extract(hdr.vlan);
+        ^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header.p4.entries.txtpb
+++ b/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header.p4.entries.txtpb
@@ -1,0 +1,3 @@
+# proto-file: p4/v1/p4runtime.proto
+# proto-message: p4.v1.WriteRequest
+

--- a/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/parser-unroll-issue4006_twice_extracted_header.p4.p4info.txtpb
@@ -1,0 +1,6 @@
+# proto-file: p4/config/v1/p4info.proto
+# proto-message: p4.config.v1.P4Info
+
+pkg_info {
+  arch: "psa"
+}

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue4006_twice_extracted_header-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue4006_twice_extracted_header-first.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> eth_addr_t;
+header ethernet_h {
+    eth_addr_t dstAddr;
+    eth_addr_t srcAddr;
+    bit<16>    etherType;
+}
+
+header vlan_h {
+    bit<16> tpid;
+    bit<16> etherType;
+}
+
+struct empty_t {
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    vlan_h     vlan;
+}
+
+parser in_parser(packet_in pkt, out headers_t hdr, inout empty_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x8100: parse_vlan1;
+            16w0x88a8: parse_vlan2;
+            default: accept;
+        }
+    }
+    state parse_vlan2 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        hdr.ethernet.etherType = 16w0x8100;
+        transition select(hdr.vlan.etherType) {
+            16w0x8100: parse_vlan1;
+            default: reject;
+        }
+    }
+    state parse_vlan1 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        transition accept;
+    }
+}
+
+control in_cntrl(inout headers_t hdr, inout empty_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control in_deparser(packet_out packet, out empty_t clone_i2e_meta, out empty_t resubmit_meta, out empty_t normal_meta, inout headers_t hdr, in empty_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<headers_t>(hdr);
+    }
+}
+
+parser e_parser(packet_in buffer, out empty_t hdr, inout empty_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control e_cntrl(inout empty_t hdr, inout empty_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control e_deparser(packet_out packet, out empty_t clone_e2e_meta, out empty_t recirculate_meta, inout empty_t hdr, in empty_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+PSA_Switch<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(IngressPipeline<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t>(in_parser(), in_cntrl(), in_deparser()), PacketReplicationEngine(), EgressPipeline<empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(e_parser(), e_cntrl(), e_deparser()), BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue4006_twice_extracted_header-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue4006_twice_extracted_header-frontend.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> eth_addr_t;
+header ethernet_h {
+    eth_addr_t dstAddr;
+    eth_addr_t srcAddr;
+    bit<16>    etherType;
+}
+
+header vlan_h {
+    bit<16> tpid;
+    bit<16> etherType;
+}
+
+struct empty_t {
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    vlan_h     vlan;
+}
+
+parser in_parser(packet_in pkt, out headers_t hdr, inout empty_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x8100: parse_vlan1;
+            16w0x88a8: parse_vlan2;
+            default: accept;
+        }
+    }
+    state parse_vlan2 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        hdr.ethernet.etherType = 16w0x8100;
+        transition select(hdr.vlan.etherType) {
+            16w0x8100: parse_vlan1;
+            default: reject;
+        }
+    }
+    state parse_vlan1 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        transition accept;
+    }
+}
+
+control in_cntrl(inout headers_t hdr, inout empty_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control in_deparser(packet_out packet, out empty_t clone_i2e_meta, out empty_t resubmit_meta, out empty_t normal_meta, inout headers_t hdr, in empty_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit<headers_t>(hdr);
+    }
+}
+
+parser e_parser(packet_in buffer, out empty_t hdr, inout empty_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control e_cntrl(inout empty_t hdr, inout empty_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control e_deparser(packet_out packet, out empty_t clone_e2e_meta, out empty_t recirculate_meta, inout empty_t hdr, in empty_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+PSA_Switch<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(IngressPipeline<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t>(in_parser(), in_cntrl(), in_deparser()), PacketReplicationEngine(), EgressPipeline<empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(e_parser(), e_cntrl(), e_deparser()), BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue4006_twice_extracted_header-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue4006_twice_extracted_header-midend.p4
@@ -1,0 +1,83 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+header ethernet_h {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header vlan_h {
+    bit<16> tpid;
+    bit<16> etherType;
+}
+
+struct empty_t {
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    vlan_h     vlan;
+}
+
+parser in_parser(packet_in pkt, out headers_t hdr, inout empty_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
+    state parse_vlan1 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        transition accept;
+    }
+    state parse_vlan2 {
+        pkt.extract<vlan_h>(hdr.vlan);
+        hdr.ethernet.etherType = 16w0x8100;
+        transition select(hdr.vlan.etherType) {
+            16w0x8100: parse_vlan1;
+            default: reject;
+        }
+    }
+    state start {
+        pkt.extract<ethernet_h>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x8100: parse_vlan1;
+            16w0x88a8: parse_vlan2;
+            default: accept;
+        }
+    }
+}
+
+control in_cntrl(inout headers_t hdr, inout empty_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control in_deparser(packet_out packet, out empty_t clone_i2e_meta, out empty_t resubmit_meta, out empty_t normal_meta, inout headers_t hdr, in empty_t meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action parserunrollissue4006_twice_extracted_header54() {
+        packet.emit<ethernet_h>(hdr.ethernet);
+        packet.emit<vlan_h>(hdr.vlan);
+    }
+    @hidden table tbl_parserunrollissue4006_twice_extracted_header54 {
+        actions = {
+            parserunrollissue4006_twice_extracted_header54();
+        }
+        const default_action = parserunrollissue4006_twice_extracted_header54();
+    }
+    apply {
+        tbl_parserunrollissue4006_twice_extracted_header54.apply();
+    }
+}
+
+parser e_parser(packet_in buffer, out empty_t hdr, inout empty_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control e_cntrl(inout empty_t hdr, inout empty_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control e_deparser(packet_out packet, out empty_t clone_e2e_meta, out empty_t recirculate_meta, inout empty_t hdr, in empty_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+PSA_Switch<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(IngressPipeline<headers_t, empty_t, empty_t, empty_t, empty_t, empty_t>(in_parser(), in_cntrl(), in_deparser()), PacketReplicationEngine(), EgressPipeline<empty_t, empty_t, empty_t, empty_t, empty_t, empty_t>(e_parser(), e_cntrl(), e_deparser()), BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue4006_twice_extracted_header.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue4006_twice_extracted_header.p4
@@ -1,0 +1,74 @@
+#include <core.p4>
+#include <dpdk/psa.p4>
+
+typedef bit<48> eth_addr_t;
+header ethernet_h {
+    eth_addr_t dstAddr;
+    eth_addr_t srcAddr;
+    bit<16>    etherType;
+}
+
+header vlan_h {
+    bit<16> tpid;
+    bit<16> etherType;
+}
+
+struct empty_t {
+}
+
+struct headers_t {
+    ethernet_h ethernet;
+    vlan_h     vlan;
+}
+
+parser in_parser(packet_in pkt, out headers_t hdr, inout empty_t user_meta, in psa_ingress_parser_input_metadata_t istd, in empty_t resubmit_meta, in empty_t recirculate_meta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x8100: parse_vlan1;
+            0x88a8: parse_vlan2;
+            default: accept;
+        }
+    }
+    state parse_vlan2 {
+        pkt.extract(hdr.vlan);
+        hdr.ethernet.etherType = 0x8100;
+        transition select(hdr.vlan.etherType) {
+            0x8100: parse_vlan1;
+            default: reject;
+        }
+    }
+    state parse_vlan1 {
+        pkt.extract(hdr.vlan);
+        transition accept;
+    }
+}
+
+control in_cntrl(inout headers_t hdr, inout empty_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control in_deparser(packet_out packet, out empty_t clone_i2e_meta, out empty_t resubmit_meta, out empty_t normal_meta, inout headers_t hdr, in empty_t meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        packet.emit(hdr);
+    }
+}
+
+parser e_parser(packet_in buffer, out empty_t hdr, inout empty_t user_meta, in psa_egress_parser_input_metadata_t istd, in empty_t normal_meta, in empty_t clone_i2e_meta, in empty_t clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control e_cntrl(inout empty_t hdr, inout empty_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control e_deparser(packet_out packet, out empty_t clone_e2e_meta, out empty_t recirculate_meta, inout empty_t hdr, in empty_t meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+PSA_Switch(IngressPipeline(in_parser(), in_cntrl(), in_deparser()), PacketReplicationEngine(), EgressPipeline(e_parser(), e_cntrl(), e_deparser()), BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue4006_twice_extracted_header.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-unroll/parser-unroll-issue4006_twice_extracted_header.p4-stderr
@@ -1,0 +1,3 @@
+parser-unroll-issue4006_twice_extracted_header.p4(44): [--Wwarn=multi_header_extract] warning: pkt.extract(hdr.vlan): Performing an extraction more than once on the same header will nearly always cause all but the last extracted header to be deleted from the packet. It may be preferable to replace previous extractions with lookaheads instead.
+        pkt.extract(hdr.vlan);
+        ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
In #4006, there are suggestions to just improve the warning instead of removing it. This PR just removes it, as I believe that having no warning is better than having a bad warning, and I don't want to spend time finding a better place for it (but if you have a suggestion that is relatively easy I will happily try it out). I don't think it belongs in `ParsersUnroll`, because if this is going to be a warning at all, then it should also be a warning when parsers are not unrolled. We can leave #4006 open to add a better warning elsewhere if that is desired.