### PR TITLE
[P4Testgen] Unify compiler options and tool options. Ensure options context is always initialized correctly.

### DIFF
--- a/backends/p4tools/BUILD.bazel
+++ b/backends/p4tools/BUILD.bazel
@@ -117,11 +117,11 @@ filegroup(
     srcs =
         glob(
             ["modules/testgen/targets/%s/**/*.h" % target for target in TESTGEN_TARGETS],
-            exclude = ["modules/testgen/targets/%s/test/**" % target for target in TESTGEN_TARGETS],
+            exclude = ["modules/testgen/targets/%s/test/**/*.h" % target for target in TESTGEN_TARGETS],
         ) +
         glob(
             ["modules/testgen/targets/%s/**/*.cpp" % target for target in TESTGEN_TARGETS],
-            exclude = ["modules/testgen/targets/%s/test/**" % target for target in TESTGEN_TARGETS],
+            exclude = ["modules/testgen/targets/%s/test/**/*.cpp" % target for target in TESTGEN_TARGETS],
         ),
 )
 

--- a/backends/p4tools/common/compiler/compiler_target.cpp
+++ b/backends/p4tools/common/compiler/compiler_target.cpp
@@ -1,9 +1,7 @@
 #include "backends/p4tools/common/compiler/compiler_target.h"
 
 #include <string>
-#include <vector>
 
-#include "backends/p4tools/common/compiler/context.h"
 #include "backends/p4tools/common/compiler/midend.h"
 #include "backends/p4tools/common/core/target.h"
 #include "frontends/common/applyOptionsPragmas.h"
