### PR TITLE
[TESTING] Switch compilation from C++17 to C++20

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,9 +3,9 @@ common --enable_workspace
 # Enable once #5066 is resolved.
 common --noenable_bzlmod
 
-# Use C++17.
-build --cxxopt=-std=c++17
-build --host_cxxopt=-std=c++17
+# Use C++20.
+build --cxxopt=-std=c++20
+build --host_cxxopt=-std=c++20
 
 # Force the use of Clang for all builds.
 build --action_env=CC=clang

--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ IncludeBlocks: Regroup
 # Force pointers to the type for C++.
 DerivePointerAlignment: false
 PointerAlignment: Right
-Standard: c++17
+Standard: c++20
 IncludeCategories:
   # Matches common headers first and sorts them before project includes
   - Regex: '^<.+/.*\.h>'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ endif()
 
 project (P4C)
 
-# set (CMAKE_CXX_EXTENSIONS OFF) # prefer using -std=c++17 rather than -std=gnu++17
-set (CMAKE_CXX_STANDARD 17)
+# set (CMAKE_CXX_EXTENSIONS OFF) # prefer using -std=c++20 rather than -std=gnu++20
+set (CMAKE_CXX_STANDARD 20)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set (CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)

--- a/backends/p4tools/common/lib/logging.h
+++ b/backends/p4tools/common/lib/logging.h
@@ -6,18 +6,17 @@
 #include <string>
 #include <utility>
 
