### PR TITLE
Fix incorrect BMv2 include.

### DIFF
--- a/backends/common/portableProgramStructure.cpp
+++ b/backends/common/portableProgramStructure.cpp
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "portableProgramStructure.h"
+#include "backends/common/portableProgramStructure.h"
 
 namespace P4 {
 

--- a/backends/common/portableProgramStructure.h
+++ b/backends/common/portableProgramStructure.h
@@ -17,8 +17,9 @@ limitations under the License.
 #ifndef BACKENDS_COMMON_PORTABLEPROGRAMSTRUCTURE_H_
 #define BACKENDS_COMMON_PORTABLEPROGRAMSTRUCTURE_H_
 
-#include "backends/bmv2/common/backend.h"
 #include "backends/common/programStructure.h"
+#include "frontends/common/resolveReferences/referenceMap.h"
+#include "frontends/p4/typeMap.h"
 #include "ir/ir.h"
 #include "lib/cstring.h"
 


### PR DESCRIPTION
The common folder included a bmv2 specific header. This is not necessary. 
@rupesh-chiluka-marvell 