### PR TITLE
Set the initial default action for tables when generating a P4Info.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,7 +420,7 @@ set(FETCHCONTENT_QUIET OFF)
 FetchContent_Declare(
   p4runtime
   GIT_REPOSITORY https://github.com/p4lang/p4runtime.git
-  GIT_TAG        62a9bd60599b87497a15feb6c7893b7ec8ba461f
+  GIT_TAG        ec4eb5ef70dbcbcbf2f8357a4b2b8c2f218845a5
   GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(p4runtime)

--- a/backends/ebpf/psa/examples/bng.p4info.txtpb
+++ b/backends/ebpf/psa/examples/bng.p4info.txtpb
@@ -47,6 +47,9 @@ tables {
     id: 17049673
   }
   const_default_action_id: 28724955
+  initial_default_action {
+    action_id: 28724955
+  }
   size: 8192
 }
 tables {
@@ -86,6 +89,13 @@ tables {
     id: 17126659
   }
   const_default_action_id: 17126659
+  initial_default_action {
+    action_id: 17126659
+    arguments {
+      param_id: 1
+      value: "\000"
+    }
+  }
   size: 1024
 }
 tables {
@@ -107,6 +117,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }
@@ -137,6 +150,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -161,6 +177,13 @@ tables {
     id: 27019812
   }
   const_default_action_id: 27019812
+  initial_default_action {
+    action_id: 27019812
+    arguments {
+      param_id: 1
+      value: "\000\000\000\000"
+    }
+  }
   size: 8192
 }
 tables {
@@ -184,6 +207,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 16
 }
 tables {
@@ -219,6 +245,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21552277
+  initial_default_action {
+    action_id: 21552277
+  }
   size: 32768
 }
 tables {
@@ -245,6 +274,9 @@ tables {
     id: 33281717
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 8192
 }
 tables {
@@ -284,6 +316,9 @@ tables {
     id: 23799701
   }
   const_default_action_id: 23799701
+  initial_default_action {
+    action_id: 23799701
+  }
   size: 256
 }
 tables {
@@ -319,6 +354,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 20119496
+  initial_default_action {
+    action_id: 20119496
+  }
   size: 1024
 }
 actions {

--- a/backends/ebpf/psa/examples/l2l3-acl.p4info.txtpb
+++ b/backends/ebpf/psa/examples/l2l3-acl.p4info.txtpb
@@ -31,6 +31,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -52,6 +55,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 24963522
+  initial_default_action {
+    action_id: 24963522
+  }
   size: 1024
 }
 tables {
@@ -75,6 +81,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -96,6 +105,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   implementation_id: 286177969
   size: 1024
@@ -128,6 +140,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }
@@ -174,6 +189,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -201,6 +219,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   direct_resource_ids: 330499363
   size: 1024

--- a/backends/ebpf/psa/examples/upf.p4info.txtpb
+++ b/backends/ebpf/psa/examples/upf.p4info.txtpb
@@ -27,6 +27,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 512
 }
 tables {
@@ -51,6 +54,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 512
 }
@@ -86,6 +92,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true
@@ -114,6 +123,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   size: 1024
 }
 tables {
@@ -137,6 +149,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   size: 1024
 }
 tables {
@@ -158,6 +173,9 @@ tables {
     id: 28485346
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   size: 1024
 }
 tables {
@@ -217,6 +235,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 19604500
+  initial_default_action {
+    action_id: 19604500
+  }
   size: 1024
 }
 tables {
@@ -241,6 +262,9 @@ tables {
     id: 19604500
   }
   const_default_action_id: 19604500
+  initial_default_action {
+    action_id: 19604500
+  }
   size: 1024
 }
 tables {
@@ -268,6 +292,9 @@ tables {
     id: 23916784
   }
   const_default_action_id: 23916784
+  initial_default_action {
+    action_id: 23916784
+  }
   size: 1024
 }
 actions {

--- a/backends/ebpf/tests/p4testdata/action-profile2.p4info.txtpb
+++ b/backends/ebpf/tests/p4testdata/action-profile2.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 298015716
   size: 1024
 }
@@ -48,6 +51,9 @@ tables {
   }
   action_refs {
     id: 23466264
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   implementation_id: 298015716
   size: 1024

--- a/backends/ebpf/tests/p4testdata/action-selector2.p4info.txtpb
+++ b/backends/ebpf/tests/p4testdata/action-selector2.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 30183046
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 294316857
   size: 1024
 }
@@ -42,6 +45,9 @@ tables {
   }
   action_refs {
     id: 30183046
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   implementation_id: 294316857
   size: 1024

--- a/backends/ebpf/tests/p4testdata/counters.p4info.txtpb
+++ b/backends/ebpf/tests/p4testdata/counters.p4info.txtpb
@@ -28,6 +28,13 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 30696436
+    arguments {
+      param_id: 1
+      value: "\000\000\000\005"
+    }
+  }
   size: 100
 }
 actions {

--- a/backends/ebpf/tests/p4testdata/meters-direct.p4info.txtpb
+++ b/backends/ebpf/tests/p4testdata/meters-direct.p4info.txtpb
@@ -25,6 +25,13 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 30696436
+    arguments {
+      param_id: 1
+      value: "\000\000\000\006"
+    }
+  }
   direct_resource_ids: 358755246
   size: 100
 }

