### PR TITLE
Make SymbolicVariable part of the core IR.

### DIFF
--- a/backends/p4tools/p4tools.def
+++ b/backends/p4tools/p4tools.def
@@ -130,27 +130,6 @@ class TaintExpression : Expression {
     dbprint { out << "TaintedExpression(" << type << ")"; }
 }
 
-/// Signifies that a particular expression is a symbolic variable with a label.
-/// These variables are intended to be consumed by SMT/SAT solvers.
-class SymbolicVariable : Expression {
-#noconstructor
-
-    /// The label of the symbolic variable.
-    cstring label;
-
-    /// A symbolic variable always has a type and no source info.
-    SymbolicVariable(Type type, cstring label) : Expression(type), label(label) {}
-
-    /// Implements comparisons so that SymbolicVariables can be used as map keys.
-    bool operator<(const SymbolicVariable &other) const {
-        return label < other.label;
-    }
-
-    toString { return "|" + label +"(" + type->toString() + ")|"; }
-
-    dbprint { out << "|" + label +"(" << type << ")|"; }
-}
-
 /// This type replaces Type_Varbits and can store information about the current size
 class Extracted_Varbits : Type_Bits {
  public:

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -611,4 +611,25 @@ class CompileTimeMethodCall : MethodCallExpression, CompileTimeValue {
 #nodbprint
 }
 
+/// Signifies that a particular expression is a symbolic variable with a label.
+/// These variables are intended to be consumed by SMT/SAT solvers.
+class SymbolicVariable : Expression {
+#noconstructor
+
+    /// The label of the symbolic variable.
+    cstring label;
+
+    /// A symbolic variable always has a type and no source info.
+    SymbolicVariable(Type type, cstring label) : Expression(type), label(label) {}
+
+    /// Implements comparisons so that SymbolicVariables can be used as map keys.
+    bool operator<(const SymbolicVariable &other) const {
+        return label < other.label;
+    }
+
+    toString { return "|" + label +"(" + type->toString() + ")|"; }
+
+    dbprint { out << "|" + label +"(" << type << ")|"; }
+}
+
 /** @} *//* end group irdefs */


### PR DESCRIPTION
[solver.h](https://github.com/p4lang/p4c/blob/main/ir/solver.h) is part of the IR folder and uses `IR::SymbolicVariable`. But `IR::SymbolicVariable` is only usable when the p4tools back end is enabled. Move `IR::SymbolicVariable` to the top-level IR.

We can also move `solver.h` into the p4tools folder again. I do not think it is used by other back ends. 