### PR TITLE
Allow extending ToP4, clean its constructors

### DIFF
--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -526,10 +526,10 @@ bool ParserOptions::isAnnotationDisabled(const IR::Annotation *a) const {
 }
 
 DebugHook ParserOptions::getDebugHook() const {
-    return getDebugHook([](std::ostream *stream, bool dumpIR, std::filesystem::path file)
-        -> std::unique_ptr<ToP4> {
-        return std::make_unique<ToP4>(stream, dumpIR, file);
-    });
+    return getDebugHook(
+        [](std::ostream *stream, bool dumpIR, std::filesystem::path file) -> std::unique_ptr<ToP4> {
+            return std::make_unique<ToP4>(stream, dumpIR, file);
+        });
 }
 
 DebugHook ParserOptions::getDebugHook(ToP4Factory toP4Fact) const {

--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -472,8 +472,8 @@ static std::filesystem::path makeFileName(const std::filesystem::path &folder,
 
 bool ParserOptions::isv1() const { return langVersion == ParserOptions::FrontendVersion::P4_14; }
 
-void ParserOptions::dumpPass(const char *manager, unsigned seq, const char *pass,
-                             const IR::Node *node) const {
+void ParserOptions::dumpPass(ToP4Factory toP4Fact, const char *manager, unsigned seq,
+                             const char *pass, const IR::Node *node) const {
     if (strncmp(pass, "P4::", 4) == 0) pass += 4;
     std::string name = absl::StrCat(manager, "_", seq, "_", pass);
     if (Log::verbose()) std::cerr << name << std::endl;
@@ -487,10 +487,10 @@ void ParserOptions::dumpPass(const char *manager, unsigned seq, const char *pass
             // regex_search checks if the regex is contained as substring
             match = std::regex_search(name.begin(), name.end(), s_regex);
         } catch (const std::regex_error &e) {
-            ::P4::error(ErrorType::ERR_INVALID,
-                        "Malformed toP4 regex string \"%s\".\n"
-                        "The regex matcher follows ECMAScript syntax.",
-                        s);
+            P4::error(ErrorType::ERR_INVALID,
+                      "Malformed toP4 regex string \"%s\".\n"
+                      "The regex matcher follows ECMAScript syntax.",
+                      s);
             exit(1);
         }
         if (match) {
@@ -501,12 +501,12 @@ void ParserOptions::dumpPass(const char *manager, unsigned seq, const char *pass
             std::unique_ptr<std::ostream> stream{openFile(fileName, true)};
             if (stream != nullptr) {
                 if (Log::verbose()) std::cerr << "Writing program to " << fileName << std::endl;
-                P4::ToP4 toP4(stream.get(), Log::verbose(), file);
+                std::unique_ptr<P4::ToP4> toP4 = toP4Fact(stream.get(), Log::verbose(), file);
                 if (noIncludes) {
-                    toP4.setnoIncludesArg(true);
+                    toP4->setnoIncludesArg(true);
                 }
                 if (node) {
-                    node->apply(toP4);
+                    node->apply(*toP4);
                 } else {
                     *stream << "No P4 program returned by the pass" << std::endl;
                 }
@@ -526,7 +526,14 @@ bool ParserOptions::isAnnotationDisabled(const IR::Annotation *a) const {
 }
 
 DebugHook ParserOptions::getDebugHook() const {
-    auto dp = std::bind(&ParserOptions::dumpPass, this, std::placeholders::_1,
+    return getDebugHook([](std::ostream *stream, bool dumpIR, std::filesystem::path file)
+        -> std::unique_ptr<ToP4> {
+        return std::make_unique<ToP4>(stream, dumpIR, file);
+    });
+}
+
+DebugHook ParserOptions::getDebugHook(ToP4Factory toP4Fact) const {
+    auto dp = std::bind(&ParserOptions::dumpPass, this, toP4Fact, std::placeholders::_1,
                         std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
     return dp;
 }

--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -487,10 +487,10 @@ void ParserOptions::dumpPass(const char *manager, unsigned seq, const char *pass
             // regex_search checks if the regex is contained as substring
             match = std::regex_search(name.begin(), name.end(), s_regex);
         } catch (const std::regex_error &e) {
-            P4::error(ErrorType::ERR_INVALID,
-                      "Malformed toP4 regex string \"%s\".\n"
-                      "The regex matcher follows ECMAScript syntax.",
-                      s);
+            error(ErrorType::ERR_INVALID,
+                  "Malformed toP4 regex string \"%s\".\n"
+                  "The regex matcher follows ECMAScript syntax.",
+                  s);
             exit(1);
         }
         if (match) {

--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -501,8 +501,7 @@ void ParserOptions::dumpPass(const char *manager, unsigned seq, const char *pass
             std::unique_ptr<std::ostream> stream{openFile(fileName, true)};
             if (stream != nullptr) {
                 if (Log::verbose()) std::cerr << "Writing program to " << fileName << std::endl;
-                // FIXME: Accept path here
-                P4::ToP4 toP4(stream.get(), Log::verbose(), cstring(file));
+                P4::ToP4 toP4(stream.get(), Log::verbose(), file);
                 if (noIncludes) {
                     toP4.setnoIncludesArg(true);
                 }

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -105,8 +105,7 @@ class PrettyPrint : public Inspector {
     bool preorder(const IR::P4Program *program) override {
         if (!ppfile.empty()) {
             std::ostream *ppStream = openFile(ppfile, true);
-            // FIXME: ToP4 should accept PathName
-            P4::ToP4 top4(ppStream, false, cstring(inputfile));
+            P4::ToP4 top4(ppStream, false, inputfile);
             (void)program->apply(top4);
         }
         return false;  // prune

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -98,9 +98,7 @@ class ToP4 : public Inspector, ResolutionContext {
         emitted. */
     std::optional<std::filesystem::path> mainFile;
 
-    ToP4(Util::SourceCodeBuilder &builder, bool showIR)
-        : showIR(showIR),
-          builder(builder) {
+    ToP4(Util::SourceCodeBuilder &builder, bool showIR) : showIR(showIR), builder(builder) {
         visitDagOnce = false;
         setName("ToP4");
     }

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -34,6 +34,7 @@ This pass converts a P4-16 IR into a P4 source (text) program.
 It can optionally emit as comments a representation of the program IR.
 */
 class ToP4 : public Inspector, ResolutionContext {
+ protected:
     /// precedence of current IR::Operation
     int expressionPrecedence = DBPrint::Prec_Low;
     bool isDeclaration = true;    /// current type is a declaration

--- a/frontends/p4/toP4/toP4.h
+++ b/frontends/p4/toP4/toP4.h
@@ -17,7 +17,10 @@ limitations under the License.
 #ifndef P4_TOP4_TOP4_H_
 #define P4_TOP4_TOP4_H_
 
+#include <filesystem>
+#include <iostream>
 #include <optional>
+#include <vector>
 
 #include "frontends/common/resolveReferences/resolveReferences.h"
 #include "ir/ir.h"
@@ -31,12 +34,13 @@ This pass converts a P4-16 IR into a P4 source (text) program.
 It can optionally emit as comments a representation of the program IR.
 */
 class ToP4 : public Inspector, ResolutionContext {
-    int expressionPrecedence;  /// precedence of current IR::Operation
-    bool isDeclaration;        /// current type is a declaration
-    bool showIR;               /// if true dump IR as comments
-    bool withinArgument;       /// if true we are within a method call argument
-    bool noIncludes = false;   /// If true do not generate #include statements.
-                               /// Used for debugging.
+    /// precedence of current IR::Operation
+    int expressionPrecedence = DBPrint::Prec_Low;
+    bool isDeclaration = true;    /// current type is a declaration
+    bool showIR;                  /// if true dump IR as comments
+    bool withinArgument = false;  /// if true we are within a method call argument
+    bool noIncludes = false;      /// If true do not generate #include statements.
+                                  /// Used for debugging.
 
     struct VecPrint {
         cstring separator;
@@ -87,46 +91,33 @@ class ToP4 : public Inspector, ResolutionContext {
      * directly to the ostream.  The SourceCodeBuilder object does not appear to add any
      * useful functionality the ostream does not already provide; it just serves to
      * obfuscate the code */
-    std::ostream *outStream;
-    /** If this is set to non-nullptr, some declarations
+    std::ostream *outStream = nullptr;
+    /** If this is set to non-empty, some declarations
         that come from libraries and models are not
         emitted. */
-    cstring mainFile;
+    std::optional<std::filesystem::path> mainFile;
 
-    ToP4(Util::SourceCodeBuilder &builder, bool showIR, cstring mainFile = nullptr)
-        : expressionPrecedence(DBPrint::Prec_Low),
-          isDeclaration(true),
-          showIR(showIR),
-          withinArgument(false),
-          builder(builder),
-          outStream(nullptr),
-          mainFile(mainFile) {
+    ToP4(Util::SourceCodeBuilder &builder, bool showIR)
+        : showIR(showIR),
+          builder(builder) {
         visitDagOnce = false;
         setName("ToP4");
     }
-    ToP4(std::ostream *outStream, bool showIR, cstring mainFile = nullptr)
-        : expressionPrecedence(DBPrint::Prec_Low),
-          isDeclaration(true),
-          showIR(showIR),
-          withinArgument(false),
-          builder(*new Util::SourceCodeBuilder()),
-          outStream(outStream),
-          mainFile(mainFile) {
-        visitDagOnce = false;
-        setName("ToP4");
+
+    ToP4(std::ostream *outStream, bool showIR) : ToP4(*new Util::SourceCodeBuilder(), showIR) {
+        this->outStream = outStream;
     }
-    ToP4()
-        :  // this is useful for debugging
-          expressionPrecedence(DBPrint::Prec_Low),
-          isDeclaration(true),
-          showIR(false),
-          withinArgument(false),
-          builder(*new Util::SourceCodeBuilder()),
-          outStream(&std::cout),
-          mainFile(nullptr) {
-        visitDagOnce = false;
-        setName("ToP4");
+
+    ToP4(Util::SourceCodeBuilder &builder, bool showIR, std::filesystem::path mainFile)
+        : ToP4(builder, showIR) {
+        this->mainFile = mainFile;
     }
+    ToP4(std::ostream *outStream, bool showIR, std::filesystem::path mainFile)
+        : ToP4(outStream, showIR) {
+        this->mainFile = mainFile;
+    }
+
+    ToP4() : ToP4(*new Util::SourceCodeBuilder(), false) {}
 
     using Inspector::preorder;
 


### PR DESCRIPTION
- Replaced the `cstring` argument in `ToP4` with `std::filesystem::path`. This is the breaking change.
- Cleaned up its constructors to avoid duplication.
- Allow re-using the dumper in `ParserOptions` with a descendant of `ToP4` -- the way I did this is not exactly nice, but I don't see other clear way to create the instance on demand.
- The `ToP4` pass is a good candidate for larger refactoring, but I don't have time for that now.