### PR TITLE
Improve cstring cache internals

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,6 +51,8 @@ cc_library(
         ":config_h",
         "@boost//:format",
         "@boost//:multiprecision",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:node_hash_set",
         "@com_google_absl//absl/numeric:bits",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",

--- a/lib/cstring.cpp
+++ b/lib/cstring.cpp
@@ -185,6 +185,16 @@ const char *save_to_cache(const char *string, std::size_t length, table_entry_fl
 
 bool cstring::is_cached(std::string_view s) { return cache().contains(s); }
 
+cstring cstring::get_cached(std::string_view s) {
+    auto entry = cache().find(s);
+    if (entry == cache().end()) return nullptr;
+
+    cstring res;
+    res.str = entry->string();
+
+    return res;
+}
+
 void cstring::construct_from_shared(const char *string, std::size_t length) {
     str = save_to_cache(string, length, table_entry_flags::none);
 }

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -148,7 +148,10 @@ class cstring {
         return result;
     }
 
+    /// @return true if a given string is interned (contained in cstring cache)
     static bool is_cached(std::string_view s);
+    /// @return corresponding cstring if it was interned, null cstring otherwise
+    static cstring get_cached(std::string_view s);
 
  private:
     // passed string is shared, we not unique owners

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -148,6 +148,8 @@ class cstring {
         return result;
     }
 
+    static bool is_cached(std::string_view s);
+
  private:
     // passed string is shared, we not unique owners
     void construct_from_shared(const char *string, std::size_t length);

--- a/test/gtest/cstring.cpp
+++ b/test/gtest/cstring.cpp
@@ -144,16 +144,14 @@ TEST(cstring, literalSuffix) {
 }
 
 TEST(cstring, is_cached) {
-    cstring test = "test"_cs;
-    (void)test;
+    [[maybe_unused]] cstring test = "test"_cs;
     EXPECT_FALSE(
         cstring::is_cached("we really do not expect that this string is already in cstring cache"));
     EXPECT_TRUE(cstring::is_cached("test"));
 }
 
 TEST(cstring, get_cached) {
-    cstring test = "test"_cs;
-    (void)test;
+    [[maybe_unused]] cstring test = "test"_cs;
     EXPECT_TRUE(
         cstring::get_cached("we really do not expect that this string is already in cstring cache")
             .isNull());

--- a/test/gtest/cstring.cpp
+++ b/test/gtest/cstring.cpp
@@ -144,9 +144,20 @@ TEST(cstring, literalSuffix) {
 }
 
 TEST(cstring, is_cached) {
+    cstring test = "test"_cs;
+    (void)test;
     EXPECT_FALSE(
         cstring::is_cached("we really do not expect that this string is already in cstring cache"));
     EXPECT_TRUE(cstring::is_cached("test"));
+}
+
+TEST(cstring, get_cached) {
+    cstring test = "test"_cs;
+    (void)test;
+    EXPECT_TRUE(
+        cstring::get_cached("we really do not expect that this string is already in cstring cache")
+            .isNull());
+    EXPECT_FALSE(cstring::get_cached("test").isNullOrEmpty());
 }
 
 }  // namespace Test

--- a/test/gtest/cstring.cpp
+++ b/test/gtest/cstring.cpp
@@ -143,4 +143,10 @@ TEST(cstring, literalSuffix) {
     EXPECT_TRUE((std::is_same_v<cstring, decltype(""_cs)>));
 }
 
+TEST(cstring, is_cached) {
+    EXPECT_FALSE(
+        cstring::is_cached("we really do not expect that this string is already in cstring cache"));
+    EXPECT_TRUE(cstring::is_cached("test"));
+}
+
 }  // namespace Test


### PR DESCRIPTION
 - Add cache introspection methods (`is_cached` / `get_cached`) without implicitly constructing cstrings
 - Refactor caching to use only single map lookup regardless whether we'd need to insert something into cache or the value is already there
 - Switch to better underlying map

This is a spin-off from https://github.com/p4lang/p4c/pull/4774