--- a/bazel/p4c_deps.bzl
+++ b/bazel/p4c_deps.bzl
@@ -47,8 +47,8 @@ filegroup(
         git_repository(
             name = "com_github_p4lang_p4runtime",
             remote = "https://github.com/p4lang/p4runtime",
-            # Newest commit on main branch as of May 30, 2024.
-            commit = "62a9bd60599b87497a15feb6c7893b7ec8ba461f",
+            # Newest commit on main branch as of August 18, 2024.
+            commit = "ec4eb5ef70dbcbcbf2f8357a4b2b8c2f218845a5",
             shallow_since = "1680213111 -0700",
             strip_prefix = "proto",
         )

--- a/control-plane/bytestrings.h
+++ b/control-plane/bytestrings.h
@@ -20,23 +20,44 @@ limitations under the License.
 #include <optional>
 #include <string>
 
-#include "lib/big_int_util.h"
+#include "lib/big_int.h"
 
 namespace P4::IR {
 
+class Type;
 class Constant;
 class BoolLiteral;
+class Expression;
 
 }  // namespace P4::IR
 
 namespace P4 {
 
+class TypeMap;
+
 namespace ControlPlaneAPI {
 
+/// getTypeWidth returns the width in bits for the @type, except if it is a
+/// user-defined type with a @p4runtime_translation annotation, in which case it
+/// returns W if the type is bit<W>, and 0 otherwise (i.e. if the type is
+/// string).
+int getTypeWidth(const IR::Type &type, const TypeMap &typeMap);
+
+/// Convert a Constant to the P4Runtime bytes representation by calling
+/// stringReprConstant.
 std::optional<std::string> stringRepr(const IR::Constant *constant, int width);
 
+/// Convert a BoolLiteral to the P4Runtime bytes representation by calling
+/// stringReprConstant.
 std::optional<std::string> stringRepr(const IR::BoolLiteral *constant, int width);
 
+/// Convert an Expression to the P4Runtime bytes representation.
+/// The type map is required to resolve complex expressions such as serializable enums.
+std::optional<std::string> stringRepr(const TypeMap &typeMap, const IR::Expression *expression);
+
+/// Convert a bignum to the P4Runtime bytes representation. The value must fit
+/// within the provided @width expressed in bits. Padding will be added as
+/// necessary (as the most significant bits).
 std::optional<std::string> stringReprConstant(big_int value, int width);
 
 }  // namespace ControlPlaneAPI

--- a/frontends/p4/typeMap.cpp
+++ b/frontends/p4/typeMap.cpp
@@ -353,7 +353,7 @@ const IR::Type *TypeMap::getCanonical(const IR::Type *type) {
     return type;
 }
 
-int TypeMap::widthBits(const IR::Type *type, const IR::Node *errorPosition, bool max) {
+int TypeMap::widthBits(const IR::Type *type, const IR::Node *errorPosition, bool max) const {
     CHECK_NULL(type);
     const IR::Type *t;
     if (auto tt = type->to<IR::Type_Type>())

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -104,7 +104,7 @@ class TypeMap final : public ProgramMap {
     /// The width in bits of this type.  If the width is not
     /// well-defined this will report an error and return -1.
     /// max indicates whether we want the max width or min width.
-    int widthBits(const IR::Type *type, const IR::Node *errorPosition, bool max);
+    int widthBits(const IR::Type *type, const IR::Node *errorPosition, bool max) const;
 
     /// True is type occupies no storage.
     bool typeIsEmpty(const IR::Type *type) const;

--- a/testdata/p4_16_errors_outputs/issue1803_same_table_name.p4.p4info.txtpb
+++ b/testdata/p4_16_errors_outputs/issue1803_same_table_name.p4.p4info.txtpb
@@ -23,6 +23,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -44,6 +47,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_errors_outputs/issue532.p4.p4info.txtpb
+++ b/testdata/p4_16_errors_outputs/issue532.p4.p4info.txtpb
@@ -17,6 +17,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.p4info.txtpb
+++ b/testdata/p4_16_errors_outputs/table-entries-lpm-2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_errors_outputs/table-entries-optional-2-bmv2.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/action-two-params.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/action-two-params.p4.p4info.txtpb
@@ -23,6 +23,9 @@ tables {
     id: 25652968
   }
   const_default_action_id: 25652968
+  initial_default_action {
+    action_id: 25652968
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/action_call_ubpf.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/action_call_ubpf.p4.p4info.txtpb
@@ -19,6 +19,13 @@ tables {
   action_refs {
     id: 26966999
   }
+  initial_default_action {
+    action_id: 16865584
+    arguments {
+      param_id: 1
+      value: "\000"
+    }
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/action_profile-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/action_profile-bmv2.p4.p4info.txtpb
@@ -17,6 +17,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 294074782
   size: 1024
 }
@@ -33,6 +36,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 300324846
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/action_profile_max_group_size_annotation.p4.p4info.txtpb
@@ -17,6 +17,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 294074782
   size: 1024
 }
@@ -33,6 +36,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 300324846
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/action_profile_sum_of_members_annotation.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/action_profile_sum_of_members_annotation.p4.p4info.txtpb
@@ -17,6 +17,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 289199568
   size: 1024
 }
@@ -33,6 +36,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 285903678
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/action_selector_shared-bmv2.p4.p4info.txtpb
@@ -17,6 +17,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 291652621
   size: 1024
 }
@@ -33,6 +36,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 291652621
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/annotation-inline-propagate.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/annotation-inline-propagate.p4.p4info.txtpb
@@ -17,6 +17,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/arith-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/arith-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 20728178
   }
   const_default_action_id: 20728178
+  initial_default_action {
+    action_id: 20728178
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/arith-inline-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/arith-inline-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 29022044
   }
   const_default_action_id: 29022044
+  initial_default_action {
+    action_id: 29022044
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/arith1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/arith1-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 25073243
   }
   const_default_action_id: 25073243
+  initial_default_action {
+    action_id: 25073243
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/arith2-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/arith2-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 25073243
   }
   const_default_action_id: 25073243
+  initial_default_action {
+    action_id: 25073243
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/arith3-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/arith3-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 32554999
   }
   const_default_action_id: 32554999
+  initial_default_action {
+    action_id: 32554999
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/arith4-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/arith4-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 32554999
   }
   const_default_action_id: 32554999
+  initial_default_action {
+    action_id: 32554999
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/arith5-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/arith5-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 32554999
   }
   const_default_action_id: 32554999
+  initial_default_action {
+    action_id: 32554999
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/basic2-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/basic2-bmv2.p4.p4info.txtpb
@@ -32,6 +32,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/basic_routing-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/basic_routing-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 65536
 }
 tables {
@@ -54,6 +57,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 131072
 }
@@ -86,6 +92,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 16384
 }
 tables {
@@ -111,6 +120,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 32768
 }
 tables {
@@ -132,6 +144,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 32768
 }
@@ -157,6 +172,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 32768
 }

--- a/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/bvec-hdr-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/checksum-l4-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/checksum-l4-bmv2.p4.p4info.txtpb
@@ -23,6 +23,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true
@@ -46,6 +49,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/checksum1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/checksum1-bmv2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 25131402
   }
+  initial_default_action {
+    action_id: 25131402
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/concat-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/concat-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 30378945
   }
   const_default_action_id: 30378945
+  initial_default_action {
+    action_id: 30378945
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/control-hs-index-test6.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/control-hs-index-test6.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/copyprop1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/copyprop1.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/crc32-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/crc32-bmv2.p4.p4info.txtpb
@@ -38,6 +38,9 @@ tables {
     id: 32121835
   }
   const_default_action_id: 32121835
+  initial_default_action {
+    action_id: 32121835
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/custom-type-restricted-fields.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/custom-type-restricted-fields.p4.p4info.txtpb
@@ -29,6 +29,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/dash/dash-pipeline-v1model-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/dash/dash-pipeline-v1model-bmv2.p4.p4info.txtpb
@@ -59,6 +59,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 23563653
+  initial_default_action {
+    action_id: 23563653
+  }
   size: 1024
 }
 tables {
@@ -91,6 +94,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }
@@ -155,6 +161,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 23563653
+  initial_default_action {
+    action_id: 23563653
+  }
   size: 1024
 }
 tables {
@@ -229,6 +238,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 23563653
+  initial_default_action {
+    action_id: 23563653
+  }
   size: 1024
 }
 tables {
@@ -323,6 +335,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 23563653
+  initial_default_action {
+    action_id: 23563653
+  }
   size: 1024
 }
 tables {
@@ -385,6 +400,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -436,6 +454,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21063902
+  initial_default_action {
+    action_id: 21063902
+  }
   size: 1024
 }
 tables {
@@ -499,6 +520,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 20772460
+  initial_default_action {
+    action_id: 20772460
+  }
   size: 1024
 }
 tables {
@@ -733,6 +757,9 @@ tables {
   }
   action_refs {
     id: 26077229
+  }
+  initial_default_action {
+    action_id: 29962337
   }
   direct_resource_ids: 324963620
   size: 1024
@@ -970,6 +997,9 @@ tables {
   action_refs {
     id: 26077229
   }
+  initial_default_action {
+    action_id: 29962337
+  }
   direct_resource_ids: 334749261
   size: 1024
 }
@@ -1206,6 +1236,9 @@ tables {
   action_refs {
     id: 26077229
   }
+  initial_default_action {
+    action_id: 29962337
+  }
   direct_resource_ids: 320450761
   size: 1024
 }
@@ -1299,6 +1332,9 @@ tables {
     id: 18759588
   }
   const_default_action_id: 18759588
+  initial_default_action {
+    action_id: 18759588
+  }
   direct_resource_ids: 331716030
   size: 1024
 }
