### PR TITLE
Minor Fix: Graphs Backend Example Images

### DIFF
--- a/docs/doxygen/doxygen.cfg
+++ b/docs/doxygen/doxygen.cfg
@@ -1061,7 +1061,8 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             = ../../docs/assets
+IMAGE_PATH             = ../../docs/assets \
+                         ../../backends/graphs/resources \
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program


### PR DESCRIPTION
# Current 
Error in rendering images, in documentation due to the relative path of images stored in resources directory. - [View](https://p4lang.github.io/p4c/md__2home_2runner_2work_2p4c_2p4c_2backends_2graphs_2_r_e_a_d_m_e.html#autotoc_md110) 
![image](https://github.com/p4lang/p4c/assets/100958893/c25845dc-5f76-4859-b96a-b3260637b9dd)


# Fix 
Added resource path to Doxygen config.
![image](https://github.com/p4lang/p4c/assets/100958893/04fad1af-c8f0-48ef-bbc2-e19cac22922e)
