### PR TITLE
Reduce extern parameters size to 64 bytes

### DIFF
--- a/backends/tc/runtime/pna.h
+++ b/backends/tc/runtime/pna.h
@@ -185,14 +185,14 @@ struct p4tc_ext_bpf_params {
     u32 tbl_id;
     u32 index;
     u32 flags;
-    u8  in_params[128]; /* extern specific params if any */
+    u8  in_params[64]; /* extern specific params if any */
 };
 
 struct p4tc_ext_bpf_val {
     u32 ext_id;
     u32 index_id;
     u32 verdict;
-    u8 out_params[128]; /* specific values if any */
+    u8 out_params[64]; /* specific values if any */
 };
 
 /* Equivalent to PNA indirect counters */


### PR DESCRIPTION
eBPF has, currently, a stack limit of 512 bytes.
In a scenario where we have declared one instance of struct p4tc_ext_bpf_params, another of struct p4tc_ext_bpf_val and one of struct p4tc_table_entry_act_bpf we have already 420 bytes of stack usage. With a few extra stack variables it's possible to see how the limit will be trivially exceeded. To avoid exceeding this limit so easily, reduce the size of the parameters in the extern structs. As of now, we don't have a use case that would require more than 64 bytes.