### PR TITLE
Split the `start` state more conservatively when a parser contains decl initializers

### DIFF
--- a/frontends/p4/moveDeclarations.cpp
+++ b/frontends/p4/moveDeclarations.cpp
@@ -97,7 +97,30 @@ const IR::Node *MoveDeclarations::postorder(IR::Declaration_Constant *decl) {
 
 ////////////////////////////////////////////////////////////////////
 
+// Returns true iff the given state is _directly_ reachable from any of the given
+// set of states.
+bool isReachable(cstring stateName, const IR::IndexedVector<IR::ParserState> &states) {
+    for (const auto *state : states) {
+        const auto *selectExpr = state->selectExpression;
+        if (selectExpr == nullptr) continue;  // implicit reject transition
+
+        if (const auto *sel = selectExpr->to<IR::SelectExpression>()) {
+            // select expression
+            for (const auto *selectCase : sel->selectCases)
+                if (selectCase->state->path->name == stateName) return true;
+        } else if (const auto *pathExpr = selectExpr->to<IR::PathExpression>()) {
+            // direct transition
+            if (pathExpr->path->name == stateName) return true;
+        }
+    }
+
+    return false;
+}
+
 const IR::Node *MoveInitializers::preorder(IR::P4Parser *parser) {
+    oldStart = nullptr;
+    loopsBackToStart = false;
+
     // Determine if we have anything to do in this parser.
     // Check if we have top-level declarations with intializers.
     auto someInitializers = false;
@@ -115,26 +138,7 @@ const IR::Node *MoveInitializers::preorder(IR::P4Parser *parser) {
         // If this is the case, then the parser's decl initializers cannot be moved
         // to the start state. A new start state that is never looped back to must
         // be inserted at the head of the graph.
-        for (const auto *state : parser->states) {
-            const auto *selectExpr = state->selectExpression;
-            if (selectExpr == nullptr) {
-                // implicit reject transition
-            } else if (selectExpr->is<IR::SelectExpression>()) {
-                // select expression
-                for (const auto *selectCase : selectExpr->to<IR::SelectExpression>()->selectCases) {
-                    if (selectCase->state->path->name == IR::ParserState::start) {
-                        loopsBackToStart = true;
-                        break;
-                    }
-                }
-            } else if (selectExpr->is<IR::PathExpression>()) {
-                // direct transition
-                const auto *pathExpr = selectExpr->to<IR::PathExpression>();
-                if (pathExpr->path->name == IR::ParserState::start) loopsBackToStart = true;
-            }
-
-            if (loopsBackToStart) break;
-        }
+        loopsBackToStart = isReachable(IR::ParserState::start, parser->states);
 
         newStartName = nameGen.newName(IR::ParserState::start.string_view());
         oldStart = parser->states.getDeclaration(IR::ParserState::start)->to<IR::ParserState>();
@@ -153,18 +157,18 @@ const IR::Node *MoveInitializers::preorder(IR::Declaration_Variable *decl) {
 
     auto varRef = new IR::PathExpression(decl->name);
     auto assign = new IR::AssignmentStatement(decl->srcInfo, varRef, decl->initializer);
-    toMove->push_back(assign);
+    toMove.push_back(assign);
     decl->initializer = nullptr;
     return decl;
 }
 
 const IR::Node *MoveInitializers::postorder(IR::ParserState *state) {
-    if (state->name == IR::ParserState::start && !toMove->empty()) {
+    if (state->name == IR::ParserState::start && !toMove.empty()) {
         if (!loopsBackToStart) {
             // Just prepend all initializing assignments to the original start
             // state if there are no loops back to the start state.
-            state->components.insert(state->components.begin(), (*toMove).begin(), (*toMove).end());
-            toMove = new IR::IndexedVector<IR::StatOrDecl>();
+            state->components.insert(state->components.begin(), toMove.begin(), toMove.end());
+            toMove.clear();
         } else {
             // Otherwise, we need to insert all such assignments into a new start state
             // that can only run once, so that the assignments are only executed one time.
@@ -189,25 +193,22 @@ const IR::Node *MoveInitializers::postorder(IR::P4Parser *parser) {
     if (oldStart && loopsBackToStart) {
         // Only add a new state if the parser has initializers and contains one
         // or more states that loop back to the start state.
-        auto newStart = new IR::ParserState(IR::ID(IR::ParserState::start), *toMove,
+        auto newStart = new IR::ParserState(IR::ID(IR::ParserState::start), toMove,
                                             new IR::PathExpression(newStartName));
-        toMove = new IR::IndexedVector<IR::StatOrDecl>();
+        toMove.clear();
         parser->states.insert(parser->states.begin(), newStart);
     }
-
-    oldStart = nullptr;
-    loopsBackToStart = false;
 
     return parser;
 }
 
 const IR::Node *MoveInitializers::postorder(IR::P4Control *control) {
-    if (toMove->empty()) return control;
-    toMove->append(control->body->components);
+    if (toMove.empty()) return control;
+    toMove.append(control->body->components);
     auto newBody =
-        new IR::BlockStatement(control->body->srcInfo, control->body->annotations, *toMove);
+        new IR::BlockStatement(control->body->srcInfo, control->body->annotations, toMove);
     control->body = newBody;
-    toMove = new IR::IndexedVector<IR::StatOrDecl>();
+    toMove.clear();
     return control;
 }
 

--- a/frontends/p4/moveDeclarations.cpp
+++ b/frontends/p4/moveDeclarations.cpp
@@ -115,14 +115,13 @@ const IR::Node *MoveInitializers::preorder(IR::P4Parser *parser) {
         // If this is the case, then the parser's decl initializers cannot be moved
         // to the start state. A new start state that is never looped back to must
         // be inserted at the head of the graph.
-        for (const auto* state : parser->states) {
-            const auto* selectExpr = state->selectExpression;
+        for (const auto *state : parser->states) {
+            const auto *selectExpr = state->selectExpression;
             if (selectExpr == nullptr) {
                 // implicit reject transition
             } else if (selectExpr->is<IR::SelectExpression>()) {
                 // select expression
-                for (const auto* selectCase
-                     : selectExpr->to<IR::SelectExpression>()->selectCases) {
+                for (const auto *selectCase : selectExpr->to<IR::SelectExpression>()->selectCases) {
                     if (selectCase->state->path->name == IR::ParserState::start) {
                         loopsBackToStart = true;
                         break;
@@ -130,12 +129,11 @@ const IR::Node *MoveInitializers::preorder(IR::P4Parser *parser) {
                 }
             } else if (selectExpr->is<IR::PathExpression>()) {
                 // direct transition
-                const auto* pathExpr = selectExpr->to<IR::PathExpression>();
+                const auto *pathExpr = selectExpr->to<IR::PathExpression>();
                 if (pathExpr->path->name == IR::ParserState::start) loopsBackToStart = true;
             }
 
-            if (loopsBackToStart)
-                break;
+            if (loopsBackToStart) break;
         }
 
         newStartName = nameGen.newName(IR::ParserState::start.string_view());
@@ -178,8 +176,7 @@ const IR::Node *MoveInitializers::postorder(IR::ParserState *state) {
 }
 
 const IR::Node *MoveInitializers::postorder(IR::Path *path) {
-    if (!oldStart || !loopsBackToStart || path->name != IR::ParserState::start)
-        return path;
+    if (!oldStart || !loopsBackToStart || path->name != IR::ParserState::start) return path;
 
     // Only rename start state references if the parser contains initializing assignments
     // and loops back to the start state.

--- a/frontends/p4/moveDeclarations.cpp
+++ b/frontends/p4/moveDeclarations.cpp
@@ -109,7 +109,35 @@ const IR::Node *MoveInitializers::preorder(IR::P4Parser *parser) {
             }
         }
     }
+
     if (someInitializers) {
+        // Check whether any of the parser's states loop back to the start state.
+        // If this is the case, then the parser's decl initializers cannot be moved
+        // to the start state. A new start state that is never looped back to must
+        // be inserted at the head of the graph.
+        for (const auto* state : parser->states) {
+            const auto* selectExpr = state->selectExpression;
+            if (selectExpr == nullptr) {
+                // implicit reject transition
+            } else if (selectExpr->is<IR::SelectExpression>()) {
+                // select expression
+                for (const auto* selectCase
+                     : selectExpr->to<IR::SelectExpression>()->selectCases) {
+                    if (selectCase->state->path->name == IR::ParserState::start) {
+                        loopsBackToStart = true;
+                        break;
+                    }
+                }
+            } else if (selectExpr->is<IR::PathExpression>()) {
+                // direct transition
+                const auto* pathExpr = selectExpr->to<IR::PathExpression>();
+                if (pathExpr->path->name == IR::ParserState::start) loopsBackToStart = true;
+            }
+
+            if (loopsBackToStart)
+                break;
+        }
+
         newStartName = nameGen.newName(IR::ParserState::start.string_view());
         oldStart = parser->states.getDeclaration(IR::ParserState::start)->to<IR::ParserState>();
         CHECK_NULL(oldStart);
@@ -117,16 +145,7 @@ const IR::Node *MoveInitializers::preorder(IR::P4Parser *parser) {
     return parser;
 }
 
-const IR::Node *MoveInitializers::postorder(IR::P4Parser *parser) {
-    if (oldStart == nullptr) return parser;
-    auto newStart = new IR::ParserState(IR::ID(IR::ParserState::start), *toMove,
-                                        new IR::PathExpression(newStartName));
-    toMove = new IR::IndexedVector<IR::StatOrDecl>();
-    parser->states.insert(parser->states.begin(), newStart);
-    return parser;
-}
-
-const IR::Node *MoveInitializers::postorder(IR::Declaration_Variable *decl) {
+const IR::Node *MoveInitializers::preorder(IR::Declaration_Variable *decl) {
     if (getContext() == nullptr) return decl;
     auto parent = getContext()->node;
     if (!parent->is<IR::P4Control>() && !parent->is<IR::P4Parser>())
@@ -142,9 +161,47 @@ const IR::Node *MoveInitializers::postorder(IR::Declaration_Variable *decl) {
 }
 
 const IR::Node *MoveInitializers::postorder(IR::ParserState *state) {
-    if (oldStart == nullptr) return state;
-    if (state->name == IR::ParserState::start) state->name = newStartName;
+    if (state->name == IR::ParserState::start && !toMove->empty()) {
+        if (!loopsBackToStart) {
+            // Just prepend all initializing assignments to the original start
+            // state if there are no loops back to the start state.
+            state->components.insert(state->components.begin(), (*toMove).begin(), (*toMove).end());
+            toMove = new IR::IndexedVector<IR::StatOrDecl>();
+        } else {
+            // Otherwise, we need to insert all such assignments into a new start state
+            // that can only run once, so that the assignments are only executed one time.
+            state->name = newStartName;
+        }
+    }
+
     return state;
+}
+
+const IR::Node *MoveInitializers::postorder(IR::Path *path) {
+    if (!oldStart || !loopsBackToStart || path->name != IR::ParserState::start)
+        return path;
+
+    // Only rename start state references if the parser contains initializing assignments
+    // and loops back to the start state.
+    auto decl = getDeclaration(getOriginal()->to<IR::Path>());
+    if (!decl->is<IR::ParserState>()) return path;
+    return new IR::Path(newStartName);
+}
+
+const IR::Node *MoveInitializers::postorder(IR::P4Parser *parser) {
+    if (oldStart && loopsBackToStart) {
+        // Only add a new state if the parser has initializers and contains one
+        // or more states that loop back to the start state.
+        auto newStart = new IR::ParserState(IR::ID(IR::ParserState::start), *toMove,
+                                            new IR::PathExpression(newStartName));
+        toMove = new IR::IndexedVector<IR::StatOrDecl>();
+        parser->states.insert(parser->states.begin(), newStart);
+    }
+
+    oldStart = nullptr;
+    loopsBackToStart = false;
+
+    return parser;
 }
 
 const IR::Node *MoveInitializers::postorder(IR::P4Control *control) {
@@ -155,13 +212,6 @@ const IR::Node *MoveInitializers::postorder(IR::P4Control *control) {
     control->body = newBody;
     toMove = new IR::IndexedVector<IR::StatOrDecl>();
     return control;
-}
-
-const IR::Node *MoveInitializers::postorder(IR::Path *path) {
-    if (oldStart == nullptr || path->name != IR::ParserState::start) return path;
-    auto decl = getDeclaration(getOriginal()->to<IR::Path>());
-    if (!decl->is<IR::ParserState>()) return path;
-    return new IR::Path(newStartName);
 }
 
 Visitor::profile_t MoveInitializers::init_apply(const IR::Node *node) {

--- a/frontends/p4/moveDeclarations.h
+++ b/frontends/p4/moveDeclarations.h
@@ -103,7 +103,8 @@ class MoveInitializers : public Transform, public ResolutionContext {
     MinimalNameGenerator nameGen;
     IR::IndexedVector<IR::StatOrDecl> *toMove;  // This contains just IR::AssignmentStatement
     const IR::ParserState *oldStart;  // nullptr if we do not want to rename the start state
-    cstring newStartName;             // name allocated to the old start state
+    cstring newStartName;             // name allocated to the new start state
+    bool loopsBackToStart = false;    // true if start is reachable from any other state
 
  public:
     MoveInitializers()
@@ -112,11 +113,11 @@ class MoveInitializers : public Transform, public ResolutionContext {
     }
     profile_t init_apply(const IR::Node *node) override;
     const IR::Node *preorder(IR::P4Parser *parser) override;
-    const IR::Node *postorder(IR::P4Parser *parser) override;
-    const IR::Node *postorder(IR::Declaration_Variable *decl) override;
+    const IR::Node *preorder(IR::Declaration_Variable *decl) override;
     const IR::Node *postorder(IR::ParserState *state) override;
-    const IR::Node *postorder(IR::P4Control *control) override;
     const IR::Node *postorder(IR::Path *path) override;
+    const IR::Node *postorder(IR::P4Parser *parser) override;
+    const IR::Node *postorder(IR::P4Control *control) override;
 };
 
 }  // namespace P4

--- a/frontends/p4/moveDeclarations.h
+++ b/frontends/p4/moveDeclarations.h
@@ -101,14 +101,13 @@ class MoveDeclarations : public Transform {
  */
 class MoveInitializers : public Transform, public ResolutionContext {
     MinimalNameGenerator nameGen;
-    IR::IndexedVector<IR::StatOrDecl> *toMove;  // This contains just IR::AssignmentStatement
+    IR::IndexedVector<IR::StatOrDecl> toMove;  // This contains just IR::AssignmentStatement
     const IR::ParserState *oldStart;  // nullptr if we do not want to rename the start state
     cstring newStartName;             // name allocated to the new start state
-    bool loopsBackToStart = false;    // true if start is reachable from any other state
+    bool loopsBackToStart;            // true if start is reachable from any other state
 
  public:
-    MoveInitializers()
-        : toMove(new IR::IndexedVector<IR::StatOrDecl>()), oldStart(nullptr), newStartName("") {
+    MoveInitializers() : newStartName("") {
         setName("MoveInitializers");
     }
     profile_t init_apply(const IR::Node *node) override;

--- a/frontends/p4/moveDeclarations.h
+++ b/frontends/p4/moveDeclarations.h
@@ -107,9 +107,7 @@ class MoveInitializers : public Transform, public ResolutionContext {
     bool loopsBackToStart;            // true if start is reachable from any other state
 
  public:
-    MoveInitializers() : newStartName("") {
-        setName("MoveInitializers");
-    }
+    MoveInitializers() : newStartName("") { setName("MoveInitializers"); }
     profile_t init_apply(const IR::Node *node) override;
     const IR::Node *preorder(IR::P4Parser *parser) override;
     const IR::Node *preorder(IR::Declaration_Variable *decl) override;

--- a/testdata/p4_16_samples/issue4901_new_start_with_no_start_loopback.p4
+++ b/testdata/p4_16_samples/issue4901_new_start_with_no_start_loopback.p4
@@ -1,0 +1,22 @@
+parser Parser1() {
+  bit<8> l = 0;
+  state start {
+    transition next;
+  }
+  state next {
+    transition select(l) {
+        default: accept;
+    }
+  }
+}
+
+parser Parser2() {
+  state start {
+    transition  accept;
+  }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;
+

--- a/testdata/p4_16_samples/issue4901_new_start_with_start_state_loopback.p4
+++ b/testdata/p4_16_samples/issue4901_new_start_with_start_state_loopback.p4
@@ -1,0 +1,23 @@
+parser Parser1() {
+  bit<8> l = 0;
+  state start {
+    transition next;
+  }
+  state next {
+    transition select(l) {
+        2 : start;
+        default: accept;
+    }
+  }
+}
+
+parser Parser2() {
+  state start {
+    transition  accept;
+  }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;
+

--- a/testdata/p4_16_samples/issue4901_new_start_with_start_state_loopback2.p4
+++ b/testdata/p4_16_samples/issue4901_new_start_with_start_state_loopback2.p4
@@ -1,0 +1,30 @@
+parser Parser1() {
+  bit<8> l = 0;
+  state start {
+    transition next;
+  }
+  state next {
+    transition select(l) {
+        2 : start;
+        default: accept;
+    }
+  }
+}
+
+parser Parser2() {
+  bit<7> l = 1;
+  state start {
+    transition select (l) {
+        0 : s0;
+        default : accept;
+    }
+  }
+  state s0 {
+    transition accept;
+  }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;
+

--- a/testdata/p4_16_samples_outputs/default-frontend.p4
+++ b/testdata/p4_16_samples_outputs/default-frontend.p4
@@ -8,9 +8,6 @@ parser p0(packet_in p, out Header h) {
     @name("p0.b") bool b_0;
     state start {
         b_0 = true;
-        transition start_0;
-    }
-    state start_0 {
         p.extract<Header>(h);
         transition select(h.data, b_0) {
             (default, true): next;

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-frontend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-frontend.p4
@@ -214,9 +214,6 @@ parser FabricParser(packet_in packet, out parsed_headers_t hdr, inout fabric_met
     @name("FabricParser.tmp") bit<4> tmp;
     @name("FabricParser.tmp_0") bit<4> tmp_0;
     state start {
-        transition start_0;
-    }
-    state start_0 {
         transition select(standard_metadata.ingress_port) {
             9w255: parse_packet_out;
             default: parse_ethernet;

--- a/testdata/p4_16_samples_outputs/initializers-frontend.p4
+++ b/testdata/p4_16_samples_outputs/initializers-frontend.p4
@@ -10,9 +10,6 @@ parser P() {
     @name("P.fake") Fake() fake_0;
     state start {
         x_0 = 32w0;
-        transition start_0;
-    }
-    state start_0 {
         fake_0.call(x_0);
         transition accept;
     }

--- a/testdata/p4_16_samples_outputs/issue1538-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1538-frontend.p4
@@ -26,9 +26,6 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         x = (bit<16>)standard_metadata.ingress_port;
         retval = x + 16w1;
         tmp_port_0 = retval;
-        transition start_0;
-    }
-    state start_0 {
         packet.extract<ethernet_t>(hdr.ethernet);
         x_6 = hdr.ethernet.etherType;
         retval_0 = x_6 + 16w1;

--- a/testdata/p4_16_samples_outputs/issue2314-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2314-frontend.p4
@@ -28,9 +28,6 @@ struct m {
 parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t std) {
     @name("MyParser.l3.etherType") bit<16> l3_etherType;
     state start {
-        transition start_0;
-    }
-    state start_0 {
         b.extract<ethernet_t>(hdr.ether);
         transition L3_start;
     }

--- a/testdata/p4_16_samples_outputs/issue281-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue281-frontend.p4
@@ -42,9 +42,6 @@ struct m {
 parser MyParser(packet_in b, out h hdr, inout m meta, inout standard_metadata_t std) {
     @name("MyParser.l3.etherType") bit<16> l3_etherType;
     state start {
-        transition start_0;
-    }
-    state start_0 {
         hdr.ether.setInvalid();
         hdr.vlan.setInvalid();
         hdr.ipv4.setInvalid();

--- a/testdata/p4_16_samples_outputs/issue2957-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2957-frontend.p4
@@ -39,9 +39,6 @@ parser p(packet_in pkt, out Headers hdr) {
         tmp_3 = hdr.h[tmp_2];
         tmp_4 = extern_call(tmp_3);
         hdr.h[tmp_2] = tmp_3;
-        transition start_0;
-    }
-    state start_0 {
         pkt.extract<ethernet_t>(hdr.eth_hdr);
         pkt.extract<H>(hdr.h.next);
         transition accept;

--- a/testdata/p4_16_samples_outputs/issue361-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue361-bmv2-frontend.p4
@@ -17,9 +17,6 @@ parser MyParser(packet_in b, out my_packet p, inout my_metadata m, inout standar
     @name("MyParser.bv") bool bv_0;
     state start {
         bv_0 = true;
-        transition start_0;
-    }
-    state start_0 {
         transition select(bv_0) {
             false: next;
             true: accept;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_no_start_loopback-first.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_no_start_loopback-first.p4
@@ -1,0 +1,21 @@
+parser Parser1() {
+    bit<8> l = 8w0;
+    state start {
+        transition next;
+    }
+    state next {
+        transition select(l) {
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    state start {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_no_start_loopback-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_no_start_loopback-frontend.p4
@@ -1,0 +1,19 @@
+parser Parser1() {
+    @name("Parser1.l") bit<8> l_0;
+    state start {
+        l_0 = 8w0;
+        transition select(l_0) {
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    state start {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_no_start_loopback-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_no_start_loopback-midend.p4
@@ -1,0 +1,15 @@
+parser Parser1() {
+    state start {
+        transition accept;
+    }
+}
+
+parser Parser2() {
+    state start {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_no_start_loopback.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_no_start_loopback.p4
@@ -1,0 +1,21 @@
+parser Parser1() {
+    bit<8> l = 0;
+    state start {
+        transition next;
+    }
+    state next {
+        transition select(l) {
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    state start {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback-first.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback-first.p4
@@ -1,0 +1,22 @@
+parser Parser1() {
+    bit<8> l = 8w0;
+    state start {
+        transition next;
+    }
+    state next {
+        transition select(l) {
+            8w2: start;
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    state start {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback-frontend.p4
@@ -1,0 +1,23 @@
+parser Parser1() {
+    @name("Parser1.l") bit<8> l_0;
+    state start {
+        l_0 = 8w0;
+        transition start_0;
+    }
+    state start_0 {
+        transition select(l_0) {
+            8w2: start_0;
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    state start {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback-midend.p4
@@ -1,0 +1,23 @@
+parser Parser1() {
+    @name("Parser1.l") bit<8> l_0;
+    state start {
+        l_0 = 8w0;
+        transition start_0;
+    }
+    state start_0 {
+        transition select(l_0) {
+            8w2: start_0;
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    state start {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback.p4
@@ -1,0 +1,22 @@
+parser Parser1() {
+    bit<8> l = 0;
+    state start {
+        transition next;
+    }
+    state next {
+        transition select(l) {
+            2: start;
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    state start {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback2-first.p4
@@ -1,0 +1,29 @@
+parser Parser1() {
+    bit<8> l = 8w0;
+    state start {
+        transition next;
+    }
+    state next {
+        transition select(l) {
+            8w2: start;
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    bit<7> l = 7w1;
+    state start {
+        transition select(l) {
+            7w0: s0;
+            default: accept;
+        }
+    }
+    state s0 {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback2-frontend.p4
@@ -1,0 +1,31 @@
+parser Parser1() {
+    @name("Parser1.l") bit<8> l_0;
+    state start {
+        l_0 = 8w0;
+        transition start_0;
+    }
+    state start_0 {
+        transition select(l_0) {
+            8w2: start_0;
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    @name("Parser2.l") bit<7> l_1;
+    state start {
+        l_1 = 7w1;
+        transition select(l_1) {
+            7w0: s0;
+            default: accept;
+        }
+    }
+    state s0 {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback2-midend.p4
@@ -1,0 +1,23 @@
+parser Parser1() {
+    @name("Parser1.l") bit<8> l_0;
+    state start {
+        l_0 = 8w0;
+        transition start_0;
+    }
+    state start_0 {
+        transition select(l_0) {
+            8w2: start_0;
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    state start {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback2.p4
+++ b/testdata/p4_16_samples_outputs/issue4901_new_start_with_start_state_loopback2.p4
@@ -1,0 +1,29 @@
+parser Parser1() {
+    bit<8> l = 0;
+    state start {
+        transition next;
+    }
+    state next {
+        transition select(l) {
+            2: start;
+            default: accept;
+        }
+    }
+}
+
+parser Parser2() {
+    bit<7> l = 1;
+    state start {
+        transition select(l) {
+            0: s0;
+            default: accept;
+        }
+    }
+    state s0 {
+        transition accept;
+    }
+}
+
+parser proto();
+package top(proto p1, proto p2);
+top(Parser1(), Parser2()) main;

--- a/testdata/p4_16_samples_outputs/parser-conditional-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-conditional-frontend.p4
@@ -7,53 +7,50 @@ parser p(out bit<32> b) {
     @name("p.tmp_1") bit<32> tmp_1;
     state start {
         a_0 = 32w1;
-        transition start_0;
-    }
-    state start_0 {
         transition select(a_0 == 32w0) {
-            true: start_0_true;
-            false: start_0_false;
+            true: start_true;
+            false: start_false;
         }
     }
-    state start_0_true {
+    state start_true {
         tmp = 32w2;
-        transition start_0_join;
+        transition start_join;
     }
-    state start_0_false {
+    state start_false {
         tmp = 32w3;
-        transition start_0_join;
+        transition start_join;
     }
-    state start_0_join {
+    state start_join {
         b = tmp;
         b = b + 32w1;
         transition select(a_0 > 32w0) {
-            true: start_0_true_0;
-            false: start_0_false_0;
+            true: start_true_0;
+            false: start_false_0;
         }
     }
-    state start_0_true_0 {
+    state start_true_0 {
         transition select(a_0 > 32w1) {
-            true: start_0_true_0_true;
-            false: start_0_true_0_false;
+            true: start_true_0_true;
+            false: start_true_0_false;
         }
     }
-    state start_0_true_0_true {
+    state start_true_0_true {
         tmp_1 = b + 32w1;
-        transition start_0_true_0_join;
+        transition start_true_0_join;
     }
-    state start_0_true_0_false {
+    state start_true_0_false {
         tmp_1 = b + 32w2;
-        transition start_0_true_0_join;
+        transition start_true_0_join;
     }
-    state start_0_true_0_join {
+    state start_true_0_join {
         tmp_0 = tmp_1;
-        transition start_0_join_0;
+        transition start_join_0;
     }
-    state start_0_false_0 {
+    state start_false_0 {
         tmp_0 = b + 32w3;
-        transition start_0_join_0;
+        transition start_join_0;
     }
-    state start_0_join_0 {
+    state start_join_0 {
         b = tmp_0;
         transition accept;
     }

--- a/testdata/p4_16_samples_outputs/parser-conditional-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-conditional-midend.p4
@@ -7,45 +7,45 @@ parser p(out bit<32> b) {
     @name("p.tmp_1") bit<32> tmp_1;
     state start {
         a_0 = 32w1;
-        transition start_0_false;
+        transition start_false;
     }
-    state start_0_false {
+    state start_false {
         tmp = 32w3;
-        transition start_0_join;
+        transition start_join;
     }
-    state start_0_join {
+    state start_join {
         b = tmp;
         b = tmp + 32w1;
         transition select((bit<1>)(a_0 > 32w0)) {
-            1w1: start_0_true_0;
-            1w0: start_0_false_0;
+            1w1: start_true_0;
+            1w0: start_false_0;
             default: noMatch;
         }
     }
-    state start_0_true_0 {
+    state start_true_0 {
         transition select((bit<1>)(a_0 > 32w1)) {
-            1w1: start_0_true_0_true;
-            1w0: start_0_true_0_false;
+            1w1: start_true_0_true;
+            1w0: start_true_0_false;
             default: noMatch;
         }
     }
-    state start_0_true_0_true {
+    state start_true_0_true {
         tmp_1 = b + 32w1;
-        transition start_0_true_0_join;
+        transition start_true_0_join;
     }
-    state start_0_true_0_false {
+    state start_true_0_false {
         tmp_1 = b + 32w2;
-        transition start_0_true_0_join;
+        transition start_true_0_join;
     }
-    state start_0_true_0_join {
+    state start_true_0_join {
         tmp_0 = tmp_1;
-        transition start_0_join_0;
+        transition start_join_0;
     }
-    state start_0_false_0 {
+    state start_false_0 {
         tmp_0 = b + 32w3;
-        transition start_0_join_0;
+        transition start_join_0;
     }
-    state start_0_join_0 {
+    state start_join_0 {
         b = tmp_0;
         transition accept;
     }


### PR DESCRIPTION
1. Currently, the `start` state always gets split when a parser contains declaration initializations. The following:
```
parser ...
bit<16> local = 2;
state start {
    ...
}
...
```
always gets split into:
```
parser ...
bit<16> local = 2;
state start {
    ...
    transition start_0;
}

state start_0 {
    ...
}
...
```
However, this is only necessary when `start` is reachable from some other state(s). This PR makes it so that the split only happens when `start` is actually reachable from some other state(s).

2. Coincidentally, also fixes #4901