### PR TITLE
Feat: PR Preview Workflow via GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -66,7 +66,6 @@ jobs:
           body: |
             **Deployment of preview started...** ${{ env.DEPLOYMENT }}
             ${{ env.COMMENT_IDENTIFIER }}
-          reactions: rocket
 
       - name: Update Comment to In-Progress
         if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' && steps.find-comment.outputs.comment-id != '' }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -80,6 +80,15 @@ jobs:
             ${{ env.COMMENT_IDENTIFIER }}
           edit-mode: replace
 
+      - name: Track intial Comment
+        if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' }}
+        id: find-comment2
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: ${{ env.COMMENT_IDENTIFIER }}
+
       - name: Install Clang
         if: ${{ github.event_name == 'push' || steps.check-label.outputs.result == 'true' }}
         run: |
@@ -139,15 +148,6 @@ jobs:
           target-folder: ${{ env.PR_PATH }}
           clean: false
 
-      - name: Find Existing Comment
-        if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' }}
-        id: find-comment2
-        uses: peter-evans/find-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: ${{ env.COMMENT_IDENTIFIER }}
-
       - name: Update Comment with Preview Link
         if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' }}
         uses: peter-evans/create-or-update-comment@v4
@@ -168,7 +168,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' && failure() }}
         uses: peter-evans/create-or-update-comment@v4
         with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          comment-id: ${{ steps.find-comment2.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             ${{ env.FAILURE_ICON }} **Deployment of this PR failed.** Please check the [Actions logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,62 +3,174 @@ permissions:
     actions: read
     contents: write
     pages: write
+    issues: write
+    pull-requests: write
 
 on:
     push:
         branches:
         - main
+    pull_request_target:
+        types: [opened, synchronize, reopened, ready_for_review, labeled]
 
-env:
-  DOXYGEN_VERSION: 1.11.0
-  DOXYGEN_AWESOME_VERSION: 2.3.3
-        
 jobs:
-    build-and-deploy:
-        runs-on: ubuntu-latest
-        concurrency: ci-${{github. ref}}
-        steps: 
-            - name : Checkout
-              uses: actions/checkout@v4
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    env:
+      DOXYGEN_VERSION: 1.11.0
+      DOXYGEN_AWESOME_VERSION: 2.3.3
+      PR_PATH: pr-preview/${{ github.event.number }}
+      DOMAIN: ${{ github.actor }}.github.io
+      DEPLOYMENT: '<img src="https://github.com/user-attachments/assets/f94fada5-45ca-4271-9106-180728235ad2" alt="Rocket" width="25"/>'
+      CELEBRATION: '<img src="https://github.com/user-attachments/assets/86eb8470-c597-4f8b-a77d-a54036075271" alt="githubloading" width="25"/>'
+      FAILURE_ICON: '<img src="https://github.com/user-attachments/assets/af921ba9-953d-465e-b597-64ed0a2dc921" alt="failed" width="25"/>'
+      COMMENT_IDENTIFIER: '<!-- preview-comment -->'
 
-            - name: Install Clang
-              run: |
-                sudo apt-get update
-                sudo apt-get install -y clang
-            
-            - name: Install Doxygen 
-              shell: bash
-              run: |
-                wget https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
-                tar xzvf doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
-                cd doxygen-${DOXYGEN_VERSION}
-                sudo make install
-                cd ..
-                rm -rf doxygen-${DOXYGEN_VERSION}*  
-            
-            - name: Install graphviz
-              run: sudo apt-get install graphviz -y
+    concurrency: ci-${{ github.ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-            - name: Clone Doxygen Awesome CSS Themes
-              working-directory: ./docs/doxygen
-              run: |
-                git clone --depth 1 -b v${{ env.DOXYGEN_AWESOME_VERSION }} https://github.com/jothepro/doxygen-awesome-css awesome_css
+      - name: Check PR Label
+        id: check-label
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const hasDocumentationLabel = labels.some(label => label.name === 'documentation');
+            return hasDocumentationLabel;
 
-            - name: Generate Doxygen Documentation
-              run: |
-                   cd docs/doxygen
-                   doxygen doxygen.cfg
-              shell: bash
-            
-            - name: Create .nojekyll 
-              run: |
-                    cd docs/doxygen/build
-                    touch html/.nojekyll
-              shell: bash
+      - name: Find Existing Comment
+        if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' }}
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: ${{ env.COMMENT_IDENTIFIER }}
 
-            - name: Deploy to GitHub Pages
-              uses: JamesIves/github-pages-deploy-action@v4
-              with:
-                token: ${{ secrets.GITHUB_TOKEN }}
-                branch: gh-pages
-                folder: docs/doxygen/build/html
+      - name: Post Initial Comment
+        if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' && steps.find-comment.outputs.comment-id == '' }}
+        id: post-initial-comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            **Deployment of preview started...** ${{ env.DEPLOYMENT }}
+            ${{ env.COMMENT_IDENTIFIER }}
+          reactions: rocket
+
+      - name: Update Comment to In-Progress
+        if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' && steps.find-comment.outputs.comment-id != '' }}
+        id: update-in-progress-comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            **Deployment in progress...** ${{ env.DEPLOYMENT }}
+            ${{ env.COMMENT_IDENTIFIER }}
+          edit-mode: replace
+
+      - name: Install Clang
+        if: ${{ github.event_name == 'push' || steps.check-label.outputs.result == 'true' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+
+      - name: Install Doxygen
+        if: ${{ github.event_name == 'push' || steps.check-label.outputs.result == 'true'}}
+        run: |
+          wget https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz
+          tar xzvf doxygen-${{ env.DOXYGEN_VERSION }}.linux.bin.tar.gz
+          cd doxygen-${{ env.DOXYGEN_VERSION }}
+          sudo make install
+          cd ..
+          rm -rf doxygen-${{ env.DOXYGEN_VERSION }}*
+
+      - name: Install Graphviz
+        if: ${{ github.event_name == 'push' || steps.check-label.outputs.result == 'true' }}
+        run: sudo apt-get install graphviz -y
+
+      - name: Clone Doxygen Awesome CSS Themes
+        if: ${{ github.event_name == 'push' || steps.check-label.outputs.result == 'true'}}
+        working-directory: ./docs/doxygen
+        run: |
+          git clone --depth 1 -b v${{ env.DOXYGEN_AWESOME_VERSION }} https://github.com/jothepro/doxygen-awesome-css awesome_css
+
+      - name: Generate Doxygen Documentation
+        if: ${{ github.event_name == 'push' || steps.check-label.outputs.result == 'true'}}
+        run: |
+          cd docs/doxygen
+          doxygen doxygen.cfg
+
+      - name: Create .nojekyll
+        if: ${{ github.event_name == 'push' || steps.check-label.outputs.result == 'true'}}
+        run: |
+          cd docs/doxygen/build/html
+          touch .nojekyll
+
+      - name: Deploy to GitHub Pages (Main Branch)
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: docs/doxygen/build/html
+          clean: true
+          clean-exclude: |
+            pr-preview/
+
+      - name: Deploy to PR preview
+        if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: docs/doxygen/build/html
+          target-folder: ${{ env.PR_PATH }}
+          clean: false
+
+      - name: Find Existing Comment
+        if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' }}
+        id: find-comment2
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: ${{ env.COMMENT_IDENTIFIER }}
+
+      - name: Update Comment with Preview Link
+        if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment2.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            | ${{ env.CELEBRATION }} **A preview of this PR is available at:** | [Preview Link](https://${{ env.DOMAIN }}/${{ github.event.repository.name }}/${{ env.PR_PATH }}/) |
+            | -- | -- |
+            | 📂 **View the source code here:** | [View Source Code](https://github.com/${{ github.repository }}/tree/gh-pages/pr-preview/${{ github.event.pull_request.number }}) |
+            | 🔧 **Commit used for deployment:** | [${{ github.event.pull_request.head.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}) |
+      
+            **Note:** Changes may take a few seconds to appear on GitHub Pages. Please refresh the page if you do not see the updates immediately.
+            ${{ env.COMMENT_IDENTIFIER }}
+          edit-mode: replace     
+
+      - name: Update Comment with Failure Message
+        if: ${{ github.event_name == 'pull_request_target' && steps.check-label.outputs.result == 'true' && failure() }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ${{ env.FAILURE_ICON }} **Deployment of this PR failed.** Please check the [Actions logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
+            ${{ env.COMMENT_IDENTIFIER }}
+          edit-mode: replace


### PR DESCRIPTION
This PR improves the existing functionality of deploying the main branch to GitHub Pages, providing an additional layer of testing for Documentation PRs by enabling previewing pull requests via GitHub Pages.

## Changes

- **PR Preview:** Each pull request with `documentation` tag will trigger a preview build that is deployed to a unique GitHub Pages URL. The preview is _dynamically updated with the latest changes_ from the PR.
- **Comment Updates:**  automatic comments on PRs with deployment status and links to the preview environment.
- **Handling Broken Builds:** The workflow includes functionality to detect and comment on broken builds,.

## Benefits

This update enhances Documentation PR review process & provides faster Iterations by offering a real-time preview of documentation changes on GitHub Pages. The preview automatically updates with each PR change, enabling immediate feedback and faster iterations. It also provides automatic notifications for build failures.

## Usage

Once a PR tagged with `documentation` label, the workflow will trigger and deploy the preview to GitHub Pages.
A comment will be posted on the PR with the link to the preview and deployment status (Passed/Failed).

## Test and Review this workflow
Please review and test this new feature on the [test documentation repo](https://github.com/AdarshRawat1/P4c-Documentation-Hosting) and check the following sample PR for reference .

- [PR from diff branch on same Repo](https://github.com/AdarshRawat1/P4c-Documentation-Hosting/pull/19)
- [PR from external fork](https://github.com/AdarshRawat1/P4c-Documentation-Hosting/pull/18)
- [PR with a broken documentation build](https://github.com/AdarshRawat1/P4c-Documentation-Hosting/pull/22) [Shows Failed test]

## Additional Context
This update addresses a concern raised in a [PR review comment](https://github.com/p4lang/p4c/pull/4793#issuecomment-2228552682) about testing Docs PRs locally before merging. For more details on how to test locally, see [my comment](https://github.com/p4lang/p4c/pull/4793#issuecomment-2238913261).

While local testing is possible, it can be redundant for maintainers. Tracking PR changes and syncing with remote updates can be difficult, leading to version mismatches and inconsistencies.