-#include <boost/format.hpp>
-
+#include "lib/boost_format_compat.h"
 #include "lib/log.h"
 
 namespace P4::P4Tools {
 
 /// Helper function for @printFeature
-inline std::string logHelper(boost::format &f) { return f.str(); }
+inline BoostFormatCompat &logHelper(BoostFormatCompat &f) { return f; }
 
 /// Helper function for @printFeature
 template <class T, class... Args>
-std::string logHelper(boost::format &f, T &&t, Args &&...args) {
+BoostFormatCompat &logHelper(BoostFormatCompat &f, T &&t, Args &&...args) {
     return logHelper(f % std::forward<T>(t), std::forward<Args>(args)...);
 }
 
@@ -32,8 +31,8 @@ void printFeature(const std::string &label, int level, const std::string &fmt,
         return;
     }
 
-    boost::format f(fmt);
-    LOG_FEATURE(label.c_str(), level, logHelper(f, std::forward<Arguments>(args)...));
+    BoostFormatCompat f(fmt.c_str());
+    LOG_FEATURE(label.c_str(), level, logHelper(f, std::forward<Arguments>(args)...).str());
 }
 
 /// Helper functions that prints strings associated with basic tool information.

--- a/backends/tofino/bf-p4c/parde/lowered/hoist_common_match_operations.cpp
+++ b/backends/tofino/bf-p4c/parde/lowered/hoist_common_match_operations.cpp
@@ -327,15 +327,13 @@ bool HoistCommonMatchOperations::can_hoist(const IR::BFN::LoweredParserMatch *a,
     all_dests.merge(b_inbuf_dests);
     if (!a_inbuf_dests.empty() || !b_inbuf_dests.empty()) return false;
 
-    auto extactors_required = extractors_used(a);
+    auto extractors_required = extractors_used(a);
     auto b_extractors = extractors_used(b);
-    extactors_required = std::accumulate(b_extractors.begin(), b_extractors.end(),
-                                         extactors_required, [](auto &map, const auto &pair) {
-                                             map[pair.first] += pair.second;
-                                             return map;
-                                         });
+    for (auto &[size, cnt] : b_extractors) {
+        extractors_required[size] += cnt;
+    }
     for (const auto &[size, max] : Device::pardeSpec().extractorSpec())
-        if (extactors_required[size] > max) return false;
+        if (extractors_required[size] > max) return false;
 
     // Do not hoist a into b if result would contain more than 2 CLOTs or if b contains a spilled
     // CLOT extract from a

--- a/bazel/example/.bazelrc
+++ b/bazel/example/.bazelrc
@@ -3,9 +3,9 @@ common --enable_workspace
 # Enable once #5066 is resolved.
 common --noenable_bzlmod
 
-# Use C++17.
-build --cxxopt=-std=c++17
-build --host_cxxopt=-std=c++17
+# Use C++20.
+build --cxxopt=-std=c++20
+build --host_cxxopt=-std=c++20
 
 # Force the use of Clang for all builds.
 build --action_env=CC=clang

--- a/docs/C++.md
+++ b/docs/C++.md
@@ -1,4 +1,4 @@
-C++ (following the C++ 11 standard) is the implementation language for
+C++ (following the C++ 20 standard) is the implementation language for
 the compiler.  This file contains notes on how we use C++ and conventions
 we use for things that C++ does not handle well.
 

--- a/frontends/p4/typeChecking/typeConstraints.cpp
+++ b/frontends/p4/typeChecking/typeConstraints.cpp
@@ -126,7 +126,7 @@ std::string TypeConstraint::localError(Explain *explainer) const {
     if (errFormat.isNullOrEmpty()) return "";
 
     std::string message, explanation;
-    boost::format fmt = boost::format(errFormat.c_str());
+    BoostFormatCompat fmt(errFormat.c_str());
     switch (errArguments.size()) {
         case 0:
             message = boost::str(fmt);

--- a/frontends/p4/typeChecking/typeConstraints.h
+++ b/frontends/p4/typeChecking/typeConstraints.h
@@ -92,7 +92,7 @@ class TypeConstraint : public IHasDbPrint, public ICastable {
         /// composed in reverse order, from bottom to top.  The top of the stack
         /// has no 'derivedFrom' field, and it contains the actual source
         /// position where the analysis started.
-        boost::format fmt(format);
+        BoostFormatCompat fmt(format);
         return reportErrorImpl(subst,
                                "  ---- Actual error:\n" +
                                    ::P4::error_helper(fmt, std::forward<Args>(args)...).toString());

--- a/frontends/parsers/parserDriver.cpp
+++ b/frontends/parsers/parserDriver.cpp
@@ -6,8 +6,6 @@
 #include <sstream>
 #include <string_view>
 
-#include <boost/format.hpp>
-
 #include "frontends/common/constantFolding.h"
 #include "frontends/common/options.h"
 #include "frontends/parsers/p4/p4AnnotationLexer.hpp"
@@ -15,6 +13,7 @@
 #include "frontends/parsers/p4/p4parser.hpp"
 #include "frontends/parsers/v1/v1lexer.hpp"
 #include "frontends/parsers/v1/v1parser.hpp"
+#include "lib/boost_format_compat.h"
 #include "lib/error.h"
 
 #ifdef HAVE_LIBBOOST_IOSTREAMS
@@ -108,7 +107,7 @@ void AbstractParserDriver::onParseError(const Util::SourceInfo &location,
     auto &context = BaseCompileContext::get();
     if (message == unexpectedIdentifierError) {
         context.errorReporter().parser_error(
-            location, boost::format("%s \"%s\"") % unexpectedIdentifierError % lastIdentifier);
+            location, BoostFormatCompat("%s \"%s\"") % unexpectedIdentifierError % lastIdentifier);
     } else {
         context.errorReporter().parser_error(location, message);
     }

--- a/ir/pattern.h
+++ b/ir/pattern.h
@@ -91,25 +91,9 @@ class Pattern {
         Match() : m(nullptr) {}
         const T *operator->() const { return m; }
         operator const T *() const { return m; }  // NOLINT(runtime/explicit)
-        Pattern operator*(const Pattern &a) { return Pattern(*this) * a; }
-        Pattern operator/(const Pattern &a) { return Pattern(*this) / a; }
-        Pattern operator%(const Pattern &a) { return Pattern(*this) % a; }
-        Pattern operator+(const Pattern &a) { return Pattern(*this) + a; }
-        Pattern operator-(const Pattern &a) { return Pattern(*this) - a; }
-        Pattern operator<<(const Pattern &a) { return Pattern(*this) << a; }
-        Pattern operator>>(const Pattern &a) { return Pattern(*this) >> a; }
-        Pattern operator==(const Pattern &a) { return Pattern(*this) == a; }
-        Pattern operator!=(const Pattern &a) { return Pattern(*this) != a; }
-        Pattern operator<(const Pattern &a) { return Pattern(*this) < a; }
-        Pattern operator<=(const Pattern &a) { return Pattern(*this) <= a; }
-        Pattern operator>(const Pattern &a) { return Pattern(*this) > a; }
-        Pattern operator>=(const Pattern &a) { return Pattern(*this) >= a; }
+
         Pattern Relation(const Pattern &a) { return Pattern(*this).Relation(a); }
-        Pattern operator&(const Pattern &a) { return Pattern(*this) & a; }
-        Pattern operator|(const Pattern &a) { return Pattern(*this) | a; }
-        Pattern operator^(const Pattern &a) { return Pattern(*this) ^ a; }
-        Pattern operator&&(const Pattern &a) { return Pattern(*this) && a; }
-        Pattern operator||(const Pattern &a) { return Pattern(*this) || a; }
+
         // avoid ambiguous overloads with operator const T * above
         Pattern operator+(int a) { return Pattern(*this) + Pattern(a); }
         Pattern operator-(int a) { return Pattern(*this) - Pattern(a); }
@@ -205,6 +189,66 @@ inline Pattern operator|(int v, const Pattern &a) { return Pattern(v) | a; }
 inline Pattern operator^(int v, const Pattern &a) { return Pattern(v) ^ a; }
 inline Pattern operator&&(int v, const Pattern &a) { return Pattern(v) && a; }
 inline Pattern operator||(int v, const Pattern &a) { return Pattern(v) || a; }
+
+// NOTE: Because of C++20 overloading rules (particularly the fact that "flipped" operators don't
+// work with non-bool return type), we must have both versions for Pattern-Match comparsion as well
+// as the Match-Match version to be non-ambiguous.
+template<typename A, typename B> Pattern operator*(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) * Pattern(b); }
+template<typename A, typename B> Pattern operator/(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) / Pattern(b); }
+template<typename A, typename B> Pattern operator%(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) % Pattern(b); }
+template<typename A, typename B> Pattern operator+(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) + Pattern(b); }
+template<typename A, typename B> Pattern operator-(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) - Pattern(b); }
+template<typename A, typename B> Pattern operator<<(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) << Pattern(b); }
+template<typename A, typename B> Pattern operator>>(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) >> Pattern(b); }
+template<typename A, typename B> Pattern operator==(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) == Pattern(b); }
+template<typename A, typename B> Pattern operator!=(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) != Pattern(b); }
+template<typename A, typename B> Pattern operator<(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) < Pattern(b); }
+template<typename A, typename B> Pattern operator<=(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) <= Pattern(b); }
+template<typename A, typename B> Pattern operator>(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) > Pattern(b); }
+template<typename A, typename B> Pattern operator>=(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) >= Pattern(b); }
+template<typename A, typename B> Pattern operator&(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) & Pattern(b); }
+template<typename A, typename B> Pattern operator|(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) | Pattern(b); }
+template<typename A, typename B> Pattern operator^(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) ^ Pattern(b); }
+template<typename A, typename B> Pattern operator&&(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) && Pattern(b); }
+template<typename A, typename B> Pattern operator||(Pattern::Match<A> &a, Pattern::Match<B> &b) { return Pattern(a) || Pattern(b); }
+
+template<typename T> Pattern operator*(const Pattern &a, Pattern::Match<T> &b) { return a * Pattern(b); }
+template<typename T> Pattern operator/(const Pattern &a, Pattern::Match<T> &b) { return a / Pattern(b); }
+template<typename T> Pattern operator%(const Pattern &a, Pattern::Match<T> &b) { return a % Pattern(b); }
+template<typename T> Pattern operator+(const Pattern &a, Pattern::Match<T> &b) { return a + Pattern(b); }
+template<typename T> Pattern operator-(const Pattern &a, Pattern::Match<T> &b) { return a - Pattern(b); }
+template<typename T> Pattern operator<<(const Pattern &a, Pattern::Match<T> &b) { return a << Pattern(b); }
+template<typename T> Pattern operator>>(const Pattern &a, Pattern::Match<T> &b) { return a >> Pattern(b); }
+template<typename T> Pattern operator==(const Pattern &a, Pattern::Match<T> &b) { return a == Pattern(b); }
+template<typename T> Pattern operator!=(const Pattern &a, Pattern::Match<T> &b) { return a != Pattern(b); }
+template<typename T> Pattern operator<(const Pattern &a, Pattern::Match<T> &b) { return a < Pattern(b); }
+template<typename T> Pattern operator<=(const Pattern &a, Pattern::Match<T> &b) { return a <= Pattern(b); }
+template<typename T> Pattern operator>(const Pattern &a, Pattern::Match<T> &b) { return a > Pattern(b); }
+template<typename T> Pattern operator>=(const Pattern &a, Pattern::Match<T> &b) { return a >= Pattern(b); }
+template<typename T> Pattern operator&(const Pattern &a, Pattern::Match<T> &b) { return a & Pattern(b); }
+template<typename T> Pattern operator|(const Pattern &a, Pattern::Match<T> &b) { return a | Pattern(b); }
+template<typename T> Pattern operator^(const Pattern &a, Pattern::Match<T> &b) { return a ^ Pattern(b); }
+template<typename T> Pattern operator&&(const Pattern &a, Pattern::Match<T> &b) { return a && Pattern(b); }
+template<typename T> Pattern operator||(const Pattern &a, Pattern::Match<T> &b) { return a || Pattern(b); }
+
+template<typename T> Pattern operator*(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) * b; }
+template<typename T> Pattern operator/(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) / b; }
+template<typename T> Pattern operator%(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) % b; }
+template<typename T> Pattern operator+(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) + b; }
+template<typename T> Pattern operator-(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) - b; }
+template<typename T> Pattern operator<<(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) << b; }
+template<typename T> Pattern operator>>(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) >> b; }
+template<typename T> Pattern operator==(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) == b; }
+template<typename T> Pattern operator!=(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) != b; }
+template<typename T> Pattern operator<(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) < b; }
+template<typename T> Pattern operator<=(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) <= b; }
+template<typename T> Pattern operator>(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) > b; }
+template<typename T> Pattern operator>=(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) >= b; }
+template<typename T> Pattern operator&(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) & b; }
+template<typename T> Pattern operator|(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) | b; }
+template<typename T> Pattern operator^(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) ^ b; }
+template<typename T> Pattern operator&&(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) && b; }
+template<typename T> Pattern operator||(const Pattern::Match<T> &a, Pattern &b) { return Patter(a) || b; }
 
 }  // namespace P4
 