@@ -1388,6 +1424,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 18759588
+  initial_default_action {
+    action_id: 18759588
+  }
   direct_resource_ids: 334791879
   size: 1024
 }
@@ -1444,6 +1483,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }
@@ -1679,6 +1721,9 @@ tables {
   }
   action_refs {
     id: 31424218
+  }
+  initial_default_action {
+    action_id: 28146588
   }
   direct_resource_ids: 320981527
   size: 1024
@@ -1916,6 +1961,9 @@ tables {
   action_refs {
     id: 31424218
   }
+  initial_default_action {
+    action_id: 28146588
+  }
   direct_resource_ids: 322865948
   size: 1024
 }
@@ -2152,6 +2200,9 @@ tables {
   action_refs {
     id: 31424218
   }
+  initial_default_action {
+    action_id: 28146588
+  }
   direct_resource_ids: 328370481
   size: 1024
 }
@@ -2214,6 +2265,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -2264,6 +2318,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }
@@ -2363,6 +2420,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -2432,6 +2492,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -2482,6 +2545,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   direct_resource_ids: 321751294
   size: 1024

--- a/testdata/p4_16_samples_outputs/def-use.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/def-use.p4.p4info.txtpb
@@ -13,6 +13,9 @@ tables {
   action_refs {
     id: 21913698
   }
+  initial_default_action {
+    action_id: 21913698
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/default-action-arg-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/default-action-arg-bmv2.p4.p4info.txtpb
@@ -20,6 +20,17 @@ tables {
     id: 29022044
   }
   const_default_action_id: 29022044
+  initial_default_action {
+    action_id: 29022044
+    arguments {
+      param_id: 1
+      value: "\000\000\000\n"
+    }
+    arguments {
+      param_id: 2
+      value: "\000\000\000\000"
+    }
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/default_action-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/default_action-bmv2.p4.p4info.txtpb
@@ -14,6 +14,13 @@ tables {
     id: 29022044
   }
   const_default_action_id: 29022044
+  initial_default_action {
+    action_id: 29022044
+    arguments {
+      param_id: 1
+      value: "\000\000\000\n"
+    }
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/default_action_ubpf.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/default_action_ubpf.p4.p4info.txtpb
@@ -13,6 +13,13 @@ tables {
   action_refs {
     id: 23144899
   }
+  initial_default_action {
+    action_id: 23144899
+    arguments {
+      param_id: 1
+      value: "\000\000\000\n"
+    }
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/drop-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/drop-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 18759588
   }
   const_default_action_id: 18759588
+  initial_default_action {
+    action_id: 18759588
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric.p4.p4info.txtpb
@@ -38,6 +38,9 @@ tables {
     id: 24266015
   }
   const_default_action_id: 17164167
+  initial_default_action {
+    action_id: 17164167
+  }
   direct_resource_ids: 326221069
   size: 1024
 }
@@ -69,6 +72,13 @@ tables {
     id: 25032921
   }
   const_default_action_id: 25032921
+  initial_default_action {
+    action_id: 25032921
+    arguments {
+      param_id: 1
+      value: "\000"
+    }
+  }
   direct_resource_ids: 335473470
   size: 1024
 }
@@ -99,6 +109,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   direct_resource_ids: 330959985
   size: 1024
 }
@@ -123,6 +136,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   direct_resource_ids: 318961579
   size: 1024
 }
@@ -150,6 +166,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   direct_resource_ids: 333425635
   size: 1024
 }
@@ -247,6 +266,9 @@ tables {
     id: 29607214
   }
   const_default_action_id: 29607214
+  initial_default_action {
+    action_id: 29607214
+  }
   direct_resource_ids: 319194241
   size: 1024
 }
@@ -271,6 +293,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   direct_resource_ids: 326370320
   size: 1024
 }
@@ -304,6 +329,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   direct_resource_ids: 321989420
   size: 1024
 }
@@ -334,6 +362,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   implementation_id: 291115404
   direct_resource_ids: 322798228
   size: 1024
@@ -359,6 +390,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   direct_resource_ids: 319194968
   size: 1024
 }
@@ -383,6 +417,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   direct_resource_ids: 334575698
   size: 1024
 }
@@ -402,6 +439,9 @@ tables {
     id: 28485346
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   size: 1024
 }
 tables {
@@ -431,6 +471,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28485346
+  initial_default_action {
+    action_id: 28485346
+  }
   direct_resource_ids: 318892680
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/flag_lost-bmv2.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 33281717
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/flowlet_switching-bmv2.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -48,6 +51,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 16384
 }
 tables {
@@ -61,6 +67,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }
@@ -85,6 +94,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 512
 }
 tables {
@@ -98,6 +110,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }
@@ -121,6 +136,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 256
 }

--- a/testdata/p4_16_samples_outputs/gauntlet_action_return-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_action_return-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_1-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_10-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_10-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_11-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_11-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_13-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_13-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_14-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_14-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_15-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_15-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_16-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_16-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_17-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_17-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -45,6 +48,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_19-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_19-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_2-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_2-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_22-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_22-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_23-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_23-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_3-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_3-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_4-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_4-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_exit_combination_9-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_exit_combination_9-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_index_2-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_index_2-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_inout_slice_table_key-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_inout_slice_table_key-bmv2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_instance_overwrite-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_instance_overwrite-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_mux_hdr-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_mux_hdr-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_nested_switch-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_nested_switch-bmv2.p4.p4info.txtpb
@@ -15,6 +15,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_nested_table_calls-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_nested_table_calls-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_switch_exclusivity-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_switch_exclusivity-bmv2.p4.p4info.txtpb
@@ -27,6 +27,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_switch_nested_table_apply-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_switch_nested_table_apply-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -40,6 +43,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/gauntlet_switch_shadowing-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_switch_shadowing-bmv2.p4.p4info.txtpb
@@ -27,6 +27,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_table_call_in_expression-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_table_call_in_expression-bmv2.p4.p4info.txtpb
@@ -27,6 +27,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_uninitialized_bool_struct-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_uninitialized_bool_struct-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/gauntlet_variable_shadowing-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/gauntlet_variable_shadowing-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/graph-annotationless-key.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/graph-annotationless-key.p4.p4info.txtpb
@@ -21,6 +21,9 @@ tables {
     id: 16785644
   }
   const_default_action_id: 16785644
+  initial_default_action {
+    action_id: 16785644
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/hit-expr-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/hit-expr-bmv2.p4.p4info.txtpb
@@ -13,6 +13,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/init-entries-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/init-entries-bmv2.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 26776898
   }
+  initial_default_action {
+    action_id: 25218163
+  }
   size: 1024
   has_initial_entries: true
 }
