### PR TITLE
Add DCO description to the contribution guidelines.

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+allowRemediationCommits:
+  individual: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 Thank you for considering contributing to the P4 Compiler Project (P4C)! Your contributions are valuable and help improve the project for everyone. Before getting started, please take a moment to review the following guidelines.
 
+## Contributing License
+The P4 organizations uses [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for contributions. Please take a look at our [guidelines](https://github.com/p4lang/governance/wiki/P4-DCO-Guidelines).
+
 ## Coding Standard Philosophy
 
 Please note that this project adheres to the [P4 Coding Standard Philosophy](https://github.com/p4lang/p4c/blob/main/docs/CodingStandardPhilosophy.md). By participating, you are expected to uphold this code. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@ Thank you for considering contributing to the P4 Compiler Project (P4C)! Your co
 ## Contributing License
 The P4 organizations uses [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for contributions. Please take a look at our [guidelines](https://github.com/p4lang/governance/wiki/P4-DCO-Guidelines).
 
+To sign off the last commit quickly use the `git commit --amend --signoff` command. The failing check will also include instructions on how to sign off all commits in two steps (using `git rebase HEAD~$NUM_COMMITS --signoff`)
+
 ## Coding Standard Philosophy
 
 Please note that this project adheres to the [P4 Coding Standard Philosophy](https://github.com/p4lang/p4c/blob/main/docs/CodingStandardPhilosophy.md). By participating, you are expected to uphold this code. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for considering contributing to the P4 Compiler Project (P4C)! Your co
 ## Contributing License
 The P4 organizations uses [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for contributions. Please take a look at our [guidelines](https://github.com/p4lang/governance/wiki/P4-DCO-Guidelines).
 
-To sign off the last commit quickly use the `git commit --amend --signoff` command. The failing check will also include instructions on how to sign off all commits in two steps (using `git rebase HEAD~$NUM_COMMITS --signoff`)
+To sign off the last commit quickly use the `git commit --amend --signoff` command. The failing check will also include instructions on how to sign off all commits in two steps (using `git rebase HEAD~$NUM_COMMITS --signoff`). https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md#dco-is-missing also provides helpful tips on fixing DCO inconveniences. Setting up a commit hook in the P4C repository will automate adding the DCO signoff.
 
 ## Coding Standard Philosophy
 


### PR DESCRIPTION
Now that we are part of the Linux foundation we will switch away from the ONF CLA to [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for Github pull requests and contributions. DCO is the main mode of license management for LF projects. The nice part is that, compared to the ONF CLA, it does not require manager approval for company contributions. This should greatly simplify the contribution process.

We will selectively enable DCO on some repositories to test it. Nothing much should change for contributors. The only thing that is necessary is to sign your commits on PRs with Signed-off-by: <Name> <email>.

https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md

Provides good tips on how to manage contributing to a DCO repository. Commit hooks are the easiest mechanism to automate signoff. 

