### PR TITLE
[P4Testgen] Fix problems with the reachability pass.

### DIFF
--- a/backends/p4tools/common/compiler/reachability.cpp
+++ b/backends/p4tools/common/compiler/reachability.cpp
@@ -104,15 +104,16 @@ bool P4ProgramDCGCreator::preorder(const IR::MethodCallExpression *call) {
             // Handle calls to header methods.
             if (method->expr->type->is<IR::Type_Header>() ||
                 method->expr->type->is<IR::Type_HeaderUnion>()) {
-                if (method->member == "isValid" || method->member == "setInvalid" ||
-                    method->member == "setValid") {
+                if (method->member == IR::Type_Header::isValid || IR::Type_Header::setInvalid ||
+                    method->member == IR::Type_Header::setValid) {
                     return false;
                 }
                 BUG("Unknown method call on header instance: %1%", call);
             }
 
             if (method->expr->type->is<IR::Type_Stack>()) {
-                if (method->member == "push_front" || method->member == "pop_front") {
+                if (method->member == IR::Type_Stack::push_front ||
+                    method->member == IR::Type_Stack::pop_front) {
                     return false;
                 }
                 BUG("Unknown method call on stack instance: %1%", call);

--- a/backends/p4tools/common/compiler/reachability.cpp
+++ b/backends/p4tools/common/compiler/reachability.cpp
@@ -1,13 +1,13 @@
 #include "backends/p4tools/common/compiler/reachability.h"
 
 #include <cstddef>
-#include <functional>
 #include <iostream>
 #include <list>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "backends/p4tools/common/lib/table_utils.h"
 #include "ir/declaration.h"
 #include "ir/indexed_vector.h"
 #include "ir/vector.h"
@@ -54,57 +54,78 @@ bool P4ProgramDCGCreator::preorder(const IR::ConstructorCallExpression *callExpr
     return true;
 }
 
-bool P4ProgramDCGCreator::preorder(const IR::MethodCallExpression *method) {
-    // Check for application of a table.
-    CHECK_NULL(method->method);
-    if (const auto *path = method->method->to<IR::PathExpression>()) {
-        const auto *currentControl = findOrigCtxt<IR::P4Control>();
-        if (currentControl != nullptr) {
-            const auto *decl = currentControl->getDeclByName(path->path->name.name);
-            if (decl != nullptr) {
-                if (const auto *action = decl->to<IR::P4Action>()) {
-                    for (const auto *arg : *method->arguments) {
-                        visit(arg);
-                    }
-                    addEdge(method);
-                    visit(action);
-                    return false;
-                }
-            }
-        }
-    }
-    if (!method->method->is<IR::Member>()) {
-        return true;
-    }
-    const auto *member = method->method->to<IR::Member>();
-    for (const auto *arg : *method->arguments) {
+bool P4ProgramDCGCreator::preorder(const IR::MethodCallExpression *call) {
+    CHECK_NULL(call->method);
+    for (const auto *arg : *call->arguments) {
         visit(arg);
     }
-    // Do not anylyse tables apply and value set index methods.
-    if (member->member != IR::IApply::applyMethodName && member->member.originalName != "index") {
-        return true;
-    }
-    if (const auto *pathExpr = member->expr->to<IR::PathExpression>()) {
-        const auto *currentControl = findOrigCtxt<IR::P4Control>();
-        if (currentControl != nullptr) {
-            const auto *decl = currentControl->getDeclByName(pathExpr->path->name.name);
-            visit(decl->checkedTo<IR::P4Table>());
-            return false;
-        }
-        const auto *parser = findOrigCtxt<IR::P4Parser>();
-        if (parser != nullptr) {
-            const auto *decl = parser->getDeclByName(pathExpr->path->name.name);
-            visit(decl->checkedTo<IR::Declaration_Instance>());
-            return true;
-        }
-        return true;
-    }
-    const auto *type = member->expr->type;
-    if (const auto *tableType = type->to<IR::Type_Table>()) {
-        visit(tableType->table);
+    if (call->method->type->is<IR::Type_Action>()) {
+        const auto *path = call->method->checkedTo<IR::PathExpression>();
+        const auto *action = getDeclaration(path->path, true)->checkedTo<IR::P4Action>();
+        addEdge(call);
+        visit(action);
         return false;
     }
-    return true;
+    if (call->method->type->is<IR::Type_Method>()) {
+        if (const auto *path = call->method->to<IR::PathExpression>()) {
+            const auto *method = getDeclaration(path->path, true)->checkedTo<IR::Method>();
+            visit(method);
+            return false;
+        }
+        if (const auto *method = call->method->to<IR::Member>()) {
+            // Case where call->method is a Member expression. For table invocations, the
+            // qualifier of the member determines the table being invoked. For extern calls,
+            // the qualifier determines the extern object containing the method being invoked.
+            BUG_CHECK(method->expr, "Method call has unexpected format: %1%", call);
+
+            // Handle table calls.
+            if (method->expr->type->is<IR::Type_Table>()) {
+                const auto *tableDecl =
+                    getDeclaration(method->expr->checkedTo<IR::PathExpression>()->path, true)
+                        ->checkedTo<IR::P4Table>();
+                visit(tableDecl);
+                return false;
+            }
+
+            // Handle extern calls. They may also be of Type_SpecializedCanonical.
+            if (method->expr->type->is<IR::Type_Extern>() ||
+                method->expr->type->is<IR::Type_SpecializedCanonical>()) {
+                // TODO: This is the wrong place to analyze parser value sets.
+                // They should be handled in the select expression.
+                if (method->member.originalName == "index") {
+                    const auto *decl =
+                        getDeclaration(method->expr->checkedTo<IR::PathExpression>()->path, true)
+                            ->checkedTo<IR::Declaration_Instance>();
+                    visit(decl);
+                }
+                return false;
+            }
+
+            // Handle calls to header methods.
+            if (method->expr->type->is<IR::Type_Header>() ||
+                method->expr->type->is<IR::Type_HeaderUnion>()) {
+                if (method->member == "isValid" || method->member == "setInvalid" ||
+                    method->member == "setValid") {
+                    return false;
+                }
+                BUG("Unknown method call on header instance: %1%", call);
+            }
+
+            if (method->expr->type->is<IR::Type_Stack>()) {
+                if (method->member == "push_front" || method->member == "pop_front") {
+                    return false;
+                }
+                BUG("Unknown method call on stack instance: %1%", call);
+            }
+
+            BUG("Unknown method member expression: %1% of type %2%", method->expr,
+                method->expr->type);
+        }
+
+        BUG("Unknown method call: %1% of type %2%", call->method, call->method->node_type_name());
+    }
+
+    BUG("Unsupported method call type for %1%: %2%", call, call->method->type);
 }
 
 bool P4ProgramDCGCreator::preorder(const IR::MethodCallStatement *method) {
@@ -133,7 +154,6 @@ bool P4ProgramDCGCreator::preorder(const IR::P4Parser *parser) {
 
 bool P4ProgramDCGCreator::preorder(const IR::P4Table *table) {
     addEdge(table, table->name);
-    DCGVertexTypeSet prevSet;
     if (table->annotations != nullptr) {
         for (const auto *annotation : table->annotations->annotations) {
             visit(annotation);
@@ -148,20 +168,40 @@ bool P4ProgramDCGCreator::preorder(const IR::P4Table *table) {
             }
         }
     }
+    TableUtils::TableProperties properties;
+    TableUtils::checkTableImmutability(*table, properties);
+
     auto storedSet = prev;
-    const auto *entryList = table->getEntries();
-    if (entryList != nullptr) {
-        for (const auto *entry : entryList->entries) {
-            prev = storedSet;
-            visit(entry);
-            prevSet.insert(prev.begin(), prev.end());
+    DCGVertexTypeSet prevSet;
+    if (properties.tableIsImmutable) {
+        // We can only match on entries when there are keys present.
+        if (table->getKey() != nullptr) {
+            const auto *entryList = table->getEntries();
+            if (entryList != nullptr) {
+                for (const auto *entry : entryList->entries) {
+                    prev = storedSet;
+                    visit(entry);
+                    prevSet.insert(prev.begin(), prev.end());
+                }
+            } else if (wasImplementations) {
+                prevSet.insert(prev.begin(), prev.end());
+            }
         }
-    } else if (wasImplementations) {
+        // If the default action is immutable, we can only match on the default action.
+        if (properties.defaultIsImmutable) {
+            prev = storedSet;
+            visit(table->getDefaultAction());
+            prevSet.insert(prev.begin(), prev.end());
+            prev = prevSet;
+            return false;
+        }
+    }
+    for (const auto *action : table->getActionList()->actionList) {
+        prev = storedSet;
+        visit(action);
         prevSet.insert(prev.begin(), prev.end());
     }
-    prev = storedSet;
-    visit(table->getDefaultAction());
-    prevSet.insert(prev.begin(), prev.end());
+
     prev = prevSet;
     return false;
 }
@@ -179,16 +219,18 @@ bool P4ProgramDCGCreator::preorder(const IR::ParserState *parserState) {
     }
     if (parserState->selectExpression != nullptr) {
         if (const auto *pathExpr = parserState->selectExpression->to<IR::PathExpression>()) {
-            if (pathExpr->path->name.name == IR::ParserState::accept ||
-                pathExpr->path->name.name == IR::ParserState::reject) {
-                addEdge(parserState->selectExpression);
-                return true;
+            const auto *declaration = getDeclaration(pathExpr->path)->checkedTo<IR::ParserState>();
+
+            BUG_CHECK(declaration != nullptr, "Parser state not found: %1%",
+                      pathExpr->path->name.name);
+            if (visited.count(declaration) != 0U) {
+                addEdge(declaration, declaration->name);
+                return false;
             }
+            visit(declaration);
+        } else {
+            visit(parserState->selectExpression);
         }
-        if (visited.count(parserState->selectExpression) != 0U) {
-            return false;
-        }
-        visit(parserState->selectExpression);
     }
     return false;
 }
@@ -220,8 +262,9 @@ bool P4ProgramDCGCreator::preorder(const IR::P4Program *program) {
             // declaration instance.
             auto filter = [pathExpr](const IR::IDeclaration *d) {
                 CHECK_NULL(d);
-                if (const auto *decl = d->to<IR::Declaration_Instance>())
+                if (const auto *decl = d->to<IR::Declaration_Instance>()) {
                     return pathExpr->path->name == decl->name;
+                }
                 return false;
             };
             // Convert the declaration instance into a constructor-call expression.
@@ -234,7 +277,7 @@ bool P4ProgramDCGCreator::preorder(const IR::P4Program *program) {
     }
     this->prev = {program};
     for (const auto *arg : v) {
-        // Apply to the arguments.,
+        // Visit the blocks in order of the constructor arguments.
         visit(arg);
     }
     return false;
@@ -248,7 +291,7 @@ bool P4ProgramDCGCreator::preorder(const IR::P4ValueSet *valueSet) {
 bool P4ProgramDCGCreator::preorder(const IR::SelectExpression *selectExpression) {
     visit(selectExpression->select);
     DCGVertexTypeSet prevSet;
-    const auto *currentParser = findOrigCtxt<IR::P4Parser>();
+    const auto *currentParser = findContext<IR::P4Parser>();
     BUG_CHECK(currentParser != nullptr, "Null parser pointer");
     auto storedSet = prev;
     for (const auto *selectCase : selectExpression->selectCases) {
@@ -278,6 +321,8 @@ bool P4ProgramDCGCreator::preorder(const IR::IfStatement *ifStatement) {
         prev = storedSet;
         visit(ifStatement->ifFalse);
         next.insert(prev.begin(), prev.end());
+    } else {
+        next.insert(storedSet.begin(), storedSet.end());
     }
     prev = next;
     return false;
@@ -317,7 +362,7 @@ bool P4ProgramDCGCreator::preorder(const IR::StatOrDecl *statOrDecl) {
     return true;
 }
 
-void P4ProgramDCGCreator::addEdge(const DCGVertexType *vertex, IR::ID vertexName) {
+void P4ProgramDCGCreator::addEdge(DCGVertexType vertex, const IR::ID &vertexName) {
     LOG1("Add edge : " << prev.size() << "(" << *prev.begin() << ") : " << vertex);
     for (const auto *p : prev) {
         dcg->calls(p, vertex);
@@ -341,13 +386,13 @@ ReachabilityEngineState *ReachabilityEngineState::copy() {
     return newState;
 }
 
-std::list<const DCGVertexType *> ReachabilityEngineState::getState() { return state; }
+std::list<DCGVertexType> ReachabilityEngineState::getState() { return state; }
 
-void ReachabilityEngineState::setState(std::list<const DCGVertexType *> ls) { state = ls; }
+void ReachabilityEngineState::setState(const std::list<DCGVertexType> &ls) { state = ls; }
 
-const DCGVertexType *ReachabilityEngineState::getPrevNode() { return prevNode; }
+DCGVertexType ReachabilityEngineState::getPrevNode() { return prevNode; }
 
-void ReachabilityEngineState::setPrevNode(const DCGVertexType *n) { prevNode = n; }
+void ReachabilityEngineState::setPrevNode(DCGVertexType n) { prevNode = n; }
 
 bool ReachabilityEngineState::isEmpty() { return state.empty(); }
 
@@ -357,7 +402,7 @@ ReachabilityEngine::ReachabilityEngine(const NodesCallGraph &dcg,
                                        std::string reachabilityExpression,
                                        bool eliminateAnnotations)
     : dcg(dcg), hash(dcg.getHash()) {
-    std::list<const DCGVertexType *> start;
+    std::list<DCGVertexType> start;
     start.push_back(nullptr);
     size_t i = 0;
     size_t j = 0;
@@ -365,7 +410,7 @@ ReachabilityEngine::ReachabilityEngine(const NodesCallGraph &dcg,
     while ((i = reachabilityExpression.find(';')) != std::string::npos) {
         auto addSubExpr = reachabilityExpression.substr(0, i);
         addSubExpr += "+";
-        std::list<const DCGVertexType *> newStart;
+        std::list<DCGVertexType> newStart;
         while ((j = addSubExpr.find('+')) != std::string::npos) {
             auto dotSubExpr = addSubExpr.substr(0, j);
             while (dotSubExpr[0] == ' ') {
@@ -377,7 +422,7 @@ ReachabilityEngine::ReachabilityEngine(const NodesCallGraph &dcg,
             }
             auto currentNames = getName(dotSubExpr);
             if (eliminateAnnotations) {
-                std::unordered_set<const DCGVertexType *> result;
+                std::unordered_set<DCGVertexType> result;
                 for (auto i : currentNames) {
                     if (!i->is<IR::Annotation>()) {
                         result.insert(i);
@@ -403,9 +448,9 @@ ReachabilityEngine::ReachabilityEngine(const NodesCallGraph &dcg,
     }
 }
 
-void ReachabilityEngine::annotationToStatements(const DCGVertexType *node,
-                                                std::unordered_set<const DCGVertexType *> &s) {
-    std::list<const DCGVertexType *> l = {node};
+void ReachabilityEngine::annotationToStatements(DCGVertexType node,
+                                                std::unordered_set<DCGVertexType> &s) {
+    std::list<DCGVertexType> l = {node};
     while (!l.empty()) {
         const auto *nd = l.front();
         l.pop_front();
@@ -427,12 +472,12 @@ void ReachabilityEngine::annotationToStatements(const DCGVertexType *node,
     }
 }
 
-void ReachabilityEngine::addTransition(const DCGVertexType *left,
-                                       const std::unordered_set<const DCGVertexType *> &rightSet) {
+void ReachabilityEngine::addTransition(DCGVertexType left,
+                                       const std::unordered_set<DCGVertexType> &rightSet) {
     for (const auto *right : rightSet) {
         auto i = userTransitions.find(left);
         if (i == userTransitions.end()) {
-            std::list<const DCGVertexType *> l;
+            std::list<DCGVertexType> l;
             l.push_back(right);
             userTransitions.emplace(left, l);
         } else {
@@ -442,7 +487,7 @@ void ReachabilityEngine::addTransition(const DCGVertexType *left,
 }
 
 const IR::Expression *ReachabilityEngine::addCondition(const IR::Expression *prev,
-                                                       const DCGVertexType *currentState) {
+                                                       DCGVertexType currentState) {
     const auto *newCond = getCondition(currentState);
     if (newCond == nullptr) {
         return prev;
@@ -450,7 +495,7 @@ const IR::Expression *ReachabilityEngine::addCondition(const IR::Expression *pre
     return new IR::BOr(IR::Type_Boolean::get(), newCond, prev);
 }
 
-std::unordered_set<const DCGVertexType *> ReachabilityEngine::getName(std::string name) {
+std::unordered_set<DCGVertexType> ReachabilityEngine::getName(std::string name) {
     std::string params;
     if ((name.length() != 0U) && name[name.length() - 1] == ')') {
         size_t n = name.find('(');
@@ -483,8 +528,7 @@ std::unordered_set<const DCGVertexType *> ReachabilityEngine::getName(std::strin
     return i->second;
 }
 
-ReachabilityResult ReachabilityEngine::next(ReachabilityEngineState *state,
-                                            const DCGVertexType *next) {
+ReachabilityResult ReachabilityEngine::next(ReachabilityEngineState *state, DCGVertexType next) {
     CHECK_NULL(state);
     CHECK_NULL(next);
     if (forbiddenVertexes.count(next)) {
@@ -502,8 +546,8 @@ ReachabilityResult ReachabilityEngine::next(ReachabilityEngineState *state,
         return std::make_pair(false, nullptr);
     }
     const IR::Expression *expr = nullptr;
-    std::list<const DCGVertexType *> newState;
-    std::list<const DCGVertexType *> currentState = state->getState();
+    std::list<DCGVertexType> newState;
+    std::list<DCGVertexType> currentState = state->getState();
     for (const auto *i : currentState) {
         if (i == nullptr) {
             // Start from intial.
@@ -553,7 +597,7 @@ ReachabilityResult ReachabilityEngine::next(ReachabilityEngineState *state,
 
 const NodesCallGraph &ReachabilityEngine::getDCG() { return dcg; }
 
-const IR::Expression *ReachabilityEngine::getCondition(const DCGVertexType *n) {
+const IR::Expression *ReachabilityEngine::getCondition(DCGVertexType n) {
     auto i = conditions.find(n);
     if (i != conditions.end()) {
         return i->second;

--- a/backends/p4tools/common/compiler/reachability.h
+++ b/backends/p4tools/common/compiler/reachability.h
@@ -51,7 +51,7 @@ class ExtendedCallGraph : public P4::CallGraph<T> {
             cstring newName = name.name.before(prev);
             i = hash.find(newName);
             if (i == hash.end()) {
-                addToHash(vertex, ((newName.size() != 0U) ? IR::ID(newName) : IR::ID()));
+                addToHash(vertex, (!newName.isNullOrEmpty() ? IR::ID(newName) : IR::ID()));
             }
         }
     }

--- a/backends/p4tools/common/compiler/reachability.h
+++ b/backends/p4tools/common/compiler/reachability.h
@@ -7,8 +7,8 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
-#include <vector>
 
+#include "frontends/common/resolveReferences/resolveReferences.h"
 #include "frontends/p4/callGraph.h"
 #include "ir/id.h"
 #include "ir/ir.h"
@@ -19,9 +19,9 @@
 
 namespace P4Tools {
 
-using DCGVertexType = const IR::Node;
-using DCGVertexTypeSet = std::unordered_set<const DCGVertexType *>;
-using ReachabilityHashType = std::unordered_map<cstring, std::unordered_set<const DCGVertexType *>>;
+using DCGVertexType = const IR::Node *;
+using DCGVertexTypeSet = std::unordered_set<DCGVertexType>;
+using ReachabilityHashType = std::unordered_map<cstring, DCGVertexTypeSet>;
 
 template <class T>
 class ExtendedCallGraph : public P4::CallGraph<T> {
@@ -34,13 +34,13 @@ class ExtendedCallGraph : public P4::CallGraph<T> {
     /// Function adds current vertex to a hash which allows to get access
     /// for vertexes from string in DCG.
     /// If name is empty then it doesn't hash it.
-    void addToHash(T vertex, IR::ID name) {
+    void addToHash(T vertex, const IR::ID &name) {
         if (name.name.size() == 0) {
             return;
         }
         auto i = hash.find(name.name);
         if (i == hash.end()) {
-            std::unordered_set<const DCGVertexType *> s;
+            std::unordered_set<DCGVertexType> s;
             s.insert(vertex);
             hash.emplace(name.name, s);
         } else {
@@ -51,7 +51,7 @@ class ExtendedCallGraph : public P4::CallGraph<T> {
             cstring newName = name.name.before(prev);
             i = hash.find(newName);
             if (i == hash.end()) {
-                addToHash(vertex, (newName.size() ? IR::ID(newName) : IR::ID()));
+                addToHash(vertex, ((newName.size() != 0U) ? IR::ID(newName) : IR::ID()));
             }
         }
     }
@@ -84,13 +84,13 @@ class ExtendedCallGraph : public P4::CallGraph<T> {
     }
 };
 
-using NodesCallGraph = ExtendedCallGraph<DCGVertexType *>;
+using NodesCallGraph = ExtendedCallGraph<DCGVertexType>;
 
 /// The main class for building control flow DCG.
-class P4ProgramDCGCreator : public Inspector {
+class P4ProgramDCGCreator : public Inspector, private P4::ResolutionContext {
     NodesCallGraph *dcg;
     DCGVertexTypeSet prev;
-    std::unordered_set<const DCGVertexType *> visited;
+    std::unordered_set<DCGVertexType> visited;
     const IR::P4Program *p4program;
 
  public:
@@ -98,7 +98,7 @@ class P4ProgramDCGCreator : public Inspector {
 
     bool preorder(const IR::Annotation *annotation) override;
     bool preorder(const IR::ConstructorCallExpression *callExpr) override;
-    bool preorder(const IR::MethodCallExpression *method) override;
+    bool preorder(const IR::MethodCallExpression *call) override;
     bool preorder(const IR::MethodCallStatement *method) override;
     bool preorder(const IR::P4Action *action) override;
     bool preorder(const IR::P4Parser *parser) override;
@@ -115,13 +115,13 @@ class P4ProgramDCGCreator : public Inspector {
  protected:
     /// Function add edge to current @vertex in DCG.
     /// The edge is a pair (@prev, @vertex).
-    void addEdge(const DCGVertexType *vertex, IR::ID vertexName = IR::ID());
+    void addEdge(DCGVertexType vertex, const IR::ID &vertexName = IR::ID());
 };
 
 /// The main data for reachability engine.
 class ReachabilityEngineState {
-    const DCGVertexType *prevNode = nullptr;
-    std::list<const DCGVertexType *> state;
+    DCGVertexType prevNode = nullptr;
+    std::list<DCGVertexType> state;
 
  public:
     /// Gets initial state.
@@ -129,13 +129,13 @@ class ReachabilityEngineState {
     /// Copies a state.
     ReachabilityEngineState *copy();
     /// Gets current state.
-    std::list<const DCGVertexType *> getState();
+    std::list<DCGVertexType> getState();
     /// Sets current state.
-    void setState(std::list<const DCGVertexType *>);
+    void setState(const std::list<DCGVertexType> &);
     /// Gets previous node.
-    const DCGVertexType *getPrevNode();
+    DCGVertexType getPrevNode();
     /// Sets previous node.
-    void setPrevNode(const DCGVertexType *);
+    void setPrevNode(DCGVertexType);
     /// Retuns true if state is empty.
     bool isEmpty();
     /// Clears state.
@@ -159,9 +159,9 @@ using ReachabilityResult = std::pair<bool, const IR::Expression *>;
 class ReachabilityEngine {
     const NodesCallGraph &dcg;
     const ReachabilityHashType &hash;
-    std::unordered_map<const DCGVertexType *, std::list<const DCGVertexType *>> userTransitions;
-    std::unordered_map<const DCGVertexType *, const IR::Expression *> conditions;
-    std::unordered_set<const DCGVertexType *> forbiddenVertexes;
+    std::unordered_map<DCGVertexType, std::list<DCGVertexType>> userTransitions;
+    std::unordered_map<DCGVertexType, const IR::Expression *> conditions;
+    std::unordered_set<DCGVertexType> forbiddenVertexes;
 
  public:
     /// Default constructor, where dcg is a control flow graph builded by P4ProgramDCGCreator,
@@ -175,23 +175,21 @@ class ReachabilityEngine {
     /// which should be checked additionally. If engine state is reachable from current node
     /// then it returns true. If engine state contain such node then it returns additional condition
     /// in case if it was inputed by user and moves engine state to the next state.
-    ReachabilityResult next(ReachabilityEngineState *, const DCGVertexType *);
+    ReachabilityResult next(ReachabilityEngineState *, DCGVertexType);
     /// Returns current control flow graph.
     const NodesCallGraph &getDCG();
 
  protected:
     /// Translates current annotation into set of the parent nodes.
-    void annotationToStatements(const DCGVertexType *node,
-                                std::unordered_set<const DCGVertexType *> &s);
+    void annotationToStatements(DCGVertexType node, std::unordered_set<DCGVertexType> &s);
     /// Adds transition to engine control flow graph.
-    void addTransition(const DCGVertexType *, const std::unordered_set<const DCGVertexType *> &);
+    void addTransition(DCGVertexType, const std::unordered_set<DCGVertexType> &);
     /// Translates string into the corresponding nodes.
-    std::unordered_set<const DCGVertexType *> getName(std::string name);
+    std::unordered_set<DCGVertexType> getName(std::string name);
     /// Gets a user's condition from a node.
-    const IR::Expression *getCondition(const DCGVertexType *);
+    const IR::Expression *getCondition(DCGVertexType);
     /// Adds user's condition the a node.
-    const IR::Expression *addCondition(const IR::Expression *prev,
-                                       const DCGVertexType *currentState);
+    const IR::Expression *addCondition(const IR::Expression *prev, DCGVertexType currentState);
     /// Translates a string representation into an IR::Expression.
     /// Not implemented yet.
     static const IR::Expression *stringToNode(std::string name);
@@ -199,7 +197,7 @@ class ReachabilityEngine {
  protected:
     /// Adds an edge to the current @vertex in DCG.
     /// The edge is a pair (@prev, @vertex).
-    void addEdge(const DCGVertexType *vertex, IR::ID vertexName = IR::ID());
+    void addEdge(DCGVertexType vertex, IR::ID vertexName = IR::ID());
 };
 
 }  // namespace P4Tools

--- a/backends/p4tools/modules/smith/common/statements.cpp
+++ b/backends/p4tools/modules/smith/common/statements.cpp
@@ -14,7 +14,6 @@
 #include "backends/p4tools/modules/smith/core/target.h"
 #include "backends/p4tools/modules/smith/util/util.h"
 #include "ir/indexed_vector.h"
-#include "ir/ir-generated.h"
 #include "ir/irutils.h"
 #include "ir/vector.h"
 #include "lib/cstring.h"

--- a/frontends/p4/callGraph.h
+++ b/frontends/p4/callGraph.h
@@ -47,11 +47,27 @@ class CallGraph {
 
  public:
     ordered_set<T> nodes;  // all nodes; do not modify this directly
-    typedef typename ordered_map<T, std::vector<T> *>::const_iterator const_iterator;
+    using const_iterator = typename ordered_map<T, std::vector<T> *>::const_iterator;
 
     explicit CallGraph(std::string_view name) : name(name) {}
 
-    const cstring &getName() const { return name; }
+    /// Get the name of the graph
+    [[nodiscard]] const cstring &getName() const { return name; }
+
+    /// Return true if the graph is empty
+    [[nodiscard]] bool empty() const { return nodes.empty(); }
+
+    /// Return the number of nodes
+    [[nodiscard]] size_t size() const { return nodes.size(); }
+
+    /// Return the number of outgoing edges
+    [[nodiscard]] const ordered_map<T, std::vector<T> *> &getOutEdges() const { return out_edges; }
+
+    /// Return the number of incoming edges
+    [[nodiscard]] const ordered_map<T, std::vector<T> *> &getInEdges() const { return in_edges; }
+
+    /// Return the set of nodes.
+    [[nodiscard]] const ordered_set<T> &getNodes() const { return nodes; }
 
     // Graph construction.
 
@@ -118,7 +134,6 @@ class CallGraph {
     void getCallees(T caller, std::set<T> &toAppend) {
         if (isCaller(caller)) toAppend.insert(out_edges[caller]->begin(), out_edges[caller]->end());
     }
-    size_t size() const { return nodes.size(); }
     // out will contain all nodes reachable from start
     void reachable(T start, std::set<T> &out) const {
         std::set<T> work;
@@ -141,7 +156,7 @@ class CallGraph {
         for (auto n : toRemove) remove(n);
     }
 
-    typedef std::unordered_set<T> Set;
+    using Set = std::unordered_set<T>;
 
     // Compute for each node the set of dominators with the indicated start node.
     // Node d dominates node n if all paths from the start to n go through d


### PR DESCRIPTION
Clean up some issues with the reachability pass and modernize the code. This pass is barely used so the changes are not of much consequence. This fixes are useful for better control-flow analysis and statistics on program complexity. Hoping to contribute some of this code soon. 

Also add some more getter/setter helper functions to `callgraph.h`. 