@@ -54,6 +57,9 @@ tables {
   }
   action_refs {
     id: 26776898
+  }
+  initial_default_action {
+    action_id: 25218163
   }
   size: 1024
   has_initial_entries: true
@@ -82,6 +88,9 @@ tables {
   action_refs {
     id: 26776898
   }
+  initial_default_action {
+    action_id: 25218163
+  }
   size: 1024
   has_initial_entries: true
 }
@@ -108,6 +117,9 @@ tables {
   }
   action_refs {
     id: 26776898
+  }
+  initial_default_action {
+    action_id: 25218163
   }
   size: 1024
   has_initial_entries: true
@@ -136,6 +148,9 @@ tables {
   action_refs {
     id: 26776898
   }
+  initial_default_action {
+    action_id: 25218163
+  }
   size: 1024
   has_initial_entries: true
 }
@@ -162,6 +177,9 @@ tables {
   }
   action_refs {
     id: 26776898
+  }
+  initial_default_action {
+    action_id: 25218163
   }
   size: 1024
   has_initial_entries: true
@@ -190,6 +208,9 @@ tables {
   action_refs {
     id: 26776898
   }
+  initial_default_action {
+    action_id: 25218163
+  }
   size: 1024
   has_initial_entries: true
 }
@@ -217,6 +238,9 @@ tables {
   action_refs {
     id: 26776898
   }
+  initial_default_action {
+    action_id: 25218163
+  }
   size: 1024
   has_initial_entries: true
 }
@@ -243,6 +267,9 @@ tables {
   }
   action_refs {
     id: 26776898
+  }
+  initial_default_action {
+    action_id: 25218163
   }
   size: 1024
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/inline-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/inline-bmv2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/inline1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/inline1-bmv2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/ipv4-actions_ubpf.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/ipv4-actions_ubpf.p4.p4info.txtpb
@@ -67,6 +67,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/ipv6-actions_ubpf.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/ipv6-actions_ubpf.p4.p4info.txtpb
@@ -43,6 +43,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/ipv6-switch-ml-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -52,6 +55,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -71,6 +77,9 @@ tables {
   }
   action_refs {
     id: 20119496
+  }
+  initial_default_action {
+    action_id: 20119496
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue-2123.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue-2123.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 65536
 }
 tables {
@@ -54,6 +57,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 131072
 }
@@ -86,6 +92,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 16384
 }
 tables {
@@ -111,6 +120,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 32768
 }
 tables {
@@ -132,6 +144,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 32768
 }
@@ -157,6 +172,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 32768
 }

--- a/testdata/p4_16_samples_outputs/issue-3312-graph-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue-3312-graph-bmv2.p4.p4info.txtpb
@@ -17,6 +17,9 @@ tables {
     id: 26265154
   }
   const_default_action_id: 20728178
+  initial_default_action {
+    action_id: 20728178
+  }
   size: 1024
 }
 tables {
@@ -29,6 +32,9 @@ tables {
     id: 26265154
   }
   const_default_action_id: 26265154
+  initial_default_action {
+    action_id: 26265154
+  }
   size: 1024
 }
 tables {
@@ -41,6 +47,9 @@ tables {
     id: 20728178
   }
   const_default_action_id: 20728178
+  initial_default_action {
+    action_id: 20728178
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1049-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1049-bmv2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 28550627
   }
+  initial_default_action {
+    action_id: 28550627
+  }
   size: 1024
 }
 tables {
@@ -41,6 +44,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue1107.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1107.p4.p4info.txtpb
@@ -30,6 +30,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/issue1193-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1193-bmv2.p4.p4info.txtpb
@@ -18,6 +18,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1352-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1352-bmv2.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -48,6 +51,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -67,6 +73,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue1412-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1412-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1478-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1478-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 3
 }
 tables {
@@ -30,6 +33,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 10
   is_const_table: true

--- a/testdata/p4_16_samples_outputs/issue1538.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1538.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 32609675
   }
+  initial_default_action {
+    action_id: 32609675
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1544-1-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 32609675
   }
+  initial_default_action {
+    action_id: 32609675
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1544-2-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 32609675
   }
+  initial_default_action {
+    action_id: 32609675
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1544-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1544-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 32609675
   }
+  initial_default_action {
+    action_id: 32609675
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1560-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1560-bmv2.p4.p4info.txtpb
@@ -27,6 +27,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 8
 }
 tables {
@@ -52,6 +55,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 8
 }
 tables {
@@ -76,6 +82,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 16
 }

--- a/testdata/p4_16_samples_outputs/issue1595.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1595.p4.p4info.txtpb
@@ -31,6 +31,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1630-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1630-bmv2.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1653-complex-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1653-complex-bmv2.p4.p4info.txtpb
@@ -30,6 +30,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1713-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1713-bmv2.p4.p4info.txtpb
@@ -23,6 +23,9 @@ tables {
     id: 27086398
   }
   const_default_action_id: 25451019
+  initial_default_action {
+    action_id: 25451019
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1739-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1739-bmv2.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 32609675
   }
+  initial_default_action {
+    action_id: 32609675
+  }
   size: 1024
 }
 tables {
@@ -49,6 +52,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1765-1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1765-1-bmv2.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 64
 }
 tables {
@@ -54,6 +57,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 64
 }
 tables {
@@ -73,6 +79,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 64
 }

--- a/testdata/p4_16_samples_outputs/issue1765-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1765-bmv2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 25131402
   }
+  initial_default_action {
+    action_id: 25131402
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1814-1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1814-1-bmv2.p4.p4info.txtpb
@@ -27,6 +27,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1814-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1814-bmv2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1829-4-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1829-4-bmv2.p4.p4info.txtpb
@@ -20,6 +20,9 @@ tables {
     id: 23080345
   }
   const_default_action_id: 23080345
+  initial_default_action {
+    action_id: 23080345
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1834-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1834-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/issue1958.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1958.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1985.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1985.p4.p4info.txtpb
@@ -18,6 +18,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue1989-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue1989-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2044-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2044-bmv2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2153-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2153-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 30461719
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2170-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2170-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 30461719
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2258-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2258-bmv2.p4.p4info.txtpb
@@ -21,6 +21,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2266.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2266.p4.p4info.txtpb
@@ -18,6 +18,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2283_1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2283_1-bmv2.p4.p4info.txtpb
@@ -39,6 +39,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2321.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2321.p4.p4info.txtpb
@@ -29,6 +29,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2344.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2344.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2362-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2362-bmv2.p4.p4info.txtpb
@@ -21,6 +21,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -39,6 +42,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue2375-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2375-bmv2.p4.p4info.txtpb
@@ -18,6 +18,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2495-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2495-bmv2.p4.p4info.txtpb
@@ -15,6 +15,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue2904.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2904.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/issue2905-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue2905-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
 }

--- a/testdata/p4_16_samples_outputs/issue297-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue297-bmv2.p4.p4info.txtpb
@@ -17,6 +17,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 289199568
   size: 1024
 }
@@ -33,6 +36,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 300324846
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue298-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue298-bmv2.p4.p4info.txtpb
@@ -13,6 +13,9 @@ tables {
   action_refs {
     id: 28773984
   }
+  initial_default_action {
+    action_id: 28773984
+  }
   size: 8
 }
 tables {
@@ -32,6 +35,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 2
 }

