### PR TITLE
Minor fix : Heading of portable_common

### DIFF
--- a/backends/bmv2/portable_common/README.md
+++ b/backends/bmv2/portable_common/README.md
@@ -1,23 +1,21 @@
-# `portable_common`
+# portable_common
 
 This directory contains reusable components common to both the `psa_switch` and `pna_nic` backends.
 
-##### midend.h, midend.cpp
+### midend.h, midend.cpp
 
 Defines the common mid-end processing of both the `psa_switch` and `pna_nic` backends.
 
-##### options.h, options.cpp
+### options.h, options.cpp
 
 Defines the common command-line options of both the `psa_switch` and `pna_nic` backends.
 
-##### portable.h, portable.cpp
+### portable.h, portable.cpp
 
 Defines common functionalities that generate representations of P4 programs.
 
-----
-
 The files `portableProgramStructure.h` and `portableProgramStructure.cpp` are in the `backends/common` directory.
 
-#### portableProgramStructure.h, portableProgramStructure.cpp
+### portableProgramStructure.h, portableProgramStructure.cpp
 
 Defines and implements the common program structure of both the `psa_switch` and `pna_nic` backends.


### PR DESCRIPTION
## Current broken heading
![image](https://github.com/user-attachments/assets/6fbc4cce-6e43-404b-a59c-7c516f025669)


## Fixed 
![image](https://github.com/user-attachments/assets/45bd806e-df93-4259-b617-851aae07084b)
