### PR TITLE
Avoid copying out/inout args when inlining functions

### DIFF
--- a/frontends/p4/functionsInlining.h
+++ b/frontends/p4/functionsInlining.h
@@ -73,6 +73,7 @@ class FunctionsInliner : public AbstractInliner<FunctionsInlineList, FunctionsIn
     const IR::Node *postCaller(const IR::Node *caller);
     const ReplacementMap *getReplacementMap() const;
     void dumpReplacementMap() const;
+    class isLocalExpression;  // functor to test actual arguments scope use
 
  public:
     FunctionsInliner() = default;

--- a/frontends/p4/parameterSubstitution.h
+++ b/frontends/p4/parameterSubstitution.h
@@ -75,12 +75,21 @@ class ParameterSubstitution : public IHasDbPrint {
     }
 
     void dbprint(std::ostream &out) const {
+        bool brief = (DBPrint::dbgetflags(out) & DBPrint::Brief);
         if (paramList != nullptr) {
-            for (auto s : *paramList->getEnumerator())
-                out << dbp(s) << "=>" << dbp(lookup(s)) << std::endl;
+            if (!brief) out << "paramList:" << Log::endl;
+            for (auto s : *paramList->getEnumerator()) {
+                out << dbp(s) << "=>" << dbp(lookup(s));
+                if (!brief) out << " " << lookup(s);
+                out << Log::endl;
+            }
         } else {
-            for (auto s : parametersByName)
-                out << dbp(s.second) << "=>" << dbp(lookupByName(s.first)) << std::endl;
+            if (!brief) out << "parametersByName:" << Log::endl;
+            for (auto s : parametersByName) {
+                out << dbp(s.second) << "=>" << dbp(lookupByName(s.first));
+                if (!brief) out << " " << lookupByName(s.first);
+                out << Log::endl;
+            }
         }
     }
 

--- a/testdata/p4_16_samples_outputs/issue2345-2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-2-frontend.p4
@@ -24,21 +24,15 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     @name("ingress.val_0") Headers val;
-    @name("ingress.val1_0") Headers val1;
-    @name("ingress.val1_1") Headers val1_2;
     @name("ingress.simple_action") action simple_action() {
         if (h.eth_hdr.eth_type == 16w1) {
             ;
         } else {
             h.eth_hdr.src_addr = 48w1;
             val = h;
-            val1 = val;
-            val1.eth_hdr.dst_addr = val1.eth_hdr.dst_addr + 48w3;
-            val = val1;
+            val.eth_hdr.dst_addr = val.eth_hdr.dst_addr + 48w3;
             val.eth_hdr.eth_type = 16w2;
-            val1_2 = val;
-            val1_2.eth_hdr.dst_addr = val1_2.eth_hdr.dst_addr + 48w3;
-            val = val1_2;
+            val.eth_hdr.dst_addr = val.eth_hdr.dst_addr + 48w3;
             h = val;
             h.eth_hdr.dst_addr = h.eth_hdr.dst_addr + 48w4;
         }

--- a/testdata/p4_16_samples_outputs/issue2345-2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2345-2-midend.p4
@@ -24,22 +24,16 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     ethernet_t val_eth_hdr;
-    ethernet_t val1_eth_hdr;
-    ethernet_t val1_2_eth_hdr;
     @name("ingress.simple_action") action simple_action() {
         if (h.eth_hdr.eth_type == 16w1) {
             ;
         } else {
             h.eth_hdr.src_addr = 48w1;
             val_eth_hdr = h.eth_hdr;
-            val1_eth_hdr = h.eth_hdr;
-            val1_eth_hdr.dst_addr = val1_eth_hdr.dst_addr + 48w3;
-            val_eth_hdr = val1_eth_hdr;
+            val_eth_hdr.dst_addr = val_eth_hdr.dst_addr + 48w3;
             val_eth_hdr.eth_type = 16w2;
-            val1_2_eth_hdr = val_eth_hdr;
-            val1_2_eth_hdr.dst_addr = val1_2_eth_hdr.dst_addr + 48w3;
-            val_eth_hdr = val1_2_eth_hdr;
-            h.eth_hdr = val1_2_eth_hdr;
+            val_eth_hdr.dst_addr = val_eth_hdr.dst_addr + 48w3;
+            h.eth_hdr = val_eth_hdr;
             h.eth_hdr.dst_addr = h.eth_hdr.dst_addr + 48w4;
         }
     }


### PR DESCRIPTION
This is a proposal/work in progress for a way of reducing the number of copies introduced when inlining.

On particularly problematic case is when you have a big struct (eg, all the headers) that is passed around to functions as an `inout` argument so they can access/modify it.  Introducing a copy of all the headers is particularly inefficient, and tough to later optimize away if it was unnecessary.

This change just has a minimal check -- if the actual argument passed to an `inout` or `out` argument is local to the caller, it can't possibly be accessed by the callee directly, so no copy is needed -- the inlined code can just access it directly.

A more general check would be to actually look at the callee -- if it does not access whatever is passed as an argument directly or indirectly, then no copy is needed.  The indirectly part is complex -- requires looking recursively at whatever the callee calls, including any extern functions or methods on instances.

Or perhaps there should be a target-specific policy that controls this -- would allow better target-specific understanding of externs and what they do.

The problem is connected to doing too much in the frontend -- function inlining happens in the frontend (when arguably it should not), in order to allow inlining into type params (`bit<N>` and `int<N>` in particular).  If we remove the general inlining in the frontend (and only do it in the midend), it would greatly help with target-specific policies and tweaks.