--- a/testdata/p4_16_samples_outputs/issue3374.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue3374.p4.p4info.txtpb
@@ -20,6 +20,9 @@ tables {
     id: 18712486
   }
   const_default_action_id: 18712486
+  initial_default_action {
+    action_id: 18712486
+  }
   size: 1000000
 }
 tables {
@@ -38,6 +41,9 @@ tables {
     id: 32723879
   }
   const_default_action_id: 32723879
+  initial_default_action {
+    action_id: 32723879
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue3483_ubpf.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue3483_ubpf.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue3488-1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue3488-1-bmv2.p4.p4info.txtpb
@@ -30,6 +30,13 @@ tables {
     annotations: "@defaut_only"
   }
   const_default_action_id: 18870058
+  initial_default_action {
+    action_id: 18870058
+    arguments {
+      param_id: 1
+      value: "\000\002"
+    }
+  }
   size: 1024
 }
 tables {
@@ -52,6 +59,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -73,6 +83,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue3488-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue3488-bmv2.p4.p4info.txtpb
@@ -30,6 +30,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -52,6 +55,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -73,6 +79,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue3550.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue3550.p4.p4info.txtpb
@@ -58,6 +58,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true
@@ -97,6 +100,9 @@ tables {
   }
   action_refs {
     id: 29480552
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
   is_const_table: true

--- a/testdata/p4_16_samples_outputs/issue364-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue364-bmv2.p4.p4info.txtpb
@@ -14,6 +14,13 @@ tables {
     id: 32530319
   }
   const_default_action_id: 32530319
+  initial_default_action {
+    action_id: 32530319
+    arguments {
+      param_id: 1
+      value: "\000\000"
+    }
+  }
   direct_resource_ids: 330698586
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue383-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue383-bmv2.p4.p4info.txtpb
@@ -30,6 +30,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue414-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue414-bmv2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 25131402
   }
+  initial_default_action {
+    action_id: 25131402
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue420.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue420.p4.p4info.txtpb
@@ -16,6 +16,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue422.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue422.p4.p4info.txtpb
@@ -16,6 +16,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue461-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue461-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 20279829
   }
+  initial_default_action {
+    action_id: 20279829
+  }
   direct_resource_ids: 323801931
   size: 1024
 }
@@ -43,6 +46,9 @@ tables {
   action_refs {
     id: 32609675
   }
+  initial_default_action {
+    action_id: 32609675
+  }
   size: 1024
 }
 tables {
@@ -62,6 +68,9 @@ tables {
   }
   action_refs {
     id: 32609675
+  }
+  initial_default_action {
+    action_id: 32609675
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue486-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue486-bmv2.p4.p4info.txtpb
@@ -37,6 +37,9 @@ tables {
   action_refs {
     id: 25131402
   }
+  initial_default_action {
+    action_id: 25131402
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue512.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue512.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 25131402
   }
+  initial_default_action {
+    action_id: 25131402
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue561-1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue561-1-bmv2.p4.p4info.txtpb
@@ -32,6 +32,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue561-2-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue561-2-bmv2.p4.p4info.txtpb
@@ -32,6 +32,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue561-3-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue561-3-bmv2.p4.p4info.txtpb
@@ -32,6 +32,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue561-4-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue561-4-bmv2.p4.p4info.txtpb
@@ -44,6 +44,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue561-5-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue561-5-bmv2.p4.p4info.txtpb
@@ -32,6 +32,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue561-6-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue561-6-bmv2.p4.p4info.txtpb
@@ -44,6 +44,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue561-7-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue561-7-bmv2.p4.p4info.txtpb
@@ -32,6 +32,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue561-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue561-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 32609675
   }
+  initial_default_action {
+    action_id: 32609675
+  }
   size: 1024
 }
 tables {
@@ -42,6 +45,9 @@ tables {
   action_refs {
     id: 32609675
   }
+  initial_default_action {
+    action_id: 32609675
+  }
   size: 1024
 }
 tables {
@@ -61,6 +67,9 @@ tables {
   }
   action_refs {
     id: 32609675
+  }
+  initial_default_action {
+    action_id: 32609675
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue949.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue949.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue983-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue983-bmv2.p4.p4info.txtpb
@@ -91,6 +91,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/issue986-1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue986-1-bmv2.p4.p4info.txtpb
@@ -13,6 +13,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -23,6 +26,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/issue986-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue986-bmv2.p4.p4info.txtpb
@@ -13,6 +13,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/junk-prop-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/junk-prop-bmv2.p4.p4info.txtpb
@@ -13,6 +13,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/key-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/key-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/key1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/key1-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/logging-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/logging-bmv2.p4.p4info.txtpb
@@ -18,6 +18,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/lpm_ubpf.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/lpm_ubpf.p4.p4info.txtpb
@@ -28,6 +28,13 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 18876683
+    arguments {
+      param_id: 1
+      value: "\000\000\000\000"
+    }
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/m_psa-dpdk-non-zero-arg-default-action-08.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/m_psa-dpdk-non-zero-arg-default-action-08.p4.p4info.txtpb
@@ -16,6 +16,13 @@ tables {
   action_refs {
     id: 29027610
   }
+  initial_default_action {
+    action_id: 20013177
+    arguments {
+      param_id: 1
+      value: "\000\000\000\003"
+    }
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/match-on-exprs-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/match-on-exprs-bmv2.p4.p4info.txtpb
@@ -38,6 +38,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/match-on-exprs2-bmv2.p4.p4info.txtpb
@@ -38,6 +38,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/metadata_ubpf.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/metadata_ubpf.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -41,6 +44,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/multicast-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/multicast-bmv2.p4.p4info.txtpb
@@ -18,6 +18,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1
 }
 tables {
@@ -42,6 +45,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 512
 }
@@ -68,6 +74,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -92,6 +101,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 256
 }

--- a/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/named_meter_1-bmv2.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 16
 }
 tables {
@@ -47,6 +50,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   direct_resource_ids: 368209065
   size: 16384

--- a/testdata/p4_16_samples_outputs/named_meter_bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/named_meter_bmv2.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 16
 }
 tables {
@@ -47,6 +50,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   direct_resource_ids: 354402025
   size: 16384

--- a/testdata/p4_16_samples_outputs/nested_if_else.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/nested_if_else.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/nested_if_lvalue_dependencies.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/nested_if_statement.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/nested_if_statement.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/nonstandard_table_names-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/nonstandard_table_names-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 24698652
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -41,6 +44,9 @@ tables {
   }
   action_refs {
     id: 24698652
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }
@@ -62,6 +68,9 @@ tables {
   action_refs {
     id: 24698652
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -82,6 +91,9 @@ tables {
   action_refs {
     id: 24698652
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -101,6 +113,9 @@ tables {
   }
   action_refs {
     id: 24698652
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/omec/up4.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/omec/up4.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -37,6 +40,21 @@ tables {
     id: 26090030
   }
   const_default_action_id: 26090030
+  initial_default_action {
+    action_id: 26090030
+    arguments {
+      param_id: 1
+      value: "\000"
+    }
+    arguments {
+      param_id: 2
+      value: "\000"
+    }
+    arguments {
+      param_id: 3
+      value: "\000"
+    }
+  }
   size: 1024
 }
 tables {
@@ -69,6 +87,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28401267
+  initial_default_action {
+    action_id: 28401267
+  }
   size: 1024
 }
 tables {
@@ -98,6 +119,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28401267
+  initial_default_action {
+    action_id: 28401267
+  }
   size: 1024
 }
 tables {
@@ -130,6 +154,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28401267
+  initial_default_action {
+    action_id: 28401267
+  }
   size: 1024
 }
 tables {
@@ -162,6 +189,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 28401267
+  initial_default_action {
+    action_id: 28401267
+  }
   size: 1024
 }
 tables {
@@ -198,6 +228,13 @@ tables {
     id: 23010411
   }
   const_default_action_id: 23010411
+  initial_default_action {
+    action_id: 23010411
+    arguments {
+      param_id: 1
+      value: "\000"
+    }
+  }
   size: 1024
 }
 tables {
@@ -220,6 +257,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -241,6 +281,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   implementation_id: 297808402
   size: 1024
@@ -327,6 +370,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 325583051
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/p416-type-use3.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/p416-type-use3.p4.p4info.txtpb
@@ -124,6 +124,9 @@ tables {
   action_refs {
     id: 21580947
   }
+  initial_default_action {
+    action_id: 21580947
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/parenthesis-test_ubpf.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/parenthesis-test_ubpf.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/parser-locals2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/parser-locals2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 25131402
   }
+  initial_default_action {
+    action_id: 25131402
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/pins/pins_fabric.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/pins/pins_fabric.p4.p4info.txtpb
@@ -38,6 +38,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 126
 }
 tables {
@@ -62,6 +65,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1
 }
@@ -162,6 +168,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 318767361
   size: 254
 }
@@ -198,6 +207,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 64
 }
 tables {
@@ -222,6 +234,9 @@ tables {
     annotations: "@proto_id(1)"
   }
   const_default_action_id: 24742814
+  initial_default_action {
+    action_id: 24742814
+  }
   size: 64
 }
 tables {
@@ -273,6 +288,9 @@ tables {
     annotations: "@proto_id(7)"
   }
   const_default_action_id: 16777222
+  initial_default_action {
+    action_id: 16777222
+  }
   size: 131072
 }
 tables {
@@ -324,6 +342,9 @@ tables {
     annotations: "@proto_id(7)"
   }
   const_default_action_id: 16777222
+  initial_default_action {
+    action_id: 16777222
+  }
   size: 17000
 }
 tables {
@@ -359,6 +380,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1600
 }
 tables {
@@ -393,6 +417,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1600
 }
@@ -573,6 +600,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 318767362
   direct_resource_ids: 352321792
   size: 255
@@ -694,6 +724,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 318767367
   direct_resource_ids: 352321794
   size: 511
@@ -753,6 +786,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 318767369
   size: 255
 }
@@ -790,6 +826,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -822,6 +861,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 256
 }
 tables {
@@ -862,6 +904,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -890,6 +935,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 2048
 }
 tables {
@@ -919,6 +967,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 299650760
   size: 3968
 }
@@ -952,6 +1003,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 4
 }
 tables {
@@ -993,6 +1047,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -1027,6 +1084,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 110
 }
@@ -1108,6 +1168,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 318767364
   size: 127
 }

--- a/testdata/p4_16_samples_outputs/pins/pins_middleblock.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/pins/pins_middleblock.p4.p4info.txtpb
@@ -38,6 +38,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 126
 }
 tables {
@@ -62,6 +65,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1
 }
@@ -154,6 +160,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 318767361
   size: 254
 }
@@ -190,6 +199,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 64
 }
 tables {
@@ -214,6 +226,9 @@ tables {
     annotations: "@proto_id(1)"
   }
   const_default_action_id: 24742814
+  initial_default_action {
+    action_id: 24742814
+  }
   size: 64
 }
 tables {
@@ -265,6 +280,9 @@ tables {
     annotations: "@proto_id(7)"
   }
   const_default_action_id: 16777222
+  initial_default_action {
+    action_id: 16777222
+  }
   size: 131072
 }
 tables {
@@ -316,6 +334,9 @@ tables {
     annotations: "@proto_id(7)"
   }
   const_default_action_id: 16777222
+  initial_default_action {
+    action_id: 16777222
+  }
   size: 17000
 }
 tables {
@@ -351,6 +372,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1600
 }
 tables {
@@ -385,6 +409,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1600
 }
@@ -549,6 +576,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 318767362
   direct_resource_ids: 352321792
   size: 255
@@ -639,6 +669,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 255
 }
 tables {
@@ -721,6 +754,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 318767370
   size: 255
 }
@@ -758,6 +794,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -790,6 +829,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 256
 }
 tables {
@@ -830,6 +872,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -858,6 +903,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 2048
 }
 tables {
@@ -887,6 +935,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 299650760
   size: 3968
 }
@@ -920,6 +971,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 4
 }
 tables {
@@ -961,6 +1015,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -995,6 +1052,9 @@ tables {
     id: 21257015
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 110
 }
@@ -1063,6 +1123,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 318767364
   size: 127
 }

