### PR TITLE
Fix loop unrolling bugs related to issue4739

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
@@ -57,6 +57,12 @@ p4tools_add_xfail_reason(
   # and more specifically when member is passed to getTypeArray
 )
 
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Unhandled node type in Bmv2V1ModelCmdStepper: ForStatement"
+  issue4739.p4
+)
+
 ####################################################################################################
 # 3. WONTFIX
 ####################################################################################################

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -101,6 +101,12 @@ p4tools_add_xfail_reason(
   issue907-bmv2.p4
 )
 
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-ptf"
+  "Unhandled node type in Bmv2V1ModelCmdStepper: ForStatement"
+  issue4739.p4
+)
+
 ####################################################################################################
 # 3. WONTFIX
 # These are failures that can not be solved by changing P4Testgen

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufIrXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufIrXfail.cmake
@@ -74,6 +74,12 @@ p4tools_add_xfail_reason(
   parser-unroll-test10.p4
 )
 
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-protobuf-ir"
+  "Unhandled node type in Bmv2V1ModelCmdStepper: ForStatement"
+  issue4739.p4
+)
+
 ####################################################################################################
 # 3. WONTFIX
 ####################################################################################################

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
@@ -101,6 +101,12 @@ p4tools_add_xfail_reason(
   issue907-bmv2.p4
 )
 
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-stf"
+  "Unhandled node type in Bmv2V1ModelCmdStepper: ForStatement"
+  issue4739.p4
+)
+
 ####################################################################################################
 # 3. WONTFIX
 # These are failures that can not be solved by changing P4Testgen

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -948,6 +948,22 @@ class FindUninitialized : public Inspector {
         return setCurrent(statement);
     }
 
+    bool preorder(const IR::ForStatement *statement) override {
+        Log::TempIndent indent;
+        LOG3("FU Visiting " << dbp(statement) << " " << statement << indent);
+        if (!unreachable) {
+            visit(statement->init, "init");
+            // use the live state from the end of the loop, as that jumps to the condition
+            setCurrent(statement);
+            visit(statement->condition, "condition");
+            visit(statement->body, "body");
+            visit(statement->updates, "updates");
+        } else {
+            LOG3("Unreachable");
+        }
+        return setCurrent(statement);
+    }
+
     bool preorder(const IR::ForInStatement *statement) override {
         Log::TempIndent indent;
         LOG3("FU Visiting " << dbp(statement) << " " << statement << indent);

--- a/midend/def_use.h
+++ b/midend/def_use.h
@@ -77,6 +77,7 @@ class ComputeDefUse : public Inspector,
             return nullptr;
         }
     };
+    typedef ordered_set<const loc_t *> locset_t;
 
  private:
     std::set<loc_t> &cached_locs;
@@ -90,13 +91,13 @@ class ComputeDefUse : public Inspector,
         // definitions of a symbol (or part of a symbol) visible at this point in the
         // program.  `defs` will be empty if `live` is; if not those defs are visible only
         // for those bits/elements/fields where live is set.
-        ordered_set<const loc_t *> defs;
+        locset_t defs;
         bitvec live;
         // FIXME -- this parent field is never used and is not set consistently, so
         // appears to be useless?
         def_info_t *parent = nullptr;
         // track valid bit access for headers separate from the rest of the header
-        ordered_set<const loc_t *> valid_bit_defs;
+        locset_t valid_bit_defs;
         // one of these maps will always be empty.
         std::map<cstring, def_info_t> fields;
         std::map<le_bitrange, def_info_t> slices;  // also used for arrays
@@ -121,10 +122,10 @@ class ComputeDefUse : public Inspector,
         // defs maps from all uses to their definitions
         // uses maps from all definitions to their uses
         // uses/defs are lvalue expressions, or param declarations.
-        ordered_map<const IR::Node *, ordered_set<const loc_t *>> defs;
-        ordered_map<const IR::Node *, ordered_set<const loc_t *>> uses;
+        ordered_map<const IR::Node *, locset_t> defs;
+        ordered_map<const IR::Node *, locset_t> uses;
     } & defuse;
