### PR TITLE
Truncate shifts to the maximum constant bit-width in the constant folding pass.

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -802,18 +802,27 @@ const IR::Node *DoConstantFolding::shift(const IR::Operation_Binary *e) {
     unsigned shift = static_cast<unsigned>(shift_amt->asInt());
     if (overflowWidth(e, shift)) return e;
 
-    auto tb = left->type->to<IR::Type_Bits>();
-    if (e->is<IR::Shl>())
+    if (e->is<IR::Shl>()) {
         value = Util::shift_left(value, shift);
-    else
+    } else {
         value = Util::shift_right(value, shift);
-    if (tb != nullptr) {
-        if (((unsigned)tb->width_bits() <= shift) && warnings)
-            ::warning(ErrorType::WARN_OVERFLOW, "%1%: Shifting %2%-bit value with %3%", e,
-                      tb->width_bits(), shift);
-        value = value & (pow(big_int{2}, tb->width_bits()) - 1);
     }
-
+    if (const auto *tb = left->type->to<IR::Type_Bits>()) {
+        if ((static_cast<unsigned>(tb->width_bits()) <= shift)) {
+            if (warnings) {
+                ::warning(ErrorType::WARN_OVERFLOW, "%1%: Shifting %2%-bit value with %3%", e,
+                          tb->width_bits(), shift);
+            }
+            // According to the P4 specification, the result of a left-shift that is larger than the
+            // width of the bit type is 0. For a right-shift of a negative signed value that is
+            // larger than the width of the bit type the result is -1.
+            if (e->is<IR::Shr>() && tb->isSigned && value < 0) {
+                value = -1;
+            } else {
+                value = 0;
+            }
+        }
+    }
     return new IR::Constant(e->srcInfo, left->type, value, cl->base);
 }
 

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -803,16 +803,17 @@ const IR::Node *DoConstantFolding::shift(const IR::Operation_Binary *e) {
     if (overflowWidth(e, shift)) return e;
 
     auto tb = left->type->to<IR::Type_Bits>();
-    if (tb != nullptr) {
-        if (((unsigned)tb->width_bits() <= shift) && warnings)
-            ::warning(ErrorType::WARN_OVERFLOW, "%1%: Shifting %2%-bit value with %3%", e,
-                      tb->width_bits(), shift);
-    }
-
     if (e->is<IR::Shl>())
         value = Util::shift_left(value, shift);
     else
         value = Util::shift_right(value, shift);
+    if (tb != nullptr) {
+        if (((unsigned)tb->width_bits() <= shift) && warnings)
+            ::warning(ErrorType::WARN_OVERFLOW, "%1%: Shifting %2%-bit value with %3%", e,
+                      tb->width_bits(), shift);
+        value = value & (pow(big_int{2}, tb->width_bits()) - 1);
+    }
+
     return new IR::Constant(e->srcInfo, left->type, value, cl->base);
 }
 

--- a/testdata/p4_16_samples_outputs/constant_folding.p4-stderr
+++ b/testdata/p4_16_samples_outputs/constant_folding.p4-stderr
@@ -1,9 +1,6 @@
 constant_folding.p4(95): [--Wwarn=overflow] warning: 1 << 9: Shifting 8-bit value with 9
         z = 8w1 << 9;
             ^^^^^^^^
-constant_folding.p4(95): [--Wwarn=mismatch] warning: 8w512: value does not fit in 8 bits
-        z = 8w1 << 9;
-            ^^^^^^^^
 constant_folding.p4(88): [--Wwarn=mismatch] warning: 8w256: value does not fit in 8 bits
         z = 128 + 128;
             ^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/gauntlet_various_ops-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_various_ops-bmv2.p4-stderr
@@ -7,13 +7,7 @@ gauntlet_various_ops-bmv2.p4(123): [--Wwarn=mismatch] warning: 4w16: value does 
 gauntlet_various_ops-bmv2.p4(124): [--Wwarn=overflow] warning: 4 << 16: Shifting 4-bit value with 16
         h.lshift.b = (bit<8>)(4w4 << 8w16);
                               ^^^^^^^^^^^
-gauntlet_various_ops-bmv2.p4(124): [--Wwarn=mismatch] warning: 4w262144: value does not fit in 4 bits
-        h.lshift.b = (bit<8>)(4w4 << 8w16);
-                              ^^^^^^^^^^^
 gauntlet_various_ops-bmv2.p4(126): [--Wwarn=overflow] warning: 1 << 256: Shifting 8-bit value with 256
-        h.lshift.d = (bit<8>)1 << 256;
-                     ^^^^^^^^^^^^^^^^
-gauntlet_various_ops-bmv2.p4(126): [--Wwarn=mismatch] warning: 8w115792089237316195423570985008687907853269984665640564039457584007913129639936: value does not fit in 8 bits
         h.lshift.d = (bit<8>)1 << 256;
                      ^^^^^^^^^^^^^^^^
 gauntlet_various_ops-bmv2.p4(132): [--Wwarn=mismatch] warning: -4w1: negative value with unsigned type

--- a/testdata/p4_16_samples_outputs/issue3289.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3289.p4-stderr
@@ -1,13 +1,7 @@
 issue3289.p4(3): [--Wwarn=overflow] warning: 1 << 5: Shifting 5-bit value with 5
   return (5w1) << 5;
          ^^^^^^^^^^
-issue3289.p4(3): [--Wwarn=mismatch] warning: 5w32: value does not fit in 5 bits
-  return (5w1) << 5;
-         ^^^^^^^^^^
 issue3289.p4(8): [--Wwarn=overflow] warning: 1 << 6: Shifting 5-bit value with 6
-  return (5w1) << 6;
-         ^^^^^^^^^^
-issue3289.p4(8): [--Wwarn=mismatch] warning: 5w64: value does not fit in 5 bits
   return (5w1) << 6;
          ^^^^^^^^^^
 [--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
IR::Constant throws a warning when the provided value overflows. This can lead to throwing unnecessary duplicated warnings in constant folding when working with shifts.

Instead, we just truncate the shifted bit value to the maximum and pass this value. We still have the option to throw a warning with the `warnings` flag. 