### PR TITLE
Ensure correct overload for diagnose() is called even in Transform context

### DIFF
--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -71,7 +71,7 @@ class ErrorReporter {
     /// and source info.
     /// If the error has been reported, return true. Otherwise, insert add the error to the
     /// list of seen errors, and return false.
-    bool error_reported(int err, const Util::SourceInfo source) {
+    bool error_reported(int err, Util::SourceInfo source) {
         if (!source.isValid()) return false;
         auto p = errorTracker.emplace(err, source);
         return !p.second;  // if insertion took place, then we have not seen the error.
@@ -106,32 +106,24 @@ class ErrorReporter {
         return ::error_helper(fmt, std::forward<Args>(args)...).toString();
     }
 
-    template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, typename... Args>
+    template <class T, typename = decltype(std::declval<T>()->getSourceInfo()), typename... Args>
     void diagnose(DiagnosticAction action, const int errorCode, const char *format,
-                  const char *suffix, const T *node, Args &&...args) {
-        if (node && !error_reported(errorCode, node->getSourceInfo())) {
-            cstring name = get_error_name(errorCode);
-            auto da = getDiagnosticAction(name, action);
-            if (name)
-                diagnose(da, name, format, suffix, node, std::forward<Args>(args)...);
-            else
-                diagnose(action, nullptr, format, suffix, node, std::forward<Args>(args)...);
-        }
-    }
+                  const char *suffix, T node, Args &&...args) {
+        if (!node || error_reported(errorCode, node->getSourceInfo())) return;
 
-    template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, typename... Args>
-    void diagnose(DiagnosticAction action, const int errorCode, const char *format,
-                  const char *suffix, const T &node, Args &&...args) {
-        diagnose(action, errorCode, format, suffix, &node, std::forward<Args>(args)...);
+        if (cstring name = get_error_name(errorCode))
+            diagnose(getDiagnosticAction(name, action), name, format, suffix, node,
+                     std::forward<Args>(args)...);
+        else
+            diagnose(action, nullptr, format, suffix, node, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void diagnose(DiagnosticAction action, const int errorCode, const char *format,
                   const char *suffix, Args &&...args) {
-        cstring name = get_error_name(errorCode);
-        auto da = getDiagnosticAction(name, action);
-        if (name)
-            diagnose(da, name, format, suffix, std::forward<Args>(args)...);
+        if (cstring name = get_error_name(errorCode))
+            diagnose(getDiagnosticAction(name, action), name, format, suffix,
+                     std::forward<Args>(args)...);
         else
             diagnose(action, nullptr, format, suffix, std::forward<Args>(args)...);
     }

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -214,8 +214,16 @@ class IHasSourceInfo {
     virtual ~IHasSourceInfo() {}
 };
 
+/// SFINAE helper to check if given class has a `getSourceInfo` method.
+template <class, class = void>
+struct has_SourceInfo : std::false_type {};
+
 template <class T>
-inline constexpr bool has_SourceInfo_v = std::is_base_of_v<Util::IHasSourceInfo, T>;
+struct has_SourceInfo<T, std::void_t<decltype(std::declval<T>().getSourceInfo())>>
+    : std::true_type {};
+
+template <class T>
+inline constexpr bool has_SourceInfo_v = has_SourceInfo<T>::value;
 
 /** A line in a source file */
 struct SourceFileLine {

--- a/testdata/p4_16_errors_outputs/issue3727.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3727.p4-stderr
@@ -1,7 +1,3 @@
 issue3727.p4(7): [--Werror=type-error] error: f2(1) is not invoking an action
     actions = {f2(1);}
                ^^^^
-issue3727.p4(7): [--Werror=type-error] error: f2(1) is not invoking an action
-    actions = {f2(1);}
-               ^^^^
-[--Werror=type-error] error: Error while analyzing t

--- a/testdata/p4_16_errors_outputs/minWidth.p4-stderr
+++ b/testdata/p4_16_errors_outputs/minWidth.p4-stderr
@@ -10,12 +10,6 @@ const int xw = x.minWidthInBits();
 minWidth.p4(8): [--Werror=type-error] error: error.minWidthInBits: Invalid enum tag
 const int ew = error.minWidthInBits();
                ^^^^^^^^^^^^^^^^^^^^
-minWidth.p4(8): [--Werror=type-error] error: error.minWidthInBits() is not a method
-const int ew = error.minWidthInBits();
-               ^^^^^^^^^^^^^^^^^^^^^^
-minWidth.p4(8): [--Werror=type-error] error: error.minWidthInBits(): Cannot evaluate initializer to a compile-time constant
-const int ew = error.minWidthInBits();
-               ^^^^^^^^^^^^^^^^^^^^^^
 minWidth.p4(9): [--Werror=type-error] error: Cannot extract field minWidthInBits from S which has type Type(string)
 const int sw = S.minWidthInBits();
                  ^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/stack_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack_e.p4-stderr
@@ -1,9 +1,6 @@
 stack_e.p4(23): [--Werror=type-error] error: Header stack struct s[5] used with non-header type struct s
         s[5] stack1; // non-header illegal in header stack
         ^^^^
-stack_e.p4(23): [--Werror=type-error] error: Error while analyzing struct s[5]
-        s[5] stack1; // non-header illegal in header stack
-        ^^^^
 stack_e.p4(26): [--Werror=overlimit] error: 1231092310293: Value too large for int
         h b = stack[1231092310293];
                     ^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/type-in-expr.p4-stderr
+++ b/testdata/p4_16_errors_outputs/type-in-expr.p4-stderr
@@ -4,9 +4,3 @@ type-in-expr.p4(5): [--Werror=type-error] error: H: Type cannot be used here, ex
 type-in-expr.p4(5): [--Werror=type-error] error: 4 < H: structured annotation must be compile-time constant values
 @foo[bar=4<H]
          ^^^
-type-in-expr.p4(5): [--Werror=type-error] error: H: Type cannot be used here, expecting an expression.
-@foo[bar=4<H]
-           ^
-type-in-expr.p4(6): [--Werror=type-error] error: Error while analyzing control p
-control p<H>(in H hdrs, out bool flag)
-        ^

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4-error
@@ -4,7 +4,4 @@ psa-dpdk-lpm-match-err5.p4(99): [--Wwarn=mismatch] warning: 8w0x3648: value does
 psa-dpdk-lpm-match-err5.p4(99): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
             8w0x3648 : exact;
             ^^^^^^^^
-psa-dpdk-lpm-match-err5.p4(99): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
-            8w0x3648 : exact;
-            ^^^^^^^^
 [--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-lpm-match-err5.p4-stderr
@@ -4,6 +4,3 @@ psa-dpdk-lpm-match-err5.p4(99): [--Wwarn=mismatch] warning: 8w0x3648: value does
 psa-dpdk-lpm-match-err5.p4(99): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
             8w0x3648 : exact;
             ^^^^^^^^
-psa-dpdk-lpm-match-err5.p4(99): [--Wwarn=mismatch] warning: 8w0x48: Constant key field
-            8w0x3648 : exact;
-            ^^^^^^^^


### PR DESCRIPTION
This ensures we do not see duplicate diagnostics from there.

Some small cleanup while there.