-    static const ordered_set<const loc_t *> empty;
+    static const locset_t empty;
 
     profile_t init_apply(const IR::Node *root) override {
         auto rv = Inspector::init_apply(root);
@@ -170,11 +171,11 @@ class ComputeDefUse : public Inspector,
         defuse.uses.clear();
     }
 
-    const ordered_set<const loc_t *> &getDefs(const IR::Node *n) const {
+    const locset_t &getDefs(const IR::Node *n) const {
         auto it = defuse.defs.find(n);
         return it == defuse.defs.end() ? empty : it->second;
     }
-    const ordered_set<const loc_t *> &getUses(const IR::Node *n) const {
+    const locset_t &getUses(const IR::Node *n) const {
         auto it = defuse.uses.find(n);
         return it == defuse.uses.end() ? empty : it->second;
     }

--- a/midend/def_use.h
+++ b/midend/def_use.h
@@ -43,7 +43,14 @@ class ComputeDefUse : public Inspector,
                       public ControlFlowVisitor,
                       public P4WriteContext,
                       public P4::ResolutionContext {
-    ComputeDefUse *clone() const override { return new ComputeDefUse(*this); }
+    static int uid_ctr;
+    int uid = 0;
+    ComputeDefUse *clone() const override {
+        auto *rv = new ComputeDefUse(*this);
+        rv->uid = ++uid_ctr;
+        LOG8("ComputeDefUse::clone " << rv->uid);
+        return rv;
+    }
     void flow_merge(Visitor &) override;
     void flow_copy(ControlFlowVisitor &) override;
     bool operator==(const ControlFlowVisitor &) const override;
@@ -122,6 +129,7 @@ class ComputeDefUse : public Inspector,
     profile_t init_apply(const IR::Node *root) override {
         auto rv = Inspector::init_apply(root);
         LOG3("## Midend ComputeDefUse");
+        uid_ctr = 0;
         state = SKIPPING;
         clear();
         return rv;
@@ -137,6 +145,7 @@ class ComputeDefUse : public Inspector,
     bool preorder(const IR::Type *) override { return false; }
     bool preorder(const IR::Annotations *) override { return false; }
     bool preorder(const IR::KeyElement *) override;
+    bool preorder(const IR::AssignmentStatement *) override;
     const IR::Expression *do_read(def_info_t &, const IR::Expression *, const Context *);
     const IR::Expression *do_write(def_info_t &, const IR::Expression *, const Context *);
     bool preorder(const IR::PathExpression *) override;

--- a/midend/unrollLoops.h
+++ b/midend/unrollLoops.h
@@ -30,6 +30,7 @@ class UnrollLoops : public Transform, public P4::ResolutionContext {
         const IR::Declaration_Variable *index = nullptr;
         std::vector<long> indexes;
     };
+    long evalLoop(const IR::Expression *, long, const ComputeDefUse::locset_t &, bool &);
     bool findLoopBounds(IR::ForStatement *, loop_bounds_t &);
     bool findLoopBounds(IR::ForInStatement *, loop_bounds_t &);
     const IR::Statement *doUnroll(const loop_bounds_t &, const IR::Statement *,

--- a/testdata/p4_16_samples/issue4739.p4
+++ b/testdata/p4_16_samples/issue4739.p4
@@ -1,0 +1,91 @@
+/*
+Copyright 2024 Andy Fingerhut
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser parserImpl(packet_in packet,
+                  out headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t stdmeta)
+{
+    state start {
+        packet.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr,
+                    inout metadata_t meta,
+                    inout standard_metadata_t stdmeta)
+{
+    bit<8> n;
+    apply {
+        n = 0;
+        for (bit<8> i = 0; i < 8; i = i + 1) {
+            i = i + 1;
+            n = n + 1;
+        }
+        hdr.ethernet.srcAddr[7:0] = n;
+        stdmeta.egress_spec = 1;
+    }
+}
+
+control egressImpl(inout headers_t hdr,
+                   inout metadata_t meta,
+                   inout standard_metadata_t stdmeta)
+{
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet,
+                     in headers_t hdr)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+V1Switch(parserImpl(),
+         verifyChecksum(),
+         ingressImpl(),
+         egressImpl(),
+         updateChecksum(),
+         deparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4739-first.p4
+++ b/testdata/p4_16_samples_outputs/issue4739-first.p4
@@ -1,0 +1,59 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    bit<8> n;
+    apply {
+        n = 8w0;
+        for (bit<8> i = 8w0; i < 8w8; i = i + 8w1) {
+            i = i + 8w1;
+            n = n + 8w1;
+        }
+        hdr.ethernet.srcAddr[7:0] = n;
+        stdmeta.egress_spec = 9w1;
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4739-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue4739-frontend.p4
@@ -1,0 +1,60 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @name("ingressImpl.n") bit<8> n_0;
+    @name("ingressImpl.i") bit<8> i_0;
+    apply {
+        n_0 = 8w0;
+        for (i_0 = 8w0; i_0 < 8w8; i_0 = i_0 + 8w1) {
+            i_0 = i_0 + 8w1;
+            n_0 = n_0 + 8w1;
+        }
+        hdr.ethernet.srcAddr[7:0] = n_0;
+        stdmeta.egress_spec = 9w1;
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4739-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue4739-midend.p4
@@ -1,0 +1,87 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    @name("ingressImpl.n") bit<8> n_0;
+    @name("ingressImpl.i") bit<8> i_0;
+    @hidden action issue4739l52() {
+        i_0 = i_0 + 8w1;
+        n_0 = n_0 + 8w1;
+    }
+    @hidden action issue4739l50() {
+        n_0 = 8w0;
+    }
+    @hidden action issue4739l55() {
+        hdr.ethernet.srcAddr[7:0] = n_0;
+        stdmeta.egress_spec = 9w1;
+    }
+    @hidden table tbl_issue4739l50 {
+        actions = {
+            issue4739l50();
+        }
+        const default_action = issue4739l50();
+    }
+    @hidden table tbl_issue4739l52 {
+        actions = {
+            issue4739l52();
+        }
+        const default_action = issue4739l52();
+    }
+    @hidden table tbl_issue4739l55 {
+        actions = {
+            issue4739l55();
+        }
+        const default_action = issue4739l55();
+    }
+    apply {
+        tbl_issue4739l50.apply();
+        for (i_0 = 8w0; i_0 < 8w8; i_0 = i_0 + 8w1) {
+            tbl_issue4739l52.apply();
+        }
+        tbl_issue4739l55.apply();
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+V1Switch<headers_t, metadata_t>(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4739.p4
+++ b/testdata/p4_16_samples_outputs/issue4739.p4
@@ -1,0 +1,59 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct metadata_t {
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+parser parserImpl(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    state start {
+        packet.extract(hdr.ethernet);
+        transition accept;
+    }
+}
+
+control ingressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    bit<8> n;
+    apply {
+        n = 0;
+        for (bit<8> i = 0; i < 8; i = i + 1) {
+            i = i + 1;
+            n = n + 1;
+        }
+        hdr.ethernet.srcAddr[7:0] = n;
+        stdmeta.egress_spec = 1;
+    }
+}
+
+control egressImpl(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control deparserImpl(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+control verifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control updateChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+V1Switch(parserImpl(), verifyChecksum(), ingressImpl(), egressImpl(), updateChecksum(), deparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4739.p4.entries.txtpb
+++ b/testdata/p4_16_samples_outputs/issue4739.p4.entries.txtpb
@@ -1,0 +1,3 @@
+# proto-file: p4/v1/p4runtime.proto
+# proto-message: p4.v1.WriteRequest
+

--- a/testdata/p4_16_samples_outputs/issue4739.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/issue4739.p4.p4info.txtpb
@@ -1,0 +1,6 @@
+# proto-file: p4/config/v1/p4info.proto
+# proto-message: p4.config.v1.P4Info
+
+pkg_info {
+  arch: "v1model"
+}


### PR DESCRIPTION
- fix FindUninitialized in simplifyDefUse.cpp to correctly get live state for for loop bodies, so as to not dead-code eliminate things unused after the loop exit
- fix midend/def_use.cpp ComputeDefUse to visit assignments right then left to get correct info for assignments that read the old value of the lhs
- fix loopUnrolling.cpp UnrollLoops to not unroll loops where the index is modified in the loop body in addition to the loop increment.
- more logging in ComputeDefUse to see help debugging