### PR TITLE
misc fixes/additions

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1313,7 +1313,7 @@ forStatement
               expression ";"
 	      forUpdateStatements ")"
       statement
-    { $$ = new IR::ForStatement(@2+@9, *$4, $6, *$8, $10); }
+    { $$ = new IR::ForStatement(@2+@9, $1, *$4, $6, *$8, $10); }
     | optAnnotations FOR "(" typeRef name IN forCollectionExpr ")" statement
     { auto decl = new IR::Declaration_Variable(@4+@5, *$5, $4);
       $$ = new IR::ForInStatement(@2+@7, $1, decl, $7, $9); }

--- a/ir/dbprint-p4.cpp
+++ b/ir/dbprint-p4.cpp
@@ -149,7 +149,7 @@ void IR::P4Action::dbprint(std::ostream &out) const {
 }
 
 void IR::BlockStatement::dbprint(std::ostream &out) const {
-    out << "{" << indent;
+    out << annotations << "{" << indent;
     bool first = true;
     for (auto p : components) {
         if (first) {

--- a/ir/dbprint-stmt.cpp
+++ b/ir/dbprint-stmt.cpp
@@ -60,6 +60,7 @@ void IR::MethodCallStatement::dbprint(std::ostream &out) const {
 }
 
 void IR::Function::dbprint(std::ostream &out) const {
+    out << annotations;
     if (type->returnType) out << type->returnType << ' ';
     out << name;
     if (type->typeParameters && !type->typeParameters->empty()) out << type->typeParameters;
@@ -87,7 +88,7 @@ void IR::SwitchStatement::dbprint(std::ostream &out) const {
 
 void IR::ForStatement::dbprint(std::ostream &out) const {
     int prec = getprec(out);
-    out << Prec_Low << "for (";
+    out << annotations << Prec_Low << "for (";
     bool first = true;
     for (auto *sd : init) {
         if (!first) out << ", ";
@@ -106,7 +107,7 @@ void IR::ForStatement::dbprint(std::ostream &out) const {
 
 void IR::ForInStatement::dbprint(std::ostream &out) const {
     int prec = getprec(out);
-    out << Prec_Low << "for (";
+    out << annotations << Prec_Low << "for (";
     if (decl) {
         out << decl;
     } else {

--- a/lib/hashvec.cpp
+++ b/lib/hashvec.cpp
@@ -318,7 +318,7 @@ void hash_vector_base::redo_hash() {
                 while (find_next(k, &cache)) {
                 }
             } else {
-                BUG("dupliacte keys in hash_vector_base::redo_hash");
+                BUG("duplicate keys in hash_vector_base::redo_hash");
             }
         }
         if (j != i) {

--- a/lib/hvec_map.h
+++ b/lib/hvec_map.h
@@ -175,6 +175,19 @@ class hvec_map : hash_vector_base {
         return idx > 0;
     }
 
+    VAL &at(const KEY &k) {
+        hash_vector_base::lookup_cache cache;
+        size_t idx = hash_vector_base::find(&k, &cache);
+        if (!idx || erased[idx - 1]) throw std::out_of_range("hvec_map::at");
+        return data[idx - 1].second;
+    }
+    const VAL &at(const KEY &k) const {
+        hash_vector_base::lookup_cache cache;
+        size_t idx = hash_vector_base::find(&k, &cache);
+        if (!idx || erased[idx - 1]) throw std::out_of_range("hvec_map::at");
+        return data[idx - 1].second;
+    }
+
     // FIXME -- how to do this without duplicating the code for lvalue/rvalue?
     VAL &operator[](const KEY &k) {
         size_t idx = hv_insert(&k);

--- a/lib/hvec_set.h
+++ b/lib/hvec_set.h
@@ -1,0 +1,255 @@
+/*
+Copyright 2023-present Intel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef LIB_HVEC_SET_H_
+#define LIB_HVEC_SET_H_
+
+#include <initializer_list>
+#include <tuple>
+#include <vector>
+
+#include "exceptions.h"
+#include "hashvec.h"
+
+template <class KEY, class HASH = std::hash<KEY>, class PRED = std::equal_to<KEY>,
+          class ALLOC = std::allocator<KEY>>
+class hvec_set : hash_vector_base {
+    HASH hf;  // FIXME -- use empty base optimization for these?
+    PRED eql;
+
+ public:
+    typedef const KEY value_type;
+    typedef HASH hasher;
+    typedef PRED key_equal;
+    typedef ALLOC allocator_type;
+    typedef value_type *pointer, *const_pointer, &reference, &const_reference;
+    typedef hash_vector_base::lookup_cache lookup_cache;
+
+    explicit hvec_set(size_t icap = 0, const hasher &hf = hasher(),
+                      const key_equal &eql = key_equal(),
+                      const allocator_type &a = allocator_type())
+        : hash_vector_base(false, false, icap), hf(hf), eql(eql), data(a) {
+        data.reserve(icap);
+    }
+    hvec_set(const hvec_set &) = default;
+    hvec_set(hvec_set &&) = default;
+    hvec_set &operator=(const hvec_set &that) {
+        if (this != std::addressof(that)) {
+            clear();
+            hf = that.hf;
+            eql = that.eql;
+
+            data.reserve(that.size());
+            insert(that.begin(), that.end());
+        }
+
+        return *this;
+    }
+    hvec_set &operator=(hvec_set &&) = default;
+    ~hvec_set() = default;
+    template <class ITER>
+    hvec_set(ITER begin, ITER end, const hasher &hf = hasher(), const key_equal &eql = key_equal(),
+             const allocator_type &a = allocator_type())
+        : hash_vector_base(false, false, end - begin), hf(hf), eql(eql), data(a) {
+        data.reserve(end - begin);
+        for (auto it = begin; it != end; ++it) insert(*it);
+    }
+    hvec_set(std::initializer_list<value_type> il, const hasher &hf = hasher(),
+             const key_equal &eql = key_equal(), const allocator_type &a = allocator_type())
+        : hash_vector_base(false, false, il.size()), hf(hf), eql(eql), data(a) {
+        data.reserve(il.size());
+        for (auto &i : il) insert(i);
+    }
+
+ private:
+    template <class HVM, class VT>
+    class _iter {
+        HVM *self;
+        size_t idx;
+
+        friend class hvec_set;
+        _iter(HVM &s, size_t i) : self(&s), idx(i) {}
+
+     public:
+        using value_type = VT;
+        using difference_type = ssize_t;
+        using pointer = typename HVM::pointer;
+        using reference = typename HVM::reference;
+        using iterator_category = std::bidirectional_iterator_tag;
+        _iter(const _iter &) = default;
+        _iter &operator=(const _iter &a) {
+            self = a.self;
+            idx = a.idx;
+            return *this;
+        }
+        value_type &operator*() const { return self->data[idx]; }
+        value_type *operator->() const { return &self->data[idx]; }
+        _iter &operator++() {
+            do {
+                ++idx;
+            } while (self->erased[idx]);
+            return *this;
+        }
+        _iter &operator--() {
+            do {
+                --idx;
+            } while (self->erased[idx]);
+            return *this;
+        }
+        _iter operator++(int) {
+            auto copy = *this;
+            ++*this;
+            return copy;
+        }
+        _iter operator--(int) {
+            auto copy = *this;
+            --*this;
+            return copy;
+        }
+        bool operator==(const _iter &a) const { return self == a.self && idx == a.idx; }
+        bool operator!=(const _iter &a) const { return self != a.self || idx != a.idx; }
+        operator _iter<const HVM, const VT>() const {
+            return _iter<const HVM, const VT>(*self, idx);
+        }
+    };
+
+ public:
+    typedef _iter<hvec_set, value_type> iterator;
+    typedef _iter<const hvec_set, const value_type> const_iterator;
+    iterator begin() { return iterator(*this, erased.ffz()); }
+    iterator end() { return iterator(*this, data.size()); }
+    const_iterator begin() const { return const_iterator(*this, erased.ffz()); }
+    const_iterator end() const { return const_iterator(*this, data.size()); }
+    const_iterator cbegin() const { return const_iterator(*this, erased.ffz()); }
+    const_iterator cend() const { return const_iterator(*this, data.size()); }
+    value_type &front() const { return *begin(); }
+    value_type &back() const {
+        auto it = end();
+        return *--it;
+    }
+
+    bool empty() const { return inuse == 0; }
+    size_t size() const { return inuse; }
+    size_t max_size() const { return UINT32_MAX; }
+    bool operator==(const hvec_set &a) const {
+        if (inuse != a.inuse) return false;
+        auto it = begin();
+        for (auto &el : a)
+            if (el != *it++) return false;
+        return true;
+    }
+    bool operator!=(const hvec_set &a) const { return !(*this == a); }
+    void clear() {
+        hash_vector_base::clear();
+        data.clear();
+    }
+
+    iterator find(const KEY &k) {
+        hash_vector_base::lookup_cache cache;
+        size_t idx = hash_vector_base::find(&k, &cache);
+        return idx ? iterator(*this, idx - 1) : end();
+    }
+    const_iterator find(const KEY &k) const {
+        hash_vector_base::lookup_cache cache;
+        size_t idx = hash_vector_base::find(&k, &cache);
+        return idx ? const_iterator(*this, idx - 1) : end();
+    }
+    size_t count(const KEY &k) const {
+        hash_vector_base::lookup_cache cache;
+        size_t idx = hash_vector_base::find(&k, &cache);
+        return idx > 0;
+    }
+
+    template <typename... KK>
+    std::pair<iterator, bool> emplace(KK &&...k) {
+        return insert(value_type(std::forward<KK>(k)...));
+    }
+    std::pair<iterator, bool> insert(const value_type &v) {
+        bool new_key = false;
+        size_t idx = hv_insert(&v);
+        if (idx >= data.size()) {
+            idx = data.size();
+            data.push_back(v);
+            new_key = true;
+        } else if ((new_key = erased[idx])) {
+            erased[idx] = 0;
+            data[idx] = v;
+        }
+        return std::make_pair(iterator(*this, idx), new_key);
+    }
+    std::pair<iterator, bool> insert(value_type &&v) {
+        bool new_key = false;
+        size_t idx = hv_insert(&v);
+        if (idx >= data.size()) {
+            idx = data.size();
+            data.push_back(v);
+            new_key = true;
+        } else if ((new_key = erased[idx])) {
+            erased[idx] = 0;
+            data[idx] = std::move(v);
+        }
+        return std::make_pair(iterator(*this, idx), new_key);
+    }
+
+    template <typename InputIterator>
+    void insert(InputIterator first, InputIterator last) {
+        for (; first != last; ++first) insert(*first);
+    }
+    void insert(std::initializer_list<value_type> vl) { return insert(vl.begin(), vl.end()); }
+    template <class HVM, class VT>
+    _iter<HVM, VT> erase(_iter<HVM, VT> it) {
+        BUG_CHECK(this == it.self, "incorrect iterator for hvec_set::erase");
+        erased[it.idx] = 1;
+        // FIXME -- would be better to call dtor here, but that will cause
+        // problems with the vector when it is resized or destroyed.  Could
+        // use raw memory and manual construct instead.
+        data[it.idx] = KEY();
+        ++it;
+        --inuse;
+        return it;
+    }
+    size_t erase(const KEY &k) {
+        size_t idx = remove(&k);
+        if (idx + 1 == 0) return 0;
+        if (idx < data.size()) {
+            data[idx] = KEY();
+        }
+        return 1;
+    }
+#ifdef DEBUG
+    using hash_vector_base::dump;
+#endif
+
+ private:
+    std::vector<KEY, ALLOC> data;
+    size_t hashfn(const void *a) const override { return hf(*static_cast<const KEY *>(a)); }
+    bool cmpfn(const void *a, const void *b) const override {
+        return eql(*static_cast<const KEY *>(a), *static_cast<const KEY *>(b));
+    }
+    bool cmpfn(const void *a, size_t b) const override {
+        return eql(*static_cast<const KEY *>(a), data[b]);
+    }
+    const void *getkey(uint32_t i) const override { return &data[i]; }
+    void *getval(uint32_t) override {
+        BUG("getval in set");
+        return nullptr;
+    }
+    uint32_t limit() override { return data.size(); }
+    void resizedata(size_t sz) override { data.resize(sz); }
+    void moveentry(size_t to, size_t from) override { data[to] = data[from]; }
+};
+
+#endif /* LIB_HVEC_SET_H_ */

--- a/lib/hvec_set.h
+++ b/lib/hvec_set.h
@@ -195,7 +195,7 @@ class hvec_set : hash_vector_base {
         size_t idx = hv_insert(&v);
         if (idx >= data.size()) {
             idx = data.size();
-            data.push_back(v);
+            data.push_back(std::move(v));
             new_key = true;
         } else if ((new_key = erased[idx])) {
             erased[idx] = 0;

--- a/midend/def_use.cpp
+++ b/midend/def_use.cpp
@@ -37,7 +37,20 @@ namespace P4 {
 using namespace literals;
 
 int ComputeDefUse::uid_ctr = 0;
-const ordered_set<const ComputeDefUse::loc_t *> ComputeDefUse::empty = {};
+const hvec_set<const ComputeDefUse::loc_t *> ComputeDefUse::empty;
+
+ComputeDefUse::ComputeDefUse()
+    : ResolutionContext(true), cached_locs(*new std::unordered_set<loc_t>), defuse(*new defuse_t) {
+    joinFlows = true;
+    visitDagOnce = false;
+}
+
+void ComputeDefUse::clear() {
+    cached_locs.clear();
+    def_info.clear();
+    defuse.defs.clear();
+    defuse.uses.clear();
+}
 
 void ComputeDefUse::flow_merge(Visitor &a_) {
     ComputeDefUse &a = dynamic_cast<ComputeDefUse &>(a_);
@@ -84,6 +97,31 @@ ComputeDefUse::def_info_t::def_info_t(def_info_t &&a)
       slices(std::move(a.slices)) {
     for (auto &v : Values(fields)) v.parent = this;
     for (auto &v : Values(slices)) v.parent = this;
+}
+
+ComputeDefUse::def_info_t &ComputeDefUse::def_info_t::operator=(
+    const ComputeDefUse::def_info_t &a) {
+    defs = a.defs;
+    live = a.live;
+    parent = a.parent;
+    valid_bit_defs = a.valid_bit_defs;
+    fields = a.fields;
+    slices = a.slices;
+    for (auto &v : Values(fields)) v.parent = this;
+    for (auto &v : Values(slices)) v.parent = this;
+    return *this;
+}
+
+ComputeDefUse::def_info_t &ComputeDefUse::def_info_t::operator=(ComputeDefUse::def_info_t &&a) {
+    defs = std::move(a.defs);
+    live = std::move(a.live);
+    parent = std::move(a.parent);
+    valid_bit_defs = std::move(a.valid_bit_defs);
+    fields = std::move(a.fields);
+    slices = std::move(a.slices);
+    for (auto &v : Values(fields)) v.parent = this;
+    for (auto &v : Values(slices)) v.parent = this;
+    return *this;
 }
 
 void ComputeDefUse::def_info_t::flow_merge(def_info_t &a) {
@@ -671,7 +709,7 @@ std::ostream &operator<<(std::ostream &out, const ComputeDefUse::loc_t &loc) {
     return out;
 }
 
-std::ostream &operator<<(std::ostream &out, const ordered_set<const ComputeDefUse::loc_t *> &s) {
+std::ostream &operator<<(std::ostream &out, const hvec_set<const ComputeDefUse::loc_t *> &s) {
     out << ": {";
     const char *sep = " ";
     for (auto *l : s) {
@@ -684,7 +722,7 @@ std::ostream &operator<<(std::ostream &out, const ordered_set<const ComputeDefUs
 
 std::ostream &operator<<(
     std::ostream &out,
-    const std::pair<const IR::Node *, const ordered_set<const ComputeDefUse::loc_t *>> &p) {
+    const std::pair<const IR::Node *, const hvec_set<const ComputeDefUse::loc_t *>> &p) {
     out << Log::endl;
     out << DBPrint::setprec(DBPrint::Prec_Low);
     p.first->dbprint(out);
@@ -710,6 +748,6 @@ std::ostream &operator<<(std::ostream &out, const ComputeDefUse::defuse_t &du) {
 }  // namespace P4
 
 void dump(const P4::ComputeDefUse::loc_t &p) { std::cout << p << std::endl; }
-void dump(const ordered_set<const P4::ComputeDefUse::loc_t *> &p) { std::cout << p << std::endl; }
+void dump(const hvec_set<const P4::ComputeDefUse::loc_t *> &p) { std::cout << p << std::endl; }
 void dump(const P4::ComputeDefUse &du) { std::cout << du << std::endl; }
 void dump(const P4::ComputeDefUse *du) { std::cout << *du << std::endl; }

--- a/midend/def_use.cpp
+++ b/midend/def_use.cpp
@@ -329,6 +329,17 @@ bool ComputeDefUse::preorder(const IR::P4Action *act) {
     return false;
 }
 
+bool ComputeDefUse::preorder(const IR::Function *fn) {
+    IndentCtl::TempIndent indent;
+    LOG5("ComputeDefUse" << uid << "(Function " << fn->name << ")" << indent);
+    auto oldstate = state;
+    if (state == SKIPPING) state = NORMAL;
+    for (auto *p : *fn->type->parameters) def_info[p].defs.insert(getLoc(p));
+    visit(fn->body, "body");
+    state = oldstate;
+    return false;
+}
+
 bool ComputeDefUse::preorder(const IR::P4Parser *p) {
     BUG_CHECK(state == SKIPPING, "Nested %s not supported in ComputeDefUse", p);
     IndentCtl::TempIndent indent;

--- a/midend/def_use.h
+++ b/midend/def_use.h
@@ -139,6 +139,7 @@ class ComputeDefUse : public Inspector,
     bool preorder(const IR::P4Table *) override;
     bool preorder(const IR::P4Action *) override;
     bool preorder(const IR::P4Parser *) override;
+    bool preorder(const IR::Function *) override;
     bool preorder(const IR::ParserState *) override;
     void revisit(const IR::ParserState *) override;
     void loop_revisit(const IR::ParserState *) override;

--- a/midend/def_use.h
+++ b/midend/def_use.h
@@ -20,6 +20,8 @@ limitations under the License.
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "ir/ir.h"
 #include "lib/bitrange.h"
+#include "lib/hvec_map.h"
+#include "lib/hvec_set.h"
 
 namespace P4 {
 
@@ -64,11 +66,28 @@ class ComputeDefUse : public Inspector,
     struct loc_t {
         const IR::Node *node;
         const loc_t *parent;
+        mutable size_t computedHash = 0;
         bool operator<(const loc_t &a) const {
             if (node != a.node) return node->id < a.node->id;
             if (!parent || !a.parent) return parent != nullptr;
             return *parent < *a.parent;
         }
+        bool operator==(const loc_t &a) const {
+            if (node != a.node) return false;
+            if (parent == a.parent) return true;
+            if (!parent || !a.parent) return false;
+            return *parent == *a.parent;
+        }
+        std::size_t hash() const {
+            if (!computedHash) {
+                if (!parent)
+                    computedHash = Util::Hash{}(node->id);
+                else
+                    computedHash = Util::Hash{}(node->id, parent->hash());
+            }
+            return computedHash;
+        }
+
         template <class T>
         const T *find() const {
             for (auto *p = this; p; p = p->parent) {
@@ -77,10 +96,11 @@ class ComputeDefUse : public Inspector,
             return nullptr;
         }
     };
-    typedef ordered_set<const loc_t *> locset_t;
+    typedef hvec_set<const loc_t *> locset_t;
 
  private:
-    std::set<loc_t> &cached_locs;
+    // DANGER -- pointers to elements of this set must be stable
+    std::unordered_set<loc_t> &cached_locs;
     const loc_t *getLoc(const Visitor::Context *ctxt);
     const loc_t *getLoc() { return getLoc(getChildContext()); }
     const loc_t *getLoc(const IR::Node *, const Visitor::Context *);
@@ -112,8 +132,10 @@ class ComputeDefUse : public Inspector,
         def_info_t() = default;
         def_info_t(const def_info_t &);
         def_info_t(def_info_t &&);
+        def_info_t &operator=(const def_info_t &);
+        def_info_t &operator=(def_info_t &&);
     };
-    ordered_map<const IR::IDeclaration *, def_info_t> def_info;
+    hvec_map<const IR::IDeclaration *, def_info_t> def_info;
     void add_uses(const loc_t *, def_info_t &);
     void set_live_from_type(def_info_t &di, const IR::Type *type);
 
@@ -122,8 +144,8 @@ class ComputeDefUse : public Inspector,
         // defs maps from all uses to their definitions
         // uses maps from all definitions to their uses
         // uses/defs are lvalue expressions, or param declarations.
-        ordered_map<const IR::Node *, locset_t> defs;
-        ordered_map<const IR::Node *, locset_t> uses;
+        hvec_map<const IR::Node *, locset_t> defs;
+        hvec_map<const IR::Node *, locset_t> uses;
     } & defuse;
     static const locset_t empty;
 
@@ -160,17 +182,8 @@ class ComputeDefUse : public Inspector,
     bool filter_join_point(const IR::Node *) override;
 
  public:
-    ComputeDefUse()
-        : ResolutionContext(true), cached_locs(*new std::set<loc_t>), defuse(*new defuse_t) {
-        joinFlows = true;
-        visitDagOnce = false;
-    }
-    void clear() {
-        cached_locs.clear();
-        def_info.clear();
-        defuse.defs.clear();
-        defuse.uses.clear();
-    }
+    ComputeDefUse();
+    void clear();
 
     const locset_t &getDefs(const IR::Node *n) const {
         auto it = defuse.defs.find(n);
@@ -190,5 +203,13 @@ class ComputeDefUse : public Inspector,
 };
 
 }  // namespace P4
+
+namespace std {
+template <>
+struct hash<P4::ComputeDefUse::loc_t> {
+    std::size_t operator()(const P4::ComputeDefUse::loc_t &loc) const { return loc.hash(); }
+};
+
+}  // namespace std
 
 #endif /* MIDEND_DEF_USE_H_ */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/helpers.cpp
   gtest/hash.cpp
   gtest/hvec_map.cpp
+  gtest/hvec_set.cpp
   gtest/indexed_vector.cpp
   gtest/json_test.cpp
   gtest/map.cpp

--- a/test/gtest/hvec_set.cpp
+++ b/test/gtest/hvec_set.cpp
@@ -1,0 +1,179 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "lib/hvec_set.h"
+
+#include <gtest/gtest.h>
+
+namespace Test {
+
+TEST(hvec_set, map_equal) {
+    hvec_set<unsigned> a;
+    hvec_set<unsigned> b;
+
+    EXPECT_TRUE(a == b);
+
+    a.insert(111);
+    a.insert(222);
+    a.insert(333);
+    a.insert(444);
+
+    b.insert(111);
+    b.insert(222);
+    b.insert(333);
+    b.insert(444);
+
+    EXPECT_TRUE(a == b);
+
+    a.erase(2);
+    b.erase(2);
+
+    EXPECT_TRUE(a == b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_TRUE(a == b);
+}
+
+TEST(hvec_set, map_not_equal) {
+    hvec_set<unsigned> a;
+    hvec_set<unsigned> b;
+
+    EXPECT_TRUE(a == b);
+
+    a.insert(111);
+    a.insert(222);
+    a.insert(333);
+    a.insert(444);
+
+    b.insert(444);
+    b.insert(333);
+    b.insert(222);
+    b.insert(111);
+
+    EXPECT_TRUE(a != b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_TRUE(a == b);
+
+    a.insert(111);
+    a.insert(222);
+
+    b.insert(111);
+    b.insert(222);
+    b.insert(333);
+
+    EXPECT_TRUE(a != b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_TRUE(a == b);
+
+    a.insert(111);
+    a.insert(222);
+    a.insert(333);
+    a.insert(444);
+
+    b.insert(111);
+    b.insert(222);
+    b.insert(333);
+    b.insert(555);
+
+    EXPECT_TRUE(a != b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_TRUE(a == b);
+
+    a.insert(111);
+    a.insert(222);
+    a.insert(333);
+    a.insert(444);
+
+    b.insert(111);
+    b.insert(111);
+    b.insert(111);
+    b.insert(111);
+
+    EXPECT_TRUE(a != b);
+}
+
+TEST(hvec_set, insert_emplace_erase) {
+    hvec_set<unsigned> om;
+    std::set<unsigned> sm;
+
+    typename hvec_set<unsigned>::const_iterator it = om.end();
+    for (auto v : {0, 1, 2, 3, 4, 5, 6, 7, 8}) {
+        sm.emplace(v);
+        if (v % 2 == 0) {
+            if ((v / 2) % 2 == 0) {
+                it = om.insert(v).first;
+            } else {
+                it = om.emplace(v).first;
+            }
+        } else {
+            unsigned tmp = v;
+            if ((v / 2) % 2 == 0) {
+                it = om.insert(std::move(tmp)).first;
+            } else {
+                it = om.emplace(std::move(tmp)).first;
+            }
+        }
+    }
+    EXPECT_TRUE(std::next(it) == om.end());
+
+    EXPECT_TRUE(std::equal(om.begin(), om.end(), sm.begin(), sm.end()));
+
+    it = std::next(om.begin(), 2);
+    om.erase(it);
+    sm.erase(std::next(sm.begin(), 2));
+
+    EXPECT_TRUE(om.size() == sm.size());
+    EXPECT_TRUE(std::equal(om.begin(), om.end(), sm.begin(), sm.end()));
+}
+
+TEST(hvec_set, string_set) {
+    hvec_set<std::string> m, m1;
+
+    for (int i = 1; i <= 100; ++i) {
+        m.insert("test" + std::to_string(i));
+    }
+    m1 = m;
+
+    hvec_set<std::string> m2(m);
+
+    EXPECT_EQ(m1.size(), 100);
+    for (int i = 1; i <= 100; i += 2) m1.erase("test" + std::to_string(i));
+    EXPECT_EQ(m1.size(), 50);
+    for (int i = 102; i <= 200; i += 2) m1.insert(std::to_string(i) + "foobar");
+    EXPECT_EQ(m1.size(), 100);
+
+    int idx = 2;
+    for (auto &el : m1) {
+        if (idx <= 100)
+            EXPECT_TRUE(el.c_str() + 4 == std::to_string(idx));
+        else
+            EXPECT_EQ(el, std::to_string(idx) + "foobar");
+        idx += 2;
+    }
+}
+
+}  // namespace Test


### PR DESCRIPTION
3 independent changes here

- don't lose annotations on for, and print them properly in dbprint/logging messages
- compute def/use info in functions in midend ComputeDefUse
- use hvec_set instead of ordered_set in midend ComputeDefUse