### PR TITLE
Add empty block for trailing case(s) with no code.

### DIFF
--- a/frontends/p4/simplify.cpp
+++ b/frontends/p4/simplify.cpp
@@ -109,7 +109,9 @@ const IR::Node *DoSimplifyControlFlow::postorder(IR::SwitchStatement *statement)
             else
                 warn(ErrorType::WARN_MISSING, "%1%: fallthrough with no statement", last);
         }
-        statement->cases.erase(it.base(), statement->cases.end());
+        auto mod = last->clone();
+        mod->statement = new IR::BlockStatement;
+        statement->cases.back() = mod;
     }
     return statement;
 }

--- a/testdata/p4_16_samples_outputs/cases-first.p4
+++ b/testdata/p4_16_samples_outputs/cases-first.p4
@@ -19,7 +19,7 @@ control ctrl() {
             b: {
                 return;
             }
-            default: {
+            c: {
             }
         }
     }

--- a/testdata/p4_16_samples_outputs/issue2617-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2617-first.p4
@@ -56,6 +56,8 @@ control c(out bit<32> v) {
             32w1: {
                 v = 32w1;
             }
+            32w2: {
+            }
         }
         switch (E.C) {
             E.A: {

--- a/testdata/p4_16_samples_outputs/issue3619-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3619-first.p4
@@ -1,5 +1,9 @@
 control c(in bit<4> v) {
     apply {
+        switch (v) {
+            default: {
+            }
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/psa-switch-expression-without-default-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-switch-expression-without-default-first.p4
@@ -121,6 +121,8 @@ control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_meta
             16w64: {
                 tmp = 16w2;
             }
+            16w92: {
+            }
         }
         switch (tbl.apply().action_run) {
             a1: {

--- a/testdata/p4_16_samples_outputs/psa-switch-expression-without-default-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-switch-expression-without-default-frontend.p4
@@ -128,6 +128,8 @@ control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_meta
             16w64: {
                 tmp_0 = 16w2;
             }
+            16w92: {
+            }
         }
         switch (tbl_0.apply().action_run) {
             a1: {

--- a/testdata/p4_16_samples_outputs/psa-switch-expression-without-default-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-switch-expression-without-default-midend.p4
@@ -124,6 +124,8 @@ control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_meta
     }
     @hidden action switch_0_case_1() {
     }
+    @hidden action switch_0_case_2() {
+    }
     @hidden table switch_0_table {
         key = {
             switch_0_key: exact;
@@ -132,12 +134,14 @@ control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_meta
             switch_0_case();
             switch_0_case_0();
             switch_0_case_1();
+            switch_0_case_2();
         }
-        const default_action = switch_0_case_1();
+        const default_action = switch_0_case_2();
         const entries = {
                         const 16w16 : switch_0_case();
                         const 16w32 : switch_0_case();
                         const 16w64 : switch_0_case_0();
+                        const 16w92 : switch_0_case_1();
         }
     }
     @hidden action psaswitchexpressionwithoutdefault124() {
@@ -187,6 +191,8 @@ control MyIC(inout headers_t hdr, inout user_meta_t b, in psa_ingress_input_meta
                 tbl_psaswitchexpressionwithoutdefault125.apply();
             }
             switch_0_case_1: {
+            }
+            switch_0_case_2: {
             }
         }
         switch (tbl_0.apply().action_run) {


### PR DESCRIPTION
Per 12.7.3 in the spec, a trailing case label in a switch with no code is treated as if it has a `{}` after it; we were instead just removing it.

The main effect here is properly generate an error (later) if that case label is a duplicate, rather than silently removing it.