### PR TITLE
Make don't care args action-local when used in actions

### DIFF
--- a/frontends/p4/dontcareArgs.h
+++ b/frontends/p4/dontcareArgs.h
@@ -44,6 +44,14 @@ class DontcareArgs : public Transform, public ResolutionContext {
         toAdd.clear();
         return function;
     }
+    const IR::Node *postorder(IR::P4Action *action) override {
+        IR::IndexedVector<IR::StatOrDecl> body;
+        for (auto d : toAdd) body.push_back(d);
+        body.append(action->body->components);
+        action->body = new IR::BlockStatement(action->body->srcInfo, body);
+        toAdd.clear();
+        return action;
+    }
     const IR::Node *postorder(IR::P4Parser *parser) override {
         toAdd.append(parser->parserLocals);
         parser->parserLocals = toAdd;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/ordered_set.cpp
   gtest/parser_unroll.cpp
   gtest/p4runtime.cpp
+  gtest/remove_dontcare_args_test.cpp
   gtest/source_file_test.cpp
   gtest/strength_reduction.cpp
   gtest/string_map.cpp

--- a/test/gtest/remove_dontcare_args_test.cpp
+++ b/test/gtest/remove_dontcare_args_test.cpp
@@ -1,0 +1,119 @@
+#include <gtest/gtest.h>
+
+#include "frontends/common/parseInput.h"
+#include "frontends/p4/frontend.h"
+#include "frontends/p4/dontcareArgs.h"
+#include "helpers.h"
+#include "ir/ir.h"
+
+using namespace P4;
+
+namespace Test {
+
+struct RemoveDontcareArgsTest : P4CTest {
+    const IR::Node *parseAndProcess(std::string program) {
+        const auto *pgm = P4::parseP4String(program, CompilerOptions::FrontendVersion::P4_16);
+        EXPECT_TRUE(pgm);
+        EXPECT_EQ(::errorCount(), 0);
+        if (!pgm) {
+            return nullptr;
+        }
+
+        P4::TypeMap typeMap;
+        RemoveDontcareArgs rdca(&typeMap);
+
+        return pgm->apply(rdca);
+    }
+};
+
+class CollectActionAndControlLocals : public Inspector {
+ public:
+
+    unsigned actionDecls = 0;
+    unsigned controlDecls = 0;
+
+    bool preorder(const IR::P4Action *action) override {
+        for (const auto *c : action->body->components) {
+            if (c->is<IR::Declaration_Variable>())
+                ++actionDecls;
+        }
+        return true;
+    }
+
+    bool preorder(const IR::P4Control *control) override {
+        for (const auto *c : control->controlLocals) {
+            if (c->is<IR::Declaration_Variable>())
+                ++controlDecls;
+        }
+        return true;
+    }
+};
+
+TEST_F(RemoveDontcareArgsTest, Default) {
+    std::string program_source = P4_SOURCE(R"(
+struct S {
+    bit<64> f;
+}
+
+control C(inout S s) {
+    @name("d") action d_0(@name("b") out bit<64> b_0) {
+        b_0 = 64w4;
+    }
+    @name("foo") action foo_0() {
+        d_0(_);
+    }
+    @name("t") table t_0 {
+        actions = {
+            foo_0();
+        }
+        default_action = foo_0();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto(inout S s);
+package top(proto p);
+top(C()) main;
+    )");
+
+    const auto *program = parseAndProcess(program_source);
+    ASSERT_TRUE(program);
+    ASSERT_EQ(::errorCount(), 0);
+
+
+    CollectActionAndControlLocals collect;
+    program->apply(collect);
+
+    // Just make sure that the control block has no decls and the action has a single decl.
+    // The expected output should look something like this:
+    // struct S {
+    //     bit<64> f;
+    // }
+    // control C(inout S s) {
+    //     @name("d") action d_0(@name("b") out bit<64> b_0) {
+    //         b_0 = 64w4;
+    //     }
+    //     @name("foo") action foo_0() {
+    //         bit<64> arg;
+    //         d_0(arg);
+    //     }
+    //     @name("t") table t_0 {
+    //         actions = {
+    //             foo_0();
+    //         }
+    //         default_action = foo_0();
+    //     }
+    //     apply {
+    //         t_0.apply();
+    //     }
+    // }
+    // control proto(inout S s);
+    // package top(proto p);
+    // top(C()) main;
+    ASSERT_EQ(collect.actionDecls, 1);
+    ASSERT_EQ(collect.controlDecls, 0);
+}
+
+}  // namespace Test

--- a/test/gtest/remove_dontcare_args_test.cpp
+++ b/test/gtest/remove_dontcare_args_test.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
 #include "frontends/common/parseInput.h"
-#include "frontends/p4/frontend.h"
 #include "frontends/p4/dontcareArgs.h"
+#include "frontends/p4/frontend.h"
 #include "helpers.h"
 #include "ir/ir.h"
 
@@ -28,22 +28,19 @@ struct RemoveDontcareArgsTest : P4CTest {
 
 class CollectActionAndControlLocals : public Inspector {
  public:
-
     unsigned actionDecls = 0;
     unsigned controlDecls = 0;
 
     bool preorder(const IR::P4Action *action) override {
         for (const auto *c : action->body->components) {
-            if (c->is<IR::Declaration_Variable>())
-                ++actionDecls;
+            if (c->is<IR::Declaration_Variable>()) ++actionDecls;
         }
         return true;
     }
 
     bool preorder(const IR::P4Control *control) override {
         for (const auto *c : control->controlLocals) {
-            if (c->is<IR::Declaration_Variable>())
-                ++controlDecls;
+            if (c->is<IR::Declaration_Variable>()) ++controlDecls;
         }
         return true;
     }
@@ -81,7 +78,6 @@ top(C()) main;
     const auto *program = parseAndProcess(program_source);
     ASSERT_TRUE(program);
     ASSERT_EQ(::errorCount(), 0);
-
 
     CollectActionAndControlLocals collect;
     program->apply(collect);

--- a/test/gtest/strength_reduction.cpp
+++ b/test/gtest/strength_reduction.cpp
@@ -80,9 +80,6 @@ struct StrengthReductionPolicy : public P4::FrontEndPolicy {
 TEST_F(StrengthReductionTest, Default) {
     auto test = createStrengthReductionTestCase(P4_SOURCE(R"(headers.h.f1 = headers.h.f1 - 1;)"));
 
-    ReferenceMap refMap;
-    TypeMap typeMap;
-
     Util::SourceCodeBuilder builder;
     ToP4 top4(builder, false);
     test->program->apply(top4);
@@ -98,9 +95,6 @@ TEST_F(StrengthReductionTest, DisableSubConstToAddConst) {
     StrengthReductionPolicy policy(false);
     auto test =
         createStrengthReductionTestCase(P4_SOURCE(R"(headers.h.f1 = headers.h.f1 - 1;)"), &policy);
-
-    ReferenceMap refMap;
-    TypeMap typeMap;
 
     Util::SourceCodeBuilder builder;
     ToP4 top4(builder, false);

--- a/testdata/p4_16_samples/localize_action_dont_care_args.p4
+++ b/testdata/p4_16_samples/localize_action_dont_care_args.p4
@@ -1,0 +1,27 @@
+struct S {
+    bit<64> f;
+}
+
+control C(inout S s) {
+    action d(out bit<64> b) {
+        b = 4;
+    }
+
+    action foo() {
+        d(_);
+    }
+
+    table t {
+        actions = { foo; }
+        default_action = foo;
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+control proto(inout S s);
+package top(proto p);
+
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/localize_action_dont_care_args-first.p4
+++ b/testdata/p4_16_samples_outputs/localize_action_dont_care_args-first.p4
@@ -1,0 +1,25 @@
+struct S {
+    bit<64> f;
+}
+
+control C(inout S s) {
+    action d(out bit<64> b) {
+        b = 64w4;
+    }
+    action foo() {
+        d(_);
+    }
+    table t {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto(inout S s);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/localize_action_dont_care_args-frontend.p4
+++ b/testdata/p4_16_samples_outputs/localize_action_dont_care_args-frontend.p4
@@ -1,0 +1,21 @@
+struct S {
+    bit<64> f;
+}
+
+control C(inout S s) {
+    @name("C.foo") action foo() {
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto(inout S s);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/localize_action_dont_care_args-midend.p4
+++ b/testdata/p4_16_samples_outputs/localize_action_dont_care_args-midend.p4
@@ -1,0 +1,21 @@
+struct S {
+    bit<64> f;
+}
+
+control C(inout S s) {
+    @name("C.foo") action foo() {
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto(inout S s);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/localize_action_dont_care_args.p4
+++ b/testdata/p4_16_samples_outputs/localize_action_dont_care_args.p4
@@ -1,0 +1,25 @@
+struct S {
+    bit<64> f;
+}
+
+control C(inout S s) {
+    action d(out bit<64> b) {
+        b = 4;
+    }
+    action foo() {
+        d(_);
+    }
+    table t {
+        actions = {
+            foo;
+        }
+        default_action = foo;
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto(inout S s);
+package top(proto p);
+top(C()) main;


### PR DESCRIPTION
It may be easier for some passes to process action-locals that are actually action-local variables instead of control-local variables in the IR. Also note that we already do this in the `DontcareArgs` pass for functions, but not actions for some reason:
```
    const IR::Node *postorder(IR::Function *function) override {
        IR::IndexedVector<IR::StatOrDecl> body;
        for (auto d : toAdd) body.push_back(d);
        body.append(function->body->components);
        function->body = new IR::BlockStatement(function->body->srcInfo, body);
        toAdd.clear();
        return function;
    }
```

On `main` branch, the output of `--top4 RemoveDontcareArgs` for the attached test is:
```
struct S {
    bit<64> f;
}

control C(inout S s) {
    bit<64> arg;
    @name("d") action d_0(@name("b") out bit<64> b_0) {
        b_0 = 64w4;
    }
    @name("foo") action foo_0() {
        d_0(arg);
    }
    @name("t") table t_0 {
        actions = {
            foo_0();
        }
        default_action = foo_0();
    }
    apply {
        t_0.apply();
    }
}

control proto(inout S s);
package top(proto p);
top(C()) main;
```

and on this branch:
```
struct S {
    bit<64> f;
}

control C(inout S s) {
    @name("d") action d_0(@name("b") out bit<64> b_0) {
        b_0 = 64w4;
    }
    @name("foo") action foo_0() {
        bit<64> arg;
        d_0(arg);
    }
    @name("t") table t_0 {
        actions = {
            foo_0();
        }
        default_action = foo_0();
    }
    apply {
        t_0.apply();
    }
}

control proto(inout S s);
package top(proto p);
top(C()) main;
```

@fruffy Is there an easy way to test the output of a specific pass? This will get cleaned up by later passes so the change is not visible in the attached reference outputs.