### PR TITLE
[p4fmt]: print comments

### DIFF
--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -241,6 +241,9 @@ bool ToP4::preorder(const IR::Type_Void *) {
 }
 
 bool ToP4::preorder(const IR::Type_Name *t) {
+    auto cmts = t->srcInfo.getComments();
+    builder.append(cmts);
+    builder.append("\n");
     visit(t->path);
     return false;
 }

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -281,6 +281,9 @@ bool ToP4::preorder(const IR::Type_Typedef *t) {
         visit(t->annotations);
         builder.spc();
     }
+    auto cmts = t->srcInfo.getComments();
+    builder.append(cmts);
+    builder.append("\n");
     builder.append("typedef ");
     visit(t->type);
     builder.spc();

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -76,10 +76,6 @@ void InputSources::addComment(SourceInfo srcInfo, bool singleLine, cstring body)
     comments.push_back(new Comment(srcPos, singleLine, body));
 }
 
-/**
- * Retrieve all comments within the range of this SourceInfo.
- * @return A string containing all comments within the range.
- */
 std::string SourceInfo::getComments() const {
     if ((sources == nullptr)) {
         return "";

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -71,10 +71,7 @@ void InputSources::addComment(SourceInfo srcInfo, bool singleLine, cstring body)
     if (!singleLine)
         // Drop the "*/"
         body = body.exceptLast(2);
-    auto srcPos =
-        SourcePosition(srcInfo.getStart());
-
-    // std::cout << srcPos.toString();
+    auto srcPos = SourcePosition(srcInfo.getStart());
 
     comments.push_back(new Comment(srcPos, singleLine, body));
 }

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -201,6 +201,8 @@ class SourceInfo final {
     inline bool operator<=(const SourceInfo &rhs) const { return !this->operator>(rhs); }
     inline bool operator>=(const SourceInfo &rhs) const { return !this->operator<(rhs); }
 
+    std::string getComments() const;
+
  private:
     const InputSources *sources = nullptr;
     SourcePosition start = SourcePosition();
@@ -230,13 +232,17 @@ struct SourceFileLine {
 
 class Comment final : IHasDbPrint {
  private:
-    SourceInfo srcInfo;
+    SourcePosition srcPos;
     bool singleLine;
     cstring body;
 
  public:
-    Comment(SourceInfo srcInfo, bool singleLine, cstring body)
-        : srcInfo(srcInfo), singleLine(singleLine), body(body) {}
+    Comment(SourcePosition srcPos, bool singleLine, cstring body)
+        : srcPos(srcPos), singleLine(singleLine), body(body) {}
+
+    // Retrieve the source position associated with this comment.
+    const SourcePosition &getSourcePosition() const { return srcPos; }
+
     cstring toString() const {
         std::string result;
         if (singleLine)
@@ -267,6 +273,7 @@ class InputSources final {
 
  public:
     InputSources();
+    friend class SourceInfo;
 
     std::string_view getLine(unsigned lineNumber) const;
     /// Original source line that produced the line with the specified number


### PR DESCRIPTION
This PR is an initial attempt to print comments using p4fmt.It is not intended to be merged (atleast for now); it serves as a preliminary draft to initiate discussion and gather feedback from the community on potential approaches moving forward.

 PR #1226 parsed and saved comments as part of the `InputSources` data structure for further use.

This PR outlines an approach where we take in that position information and associate it with the nodes _while_ printing with [`toP4` ](https://github.com/p4lang/p4c/blob/main/frontends/p4/toP4/toP4.h). For this to work we need to modify _each_ node type of `toP4` to access comments related to that particular node(based solely on position info) and print accordingly. 
(The PR demonstrates this wherein comments are printed related to `Typedef` nodes, It only associates the comments which are closest, things like comments on same line are not handled, multi-line comments are not handled, efficiency is not taken into account etc. This is just an intial attempt and code is very _hack-ish_).

*Sample Input*:
```
typedef bit<9>  egressSpec_t;
// comm1
typedef bit<48> macAddr_t;
// comm2
typedef bit<32> ip4Addr_t;

header ethernet_t {
    macAddr_t dstAddr;
    // Comm3
    macAddr_t srcAddr;
    bit<16>   etherType;
}
```
*Sample Output*:
```
typedef bit<9> egressSpec_t;
// comm1
typedef bit<48> macAddr_t;
// comm2
typedef bit<32> ip4Addr_t;
header ethernet_t {
    macAddr_t dstAddr;
    macAddr_t srcAddr;
    bit<16>   etherType;
}
```
A more sophisticated [approach](https://jayconrod.com/posts/129/preserving-comments-when-parsing-and-formatting-code) would be to include a separate common comments field in each node. By using the comment position information along with the nodes, we could traverse the AST nodes and associate the comments with the relevant nodes.