### PR TITLE
Fix `loc_t::operator<` when `parent` is `nullptr`

### DIFF
--- a/midend/def_use.h
+++ b/midend/def_use.h
@@ -66,7 +66,7 @@ class ComputeDefUse : public Inspector,
         const loc_t *parent;
         bool operator<(const loc_t &a) const {
             if (node != a.node) return node->id < a.node->id;
-            if (!a.parent) return parent != nullptr;
+            if (!parent || !a.parent) return parent != nullptr;
             return *parent < *a.parent;
         }
         template <class T>


### PR DESCRIPTION
Found while working on https://github.com/p4lang/p4c/pull/4797: Bad things will happen in `loc_t::operator<` when `parent` is `nullptr`.