### PR TITLE
Fix naming of CMake Release configuration.

### DIFF
--- a/.github/workflows/ci-test-fedora.yml
+++ b/.github/workflows/ci-test-fedora.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build p4c (Fedora Linux)
         run: |
-          ./bootstrap.sh -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_UNITY_BUILD=ON --build-generator "Ninja"
+          ./bootstrap.sh -DCMAKE_BUILD_TYPE=Release -DCMAKE_UNITY_BUILD=ON --build-generator "Ninja"
           cmake --build build -- -j $(nproc)
 
       - name: Run p4c tests (Fedora Linux)

--- a/.github/workflows/ci-test-mac.yml
+++ b/.github/workflows/ci-test-mac.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Build (MacOS)
         run: |
           source ~/.bash_profile
-          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE \
+          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_UNITY_BUILD=ON -DENABLE_TEST_TOOLS=ON --build-generator "Ninja"
           cmake --build build -- -j $(nproc)
 
@@ -104,7 +104,7 @@ jobs:
       - name: Build (MacOS)
         run: |
           source ~/.bash_profile
-          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=RELEASE \
+          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_UNITY_BUILD=ON -DENABLE_TEST_TOOLS=ON --build-generator "Ninja"
           cmake --build build -- -j $(nproc)
 

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -247,7 +247,7 @@ CMAKE_FLAGS+="-DENABLE_GTESTS=${ENABLE_GTESTS} "
 # Toggle the installation of the tools back end.
 CMAKE_FLAGS+="-DENABLE_TEST_TOOLS=${ENABLE_TEST_TOOLS} "
 # RELEASE should be default, but we want to make sure.
-CMAKE_FLAGS+="-DCMAKE_BUILD_TYPE=RELEASE "
+CMAKE_FLAGS+="-DCMAKE_BUILD_TYPE=Release "
 # Treat warnings as errors.
 CMAKE_FLAGS+="-DENABLE_WERROR=${ENABLE_WERROR} "
 # Enable sanitizers.

--- a/tools/debian-build/packaging.conf
+++ b/tools/debian-build/packaging.conf
@@ -12,7 +12,7 @@ export CXXFLAGS="${CXXFLAGS} -O3"
 # Enable unity compilation.
 CONFOPT+="-DCMAKE_UNITY_BUILD=ON "
 # RELEASE should be default, but we want to make sure.
-CONFOPT+="-DCMAKE_BUILD_TYPE=RELEASE "
+CONFOPT+="-DCMAKE_BUILD_TYPE=Release "
 # The binaries we produce should not depend on system libraries.
 CONFOPT+="-DSTATIC_BUILD_WITH_DYNAMIC_GLIBC=ON "
 MAKE_DIST="cd ${P4C_DIR}/backends/ebpf && ./build_libbpf && mkdir -p ${P4C_DIR}/build && cd ${P4C_DIR}/build && cmake .. $CONFOPT && make && make dist"


### PR DESCRIPTION
The casing for build types is CamelCase: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html#variable:CMAKE_BUILD_TYPE