### PR TITLE
[P4Testgen] Represent bits of width zero as an empty string.

### DIFF
--- a/backends/p4tools/common/lib/format_int.cpp
+++ b/backends/p4tools/common/lib/format_int.cpp
@@ -19,12 +19,8 @@ namespace P4Tools {
 
 std::string formatBin(const big_int &value, int width, const FormatOptions &formatOptions) {
     std::stringstream out;
-    // Ensure we output at least _something_.
+    // If the width of the value is 0 return an empty string.
     if (width == 0) {
-        if (formatOptions.usePrefix) {
-            out << "0b";
-        }
-        out << 0;
         return out.str();
     }
 
@@ -56,12 +52,8 @@ std::string formatBin(const big_int &value, int width, const FormatOptions &form
 
 std::string formatOctal(const big_int &value, int width, const FormatOptions &formatOptions) {
     std::stringstream out;
-    // Ensure we output at least _something_.
+    // If the width of the value is 0 return an empty string.
     if (width == 0) {
-        if (formatOptions.usePrefix) {
-            out << "0";
-        }
-        out << 0;
         return out.str();
     }
 
@@ -91,12 +83,8 @@ std::string formatOctal(const big_int &value, int width, const FormatOptions &fo
 
 std::string formatHex(const big_int &value, int width, const FormatOptions &formatOptions) {
     std::stringstream out;
-    // Ensure we output at least _something_.
+    // If the width of the value is 0 return an empty string.
     if (width == 0) {
-        if (formatOptions.usePrefix) {
-            out << "0x";
-        }
-        out << 0;
         return out.str();
     }
 
@@ -240,6 +228,9 @@ std::string formatBinOrHexExpr(const IR::Expression *expr, const FormatOptions &
 std::string insertSeparators(const std::string &dataStr, const std::string &separator,
                              size_t stride, bool skipFirst) {
     size_t stringWidth = dataStr.size();
+    if (stringWidth == 0) {
+        return dataStr;
+    }
     // Nothing to do if we skip the first character and the stride is as wide as the string itself.
     if (stringWidth <= stride && skipFirst) {
         return dataStr;

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -282,8 +282,4 @@ p4tools_add_xfail_reason(
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
   "Expected packet was not received on device"
-  # The packet has a zero width and is dropped by PTF.
-  parser-unroll-issue3537-1.p4
-  parser-unroll-issue3537.p4
-  parser-unroll-test2.p4
 )

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend.cpp
@@ -75,7 +75,8 @@ TestBackEnd::TestInfo Bmv2TestBackend::produceTestInfo(
                                                  outputPortExpr, programTraces);
     // This is a hack to deal with a behavioral model quirk.
     // Packets that are too small are truncated to 02000000 (in hex) with width 32 bit.
-    if (testInfo.outputPacket->type->width_bits() == 0) {
+    if (testInfo.outputPacket->type->width_bits() == 0 &&
+        TestgenOptions::get().testBackend == "STF") {
         int outPktSize = ZERO_PKT_WIDTH;
         testInfo.outputPacket =
             IR::Constant::get(IR::Type_Bits::get(outPktSize), Bmv2TestBackend::ZERO_PKT_VAL);

--- a/backends/p4tools/modules/testgen/targets/bmv2/test_backend/ptf.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test_backend/ptf.cpp
@@ -16,8 +16,6 @@
 #include "lib/log.h"
 #include "nlohmann/json.hpp"
 
-#include "backends/p4tools/modules/testgen/options.h"
-
 namespace P4Tools::P4Testgen::Bmv2 {
 
 PTF::PTF(const TestBackendConfiguration &testBackendConfiguration)
@@ -26,6 +24,9 @@ PTF::PTF(const TestBackendConfiguration &testBackendConfiguration)
 std::vector<std::pair<size_t, size_t>> PTF::getIgnoreMasks(const IR::Constant *mask) {
     std::vector<std::pair<size_t, size_t>> ignoreMasks;
     if (mask == nullptr) {
+        return ignoreMasks;
+    }
+    if (mask->type->width_bits() == 0) {
         return ignoreMasks;
     }
     auto maskBinStr = formatBinExpr(mask, {false, true, false});

--- a/backends/p4tools/modules/testgen/test/lib/format_int.cpp
+++ b/backends/p4tools/modules/testgen/test/lib/format_int.cpp
@@ -1,7 +1,5 @@
 #include "backends/p4tools/modules/testgen/test/lib/format_int.h"
 
-#include <stdint.h>
-
 #include <gtest/gtest.h>
 
 #include <string>
@@ -27,8 +25,7 @@ using P4Tools::insertHexSeparators;
 using P4Tools::insertOctalSeparators;
 using P4Tools::insertSeparators;
 
-// Tests for formatHexExpr
-TEST_F(FormatTest, Format01) {
+TEST_F(FormatTest, FormatHex) {
     {
         const auto *typeBits = IR::Type_Bits::get(16);
         const auto *sixteenBits = IR::Constant::get(typeBits, 0x10);
@@ -83,6 +80,19 @@ TEST_F(FormatTest, Format01) {
         ASSERT_STREQ(formatHexExpr(sixteenBits, {true, true, true}).c_str(), "0x1");
     }
     {
+        const auto *typeBits = IR::Type_Bits::get(0);
+        const auto *zeroBits = IR::Constant::get(typeBits, 0x0);
+        ASSERT_STREQ(formatHexExpr(zeroBits).c_str(), "");
+        ASSERT_STREQ(formatHexExpr(zeroBits, {false, false, false}).c_str(), "");
+        ASSERT_STREQ(formatHexExpr(zeroBits, {false, false, true}).c_str(), "");
+        ASSERT_STREQ(formatHexExpr(zeroBits, {false, true, false}).c_str(), "");
+        ASSERT_STREQ(formatHexExpr(zeroBits, {false, true, true}).c_str(), "");
+        ASSERT_STREQ(formatHexExpr(zeroBits, {true, false, false}).c_str(), "");
+        ASSERT_STREQ(formatHexExpr(zeroBits, {true, false, true}).c_str(), "");
+        ASSERT_STREQ(formatHexExpr(zeroBits, {true, true, false}).c_str(), "");
+        ASSERT_STREQ(formatHexExpr(zeroBits, {true, true, true}).c_str(), "");
+    }
+    {
         const auto *typeBits = IR::Type_Bits::get(16, true);
         const auto *sixteenBits = IR::Constant::get(typeBits, -1);
         ASSERT_EQ(static_cast<uint16_t>(sixteenBits->asInt64()), 0xFFFF);
@@ -123,8 +133,7 @@ TEST_F(FormatTest, Format01) {
     }
 }
 
-// Tests for formatOctalExpr
-TEST_F(FormatTest, Format02) {
+TEST_F(FormatTest, FormatOctal) {
     {
         const auto *typeBits = IR::Type_Bits::get(8);
         const auto *sixteenBits = IR::Constant::get(typeBits, 012);
@@ -200,10 +209,22 @@ TEST_F(FormatTest, Format02) {
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {true, true, false}).c_str(), "0370");
         ASSERT_STREQ(formatOctalExpr(sixteenBits, {true, true, true}).c_str(), "00370");
     }
+    {
+        const auto *typeBits = IR::Type_Bits::get(0);
+        const auto *zeroBits = IR::Constant::get(typeBits, 0x0);
+        ASSERT_STREQ(formatHexExpr(zeroBits).c_str(), "");
+        ASSERT_STREQ(formatOctalExpr(zeroBits, {false, false, false}).c_str(), "");
+        ASSERT_STREQ(formatOctalExpr(zeroBits, {false, false, true}).c_str(), "");
+        ASSERT_STREQ(formatOctalExpr(zeroBits, {false, true, false}).c_str(), "");
+        ASSERT_STREQ(formatOctalExpr(zeroBits, {false, true, true}).c_str(), "");
+        ASSERT_STREQ(formatOctalExpr(zeroBits, {true, false, false}).c_str(), "");
+        ASSERT_STREQ(formatOctalExpr(zeroBits, {true, false, true}).c_str(), "");
+        ASSERT_STREQ(formatOctalExpr(zeroBits, {true, true, false}).c_str(), "");
+        ASSERT_STREQ(formatOctalExpr(zeroBits, {true, true, true}).c_str(), "");
+    }
 }
 
-// Tests for formatBinExpr
-TEST_F(FormatTest, Format03) {
+TEST_F(FormatTest, FormatBin) {
     {
         const auto *typeBits = IR::Type_Bits::get(8);
         const auto *sixteenBits = IR::Constant::get(typeBits, 0b11);
@@ -261,19 +282,35 @@ TEST_F(FormatTest, Format03) {
         ASSERT_STREQ(formatBinExpr(sixteenBits, {true, true, true}).c_str(),
                      "0b1111_1111_1111_0000");
     }
+    {
+        const auto *typeBits = IR::Type_Bits::get(0);
+        const auto *zeroBits = IR::Constant::get(typeBits, 0x0);
+        ASSERT_STREQ(formatHexExpr(zeroBits).c_str(), "");
+        ASSERT_STREQ(formatBinExpr(zeroBits, {false, false, false}).c_str(), "");
+        ASSERT_STREQ(formatBinExpr(zeroBits, {false, false, true}).c_str(), "");
+        ASSERT_STREQ(formatBinExpr(zeroBits, {false, true, false}).c_str(), "");
+        ASSERT_STREQ(formatBinExpr(zeroBits, {false, true, true}).c_str(), "");
+        ASSERT_STREQ(formatBinExpr(zeroBits, {true, false, false}).c_str(), "");
+        ASSERT_STREQ(formatBinExpr(zeroBits, {true, false, true}).c_str(), "");
+        ASSERT_STREQ(formatBinExpr(zeroBits, {true, true, false}).c_str(), "");
+        ASSERT_STREQ(formatBinExpr(zeroBits, {true, true, true}).c_str(), "");
+    }
 }
 
-// Tests for insertOctalSeparators and insertHexSeparators
-TEST_F(FormatTest, Format04) {
+TEST_F(FormatTest, InsertSeparators) {
     {
         ASSERT_STREQ(insertHexSeparators("AEC192").c_str(), "\\xAE\\xC1\\x92");
         ASSERT_STREQ(insertHexSeparators("E3D4").c_str(), "\\xE3\\xD4");
+        ASSERT_STREQ(insertHexSeparators("").c_str(), "");
         ASSERT_STREQ(insertOctalSeparators("0712522321").c_str(), "\\000\\712\\522\\321");
         ASSERT_STREQ(insertOctalSeparators("02310").c_str(), "\\002\\310");
+        ASSERT_STREQ(insertOctalSeparators("").c_str(), "");
         ASSERT_STREQ(insertSeparators("02310", "\\", 2, true).c_str(), "00\\23\\10");
         ASSERT_STREQ(insertSeparators("0712522321", "\\", 2, true).c_str(), "07\\12\\52\\23\\21");
+        ASSERT_STREQ(insertSeparators("", "\\", 2, true).c_str(), "");
         ASSERT_STREQ(insertSeparators("E3D4", "\\x", 2, true).c_str(), "E3\\xD4");
         ASSERT_STREQ(insertSeparators("AEC192", "\\x", 2, true).c_str(), "AE\\xC1\\x92");
+        ASSERT_STREQ(insertSeparators("", "\\x", 2, true).c_str(), "");
     }
 }
 


### PR DESCRIPTION
Do not return "something" when the bitwidth is zero. Instead handle this case separately. This fixes some problems when trying to test for 0 bit packets emitted in the packet test framework. 