### PR TITLE
Make isSystemFile() part of the parser options file.

### DIFF
--- a/backends/p4tools/modules/smith/common/expressions.cpp
+++ b/backends/p4tools/modules/smith/common/expressions.cpp
@@ -586,7 +586,6 @@ IR::Expression *ExpressionGenerator::constructBinaryBitExpr(const IR::Type_Bits 
             const auto *tl = IR::Type_Bits::get(typeWidth - split, false);
             const auto *tr = IR::Type_Bits::get(split, false);
             // width must be known so we cast
-            printf("Concat: %s, %s\n", tl->toString().c_str(), tr->toString().c_str());
             IR::Expression *left = constructBitExpr(tl);
             if (P4Scope::prop.width_unknown) {
                 left = new IR::Cast(tl, left);

--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -48,6 +48,8 @@ const char *p4_14includePath = CONFIG_PKGDATADIR "/p4_14include";
 
 using namespace P4::literals;
 
+bool isSystemFile(cstring file) { return file.startsWith(p4includePath); }
+
 void ParserOptions::closeFile(FILE *file) {
     if (file == nullptr) {
         return;

--- a/frontends/common/parser_options.h
+++ b/frontends/common/parser_options.h
@@ -36,6 +36,9 @@ namespace P4 {
 extern const char *p4includePath;
 extern const char *p4_14includePath;
 
+/// Try to guess whether a file is a "system" file
+bool isSystemFile(cstring filename);
+
 /// Base class for compiler options.
 /// This class contains the options for the front-ends.
 /// Each back-end should subclass this file.

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -46,17 +46,14 @@ void ToP4::end_apply(const IR::Node *) {
               "inconsistent vectorSeparator");
 }
 
-// Try to guess whether a file is a "system" file
-bool ToP4::isSystemFile(cstring file) {
-    if (noIncludes) return false;
-    if (file.startsWith(p4includePath)) return true;
-    return false;
-}
-
 cstring ToP4::ifSystemFile(const IR::Node *node) {
-    if (!node->srcInfo.isValid()) return nullptr;
+    if (!node->srcInfo.isValid() || noIncludes) {
+        return nullptr;
+    }
     auto sourceFile = node->srcInfo.getSourceFile();
-    if (isSystemFile(sourceFile)) return sourceFile;
+    if (isSystemFile(sourceFile)) {
+        return sourceFile;
+    }
     return nullptr;
 }
 

--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -46,15 +46,15 @@ void ToP4::end_apply(const IR::Node *) {
               "inconsistent vectorSeparator");
 }
 
-cstring ToP4::ifSystemFile(const IR::Node *node) {
+std::optional<cstring> ToP4::ifSystemFile(const IR::Node *node) {
     if (!node->srcInfo.isValid() || noIncludes) {
-        return nullptr;
+        return std::nullopt;
     }
     auto sourceFile = node->srcInfo.getSourceFile();
     if (isSystemFile(sourceFile)) {
         return sourceFile;
     }
-    return nullptr;
+    return std::nullopt;
 }
 
 namespace {
@@ -150,9 +150,9 @@ bool ToP4::preorder(const IR::P4Program *program) {
     dump(2);
     for (auto a : program->objects) {
         // Check where this declaration originates
-        cstring sourceFile = ifSystemFile(a);
-        if (!a->is<IR::Type_Error>() &&  // errors can come from multiple files
-            sourceFile != nullptr) {
+        auto sourceFileOpt = ifSystemFile(a);
+        // Errors can come from multiple files
+        if (!a->is<IR::Type_Error>() && sourceFileOpt.has_value()) {
             /* FIXME -- when including a user header file (sourceFile !=
              * mainFile), do we want to emit an #include of it or not?  Probably
              * not when translating from P4-14, as that would create a P4-16
@@ -160,7 +160,7 @@ bool ToP4::preorder(const IR::P4Program *program) {
              * allow converting headers independently (is that even possible?).
              * For now we ignore mainFile and don't emit #includes for any
              * non-system header */
-
+            auto sourceFile = sourceFileOpt.value();
             if (includesEmitted.find(sourceFile) == includesEmitted.end()) {
                 if (sourceFile.startsWith(p4includePath)) {
                     const char *p = sourceFile.c_str() + strlen(p4includePath);
@@ -688,7 +688,7 @@ bool ToP4::preorder(const IR::Type_Error *d) {
     dump(1);
     bool first = true;
     for (auto a : *d->getDeclarations()) {
-        if (ifSystemFile(a->getNode()))
+        if (ifSystemFile(a->getNode()).has_value())
             // only print if not from a system file
             continue;
         if (!first) {

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -17,6 +17,8 @@ limitations under the License.
 #ifndef P4_TOP4_TOP4_H_
 #define P4_TOP4_TOP4_H_
 
+#include <optional>
+
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "ir/ir.h"
 #include "ir/visitor.h"
@@ -72,9 +74,9 @@ class ToP4 : public Inspector, ResolutionContext {
         BUG_CHECK(!listTerminators.empty(), "Empty listTerminators");
         listTerminators.pop_back();
     }
-    // return file containing node if system file
-    cstring ifSystemFile(const IR::Node *node);
-    // dump node IR tree up to depth - in the form of a comment
+    /// @returns the file that contains the node, if the node is part of a system file.
+    std::optional<cstring> ifSystemFile(const IR::Node *node);
+    /// dump node IR tree up to depth - in the form of a comment
     void dump(unsigned depth, const IR::Node *node = nullptr, unsigned adjDepth = 0);
     unsigned curDepth() const;
 

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -72,8 +72,8 @@ class ToP4 : public Inspector, ResolutionContext {
         BUG_CHECK(!listTerminators.empty(), "Empty listTerminators");
         listTerminators.pop_back();
     }
-    bool isSystemFile(cstring file);
-    cstring ifSystemFile(const IR::Node *node);  // return file containing node if system file
+    // return file containing node if system file
+    cstring ifSystemFile(const IR::Node *node);
     // dump node IR tree up to depth - in the form of a comment
     void dump(unsigned depth, const IR::Node *node = nullptr, unsigned adjDepth = 0);
     unsigned curDepth() const;


### PR DESCRIPTION
This function is static and checks the p4IncludePath which is part of the parser options file. It should be part of this file such that it can be used in other contexts. 

Among others, this call can be used by the formatter or to determine whether a particular source info objects comes from a systems file.