### PR TITLE
simplifyDefUse: Report the specific uninitialized struct field

### DIFF
--- a/testdata/p4_16_samples_outputs/annotation-bug.p4-stderr
+++ b/testdata/p4_16_samples_outputs/annotation-bug.p4-stderr
@@ -1,3 +1,3 @@
-annotation-bug.p4(24): [--Wwarn=uninitialized_use] warning: hdr.ipv4_option_timestamp may not be completely initialized
+annotation-bug.p4(24): [--Wwarn=uninitialized_use] warning: hdr.ipv4_option_timestamp.len may be uninitialized
         get<headers>({ hdr.ipv4_option_timestamp });
                        ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/equality.p4-stderr
+++ b/testdata/p4_16_samples_outputs/equality.p4-stderr
@@ -4,16 +4,16 @@ equality.p4(22): [--Wwarn=uninitialized_use] warning: a may be uninitialized
 equality.p4(22): [--Wwarn=uninitialized_use] warning: b may be uninitialized
         if (a == b) {
                  ^
-equality.p4(24): [--Wwarn=uninitialized_use] warning: h1 may not be completely initialized
+equality.p4(24): [--Wwarn=uninitialized_use] warning: h1.a may be uninitialized
         } else if (h1 == h2) {
                    ^^
-equality.p4(24): [--Wwarn=uninitialized_use] warning: h2 may not be completely initialized
+equality.p4(24): [--Wwarn=uninitialized_use] warning: h2.a may be uninitialized
         } else if (h1 == h2) {
                          ^^
-equality.p4(26): [--Wwarn=uninitialized_use] warning: s1 may not be completely initialized
+equality.p4(26): [--Wwarn=uninitialized_use] warning: s1.a may be uninitialized
         } else if (s1 == s2) {
                    ^^
-equality.p4(26): [--Wwarn=uninitialized_use] warning: s2 may not be completely initialized
+equality.p4(26): [--Wwarn=uninitialized_use] warning: s2.a may be uninitialized
         } else if (s1 == s2) {
                          ^^
 equality.p4(28): [--Wwarn=uninitialized_use] warning: a1 may not be completely initialized

--- a/testdata/p4_16_samples_outputs/gauntlet_hdr_out_in_action-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_hdr_out_in_action-bmv2.p4-stderr
@@ -1,6 +1,6 @@
 gauntlet_hdr_out_in_action-bmv2.p4(35): [--Wwarn=unused] warning: 'val' is unused
     action do_action(out ethernet_t val) {
                                     ^^^
-gauntlet_hdr_out_in_action-bmv2.p4(35): [--Wwarn=uninitialized_use] warning: val may not be completely initialized
+gauntlet_hdr_out_in_action-bmv2.p4(35): [--Wwarn=uninitialized_use] warning: val.dst_addr may be uninitialized
     action do_action(out ethernet_t val) {
                                     ^^^

--- a/testdata/p4_16_samples_outputs/gauntlet_infinite_loop.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_infinite_loop.p4-stderr
@@ -22,10 +22,13 @@ gauntlet_infinite_loop.p4(23): [--Wwarn=uninitialized_use] warning: padding.p ma
 gauntlet_infinite_loop.p4(23): [--Wwarn=invalid_header] warning: accessing a field of an invalid header padding
         transition select(padding.p) {
                           ^^^^^^^
-[--Wwarn=uninitialized_use] warning: tmp may not be completely initialized
-[--Wwarn=uninitialized_use] warning: tmp_0 may not be completely initialized
-[--Wwarn=uninitialized_use] warning: tmp may not be completely initialized
-[--Wwarn=uninitialized_use] warning: tmp_0 may not be completely initialized
+[--Wwarn=uninitialized_use] warning: tmp.nop may be uninitialized
+[--Wwarn=uninitialized_use] warning: tmp.p may be uninitialized
+[--Wwarn=uninitialized_use] warning: tmp_0.p may be uninitialized
+[--Wwarn=uninitialized_use] warning: tmp.nop may be uninitialized
+[--Wwarn=uninitialized_use] warning: tmp.p may be uninitialized
+[--Wwarn=uninitialized_use] warning: tmp_0.p may be uninitialized
 [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp_0
-[--Wwarn=uninitialized_use] warning: tmp may not be completely initialized
-[--Wwarn=uninitialized_use] warning: tmp_0 may not be completely initialized
+[--Wwarn=uninitialized_use] warning: tmp.nop may be uninitialized
+[--Wwarn=uninitialized_use] warning: tmp.p may be uninitialized
+[--Wwarn=uninitialized_use] warning: tmp_0.p may be uninitialized

--- a/testdata/p4_16_samples_outputs/gauntlet_invalid_hdr_assign-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_invalid_hdr_assign-bmv2.p4-stderr
@@ -1,4 +1,5 @@
-[--Wwarn=uninitialized_use] warning: tmp_0 may not be completely initialized
+[--Wwarn=uninitialized_use] warning: tmp_0.a may be uninitialized
+[--Wwarn=uninitialized_use] warning: tmp_0.b may be uninitialized
 gauntlet_invalid_hdr_assign-bmv2.p4(39): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header h.h
         h.eth_hdr.eth_type = (bit<16>)h.h.a;
                                       ^^^

--- a/testdata/p4_16_samples_outputs/gauntlet_invalid_hdr_short_circuit-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_invalid_hdr_short_circuit-bmv2.p4-stderr
@@ -1,3 +1,9 @@
-[--Wwarn=uninitialized_use] warning: dummy_0 may not be completely initialized
-[--Wwarn=uninitialized_use] warning: dummy_0 may not be completely initialized
-[--Wwarn=uninitialized_use] warning: dummy_0 may not be completely initialized
+[--Wwarn=uninitialized_use] warning: dummy_0.a may be uninitialized
+[--Wwarn=uninitialized_use] warning: dummy_0.b may be uninitialized
+[--Wwarn=uninitialized_use] warning: dummy_0.c may be uninitialized
+[--Wwarn=uninitialized_use] warning: dummy_0.a may be uninitialized
+[--Wwarn=uninitialized_use] warning: dummy_0.b may be uninitialized
+[--Wwarn=uninitialized_use] warning: dummy_0.c may be uninitialized
+[--Wwarn=uninitialized_use] warning: dummy_0.a may be uninitialized
+[--Wwarn=uninitialized_use] warning: dummy_0.b may be uninitialized
+[--Wwarn=uninitialized_use] warning: dummy_0.c may be uninitialized

--- a/testdata/p4_16_samples_outputs/gauntlet_mux_hdr-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_mux_hdr-bmv2.p4-stderr
@@ -4,10 +4,10 @@ gauntlet_mux_hdr-bmv2.p4(26): [--Wwarn=invalid_header] warning: accessing a fiel
 gauntlet_mux_hdr-bmv2.p4(26): [--Wwarn=uninitialized_use] warning: tmp2[0].a may be uninitialized
     if (tmp2[0].a <= 3) {
         ^^^^^^^^^
-gauntlet_mux_hdr-bmv2.p4(27): [--Wwarn=uninitialized_use] warning: tmp2[1] may not be completely initialized
+gauntlet_mux_hdr-bmv2.p4(27): [--Wwarn=uninitialized_use] warning: tmp2[1].a may be uninitialized
         tmp1[0] = tmp2[1];
                   ^^^^^^^
-gauntlet_mux_hdr-bmv2.p4(28): [--Wwarn=uninitialized_use] warning: tmp1[1] may not be completely initialized
+gauntlet_mux_hdr-bmv2.p4(28): [--Wwarn=uninitialized_use] warning: tmp1[1].a may be uninitialized
         tmp2[1] = tmp1[1];
                   ^^^^^^^
 gauntlet_mux_hdr-bmv2.p4(30): [--Wwarn=invalid_header] warning: accessing a field of an invalid header tmp1[0]

--- a/testdata/p4_16_samples_outputs/gauntlet_switch_nested_table_apply-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_switch_nested_table_apply-bmv2.p4-stderr
@@ -10,6 +10,6 @@ gauntlet_switch_nested_table_apply-bmv2.p4(34): [--Wwarn=mismatch] warning: 128w
 gauntlet_switch_nested_table_apply-bmv2.p4(42): [--Wwarn=mismatch] warning: 48w1: Constant key field
             48w1: exact @name("qkgOtm") ;
             ^^^^
-gauntlet_switch_nested_table_apply-bmv2.p4(27): [--Wwarn=uninitialized_use] warning: tmp may not be completely initialized
+gauntlet_switch_nested_table_apply-bmv2.p4(27): [--Wwarn=uninitialized_use] warning: tmp.eth_hdr may be uninitialized
     action set_valid_action(out Headers tmp) {
                                         ^^^

--- a/testdata/p4_16_samples_outputs/gauntlet_uninitialized_bool_struct-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_uninitialized_bool_struct-bmv2.p4-stderr
@@ -19,6 +19,6 @@ gauntlet_uninitialized_bool_struct-bmv2.p4(33)
 gauntlet_uninitialized_bool_struct-bmv2.p4(33): [--Wwarn=uninitialized_use] warning: dummy_bit may be uninitialized
     action dummy_action(out bit<16> dummy_bit, out bool_struct dummy_struct) {
                                     ^^^^^^^^^
-gauntlet_uninitialized_bool_struct-bmv2.p4(33): [--Wwarn=uninitialized_use] warning: dummy_struct may not be completely initialized
+gauntlet_uninitialized_bool_struct-bmv2.p4(33): [--Wwarn=uninitialized_use] warning: dummy_struct.is_bool may be uninitialized
     action dummy_action(out bit<16> dummy_bit, out bool_struct dummy_struct) {
                                                                ^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/invalid-hdr-warnings4.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid-hdr-warnings4.p4-stderr
@@ -4,7 +4,7 @@ invalid-hdr-warnings4.p4(20): [--Wwarn=invalid_header] warning: accessing a fiel
 invalid-hdr-warnings4.p4(26): [--Wwarn=invalid_header] warning: accessing a field of a potentially invalid header hdr.h1[0]
         hdr.h1[0].data = 1;
         ^^^^^^^^^
-invalid-hdr-warnings4.p4(63): [--Wwarn=uninitialized_use] warning: h.h1[0] may not be completely initialized
+invalid-hdr-warnings4.p4(63): [--Wwarn=uninitialized_use] warning: h.h1[0].data may be uninitialized
         validateHeader(h.h1[0]);
                        ^^^^^^^
 invalid-hdr-warnings4.p4(82): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h_copy2.h2[0]

--- a/testdata/p4_16_samples_outputs/issue1717.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1717.p4-stderr
@@ -1,7 +1,7 @@
-issue1717.p4(52): [--Wwarn=uninitialized_use] warning: h1 may not be completely initialized
+issue1717.p4(52): [--Wwarn=uninitialized_use] warning: h1.isValid may be uninitialized
         size = v(h1, h2);
                  ^^
-issue1717.p4(52): [--Wwarn=uninitialized_use] warning: h2 may not be completely initialized
+issue1717.p4(52): [--Wwarn=uninitialized_use] warning: h2.f may be uninitialized
         size = v(h1, h2);
                      ^^
 [--Wwarn=invalid_header] warning: accessing a field of an invalid header h2_0

--- a/testdata/p4_16_samples_outputs/issue1897-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1897-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-issue1897-bmv2.p4(40): [--Wwarn=uninitialized_use] warning: addr_0 may not be completely initialized
+issue1897-bmv2.p4(40): [--Wwarn=uninitialized_use] warning: addr_0.ipv4 may be uninitialized
                        out addr_t addr) {
                                   ^^^^

--- a/testdata/p4_16_samples_outputs/issue1955.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1955.p4-stderr
@@ -1,12 +1,12 @@
-issue1955.p4(84): [--Wwarn=uninitialized_use] warning: hdr.ethernet_1 may not be completely initialized
+issue1955.p4(84): [--Wwarn=uninitialized_use] warning: hdr.ethernet_1.dstAddr may be uninitialized
         p1.apply(packet, hdr.ethernet_1, hdr.ipv4_1);
                          ^^^^^^^^^^^^^^
-issue1955.p4(84): [--Wwarn=uninitialized_use] warning: hdr.ipv4_1 may not be completely initialized
+issue1955.p4(84): [--Wwarn=uninitialized_use] warning: hdr.ipv4_1.version may be uninitialized
         p1.apply(packet, hdr.ethernet_1, hdr.ipv4_1);
                                          ^^^^^^^^^^
-issue1955.p4(85): [--Wwarn=uninitialized_use] warning: hdr.ethernet_2 may not be completely initialized
+issue1955.p4(85): [--Wwarn=uninitialized_use] warning: hdr.ethernet_2.dstAddr may be uninitialized
         p2.apply(packet, hdr.ethernet_2, hdr.ipv4_2);
                          ^^^^^^^^^^^^^^
-issue1955.p4(85): [--Wwarn=uninitialized_use] warning: hdr.ipv4_2 may not be completely initialized
+issue1955.p4(85): [--Wwarn=uninitialized_use] warning: hdr.ipv4_2.version may be uninitialized
         p2.apply(packet, hdr.ethernet_2, hdr.ipv4_2);
                                          ^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue2314.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2314.p4-stderr
@@ -1,3 +1,3 @@
-issue2314.p4(71): [--Wwarn=uninitialized_use] warning: hdr may not be completely initialized
+issue2314.p4(71): [--Wwarn=uninitialized_use] warning: hdr.h may be uninitialized
     l3.apply(b, hdr);
                 ^^^

--- a/testdata/p4_16_samples_outputs/issue2957.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2957.p4-stderr
@@ -1,3 +1,3 @@
-issue2957.p4(23): [--Wwarn=uninitialized_use] warning: hdr.h[tmp_3] may not be completely initialized
+issue2957.p4(23): [--Wwarn=uninitialized_use] warning: hdr.h[tmp_3].a may be uninitialized
     H tmp = { extern_call(hdr.h[max(3w1, 3w2)]) };
                           ^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/issue3001-1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3001-1.p4-stderr
@@ -1,7 +1,7 @@
-issue3001-1.p4(41): [--Wwarn=uninitialized_use] warning: h may not be completely initialized
+issue3001-1.p4(41): [--Wwarn=uninitialized_use] warning: h.x may be uninitialized
     return h;
            ^
-issue3001-1.p4(46): [--Wwarn=uninitialized_use] warning: u may not be completely initialized
+issue3001-1.p4(46): [--Wwarn=uninitialized_use] warning: u.h may be uninitialized
     return u;
            ^
 issue3001-1.p4(51): [--Wwarn=uninitialized_use] warning: s may not be completely initialized

--- a/testdata/p4_16_samples_outputs/issue3001.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue3001.p4-stderr
@@ -1,3 +1,3 @@
-issue3001.p4(23): [--Wwarn=uninitialized_use] warning: h may not be completely initialized
+issue3001.p4(23): [--Wwarn=uninitialized_use] warning: h.x may be uninitialized
     return h;
            ^

--- a/testdata/p4_16_samples_outputs/issue982.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue982.p4-stderr
@@ -16,7 +16,7 @@ issue982.p4(385): [--Wwarn=uninitialized_out_param] warning: out parameter 'ostd
 issue982.p4(385)
 parser IngressParserImpl(packet_in buffer, out headers parsed_hdr, inout metadata user_meta, in p...
        ^^^^^^^^^^^^^^^^^
-issue982.p4(420): [--Wwarn=uninitialized_use] warning: clone_md may not be completely initialized
+issue982.p4(420): [--Wwarn=uninitialized_use] warning: clone_md.data may be uninitialized
             ostd.clone_metadata = clone_md;
                                   ^^^^^^^^
 issue982.p4(414): [--Wwarn=uninitialized_out_param] warning: out parameter 'ostd' may be uninitialized when 'IngressDeparserImpl' terminates

--- a/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test13.p4-stderr
+++ b/testdata/p4_16_samples_outputs/parser-inline/parser-inline-test13.p4-stderr
@@ -1,3 +1,3 @@
-parser-inline-test13.p4(32): [--Wwarn=uninitialized_use] warning: hdr_0 may not be completely initialized
+parser-inline-test13.p4(32): [--Wwarn=uninitialized_use] warning: hdr_0.h2 may be uninitialized
                  out headers hdr,
                              ^^^

--- a/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/subparser-with-header-stack-bmv2.p4-stderr
@@ -1,3 +1,3 @@
-subparser-with-header-stack-bmv2.p4(84): [--Wwarn=uninitialized_use] warning: hdr may not be completely initialized
+subparser-with-header-stack-bmv2.p4(84): [--Wwarn=uninitialized_use] warning: hdr.h2 may be uninitialized
         subp.apply(pkt, hdr, my_next_hdr_type);
                         ^^^

--- a/testdata/p4_16_samples_outputs/uninit.p4-stderr
+++ b/testdata/p4_16_samples_outputs/uninit.p4-stderr
@@ -4,7 +4,7 @@ uninit.p4(36): [--Wwarn=ordering] warning: h.data2: 'out' argument has fields in
 uninit.p4(36)
         g(h.data2, g(h.data2, h.data2)); // uninitialized
                      ^^^^^^^
-uninit.p4(35): [--Wwarn=uninitialized_use] warning: h may not be completely initialized
+uninit.p4(35): [--Wwarn=uninitialized_use] warning: h.data2 may be uninitialized
         func(h); // uninitialized
              ^
 uninit.p4(36): [--Wwarn=uninitialized_use] warning: h.data2 may be uninitialized
@@ -19,7 +19,7 @@ uninit.p4(36): [--Wwarn=uninitialized_use] warning: h.data2 may be uninitialized
 uninit.p4(41): [--Wwarn=uninitialized_use] warning: h.data3 may be uninitialized
         h.data2 = h.data3 + 1; // uninitialized
                   ^^^^^^^
-uninit.p4(42): [--Wwarn=uninitialized_use] warning: stack[1] may not be completely initialized
+uninit.p4(42): [--Wwarn=uninitialized_use] warning: stack[1].data1 may be uninitialized
         stack[0] = stack[1]; // uninitialized
                    ^^^^^^^^
 uninit.p4(62): [--Wwarn=uninitialized_use] warning: c may be uninitialized


### PR DESCRIPTION
Rather than reporting the whole struct, report the specific field(s) that is(are) uninitialized.