### PR TITLE
[P4Testgen] Set other headers also invalid when calling setInvalid on a union header.

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/abstract_stepper.cpp
@@ -209,38 +209,48 @@ bool AbstractStepper::stepGetHeaderValidity(const IR::StateVariable &headerRef) 
     return false;
 }
 
-void AbstractStepper::setHeaderValidity(const IR::StateVariable &headerRef, bool validity,
-                                        ExecutionState &nextState) {
+namespace {
+
+void setHeaderValidityHelper(const IR::StateVariable &headerRef, bool validity,
+                             const ProgramInfo &programInfo, ExecutionState &nextState) {
     const auto &headerRefValidity = ToolsVariables::getHeaderValidity(headerRef);
     nextState.set(headerRefValidity, IR::BoolLiteral::get(validity));
 
-    // In some cases, the header may be `part of a union.
-    if (validity) {
-        const auto *headerBaseMember = headerRef.ref->to<IR::Member>();
-        if (headerBaseMember == nullptr) {
-            return;
+    // The header is going to be invalid. Set all fields to taint constants.
+    // TODO: Should we make this target specific? Some targets set the header fields to 0...
+    if (!validity) {
+        std::vector<IR::StateVariable> validityVector;
+        for (const auto &field : validityVector) {
+            nextState.set(field, IR::BoolLiteral::get(false));
         }
-        const auto *headerBase = headerBaseMember->expr;
+        auto fieldsVector = nextState.getFlatFields(headerRef, &validityVector);
+        for (const auto &field : fieldsVector) {
+            nextState.set(field, programInfo.createTargetUninitialized(field->type, true));
+        }
+    }
+}
+
+}  // namespace
+
+void AbstractStepper::setHeaderValidity(const IR::StateVariable &headerRef, bool validity,
+                                        ExecutionState &nextState) {
+    setHeaderValidityHelper(headerRef, validity, programInfo, nextState);
+
+    // In some cases, the header may be nested.
+    if (const auto *headerBase = headerRef.ref->to<IR::Member>()) {
         // In the case of header unions, we need to set all other union members invalid.
-        if (const auto *hdrUnion = headerBase->type->to<IR::Type_HeaderUnion>()) {
+        CHECK_NULL(headerBase->expr->type);
+        if (const auto *hdrUnion = headerBase->expr->type->to<IR::Type_HeaderUnion>()) {
             for (const auto *field : hdrUnion->fields) {
-                auto *member = new IR::Member(field->type, headerBase, field->name);
-                // Ignore the member we are setting to valid.
+                auto *member = new IR::Member(field->type, headerBase->expr, field->name);
+                // Ignore the member we are setting.
                 if (headerRef->equiv(*member)) {
                     continue;
                 }
                 // Set all other members to invalid.
-                setHeaderValidity(member, false, nextState);
+                setHeaderValidityHelper(member, false, programInfo, nextState);
             }
         }
-        return;
-    }
-    std::vector<IR::StateVariable> validityVector;
-    auto fieldsVector = nextState.getFlatFields(headerRef, &validityVector);
-    // The header is going to be invalid. Set all fields to taint constants.
-    // TODO: Should we make this target specific? Some targets set the header fields to 0.
-    for (const auto &field : fieldsVector) {
-        nextState.set(field, programInfo.createTargetUninitialized(field->type, true));
     }
 }
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_invalid_hu.p4
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/p4-programs/bmv2_invalid_hu.p4
@@ -1,0 +1,76 @@
+#include <v1model.p4>
+
+header opt_t {
+    bit<8> opt;
+}
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+    bit<8> a1;
+    bit<8> b;
+}
+
+header_union U {
+    ethernet_t e;
+    H h;
+}
+
+struct Headers {
+    opt_t opt;
+    U u;
+}
+
+struct Meta {}
+
+parser p(packet_in pkt, out Headers h, inout Meta meta, inout standard_metadata_t stdmeta) {
+    state start {
+        pkt.extract(h.opt);
+        transition select(h.opt.opt) {
+            0x0: parse_e;
+            0x1: parse_h;
+            default: accept;
+        }
+    }
+
+    state parse_e {
+        pkt.extract(h.u.e);
+        transition accept;
+    }
+
+    state parse_h {
+        pkt.extract(h.u.h);
+        transition accept;
+    }
+}
+
+control vrfy(inout Headers h, inout Meta meta) {
+    apply { }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply {
+        h.u.e.setInvalid();
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t s) {
+    apply { }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply { }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;


### PR DESCRIPTION
Fixes #4448.