### PR TITLE
Do not recompute write sets for equal child nodes belonging to a given `IR::Vector`

### DIFF
--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -638,8 +638,10 @@ bool ComputeWriteSet::preorder(const IR::SelectExpression *expression) {
     visit(expression->select);
     visit(&expression->selectCases);
     auto l = getWrites(expression->select);
-    for (auto c : expression->selectCases) {
-        auto s = getWrites(c->keyset);
+    const loc_t *selectCasesLoc = getLoc(&expression->selectCases, getChildContext());
+    for (auto *c : expression->selectCases) {
+        const loc_t *selectCaseLoc = getLoc(c, selectCasesLoc);
+        auto s = getWrites(c->keyset, selectCaseLoc);
         l = l->join(s);
     }
     expressionWrites(expression, l);
@@ -673,7 +675,8 @@ bool ComputeWriteSet::preorder(const IR::MethodCallExpression *expression) {
     lhs = save;
     auto mi = MethodInstance::resolve(expression, storageMap->refMap, storageMap->typeMap);
     if (auto bim = mi->to<BuiltInMethod>()) {
-        auto base = getWrites(bim->appliedTo);
+        const loc_t *methodLoc = getLoc(expression->method, getChildContext());
+        auto base = getWrites(bim->appliedTo, methodLoc);
         cstring name = bim->name.name;
         if (name == IR::Type_Header::setInvalid || name == IR::Type_Header::setValid) {
             // modifies only the valid field.
@@ -712,7 +715,7 @@ bool ComputeWriteSet::preorder(const IR::MethodCallExpression *expression) {
         LOG3("Analyzing callees of " << expression << DBPrint::Brief << callees << DBPrint::Reset
                                      << indent);
         ProgramPoint pt(callingContext, expression);
-        ComputeWriteSet cw(this, pt, currentDefinitions);
+        ComputeWriteSet cw(this, pt, currentDefinitions, cached_locs);
         cw.setCalledBy(this);
         for (auto c : callees) (void)c->getNode()->apply(cw);
         currentDefinitions = cw.currentDefinitions;
@@ -735,7 +738,8 @@ bool ComputeWriteSet::preorder(const IR::MethodCallExpression *expression) {
         visit(arg);
         lhs = save;
         if (p->direction == IR::Direction::Out || p->direction == IR::Direction::InOut) {
-            auto val = getWrites(arg->expression);
+            const loc_t *argLoc = getLoc(arg, getChildContext());
+            auto val = getWrites(arg->expression, argLoc);
             result = result->join(val);
         }
     }
@@ -757,6 +761,35 @@ void ComputeWriteSet::visitVirtualMethods(const IR::IndexedVector<IR::Declaratio
             }
         }
     }
+}
+
+// Returns program location of n, given the program location of n's direct parent.
+// Use to get loc if n is indirect child (e.g. grandchild) of currently being visited node.
+// In this case parentLoc is the loc of n's direct parent.
+const P4::ComputeWriteSet::loc_t *ComputeWriteSet::getLoc(const IR::Node *n,
+                                                          const loc_t *parentLoc) {
+    loc_t tmp{n, parentLoc};
+    return &*cached_locs.insert(tmp).first;
+}
+
+// Returns program location given the context of the currently being visited node.
+// Use to get loc of currently being visited node.
+const P4::ComputeWriteSet::loc_t *ComputeWriteSet::getLoc(const Visitor::Context *ctxt) {
+    if (!ctxt) return nullptr;
+    loc_t tmp{ctxt->node, getLoc(ctxt->parent)};
+    return &*cached_locs.insert(tmp).first;
+}
+
+// Returns program location of a child node n, given the context of the
+// currently being visited node.
+// Use to get loc if n is direct child of currently being visited node.
+const P4::ComputeWriteSet::loc_t *ComputeWriteSet::getLoc(const IR::Node *n,
+                                                          const Visitor::Context *ctxt) {
+    for (auto *p = ctxt; p; p = p->parent)
+        if (p->node == n) return getLoc(p);
+    auto rv = getLoc(ctxt);
+    loc_t tmp{n, rv};
+    return &*cached_locs.insert(tmp).first;
 }
 
 // Symbolic execution of the parser
@@ -784,7 +817,7 @@ bool ComputeWriteSet::preorder(const IR::P4Parser *parser) {
         // but we use the same data structures
         ProgramPoint pt(state);
         currentDefinitions = allDefinitions->getDefinitions(pt);
-        ComputeWriteSet cws(this, pt, currentDefinitions);
+        ComputeWriteSet cws(this, pt, currentDefinitions, cached_locs);
         cws.setCalledBy(this);
         (void)state->apply(cws);
 

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -636,11 +636,10 @@ bool ComputeWriteSet::preorder(const IR::Mux *expression) {
 bool ComputeWriteSet::preorder(const IR::SelectExpression *expression) {
     BUG_CHECK(!lhs, "%1%: unexpected in lhs", expression);
     visit(expression->select);
-    visit(&expression->selectCases);
+    expression->selectCases.visit_unique_children(*this);
     auto l = getWrites(expression->select);
-    const loc_t *selectCasesLoc = getLoc(&expression->selectCases, getChildContext());
     for (auto *c : expression->selectCases) {
-        const loc_t *selectCaseLoc = getLoc(c, selectCasesLoc);
+        const loc_t *selectCaseLoc = getLoc(c, getChildContext());
         auto s = getWrites(c->keyset, selectCaseLoc);
         l = l->join(s);
     }
@@ -649,7 +648,7 @@ bool ComputeWriteSet::preorder(const IR::SelectExpression *expression) {
 }
 
 bool ComputeWriteSet::preorder(const IR::ListExpression *expression) {
-    visit(expression->components, "components");
+    expression->components.visit_unique_children(*this);
     auto l = LocationSet::empty;
     for (auto c : expression->components) {
         auto cl = getWrites(c);
@@ -874,7 +873,7 @@ bool ComputeWriteSet::preorder(const IR::IfStatement *statement) {
 bool ComputeWriteSet::preorder(const IR::ForStatement *statement) {
     LOG3("CWS Visiting " << dbp(statement));
     if (currentDefinitions->isUnreachable()) return setDefinitions(currentDefinitions);
-    visit(statement->init, "init");
+    statement->init.visit_unique_children(*this);
 
     auto saveBreak = breakDefinitions;
     auto saveContinue = continueDefinitions;
@@ -892,7 +891,7 @@ bool ComputeWriteSet::preorder(const IR::ForStatement *statement) {
         (void)setDefinitions(exitDefs, statement->condition, true);
         visit(statement->body, "body");
         currentDefinitions = currentDefinitions->joinDefinitions(continueDefinitions);
-        visit(statement->updates, "updates");
+        statement->updates.visit_unique_children(*this);
         currentDefinitions = currentDefinitions->joinDefinitions(startDefs);
     } while (!(*startDefs == *currentDefinitions));
 
@@ -936,7 +935,7 @@ bool ComputeWriteSet::preorder(const IR::ForInStatement *statement) {
 
 bool ComputeWriteSet::preorder(const IR::BlockStatement *statement) {
     if (currentDefinitions->isUnreachable()) return setDefinitions(currentDefinitions);
-    visit(statement->components, "components");
+    statement->components.visit_unique_children(*this);
     return setDefinitions(currentDefinitions);
 }
 
@@ -991,6 +990,12 @@ bool ComputeWriteSet::preorder(const IR::AssignmentStatement *statement) {
     return setDefinitions(defs);
 }
 
+bool ComputeWriteSet::preorder(const IR::SwitchCase *c) {
+    visit(c->statement);
+    // Do not visit c->label, as it cannot write anything.
+    return false;
+}
+
 bool ComputeWriteSet::preorder(const IR::SwitchStatement *statement) {
     LOG3("CWS Visiting " << dbp(statement));
     if (currentDefinitions->isUnreachable()) return setDefinitions(currentDefinitions);
@@ -1001,11 +1006,16 @@ bool ComputeWriteSet::preorder(const IR::SwitchStatement *statement) {
     auto save = currentDefinitions;
     auto result = new Definitions();
     bool seenDefault = false;
-    for (auto s : statement->cases) {
+    std::unordered_set<const IR::Node *> visitedCases;
+    for (auto *c : statement->cases) {
+        if (visitedCases.find(c) != visitedCases.end()) continue;
+
         currentDefinitions = save;
-        if (s->label->is<IR::DefaultExpression>()) seenDefault = true;
-        visit(s->statement);
+        if (c->label->is<IR::DefaultExpression>()) seenDefault = true;
+        visit(c);
         result = result->joinDefinitions(currentDefinitions);
+
+        visitedCases.emplace(c);
     }
     auto table = TableApplySolver::isActionRun(statement->expression, storageMap->refMap,
                                                storageMap->typeMap);

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -41,8 +41,9 @@ struct loc_t {
     const loc_t *parent;
     bool operator==(const loc_t &a) const {
         if (node != a.node) return false;
-        if (parent && a.parent) return *parent == *a.parent;
-        return parent == a.parent;
+        if (parent == a.parent) return true;
+        if (!parent || !a.parent) return false;
+        return *parent == *a.parent;
     }
     std::size_t hash() const;
 };

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -550,6 +550,7 @@ class ComputeWriteSet : public Inspector, public IHasDbPrint {
     bool preorder(const IR::ForStatement *statement) override;
     bool preorder(const IR::ForInStatement *statement) override;
     bool preorder(const IR::BlockStatement *statement) override;
+    bool preorder(const IR::SwitchCase *c) override;
     bool preorder(const IR::SwitchStatement *statement) override;
     bool preorder(const IR::EmptyStatement *statement) override;
     bool preorder(const IR::MethodCallStatement *statement) override;

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -195,6 +195,7 @@ class Vector : public VectorBase {
     cstring node_type_name() const override { return "Vector<" + T::static_type_name() + ">"; }
     static cstring static_type_name() { return "Vector<" + T::static_type_name() + ">"; }
     void visit_children(Visitor &v) override;
+    void visit_unique_children(Visitor &v) const;
     void visit_children(Visitor &v) const override;
     virtual void parallel_visit_children(Visitor &v);
     virtual void parallel_visit_children(Visitor &v) const;


### PR DESCRIPTION
built on top of #https://github.com/p4lang/p4c/pull/4797

Title and discussion in https://github.com/p4lang/p4c/pull/4797 are self-explanatory.

This still does not fully fix the problem described in https://github.com/p4lang/p4c/pull/4797 (but it is yet another incremental improvement). `ComputeWriteSet`'s `callingContext` is not properly updated during the IR traversal, so `ProgramPoint`s are not correct in many places. This can be fixed by either:

- Making sure that `ComputeWriteSet`'s `callingContext` is properly updated and `ProgramPoint`s created correctly everywhere, or
- Replace all `ProgramPoint`s with `loc_t`, so that updating the calling context is the responsibility of the `Visitor` overhead, rather than of `ComputeWriteSet`.

Neither of these are trivial, but the latter is probably the most invasive option.