### PR TITLE
Add back in heading for P4Smith README file

### DIFF
--- a/backends/p4tools/modules/smith/README.md
+++ b/backends/p4tools/modules/smith/README.md
@@ -1,8 +1,7 @@
 # P4Smith
 
+<img src="https://p4.org/wp-content/uploads/2021/05/Group-81.png" width="40">
 [![Status](https://github.com/p4lang/p4c/actions/workflows/ci-p4tools.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-p4tools.yml)
-
-# <img src="https://p4.org/wp-content/uploads/2021/05/Group-81.png" width="40">P4Smith
 
 ## Table of Contents
 

--- a/backends/p4tools/modules/smith/README.md
+++ b/backends/p4tools/modules/smith/README.md
@@ -1,6 +1,5 @@
 # P4Smith
 
-<img src="https://p4.org/wp-content/uploads/2021/05/Group-81.png" width="40">
 [![Status](https://github.com/p4lang/p4c/actions/workflows/ci-p4tools.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-p4tools.yml)
 
 ## Table of Contents

--- a/backends/p4tools/modules/smith/README.md
+++ b/backends/p4tools/modules/smith/README.md
@@ -1,3 +1,5 @@
+# P4Smith
+
 [![Status](https://github.com/p4lang/p4c/actions/workflows/ci-p4tools.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-p4tools.yml)
 
 # <img src="https://p4.org/wp-content/uploads/2021/05/Group-81.png" width="40">P4Smith

--- a/backends/p4tools/modules/testgen/README.md
+++ b/backends/p4tools/modules/testgen/README.md
@@ -2,8 +2,6 @@
 
 [![Status](https://github.com/p4lang/p4c/actions/workflows/ci-p4tools.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-p4tools.yml)
 
-# <img src="https://p4.org/wp-content/uploads/2021/05/Group-81.png" width="40">Testgen
-
 ## Table of Contents
 
 - [Installation](#installation)


### PR DESCRIPTION
This makes the auto-generated doxygen index easier to distinguish this files from others, instead of merely being called "README" there.