--- a/testdata/p4_16_samples_outputs/pins/pins_wbb.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/pins/pins_wbb.p4.p4info.txtpb
@@ -65,6 +65,9 @@ tables {
     scope: DEFAULT_ONLY
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 318767363
   direct_resource_ids: 352321793
   size: 8

--- a/testdata/p4_16_samples_outputs/psa-action-profile1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-action-profile1.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 298015716
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-action-profile3.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-action-profile3.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 298015716
   size: 1024
 }
@@ -48,6 +51,9 @@ tables {
   }
   action_refs {
     id: 23466264
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   implementation_id: 298015716
   size: 1024

--- a/testdata/p4_16_samples_outputs/psa-action-profile4.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-action-profile4.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 298015716
   size: 1024
 }
@@ -42,6 +45,9 @@ tables {
   }
   action_refs {
     id: 21832421
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   implementation_id: 298015716
   size: 1024

--- a/testdata/p4_16_samples_outputs/psa-action-selector1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-action-selector1.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 294316857
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-action-selector2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-action-selector2.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 294316857
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-action-selector3.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-action-selector3.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-action-selector4.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-action-selector4.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 294316857
   size: 1024
 }
@@ -36,6 +39,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-action-selector5.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-action-selector5.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 28661769
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 294316857
   size: 1024
 }
@@ -37,6 +40,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -47,6 +53,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-action-selector6.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-action-selector6.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 28661769
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 294316857
   size: 1024
 }
