### PR TITLE
[P4Testgen] Run typechecking after front and mid end.

### DIFF
--- a/backends/p4tools/common/compiler/midend.cpp
+++ b/backends/p4tools/common/compiler/midend.cpp
@@ -156,9 +156,18 @@ void MidEnd::addDefaultPasses() {
         new P4::EliminateTuples(&typeMap),
         new P4::ConstantFolding(&typeMap),
         new P4::SimplifyControlFlow(&typeMap),
+        // Perform a last round of type-checking before passes which do not type-check begin.
+        new P4::TypeChecking(&refMap, &typeMap, true),
+    });
+    addNonTypeCheckingPasses();
+}
+
+void MidEnd::addNonTypeCheckingPasses() {
+    addPasses({
         // Simplify header stack assignments with runtime indices into conditional statements.
         new P4::HSIndexSimplifier(&typeMap),
-        // Convert Type_Varbits into a type that contains information about the assigned width.
+        // Convert Type_Varbits into a type that contains information about the assigned
+        // width.
         new ConvertVarbits(),
         // Convert any StructExpressions with Type_Header into a HeaderExpression.
         new ConvertStructExpr(&typeMap),
@@ -166,5 +175,4 @@ void MidEnd::addDefaultPasses() {
         new P4::CastBooleanTableKeys(),
     });
 }
-
 }  // namespace P4::P4Tools

--- a/backends/p4tools/common/compiler/midend.h
+++ b/backends/p4tools/common/compiler/midend.h
@@ -64,7 +64,11 @@ class MidEnd : public PassManager {
 
     /// Add the list of default passes to the mid end. This is not part of the initializer because
     /// some targets may add their own passes to the beginning of the pass list.
-    void addDefaultPasses();
+    virtual void addDefaultPasses();
+
+    /// Add passes that break type checking. These passes may involve  IR modifications the front
+    /// end type checker does not recognize.
+    virtual void addNonTypeCheckingPasses();
 };
 
 }  // namespace P4::P4Tools


### PR DESCRIPTION
Ensure that the program is still well-typed at this step. In some scenarios it can happen that a front or mid end pass leaves typing information incomplete or inaccurate which requires a rerun of type checking. There is no invariant enforcing well-typedness of the program. 