### PR TITLE
Trim overlong source fragments in error messages

### DIFF
--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -172,7 +172,14 @@ class SourceInfo final {
 
     void dbprint(std::ostream &out) const { out << this->toString(); }
 
-    cstring toSourceFragment(bool useMarker = true) const;
+    /**
+        Create a string with a line of source, optionally with carets on the following line
+        marking the spot of this SourceInfo.  If trimWidth is >= 10, trim the line to be
+        at most trimWidth characters, as too-long lines are unreadable.  trimWidth = -1
+        defaults to 0 (disable) if useMarker is false or the COLUMNS envvar or 100 if
+        useMarker is true */
+    cstring toSourceFragment(int trimWidth = -1, bool useMarker = true) const;
+    cstring toSourceFragment(bool useMarker) const { return toSourceFragment(-1, useMarker); }
     cstring toBriefSourceFragment() const;
     cstring toPositionString() const;
     cstring toSourcePositionData(unsigned *outLineNumber, unsigned *outColumnNumber) const;
@@ -305,8 +312,8 @@ class InputSources final {
        string describing a position in the sources, e.g.:
        int<32> variable;
                ^^^^^^^^ */
-    cstring getSourceFragment(const SourcePosition &position, bool useMarker) const;
-    cstring getSourceFragment(const SourceInfo &position, bool useMarker) const;
+    cstring getSourceFragment(const SourcePosition &position, int trimWidth, bool useMarker) const;
+    cstring getSourceFragment(const SourceInfo &position, int trimWidth, bool useMarker) const;
     cstring getBriefSourceFragment(const SourceInfo &position) const;
 
     cstring toDebugString() const;

--- a/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
+++ b/testdata/p4_14_samples_outputs/sai_p4.p4-stderr
@@ -5,79 +5,79 @@ sai_p4.p4(429): [--Wwarn=type-inference] warning: Could not infer type for ip, u
 action set_next_hop(type_, ip, router_interface_id) {
                            ^^
 sai_p4.p4(280): [--Wwarn=type-inference] warning: Could not infer type for admin_state, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                    ^^^^^^^^^^^
+..._in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, in...
+                                             ^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=type-inference] warning: Could not infer type for default_vlan_priority, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                               ^^^^^^^^^^^^^^^^^^^^^
+...s, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, ...
+                                        ^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=type-inference] warning: Could not infer type for sflow, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                    ^^^^^
+..., fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_contr...
+                                                ^^^^^
 sai_p4.p4(280): [--Wwarn=type-inference] warning: Could not infer type for flood_storm_control, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                           ^^^^^^^^^^^^^^^^^^^
+..., stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_...
+                                         ^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=type-inference] warning: Could not infer type for broadcast_storm_control, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                                                ^^^^^^^^^^^^^^^^^^^^^^^
+...p, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_f...
+                                       ^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=type-inference] warning: Could not infer type for multicast_storm_control, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                                                                         ^^^^^^^^^^^^^^^^^^^^^^^
+...m_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_...
+                                       ^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=type-inference] warning: Could not infer type for fdb_learning_limit_violation, using bit<8>
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...ulticast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
+                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for max_virtual_routers, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
+action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_suppo...
                                          ^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for fdb_table_size, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                              ^^^^^^^^^^^^^^
+..._number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, ...
+                                           ^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for on_link_route_supported, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                              ^^^^^^^^^^^^^^^^^^^^^^^
+...ax_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_...
+                                       ^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for max_temp, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                    ^^^^^^^^
+...ize, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_ac...
+                                              ^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for switching_mode, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                              ^^^^^^^^^^^^^^
+...route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vl...
+                                           ^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for cpu_flood_enable, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                              ^^^^^^^^^^^^^^^^
+...oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_ad...
+                                          ^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for ttl1_action, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                ^^^^^^^^^^^
+...x_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_agin...
+                                             ^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for fdb_aging_time, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                            ^^^^^^^^^^^^^^
+..._action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast...
+                                           ^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for fdb_unicast_miss_action, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^
+...d, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_mu...
+                                       ^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for fdb_broadcast_miss_action, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+...ing_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_...
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for fdb_multicast_miss_action, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+...action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ...
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_seed, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                                                                           ^^^^^^^^^^^^^^
+...miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp...
+                                           ^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_type, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                                                                                           ^^^^^^^^^^^^^^
+..._multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_i...
+                                           ^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for ecmp_hash_fields, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                                                                                                           ^^^^^^^^^^^^^^^^
+...multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
+                                                          ^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=type-inference] warning: Could not infer type for ecmp_max_paths, using bit<8>
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                                                                                                                             ^^^^^^^^^^^^^^
+...multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
+                                                                            ^^^^^^^^^^^^^^
 sai_p4.p4(580): [--Wwarn=type-inference] warning: Could not infer type for violation_ttl1_action, using bit<8>
