### PR TITLE
Do not consider unsupported inlining candidates. 

### DIFF
--- a/frontends/p4/functionsInlining.cpp
+++ b/frontends/p4/functionsInlining.cpp
@@ -37,6 +37,11 @@ void DiscoverFunctionsInlining::postorder(const IR::MethodCallExpression *mce) {
     BUG_CHECK(stat->is<IR::MethodCallStatement>() || stat->is<IR::AssignmentStatement>(),
               "%1%: unexpected statement with call", stat);
 
+    // We can only inline directly into RHS of IR::AssignmentStatement now
+    if (const auto *assign = stat->to<IR::AssignmentStatement>()) {
+        if (assign->right != mce) return;
+    }
+
     auto aci = new FunctionCallInfo(caller, ac->function, stat);
     toInline->add(aci);
 }

--- a/testdata/p4_16_samples/issue4796.p4
+++ b/testdata/p4_16_samples/issue4796.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    return val < bound ? val : bound;
+}
+header ethernet_t {
+    bit<16> eth_type;
+}
+header priceX {
+}
+struct Headers {
+    ethernet_t eth_hdr;
+    priceX[4]  heal;
+}
+struct main_metadata_t {
+}
+bit<8> shouldr() {
+    return 0;
+}
+
+parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+    }
+}
+
+control PreControlImpl(in Headers hdr, inout main_metadata_t user_meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control MainControlImpl(inout Headers hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action revie(out priceX year, bit<128> orde, bit<128> priv) {
+    }
+    action compa() {
+    }
+    action resea(out bit<32> janu, bit<4> revi) {
+    }
+    table greatY {
+        key = {
+        }
+        actions = {
+            revie(hdr.heal[max((bit<3>)shouldr(), 3w3)]);
+        }
+    }
+    apply {
+        hdr.eth_hdr.eth_type = (greatY.apply().hit ? 16w48951 : 91w213560861023984182890738508[76:61] |-| 116w64291011913438215645283401046339830[19:4]);
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in Headers hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4796-first.p4
+++ b/testdata/p4_16_samples_outputs/issue4796-first.p4
@@ -1,0 +1,60 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    return (val < bound ? val : bound);
+}
+header ethernet_t {
+    bit<16> eth_type;
+}
+
+header priceX {
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    priceX[4]  heal;
+}
+
+struct main_metadata_t {
+}
+
+bit<8> shouldr() {
+    return 8w0;
+}
+parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        transition reject;
+    }
+}
+
+control PreControlImpl(in Headers hdr, inout main_metadata_t user_meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control MainControlImpl(inout Headers hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action revie(out priceX year, bit<128> orde, bit<128> priv) {
+    }
+    action compa() {
+    }
+    action resea(out bit<32> janu, bit<4> revi) {
+    }
+    table greatY {
+        actions = {
+            revie(hdr.heal[max((bit<3>)shouldr(), 3w3)]);
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        hdr.eth_hdr.eth_type = (greatY.apply().hit ? 16w48951 : 16w0);
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in Headers hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+PNA_NIC<Headers, main_metadata_t, Headers, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4796-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue4796-frontend.p4
@@ -1,0 +1,78 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    @name("retval") bit<3> retval;
+    @name("tmp") bit<3> tmp;
+    if (val < bound) {
+        tmp = val;
+    } else {
+        tmp = bound;
+    }
+    retval = tmp;
+    return retval;
+}
+header ethernet_t {
+    bit<16> eth_type;
+}
+
+header priceX {
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    priceX[4]  heal;
+}
+
+struct main_metadata_t {
+}
+
+bit<8> shouldr() {
+    @name("retval_0") bit<8> retval_0;
+    retval_0 = 8w0;
+    return retval_0;
+}
+parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        transition reject;
+    }
+}
+
+control PreControlImpl(in Headers hdr, inout main_metadata_t user_meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control MainControlImpl(inout Headers hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp_0") bool tmp_0;
+    @name("MainControlImpl.tmp_1") bit<16> tmp_1;
+    @name("MainControlImpl.year") priceX year_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("MainControlImpl.revie") action revie(@name("orde") bit<128> orde, @name("priv") bit<128> priv) {
+        hdr.heal[max((bit<3>)shouldr(), 3w3)] = year_0;
+    }
+    @name("MainControlImpl.greatY") table greatY_0 {
+        actions = {
+            revie();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        tmp_0 = greatY_0.apply().hit;
+        if (tmp_0) {
+            tmp_1 = 16w48951;
+        } else {
+            tmp_1 = 16w0;
+        }
+        hdr.eth_hdr.eth_type = tmp_1;
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in Headers hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+PNA_NIC<Headers, main_metadata_t, Headers, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4796-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue4796-midend.p4
@@ -1,0 +1,133 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    @name("tmp") bit<3> tmp;
+    if (val < bound) {
+        tmp = val;
+    } else {
+        tmp = bound;
+    }
+    return tmp;
+}
+header ethernet_t {
+    bit<16> eth_type;
+}
+
+header priceX {
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    priceX[4]  heal;
+}
+
+struct main_metadata_t {
+}
+
+bit<8> shouldr() {
+    return 8w0;
+}
+parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+        transition reject;
+    }
+}
+
+control PreControlImpl(in Headers hdr, inout main_metadata_t user_meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control MainControlImpl(inout Headers hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    @name("MainControlImpl.tmp_0") bool tmp_0;
+    @name("MainControlImpl.tmp_1") bit<16> tmp_1;
+    @name("MainControlImpl.year") priceX year_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    bit<3> hsiVar;
+    @name("MainControlImpl.revie") action revie(@name("orde") bit<128> orde, @name("priv") bit<128> priv) {
+        hsiVar = max((bit<3>)shouldr(), 3w3);
+        if (hsiVar == 3w0) {
+            hdr.heal[3w0] = year_0;
+        } else if (hsiVar == 3w1) {
+            hdr.heal[3w1] = year_0;
+        } else if (hsiVar == 3w2) {
+            hdr.heal[3w2] = year_0;
+        } else if (hsiVar == 3w3) {
+            hdr.heal[3w3] = year_0;
+        }
+    }
+    @name("MainControlImpl.greatY") table greatY_0 {
+        actions = {
+            revie();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action act() {
+        tmp_0 = true;
+    }
+    @hidden action act_0() {
+        tmp_0 = false;
+    }
+    @hidden action issue4796l47() {
+        tmp_1 = 16w48951;
+    }
+    @hidden action issue4796l47_0() {
+        tmp_1 = 16w0;
+    }
+    @hidden action issue4796l47_1() {
+        hdr.eth_hdr.eth_type = tmp_1;
+    }
+    @hidden table tbl_act {
+        actions = {
+            act();
+        }
+        const default_action = act();
+    }
+    @hidden table tbl_act_0 {
+        actions = {
+            act_0();
+        }
+        const default_action = act_0();
+    }
+    @hidden table tbl_issue4796l47 {
+        actions = {
+            issue4796l47();
+        }
+        const default_action = issue4796l47();
+    }
+    @hidden table tbl_issue4796l47_0 {
+        actions = {
+            issue4796l47_0();
+        }
+        const default_action = issue4796l47_0();
+    }
+    @hidden table tbl_issue4796l47_1 {
+        actions = {
+            issue4796l47_1();
+        }
+        const default_action = issue4796l47_1();
+    }
+    apply {
+        if (greatY_0.apply().hit) {
+            tbl_act.apply();
+        } else {
+            tbl_act_0.apply();
+        }
+        if (tmp_0) {
+            tbl_issue4796l47.apply();
+        } else {
+            tbl_issue4796l47_0.apply();
+        }
+        tbl_issue4796l47_1.apply();
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in Headers hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+PNA_NIC<Headers, main_metadata_t, Headers, main_metadata_t>(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4796.p4
+++ b/testdata/p4_16_samples_outputs/issue4796.p4
@@ -1,0 +1,59 @@
+#include <core.p4>
+#include <dpdk/pna.p4>
+
+bit<3> max(in bit<3> val, in bit<3> bound) {
+    return (val < bound ? val : bound);
+}
+header ethernet_t {
+    bit<16> eth_type;
+}
+
+header priceX {
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    priceX[4]  heal;
+}
+
+struct main_metadata_t {
+}
+
+bit<8> shouldr() {
+    return 0;
+}
+parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+    state start {
+    }
+}
+
+control PreControlImpl(in Headers hdr, inout main_metadata_t user_meta, in pna_pre_input_metadata_t istd, inout pna_pre_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control MainControlImpl(inout Headers hdr, inout main_metadata_t user_meta, in pna_main_input_metadata_t istd, inout pna_main_output_metadata_t ostd) {
+    action revie(out priceX year, bit<128> orde, bit<128> priv) {
+    }
+    action compa() {
+    }
+    action resea(out bit<32> janu, bit<4> revi) {
+    }
+    table greatY {
+        key = {
+        }
+        actions = {
+            revie(hdr.heal[max((bit<3>)shouldr(), 3w3)]);
+        }
+    }
+    apply {
+        hdr.eth_hdr.eth_type = (greatY.apply().hit ? 16w48951 : 91w213560861023984182890738508[76:61] |-| 116w64291011913438215645283401046339830[19:4]);
+    }
+}
+
+control MainDeparserImpl(packet_out pkt, in Headers hdr, in main_metadata_t user_meta, in pna_main_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+PNA_NIC(MainParserImpl(), PreControlImpl(), MainControlImpl(), MainDeparserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4796.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue4796.p4-stderr
@@ -1,0 +1,18 @@
+issue4796.p4(23): [--Wwarn=parser-transition] warning: start: implicit transition to `reject'
+    state start {
+          ^^^^^
+issue4796.p4(33): [--Wwarn=unused] warning: 'year' is unused
+    action revie(out priceX year, bit<128> orde, bit<128> priv) {
+                            ^^^^
+issue4796.p4(33): [--Wwarn=unused] warning: 'orde' is unused
+    action revie(out priceX year, bit<128> orde, bit<128> priv) {
+                                           ^^^^
+issue4796.p4(33): [--Wwarn=unused] warning: 'priv' is unused
+    action revie(out priceX year, bit<128> orde, bit<128> priv) {
+                                                          ^^^^
+issue4796.p4(22): [--Wwarn=parser-transition] warning: accept state in parser MainParserImpl is unreachable
+parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+       ^^^^^^^^^^^^^^
+issue4796.p4(22): [--Wwarn=parser-transition] warning: accept state in parser MainParserImpl is unreachable
+parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+       ^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently function inliner could inline only directly into RHS of an assignment statement (or direct method call statement)