### PR TITLE
[P4Testgen] Hotfix for failing P4Testgen benchmark test.

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
@@ -17,7 +17,7 @@ using namespace P4::literals;
 
 TEST(P4TestgenBenchmark, SuccessfullyGenerate1000Tests) {
     // Set the compiler options.
-    auto *context = new P4Tools::CompileContext<CompilerOptions>;
+    auto *context = new P4Tools::CompileContext<CompilerOptions>();
     AutoCompileContext autoContext(context);
     auto &compilerOptions = context->options();
     compilerOptions.target = "bmv2"_cs;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/testgen_api/benchmark.cpp
@@ -1,7 +1,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "backends/p4tools/common/compiler/context.h"
 #include "backends/p4tools/common/lib/logging.h"
+#include "frontends/common/options.h"
+#include "lib/compile_context.h"
 #include "test/gtest/helpers.h"
 
 #include "backends/p4tools/modules/testgen/core/symbolic_executor/path_selection.h"
@@ -13,7 +16,10 @@ namespace Test {
 using namespace P4::literals;
 
 TEST(P4TestgenBenchmark, SuccessfullyGenerate1000Tests) {
-    auto compilerOptions = P4CContextWithOptions<CompilerOptions>::get().options();
+    // Set the compiler options.
+    auto *context = new P4Tools::CompileContext<CompilerOptions>;
+    AutoCompileContext autoContext(context);
+    auto &compilerOptions = context->options();
     compilerOptions.target = "bmv2"_cs;
     compilerOptions.arch = "v1model"_cs;
     auto includePath = P4CTestEnvironment::getProjectRoot() / "p4include";

--- a/backends/p4tools/modules/testgen/testgen.cpp
+++ b/backends/p4tools/modules/testgen/testgen.cpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <utility>
 
-#include "backends/p4tools/common/compiler/context.h"
 #include "backends/p4tools/common/core/z3_solver.h"
 #include "frontends/common/parser_options.h"
 #include "ir/solver.h"
@@ -150,10 +149,6 @@ std::optional<AbstractTestList> generateTestsImpl(std::optional<std::string_view
     registerTestgenTargets();
     P4Tools::Target::init(compilerOptions.target.c_str(), compilerOptions.arch.c_str());
 
-    // Set up the compilation context.
-    auto *compileContext = new CompileContext<CompilerOptions>();
-    compileContext->options() = compilerOptions;
-    AutoCompileContext autoContext(compileContext);
     CompilerResultOrError compilerResultOpt;
     if (program.has_value()) {
         // Run the compiler to get an IR and invoke the tool.


### PR DESCRIPTION
More motivation for getting rid of static options. It's just a mess when trying to use P4C as a library. 