### PR TITLE
Fix: Links in Generated Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for considering contributing to the P4 Compiler Project (P4C)! Your co
 ## Contributing License
 The P4 organizations uses [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for contributions. Please take a look at our [guidelines](https://github.com/p4lang/governance/wiki/P4-DCO-Guidelines).
 
-To sign off the last commit quickly use the `git commit --amend --signoff` command. The failing check will also include instructions on how to sign off all commits in two steps (using `git rebase HEAD~$NUM_COMMITS --signoff`). https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md#dco-is-missing also provides helpful tips on fixing DCO inconveniences. Setting up a commit hook in the P4C repository will automate adding the DCO signoff.
+To sign off the last commit quickly use the `git commit --amend --signoff` command. The failing check will also include instructions on how to sign off all commits in two steps (using `git rebase HEAD~$NUM_COMMITS --signoff`). The [Developer Community DCO guide](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md#dco-is-missing) also provides helpful tips on fixing DCO inconveniences. Setting up a commit hook in the P4C repository will automate adding the DCO signoff.
 
 ## Coding Standard Philosophy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ To sign off the last commit quickly use the `git commit --amend --signoff` comma
 
 ## Coding Standard Philosophy
 
-Please note that this project adheres to the [P4 Coding Standard Philosophy](https://github.com/p4lang/p4c/blob/main/docs/CodingStandardPhilosophy.md). By participating, you are expected to uphold this code. 
+Please note that this project adheres to the [P4 Coding Standard Philosophy](docs/CodingStandardPhilosophy.md). By participating, you are expected to uphold this code. 
 
 ## How to Contribute
 We welcome and appreciate new contributions. Check out [git usage](https://github.com/p4lang/p4c/tree/main/docs#git-usage) to get started.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ sudo dpkg -i /path/to/package.deb
 2.  Install [dependencies](#dependencies). You can find specific instructions
     for Ubuntu 20.04 [here](#ubuntu-dependencies) and for macOS 11
     [here](#macos-dependencies).  You can also look at the
-    [CI installation script](tools/ci-build.sh).
+    [CI installation script](https://github.com/p4lang/p4c/blob/main/tools/ci-build.sh).
 
 3.  Build. Building should also take place in a subdirectory named `build`.
     ```
@@ -336,7 +336,7 @@ sudo dnf install -y doxygen graphviz
 git clone --depth 1 -b v2.3.3 https://github.com/jothepro/doxygen-awesome-css ./docs/doxygen/awesome_css
 ```
 
-You can also look at the [dependencies installation script](tools/install_fedora_deps.sh)
+You can also look at the [dependencies installation script](https://github.com/p4lang/p4c/blob/main/tools/install_fedora_deps.sh)
 for a fresh Fedora instance.
 
 ### macOS dependencies
@@ -478,10 +478,10 @@ bazel build //...
 We run continuous integration to ensure this works with the latest version of
 Bazel.
 
-We also provide a [`p4_library` rule](bazel/p4_library.bzl) for invoking
+We also provide a [`p4_library` rule](https://github.com/p4lang/p4c/blob/main/bazel/p4_library.bzl) for invoking
 P4C during the build process of 3rd party Bazel projects.
 
-See [bazel/example](bazel/example) for an example of how to use or extend P4C in
+See [bazel/example](https://github.com/p4lang/p4c/tree/main/bazel/example) for an example of how to use or extend P4C in
 your own Bazel project. You may use it as a template to get you started.
 
 ## Build system

--- a/docs/README.md
+++ b/docs/README.md
@@ -158,7 +158,7 @@ git push -f
 * After committing changes, create a pull request (using the github web UI)
 
 * Follow these
-  [guidelines](CodingStandardPhilosophy.md#Git-commits-and-pull-requests)
+  [guidelines](CodingStandardPhilosophy.md#git-commits-and-pull-requests)
   to write commit messages and open pull requests.
 
 ## Debugging
@@ -297,7 +297,7 @@ To add a new input test with a sample P4 code file (under `testdata/p4_16_sample
     informative error message.
 
   * Use `::error()` and `::warning()` for error reporting. See the
-    [guidelines](CodingStandardPhilosophy.md#Handling-errors) for more
+    [guidelines](CodingStandardPhilosophy.md#handling-errors) for more
     details.
 
   * Use `LOGn()` for log messages -- the `n` is an integer constant for

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,10 +86,10 @@ p4c
 * the core design of the compiler intermediate representation (IR) and
   the visitor patterns are briefly described in [IR](IR.md)
 
-* The [migration guide](migration-guide.pptx) describes how P4_14 (v1.0)
+* The [migration guide](https://github.com/p4lang/p4c/blob/main/docs/migration-guide.pptx) describes how P4_14 (v1.0)
   programs are translated into P4_16 programs
 
-* The [compiler design](compiler-design.pptx) describes the salient
+* The [compiler design](https://github.com/p4lang/p4c/blob/main/docs/compiler-design.pptx) describes the salient
   features of the compiler design and implementation; this document has several subsections:
   * Compiler goals
   * Compiler architecture

--- a/docs/doxygen/01_overview.md
+++ b/docs/doxygen/01_overview.md
@@ -19,5 +19,5 @@ The P4C compiler is a compiler infrastructure for the P4 compiler designed with 
 * the core design of the compiler intermediate representation (IR) and
   the visitor patterns are briefly described in [IR](../IR.md)
 
-* The [migration guide](../migration-guide.pptx) describes how P4_14 (v1.0)
+* The [migration guide](https://github.com/p4lang/p4c/blob/main/docs/migration-guide.pptx) describes how P4_14 (v1.0)
   programs are translated into P4_16 programs

--- a/docs/doxygen/Doxymain.md
+++ b/docs/doxygen/Doxymain.md
@@ -47,7 +47,7 @@ P4C is the official open-source reference compiler for the [P4](https://p4.org/)
 <div class="card-container">
 
   <div class="card-item">
-    <a href="https://p4lang.github.io/p4c/md__2home_2runner_2work_2p4c_2p4c_2_r_e_a_d_m_e.html#autotoc_md80"> 
+    <a href="https://p4lang.github.io/p4c/md__2home_2runner_2work_2p4c_2p4c_2_r_e_a_d_m_e.html#autotoc_md41"> 
     <div class="card-content">
    <?xml version="1.0" encoding="utf-8"?>
       <svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -59,7 +59,7 @@ P4C is the official open-source reference compiler for the [P4](https://p4.org/)
   </div>
 
   <div class="card-item">
-    <a href="https://p4lang.github.io/p4c/md__2home_2runner_2work_2p4c_2p4c_2_r_e_a_d_m_e.html#autotoc_md51"> 
+    <a href="https://p4lang.github.io/p4c/md__2home_2runner_2work_2p4c_2p4c_2_r_e_a_d_m_e.html#autotoc_md12"> 
     <div class="card-content">
       <svg width="800px" height="800px" viewBox="0 0 24 24" fill="none"  class="card_svg" xmlns="http://www.w3.org/2000/svg">
         <path opacity="0.1" fill-rule="evenodd" clip-rule="evenodd" d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.224 13.0171C16.011 12.5674 16.011 11.4326 15.224 10.9829L10.7817 8.44446C10.0992 8.05446 9.25 8.54727 9.25 9.33333L9.25 14.6667C9.25 15.4527 10.0992 15.9455 10.7817 15.5555L15.224 13.0171Z" fill="#323232"/>

--- a/docs/doxygen/Doxymain.md
+++ b/docs/doxygen/Doxymain.md
@@ -47,7 +47,7 @@ P4C is the official open-source reference compiler for the [P4](https://p4.org/)
 <div class="card-container">
 
   <div class="card-item">
-    <a href="https://p4lang.github.io/p4c/md__2home_2runner_2work_2p4c_2p4c_2_r_e_a_d_m_e.html#autotoc_md41"> 
+    <a href="https://p4lang.github.io/p4c/md__2home_2runner_2work_2p4c_2p4c_2_r_e_a_d_m_e.html#p4-compiler-onboarding"> 
     <div class="card-content">
    <?xml version="1.0" encoding="utf-8"?>
       <svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -59,7 +59,7 @@ P4C is the official open-source reference compiler for the [P4](https://p4.org/)
   </div>
 
   <div class="card-item">
-    <a href="https://p4lang.github.io/p4c/md__2home_2runner_2work_2p4c_2p4c_2_r_e_a_d_m_e.html#autotoc_md12"> 
+    <a href="https://p4lang.github.io/p4c/md__2home_2runner_2work_2p4c_2p4c_2_r_e_a_d_m_e.html#getting-started"> 
     <div class="card-content">
       <svg width="800px" height="800px" viewBox="0 0 24 24" fill="none"  class="card_svg" xmlns="http://www.w3.org/2000/svg">
         <path opacity="0.1" fill-rule="evenodd" clip-rule="evenodd" d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.224 13.0171C16.011 12.5674 16.011 11.4326 15.224 10.9829L10.7817 8.44446C10.0992 8.05446 9.25 8.54727 9.25 9.33333L9.25 14.6667C9.25 15.4527 10.0992 15.9455 10.7817 15.5555L15.224 13.0171Z" fill="#323232"/>

--- a/docs/doxygen/doxygen.cfg
+++ b/docs/doxygen/doxygen.cfg
@@ -946,9 +946,9 @@ INPUT                 = ../../docs/README.md \
                         ../../docs/doxygen \
                         ../../frontends \
                         ../../midend \
-                        ../../docs/IR.md \
                         ../../lib/README.md \
                         ../../lib \
+                        ../../docs/IR.md \
                         ../../ir/README.md \
                         ../../ir \
                         ../../CHANGELOG.md \ 

--- a/docs/doxygen/doxygen.cfg
+++ b/docs/doxygen/doxygen.cfg
@@ -368,7 +368,7 @@ TOC_INCLUDE_HEADINGS   = 5
 # The default value is: DOXYGEN.
 # This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
 
-MARKDOWN_ID_STYLE      = DOXYGEN
+MARKDOWN_ID_STYLE      = GITHUB
 
 # When enabled doxygen tries to link words that correspond to documented
 # classes, or namespaces to their corresponding documentation. Such a link can

--- a/docs/doxygen/doxygen.cfg
+++ b/docs/doxygen/doxygen.cfg
@@ -971,7 +971,8 @@ INPUT                 = ../../docs/README.md \
                         ../../backends/ubpf/tests/README.md \
                         ../../backends \
                         ../../control-plane \
-                        ../../CONTRIBUTING.md
+                        ../../CONTRIBUTING.md \
+                        ../../docs/CodingStandardPhilosophy.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
For better Presentation of content in generated documentation.

## Changes 


- [x] Enabled GitHub Markdown Style TOC  (i.e. TOC given in README was no functional in generated output.)
- [x] Generated Relative link fixes to non README files and PPTs/PDF.
- [x] Docs : Added P4 Coding Standard Philosophy to Docs 
- [x] Fix : Sequence of IR introduction in docs
- [x] Fix: relative linking to subsections in Doxygen output 

## Links fixed

### on Main Page [P4 Compiler Documentation]

- Card links on "p4 Compiler Onboarding" and "Getting Started" 

### on Repository Page 
- migration guide
- compiler design
- "guidelines" link https://p4lang.github.io/p4c/CodingStandardPhilosophy.md#git-commits-and-pull-requests
- "guidelines" link https://p4lang.github.io/p4c/CodingStandardPhilosophy.md#handling-errors


### on P4C Page 
- CI installation script link 
- dependencies installation script
- "rule" link
- bazel/example
- "unsupported P4_16 language features" link https://p4lang.github.io/p4c/backends/bmv2/README.md#unsupported-p4_16-language-features




 