### PR TITLE
Remove multimap usage from `memoizeDeclsByName`

### DIFF
--- a/frontends/common/resolveReferences/resolveReferences.cpp
+++ b/frontends/common/resolveReferences/resolveReferences.cpp
@@ -38,10 +38,10 @@ const std::vector<const IR::IDeclaration *> &ResolutionContext::memoizeDeclarati
     return (namespaceDecls[ns] = std::move(decls));
 }
 
-std::unordered_multimap<cstring, const IR::IDeclaration *> &ResolutionContext::memoizeDeclsByName(
+ResolutionContext::NamespaceDeclsByName &ResolutionContext::memoizeDeclsByName(
     const IR::INamespace *ns) const {
     auto &namesToDecls = namespaceDeclNames[ns];
-    for (const auto *d : getDeclarations(ns)) namesToDecls.emplace(d->getName().name, d);
+    for (const auto *d : getDeclarations(ns)) namesToDecls[d->getName().name].push_back(d);
     return namesToDecls;
 }
 
@@ -63,7 +63,7 @@ std::vector<const IR::IDeclaration *> ResolutionContext::lookup(const IR::INames
 
     if (const auto *gen = current->to<IR::IGeneralNamespace>()) {
         // FIXME: implement range filtering without enumerator wrappers
-        auto *decls = Util::enumerate(getDeclsByName(gen, name));
+        auto *decls = getDeclsByName(gen, name);
         switch (type) {
             case P4::ResolutionType::Any:
                 break;

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -196,17 +196,17 @@ class Enumerator {
 
 /// A generic iterator returning elements of type T.
 template <typename Iter>
-class IteratorEnumerator : public Enumerator<typename Iter::value_type> {
+class IteratorEnumerator : public Enumerator<typename std::iterator_traits<Iter>::value_type> {
  protected:
     Iter begin;
     Iter end;
     Iter current;
     const char *name;
-    friend class Enumerator<typename Iter::value_type>;
+    friend class Enumerator<typename std::iterator_traits<Iter>::value_type>;
 
  public:
     IteratorEnumerator(Iter begin, Iter end, const char *name)
-        : Enumerator<typename Iter::value_type>(),
+        : Enumerator<typename std::iterator_traits<Iter>::value_type>(),
           begin(begin),
           end(end),
           current(begin),
@@ -241,7 +241,7 @@ class IteratorEnumerator : public Enumerator<typename Iter::value_type> {
         throw std::runtime_error("Unexpected enumerator state");
     }
 
-    typename Iter::value_type getCurrent() const {
+    typename std::iterator_traits<Iter>::value_type getCurrent() const {
         switch (this->state) {
             case EnumeratorState::NotStarted:
                 throw std::logic_error("You cannot call 'getCurrent' before 'moveNext'");
@@ -638,12 +638,12 @@ bool EnumeratorHandle<T>::operator!=(const EnumeratorHandle<T> &other) const {
 }
 
 template <typename Iter>
-Enumerator<typename Iter::value_type> *enumerate(Iter begin, Iter end) {
+Enumerator<typename std::iterator_traits<Iter>::value_type> *enumerate(Iter begin, Iter end) {
     return new IteratorEnumerator(begin, end, "iterator");
 }
 
 template <typename Iter>
-Enumerator<typename Iter::value_type> *enumerate(iterator_range<Iter> range) {
+Enumerator<typename std::iterator_traits<Iter>::value_type> *enumerate(iterator_range<Iter> range) {
     return new IteratorEnumerator(range.begin(), range.end(), "range");
 }
 


### PR DESCRIPTION
Use used `std::unordered_multimap` to store declarations within a namespace having the same name. It turned out it was a bit of overkill:
 - In the vast majority of cases namespace only has unique declarations
 - There was no multimap in Abseil, so we were unable to use these more efficient maps
 - Profiling shows some elevated malloc traffic around these multimaps in downstream applications

This PR switches to:
 - Abseil flat_hash_map to store declarations given name
 - Use inlined vector to store up to 2 declarations inline within a map (so no additional memory allocation is required in the vast majority of cases)

Few improvements along the way. No functionality change