@@ -49,6 +52,9 @@ tables {
   action_refs {
     id: 28661769
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 298015716
   size: 1024
 }
@@ -61,6 +67,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -71,6 +80,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-basic-counter-bmv2.p4.p4info.txtpb
@@ -13,6 +13,9 @@ tables {
   action_refs {
     id: 17064084
   }
+  initial_default_action {
+    action_id: 17064084
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-conditional_operator.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 22078320
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-counter1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-counter1.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 22078320
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-counter2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-counter2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 22078320
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-counter4.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-counter4.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 319980461
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-custom-type-counter-index.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 22078320
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-128bitCast.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-128bitCast.p4.p4info.txtpb
@@ -18,6 +18,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-1.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 25756908
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 25756908
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-checksum-arg-header.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-checksum-arg-header.p4.p4info.txtpb
@@ -23,6 +23,9 @@ tables {
     id: 33281717
   }
   const_default_action_id: 33281717
+  initial_default_action {
+    action_id: 33281717
+  }
   size: 1048576
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-1.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode-2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-errorcode.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-errorcode.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-flatten-local-struct.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-flatten-local-struct.p4.p4info.txtpb
@@ -23,6 +23,9 @@ tables {
     id: 33281717
   }
   const_default_action_id: 33281717
+  initial_default_action {
+    action_id: 33281717
+  }
   size: 1048576
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-hdr-field-non-align.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-hdr-field-non-align.p4.p4info.txtpb
@@ -18,6 +18,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-header-union-typedef.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-header-union-typedef.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 25756908
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-large-header-fields.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-large-header-fields.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-large-struct-fields.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-large-struct-fields.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err3.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err3.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err4.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-valid.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-01.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-01.p4.p4info.txtpb
@@ -17,6 +17,17 @@ tables {
     id: 29027610
   }
   const_default_action_id: 20013177
+  initial_default_action {
+    action_id: 20013177
+    arguments {
+      param_id: 1
+      value: "\000\000\000\001"
+    }
+    arguments {
+      param_id: 2
+      value: "\000\000\000\002"
+    }
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-02.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-02.p4.p4info.txtpb
@@ -16,6 +16,17 @@ tables {
   action_refs {
     id: 29027610
   }
+  initial_default_action {
+    action_id: 20013177
+    arguments {
+      param_id: 1
+      value: "\000\000\000\001"
+    }
+    arguments {
+      param_id: 2
+      value: "\000\000\000\002"
+    }
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-03.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-03.p4.p4info.txtpb
@@ -17,6 +17,9 @@ tables {
     id: 29027610
   }
   const_default_action_id: 20013177
+  initial_default_action {
+    action_id: 20013177
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-04.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-04.p4.p4info.txtpb
@@ -16,6 +16,9 @@ tables {
   action_refs {
     id: 29027610
   }
+  initial_default_action {
+    action_id: 20013177
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-05.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-05.p4.p4info.txtpb
@@ -20,6 +20,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-06.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-06.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-07.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-07.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-08.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-08.p4.p4info.txtpb
@@ -16,6 +16,13 @@ tables {
   action_refs {
     id: 29027610
   }
+  initial_default_action {
+    action_id: 20013177
+    arguments {
+      param_id: 1
+      value: "\000\000\000\003"
+    }
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-09.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-non-zero-arg-default-action-09.p4.p4info.txtpb
@@ -17,6 +17,17 @@ tables {
     id: 29027610
   }
   const_default_action_id: 20013177
+  initial_default_action {
+    action_id: 20013177
+    arguments {
+      param_id: 1
+      value: "\000\000\000\001"
+    }
+    arguments {
+      param_id: 2
+      value: "\000"
+    }
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-struct-field.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-struct-field.p4.p4info.txtpb
@@ -18,6 +18,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-entries-exact-ternary.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if-1.p4.p4info.txtpb
@@ -37,6 +37,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -72,6 +75,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -82,6 +88,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-if.p4.p4info.txtpb
@@ -37,6 +37,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -48,6 +51,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -58,6 +64,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-1.p4.p4info.txtpb
@@ -40,6 +40,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-10.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-10.p4.p4info.txtpb
@@ -40,6 +40,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-2.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-3.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-4.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 17082815
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-5.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-6.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-7.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-8.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys-9.p4.p4info.txtpb
@@ -64,6 +64,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-mixed-keys.p4.p4info.txtpb
@@ -40,6 +40,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-consolidation-switch.p4.p4info.txtpb
@@ -31,6 +31,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -42,6 +45,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -52,6 +58,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error-1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error-1.p4.p4info.txtpb
@@ -70,6 +70,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-error.p4.p4info.txtpb
@@ -40,6 +40,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid1.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid2.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid3.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid4.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid5.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid6.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid7.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-table-key-isValid7.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-tmp-mask-align.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-tmp-mask-align.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-token-too-big.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-token-too-big.p4.p4info.txtpb
@@ -23,6 +23,9 @@ tables {
     id: 33281717
   }
   const_default_action_id: 33281717
+  initial_default_action {
+    action_id: 33281717
+  }
   size: 1048576
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-counters-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-counters-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 25648360
   }
+  initial_default_action {
+    action_id: 25648360
+  }
   direct_resource_ids: 332805598
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-example-digest-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-digest-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 26564927
   }
+  initial_default_action {
+    action_id: 26564927
+  }
   size: 1024
 }
 tables {
@@ -41,6 +44,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }
@@ -64,6 +70,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_1.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_3.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_4.p4.p4info.txtpb
@@ -27,6 +27,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_5.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_6.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_7.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_8.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-byte-alignment_9.p4.p4info.txtpb
@@ -34,6 +34,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-directmeter.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 18579058
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 368068636
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-externs.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter-execute-err.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-meter1.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-dpdk-varbit-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   implementation_id: 298015716
   size: 1024
 }
@@ -42,6 +45,9 @@ tables {
   }
   action_refs {
     id: 21832421
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   implementation_id: 298015716
   size: 1024

--- a/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-incremental-checksum.p4.p4info.txtpb
@@ -27,6 +27,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-logical-operations.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-mask-range1.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-optional-match.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-optional-match.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-range-match.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-range-match.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-1.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-mask.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple-wc.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-select_tuple.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 29480552
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-example-switch-with-constant-expr.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-example-switch-with-constant-expr.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-hash-02.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-hash-02.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21832421
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-hash-03.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-hash-03.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21832421
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-hash-04.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-hash-04.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21832421
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-hash-05.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-hash-05.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21832421
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-hash-06.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-hash-06.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21832421
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-hash-07.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-hash-07.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21832421
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-hash-08.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-hash-08.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21832421
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-hash-09.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-hash-09.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21832421
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-hash-10.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-hash-10.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21832421
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-hash.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-hash.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21832421
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-header-stack.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-header-stack.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-idle-timeout.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
   idle_timeout_behavior: NOTIFY_CONTROL
 }
@@ -49,6 +52,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -71,6 +77,9 @@ tables {
   }
   action_refs {
     id: 23466264
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-isvalid.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-isvalid.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-meter1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-meter1.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 22078320
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-meter3.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-meter3.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-meter4.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-meter4.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 368068636
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-meter5.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-meter5.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   direct_resource_ids: 368068636
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-random.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-random.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 18493089
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-recirculate-no-meta-bmv2.p4.p4info.txtpb
@@ -13,6 +13,9 @@ tables {
   action_refs {
     id: 25218586
   }
+  initial_default_action {
+    action_id: 25218586
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-register1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-register1.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 23115527
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-register2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-register2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 23115527
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-register3.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-register3.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 23115527
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-remove-header.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-remove-header.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21620615
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-subtract-inst1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-subtract-inst1.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 29027610
   }
   const_default_action_id: 29027610
+  initial_default_action {
+    action_id: 29027610
+  }
   size: 1000000
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4.p4info.txtpb
@@ -31,6 +31,9 @@ tables {
   action_refs {
     id: 23466264
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -42,6 +45,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -52,6 +58,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-table-hit-miss.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21620615
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/psa-variable-index.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-variable-index.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/pvs-bitstring-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/pvs-struct-1-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/pvs-struct-2-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/pvs-struct-3-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/same_name_for_table_and_action.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/same_name_for_table_and_action.p4.p4info.txtpb
@@ -23,6 +23,9 @@ tables {
     id: 21257015
   }
   const_default_action_id: 21257015
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/saturated-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/saturated-bmv2.p4.p4info.txtpb
@@ -31,6 +31,9 @@ tables {
   action_refs {
     id: 33281717
   }
+  initial_default_action {
+    action_id: 33281717
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/simple-actions_ubpf.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/simple-actions_ubpf.p4.p4info.txtpb
@@ -49,6 +49,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/slice-def-use1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/slice-def-use1.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 30218393
   }
   const_default_action_id: 30218393
+  initial_default_action {
+    action_id: 30218393
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/stack_complex-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/stack_complex-bmv2.p4.p4info.txtpb
@@ -14,6 +14,9 @@ tables {
     id: 29666769
   }
   const_default_action_id: 29666769
+  initial_default_action {
+    action_id: 29666769
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/std_meta_inlining.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/std_meta_inlining.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/strength3.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/strength3.p4.p4info.txtpb
@@ -35,6 +35,9 @@ tables {
     id: 19874155
   }
   const_default_action_id: 25451019
+  initial_default_action {
+    action_id: 25451019
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/strength6.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/strength6.p4.p4info.txtpb
@@ -26,6 +26,9 @@ tables {
     id: 32959729
   }
   const_default_action_id: 25451019
+  initial_default_action {
+    action_id: 25451019
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/structured_annotations.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/structured_annotations.p4.p4info.txtpb
@@ -78,6 +78,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/table-entries-exact-ternary-bmv2.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/table-entries-lpm-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/table-entries-optional-bmv2.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/table-entries-priority-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/table-entries-range-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/table-entries-ser-enum-bmv2.p4.p4info.txtpb
@@ -29,6 +29,9 @@ tables {
     id: 17165658
   }
   const_default_action_id: 21186165
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/table-entries-ternary-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/table-entries-valid-bmv2.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 17165658
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/table-key-serenum-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/table-key-serenum-bmv2.p4.p4info.txtpb
@@ -24,6 +24,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/ternary2-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/ternary2-bmv2.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 27489497
   }
+  initial_default_action {
+    action_id: 27489497
+  }
   size: 1024
 }
 tables {
@@ -51,6 +54,9 @@ tables {
   action_refs {
     id: 27489497
   }
+  initial_default_action {
+    action_id: 27489497
+  }
   size: 1024
 }
 tables {
@@ -70,6 +76,9 @@ tables {
   }
   action_refs {
     id: 27489497
+  }
+  initial_default_action {
+    action_id: 27489497
   }
   size: 1024
 }
@@ -91,6 +100,9 @@ tables {
   action_refs {
     id: 27489497
   }
+  initial_default_action {
+    action_id: 27489497
+  }
   size: 1024
 }
 tables {
@@ -110,6 +122,9 @@ tables {
   }
   action_refs {
     id: 27489497
+  }
+  initial_default_action {
+    action_id: 27489497
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/tunneling_ubpf.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/tunneling_ubpf.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -41,6 +44,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/union-valid-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/union-valid-bmv2.p4.p4info.txtpb
@@ -19,6 +19,9 @@ tables {
   action_refs {
     id: 21186165
   }
+  initial_default_action {
+    action_id: 21186165
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/unused-counter-bmv2.p4.p4info.txtpb
@@ -14,6 +14,13 @@ tables {
     id: 32530319
   }
   const_default_action_id: 32530319
+  initial_default_action {
+    action_id: 32530319
+    arguments {
+      param_id: 1
+      value: "\000\000"
+    }
+  }
   direct_resource_ids: 330698586
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/use-priority-as-name.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/use-priority-as-name.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 32254556
   }
+  initial_default_action {
+    action_id: 32254556
+  }
   size: 1024
 }
 tables {
@@ -42,6 +45,9 @@ tables {
   action_refs {
     id: 32254556
   }
+  initial_default_action {
+    action_id: 32254556
+  }
   size: 1024
 }
 tables {
@@ -61,6 +67,9 @@ tables {
   }
   action_refs {
     id: 27859478
+  }
+  initial_default_action {
+    action_id: 27859478
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/v1model-const-entries-bmv2.p4.p4info.txtpb
@@ -23,6 +23,9 @@ tables {
     id: 28447573
   }
   const_default_action_id: 30352513
+  initial_default_action {
+    action_id: 30352513
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true

--- a/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/v1model-digest-containing-ser-enum.p4.p4info.txtpb
@@ -25,6 +25,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -48,6 +51,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -67,6 +73,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/v1model-digest-custom-type.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/v1model-digest-custom-type.p4.p4info.txtpb
@@ -28,6 +28,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -54,6 +57,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -73,6 +79,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-enumint-types1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-enumint-types1.p4.p4info.txtpb
@@ -238,6 +238,9 @@ tables {
   action_refs {
     id: 21580947
   }
+  initial_default_action {
+    action_id: 21580947
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/v1model-p4runtime-most-types1.p4.p4info.txtpb
@@ -238,6 +238,9 @@ tables {
   action_refs {
     id: 21580947
   }
+  initial_default_action {
+    action_id: 21580947
+  }
   size: 1024
 }
 actions {

--- a/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/v1model-special-ops-bmv2.p4.p4info.txtpb
@@ -31,6 +31,9 @@ tables {
   action_refs {
     id: 32609675
   }
+  initial_default_action {
+    action_id: 32609675
+  }
   size: 1024
 }
 tables {
@@ -50,6 +53,9 @@ tables {
   }
   action_refs {
     id: 32609675
+  }
+  initial_default_action {
+    action_id: 32609675
   }
   size: 1024
 }
@@ -79,6 +85,9 @@ tables {
     annotations: "@defaultonly"
     scope: DEFAULT_ONLY
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
 }
 tables {
@@ -104,6 +113,9 @@ tables {
   }
   action_refs {
     id: 32609675
+  }
+  initial_default_action {
+    action_id: 32609675
   }
   size: 1024
 }

--- a/testdata/p4_16_samples_outputs/xor_test.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/xor_test.p4.p4info.txtpb
@@ -22,6 +22,9 @@ tables {
   action_refs {
     id: 21257015
   }
+  initial_default_action {
+    action_id: 21257015
+  }
   size: 1024
   is_const_table: true
   has_initial_entries: true
@@ -82,6 +85,9 @@ tables {
   }
   action_refs {
     id: 21257015
+  }
+  initial_default_action {
+    action_id: 21257015
   }
   size: 1024
 }


### PR DESCRIPTION
Corresponding P4Runtime PR: https://github.com/p4lang/p4runtime/pull/486

Adds information about the default action of a table and the arguments it is invoked with to the generated P4Info file. 

This change also required some small additions to the `bytestrings` utility file. Moved `getTypeWidth` to the file and also added a new helper for general `IR::Expression` inputs. 


Fixes #4662.