--- a/lib/boost_format_compat.h
+++ b/lib/boost_format_compat.h
@@ -1,0 +1,53 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef LIB_BOOST_FORMAT_COMPAT_H_
+#define LIB_BOOST_FORMAT_COMPAT_H_
+
+#include <boost/format.hpp>
+
+namespace P4 {
+
+/// Allocator wrapper that adds the overload removed in C++20 for the sake of Boost.
+template <typename T>
+struct BoostCompatAllocator : std::allocator<T> {
+    /// Inherit constructors.
+    using std::allocator<T>::allocator;
+
+    BoostCompatAllocator() = default;
+    /// Explictly make it possible to construct our allocator from std::allocator.
+    /// Some parts of libstdc++ 9 require that for some reason.
+    BoostCompatAllocator(const std::allocator<T> &other)
+        : std::allocator<T>(other) {}  // NOLINT(runtime/explicit)
+    BoostCompatAllocator(std::allocator<T> &&other)
+        : std::allocator<T>(std::move(other)) {}  // NOLINT(runtime/explicit)
+
+    /// This one was removed in C++20, but boost::format < 1.74 needs it.
+    T *allocate(typename std::allocator<T>::size_type n, const void *) { return allocate(n); }
+
+    /// Explicitly wrap the other overload (instead of using using std::allocator<T>::allocate.
+    /// The latter does not work with GCC 9.
+    T *allocate(typename std::allocator<T>::size_type n) { return std::allocator<T>::allocate(n); }
+};
+
+/// Boost < 1.74 is not compatible with C++20 as it expect deprecated
+/// allocator::allocate(size_type, void*) to exist. To work around that, we use a simple wrapper
+/// over std::allocator that adds this overload back. All uses of boost::format in P4C should use
+// this type instead.
+using BoostFormatCompat =
+    boost::basic_format<char, std::char_traits<char>, BoostCompatAllocator<char>>;
+
+}  // namespace P4
+
+#endif  // LIB_BOOST_FORMAT_COMPAT_H_

