### PR TITLE
Move ProgramStructure out the BMv2 folder such that it can be used in other back ends.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -264,12 +264,23 @@ cc_library(
 )
 
 cc_library(
+    name = "p4c_backends_common_lib",
+    srcs = glob(["backends/common/*.cpp"]),
+    hdrs = glob(["backends/common/*.h"]),
+    deps = [
+        ":ir_frontend_midend_control_plane",
+        ":lib",
+    ],
+)
+
+cc_library(
     name = "p4c_bmv2_common_lib",
     srcs = glob(["backends/bmv2/common/*.cpp"]),
     hdrs = glob(["backends/bmv2/common/*.h"]),
     deps = [
         ":ir_frontend_midend_control_plane",
         ":lib",
+        ":p4c_backends_common_lib",
     ],
 )
 
@@ -283,6 +294,7 @@ cc_library(
     deps = [
         ":ir_frontend_midend_control_plane",
         ":lib",
+        ":p4c_backends_common_lib",
         ":p4c_bmv2_common_lib",
     ],
 )
@@ -305,6 +317,7 @@ cc_binary(
     deps = [
         ":ir_frontend_midend_control_plane",
         ":lib",
+        ":p4c_backends_common_lib",
         ":p4c_bmv2_common_lib",
         ":p4c_bmv2_simple_lib",
     ],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,6 +459,7 @@ add_subdirectory (control-plane)
 # share the same set of IR classes (frontend and backend). Backends such as the DPDK backend
 # can introduce additional IR classes and cpp sources which need to be added to
 # EXTENSION_IR_SOURCES.
+add_subdirectory(backends/common)
 if (ENABLE_BMV2)
     add_subdirectory (backends/bmv2)
 endif ()

--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -36,8 +36,6 @@ set (BMV2_PSA_SWITCH_SRCS
     psa_switch/midend.h
     psa_switch/psaSwitch.cpp
     psa_switch/psaSwitch.h
-    psa_switch/psaProgramStructure.cpp
-    psa_switch/psaProgramStructure.h
     psa_switch/options.cpp
     psa_switch/options.h
     )
@@ -53,9 +51,7 @@ set (BMV2_BACKEND_COMMON_SRCS
   common/header.cpp
   common/helpers.cpp
   common/lower.cpp
-  common/metermap.cpp
   common/parser.cpp
-  common/programStructure.cpp
   )
 
 set (BMV2_BACKEND_COMMON_HDRS
@@ -73,18 +69,16 @@ set (BMV2_BACKEND_COMMON_HDRS
   common/header.h
   common/helpers.h
   common/lower.h
-  common/metermap.h
   common/midend.h
   common/options.h
   common/parser.h
-  common/programStructure.h
   common/sharedActionSelectorCheck.h
   )
 
 set (IR_DEF_FILES ${IR_DEF_FILES} ${CMAKE_CURRENT_SOURCE_DIR}/bmv2.def PARENT_SCOPE)
 
 add_library(bmv2backend STATIC ${BMV2_BACKEND_COMMON_SRCS})
-target_link_libraries(bmv2backend ir-generated frontend)
+target_link_libraries(bmv2backend ir-generated frontend backends-common)
 
 add_executable(p4c-bm2-ss ${BMV2_SIMPLE_SWITCH_SRCS})
 target_link_libraries (p4c-bm2-ss bmv2backend ${P4C_LIBRARIES} ${P4C_LIB_DEPS})

--- a/backends/bmv2/common/backend.h
+++ b/backends/bmv2/common/backend.h
@@ -31,7 +31,6 @@ limitations under the License.
 #include "lib/json.h"
 #include "lib/log.h"
 #include "lib/nullstream.h"
-#include "metermap.h"
 #include "midend/actionSynthesis.h"
 #include "midend/convertEnums.h"
 #include "midend/removeComplexExpressions.h"

--- a/backends/bmv2/common/expression.h
+++ b/backends/bmv2/common/expression.h
@@ -17,6 +17,7 @@ limitations under the License.
 #ifndef BACKENDS_BMV2_COMMON_EXPRESSION_H_
 #define BACKENDS_BMV2_COMMON_EXPRESSION_H_
 
+#include "backends/common/programStructure.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/coreLibrary.h"
 #include "frontends/p4/enumInstance.h"
@@ -26,7 +27,6 @@ limitations under the License.
 #include "lib/big_int_util.h"
 #include "lib/json.h"
 #include "lower.h"
-#include "programStructure.h"
 
 namespace BMV2 {
 
@@ -51,7 +51,7 @@ class ArithmeticFixup : public Transform {
 class ExpressionConverter : public Inspector {
     P4::ReferenceMap *refMap;
     P4::TypeMap *typeMap;
-    ProgramStructure *structure;
+    P4::ProgramStructure *structure;
     P4::P4CoreLibrary &corelib;
     cstring scalarsName;
 
@@ -68,8 +68,8 @@ class ExpressionConverter : public Inspector {
     bool withConstantWidths{false};
 
  public:
-    ExpressionConverter(P4::ReferenceMap *refMap, P4::TypeMap *typeMap, ProgramStructure *structure,
-                        cstring scalarsName)
+    ExpressionConverter(P4::ReferenceMap *refMap, P4::TypeMap *typeMap,
+                        P4::ProgramStructure *structure, cstring scalarsName)
         : refMap(refMap),
           typeMap(typeMap),
           structure(structure),

--- a/backends/bmv2/common/extern.h
+++ b/backends/bmv2/common/extern.h
@@ -17,10 +17,10 @@ limitations under the License.
 #ifndef BACKENDS_BMV2_COMMON_EXTERN_H_
 #define BACKENDS_BMV2_COMMON_EXTERN_H_
 
+#include "backends/common/programStructure.h"
 #include "frontends/p4/methodInstance.h"
 #include "helpers.h"
 #include "ir/ir.h"
-#include "programStructure.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/common/header.h
+++ b/backends/bmv2/common/header.h
@@ -21,12 +21,12 @@ limitations under the License.
 
 #include "JsonObjects.h"
 #include "backends/bmv2/common/options.h"
+#include "backends/common/programStructure.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/typeMap.h"
 #include "helpers.h"
 #include "ir/ir.h"
 #include "lib/json.h"
-#include "programStructure.h"
 
 namespace BMV2 {
 

--- a/backends/bmv2/common/helpers.h
+++ b/backends/bmv2/common/helpers.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define BACKENDS_BMV2_COMMON_HELPERS_H_
 
 #include "JsonObjects.h"
+#include "backends/common/programStructure.h"
 #include "controlFlowGraph.h"
 #include "expression.h"
 #include "frontends/common/model.h"
@@ -26,7 +27,6 @@ limitations under the License.
 #include "lib/cstring.h"
 #include "lib/json.h"
 #include "lib/ordered_map.h"
-#include "programStructure.h"
 
 namespace BMV2 {
 
@@ -56,6 +56,17 @@ class V1ModelProperties {
     /// automatically added by BMV2 to all header types; reading from it tells
     /// you whether the header is valid, just as if you had called isValid().
     static const cstring validField;
+};
+
+// V1Model-specific blocks.
+enum class BlockConverted {
+    None,
+    Parser,
+    Ingress,
+    Egress,
+    Deparser,
+    ChecksumCompute,
+    ChecksumVerify
 };
 
 namespace Standard {
@@ -268,7 +279,7 @@ struct ConversionContext {
     /// Block currently being converted.
     BlockConverted blockConverted;
     /// ProgramStructure pointer.
-    ProgramStructure *structure;
+    P4::ProgramStructure *structure;
     /// Expression converter is used in many places.
     ExpressionConverter *conv;
     /// Final json output.
@@ -286,7 +297,7 @@ struct ConversionContext {
     }
 
     ConversionContext(P4::ReferenceMap *refMap, P4::TypeMap *typeMap,
-                      const IR::ToplevelBlock *toplevel, ProgramStructure *structure,
+                      const IR::ToplevelBlock *toplevel, P4::ProgramStructure *structure,
                       ExpressionConverter *conv, JsonObjects *json)
         : refMap(refMap),
           typeMap(typeMap),

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -253,7 +253,7 @@ void PsaSwitchBackend::convert(const IR::ToplevelBlock *tlb) {
     CHECK_NULL(tlb);
     PsaCodeGenerator structure(refMap, typeMap);
 
-    auto parsePsaArch = new ParsePsaArchitecture(&structure);
+    auto parsePsaArch = new P4::ParsePsaArchitecture(&structure);
     auto main = tlb->getMain();
     if (!main) return;
 
@@ -298,7 +298,7 @@ void PsaSwitchBackend::convert(const IR::ToplevelBlock *tlb) {
     program->apply(simplify);
 
     // map IR node to compile-time allocated resource blocks.
-    toplevel->apply(*new BMV2::BuildResourceMap(&structure.resourceMap));
+    toplevel->apply(*new P4::BuildResourceMap(&structure.resourceMap));
 
     main = toplevel->getMain();
     if (!main) return;  // no main
@@ -306,8 +306,8 @@ void PsaSwitchBackend::convert(const IR::ToplevelBlock *tlb) {
     if (::errorCount() > 0) return;
     program = toplevel->getProgram();
 
-    PassManager toJson = {new DiscoverStructure(&structure),
-                          new InspectPsaProgram(refMap, typeMap, &structure),
+    PassManager toJson = {new P4::DiscoverStructure(&structure),
+                          new P4::InspectPsaProgram(refMap, typeMap, &structure),
                           new ConvertPsaToJson(refMap, typeMap, toplevel, json, &structure)};
     for (const auto &pEnum : *enumMap) {
         auto name = pEnum.first->getName();
@@ -681,7 +681,7 @@ void ExternConverter_InternetChecksum::convertExternInstance(UNUSED ConversionCo
     cstring name = inst->controlPlaneName();
     auto trim = inst->controlPlaneName().find(".");
     auto block = inst->controlPlaneName().trim(trim);
-    auto psaStructure = static_cast<PsaProgramStructure *>(ctxt->structure);
+    auto psaStructure = static_cast<P4::PsaProgramStructure *>(ctxt->structure);
     auto ingressParser = psaStructure->parsers.at("ingress"_cs)->controlPlaneName();
     auto ingressDeparser = psaStructure->deparsers.at("ingress"_cs)->controlPlaneName();
     auto egressParser = psaStructure->parsers.at("egress"_cs)->controlPlaneName();

--- a/backends/bmv2/psa_switch/psaSwitch.h
+++ b/backends/bmv2/psa_switch/psaSwitch.h
@@ -25,7 +25,8 @@ limitations under the License.
 #include "backends/bmv2/common/helpers.h"
 #include "backends/bmv2/common/lower.h"
 #include "backends/bmv2/common/parser.h"
-#include "backends/bmv2/common/programStructure.h"
+#include "backends/common/programStructure.h"
+#include "backends/common/psaProgramStructure.h"
 #include "frontends/common/constantFolding.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/p4/coreLibrary.h"
@@ -39,14 +40,13 @@ limitations under the License.
 #include "ir/ir.h"
 #include "lib/big_int_util.h"
 #include "lib/json.h"
-#include "psaProgramStructure.h"
 
 namespace BMV2 {
 
 class PsaSwitchExpressionConverter : public ExpressionConverter {
  public:
     PsaSwitchExpressionConverter(P4::ReferenceMap *refMap, P4::TypeMap *typeMap,
-                                 ProgramStructure *structure, cstring scalarsName)
+                                 P4::ProgramStructure *structure, cstring scalarsName)
         : BMV2::ExpressionConverter(refMap, typeMap, structure, scalarsName) {}
 
     void modelError(const char *format, const cstring field) {
@@ -56,7 +56,7 @@ class PsaSwitchExpressionConverter : public ExpressionConverter {
 
     Util::IJson *convertParam(UNUSED const IR::Parameter *param, cstring fieldName) override {
         cstring ptName = param->type->toString();
-        if (PsaProgramStructure::isCounterMetadata(ptName)) {  // check if its counter metadata
+        if (P4::PsaProgramStructure::isCounterMetadata(ptName)) {  // check if its counter metadata
             auto jsn = new Util::JsonObject();
             jsn->emplace("name"_cs, param->toString());
             jsn->emplace("type"_cs, "hexstr");
@@ -77,7 +77,8 @@ class PsaSwitchExpressionConverter : public ExpressionConverter {
                 return nullptr;
             }
             return jsn;
-        } else if (PsaProgramStructure::isStandardMetadata(ptName)) {  // check if its psa metadata
+        } else if (P4::PsaProgramStructure::isStandardMetadata(
+                       ptName)) {  // check if its psa metadata
             auto jsn = new Util::JsonObject();
 
             // encode the metadata type and field in json
@@ -94,10 +95,10 @@ class PsaSwitchExpressionConverter : public ExpressionConverter {
     }
 };
 
-class PsaCodeGenerator : public PsaProgramStructure {
+class PsaCodeGenerator : public P4::PsaProgramStructure {
  public:
     PsaCodeGenerator(P4::ReferenceMap *refMap, P4::TypeMap *typeMap)
-        : PsaProgramStructure(refMap, typeMap) {}
+        : P4::PsaProgramStructure(refMap, typeMap) {}
 
     void create(ConversionContext *ctxt);
     void createStructLike(ConversionContext *ctxt, const IR::Type_StructLike *st);

--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -1199,7 +1199,7 @@ void SimpleSwitchBackend::convert(const IR::ToplevelBlock *tlb) {
     program->apply(simplify);
 
     // map IR node to compile-time allocated resource blocks.
-    toplevel->apply(*new BMV2::BuildResourceMap(&structure->resourceMap));
+    toplevel->apply(*new P4::BuildResourceMap(&structure->resourceMap));
 
     // field list and learn list ids in bmv2 are not consistent with ids for
     // other objects: they need to start at 1 (not 0) since the id is also used
@@ -1223,7 +1223,7 @@ void SimpleSwitchBackend::convert(const IR::ToplevelBlock *tlb) {
     if (!main) return;  // no main
     main->apply(*parseV1Arch);
     program = toplevel->getProgram();
-    program->apply(DiscoverStructure(structure));
+    program->apply(P4::DiscoverStructure(structure));
 
     /// generate error types
     for (const auto &p : structure->errorCodesMap) {

--- a/backends/bmv2/simple_switch/simpleSwitch.h
+++ b/backends/bmv2/simple_switch/simpleSwitch.h
@@ -29,8 +29,8 @@ limitations under the License.
 #include "backends/bmv2/common/header.h"
 #include "backends/bmv2/common/options.h"
 #include "backends/bmv2/common/parser.h"
-#include "backends/bmv2/common/programStructure.h"
 #include "backends/bmv2/common/sharedActionSelectorCheck.h"
+#include "backends/common/programStructure.h"
 #include "frontends/common/constantFolding.h"
 #include "frontends/p4/evaluator/evaluator.h"
 #include "frontends/p4/fromv1.0/v1model.h"
@@ -40,7 +40,7 @@ limitations under the License.
 
 namespace BMV2 {
 
-class V1ProgramStructure : public ProgramStructure {
+class V1ProgramStructure : public P4::ProgramStructure {
  public:
     std::set<cstring> pipeline_controls;
     std::set<cstring> non_pipeline_controls;

--- a/backends/common/CMakeLists.txt
+++ b/backends/common/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(BACKENDS_COMMON_SRCS
+    metermap.cpp
+    programStructure.cpp
+    psaProgramStructure.cpp
+)
+
+add_library(backends-common STATIC ${BACKENDS_COMMON_SRCS})
+
+target_link_libraries(backends-common
+  # These libraries are exposed by a header.
+  PUBLIC absl::bits
+  PUBLIC absl::strings
+  PUBLIC ${LIBGC_LIBRARIES}
+  PUBLIC ${P4C_LIBRARIES}
+)

--- a/backends/common/metermap.cpp
+++ b/backends/common/metermap.cpp
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "metermap.h"
+#include "backends/common/metermap.h"
 
-namespace BMV2 {
+namespace P4 {
 
 /// @returns direct meter information from the direct meter map.
 DirectMeterMap::DirectMeterInfo *DirectMeterMap::createInfo(const IR::IDeclaration *meter) {
@@ -90,4 +90,4 @@ void DirectMeterMap::setSize(const IR::IDeclaration *meter, unsigned size) {
     info->tableSize = size;
 }
 
-}  // namespace BMV2
+}  // namespace P4

--- a/backends/common/metermap.h
+++ b/backends/common/metermap.h
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef BACKENDS_BMV2_COMMON_METERMAP_H_
-#define BACKENDS_BMV2_COMMON_METERMAP_H_
+#ifndef BACKENDS_COMMON_METERMAP_H_
+#define BACKENDS_COMMON_METERMAP_H_
 
 #include "ir/ir.h"
 
-namespace BMV2 {
+namespace P4 {
 
+// TODO: This file should be in the BMv2 folder, but ProgramStructure still depends on it.
 class DirectMeterMap final {
  public:
     struct DirectMeterInfo {
@@ -43,6 +44,6 @@ class DirectMeterMap final {
     void setSize(const IR::IDeclaration *meter, unsigned size);
 };
 
-}  // namespace BMV2
+}  // namespace P4
 
-#endif /* BACKENDS_BMV2_COMMON_METERMAP_H_ */
+#endif /* BACKENDS_COMMON_METERMAP_H_ */

--- a/backends/common/programStructure.cpp
+++ b/backends/common/programStructure.cpp
@@ -14,25 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "programStructure.h"
+#include "backends/common/programStructure.h"
 
 #include "lib/log.h"
 
-namespace BMV2 {
+namespace P4 {
 
 void DiscoverStructure::postorder(const IR::ParameterList *paramList) {
     bool inAction = findContext<IR::P4Action>() != nullptr;
     unsigned index = 0;
-    for (auto p : *paramList->getEnumerator()) {
+    for (const auto *p : *paramList->getEnumerator()) {
         structure->index.emplace(p, index);
-        if (!inAction) structure->nonActionParameters.emplace(p);
+        if (!inAction) {
+            structure->nonActionParameters.emplace(p);
+        }
         index++;
     }
 }
 
 void DiscoverStructure::postorder(const IR::P4Action *action) {
     LOG2("discovered action " << action);
-    auto control = findContext<IR::P4Control>();
+    const auto *control = findContext<IR::P4Control>();
     structure->actions.emplace(action, control);
 }
 
@@ -42,16 +44,16 @@ void DiscoverStructure::postorder(const IR::Declaration_Variable *decl) {
 
 void DiscoverStructure::postorder(const IR::Type_Error *errors) {
     auto &map = structure->errorCodesMap;
-    for (auto m : *errors->getDeclarations()) {
+    for (const auto *m : *errors->getDeclarations()) {
         BUG_CHECK(map.find(m) == map.end(), "Duplicate error");
         map[m] = map.size();
     }
 }
 
 void DiscoverStructure::postorder(const IR::Declaration_MatchKind *kind) {
-    for (auto member : kind->members) {
+    for (const auto *member : kind->members) {
         structure->match_kinds.insert(member->name);
     }
 }
 
-}  // namespace BMV2
+}  // namespace P4

--- a/backends/common/psaProgramStructure.cpp
+++ b/backends/common/psaProgramStructure.cpp
@@ -15,9 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "psaProgramStructure.h"
+#include "backends/common/psaProgramStructure.h"
 
-namespace BMV2 {
+namespace P4 {
 
 using namespace P4::literals;
 
@@ -334,4 +334,4 @@ bool ParsePsaArchitecture::preorder(const IR::PackageBlock *block) {
     return false;
 }
 
-}  // namespace BMV2
+}  // namespace P4

--- a/backends/common/psaProgramStructure.h
+++ b/backends/common/psaProgramStructure.h
@@ -15,16 +15,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#ifndef BACKENDS_BMV2_PSA_SWITCH_PSAPROGRAMSTRUCTURE_H_
-#define BACKENDS_BMV2_PSA_SWITCH_PSAPROGRAMSTRUCTURE_H_
+#ifndef BACKENDS_COMMON_PSAPROGRAMSTRUCTURE_H_
+#define BACKENDS_COMMON_PSAPROGRAMSTRUCTURE_H_
 
-#include "backends/bmv2/common/backend.h"
-#include "backends/bmv2/common/programStructure.h"
+#include "backends/common/programStructure.h"
+#include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 
-/// TODO: this is not really specific to BMV2, it should reside somewhere else.
-namespace BMV2 {
+namespace P4 {
+
+enum gress_t { INGRESS, EGRESS };
+enum block_t {
+    PARSER,
+    PIPELINE,
+    DEPARSER,
+};
 
 class PsaProgramStructure : public ProgramStructure {
  protected:
@@ -148,6 +155,6 @@ class InspectPsaProgram : public Inspector {
     bool preorder(const IR::Parameter *parameter) override;
 };
 
-}  // namespace BMV2
+}  // namespace P4
 
-#endif /* BACKENDS_BMV2_PSA_SWITCH_PSAPROGRAMSTRUCTURE_H_ */
+#endif /* BACKENDS_COMMON_PSAPROGRAMSTRUCTURE_H_ */

--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -61,8 +61,6 @@ set (P4C_EBPF_SRCS
   ebpfModel.cpp
   midend.cpp
   lower.cpp
-  ../bmv2/common/programStructure.cpp
-  ../bmv2/psa_switch/psaProgramStructure.cpp
   psa/ebpfPsaGen.cpp
   psa/ebpfPipeline.cpp
   psa/ebpfPsaParser.cpp
@@ -95,9 +93,6 @@ set (P4C_EBPF_HDRS
   midend.h
   target.h
   lower.h
-  ../bmv2/common/programStructure.h
-  ../bmv2/psa_switch/psaProgramStructure.h
-  ../bmv2/psa_switch/psaSwitch.h
   psa/backend.h
   psa/ebpfPsaGen.h
   psa/xdpHelpProgram.h
@@ -122,7 +117,7 @@ set (P4C_EBPF_DIST_HEADERS
 )
 
 add_executable(p4c-ebpf ${P4C_EBPF_SRCS})
-target_link_libraries (p4c-ebpf ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
+target_link_libraries (p4c-ebpf ${P4C_LIBRARIES} ${P4C_LIB_DEPS} backends-common)
 add_dependencies(p4c-ebpf ir-generated frontend)
 
 install (TARGETS p4c-ebpf

--- a/backends/ebpf/ebpfBackend.cpp
+++ b/backends/ebpf/ebpfBackend.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 
 #include "ebpfBackend.h"
 
-#include "backends/bmv2/psa_switch/psaSwitch.h"
 #include "ebpfProgram.h"
 #include "ebpfType.h"
 #include "frontends/p4/evaluator/evaluator.h"

--- a/backends/ebpf/psa/ebpfPsaGen.h
+++ b/backends/ebpf/psa/ebpfPsaGen.h
@@ -17,7 +17,6 @@ limitations under the License.
 #ifndef BACKENDS_EBPF_PSA_EBPFPSAGEN_H_
 #define BACKENDS_EBPF_PSA_EBPFPSAGEN_H_
 
-#include "backends/bmv2/psa_switch/psaSwitch.h"
 #include "backends/ebpf/codeGen.h"
 #include "backends/ebpf/ebpfObject.h"
 #include "backends/ebpf/ebpfOptions.h"

--- a/backends/tc/CMakeLists.txt
+++ b/backends/tc/CMakeLists.txt
@@ -37,8 +37,6 @@ set(P4TC_BACKEND_SOURCES
     ../ebpf/ebpfModel.cpp
     ../ebpf/midend.cpp
     ../ebpf/lower.cpp
-    ../bmv2/common/programStructure.cpp
-    ../bmv2/psa_switch/psaProgramStructure.cpp
     ../ebpf/psa/ebpfPsaGen.cpp
     ../ebpf/psa/ebpfPipeline.cpp
     ../ebpf/psa/ebpfPsaParser.cpp
@@ -80,9 +78,6 @@ set(P4TC_BACKEND_HEADERS
    ../ebpf/midend.h
    ../ebpf/target.h
    ../ebpf/lower.h
-   ../bmv2/common/programStructure.h
-   ../bmv2/psa_switch/psaProgramStructure.h
-   ../bmv2/psa_switch/psaSwitch.h
    ../ebpf/psa/backend.h
    ../ebpf/psa/ebpfPsaGen.h
    ../ebpf/psa/xdpHelpProgram.h
@@ -105,7 +100,7 @@ set (IR_DEF_FILES ${IR_DEF_FILES} ${CMAKE_CURRENT_SOURCE_DIR}/tc.def PARENT_SCOP
 
 # build
 add_executable(p4c-pna-p4tc ${P4TC_BACKEND_SOURCES})
-target_link_libraries (p4c-pna-p4tc ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
+target_link_libraries (p4c-pna-p4tc ${P4C_LIBRARIES} ${P4C_LIB_DEPS} backends-common)
 add_dependencies(p4c-pna-p4tc genIR)
 
 # install

--- a/backends/tc/backend.cpp
+++ b/backends/tc/backend.cpp
@@ -94,7 +94,7 @@ bool Backend::ebpfCodeGen(P4::ReferenceMap *refMapEBPF, P4::TypeMap *typeMapEBPF
     program = program->apply(rewriteToEBPF);
 
     // map IR node to compile-time allocated resource blocks.
-    top->apply(*new BMV2::BuildResourceMap(&structure.resourceMap));
+    top->apply(*new P4::BuildResourceMap(&structure.resourceMap));
 
     main = top->getMain();
     if (!main) return false;  // no main
@@ -104,7 +104,7 @@ bool Backend::ebpfCodeGen(P4::ReferenceMap *refMapEBPF, P4::TypeMap *typeMapEBPF
     EBPF::EBPFTypeFactory::createFactory(typeMapEBPF);
     auto convertToEbpf = new ConvertToEbpfPNA(ebpfOption, refMapEBPF, typeMapEBPF, tcIR);
     PassManager toEBPF = {
-        new BMV2::DiscoverStructure(&structure),
+        new P4::DiscoverStructure(&structure),
         new InspectPnaProgram(refMapEBPF, typeMapEBPF, &structure),
         // convert to EBPF objects
         new VisitFunctor([evaluator, convertToEbpf]() {

--- a/backends/tc/pnaProgramStructure.cpp
+++ b/backends/tc/pnaProgramStructure.cpp
@@ -204,16 +204,16 @@ bool InspectPnaProgram::preorder(const IR::Parameter *param) {
 void InspectPnaProgram::postorder(const IR::P4Parser *p) {
     if (pinfo->block_type.count(p)) {
         auto info = pinfo->block_type.at(p);
-        if (info == BMV2::PARSER) pinfo->parsers.emplace(p->name, p);
+        if (info == PARSER) pinfo->parsers.emplace(p->name, p);
     }
 }
 
 void InspectPnaProgram::postorder(const IR::P4Control *c) {
     if (pinfo->block_type.count(c)) {
         auto info = pinfo->block_type.at(c);
-        if (info == BMV2::PIPELINE)
+        if (info == PIPELINE)
             pinfo->pipelines.emplace(c->name, c);
-        else if (info == BMV2::DEPARSER)
+        else if (info == DEPARSER)
             pinfo->deparsers.emplace(c->name, c);
     }
 }
@@ -266,9 +266,9 @@ bool ParsePnaArchitecture::preorder(const IR::PackageBlock *block) {
                        block);
             return false;
         }
-        structure->block_type.emplace(parser->container, BMV2::PARSER);
-        structure->block_type.emplace(pipeline->container, BMV2::PIPELINE);
-        structure->block_type.emplace(deparser->container, BMV2::DEPARSER);
+        structure->block_type.emplace(parser->container, PARSER);
+        structure->block_type.emplace(pipeline->container, PIPELINE);
+        structure->block_type.emplace(deparser->container, DEPARSER);
         structure->pipeline_controls.emplace(pipeline->container->name);
         structure->non_pipeline_controls.emplace(deparser->container->name);
     } else {

--- a/backends/tc/pnaProgramStructure.h
+++ b/backends/tc/pnaProgramStructure.h
@@ -17,14 +17,21 @@ and limitations under the License.
 #ifndef BACKENDS_TC_PNAPROGRAMSTRUCTURE_H_
 #define BACKENDS_TC_PNAPROGRAMSTRUCTURE_H_
 
-#include "backends/bmv2/common/backend.h"
-#include "backends/bmv2/common/programStructure.h"
+#include "backends/common/programStructure.h"
+#include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 
 namespace TC {
 
-class PnaProgramStructure : public BMV2::ProgramStructure {
+enum block_t {
+    PARSER,
+    PIPELINE,
+    DEPARSER,
+};
+
+class PnaProgramStructure : public P4::ProgramStructure {
  protected:
     P4::ReferenceMap *refMap;
     P4::TypeMap *typeMap;
@@ -38,7 +45,7 @@ class PnaProgramStructure : public BMV2::ProgramStructure {
     unsigned bool_width = 1;
 
     // architecture related information
-    ordered_map<const IR::Node *, BMV2::block_t> block_type;
+    ordered_map<const IR::Node *, block_t> block_type;
 
     ordered_map<cstring, const IR::Type_Header *> header_types;
     ordered_map<cstring, const IR::Type_Struct *> metadata_types;


### PR DESCRIPTION
The ProgramStructure class in the BMv2 back end was used all across other back ends. The abstraction here was a bit leaky. I pulled it out and moved it in the "common" folder in `backends`. Refactoring suggestions or ideas are welcome here. There are still a bunch of leaky abstractions. The program structure class should ideally work for all back ends. 

@qobilidop @rupesh-chiluka-marvell 