-action set_router(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
-                                                                   ^^^^^^^^^^^^^^^^^^^^^
+...r(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
+                                                      ^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(580): [--Wwarn=type-inference] warning: Could not infer type for violation_ip_options, using bit<8>
-action set_router(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
-                                                                                          ^^^^^^^^^^^^^^^^^^^^
+...r(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
+                                                                             ^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=shadow] warning: 'port' shadows '.port'
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
+action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_prior...
                    ^^^^
 sai_p4.p4(303)
 table port {
@@ -95,74 +95,74 @@ sai_p4.p4(429): [--Wwarn=unused] warning: 'ip' is unused
 action set_next_hop(type_, ip, router_interface_id) {
                            ^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'max_virtual_routers' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
+action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_suppo...
                                          ^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'fdb_table_size' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                              ^^^^^^^^^^^^^^
+..._number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, ...
+                                           ^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'on_link_route_supported' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                              ^^^^^^^^^^^^^^^^^^^^^^^
+...ax_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_...
+                                       ^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'max_temp' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                    ^^^^^^^^
+...ize, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_ac...
+                                              ^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'switching_mode' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                              ^^^^^^^^^^^^^^
+...route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vl...
+                                           ^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'cpu_flood_enable' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                              ^^^^^^^^^^^^^^^^
+...oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_ad...
+                                          ^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'ttl1_action' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                ^^^^^^^^^^^
+...x_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_agin...
+                                             ^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'fdb_aging_time' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                            ^^^^^^^^^^^^^^
+..._action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast...
+                                           ^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'fdb_unicast_miss_action' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^
+...d, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_mu...
+                                       ^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'fdb_broadcast_miss_action' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+...ing_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_...
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'fdb_multicast_miss_action' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+...action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ...
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'ecmp_hash_seed' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                                                                           ^^^^^^^^^^^^^^
+...miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp...
+                                           ^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'ecmp_hash_type' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                                                                                           ^^^^^^^^^^^^^^
+..._multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_i...
+                                           ^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'ecmp_hash_fields' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                                                                                                           ^^^^^^^^^^^^^^^^
+...multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
+                                                          ^^^^^^^^^^^^^^^^
 sai_p4.p4(263): [--Wwarn=unused] warning: 'ecmp_max_paths' is unused
-action set_switch(port_number, cpu_port, max_virtual_routers, fdb_table_size, on_link_route_supported, oper_status, max_temp, switching_mode, cpu_flood_enable, ttl1_action, port_vlan_id, src_mac_address, fdb_aging_time, fdb_unicast_miss_action, fdb_broadcast_miss_action, fdb_multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
-                                                                                                                                                                                                                                                                                                                                                             ^^^^^^^^^^^^^^
+...multicast_miss_action, ecmp_hash_seed, ecmp_hash_type, ecmp_hash_fields, ecmp_max_paths, vr_id) {
+                                                                            ^^^^^^^^^^^^^^
 sai_p4.p4(580): [--Wwarn=unused] warning: 'violation_ttl1_action' is unused
-action set_router(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
-                                                                   ^^^^^^^^^^^^^^^^^^^^^
+...r(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
+                                                      ^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(580): [--Wwarn=unused] warning: 'violation_ip_options' is unused
-action set_router(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
-                                                                                          ^^^^^^^^^^^^^^^^^^^^
+...r(admin_v4_state, admin_v6_state, src_mac_address, violation_ttl1_action, violation_ip_options) {
+                                                                             ^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=unused] warning: 'admin_state' is unused
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                    ^^^^^^^^^^^
+..._in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, in...
+                                             ^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=unused] warning: 'default_vlan_priority' is unused
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                               ^^^^^^^^^^^^^^^^^^^^^
+...s, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, ...
+                                        ^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=unused] warning: 'sflow' is unused
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                    ^^^^^
+..., fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_contr...
+                                                ^^^^^
 sai_p4.p4(280): [--Wwarn=unused] warning: 'flood_storm_control' is unused
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                           ^^^^^^^^^^^^^^^^^^^
+..., stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_...
+                                         ^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=unused] warning: 'broadcast_storm_control' is unused
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                                                ^^^^^^^^^^^^^^^^^^^^^^^
+...p, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_f...
+                                       ^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=unused] warning: 'multicast_storm_control' is unused
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                                                                         ^^^^^^^^^^^^^^^^^^^^^^^
+...m_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_...
+                                       ^^^^^^^^^^^^^^^^^^^^^^^
 sai_p4.p4(280): [--Wwarn=unused] warning: 'fdb_learning_limit_violation' is unused
-action set_in_port(port, type_, oper_status, speed, admin_state, default_vlan, default_vlan_priority, ingress_filtering, drop_untagged, drop_tagged, port_loopback_mode, fdb_learning, stp_state, update_dscp, mtu, sflow, flood_storm_control, broadcast_storm_control, multicast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
-                                                                                                                                                                                                                                                                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...ulticast_storm_control, global_flow_control, max_learned_address, fdb_learning_limit_violation) {
+                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue2835-bmv2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2835-bmv2.p4-stderr
@@ -1,6 +1,6 @@
 issue2835-bmv2.p4(86): [--Werror=unsupported] error: t_two.apply(): table invocation in action argument
-            a_two(t_two.apply().hit ? bump_val(hdr.ethernet.etherType) : hdr.ethernet.etherType, bump_val(hdr.ethernet.etherType));
+            a_two(t_two.apply().hit ? bump_val(hdr.ethernet.etherType) : hdr.ethernet.etherType, ...
                   ^^^^^^^^^^^^^
 issue2835-bmv2.p4(86): [--Werror=unsupported] error: a_two(?:, bump_val(hdr.ethernet.etherType)): table invocation in action argument
-            a_two(t_two.apply().hit ? bump_val(hdr.ethernet.etherType) : hdr.ethernet.etherType, bump_val(hdr.ethernet.etherType));
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...a_two(t_two.apply().hit ? bump_val(hdr.ethernet.etherType) : hdr.ethernet.etherType, bump_val(...
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_pna_errors_outputs/pna-add-on-miss-err.p4-error
+++ b/testdata/p4_16_pna_errors_outputs/pna-add-on-miss-err.p4-error
@@ -1,3 +1,3 @@
 pna-add-on-miss-err.p4(138): [--Werror=unexpected] error: add_entry(action_name = "next_hop", action_params = 32w0, expire_time_profile_id = user_meta.timeout) must only be called from within an action with ' add_on_miss_action' property equal to true
-        add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.time...
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_pna_errors_outputs/pna-example-addhit.p4-error
+++ b/testdata/p4_16_pna_errors_outputs/pna-example-addhit.p4-error
@@ -1,6 +1,6 @@
 pna-example-addhit.p4(143): [--Werror=unexpected] error: add_entry(action_name = "next_hop", action_params = 32w0, expire_time_profile_id = user_meta.timeout) is not called from a default action: next_hop 
-        add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.timeout);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...add_entry(action_name="next_hop", action_params = tmp, expire_time_profile_id = user_meta.time...
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 pna-example-addhit.p4(175): [--Werror=unexpected] error: add_entry(action_name = "next_hop", action_params = { f0 = tmp, f1 = tmp_0 }, expire_time_profile_id = user_meta.timeout) first arg action name next_hop is not any action in table ipv4_da2_0
-        add_entry(action_name="next_hop", action_params = {32w0, 32w1234}, expire_time_profile_id = user_meta.timeout);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...add_entry(action_name="next_hop", action_params = {32w0, 32w1234}, expire_time_profile_id = us...
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_pna_errors_outputs/pna-example-miss.p4-error
+++ b/testdata/p4_16_pna_errors_outputs/pna-example-miss.p4-error
@@ -1,6 +1,6 @@
 pna-example-miss.p4(147): [--Werror=unexpected] error: add_entry(action_name = "add_on_miss_action", action_params = 32w0, expire_time_profile_id = user_meta.timeout) action cannot be default action: add_on_miss_action:
-        res = add_entry(action_name="add_on_miss_action", action_params = tmp, expire_time_profile_id = user_meta.timeout);
+        res = add_entry(action_name="add_on_miss_action", action_params = tmp, expire_time_profil...
             ^
 pna-example-miss.p4(174): [--Werror=unexpected] error: add_entry(action_name = "next_hop", action_params = { f0 = tmp, f1 = tmp_2 }, expire_time_profile_id = user_meta.timeout) first arg action name next_hop is not any action in table ipv4_da2_0
-        add_entry(action_name="next_hop", action_params = {32w0, 32w1234}, expire_time_profile_id = user_meta.timeout);
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...add_entry(action_name="next_hop", action_params = {32w0, 32w1234}, expire_time_profile_id = us...
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/dash/dash-pipeline-pna-dpdk.p4-stderr
+++ b/testdata/p4_16_samples_outputs/dash/dash-pipeline-pna-dpdk.p4-stderr
@@ -1,54 +1,54 @@
 dash-pipeline-pna-dpdk.p4(587): [--Wwarn=unused] warning: 'hdr' is unused
-action push_action_static_encap(in headers_t hdr, inout metadata_t meta, in dash_encapsulation_t encap=dash_encapsulation_t.VXLAN, in bit<24> vni=0, in IPv4Address underlay_sip=0, in IPv4Address underlay_dip=0, in EthernetAddress underlay_smac=0, in EthernetAddress underlay_dmac=0, in EthernetAddress overlay_dmac=0) {
+action push_action_static_encap(in headers_t hdr, inout metadata_t meta, in dash_encapsulation_t ...
                                              ^^^
 dash-pipeline-pna-dpdk.p4(619): [--Wwarn=unused] warning: 'hdr' is unused
-action push_action_nat46(in headers_t hdr, inout metadata_t meta, in IPv6Address sip, in IPv6Address sip_mask, in IPv6Address dip, in IPv6Address dip_mask) {
+action push_action_nat46(in headers_t hdr, inout metadata_t meta, in IPv6Address sip, in IPv6Addr...
                                       ^^^
 dash-pipeline-pna-dpdk.p4(689): [--Wwarn=unused] warning: 'hdr' is unused
-action route_vnet(inout headers_t hdr, inout metadata_t meta, @SaiVal[type="sai_object_id_t"] bit<16> dst_vnet_id, bit<1> meter_policy_en, bit<16> meter_class) {
+action route_vnet(inout headers_t hdr, inout metadata_t meta, @SaiVal[type="sai_object_id_t"] bit...
                                   ^^^
 dash-pipeline-pna-dpdk.p4(694): [--Wwarn=unused] warning: 'hdr' is unused
-action route_vnet_direct(inout headers_t hdr, inout metadata_t meta, bit<16> dst_vnet_id, bit<1> overlay_ip_is_v6, @SaiVal[type="sai_ip_address_t"] IPv4ORv6Address overlay_ip, bit<1> meter_policy_en, bit<16> meter_class) {
+action route_vnet_direct(inout headers_t hdr, inout metadata_t meta, bit<16> dst_vnet_id, bit<1> ...
                                          ^^^
 dash-pipeline-pna-dpdk.p4(701): [--Wwarn=unused] warning: 'hdr' is unused
-action route_direct(inout headers_t hdr, inout metadata_t meta, bit<1> meter_policy_en, bit<16> meter_class) {
+action route_direct(inout headers_t hdr, inout metadata_t meta, bit<1> meter_policy_en, bit<16> m...
                                     ^^^
 dash-pipeline-pna-dpdk.p4(705): [--Wwarn=unused] warning: 'overlay_dip_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                               ^^^^^^^^^^^^^^^^^
+...s_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> ...
+                                          ^^^^^^^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(705): [--Wwarn=unused] warning: 'overlay_dip_mask_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                                                                                      ^^^^^^^^^^^^^^^^^^^^^^
+...IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, ...
+                                       ^^^^^^^^^^^^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(705): [--Wwarn=unused] warning: 'overlay_sip_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                                                                                                                                                       ^^^^^^^^^^^^^^^^^
+...v4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> ...
+                                          ^^^^^^^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(705): [--Wwarn=unused] warning: 'overlay_sip_mask_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                                                                                                                                                                                                              ^^^^^^^^^^^^^^^^^^^^^^
+...IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, ...
+                                       ^^^^^^^^^^^^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(705): [--Wwarn=unused] warning: 'underlay_dip_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                                                                                                                                                                                                                                                                               ^^^^^^^^^^^^^^^^^^
+...4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1>...
+                                         ^^^^^^^^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(705): [--Wwarn=unused] warning: 'underlay_sip_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                                                                                                                                                                                                                                                                                                                                        ^^^^^^^^^^^^^^^^^^
+... IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVa...
+                                         ^^^^^^^^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(994): [--Wwarn=unused] warning: 'next_hop_id' is unused
     action set_nhop(bit<9> next_hop_id) {
                            ^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(708): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-    push_action_static_encap(hdr = hdr, meta = meta, encap = dash_encapsulation, vni = tunnel_key, underlay_sip = (underlay_sip == 0 ? hdr.u0_ipv4.src_addr : (IPv4Address)underlay_sip), underlay_dip = (underlay_dip == 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip), overlay_dmac = hdr.u0_ethernet.dst_addr);
-                                                                                                                                       ^^^^^^^^^^^
+..._key, underlay_sip = (underlay_sip == 0 ? hdr.u0_ipv4.src_addr : (IPv4Address)underlay_sip), u...
+                                             ^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(708): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-    push_action_static_encap(hdr = hdr, meta = meta, encap = dash_encapsulation, vni = tunnel_key, underlay_sip = (underlay_sip == 0 ? hdr.u0_ipv4.src_addr : (IPv4Address)underlay_sip), underlay_dip = (underlay_dip == 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip), overlay_dmac = hdr.u0_ethernet.dst_addr);
-                                                                                                                                                                                                                              ^^^^^^^^^^^
+...sip), underlay_dip = (underlay_dip == 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip), o...
+                                             ^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(708): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ethernet
-    push_action_static_encap(hdr = hdr, meta = meta, encap = dash_encapsulation, vni = tunnel_key, underlay_sip = (underlay_sip == 0 ? hdr.u0_ipv4.src_addr : (IPv4Address)underlay_sip), underlay_dip = (underlay_dip == 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip), overlay_dmac = hdr.u0_ethernet.dst_addr);
-                                                                                                                                                                                                                                                                                                ^^^^^^^^^^^^^^^
+... 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip), overlay_dmac = hdr.u0_ethernet.dst_addr);
+                                                                          ^^^^^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(721): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ethernet
-    push_action_static_encap(hdr = hdr, meta = meta, encap = dash_encapsulation, vni = tunnel_key, underlay_sip = meta.eni_data.pl_underlay_sip, underlay_dip = underlay_dip, overlay_dmac = hdr.u0_ethernet.dst_addr);
-                                                                                                                                                                                             ^^^^^^^^^^^^^^^
+....eni_data.pl_underlay_sip, underlay_dip = underlay_dip, overlay_dmac = hdr.u0_ethernet.dst_addr);
+                                                                          ^^^^^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(722): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-    push_action_nat46(hdr = hdr, meta = meta, dip = overlay_dip, dip_mask = 0xffffffffffffffffffffffff, sip = overlay_sip & ~meta.eni_data.pl_sip_mask | meta.eni_data.pl_sip | (IPv6Address)hdr.u0_ipv4.src_addr, sip_mask = 0xffffffffffffffffffffffff);
-                                                                                                                                                                                             ^^^^^^^^^^^
+...ask | meta.eni_data.pl_sip | (IPv6Address)hdr.u0_ipv4.src_addr, sip_mask = 0xfffffffffffffffff...
+                                             ^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(371): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ethernet
     hdr.u0_ethernet.dst_addr = overlay_dmac;
     ^^^^^^^^^^^^^^^
@@ -62,10 +62,10 @@ dash-pipeline-pna-dpdk.p4(639): [--Wwarn=invalid_header] warning: accessing a fi
         hdr.u0_ipv6.hop_limit = hdr.u0_ipv4.ttl;
                                 ^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(640): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-        hdr.u0_ipv6.dst_addr = (IPv6Address)hdr.u0_ipv4.dst_addr & ~meta.overlay_data.dip_mask | meta.overlay_data.dip & meta.overlay_data.dip_mask;
+        hdr.u0_ipv6.dst_addr = (IPv6Address)hdr.u0_ipv4.dst_addr & ~meta.overlay_data.dip_mask | ...
                                             ^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(641): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-        hdr.u0_ipv6.src_addr = (IPv6Address)hdr.u0_ipv4.src_addr & ~meta.overlay_data.sip_mask | meta.overlay_data.sip & meta.overlay_data.sip_mask;
+        hdr.u0_ipv6.src_addr = (IPv6Address)hdr.u0_ipv4.src_addr & ~meta.overlay_data.sip_mask | ...
                                             ^^^^^^^^^^^
 dash-pipeline-pna-dpdk.p4(643): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ethernet
         hdr.u0_ethernet.ether_type = 0x86dd;

--- a/testdata/p4_16_samples_outputs/dash/dash-pipeline-v1model-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/dash/dash-pipeline-v1model-bmv2.p4-stderr
@@ -1,51 +1,51 @@
 dash-pipeline-v1model-bmv2.p4(566): [--Wwarn=unused] warning: 'hdr' is unused
-action push_action_static_encap(in headers_t hdr, inout metadata_t meta, in dash_encapsulation_t encap=dash_encapsulation_t.VXLAN, in bit<24> vni=0, in IPv4Address underlay_sip=0, in IPv4Address underlay_dip=0, in EthernetAddress underlay_smac=0, in EthernetAddress underlay_dmac=0, in EthernetAddress overlay_dmac=0) {
+action push_action_static_encap(in headers_t hdr, inout metadata_t meta, in dash_encapsulation_t ...
                                              ^^^
 dash-pipeline-v1model-bmv2.p4(598): [--Wwarn=unused] warning: 'hdr' is unused
-action push_action_nat46(in headers_t hdr, inout metadata_t meta, in IPv6Address sip, in IPv6Address sip_mask, in IPv6Address dip, in IPv6Address dip_mask) {
+action push_action_nat46(in headers_t hdr, inout metadata_t meta, in IPv6Address sip, in IPv6Addr...
                                       ^^^
 dash-pipeline-v1model-bmv2.p4(668): [--Wwarn=unused] warning: 'hdr' is unused
-action route_vnet(inout headers_t hdr, inout metadata_t meta, @SaiVal[type="sai_object_id_t"] bit<16> dst_vnet_id, bit<1> meter_policy_en, bit<16> meter_class) {
+action route_vnet(inout headers_t hdr, inout metadata_t meta, @SaiVal[type="sai_object_id_t"] bit...
                                   ^^^
 dash-pipeline-v1model-bmv2.p4(673): [--Wwarn=unused] warning: 'hdr' is unused
-action route_vnet_direct(inout headers_t hdr, inout metadata_t meta, bit<16> dst_vnet_id, bit<1> overlay_ip_is_v6, @SaiVal[type="sai_ip_address_t"] IPv4ORv6Address overlay_ip, bit<1> meter_policy_en, bit<16> meter_class) {
+action route_vnet_direct(inout headers_t hdr, inout metadata_t meta, bit<16> dst_vnet_id, bit<1> ...
                                          ^^^
 dash-pipeline-v1model-bmv2.p4(680): [--Wwarn=unused] warning: 'hdr' is unused
-action route_direct(inout headers_t hdr, inout metadata_t meta, bit<1> meter_policy_en, bit<16> meter_class) {
+action route_direct(inout headers_t hdr, inout metadata_t meta, bit<1> meter_policy_en, bit<16> m...
                                     ^^^
 dash-pipeline-v1model-bmv2.p4(684): [--Wwarn=unused] warning: 'overlay_dip_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                               ^^^^^^^^^^^^^^^^^
+...s_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> ...
+                                          ^^^^^^^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(684): [--Wwarn=unused] warning: 'overlay_dip_mask_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                                                                                      ^^^^^^^^^^^^^^^^^^^^^^
+...IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, ...
+                                       ^^^^^^^^^^^^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(684): [--Wwarn=unused] warning: 'overlay_sip_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                                                                                                                                                       ^^^^^^^^^^^^^^^^^
+...v4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> ...
+                                          ^^^^^^^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(684): [--Wwarn=unused] warning: 'overlay_sip_mask_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                                                                                                                                                                                                              ^^^^^^^^^^^^^^^^^^^^^^
+...IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, ...
+                                       ^^^^^^^^^^^^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(684): [--Wwarn=unused] warning: 'underlay_dip_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                                                                                                                                                                                                                                                                               ^^^^^^^^^^^^^^^^^^
+...4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1>...
+                                         ^^^^^^^^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(684): [--Wwarn=unused] warning: 'underlay_sip_is_v6' is unused
-action route_service_tunnel(inout headers_t hdr, inout metadata_t meta, bit<1> overlay_dip_is_v6, IPv4ORv6Address overlay_dip, bit<1> overlay_dip_mask_is_v6, IPv4ORv6Address overlay_dip_mask, bit<1> overlay_sip_is_v6, IPv4ORv6Address overlay_sip, bit<1> overlay_sip_mask_is_v6, IPv4ORv6Address overlay_sip_mask, bit<1> underlay_dip_is_v6, IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVal[type="sai_dash_encapsulation_t", default_value="SAI_DASH_ENCAPSULATION_VXLAN"] dash_encapsulation_t dash_encapsulation, bit<24> tunnel_key, bit<1> meter_policy_en, bit<16> meter_class) {
-                                                                                                                                                                                                                                                                                                                                                                                        ^^^^^^^^^^^^^^^^^^
+... IPv4ORv6Address underlay_dip, bit<1> underlay_sip_is_v6, IPv4ORv6Address underlay_sip, @SaiVa...
+                                         ^^^^^^^^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(687): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-    push_action_static_encap(hdr = hdr, meta = meta, encap = dash_encapsulation, vni = tunnel_key, underlay_sip = (underlay_sip == 0 ? hdr.u0_ipv4.src_addr : (IPv4Address)underlay_sip), underlay_dip = (underlay_dip == 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip), overlay_dmac = hdr.u0_ethernet.dst_addr);
-                                                                                                                                       ^^^^^^^^^^^
+..._key, underlay_sip = (underlay_sip == 0 ? hdr.u0_ipv4.src_addr : (IPv4Address)underlay_sip), u...
+                                             ^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(687): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-    push_action_static_encap(hdr = hdr, meta = meta, encap = dash_encapsulation, vni = tunnel_key, underlay_sip = (underlay_sip == 0 ? hdr.u0_ipv4.src_addr : (IPv4Address)underlay_sip), underlay_dip = (underlay_dip == 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip), overlay_dmac = hdr.u0_ethernet.dst_addr);
-                                                                                                                                                                                                                              ^^^^^^^^^^^
+...sip), underlay_dip = (underlay_dip == 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip), o...
+                                             ^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(687): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ethernet
-    push_action_static_encap(hdr = hdr, meta = meta, encap = dash_encapsulation, vni = tunnel_key, underlay_sip = (underlay_sip == 0 ? hdr.u0_ipv4.src_addr : (IPv4Address)underlay_sip), underlay_dip = (underlay_dip == 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip), overlay_dmac = hdr.u0_ethernet.dst_addr);
-                                                                                                                                                                                                                                                                                                ^^^^^^^^^^^^^^^
+... 0 ? hdr.u0_ipv4.dst_addr : (IPv4Address)underlay_dip), overlay_dmac = hdr.u0_ethernet.dst_addr);
+                                                                          ^^^^^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(700): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ethernet
-    push_action_static_encap(hdr = hdr, meta = meta, encap = dash_encapsulation, vni = tunnel_key, underlay_sip = meta.eni_data.pl_underlay_sip, underlay_dip = underlay_dip, overlay_dmac = hdr.u0_ethernet.dst_addr);
-                                                                                                                                                                                             ^^^^^^^^^^^^^^^
+....eni_data.pl_underlay_sip, underlay_dip = underlay_dip, overlay_dmac = hdr.u0_ethernet.dst_addr);
+                                                                          ^^^^^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(701): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-    push_action_nat46(hdr = hdr, meta = meta, dip = overlay_dip, dip_mask = 0xffffffffffffffffffffffff, sip = overlay_sip & ~meta.eni_data.pl_sip_mask | meta.eni_data.pl_sip | (IPv6Address)hdr.u0_ipv4.src_addr, sip_mask = 0xffffffffffffffffffffffff);
-                                                                                                                                                                                             ^^^^^^^^^^^
+...ask | meta.eni_data.pl_sip | (IPv6Address)hdr.u0_ipv4.src_addr, sip_mask = 0xfffffffffffffffff...
+                                             ^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(365): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ethernet
     hdr.u0_ethernet.dst_addr = (overlay_dmac == 0 ? hdr.u0_ethernet.dst_addr : overlay_dmac);
                                                     ^^^^^^^^^^^^^^^
@@ -53,11 +53,11 @@ dash-pipeline-v1model-bmv2.p4(365): [--Wwarn=invalid_header] warning: accessing 
     hdr.u0_ethernet.dst_addr = (overlay_dmac == 0 ? hdr.u0_ethernet.dst_addr : overlay_dmac);
     ^^^^^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(371): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-    hdr.u1_ipv4.total_len = hdr.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr.u0_ipv4.isValid() + hdr.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + IPV6_HDR_SIZE * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + ETHER_HDR_SIZE + IPV4_HDR_SIZE + UDP_HDR_SIZE + VXLAN_HDR_SIZE;
+    hdr.u1_ipv4.total_len = hdr.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr.u0_ipv4.isValid() + hdr....
                             ^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(371): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv6
-    hdr.u1_ipv4.total_len = hdr.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr.u0_ipv4.isValid() + hdr.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + IPV6_HDR_SIZE * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + ETHER_HDR_SIZE + IPV4_HDR_SIZE + UDP_HDR_SIZE + VXLAN_HDR_SIZE;
-                                                                                             ^^^^^^^^^^^
+... (bit<16>)(bit<1>)hdr.u0_ipv4.isValid() + hdr.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr.u0...
+                                             ^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(616): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
         hdr.u0_ipv6.payload_length = hdr.u0_ipv4.total_len - IPV4_HDR_SIZE;
                                      ^^^^^^^^^^^
@@ -68,10 +68,10 @@ dash-pipeline-v1model-bmv2.p4(618): [--Wwarn=invalid_header] warning: accessing 
         hdr.u0_ipv6.hop_limit = hdr.u0_ipv4.ttl;
                                 ^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(619): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-        hdr.u0_ipv6.dst_addr = (IPv6Address)hdr.u0_ipv4.dst_addr & ~meta.overlay_data.dip_mask | meta.overlay_data.dip & meta.overlay_data.dip_mask;
+        hdr.u0_ipv6.dst_addr = (IPv6Address)hdr.u0_ipv4.dst_addr & ~meta.overlay_data.dip_mask | ...
                                             ^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(620): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ipv4
-        hdr.u0_ipv6.src_addr = (IPv6Address)hdr.u0_ipv4.src_addr & ~meta.overlay_data.sip_mask | meta.overlay_data.sip & meta.overlay_data.sip_mask;
+        hdr.u0_ipv6.src_addr = (IPv6Address)hdr.u0_ipv4.src_addr & ~meta.overlay_data.sip_mask | ...
                                             ^^^^^^^^^^^
 dash-pipeline-v1model-bmv2.p4(622): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.u0_ethernet
         hdr.u0_ethernet.ether_type = 0x86dd;

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings1.p4-stderr
@@ -2,17 +2,17 @@ invalid-hdr-warnings1.p4(18): [--Wwarn=invalid_header] warning: accessing a fiel
         hdr.h2.data = 1; // always invalid
         ^^^^^^
 invalid-hdr-warnings1.p4(23): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.h2
-        if (hdr.h2.data == 1) { // from start: invalid, from state0: may be invalid  =>  hdr.h2 may be invalid
+        if (hdr.h2.data == 1) { // from start: invalid, from state0: may be invalid  =>  hdr.h2 m...
             ^^^^^^
 invalid-hdr-warnings1.p4(24): [--Wwarn=invalid_header] warning: accessing a field of an invalid header hdr.h1
             hdr.h1.data = 0; // from start: invalid, from state0: invalid => hdr.h1 is invalid
             ^^^^^^
 invalid-hdr-warnings1.p4(37): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.h2
-        transition select (hdr.h2.data) { // from next: invalid, from state1: valid => hdr.h2 may be invalid
+        transition select (hdr.h2.data) { // from next: invalid, from state1: valid => hdr.h2 may...
                            ^^^^^^
 invalid-hdr-warnings1.p4(44): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.h2
-        hdr.h2.data = hdr.h2.data + 1; // from next: invalid, from state0: may be invalid, from state1: valid
+        hdr.h2.data = hdr.h2.data + 1; // from next: invalid, from state0: may be invalid, from s...
         ^^^^^^
 invalid-hdr-warnings1.p4(44): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.h2
-        hdr.h2.data = hdr.h2.data + 1; // from next: invalid, from state0: may be invalid, from state1: valid
+        hdr.h2.data = hdr.h2.data + 1; // from next: invalid, from state0: may be invalid, from s...
                       ^^^^^^

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings6.p4-stderr
@@ -14,7 +14,7 @@ invalid-hdr-warnings6.p4(51): [--Wwarn=invalid_header] warning: accessing a fiel
         hdr.u[0].h3.data = 1;
         ^^^^^^^^^^^
 invalid-hdr-warnings6.p4(74): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u[0].h1
-        u[0].h1.data = 1; // u[0].h1 is invalid either if the then branch is executed (for any i) or not
+        u[0].h1.data = 1; // u[0].h1 is invalid either if the then branch is executed (for any i)...
         ^^^^^^^
 invalid-hdr-warnings6.p4(82): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header u[0].h1
         u[0].h1.data = 1;

--- a/testdata/p4_16_samples_outputs/issue4796.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue4796.p4-stderr
@@ -11,8 +11,8 @@ issue4796.p4(33): [--Wwarn=unused] warning: 'priv' is unused
     action revie(out priceX year, bit<128> orde, bit<128> priv) {
                                                           ^^^^
 issue4796.p4(22): [--Wwarn=parser-transition] warning: accept state in parser MainParserImpl is unreachable
-parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_mai...
        ^^^^^^^^^^^^^^
 issue4796.p4(22): [--Wwarn=parser-transition] warning: accept state in parser MainParserImpl is unreachable
-parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_main_parser_input_metadata_t istd) {
+parser MainParserImpl(packet_in pkt, out Headers hdr, inout main_metadata_t user_meta, in pna_mai...
        ^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue982.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue982.p4-stderr
@@ -5,29 +5,29 @@ issue982.p4(203): [--Wwarn=unused] warning: 'W' is unused
 extern DirectCounter<W> {
                      ^
 issue982.p4(343): [--Wwarn=uninitialized_out_param] warning: out parameter 'ostd' may be uninitialized when 'EgressParserImpl' terminates
-parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
-                                                                                                                                                                         ^^^^
+...a user_meta, in psa_egress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
+                                                                                             ^^^^
 issue982.p4(343)
-parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_egress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
+parser EgressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in ps...
        ^^^^^^^^^^^^^^^^
 issue982.p4(385): [--Wwarn=uninitialized_out_param] warning: out parameter 'ostd' may be uninitialized when 'IngressParserImpl' terminates
-parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
-                                                                                                                                                                           ^^^^
+... user_meta, in psa_ingress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
+                                                                                             ^^^^
 issue982.p4(385)
-parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in psa_ingress_parser_input_metadata_t istd, out psa_parser_output_metadata_t ostd) {
+parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in p...
        ^^^^^^^^^^^^^^^^^
 issue982.p4(420): [--Wwarn=uninitialized_use] warning: clone_md may not be completely initialized
             ostd.clone_metadata = clone_md;
                                   ^^^^^^^^
 issue982.p4(414): [--Wwarn=uninitialized_out_param] warning: out parameter 'ostd' may be uninitialized when 'IngressDeparserImpl' terminates
-control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd, out psa_ingress_deparser_output_metadata_t ostd) {
-                                                                                                                                                                      ^^^^
+...a meta, in psa_ingress_output_metadata_t istd, out psa_ingress_deparser_output_metadata_t ostd) {
+                                                                                             ^^^^
 issue982.p4(414)
-control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_ingress_output_metadata_t istd, out psa_ingress_deparser_output_metadata_t ostd) {
+control IngressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_ingres...
         ^^^^^^^^^^^^^^^^^^^
 issue982.p4(427): [--Wwarn=uninitialized_out_param] warning: out parameter 'ostd' may be uninitialized when 'EgressDeparserImpl' terminates
-control EgressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, out psa_egress_deparser_output_metadata_t ostd) {
-                                                                                                                                                                   ^^^^
+...ata meta, in psa_egress_output_metadata_t istd, out psa_egress_deparser_output_metadata_t ostd) {
+                                                                                             ^^^^
 issue982.p4(427)
-control EgressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_egress_output_metadata_t istd, out psa_egress_deparser_output_metadata_t ostd) {
+control EgressDeparserImpl(packet_out packet, inout headers hdr, in metadata meta, in psa_egress_...
         ^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/pins/pins_fabric.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pins/pins_fabric.p4-stderr
@@ -2,59 +2,59 @@ pins_fabric.p4(615): [--Wwarn=deprecated] warning: set_nexthop: Using deprecated
             @proto_id(1) set_nexthop;
                          ^^^^^^^^^^^
 pins_fabric.p4(603)
-    @id(0x01000003) @deprecated("Use set_ip_nexthop instead.") action set_nexthop(@id(1) @refers_to(router_interface_table , router_interface_id) @refers_to(neighbor_table , router_interface_id) router_interface_id_t router_interface_id, @id(2) @format(IPV6_ADDRESS) @refers_to(neighbor_table , neighbor_id) ipv6_addr_t neighbor_id) {
-                                                                      ^^^^^^^^^^^
+...ted("Use set_ip_nexthop instead.") action set_nexthop(@id(1) @refers_to(router_interface_table...
+                                             ^^^^^^^^^^^
 pins_fabric.p4(846): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
             1w1: ternary @id(1) @name("dummy_match");
             ^^^
 pins_fabric.p4(717): [--Wwarn=unused] warning: 'port' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                  ^^^^
+...ction mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t sr...
+                                                ^^^^
 pins_fabric.p4(717): [--Wwarn=unused] warning: 'src_ip' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                 ^^^^^^
+...t, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t d...
+                                               ^^^^^^
 pins_fabric.p4(717): [--Wwarn=unused] warning: 'dst_ip' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                                                                  ^^^^^^
+...p, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_...
+                                               ^^^^^^
 pins_fabric.p4(717): [--Wwarn=unused] warning: 'src_mac' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                                                                                                                      ^^^^^^^
+...@id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr...
+                                               ^^^^^^^
 pins_fabric.p4(717): [--Wwarn=unused] warning: 'dst_mac' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                                                                                                                                                                           ^^^^^^^
+...mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
+                                                    ^^^^^^^
 pins_fabric.p4(717): [--Wwarn=unused] warning: 'ttl' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                                                                                                                                                                                                  ^^^
+...mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
+                                                                           ^^^
 pins_fabric.p4(717): [--Wwarn=unused] warning: 'tos' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                                                                                                                                                                                                                     ^^^
+...mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
+                                                                                              ^^^
 pins_fabric.p4(719): [--Wwarn=unused] warning: 'monitor_failover_port' is unused
-    @id(0x0100001D) @unsupported action mirror_with_vlan_tag_and_ipfix_encapsulation(@id(1) port_id_t monitor_port, @id(2) port_id_t monitor_failover_port, @id(3) @format(MAC_ADDRESS) ethernet_addr_t mirror_encap_src_mac, @id(4) @format(MAC_ADDRESS) ethernet_addr_t mirror_encap_dst_mac, @id(6) vlan_id_t mirror_encap_vlan_id, @id(7) @format(IPV6_ADDRESS) ipv6_addr_t mirror_encap_dst_ip, @id(8) @format(IPV6_ADDRESS) ipv6_addr_t mirror_encap_src_ip, @id(9) bit<16> mirror_encap_udp_src_port, @id(10) bit<16> mirror_encap_udp_dst_port) {
-                                                                                                                                     ^^^^^^^^^^^^^^^^^^^^^
+..._id_t monitor_port, @id(2) port_id_t monitor_failover_port, @id(3) @format(MAC_ADDRESS) ethern...
+                                        ^^^^^^^^^^^^^^^^^^^^^
 pins_fabric.p4(1082): [--Wwarn=unused] warning: Table acl_egress_dhcp_to_host_table is not used; removing
   ") table acl_egress_dhcp_to_host_table {
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 pins_fabric.p4(1128): [--Wwarn=unused] warning: 'qos_queue' is unused
-    @id(0x01000101) @sai_action(SAI_PACKET_ACTION_COPY , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_RED) action acl_copy(@sai_action_param(QOS_QUEUE) @id(1) qos_queue_t qos_queue) {
-                                                                                                                                                                                                               ^^^^^^^^^
+...AI_PACKET_COLOR_RED) action acl_copy(@sai_action_param(QOS_QUEUE) @id(1) qos_queue_t qos_queue) {
+                                                                                        ^^^^^^^^^
 pins_fabric.p4(1148): [--Wwarn=unused] warning: 'qos_queue' is unused
-    @id(0x0100010C) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_COPY_CANCEL , SAI_PACKET_COLOR_RED) action set_qos_queue_and_cancel_copy_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t qos_queue) {
-                                                                                                                                                                                                                                                            ^^^^^^^^^
+...eue_and_cancel_copy_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t qos_queue) {
+                                                                                        ^^^^^^^^^
 pins_fabric.p4(1151): [--Wwarn=unused] warning: 'cpu_queue' is unused
-    @id(0x01000111) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_DENY , SAI_PACKET_COLOR_RED) @unsupported action set_cpu_and_multicast_queues_and_deny_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue, @id(2) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_GREEN) qos_queue_t green_multicast_queue, @id(3) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_RED) qos_queue_t red_multicast_queue) {
-                                                                                                                                                                                                                                                                          ^^^^^^^^^
+...) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue, @id(2) @sai_action_param(MULTICAST_QOS_Q...
+                                              ^^^^^^^^^
 pins_fabric.p4(1151): [--Wwarn=unused] warning: 'green_multicast_queue' is unused
-    @id(0x01000111) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_DENY , SAI_PACKET_COLOR_RED) @unsupported action set_cpu_and_multicast_queues_and_deny_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue, @id(2) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_GREEN) qos_queue_t green_multicast_queue, @id(3) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_RED) qos_queue_t red_multicast_queue) {
-                                                                                                                                                                                                                                                                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^
+... SAI_PACKET_COLOR_GREEN) qos_queue_t green_multicast_queue, @id(3) @sai_action_param(MULTICAST...
+                                        ^^^^^^^^^^^^^^^^^^^^^
 pins_fabric.p4(1151): [--Wwarn=unused] warning: 'red_multicast_queue' is unused
-    @id(0x01000111) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_DENY , SAI_PACKET_COLOR_RED) @unsupported action set_cpu_and_multicast_queues_and_deny_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue, @id(2) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_GREEN) qos_queue_t green_multicast_queue, @id(3) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_RED) qos_queue_t red_multicast_queue) {
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ^^^^^^^^^^^^^^^^^^^
+... @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_RED) qos_queue_t red_multicast_queue) {
+                                                                              ^^^^^^^^^^^^^^^^^^^
 pins_fabric.p4(1154): [--Wwarn=unused] warning: 'cpu_queue' is unused
-    @id(0x0100010E) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_DENY , SAI_PACKET_COLOR_RED) action set_cpu_queue_and_deny_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue) {
-                                                                                                                                                                                                                                              ^^^^^^^^^
+..._cpu_queue_and_deny_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue) {
+                                                                                        ^^^^^^^^^
 pins_fabric.p4(1157): [--Wwarn=unused] warning: 'cpu_queue' is unused
-    @id(0x01000110) @sai_action(SAI_PACKET_ACTION_FORWARD) action set_cpu_queue(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue) {
-                                                                                                                                ^^^^^^^^^
+...ACTION_FORWARD) action set_cpu_queue(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue) {
+                                                                                        ^^^^^^^^^
 pins_fabric.p4(1341): [--Wwarn=unused] warning: Table acl_ingress_mirror_and_redirect_table is not used; removing
   ") table acl_ingress_mirror_and_redirect_table {
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -86,7 +86,7 @@ pins_fabric.p4(580): [--Wwarn=uninitialized_use] warning: router_interface_id_va
             router_interface_id_value: exact @id(1) @name("router_interface_id");
             ^^^^^^^^^^^^^^^^^^^^^^^^^
 pins_fabric.p4(558): [--Wwarn=uninitialized_use] warning: router_interface_id_value may not be completely initialized
-            router_interface_id_value: exact @id(1) @name("router_interface_id") @refers_to(router_interface_table , router_interface_id);
+            router_interface_id_value: exact @id(1) @name("router_interface_id") @refers_to(route...
             ^^^^^^^^^^^^^^^^^^^^^^^^^
 pins_fabric.p4(559): [--Wwarn=uninitialized_use] warning: neighbor_id_value may be uninitialized
             neighbor_id_value : exact @id(2) @format(IPV6_ADDRESS) @name("neighbor_id");
@@ -95,8 +95,8 @@ pins_fabric.p4(846): [--Wwarn=mismatch] warning: 1w1: Constant key field
             1w1: ternary @id(1) @name("dummy_match");
             ^^^
 pins_fabric.p4(1572): [--Wwarn=overflow] warning: local_metadata._wcmp_selector_input13 << 8: shifting value with 8 bits by 8
-        local_metadata.wcmp_selector_input = local_metadata.wcmp_selector_input >> offset | local_metadata.wcmp_selector_input << 8 - offset;
-                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+... local_metadata.wcmp_selector_input >> offset | local_metadata.wcmp_selector_input << 8 - offset;
+                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 pins_fabric.p4(1576): [--Wwarn=overflow] warning: local_metadata._wcmp_selector_input13 << 8: shifting value with 8 bits by 8
-        local_metadata.wcmp_selector_input = local_metadata.wcmp_selector_input >> offset | local_metadata.wcmp_selector_input << 8 - offset;
-                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+... local_metadata.wcmp_selector_input >> offset | local_metadata.wcmp_selector_input << 8 - offset;
+                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/pins/pins_middleblock.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pins/pins_middleblock.p4-stderr
@@ -2,59 +2,59 @@ pins_middleblock.p4(615): [--Wwarn=deprecated] warning: set_nexthop: Using depre
             @proto_id(1) set_nexthop;
                          ^^^^^^^^^^^
 pins_middleblock.p4(603)
-    @id(0x01000003) @deprecated("Use set_ip_nexthop instead.") action set_nexthop(@id(1) @refers_to(router_interface_table , router_interface_id) @refers_to(neighbor_table , router_interface_id) router_interface_id_t router_interface_id, @id(2) @format(IPV6_ADDRESS) @refers_to(neighbor_table , neighbor_id) ipv6_addr_t neighbor_id) {
-                                                                      ^^^^^^^^^^^
+...ted("Use set_ip_nexthop instead.") action set_nexthop(@id(1) @refers_to(router_interface_table...
+                                             ^^^^^^^^^^^
 pins_middleblock.p4(846): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
             1w1: ternary @id(1) @name("dummy_match");
             ^^^
 pins_middleblock.p4(717): [--Wwarn=unused] warning: 'port' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                  ^^^^
+...ction mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t sr...
+                                                ^^^^
 pins_middleblock.p4(717): [--Wwarn=unused] warning: 'src_ip' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                 ^^^^^^
+...t, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t d...
+                                               ^^^^^^
 pins_middleblock.p4(717): [--Wwarn=unused] warning: 'dst_ip' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                                                                  ^^^^^^
+...p, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_...
+                                               ^^^^^^
 pins_middleblock.p4(717): [--Wwarn=unused] warning: 'src_mac' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                                                                                                                      ^^^^^^^
+...@id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr...
+                                               ^^^^^^^
 pins_middleblock.p4(717): [--Wwarn=unused] warning: 'dst_mac' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                                                                                                                                                                           ^^^^^^^
+...mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
+                                                    ^^^^^^^
 pins_middleblock.p4(717): [--Wwarn=unused] warning: 'ttl' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                                                                                                                                                                                                  ^^^
+...mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
+                                                                           ^^^
 pins_middleblock.p4(717): [--Wwarn=unused] warning: 'tos' is unused
-    @id(0x01000007) action mirror_as_ipv4_erspan(@id(1) port_id_t port, @id(2) @format(IPV4_ADDRESS) ipv4_addr_t src_ip, @id(3) @format(IPV4_ADDRESS) ipv4_addr_t dst_ip, @id(4) @format(MAC_ADDRESS) ethernet_addr_t src_mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
-                                                                                                                                                                                                                                                                                                                     ^^^
+...mac, @id(5) @format(MAC_ADDRESS) ethernet_addr_t dst_mac, @id(6) bit<8> ttl, @id(7) bit<8> tos) {
+                                                                                              ^^^
 pins_middleblock.p4(719): [--Wwarn=unused] warning: 'monitor_failover_port' is unused
-    @id(0x0100001D) @unsupported action mirror_with_vlan_tag_and_ipfix_encapsulation(@id(1) port_id_t monitor_port, @id(2) port_id_t monitor_failover_port, @id(3) @format(MAC_ADDRESS) ethernet_addr_t mirror_encap_src_mac, @id(4) @format(MAC_ADDRESS) ethernet_addr_t mirror_encap_dst_mac, @id(6) vlan_id_t mirror_encap_vlan_id, @id(7) @format(IPV6_ADDRESS) ipv6_addr_t mirror_encap_dst_ip, @id(8) @format(IPV6_ADDRESS) ipv6_addr_t mirror_encap_src_ip, @id(9) bit<16> mirror_encap_udp_src_port, @id(10) bit<16> mirror_encap_udp_dst_port) {
-                                                                                                                                     ^^^^^^^^^^^^^^^^^^^^^
+..._id_t monitor_port, @id(2) port_id_t monitor_failover_port, @id(3) @format(MAC_ADDRESS) ethern...
+                                        ^^^^^^^^^^^^^^^^^^^^^
 pins_middleblock.p4(1080): [--Wwarn=unused] warning: Table acl_egress_dhcp_to_host_table is not used; removing
   ") table acl_egress_dhcp_to_host_table {
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 pins_middleblock.p4(1126): [--Wwarn=unused] warning: 'qos_queue' is unused
-    @id(0x01000101) @sai_action(SAI_PACKET_ACTION_COPY , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_RED) action acl_copy(@sai_action_param(QOS_QUEUE) @id(1) qos_queue_t qos_queue) {
-                                                                                                                                                                                                               ^^^^^^^^^
+...AI_PACKET_COLOR_RED) action acl_copy(@sai_action_param(QOS_QUEUE) @id(1) qos_queue_t qos_queue) {
+                                                                                        ^^^^^^^^^
 pins_middleblock.p4(1146): [--Wwarn=unused] warning: 'qos_queue' is unused
-    @id(0x0100010C) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_COPY_CANCEL , SAI_PACKET_COLOR_RED) action set_qos_queue_and_cancel_copy_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t qos_queue) {
-                                                                                                                                                                                                                                                            ^^^^^^^^^
+...eue_and_cancel_copy_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t qos_queue) {
+                                                                                        ^^^^^^^^^
 pins_middleblock.p4(1149): [--Wwarn=unused] warning: 'cpu_queue' is unused
-    @id(0x01000111) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_DENY , SAI_PACKET_COLOR_RED) @unsupported action set_cpu_and_multicast_queues_and_deny_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue, @id(2) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_GREEN) qos_queue_t green_multicast_queue, @id(3) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_RED) qos_queue_t red_multicast_queue) {
-                                                                                                                                                                                                                                                                          ^^^^^^^^^
+...) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue, @id(2) @sai_action_param(MULTICAST_QOS_Q...
+                                              ^^^^^^^^^
 pins_middleblock.p4(1149): [--Wwarn=unused] warning: 'green_multicast_queue' is unused
-    @id(0x01000111) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_DENY , SAI_PACKET_COLOR_RED) @unsupported action set_cpu_and_multicast_queues_and_deny_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue, @id(2) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_GREEN) qos_queue_t green_multicast_queue, @id(3) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_RED) qos_queue_t red_multicast_queue) {
-                                                                                                                                                                                                                                                                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^
+... SAI_PACKET_COLOR_GREEN) qos_queue_t green_multicast_queue, @id(3) @sai_action_param(MULTICAST...
+                                        ^^^^^^^^^^^^^^^^^^^^^
 pins_middleblock.p4(1149): [--Wwarn=unused] warning: 'red_multicast_queue' is unused
-    @id(0x01000111) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_DENY , SAI_PACKET_COLOR_RED) @unsupported action set_cpu_and_multicast_queues_and_deny_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue, @id(2) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_GREEN) qos_queue_t green_multicast_queue, @id(3) @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_RED) qos_queue_t red_multicast_queue) {
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                ^^^^^^^^^^^^^^^^^^^
+... @sai_action_param(MULTICAST_QOS_QUEUE , SAI_PACKET_COLOR_RED) qos_queue_t red_multicast_queue) {
+                                                                              ^^^^^^^^^^^^^^^^^^^
 pins_middleblock.p4(1152): [--Wwarn=unused] warning: 'cpu_queue' is unused
-    @id(0x0100010E) @sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN) @sai_action(SAI_PACKET_ACTION_DENY , SAI_PACKET_COLOR_RED) action set_cpu_queue_and_deny_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue) {
-                                                                                                                                                                                                                                              ^^^^^^^^^
+..._cpu_queue_and_deny_above_rate_limit(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue) {
+                                                                                        ^^^^^^^^^
 pins_middleblock.p4(1155): [--Wwarn=unused] warning: 'cpu_queue' is unused
-    @id(0x01000110) @sai_action(SAI_PACKET_ACTION_FORWARD) action set_cpu_queue(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue) {
-                                                                                                                                ^^^^^^^^^
+...ACTION_FORWARD) action set_cpu_queue(@id(1) @sai_action_param(QOS_QUEUE) qos_queue_t cpu_queue) {
+                                                                                        ^^^^^^^^^
 pins_middleblock.p4(1249): [--Wwarn=unused] warning: Table acl_ingress_qos_table is not used; removing
   ") table acl_ingress_qos_table {
            ^^^^^^^^^^^^^^^^^^^^^
@@ -77,8 +77,8 @@ pins_middleblock.p4(1123): [--Wwarn=unused] warning: acl_ingress_qos_counter: un
     @id(0x13000107) direct_counter(CounterType.packets_and_bytes) acl_ingress_qos_counter;
                                                                   ^^^^^^^^^^^^^^^^^^^^^^^
 pins_middleblock.p4(1121): [--Wwarn=unused] warning: acl_ingress_qos_meter: unused instance
-    @id(0x15000102) @mode(single_rate_two_color) direct_meter<MeterColor_t>(MeterType.bytes) acl_ingress_qos_meter;
-                                                                                             ^^^^^^^^^^^^^^^^^^^^^
+...) @mode(single_rate_two_color) direct_meter<MeterColor_t>(MeterType.bytes) acl_ingress_qos_meter;
+                                                                              ^^^^^^^^^^^^^^^^^^^^^
 pins_middleblock.p4(1124): [--Wwarn=unused] warning: acl_ingress_counting_counter: unused instance
     @id(0x13000109) direct_counter(CounterType.packets_and_bytes) acl_ingress_counting_counter;
                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ pins_middleblock.p4(580): [--Wwarn=uninitialized_use] warning: router_interface_
             router_interface_id_value: exact @id(1) @name("router_interface_id");
             ^^^^^^^^^^^^^^^^^^^^^^^^^
 pins_middleblock.p4(558): [--Wwarn=uninitialized_use] warning: router_interface_id_value may not be completely initialized
-            router_interface_id_value: exact @id(1) @name("router_interface_id") @refers_to(router_interface_table , router_interface_id);
+            router_interface_id_value: exact @id(1) @name("router_interface_id") @refers_to(route...
             ^^^^^^^^^^^^^^^^^^^^^^^^^
 pins_middleblock.p4(559): [--Wwarn=uninitialized_use] warning: neighbor_id_value may be uninitialized
             neighbor_id_value : exact @id(2) @format(IPV6_ADDRESS) @name("neighbor_id");
@@ -104,8 +104,8 @@ pins_middleblock.p4(846): [--Wwarn=mismatch] warning: 1w1: Constant key field
             1w1: ternary @id(1) @name("dummy_match");
             ^^^
 pins_middleblock.p4(1558): [--Wwarn=overflow] warning: local_metadata._wcmp_selector_input13 << 8: shifting value with 8 bits by 8
-        local_metadata.wcmp_selector_input = local_metadata.wcmp_selector_input >> offset | local_metadata.wcmp_selector_input << 8 - offset;
-                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+... local_metadata.wcmp_selector_input >> offset | local_metadata.wcmp_selector_input << 8 - offset;
+                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 pins_middleblock.p4(1562): [--Wwarn=overflow] warning: local_metadata._wcmp_selector_input13 << 8: shifting value with 8 bits by 8
-        local_metadata.wcmp_selector_input = local_metadata.wcmp_selector_input >> offset | local_metadata.wcmp_selector_input << 8 - offset;
-                                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+... local_metadata.wcmp_selector_input >> offset | local_metadata.wcmp_selector_input << 8 - offset;
+                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings6.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-invalid-hdr-warnings6.p4-stderr
@@ -14,7 +14,7 @@ pna-dpdk-invalid-hdr-warnings6.p4(51): [--Wwarn=invalid_header] warning: accessi
         hdr.u[0].h3.data = 1;
         ^^^^^^^^^^^
 pna-dpdk-invalid-hdr-warnings6.p4(76): [--Wwarn=invalid_header] warning: accessing a field of an invalid header u[0].h1
-        u[0].h1.data = 1; // u[0].h1 is invalid either if the then branch is executed (for any i) or not
+        u[0].h1.data = 1; // u[0].h1 is invalid either if the then branch is executed (for any i)...
         ^^^^^^^
 pna-dpdk-invalid-hdr-warnings6.p4(84): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header u[0].h1
         u[0].h1.data = 1;

--- a/testdata/p4tc_samples_outputs/global_action_example_01.p4-stderr
+++ b/testdata/p4tc_samples_outputs/global_action_example_01.p4-stderr
@@ -2,5 +2,5 @@ p4tc_samples/global_action_example_01.p4(86): [--Wwarn=shadow] warning: 'send_nh
     action send_nh(@tc_type("dev") PortId_t port_id, @tc_type("macaddr") bit<48> dmac) {
            ^^^^^^^
 p4tc_samples/global_action_example_01.p4(45)
-action send_nh(@tc_type("macaddr") inout bit<48> hdr_dmac, @tc_type("macaddr") inout bit<48> hdr_smac, @tc_type("dev") PortId_t port_id, @tc_type("macaddr") bit<48> dmac, @tc_type("macaddr") bit<48> smac) {
+action send_nh(@tc_type("macaddr") inout bit<48> hdr_dmac, @tc_type("macaddr") inout bit<48> hdr_...
        ^^^^^^^


### PR DESCRIPTION
- too-long source lines (particularly those that come from preprocessor macros) tend to give unreadble error messages.  Ideally they should be trimmed based on the width of the output terminal.

This code is a compromise that defaults the trim width to 100 when the `useMarker` flag is defaulted to true (the way this is used for user-facing error messages) and to 0 (no trimming) when the flag is set explicit (generally to false) -- one place this is used is in some logging code.