### PR TITLE
Remove priority field from ternary table's action

### DIFF
--- a/backends/tc/ebpfCodeGen.cpp
+++ b/backends/tc/ebpfCodeGen.cpp
@@ -896,12 +896,6 @@ void EBPFTablePNA::emitValueStructStructure(EBPF::CodeBuilder *builder) {
     builder->append("is_default_hit_act:1;");
     builder->newline();
 
-    if (isTernaryTable()) {
-        builder->emitIndent();
-        builder->append("__u32 priority;");
-        builder->newline();
-    }
-
     builder->emitIndent();
     builder->append("union ");
     builder->blockStart();

--- a/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
@@ -23,7 +23,6 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_value {
     u32 hit:1,
     is_default_miss_act:1,
     is_default_hit_act:1;
-    __u32 priority;
     union {
         struct {
         } _NoAction;

--- a/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
@@ -47,7 +47,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     u32 hit:1,
     is_default_miss_act:1,
     is_default_hit_act:1;
-    __u32 priority;
     union {
         struct {
         } _NoAction;

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
@@ -47,7 +47,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_2_value {
     u32 hit:1,
     is_default_miss_act:1,
     is_default_hit_act:1;
-    __u32 priority;
     union {
         struct {
         } _NoAction;
@@ -76,7 +75,6 @@ struct __attribute__((__packed__)) MainControlImpl_ipv4_tbl_3_value {
     u32 hit:1,
     is_default_miss_act:1,
     is_default_hit_act:1;
-    __u32 priority;
     union {
         struct {
         } _NoAction;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
@@ -179,7 +179,6 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_value {
     u32 hit:1,
     is_default_miss_act:1,
     is_default_hit_act:1;
-    __u32 priority;
     union {
         struct {
         } _NoAction;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
@@ -176,7 +176,6 @@ struct __attribute__((__packed__)) MainControlImpl_set_ct_options_value {
     u32 hit:1,
     is_default_miss_act:1,
     is_default_hit_act:1;
-    __u32 priority;
     union {
         struct {
         } _NoAction;

--- a/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
@@ -23,7 +23,6 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
     u32 hit:1,
     is_default_miss_act:1,
     is_default_hit_act:1;
-    __u32 priority;
     union {
         struct {
         } _NoAction;


### PR DESCRIPTION
In P4TC, the kernel doesn't expand the returned bpf action with a priority field because, at least as of now, there is no need for such field. So when this priority field is emitted by the compiler, it causes a mismatch between what the kernel returns and what the eBPF program is expecting