### PR TITLE
Add operator< to some compiler classes

### DIFF
--- a/frontends/common/constantParsing.cpp
+++ b/frontends/common/constantParsing.cpp
@@ -30,7 +30,8 @@ std::ostream &operator<<(std::ostream &out, const UnparsedConstant &constant) {
 }
 
 bool operator<(const UnparsedConstant &a, const UnparsedConstant &b) {
-    return a.text < b.text || a.skip < b.skip || a.base < b.base || (!a.hasWidth && b.hasWidth);
+    return std::tie(a.text, a.skip, a.base, a.hasWidth) <
+           std::tie(b.text, b.skip, b.base, b.hasWidth);
 }
 
 /// A helper to parse constants which have an explicit width;

--- a/frontends/common/constantParsing.cpp
+++ b/frontends/common/constantParsing.cpp
@@ -29,6 +29,10 @@ std::ostream &operator<<(std::ostream &out, const UnparsedConstant &constant) {
     return out;
 }
 
+bool operator<(const UnparsedConstant &a, const UnparsedConstant &b) {
+    return a.text < b.text || a.skip < b.skip || a.base < b.base || (!a.hasWidth && b.hasWidth);
+}
+
 /// A helper to parse constants which have an explicit width;
 /// @see UnparsedConstant for an explanation of the parameters.
 static IR::Constant *parseConstantWithWidth(Util::SourceInfo srcInfo, const char *text,

--- a/frontends/common/constantParsing.h
+++ b/frontends/common/constantParsing.h
@@ -71,6 +71,8 @@ struct UnparsedConstant {
 
 std::ostream &operator<<(std::ostream &out, const UnparsedConstant &constant);
 
+bool operator<(const UnparsedConstant &a, const UnparsedConstant &b);
+
 /**
  * Parses an UnparsedConstant @constant into an IR::Constant object, with
  * location information taken from @srcInfo. If parsing fails, an IR::Constant

--- a/ir/id.h
+++ b/ir/id.h
@@ -48,10 +48,13 @@ struct ID : Util::IHasSourceInfo, public IHasDbPrint {
     }
     bool operator==(const ID &a) const { return name == a.name; }
     bool operator!=(const ID &a) const { return name != a.name; }
+    bool operator<(const ID &a) const { return name < a.name; }
     bool operator==(cstring a) const { return name == a; }
     bool operator!=(cstring a) const { return name != a; }
+    bool operator<(cstring a) const { return name < a; }
     bool operator==(const char *a) const { return name == a; }
     bool operator!=(const char *a) const { return name != a; }
+    bool operator<(const char *a) const { return name < a; }
     explicit operator bool() const { return name; }
     operator cstring() const { return name; }
     std::string string() const { return name.string(); }

--- a/ir/id.h
+++ b/ir/id.h
@@ -48,12 +48,15 @@ struct ID : Util::IHasSourceInfo, public IHasDbPrint {
     }
     bool operator==(const ID &a) const { return name == a.name; }
     bool operator!=(const ID &a) const { return name != a.name; }
+    /// Defer to cstring's notion of less, which is a lexicographical and not a pointer comparison.
     bool operator<(const ID &a) const { return name < a.name; }
     bool operator==(cstring a) const { return name == a; }
     bool operator!=(cstring a) const { return name != a; }
+    /// Defer to cstring's notion of less, which is a lexicographical and not a pointer comparison.
     bool operator<(cstring a) const { return name < a; }
     bool operator==(const char *a) const { return name == a; }
     bool operator!=(const char *a) const { return name != a; }
+    /// Defer to cstring's notion of less, which is a lexicographical and not a pointer comparison.
     bool operator<(const char *a) const { return name < a; }
     explicit operator bool() const { return name; }
     operator cstring() const { return name; }

--- a/lib/ordered_map.h
+++ b/lib/ordered_map.h
@@ -131,6 +131,8 @@ class ordered_map {
         // two ordered_maps where !(a < b) && !(b < a) && !(a == b) -- such sets have the
         // same elements but in a different order.  This is generally what you want if you
         // have a set of ordered_maps (or use ordered_map as a map key).
+        // For individual element comparison, we defer to COMP, which is 'operator<' in the
+        // common case.
         auto it = a.data_map.begin();
         for (auto &el : data_map) {
             if (it == a.data_map.end()) return false;

--- a/lib/ordered_map.h
+++ b/lib/ordered_map.h
@@ -126,6 +126,20 @@ class ordered_map {
     size_type max_size() const noexcept { return data_map.max_size(); }
     bool operator==(const ordered_map &a) const { return data == a.data; }
     bool operator!=(const ordered_map &a) const { return data != a.data; }
+    bool operator<(const ordered_map &a) const {
+        // we define this to work INDEPENDENT of the order -- so it is possible to have
+        // two ordered_maps where !(a < b) && !(b < a) && !(a == b) -- such sets have the
+        // same elements but in a different order.  This is generally what you want if you
+        // have a set of ordered_maps (or use ordered_map as a map key).
+        auto it = a.data_map.begin();
+        for (auto &el : data_map) {
+            if (it == a.data_map.end()) return false;
+            if (mapcmp()(el.first, it->first)) return true;
+            if (mapcmp()(it->first, el.first)) return false;
+            ++it;
+        }
+        return it != a.data_map.end();
+    }
     void clear() {
         data.clear();
         data_map.clear();

--- a/lib/ordered_set.h
+++ b/lib/ordered_set.h
@@ -130,6 +130,8 @@ class ordered_set {
         // two ordered_sets where !(a < b) && !(b < a) && !(a == b) -- such sets have the
         // same elements but in a different order.  This is generally what you want if you
         // have a set of ordered_sets (or use ordered_set as a map key).
+        // For individual element comparison, we defer to COMP, which is 'operator<' in the
+        // common case.
         auto it = a.data_map.begin();
         for (auto &el : data_map) {
             if (it == a.data_map.end()) return false;

--- a/tools/ir-generator/irclass.h
+++ b/tools/ir-generator/irclass.h
@@ -252,6 +252,7 @@ class IrClass : public IrElement {
     int generateConstructor(const ctor_args_t &args, const IrMethod *user, unsigned skip_opt);
     void generateMethods();
     bool shouldSkip(cstring feature) const;
+    bool hasNoDirective(cstring feature) const;
 
  public:
     const IrClass *getParent() const {

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -322,10 +322,14 @@ void IrClass::generateMethods() {
                 }
             }
         }
-        for (auto *parent = getParent(); parent; parent = parent->getParent()) {
-            auto eq_overload = new IrMethod("operator=="_cs, "{ return a == *this; }"_cs);
+        for (const auto *parent = getParent(); parent != nullptr; parent = parent->getParent()) {
+            if (hasNoDirective("operator=="_cs)) {
+                continue;
+            }
+            auto *eq_overload = new IrMethod("operator=="_cs, "{ return a == *this; }"_cs);
             eq_overload->clss = this;
             eq_overload->isOverride = true;
+            eq_overload->inImpl = true;
             eq_overload->rtype = &NamedType::Bool();
             eq_overload->args.push_back(
                 new IrField(new ReferenceType(new NamedType(parent), true), "a"_cs));


### PR DESCRIPTION
Small changes forked from #4302. 

1. Add operator< to some more nodes.
2. Move the check for `hasNoDirective` in IRClass into a separate helper. 
3. Use this helper to skip generating `operator==` if requested. Also ensure `operator==` is moved to the implementation. 