### PR TITLE
Docs: Fixing diagram paths in generated docs

### DIFF
--- a/docs/doxygen/doxygen.cfg
+++ b/docs/doxygen/doxygen.cfg
@@ -1063,6 +1063,8 @@ EXAMPLE_RECURSIVE      = NO
 
 IMAGE_PATH             = ../../docs/assets \
                          ../../backends/graphs/resources \
+                         ../../backends/ebpf/scope.png  \
+                         
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program

--- a/docs/doxygen/doxygen.cfg
+++ b/docs/doxygen/doxygen.cfg
@@ -1064,7 +1064,9 @@ EXAMPLE_RECURSIVE      = NO
 IMAGE_PATH             = ../../docs/assets \
                          ../../backends/graphs/resources \
                          ../../backends/ebpf/scope.png  \
-                         
+                         ../../backends/ebpf/psa/psa-ebpf-xdp-design.png \
+                         ../../backends/ebpf/psa/psa-ebpf-design.png \
+
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program


### PR DESCRIPTION
Fixing the issue of diagrams not being rendered in Doxygen output by adding them to the path throughout the documentation.

![image](https://github.com/p4lang/p4c/assets/100958893/2883867b-b845-4a68-88da-43aaa388e5a7)