--- a/lib/bug_helper.h
+++ b/lib/bug_helper.h
@@ -23,9 +23,8 @@ limitations under the License.
 #include <string_view>
 #include <utility>
 
-#include <boost/format.hpp>
-
 #include "absl/strings/str_cat.h"
+#include "boost_format_compat.h"
 #include "cstring.h"
 #include "source_file.h"
 #include "stringify.h"
@@ -60,27 +59,27 @@ std::pair<std::string_view, std::string> maybeAddSourceInfo(const T &t, std::str
     return {"", ""};
 }
 
-static inline std::string bug_helper(boost::format &f, std::string_view position,
+static inline std::string bug_helper(BoostFormatCompat &f, std::string_view position,
                                      std::string_view tail) {
     return absl::StrCat(position, position.empty() ? "" : ": ", boost::str(f), "\n", tail);
 }
 
 template <typename T, class... Args>
-auto bug_helper(boost::format &f, std::string_view position, std::string_view tail, const T *t,
+auto bug_helper(BoostFormatCompat &f, std::string_view position, std::string_view tail, const T *t,
                 Args &&...args);
 
 template <typename T, class... Args>
-auto bug_helper(boost::format &f, std::string_view position, std::string_view tail, const T &t,
+auto bug_helper(BoostFormatCompat &f, std::string_view position, std::string_view tail, const T &t,
                 Args &&...args) -> std::enable_if_t<!std::is_pointer_v<T>, std::string>;
 
 template <class... Args>
-std::string bug_helper(boost::format &f, std::string_view position, std::string_view tail,
+std::string bug_helper(BoostFormatCompat &f, std::string_view position, std::string_view tail,
                        const char *t, Args &&...args) {
     return bug_helper(f % t, position, tail, std::forward<Args>(args)...);
 }
 
 template <class... Args>
-std::string bug_helper(boost::format &f, std::string_view position, std::string_view tail,
+std::string bug_helper(BoostFormatCompat &f, std::string_view position, std::string_view tail,
                        const Util::SourceInfo &info, Args &&...args) {
     auto [outPos, outTail] = detail::getPositionTail(info, position, tail);
     return bug_helper(f % "", outPos, outTail, std::forward<Args>(args)...);
@@ -105,7 +104,7 @@ std::ostream &operator<<(std::ostream &os, const DbprintDispatchPtr<T> &dispatch
 }
 
 template <typename T, class... Args>
-auto bug_helper(boost::format &f, std::string_view position, std::string_view tail, const T *t,
+auto bug_helper(BoostFormatCompat &f, std::string_view position, std::string_view tail, const T *t,
                 Args &&...args) {
     if (t == nullptr) return bug_helper(f, position, tail, std::forward<Args>(args)...);
 
@@ -132,7 +131,7 @@ std::ostream &operator<<(std::ostream &os, const DbprintDispatchRef<T> &dispatch
 }
 
 template <typename T, class... Args>
-auto bug_helper(boost::format &f, std::string_view position, std::string_view tail, const T &t,
+auto bug_helper(BoostFormatCompat &f, std::string_view position, std::string_view tail, const T &t,
                 Args &&...args) -> std::enable_if_t<!std::is_pointer_v<T>, std::string> {
     auto [outPos, outTail] = maybeAddSourceInfo(t, position, tail);
     return bug_helper(f % DbprintDispatchRef<T>{t}, outPos, outTail, std::forward<Args>(args)...);
@@ -141,7 +140,7 @@ auto bug_helper(boost::format &f, std::string_view position, std::string_view ta
 
 // Most direct invocations of bug_helper usually only reduce arguments
 template <class... Args>
-std::string bug_helper(boost::format &f, std::string_view position, std::string_view tail,
+std::string bug_helper(BoostFormatCompat &f, std::string_view position, std::string_view tail,
                        Args &&...args) {
     return detail::bug_helper(f, position, tail, std::forward<Args>(args)...);
 }

--- a/lib/error_helper.h
+++ b/lib/error_helper.h
@@ -18,8 +18,7 @@ limitations under the License.
 
 #include <type_traits>
 
-#include <boost/format.hpp>
-
+#include "lib/boost_format_compat.h"
 #include "lib/error_message.h"
 #include "lib/source_file.h"
 #include "lib/stringify.h"
@@ -29,26 +28,26 @@ namespace priv {
 
 // All these methods return std::string because this is the native format of boost::format
 // Position is printed at the beginning.
-static inline ErrorMessage error_helper(boost::format &f, ErrorMessage out) {
+static inline ErrorMessage error_helper(BoostFormatCompat &f, ErrorMessage out) {
     out.message = boost::str(f);
     return out;
 }
 
 template <class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const char *t, Args &&...args) {
+auto error_helper(BoostFormatCompat &f, ErrorMessage out, const char *t, Args &&...args) {
     return error_helper(f % t, out, std::forward<Args>(args)...);
 }
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T &t,
-                  Args &&...args) -> std::enable_if_t<Util::has_toString_v<T>, ErrorMessage>;
+auto error_helper(BoostFormatCompat &f, ErrorMessage out, const T &t, Args &&...args)
+    -> std::enable_if_t<Util::has_toString_v<T>, ErrorMessage>;
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args &&...args)
+auto error_helper(BoostFormatCompat &f, ErrorMessage out, const T &t, Args &&...args)
     -> std::enable_if_t<!Util::has_toString_v<T> && !std::is_pointer_v<T>, ErrorMessage>;
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args &&...args) {
+auto error_helper(BoostFormatCompat &f, ErrorMessage out, const T *t, Args &&...args) {
     // Contrary to bug_helper we do not want to show raw pointers to users in
     // ordinary error messages. Therefore we explicitly delegate to
     // reference-arg implementation here.
@@ -56,7 +55,7 @@ auto error_helper(boost::format &f, ErrorMessage out, const T *t, Args &&...args
 }
 
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage out, const Util::SourceInfo &info,
+ErrorMessage error_helper(BoostFormatCompat &f, ErrorMessage out, const Util::SourceInfo &info,
                           Args &&...args) {
     if (info.isValid()) out.locations.push_back(info);
     return error_helper(f % "", std::move(out), std::forward<Args>(args)...);
@@ -71,15 +70,15 @@ void maybeAddSourceInfo(ErrorMessage &out, const T &t) {
 }
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T &t, Args &&...args)
+auto error_helper(BoostFormatCompat &f, ErrorMessage out, const T &t, Args &&...args)
     -> std::enable_if_t<!Util::has_toString_v<T> && !std::is_pointer_v<T>, ErrorMessage> {
     maybeAddSourceInfo(out, t);
     return error_helper(f % t, std::move(out), std::forward<Args>(args)...);
 }
 
 template <typename T, class... Args>
-auto error_helper(boost::format &f, ErrorMessage out, const T &t,
-                  Args &&...args) -> std::enable_if_t<Util::has_toString_v<T>, ErrorMessage> {
+auto error_helper(BoostFormatCompat &f, ErrorMessage out, const T &t, Args &&...args)
+    -> std::enable_if_t<Util::has_toString_v<T>, ErrorMessage> {
     maybeAddSourceInfo(out, t);
     return error_helper(f % t.toString(), std::move(out), std::forward<Args>(args)...);
 }
@@ -88,21 +87,21 @@ auto error_helper(boost::format &f, ErrorMessage out, const T &t,
 
 // Most direct invocations of error_helper usually only reduce arguments
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, Args &&...args) {
+ErrorMessage error_helper(BoostFormatCompat &f, Args &&...args) {
     ErrorMessage msg;
     return priv::error_helper(f, msg, std::forward<Args>(args)...);
 }
 
 // Invoked from ErrorReporter
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, ErrorMessage msg, Args &&...args) {
+ErrorMessage error_helper(BoostFormatCompat &f, ErrorMessage msg, Args &&...args) {
     return priv::error_helper(f, std::move(msg), std::forward<Args>(args)...);
 }
 
 // This overload exists for backwards compatibility
 template <class... Args>
-ErrorMessage error_helper(boost::format &f, const std::string &prefix, const Util::SourceInfo &info,
-                          const std::string &suffix, Args &&...args) {
+ErrorMessage error_helper(BoostFormatCompat &f, const std::string &prefix,
+                          const Util::SourceInfo &info, const std::string &suffix, Args &&...args) {
     return priv::error_helper(f, ErrorMessage(prefix, info, suffix), std::forward<Args>(args)...);
 }
 

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -23,9 +23,8 @@ limitations under the License.
 #include <type_traits>
 #include <unordered_map>
 
-#include <boost/format.hpp>
-
 #include "absl/strings/str_format.h"
+#include "boost_format_compat.h"
 #include "bug_helper.h"
 #include "error_catalog.h"
 #include "error_helper.h"
@@ -98,7 +97,7 @@ class ErrorReporter {
     // error message for a bug
     template <typename... Args>
     std::string bug_message(const char *format, Args &&...args) {
-        boost::format fmt(format);
+        BoostFormatCompat fmt(format);
         // FIXME: This will implicitly take location of the first argument having
         // SourceInfo. Not sure if this always desireable or not.
         return ::P4::bug_helper(fmt, "", "", std::forward<Args>(args)...);
@@ -106,7 +105,7 @@ class ErrorReporter {
 
     template <typename... Args>
     std::string format_message(const char *format, Args &&...args) {
-        boost::format fmt(format);
+        BoostFormatCompat fmt(format);
         return ::P4::error_helper(fmt, std::forward<Args>(args)...).toString();
     }
 
@@ -159,7 +158,7 @@ class ErrorReporter {
             msgType = ErrorMessage::MessageType::Error;
         }
 
-        boost::format fmt(format);
+        BoostFormatCompat fmt(format);
         ErrorMessage msg(msgType, diagnosticName ? diagnosticName : "", suffix);
         msg = ::P4::error_helper(fmt, msg, std::forward<Args>(args)...);
         emit_message(msg);

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -76,7 +76,7 @@ class P4CExceptionBase : public std::exception {
     template <typename... Args>
     explicit P4CExceptionBase(const char *format, Args &&...args) {
         traceCreation();
-        boost::format fmt(format);
+        BoostFormatCompat fmt(format);
         // FIXME: This will implicitly take location of the first argument having
         // SourceInfo. Not sure if this always desireable or not.
         message = ::P4::bug_helper(fmt, "", "", std::forward<Args>(args)...);


### PR DESCRIPTION
Based on #4347. This applies a workaround that makes boost < 1.74 compatible with GCC >= 10 in the C++20 mode.