@@ -15,15 +13,6 @@
 #include "lib/error.h"
 
 namespace P4::P4Tools {
-
-ICompileContext *CompilerTarget::makeContext(std::string_view toolName) {
-    return get(toolName).makeContextImpl();
-}
-
-std::vector<const char *> *CompilerTarget::initCompiler(std::string_view toolName, int argc,
-                                                        char **argv) {
-    return get(toolName).initCompilerImpl(argc, argv);
-}
 
 CompilerResultOrError CompilerTarget::runCompiler(const CompilerOptions &options,
                                                   std::string_view toolName) {
@@ -65,15 +54,6 @@ CompilerResultOrError CompilerTarget::runCompilerImpl(const CompilerOptions &opt
     }
 
     return *new CompilerResult(*program);
-}
-
-ICompileContext *CompilerTarget::makeContextImpl() const {
-    return new CompileContext<CompilerOptions>();
-}
-
-std::vector<const char *> *CompilerTarget::initCompilerImpl(int argc, char **argv) const {
-    auto *result = CompileContext<CompilerOptions>::get().options().process(argc, argv);
-    return ::P4::errorCount() > 0 ? nullptr : result;
 }
 
 const IR::P4Program *CompilerTarget::runParser(const ParserOptions &options) {

--- a/backends/p4tools/common/compiler/compiler_target.h
+++ b/backends/p4tools/common/compiler/compiler_target.h
@@ -2,7 +2,6 @@
 #define BACKENDS_P4TOOLS_COMMON_COMPILER_COMPILER_TARGET_H_
 
 #include <string>
-#include <vector>
 
 #include "backends/p4tools/common/compiler/compiler_result.h"
 #include "backends/p4tools/common/compiler/context.h"
@@ -19,15 +18,6 @@ namespace P4::P4Tools {
 /// Encapsulates the details of invoking the P4 compiler for a target device and architecture.
 class CompilerTarget : public Target {
  public:
-    /// @returns a new compilation context for the compiler.
-    static ICompileContext *makeContext(std::string_view toolName);
-
-    /// Initializes the P4 compiler with the given compiler-specific command-line arguments.
-    ///
-    /// @returns any unprocessed arguments, or nullptr if there was an error.
-    static std::vector<const char *> *initCompiler(std::string_view toolName, int argc,
-                                                   char **argv);
-
     /// Runs the P4 compiler to produce an IR and various other kinds of information on the input
     /// program.
     ///
@@ -49,17 +39,9 @@ class CompilerTarget : public Target {
                                              std::string_view toolName, const IR::P4Program *);
 
  protected:
-    /// @see @makeContext.
-    [[nodiscard]] virtual ICompileContext *makeContextImpl() const;
-
     /// @see runCompiler.
     virtual CompilerResultOrError runCompilerImpl(const CompilerOptions &options,
                                                   const IR::P4Program *) const;
-
-    /// This implementation just forwards the given arguments to the compiler.
-    ///
-    /// @see @initCompiler.
-    virtual std::vector<const char *> *initCompilerImpl(int argc, char **argv) const;
 
     /// Parses the P4 program specified on the command line.
     ///

--- a/backends/p4tools/common/compiler/context.h
+++ b/backends/p4tools/common/compiler/context.h
@@ -2,7 +2,7 @@
 #define BACKENDS_P4TOOLS_COMMON_COMPILER_CONTEXT_H_
 
 #include "backends/p4tools/common/compiler/configuration.h"
-#include "frontends/common/options.h"
+#include "frontends/common/parser_options.h"
 
 namespace P4::P4Tools {
 
@@ -18,17 +18,17 @@ class CompileContext : public virtual P4CContext {
 
     template <typename OptionsDerivedType>
     explicit CompileContext(CompileContext<OptionsDerivedType> &context)
-        : optionsInstance(context.options()) {}
+        : _optionsInstance(context.options()) {}
 
     /// @return the compiler options for this compilation context.
-    OptionsType &options() override { return optionsInstance; }
+    OptionsType &options() override { return _optionsInstance; }
 
  protected:
     const CompilerConfiguration &getConfigImpl() override { return CompilerConfiguration::get(); }
 
  private:
     /// The compiler options for this compilation context.
-    OptionsType optionsInstance;
+    OptionsType _optionsInstance;
 };
 
 }  // namespace P4::P4Tools

--- a/backends/p4tools/common/core/target.cpp
+++ b/backends/p4tools/common/core/target.cpp
@@ -6,15 +6,14 @@
 #include <map>
 #include <optional>
 #include <string>
-#include <utility>
 
 #include "backends/p4tools/common/lib/variables.h"
 #include "ir/irutils.h"
 
 namespace P4::P4Tools {
 
-Target::Spec::Spec(std::string deviceName, std::string archName)
-    : deviceName(std::move(deviceName)), archName(std::move(archName)) {
+Target::Spec::Spec(std::string_view deviceName, std::string_view archName)
+    : deviceName(deviceName), archName(archName) {
     // Convert names to lower case.
     std::transform(this->archName.begin(), this->archName.end(), this->archName.begin(), ::tolower);
     std::transform(this->deviceName.begin(), this->deviceName.end(), this->deviceName.begin(),
@@ -37,8 +36,8 @@ std::map<Target::Spec, std::map<std::string, const Target *, std::less<>>> Targe
 std::map<std::string, std::string, std::less<>> Target::defaultArchByDevice = {};
 std::map<std::string, std::string, std::less<>> Target::defaultDeviceByArch = {};
 
-bool Target::init(std::string deviceName, std::string archName) {
-    Spec spec(std::move(deviceName), std::move(archName));
+bool Target::init(std::string_view deviceName, std::string_view archName) {
+    Spec spec(deviceName, archName);
 
     if (registry.count(spec) != 0U) {
         curTarget = spec;
@@ -48,23 +47,95 @@ bool Target::init(std::string deviceName, std::string archName) {
     return false;
 }
 
-bool Target::setDevice(std::string deviceName) {
-    std::transform(deviceName.begin(), deviceName.end(), deviceName.begin(), ::tolower);
-    if (defaultArchByDevice.count(deviceName) == 0U) {
+std::optional<ICompileContext *> Target::initializeTarget(std::string_view toolName,
+                                                          std::string_view target,
+                                                          std::string_view arch) {
+    // Establish a dummy compilation context so that we can use ::error to report errors while
+    // processing target and arch.
+    class DummyCompileContext : public BaseCompileContext {
+    } dummyContext;
+    AutoCompileContext autoDummyContext(&dummyContext);
+    if (!P4Tools::Target::setDevice(target)) {
+        ::P4::error("Unsupported device: %s", target);
+        return std::nullopt;
+    }
+    if (!P4Tools::Target::setArch(arch)) {
+        ::P4::error("Unsupported architecture: %s", arch);
+        return std::nullopt;
+    }
+    const auto &instances = registry.at(*curTarget);
+    auto instance = instances.find(toolName);
+    BUG_CHECK(instance != instances.end(), "Architecture %1% on device %2% not supported for %3%",
+              curTarget->archName, curTarget->deviceName, toolName);
+
+    return instance->second->makeContext();
+}
+
+std::optional<ICompileContext *> Target::initializeTarget(std::string_view toolName,
+                                                          const std::vector<const char *> &args) {
+    // Establish a dummy compilation context so that we can use ::error to report errors while
+    // processing target and arch.
+    class DummyCompileContext : public BaseCompileContext {
+    } dummyContext;
+    AutoCompileContext autoDummyContext(&dummyContext);
+    if (args.size() < 3) {
+        ::P4::error("Missing --target and --arch arguments");
+        return std::nullopt;
+    }
+    std::optional<std::string> target;
+    std::optional<std::string> arch;
+    // Loop through arguments (skip the program name)
+    for (size_t i = 1; i < args.size(); ++i) {
+        const std::string &arg = args[i];
+        if (arg == "--arch") {
+            if (i + 1 < args.size()) {
+                arch = args[i + 1];
+            } else {
+                ::P4::error("Missing architecture name after --arch");
+                return std::nullopt;
+            }
+        }
+        if (arg == "--target") {
+            if (i + 1 < args.size()) {
+                target = args[i + 1];
+            } else {
+                ::P4::error("Missing device name after --target");
+                return std::nullopt;
+            }
+        }
+    }
+    if (!target) {
+        ::P4::error("Missing --target argument");
+        return std::nullopt;
+    }
+    if (!arch) {
+        ::P4::error("Missing --arch argument");
+        return std::nullopt;
+    }
+    return initializeTarget(toolName, target.value(), arch.value());
+}
+
+bool Target::setDevice(std::string_view deviceName) {
+    std::string lowerCaseDeviceName(deviceName);
+    std::transform(lowerCaseDeviceName.begin(), lowerCaseDeviceName.end(),
+                   lowerCaseDeviceName.begin(), ::tolower);
+    if (defaultArchByDevice.count(lowerCaseDeviceName) == 0U) {
         return false;
     }
 
-    auto archName = curTarget ? curTarget->archName : defaultArchByDevice.at(deviceName);
+    auto archName = curTarget ? curTarget->archName : defaultArchByDevice.at(deviceName.data());
     return init(deviceName, archName);
 }
 
-bool Target::setArch(std::string archName) {
-    std::transform(archName.begin(), archName.end(), archName.begin(), ::tolower);
-    if (defaultDeviceByArch.count(archName) == 0U) {
+bool Target::setArch(std::string_view archName) {
+    std::string lowerCaseArchName(archName);
+    std::transform(lowerCaseArchName.begin(), lowerCaseArchName.end(), lowerCaseArchName.begin(),
+                   ::tolower);
+    if (defaultDeviceByArch.count(lowerCaseArchName) == 0U) {
         return false;
     }
 
-    auto deviceName = curTarget ? curTarget->deviceName : defaultDeviceByArch.at(archName);
+    auto deviceName = curTarget ? curTarget->deviceName : defaultDeviceByArch.at(archName.data());
     return init(deviceName, archName);
 }
 

--- a/backends/p4tools/common/core/target.cpp
+++ b/backends/p4tools/common/core/target.cpp
@@ -7,14 +7,14 @@
 #include <optional>
 #include <string>
 
+#include "absl/strings/ascii.h"
 #include "backends/p4tools/common/lib/variables.h"
 #include "ir/irutils.h"
-#include "lib/stringify.h"
 
 namespace P4::P4Tools {
 
 Target::Spec::Spec(std::string_view deviceName, std::string_view archName)
-    : deviceName(Util::lowerString(deviceName)), archName(Util::lowerString(archName)) {}
+    : deviceName(absl::AsciiStrToLower(deviceName)), archName(absl::AsciiStrToLower(archName)) {}
 
 bool Target::Spec::operator<(const Spec &other) const {
     if (deviceName != other.deviceName) {
@@ -112,7 +112,7 @@ std::optional<ICompileContext *> Target::initializeTarget(std::string_view toolN
 }
 
 bool Target::setDevice(std::string_view deviceName) {
-    std::string lowerCaseDeviceName(Util::lowerString(deviceName));
+    std::string lowerCaseDeviceName(absl::AsciiStrToLower(deviceName));
     auto archList = defaultArchByDevice.find(lowerCaseDeviceName);
     if (archList == defaultArchByDevice.end()) {
         return false;
@@ -122,7 +122,7 @@ bool Target::setDevice(std::string_view deviceName) {
 }
 
 bool Target::setArch(std::string_view archName) {
-    std::string lowerCaseArchName(Util::lowerString(archName));
+    std::string lowerCaseArchName(absl::AsciiStrToLower(archName));
     std::transform(lowerCaseArchName.begin(), lowerCaseArchName.end(), lowerCaseArchName.begin(),
                    ::tolower);
     auto deviceList = defaultDeviceByArch.find(lowerCaseArchName);

--- a/backends/p4tools/common/core/target.h
+++ b/backends/p4tools/common/core/target.h
@@ -20,6 +20,7 @@ class Target {
  public:
     /// Specifies a target device and architecture by their names in lower case.
     struct Spec {
+        // TODO: Prefix the variables here and in target with "_" to avoid ambiguities.
         std::string deviceName;
         std::string archName;
 

--- a/backends/p4tools/common/options.h
+++ b/backends/p4tools/common/options.h
@@ -6,16 +6,15 @@
 #include <tuple>
 #include <vector>
 
+#include "frontends/common/options.h"
 #include "lib/compile_context.h"
-#include "lib/cstring.h"
-#include "lib/options.h"
 
 namespace P4::P4Tools {
 
 /// Encapsulates and processes command-line options for a compiler-based tool. Implementations
 /// should use the singleton pattern and define a static get() for obtaining the singleton
 /// instance.
-class AbstractP4cToolOptions : protected Util::Options {
+class AbstractP4cToolOptions : public CompilerOptions {
  private:
     /// The name of the tool associated with these options.
     std::string _toolName;
@@ -30,8 +29,8 @@ class AbstractP4cToolOptions : protected Util::Options {
 
     /// Processes options.
     ///
-    /// @returns a compilation context on success, std::nullopt on error.
-    std::optional<ICompileContext *> process(const std::vector<const char *> &args);
+    /// @returns an EXIT_SUCCESS context on success, EXIT_FAILURE on error.
+    int process(const std::vector<const char *> &args);
 
     /// Command-line arguments to be sent to the compiler. Populated by @process.
     std::vector<const char *> compilerArgs;

--- a/backends/p4tools/common/p4ctool.h
+++ b/backends/p4tools/common/p4ctool.h
@@ -45,8 +45,8 @@ class AbstractP4cTool {
         Options &toolOptions = dynamic_cast<CompileContext<Options> *>(context.value())->options();
 
         // Process command-line options.
-        auto compileContext = toolOptions.process(args);
-        if (compileContext != EXIT_SUCCESS) {
+        auto result = toolOptions.process(args);
+        if (result != EXIT_SUCCESS) {
             return EXIT_FAILURE;
         }
 

--- a/backends/p4tools/common/p4ctool.h
+++ b/backends/p4tools/common/p4ctool.h
@@ -36,15 +36,21 @@ class AbstractP4cTool {
         // Register supported compiler targets.
         registerTarget();
 
+        // Initialize the target and the context.
+        auto context = Target::initializeTarget(toolName, args);
+        if (!context.has_value()) {
+            return EXIT_FAILURE;
+        }
+        AutoCompileContext autoContext(context.value());
+        Options &toolOptions = dynamic_cast<CompileContext<Options> *>(context.value())->options();
+
         // Process command-line options.
-        auto &toolOptions = Options::get();
         auto compileContext = toolOptions.process(args);
-        if (!compileContext) {
+        if (compileContext != EXIT_SUCCESS) {
             return EXIT_FAILURE;
         }
 
         // Set up the compilation context.
-        AutoCompileContext autoContext(*compileContext);
         // If not explicitly disabled, print basic information to standard output.
         if (!toolOptions.disableInformationLogging) {
             enableInformationLogging();
@@ -56,8 +62,7 @@ class AbstractP4cTool {
         }
 
         // Run the compiler to get an IR and invoke the tool.
-        const auto compilerResult = P4Tools::CompilerTarget::runCompiler(
-            CompileContext<CompilerOptions>::get().options(), toolName);
+        const auto compilerResult = P4Tools::CompilerTarget::runCompiler(toolOptions, toolName);
         if (!compilerResult.has_value()) {
             return EXIT_FAILURE;
         }

--- a/backends/p4tools/modules/smith/core/target.cpp
+++ b/backends/p4tools/modules/smith/core/target.cpp
@@ -3,12 +3,18 @@
 #include <string>
 
 #include "backends/p4tools/common/compiler/compiler_target.h"
+#include "backends/p4tools/common/compiler/context.h"
 #include "backends/p4tools/common/core/target.h"
+#include "backends/p4tools/modules/smith/options.h"
 
 namespace P4::P4Tools::P4Smith {
 
 SmithTarget::SmithTarget(const std::string &deviceName, const std::string &archName)
     : P4Tools::CompilerTarget("smith", deviceName, archName) {}
+
+ICompileContext *SmithTarget::makeContext() const {
+    return new P4Tools::CompileContext<SmithOptions>;
+}
 
 const SmithTarget &SmithTarget::get() { return P4Tools::Target::get<SmithTarget>("smith"); }
 

--- a/backends/p4tools/modules/smith/core/target.h
+++ b/backends/p4tools/modules/smith/core/target.h
@@ -31,6 +31,8 @@ class SmithTarget : public CompilerTarget {
     [[nodiscard]] virtual ParserGenerator &parserGenerator() const = 0;
     [[nodiscard]] virtual TableGenerator &tableGenerator() const = 0;
 
+    [[nodiscard]] ICompileContext *makeContext() const override;
+
  protected:
     explicit SmithTarget(const std::string &deviceName, const std::string &archName);
 

--- a/backends/p4tools/modules/smith/options.cpp
+++ b/backends/p4tools/modules/smith/options.cpp
@@ -8,17 +8,12 @@
 #include "backends/p4tools/modules/smith/toolname.h"
 #include "lib/compile_context.h"
 #include "lib/error.h"
-#include "lib/exceptions.h"
 
 namespace P4::P4Tools {
 
 SmithOptions &SmithOptions::get() {
     static SmithOptions INSTANCE;
     return INSTANCE;
-}
-
-const char *SmithOptions::getIncludePath() const {
-    P4C_UNIMPLEMENTED("getIncludePath is not implemented for P4Smith.");
 }
 
 void SmithOptions::processArgs(const std::vector<const char *> &args) {

--- a/backends/p4tools/modules/smith/options.h
+++ b/backends/p4tools/modules/smith/options.h
@@ -8,17 +8,12 @@ namespace P4::P4Tools {
 
 class SmithOptions : public AbstractP4cToolOptions {
  public:
+    SmithOptions();
     ~SmithOptions() override = default;
     static SmithOptions &get();
 
-    const char *getIncludePath() const override;
     void processArgs(const std::vector<const char *> &args);
-
- private:
-    SmithOptions();
 };
-
-// using P4toZ3Context = P4CContextWithOptions<SmithOptions>;
 
 }  // namespace P4::P4Tools
 

--- a/backends/p4tools/modules/testgen/core/target.cpp
+++ b/backends/p4tools/modules/testgen/core/target.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "backends/p4tools/common/compiler/compiler_target.h"
+#include "backends/p4tools/common/compiler/context.h"
 #include "backends/p4tools/common/core/target.h"
 #include "ir/declaration.h"
 #include "ir/ir.h"
@@ -86,6 +87,10 @@ CompilerResultOrError TestgenTarget::runCompilerImpl(const CompilerOptions &opti
 
     return {
         *new TestgenCompilerResult(CompilerResult(*program), coverage.getCoverableNodes(), dcg)};
+}
+
+ICompileContext *TestgenTarget::makeContext() const {
+    return new P4Tools::CompileContext<TestgenOptions>();
 }
 
 }  // namespace P4::P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/core/target.h
+++ b/backends/p4tools/modules/testgen/core/target.h
@@ -65,6 +65,8 @@ class TestgenTarget : public CompilerTarget {
 
     CompilerResultOrError runCompilerImpl(const CompilerOptions &options,
                                           const IR::P4Program *program) const override;
+
+    [[nodiscard]] ICompileContext *makeContext() const override;
 };
 
 }  // namespace P4::P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "backends/p4tools/common/compiler/context.h"
 #include "backends/p4tools/common/lib/util.h"
 #include "backends/p4tools/common/options.h"
 #include "lib/error.h"
@@ -19,14 +20,7 @@ namespace P4::P4Tools::P4Testgen {
 
 using namespace P4::literals;
 
-TestgenOptions &TestgenOptions::get() {
-    static TestgenOptions INSTANCE;
-    return INSTANCE;
-}
-
-const char *TestgenOptions::getIncludePath() const {
-    P4C_UNIMPLEMENTED("getIncludePath not implemented for P4Testgen.");
-}
+TestgenOptions &TestgenOptions::get() { return CompileContext<TestgenOptions>::get().options(); }
 
 const std::set<cstring> TestgenOptions::SUPPORTED_STOP_METRICS = {"MAX_NODE_COVERAGE"_cs};
 

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -18,6 +18,7 @@ namespace P4::P4Tools::P4Testgen {
 /// Encapsulates and processes command-line options for P4Testgen.
 class TestgenOptions : public AbstractP4cToolOptions {
  public:
+    TestgenOptions();
     virtual ~TestgenOptions() = default;
 
     /// Maximum number of tests to be generated. Defaults to 1.
@@ -102,13 +103,8 @@ class TestgenOptions : public AbstractP4cToolOptions {
     /// Defaults to the name of the input program, if provided.
     std::optional<cstring> testBaseName;
 
-    const char *getIncludePath() const override;
-
  protected:
     bool validateOptions() const override;
-
- private:
-    TestgenOptions();
 };
 
 }  // namespace P4::P4Tools::P4Testgen

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/gtest_utils.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/gtest_utils.h
@@ -7,14 +7,37 @@
 namespace P4::P4Tools::Test {
 
 /// Sets up the correct context for a P4Testgen BMv2 test.
-class P4TestgenBmv2Test : public P4TestgenTest {};
+class P4TestgenBmv2Test : public P4TestgenTest {
+    std::unique_ptr<AutoCompileContext> compileContext;
+
+ public:
+    void SetUp() override {
+        auto result = P4TestgenTest::SetUp("bmv2", "v1model");
+        if (!result.has_value()) {
+            FAIL() << "Failed to set up P4Testgen BMv2 test";
+            return;
+        }
+        compileContext = std::move(result.value());
+    }
+};
 
 /// Creates a test case with the @hdrFields for stepping on an @expr.
 std::optional<const P4ToolsTestCase> createBmv2V1modelSmallStepExprTest(
     const std::string &hdrFields, const std::string &expr);
 
-/// BMv2-specific version of a small step test.
-class Bmv2SmallStepTest : public SmallStepTest {};
+class Bmv2SmallStepTest : public SmallStepTest {
+    std::unique_ptr<AutoCompileContext> compileContext;
+
+ public:
+    void SetUp() override {
+        auto result = P4TestgenTest::SetUp("bmv2", "v1model");
+        if (!result.has_value()) {
+            FAIL() << "Failed to set up P4Testgen BMv2 test";
+            return;
+        }
+        compileContext = std::move(result.value());
+    }
+};
 
 }  // namespace P4::P4Tools::Test
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/gtest_utils.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/gtest_utils.h
@@ -12,12 +12,11 @@ class P4TestgenBmv2Test : public P4TestgenTest {
 
  public:
     void SetUp() override {
-        auto result = P4TestgenTest::SetUp("bmv2", "v1model");
-        if (!result.has_value()) {
+        compileContext = P4TestgenTest::SetUp("bmv2", "v1model");
+        if (compileContext == nullptr) {
             FAIL() << "Failed to set up P4Testgen BMv2 test";
             return;
         }
-        compileContext = std::move(result.value());
     }
 };
 
@@ -30,12 +29,11 @@ class Bmv2SmallStepTest : public SmallStepTest {
 
  public:
     void SetUp() override {
-        auto result = P4TestgenTest::SetUp("bmv2", "v1model");
-        if (!result.has_value()) {
+        compileContext = P4TestgenTest::SetUp("bmv2", "v1model");
+        if (compileContext == nullptr) {
             FAIL() << "Failed to set up P4Testgen BMv2 test";
             return;
         }
-        compileContext = std::move(result.value());
     }
 };
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/api_test.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/api_test.cpp
@@ -60,10 +60,9 @@ V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), depa
 )p4";
 
     auto source = P4_SOURCE(P4Headers::V1MODEL, streamTest.str().c_str());
-    auto compilerOptions = P4CContextWithOptions<CompilerOptions>::get().options();
-    compilerOptions.target = "bmv2"_cs;
-    compilerOptions.arch = "v1model"_cs;
-    auto &testgenOptions = P4Tools::P4Testgen::TestgenOptions::get();
+    auto &testgenOptions = P4Testgen::TestgenOptions::get();
+    testgenOptions.target = "bmv2"_cs;
+    testgenOptions.arch = "v1model"_cs;
     testgenOptions.testBackend = "PROTOBUF_IR"_cs;
     testgenOptions.testBaseName = "dummy"_cs;
     // Create a bespoke packet for the Ethernet extract call.
@@ -73,11 +72,10 @@ V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), depa
     testgenOptions.maxTests = 1;
 
     {
-        auto testListOpt =
-            P4Tools::P4Testgen::Testgen::generateTests(source, compilerOptions, testgenOptions);
+        auto testListOpt = P4Testgen::Testgen::generateTests(source, testgenOptions);
 
         ASSERT_TRUE(testListOpt.has_value());
-        auto testList = testListOpt.value();
+        const auto &testList = testListOpt.value();
         ASSERT_EQ(testList.size(), 1);
         const auto *protobufIrTest =
             testList[0]->checkedTo<P4Tools::P4Testgen::Bmv2::ProtobufIrTest>();
@@ -86,11 +84,10 @@ V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), depa
     /// Now try running again with the test back end set to Protobuf. The result should be the same.
     testgenOptions.testBackend = "PROTOBUF"_cs;
 
-    auto testListOpt =
-        P4Tools::P4Testgen::Testgen::generateTests(source, compilerOptions, testgenOptions);
+    auto testListOpt = P4Testgen::Testgen::generateTests(source, testgenOptions);
 
     ASSERT_TRUE(testListOpt.has_value());
-    auto testList = testListOpt.value();
+    const auto &testList = testListOpt.value();
     ASSERT_EQ(testList.size(), 1);
     const auto *protobufTest = testList[0]->checkedTo<P4Tools::P4Testgen::Bmv2::ProtobufTest>();
     EXPECT_THAT(protobufTest->getFormattedTest(), ::testing::HasSubstr(R"(input_packet)"));

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
@@ -18,19 +18,15 @@ using namespace P4::literals;
 
 class P4TestgenBenchmark : public P4TestgenBmv2Test {};
 
-TEST(P4TestgenBenchmark, SuccessfullyGenerate1000Tests) {
-    // Set the compiler options.
-    auto *context = new P4Tools::CompileContext<CompilerOptions>();
-    AutoCompileContext autoContext(context);
-    auto &compilerOptions = context->options();
-    compilerOptions.target = "bmv2"_cs;
-    compilerOptions.arch = "v1model"_cs;
+TEST_F(P4TestgenBenchmark, SuccessfullyGenerate1000Tests) {
+    auto &testgenOptions = P4Testgen::TestgenOptions::get();
+    testgenOptions.target = "bmv2"_cs;
+    testgenOptions.arch = "v1model"_cs;
     auto includePath = P4CTestEnvironment::getProjectRoot() / "p4include";
-    compilerOptions.preprocessor_options = "-I" + includePath.string();
+    testgenOptions.preprocessor_options = "-I" + includePath.string();
     auto fabricFile =
         P4CTestEnvironment::getProjectRoot() / "testdata/p4_16_samples/fabric_20190420/fabric.p4";
-    compilerOptions.file = fabricFile.string();
-    auto &testgenOptions = P4Tools::P4Testgen::TestgenOptions::get();
+    testgenOptions.file = fabricFile.string();
     testgenOptions.testBackend = "PROTOBUF_IR"_cs;
     testgenOptions.testBaseName = "dummy"_cs;
     testgenOptions.seed = 1;
@@ -44,7 +40,7 @@ TEST(P4TestgenBenchmark, SuccessfullyGenerate1000Tests) {
     // This enables performance printing.
     P4Tools::enablePerformanceLogging();
 
-    auto testList = P4Tools::P4Testgen::Testgen::generateTests(compilerOptions, testgenOptions);
+    auto testList = P4Testgen::Testgen::generateTests(testgenOptions);
     ASSERT_TRUE(testList.has_value());
 
     // Print the report.

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/control_plane_filter_test.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/control_plane_filter_test.cpp
@@ -66,17 +66,12 @@ V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), depa
     return P4_SOURCE(P4Headers::V1MODEL, templateString.str().c_str());
 }
 
-CompilerOptions generateDefaultApiTestCompilerOptions() {
-    auto compilerOptions = P4CContextWithOptions<CompilerOptions>::get().options();
-    compilerOptions.target = "bmv2"_cs;
-    compilerOptions.arch = "v1model"_cs;
-    return compilerOptions;
-}
-
-P4Tools::P4Testgen::TestgenOptions &generateDefaultApiTestTestgenOptions() {
-    auto &testgenOptions = P4Tools::P4Testgen::TestgenOptions::get();
+P4Testgen::TestgenOptions &generateDefaultApiTestTestgenOptions() {
+    auto &testgenOptions = P4Testgen::TestgenOptions::get();
     testgenOptions.testBackend = "PROTOBUF_IR"_cs;
     testgenOptions.testBaseName = "dummy"_cs;
+    testgenOptions.target = "bmv2"_cs;
+    testgenOptions.arch = "v1model"_cs;
     testgenOptions.seed = 1;
     testgenOptions.maxTests = 0;
     // Create a bespoke packet for the Ethernet extract call.
@@ -108,13 +103,11 @@ TEST_F(P4TestgenControlPlaneFilterTest, GeneratesCorrectTests) {
             drop_table.apply();
         }
     })");
-    auto compilerOptions = generateDefaultApiTestCompilerOptions();
     auto &testgenOptions = generateDefaultApiTestTestgenOptions();
 
     // First, we ensure that tests are generated correctly. We expect two tests.
     // One which exercises action acl_drop and one which exercises the default action, NoAction.
-    auto testListOpt =
-        P4Tools::P4Testgen::Testgen::generateTests(source, compilerOptions, testgenOptions);
+    auto testListOpt = P4Testgen::Testgen::generateTests(source, testgenOptions);
 
     ASSERT_TRUE(testListOpt.has_value());
     const auto &testList = testListOpt.value();
@@ -156,15 +149,13 @@ TEST_F(P4TestgenControlPlaneFilterTest, FiltersControlPlaneEntities) {
             drop_table.apply();
         }
     })");
-    auto compilerOptions = generateDefaultApiTestCompilerOptions();
     auto &testgenOptions = generateDefaultApiTestTestgenOptions();
 
     // We install a filter.
     // Since we can not generate a config for the table we should only generate one test.
     testgenOptions.skippedControlPlaneEntities = {"ingress.drop_table"_cs};
 
-    auto testListOpt =
-        P4Tools::P4Testgen::Testgen::generateTests(source, compilerOptions, testgenOptions);
+    auto testListOpt = P4Testgen::Testgen::generateTests(source, testgenOptions);
 
     ASSERT_TRUE(testListOpt.has_value());
     const auto &testList = testListOpt.value();
@@ -196,15 +187,13 @@ TEST_F(P4TestgenControlPlaneFilterTest, IgnoresBogusControlPlaneEntities) {
             drop_table.apply();
         }
     })");
-    auto compilerOptions = generateDefaultApiTestCompilerOptions();
     auto &testgenOptions = generateDefaultApiTestTestgenOptions();
 
     // This is a bogus control plane element, which is ignored. We expect two tests.
     // One which exercises action acl_drop and one which exercises the default action, NoAction.
     testgenOptions.skippedControlPlaneEntities = {"ingress.bogus_table"_cs};
 
-    auto testListOpt =
-        P4Tools::P4Testgen::Testgen::generateTests(source, compilerOptions, testgenOptions);
+    auto testListOpt = P4Testgen::Testgen::generateTests(source, testgenOptions);
 
     ASSERT_TRUE(testListOpt.has_value());
     const auto &testList = testListOpt.value();
@@ -262,7 +251,6 @@ TEST_F(P4TestgenControlPlaneFilterTest, FiltersMultipleControlPlaneEntities) {
             set_eth_table.apply();
         }
     })");
-    auto compilerOptions = generateDefaultApiTestCompilerOptions();
     auto &testgenOptions = generateDefaultApiTestTestgenOptions();
 
     // We install a filter.
@@ -270,8 +258,7 @@ TEST_F(P4TestgenControlPlaneFilterTest, FiltersMultipleControlPlaneEntities) {
     testgenOptions.skippedControlPlaneEntities = {"ingress.drop_table"_cs,
                                                   "ingress.set_eth_table"_cs};
 
-    auto testListOpt =
-        P4Tools::P4Testgen::Testgen::generateTests(source, compilerOptions, testgenOptions);
+    auto testListOpt = P4Testgen::Testgen::generateTests(source, testgenOptions);
 
     ASSERT_TRUE(testListOpt.has_value());
     const auto &testList = testListOpt.value();

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/output_option_test.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/output_option_test.cpp
@@ -59,10 +59,9 @@ V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), depa
 )p4";
 
     auto source = P4_SOURCE(P4Headers::V1MODEL, streamTest.str().c_str());
-    auto compilerOptions = P4CContextWithOptions<CompilerOptions>::get().options();
-    compilerOptions.target = "bmv2"_cs;
-    compilerOptions.arch = "v1model"_cs;
-    auto &testgenOptions = P4Tools::P4Testgen::TestgenOptions::get();
+    auto &testgenOptions = P4Testgen::TestgenOptions::get();
+    testgenOptions.target = "bmv2"_cs;
+    testgenOptions.arch = "v1model"_cs;
     testgenOptions.testBackend = "PROTOBUF_IR"_cs;
     testgenOptions.testBaseName = "dummy"_cs;
     testgenOptions.seed = 1;
@@ -75,11 +74,10 @@ V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), depa
     {
         testgenOptions.droppedPacketOnly = true;
 
-        auto testListOpt =
-            P4Tools::P4Testgen::Testgen::generateTests(source, compilerOptions, testgenOptions);
+        auto testListOpt = P4Testgen::Testgen::generateTests(source, testgenOptions);
 
         ASSERT_TRUE(testListOpt.has_value());
-        auto testList = testListOpt.value();
+        const auto &testList = testListOpt.value();
         ASSERT_EQ(testList.size(), 1);
         const auto *protobufIrTest =
             testList[0]->checkedTo<P4Tools::P4Testgen::Bmv2::ProtobufIrTest>();
@@ -92,11 +90,10 @@ V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), depa
         testgenOptions.droppedPacketOnly = false;
         testgenOptions.outputPacketOnly = true;
 
-        auto testListOpt =
-            P4Tools::P4Testgen::Testgen::generateTests(source, compilerOptions, testgenOptions);
+        auto testListOpt = P4Testgen::Testgen::generateTests(source, testgenOptions);
 
         ASSERT_TRUE(testListOpt.has_value());
-        auto testList = testListOpt.value();
+        const auto &testList = testListOpt.value();
         ASSERT_EQ(testList.size(), 1);
         const auto *protobufIrTest =
             testList[0]->checkedTo<P4Tools::P4Testgen::Bmv2::ProtobufIrTest>();

--- a/backends/p4tools/modules/testgen/test/gtest_utils.cpp
+++ b/backends/p4tools/modules/testgen/test/gtest_utils.cpp
@@ -29,13 +29,18 @@ std::optional<const P4ToolsTestCase> P4ToolsTestCase::create(
               deviceName, archName);
 
     // Set up the compilation context and set the source language.
-    AutoCompileContext autoCompileContext(
-        P4Tools::CompilerTarget::makeContext(P4Tools::P4Testgen::TOOL_NAME));
-    P4CContext::get().options().langVersion = langVersion;
+    auto context =
+        P4Tools::Target::initializeTarget(P4Tools::P4Testgen::TOOL_NAME, deviceName, archName);
+    if (!context.has_value()) {
+        return std::nullopt;
+    }
+    AutoCompileContext autoContext(context.value());
+    auto *compileContext =
+        dynamic_cast<P4Tools::CompileContext<P4Testgen::TestgenOptions> *>(context.value());
+    compileContext->options().langVersion = langVersion;
 
     auto compilerResults = P4Tools::CompilerTarget::runCompiler(
-        P4Tools::CompileContext<CompilerOptions>::get().options(), P4Tools::P4Testgen::TOOL_NAME,
-        source);
+        compileContext->options(), P4Tools::P4Testgen::TOOL_NAME, source);
     if (!compilerResults.has_value()) {
         return std::nullopt;
     }

--- a/backends/p4tools/modules/testgen/test/gtest_utils.h
+++ b/backends/p4tools/modules/testgen/test/gtest_utils.h
@@ -54,8 +54,8 @@ class P4ToolsTestCase {
 
 class P4TestgenTest : public testing::Test {
  public:
-    [[nodiscard]] static std::optional<std::unique_ptr<AutoCompileContext>> SetUp(
-        std::string_view target, std::string_view archName) {
+    [[nodiscard]] static std::unique_ptr<AutoCompileContext> SetUp(std::string_view target,
+                                                                   std::string_view archName) {
         P4Tools::P4Testgen::registerTestgenTargets();
         /// Set up the appropriate compile context for P4Testgen tests.
         /// TODO: Remove this once options are not initialized statically anymore.
@@ -63,7 +63,7 @@ class P4TestgenTest : public testing::Test {
                                                                  target, archName);
 
         if (!ctxOpt.has_value()) {
-            return std::nullopt;
+            return nullptr;
         }
         return std::make_unique<AutoCompileContext>(ctxOpt.value());
     }

--- a/backends/p4tools/modules/testgen/testgen.h
+++ b/backends/p4tools/modules/testgen/testgen.h
@@ -3,6 +3,7 @@
 
 #include "backends/p4tools/common/p4ctool.h"
 
+#include "backends/p4tools/modules/testgen/core/target.h"
 #include "backends/p4tools/modules/testgen/lib/test_framework.h"
 #include "backends/p4tools/modules/testgen/options.h"
 
@@ -20,15 +21,13 @@ class Testgen : public AbstractP4cTool<TestgenOptions> {
     /// input TestgenOptions. The abstract tests can be further specialized depending on the select
     /// test back end. CompilerOptions is required to invoke the correct preprocessor and P4
     /// compiler. It is assumed that `.file` in the compiler options is set.
-    static std::optional<AbstractTestList> generateTests(const CompilerOptions &options,
-                                                         const TestgenOptions &testgenOptions);
+    static std::optional<AbstractTestList> generateTests(const TestgenOptions &testgenOptions);
     /// Invokes P4Testgen and returns a list of abstract tests which are generated based on the
     /// input TestgenOptions. The abstract tests can be further specialized depending on the select
     /// test back end. CompilerOptions is required to invoke the correct P4 compiler. This function
     /// assumes that @param program is already preprocessed. P4Testgen will directly parse the input
     /// program.
     static std::optional<AbstractTestList> generateTests(std::string_view program,
-                                                         const CompilerOptions &options,
                                                          const TestgenOptions &testgenOptions);
 
     /// Invokes P4Testgen and writes a list of abstract tests to a specified output directory which
@@ -36,14 +35,13 @@ class Testgen : public AbstractP4cTool<TestgenOptions> {
     /// specialized depending on the select test back end. CompilerOptions is required to invoke the
     /// correct preprocessor and P4 compiler. It is assumed that `.file` in the compiler options is
     /// set.
-    static int writeTests(const CompilerOptions &options, const TestgenOptions &testgenOptions);
+    static int writeTests(const TestgenOptions &testgenOptions);
 
     /// Invokes P4Testgen and writes a list of abstract tests to a specified output directory which
     /// are generated based on the input TestgenOptions. CompilerOptions is required to invoke the
     /// correct P4 compiler. This function assumes that @param program is already preprocessed.
     /// P4Testgen will directly parse the input program.
-    static int writeTests(std::string_view program, const CompilerOptions &options,
-                          const TestgenOptions &testgenOptions);
+    static int writeTests(std::string_view program, const TestgenOptions &testgenOptions);
 
     virtual ~Testgen() = default;
 };

--- a/lib/stringify.cpp
+++ b/lib/stringify.cpp
@@ -128,20 +128,4 @@ cstring toString(cstring value) {
 
 cstring toString(std::string_view value) { return cstring(value); }
 
-void lowerString(std::string &s) {
-    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
-}
-
-std::string createLowerString(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
-    return s;
-}
-
-std::string lowerString(std::string_view s) {
-    std::string loweredString(s);
-    std::transform(loweredString.begin(), loweredString.end(), loweredString.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
-    return loweredString;
-}
-
 }  // namespace P4::Util

--- a/lib/stringify.cpp
+++ b/lib/stringify.cpp
@@ -128,4 +128,20 @@ cstring toString(cstring value) {
 
 cstring toString(std::string_view value) { return cstring(value); }
 
+void lowerString(std::string &s) {
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+}
+
+std::string createLowerString(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+    return s;
+}
+
+std::string lowerString(std::string_view s) {
+    std::string loweredString(s);
+    std::transform(loweredString.begin(), loweredString.end(), loweredString.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return loweredString;
+}
+
 }  // namespace P4::Util

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -123,6 +123,18 @@ cstring toString(const void *value);
 
 char DigitToChar(int digit);
 
+/// Convert a string to lower case. This is not safe for non-ASCII strings.
+/// Performs the lowering operation in place.
+void lowerString(std::string &s);
+
+/// Convert a string to lower case. This is not safe for non-ASCII strings.
+/// Returns a copy of the string.
+std::string createLowerString(std::string s);
+
+/// Convert a string view to lower case. This is not safe for non-ASCII strings.
+/// Returns a copy of the string view.
+std::string lowerString(std::string_view s);
+
 }  // namespace Util
 }  // namespace P4
 

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -123,18 +123,6 @@ cstring toString(const void *value);
 
 char DigitToChar(int digit);
 
-/// Convert a string to lower case. This is not safe for non-ASCII strings.
-/// Performs the lowering operation in place.
-void lowerString(std::string &s);
-
-/// Convert a string to lower case. This is not safe for non-ASCII strings.
-/// Returns a copy of the string.
-std::string createLowerString(std::string s);
-
-/// Convert a string view to lower case. This is not safe for non-ASCII strings.
-/// Returns a copy of the string view.
-std::string lowerString(std::string_view s);
-
 }  // namespace Util
 }  // namespace P4
 


### PR DESCRIPTION
This is a larger rewrite of the core parts of P4Testgen's target initialization. The goal is to fix several problems when trying to use P4Testgen and other tools as a library. We need to make sure that the CompileContext we are accessing is the correct one. 

- We decouple initialization of the options and the initialization of the target. This way we can initialize a target before we even know which options we need. This means we can make the options target-dependent (e.g., different options for BMv2, Tofino, etc). This can be really nice for usability since we can create bespoke options per target. 

- To reduce the amount of random static objects floating around we fold P4ToolsOptions and the CompilerOptions together. There is no reason why need two classes here.

- Options are only accessed by passing them along or retrieving them from the context stack. Ideally, we get rid of the context stack entirely but this requires a lot more work. 
