### PR TITLE
Add a signature for the release bot for DCO support. 

### DIFF
--- a/.github/workflows/ci-auto-release.yml
+++ b/.github/workflows/ci-auto-release.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           COMMIT_MSG=$(cat << EOF
           Release v${{ env.VERSION }}
+          Signed-off-by: rst0git <9142901+rst0git@users.noreply.github.com>
 
           ${{ steps.changelog.outputs.content }}
           EOF


### PR DESCRIPTION
Reusing the current signature of the bot, but maybe there is a better one. @rst0git 