### PR TITLE
Simplify dependabot label generation.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Specify labels for github-actions pull requests
+    labels:
+      - "infrastructure"


### PR DESCRIPTION
Dependabot was adding new labels. Stop that. 