### PR TITLE
Reduce the number of memory allocations in def-use

### DIFF
--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -334,19 +334,17 @@ Definitions *Definitions::joinDefinitions(const Definitions *other) const {
 }
 
 void Definitions::setDefinition(const StorageLocation *location, const ProgramPoints *point) {
-    LocationSet locset;
-    locset.addCanonical(location);
-    for (auto sl : locset) definitions[sl->to<BaseLocation>()] = point;
+    LocationSet locset(location);
+    for (const auto *sl : locset.canonical()) definitions[sl->to<BaseLocation>()] = point;
 }
 
 void Definitions::setDefinition(const LocationSet *locations, const ProgramPoints *point) {
-    for (auto sl : *locations->canonicalize()) definitions[sl->to<BaseLocation>()] = point;
+    for (const auto *sl : locations->canonical()) definitions[sl->to<BaseLocation>()] = point;
 }
 
 void Definitions::removeLocation(const StorageLocation *location) {
-    auto loc = new LocationSet();
-    loc->addCanonical(location);
-    for (auto sl : *loc) {
+    LocationSet locset(location);
+    for (const auto *sl : locset.canonical()) {
         auto bl = sl->to<BaseLocation>();
         auto it = definitions.find(bl);
         if (it != definitions.end()) definitions.erase(it);
@@ -355,7 +353,7 @@ void Definitions::removeLocation(const StorageLocation *location) {
 
 const ProgramPoints *Definitions::getPoints(const LocationSet *locations) const {
     ProgramPoints *result = new ProgramPoints();
-    for (const auto *sl : *locations->canonicalize()) {
+    for (const auto *sl : locations->canonical()) {
         const auto *points = getPoints(sl->to<BaseLocation>());
         result->add(points);
     }
@@ -365,8 +363,7 @@ const ProgramPoints *Definitions::getPoints(const LocationSet *locations) const 
 Definitions *Definitions::writes(ProgramPoint point, const LocationSet *locations) const {
     auto result = new Definitions(*this);
     auto points = new ProgramPoints(point);
-    auto canon = locations->canonicalize();
-    for (auto l : *canon) result->setDefinition(l->to<BaseLocation>(), points);
+    for (auto l : locations->canonical()) result->setDefinition(l->to<BaseLocation>(), points);
     return result;
 }
 

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -113,35 +113,35 @@ const LocationSet *StorageLocation::removeHeaders() const {
 
 void BaseLocation::removeHeaders(LocationSet *result) const { result->add(this); }
 
+void IndexedLocation::removeHeaders(LocationSet *result) const {
+    for (const auto &f : elements) f->removeHeaders(result);
+}
+
+void WithFieldsLocation::removeHeaders(LocationSet *result) const {
+    if (!type->is<IR::Type_Struct>()) return;
+    for (const auto &f : fieldLocations) f.second->removeHeaders(result);
+}
+
 void StructLocation::addValidBits(LocationSet *result) const {
     if (type->is<IR::Type_Header>()) {
         addField(StorageFactory::validFieldName, result);
     } else {
-        for (auto f : fields()) f->addValidBits(result);
+        for (const auto &f : fields()) f->addValidBits(result);
     }
 }
 
 void StructLocation::addLastIndexField(LocationSet *result) const {
-    for (auto f : fields()) f->addLastIndexField(result);
+    for (const auto &f : fields()) f->addLastIndexField(result);
 }
 
-void StructLocation::addField(cstring field, LocationSet *result) const {
-    auto f = ::P4::get(fieldLocations, field);
+void WithFieldsLocation::addField(cstring field, LocationSet *addTo) const {
+    const auto *f = ::P4::get(fieldLocations, field);
     CHECK_NULL(f);
-    result->add(f);
-}
-
-void TupleLocation::removeHeaders(LocationSet *result) const {
-    for (auto f : elements) f->removeHeaders(result);
-}
-
-void StructLocation::removeHeaders(LocationSet *result) const {
-    if (!type->is<IR::Type_Struct>()) return;
-    for (auto f : fieldLocations) f.second->removeHeaders(result);
+    addTo->add(f);
 }
 
 void ArrayLocation::addValidBits(LocationSet *result) const {
-    for (auto e : *this) e->addValidBits(result);
+    for (const auto *e : *this) e->addValidBits(result);
 }
 
 void ArrayLocation::addLastIndexField(LocationSet *result) const {

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -162,15 +162,15 @@ void IndexedLocation::addElement(unsigned index, LocationSet *result) const {
     result->add(elements.at(index));
 }
 
-const LocationSet *StorageLocation::getValidBits() const {
-    auto result = new LocationSet();
-    addValidBits(result);
+LocationSet StorageLocation::getValidBits() const {
+    LocationSet result;
+    addValidBits(&result);
     return result;
 }
 
-const LocationSet *StorageLocation::getLastIndexField() const {
-    auto result = new LocationSet();
-    addLastIndexField(result);
+LocationSet StorageLocation::getLastIndexField() const {
+    LocationSet result;
+    addLastIndexField(&result);
     return result;
 }
 
@@ -335,11 +335,11 @@ Definitions *Definitions::joinDefinitions(const Definitions *other) const {
 
 void Definitions::setDefinition(const StorageLocation *location, const ProgramPoints *point) {
     LocationSet locset(location);
-    for (const auto *sl : locset.canonical()) definitions[sl->to<BaseLocation>()] = point;
+    setDefinition(locset, point);
 }
 
-void Definitions::setDefinition(const LocationSet *locations, const ProgramPoints *point) {
-    for (const auto *sl : locations->canonical()) definitions[sl->to<BaseLocation>()] = point;
+void Definitions::setDefinition(const LocationSet &locations, const ProgramPoints *point) {
+    for (const auto *sl : locations.canonical()) definitions[sl->to<BaseLocation>()] = point;
 }
 
 void Definitions::removeLocation(const StorageLocation *location) {
@@ -403,10 +403,8 @@ void ComputeWriteSet::enterScope(const IR::ParameterList *parameters,
                 defs->setDefinition(loc, startPoints);
             else if (p->direction == IR::Direction::Out)
                 defs->setDefinition(loc, uninit);
-            auto valid = loc->getValidBits();
-            defs->setDefinition(valid, startPoints);
-            auto lastIndex = loc->getLastIndexField();
-            defs->setDefinition(lastIndex, startPoints);
+            defs->setDefinition(loc->getValidBits(), startPoints);
+            defs->setDefinition(loc->getLastIndexField(), startPoints);
         }
     }
     if (locals != nullptr) {
@@ -415,10 +413,8 @@ void ComputeWriteSet::enterScope(const IR::ParameterList *parameters,
                 StorageLocation *loc = allDefinitions->getOrAddStorage(d);
                 if (loc != nullptr) {
                     defs->setDefinition(loc, uninit);
-                    auto valid = loc->getValidBits();
-                    defs->setDefinition(valid, startPoints);
-                    auto lastIndex = loc->getLastIndexField();
-                    defs->setDefinition(lastIndex, startPoints);
+                    defs->setDefinition(loc->getValidBits(), startPoints);
+                    defs->setDefinition(loc->getLastIndexField(), startPoints);
                 }
             }
         }

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -274,16 +274,6 @@ bool LocationSet::operator==(const LocationSet &other) const {
     return it == other.end();
 }
 
-void ProgramPoints::add(const ProgramPoints *from) {
-    points.insert(from->points.begin(), from->points.end());
-}
-
-const ProgramPoints *ProgramPoints::merge(const ProgramPoints *with) const {
-    auto *result = new ProgramPoints(points);
-    result->points.insert(with->points.begin(), with->points.end());
-    return result;
-}
-
 ProgramPoint::ProgramPoint(const ProgramPoint &context, const IR::Node *node) {
     assign(context, node);
 }
@@ -301,6 +291,16 @@ bool ProgramPoint::operator==(const ProgramPoint &other) const {
 }
 
 std::size_t ProgramPoint::hash() const { return Util::hash_range(stack.begin(), stack.end()); }
+
+void ProgramPoints::add(const ProgramPoints *from) {
+    points.insert(from->points.begin(), from->points.end());
+}
+
+const ProgramPoints *ProgramPoints::merge(const ProgramPoints *with) const {
+    auto *result = new ProgramPoints(points);
+    result->points.insert(with->points.begin(), with->points.end());
+    return result;
+}
 
 bool ProgramPoints::operator==(const ProgramPoints &other) const {
     if (points.size() != other.points.size()) return false;
@@ -364,8 +364,7 @@ const ProgramPoints *Definitions::getPoints(const LocationSet *locations) const 
 
 Definitions *Definitions::writes(ProgramPoint point, const LocationSet *locations) const {
     auto result = new Definitions(*this);
-    auto points = new ProgramPoints();
-    points->add(point);
+    auto points = new ProgramPoints(point);
     auto canon = locations->canonicalize();
     for (auto l : *canon) result->setDefinition(l->to<BaseLocation>(), points);
     return result;

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -396,7 +396,7 @@ void ComputeWriteSet::enterScope(const IR::ParameterList *parameters,
 
     if (parameters != nullptr) {
         for (auto p : parameters->parameters) {
-            StorageLocation *loc = allDefinitions->getOrAddStorage(p);
+            const StorageLocation *loc = allDefinitions->getOrAddStorage(p);
             if (loc == nullptr) continue;
             if (p->direction == IR::Direction::In || p->direction == IR::Direction::InOut ||
                 p->direction == IR::Direction::None)
@@ -410,8 +410,7 @@ void ComputeWriteSet::enterScope(const IR::ParameterList *parameters,
     if (locals != nullptr) {
         for (auto d : *locals) {
             if (d->is<IR::Declaration_Variable>()) {
-                StorageLocation *loc = allDefinitions->getOrAddStorage(d);
-                if (loc != nullptr) {
+                if (const StorageLocation *loc = allDefinitions->getOrAddStorage(d)) {
                     defs->setDefinition(loc, uninit);
                     defs->setDefinition(loc->getValidBits(), startPoints);
                     defs->setDefinition(loc->getLastIndexField(), startPoints);
@@ -434,7 +433,7 @@ void ComputeWriteSet::exitScope(const IR::ParameterList *parameters,
     currentDefinitions = currentDefinitions->cloneDefinitions();
     if (parameters != nullptr) {
         for (auto p : parameters->parameters) {
-            StorageLocation *loc = allDefinitions->getStorage(p);
+            const StorageLocation *loc = allDefinitions->getStorage(p);
             if (loc != nullptr) {
                 LOG5("Removing location " << loc);
                 currentDefinitions->removeLocation(loc);
@@ -444,7 +443,7 @@ void ComputeWriteSet::exitScope(const IR::ParameterList *parameters,
     if (locals != nullptr) {
         for (auto d : *locals) {
             if (d->is<IR::Declaration_Variable>()) {
-                StorageLocation *loc = allDefinitions->getStorage(d);
+                const StorageLocation *loc = allDefinitions->getStorage(d);
                 if (loc != nullptr) {
                     LOG5("Removing location " << loc);
                     currentDefinitions->removeLocation(loc);

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -31,7 +31,9 @@ const cstring StorageFactory::indexFieldName = "$lastIndex"_cs;
 const LocationSet *LocationSet::empty = new LocationSet();
 ProgramPoint ProgramPoint::beforeStart;
 
+#ifdef DEBUG_LOCATION_IDS
 unsigned StorageLocation::crtid = 0;
+#endif
 
 StorageLocation *StorageFactory::create(const IR::Type *type, cstring name) const {
     if (type->is<IR::Type_Bits>() || type->is<IR::Type_Boolean>() || type->is<IR::Type_Varbits>() ||

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "ir/ir.h"
 #include "lib/alloc_trace.h"
+#include "lib/flat_map.h"
 #include "lib/hash.h"
 #include "lib/hvec_map.h"
 #include "lib/ordered_set.h"
@@ -105,8 +106,9 @@ class BaseLocation : public StorageLocation {
 /// Base class for location sets that contain fields
 class WithFieldsLocation : public StorageLocation {
  protected:
-    // FIXME: replace with small flat map with inlined storage
-    hvec_map<cstring, const StorageLocation *> fieldLocations;
+    flat_map<cstring, const StorageLocation *, std::less<>,
+             absl::InlinedVector<std::pair<cstring, const StorageLocation *>, 4>>
+        fieldLocations;
 
     friend class StorageFactory;
     WithFieldsLocation(const IR::Type *type, cstring name) : StorageLocation(type, name) {}

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -82,13 +82,13 @@ class StorageLocation : public IHasDbPrint, public ICastable {
     cstring toString() const { return name; }
 
     /// @returns All locations inside that represent valid bits.
-    const LocationSet *getValidBits() const;
+    LocationSet getValidBits() const;
     virtual void addValidBits(LocationSet *result) const = 0;
     /// @returns All locations inside if we exclude all headers.
     const LocationSet *removeHeaders() const;
     virtual void removeHeaders(LocationSet *result) const = 0;
     /// @returns All locations inside that represent the 'lastIndex' of an array.
-    const LocationSet *getLastIndexField() const;
+    LocationSet getLastIndexField() const;
     virtual void addLastIndexField(LocationSet *result) const = 0;
 
     DECLARE_TYPEINFO(StorageLocation);
@@ -511,7 +511,7 @@ class Definitions : public IHasDbPrint {
         definitions[loc] = point;
     }
     void setDefinition(const StorageLocation *loc, const ProgramPoints *point);
-    void setDefinition(const LocationSet *loc, const ProgramPoints *point);
+    void setDefinition(const LocationSet &loc, const ProgramPoints *point);
     Definitions *setUnreachable() {
         unreachable = true;
         return this;

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -52,17 +52,31 @@ struct loc_t {
 
 /// Abstraction for something that is has a left value (variable, parameter)
 class StorageLocation : public IHasDbPrint, public ICastable {
+#ifdef DEBUG_LOCATION_IDS
     static unsigned crtid;
     unsigned id;
+#endif
 
  public:
     virtual ~StorageLocation() {}
     const IR::Type *type;
     const cstring name;
-    StorageLocation(const IR::Type *type, cstring name) : id(crtid++), type(type), name(name) {
+    StorageLocation(const IR::Type *type, cstring name)
+        :
+#ifdef DEBUG_LOCATION_IDS
+          id(crtid++),
+#endif
+          type(type),
+          name(name) {
         CHECK_NULL(type);
     }
-    void dbprint(std::ostream &out) const override { out << id << " " << name; }
+    void dbprint(std::ostream &out) const override {
+#ifdef DEBUG_LOCATION_IDS
+        out << id << " " << name;
+#else
+        out << dbp(type) << " " << name;
+#endif
+    }
     cstring toString() const { return name; }
 
     /// @returns All locations inside that represent valid bits.

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -355,7 +355,7 @@ class LocationSet : public IHasDbPrint {
 /// Maps a declaration to its associated storage.
 class StorageMap : public IHasDbPrint {
     /// Storage location for each declaration.
-    hvec_map<const IR::IDeclaration *, StorageLocation *> storage;
+    hvec_map<const IR::IDeclaration *, const StorageLocation *> storage;
     StorageFactory factory;
 
  public:
@@ -366,19 +366,19 @@ class StorageMap : public IHasDbPrint {
         CHECK_NULL(refMap);
         CHECK_NULL(typeMap);
     }
-    StorageLocation *add(const IR::IDeclaration *decl) {
+    const StorageLocation *add(const IR::IDeclaration *decl) {
         CHECK_NULL(decl);
         auto type = typeMap->getType(decl->getNode(), true);
         auto loc = factory.create(type, decl->getName() + "/" + decl->externalName());
         if (loc != nullptr) storage.emplace(decl, loc);
         return loc;
     }
-    StorageLocation *getOrAdd(const IR::IDeclaration *decl) {
-        auto s = getStorage(decl);
+    const StorageLocation *getOrAdd(const IR::IDeclaration *decl) {
+        const auto *s = getStorage(decl);
         if (s != nullptr) return s;
         return add(decl);
     }
-    StorageLocation *getStorage(const IR::IDeclaration *decl) const {
+    const StorageLocation *getStorage(const IR::IDeclaration *decl) const {
         CHECK_NULL(decl);
         auto result = ::P4::get(storage, decl);
         return result;
@@ -580,11 +580,11 @@ class AllDefinitions : public IHasDbPrint {
         atPoint[point] = defs;
     }
 
-    StorageLocation *getStorage(const IR::IDeclaration *decl) const {
+    const StorageLocation *getStorage(const IR::IDeclaration *decl) const {
         return storageMap.getStorage(decl);
     }
 
-    StorageLocation *getOrAddStorage(const IR::IDeclaration *decl) {
+    const StorageLocation *getOrAddStorage(const IR::IDeclaration *decl) {
         return storageMap.getOrAdd(decl);
     }
 

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -110,10 +110,8 @@ class WithFieldsLocation : public StorageLocation {
              absl::InlinedVector<std::pair<cstring, const StorageLocation *>, 4>>
         fieldLocations;
 
-    friend class StorageFactory;
     WithFieldsLocation(const IR::Type *type, cstring name) : StorageLocation(type, name) {}
 
- public:
     void createField(cstring name, StorageLocation *field) {
         fieldLocations.emplace(name, field);
         CHECK_NULL(field);
@@ -121,6 +119,10 @@ class WithFieldsLocation : public StorageLocation {
     void replaceField(cstring field, StorageLocation *replacement) {
         fieldLocations[field] = replacement;
     }
+
+    friend class StorageFactory;
+
+ public:
     auto fields() const { return Values(fieldLocations); }
     void dbprint(std::ostream &out) const override {
         for (auto f : fieldLocations) out << *f.second << " ";
@@ -150,12 +152,13 @@ class StructLocation : public WithFieldsLocation {
 class IndexedLocation : public StorageLocation {
  protected:
     absl::InlinedVector<const StorageLocation *, 8> elements;
-    friend class StorageFactory;
 
     void createElement(unsigned index, StorageLocation *element) {
         elements[index] = element;
         CHECK_NULL(element);
     }
+
+    friend class StorageFactory;
 
  public:
     IndexedLocation(const IR::Type *type, cstring name) : StorageLocation(type, name) {

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -85,7 +85,7 @@ class StorageLocation : public IHasDbPrint, public ICastable {
     LocationSet getValidBits() const;
     virtual void addValidBits(LocationSet *result) const = 0;
     /// @returns All locations inside if we exclude all headers.
-    const LocationSet *removeHeaders() const;
+    LocationSet removeHeaders() const;
     virtual void removeHeaders(LocationSet *result) const = 0;
     /// @returns All locations inside that represent the 'lastIndex' of an array.
     LocationSet getLastIndexField() const;
@@ -504,7 +504,7 @@ class Definitions : public IHasDbPrint {
         : definitions(other.definitions), unreachable(other.unreachable) {}
     Definitions *joinDefinitions(const Definitions *other) const;
     /// Point writes the specified LocationSet.
-    Definitions *writes(ProgramPoint point, const LocationSet *locations) const;
+    Definitions *writes(ProgramPoint point, const LocationSet &locations) const;
     void setDefintion(const BaseLocation *loc, const ProgramPoints *point) {
         CHECK_NULL(loc);
         CHECK_NULL(point);
@@ -525,7 +525,7 @@ class Definitions : public IHasDbPrint {
         BUG_CHECK(r != nullptr, "no definitions found for %1%", location);
         return r;
     }
-    const ProgramPoints *getPoints(const LocationSet *locations) const;
+    const ProgramPoints *getPoints(const LocationSet &locations) const;
     bool operator==(const Definitions &other) const;
     void dbprint(std::ostream &out) const override {
         if (unreachable) {

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -414,7 +414,6 @@ class ProgramPoints : public IHasDbPrint {
  public:
     ProgramPoints() = default;
     explicit ProgramPoints(ProgramPoint point) { points.emplace(point); }
-    void add(ProgramPoint point) { points.emplace(point); }
     void add(const ProgramPoints *from);
     const ProgramPoints *merge(const ProgramPoints *with) const;
     bool operator==(const ProgramPoints &other) const;

--- a/frontends/p4/def_use.h
+++ b/frontends/p4/def_use.h
@@ -52,10 +52,10 @@ struct loc_t {
 /// Abstraction for something that is has a left value (variable, parameter)
 class StorageLocation : public IHasDbPrint, public ICastable {
     static unsigned crtid;
+    unsigned id;
 
  public:
     virtual ~StorageLocation() {}
-    unsigned id;
     const IR::Type *type;
     const cstring name;
     StorageLocation(const IR::Type *type, cstring name) : id(crtid++), type(type), name(name) {
@@ -105,7 +105,9 @@ class BaseLocation : public StorageLocation {
 /// Base class for location sets that contain fields
 class WithFieldsLocation : public StorageLocation {
  protected:
+    // FIXME: replace with small flat map with inlined storage
     hvec_map<cstring, const StorageLocation *> fieldLocations;
+
     friend class StorageFactory;
     WithFieldsLocation(const IR::Type *type, cstring name) : StorageLocation(type, name) {}
 
@@ -117,9 +119,7 @@ class WithFieldsLocation : public StorageLocation {
     void replaceField(cstring field, StorageLocation *replacement) {
         fieldLocations[field] = replacement;
     }
-    IterValues<hvec_map<cstring, const StorageLocation *>::const_iterator> fields() const {
-        return Values(fieldLocations);
-    }
+    auto fields() const { return Values(fieldLocations); }
     void dbprint(std::ostream &out) const override {
         for (auto f : fieldLocations) out << *f.second << " ";
     }

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -1539,14 +1539,13 @@ class RemoveUnused : public Transform {
 
 // Run for each parser and control separately.
 class ProcessDefUse : public PassManager {
-    AllDefinitions *definitions;
+    AllDefinitions definitions;
     HasUses hasUses;
 
  public:
-    ProcessDefUse(ReferenceMap *refMap, TypeMap *typeMap)
-        : definitions(new AllDefinitions(refMap, typeMap)) {
-        passes.push_back(new ComputeWriteSet(definitions));
-        passes.push_back(new FindUninitialized(definitions, &hasUses));
+    ProcessDefUse(ReferenceMap *refMap, TypeMap *typeMap) : definitions(refMap, typeMap) {
+        passes.push_back(new ComputeWriteSet(&definitions));
+        passes.push_back(new FindUninitialized(&definitions, &hasUses));
         passes.push_back(new RemoveUnused(&hasUses, refMap, typeMap));
         setName("ProcessDefUse");
     }

--- a/lib/flat_map.h
+++ b/lib/flat_map.h
@@ -1,0 +1,311 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef LIB_FLAT_MAP_H_
+#define LIB_FLAT_MAP_H_
+
+#include <algorithm>
+#include <functional>
+#include <vector>
+
+namespace P4 {
+
+/// A header-only implementation of a memory-efficient flat_map.
+/// TODO: Replace this map with std::flat_map once available in C++23:
+/// https://en.cppreference.com/w/cpp/container/flat_map
+template <typename K, typename V, typename Compare = std::less<>,
+          typename Container = std::vector<std::pair<K, V>>>
+struct flat_map {
+    using key_type = K;
+    using mapped_type = V;
+    using value_type = typename Container::value_type;
+    using key_compare = Compare;
+
+    struct value_compare {
+        bool operator()(const value_type &lhs, const value_type &rhs) const {
+            return key_compare()(lhs.first, rhs.first);
+        }
+    };
+
+    using allocator_type = typename Container::allocator_type;
+    using reference = typename Container::reference;
+    using const_reference = typename Container::const_reference;
+    using pointer = typename Container::pointer;
+    using const_pointer = typename Container::const_pointer;
+    using iterator = typename Container::iterator;
+    using const_iterator = typename Container::const_iterator;
+    using reverse_iterator = typename Container::reverse_iterator;
+    using const_reverse_iterator = typename Container::const_reverse_iterator;
+    using difference_type = typename Container::difference_type;
+    using size_type = typename Container::size_type;
+
+    flat_map() = default;
+
+    template <typename It>
+    flat_map(It begin, It end) {
+        insert(begin, end);
+    }
+
+    flat_map(std::initializer_list<value_type> il) : flat_map(il.begin(), il.end()) {}
+
+    iterator begin() { return data_.begin(); }
+    iterator end() { return data_.end(); }
+    const_iterator begin() const { return data_.begin(); }
+    const_iterator end() const { return data_.end(); }
+    const_iterator cbegin() const { return data_.cbegin(); }
+    const_iterator cend() const { return data_.cend(); }
+    reverse_iterator rbegin() { return data_.rbegin(); }
+    reverse_iterator rend() { return data_.rend(); }
+    const_reverse_iterator rbegin() const { return data_.rbegin(); }
+    const_reverse_iterator rend() const { return data_.rend(); }
+    const_reverse_iterator crbegin() const { return data_.crbegin(); }
+    const_reverse_iterator crend() const { return data_.crend(); }
+
+    bool empty() const { return data_.empty(); }
+    size_type size() const { return data_.size(); }
+    size_type max_size() const { return data_.max_size(); }
+    size_type capacity() const { return data_.capacity(); }
+    void reserve(size_type size) { data_.reserve(size); }
+    void shrink_to_fit() { data_.shrink_to_fit(); }
+    size_type bytes_used() const { return capacity() * sizeof(value_type) + sizeof(data_); }
+
+    mapped_type &operator[](const key_type &key) {
+        KeyOrValueCompare comp;
+        auto lower = lower_bound(key);
+        if (lower == end() || comp(key, *lower))
+            return data_.emplace(lower, key, mapped_type())->second;
+
+        return lower->second;
+    }
+
+    mapped_type &operator[](key_type &&key) {
+        KeyOrValueCompare comp;
+        auto lower = lower_bound(key);
+        if (lower == end() || comp(key, *lower))
+            return data_.emplace(lower, std::move(key), mapped_type())->second;
+
+        return lower->second;
+    }
+
+    template <class Key>
+    mapped_type &at(const Key &key) {
+        auto found = lower_bound(key);
+        if (found == end()) throw std::out_of_range("key is out of range");
+        return found->second;
+    }
+    template <class Key>
+    const mapped_type &at(const Key &key) const {
+        auto found = lower_bound(key);
+        if (found == end()) throw std::out_of_range("key is out of range");
+        return found->second;
+    }
+
+    std::pair<iterator, bool> insert(value_type &&value) { return emplace(std::move(value)); }
+
+    std::pair<iterator, bool> insert(const value_type &value) { return emplace(value); }
+
+    iterator insert(const_iterator hint, value_type &&value) {
+        return emplace_hint(hint, std::move(value));
+    }
+
+    iterator insert(const_iterator hint, const value_type &value) {
+        return emplace_hint(hint, value);
+    }
+
+    template <typename It>
+    void insert(It begin, It end) {
+        // If we need to increase the capacity, utilize this fact and emplace
+        // the stuff.
+        for (; begin != end && size() == capacity(); ++begin) {
+            emplace(*begin);
+        }
+        if (begin == end) return;
+
+        // If we don't need to increase capacity, then we can use a more efficient
+        // insert method where everything is just put in the same vector
+        // and then merge in place.
+        size_type size_before = data_.size();
+        try {
+            for (size_t i = capacity(); i > size_before && begin != end; --i, ++begin) {
+                data_.emplace_back(*begin);
+            }
+        } catch (...) {
+            // If emplace_back throws an exception, the easiest way to make sure
+            // that our invariants are still in place is to resize to the state
+            // we were in before
+            for (size_t i = data_.size(); i > size_before; --i) {
+                data_.pop_back();
+            }
+            throw;
+        }
+
+        value_compare comp;
+        auto mid = data_.begin() + size_before;
+        std::stable_sort(mid, data_.end(), comp);
+        std::inplace_merge(data_.begin(), mid, data_.end(), comp);
+        data_.erase(std::unique(data_.begin(), data_.end(), std::not_fn(comp)), data_.end());
+
+        // Make sure that we inserted at least one element before
+        // recursing. Otherwise we'd recurse too often if we were to insert the
+        // same element many times
+        if (data_.size() == size_before) {
+            for (; begin != end; ++begin) {
+                if (emplace(*begin).second) {
+                    ++begin;
+                    break;
+                }
+            }
+        }
+
+        // Insert the remaining elements that didn't fit by calling this function recursively.
+        return insert(begin, end);
+    }
+
+    void insert(std::initializer_list<value_type> il) { insert(il.begin(), il.end()); }
+
+    iterator erase(iterator it) { return data_.erase(it); }
+
+    iterator erase(const_iterator it) { return erase(iterator_const_cast(it)); }
+
+    size_type erase(const key_type &key) {
+        auto found = find(key);
+        if (found == end()) return 0;
+        erase(found);
+        return 1;
+    }
+
+    iterator erase(const_iterator first, const_iterator last) {
+        return data_.erase(iterator_const_cast(first), iterator_const_cast(last));
+    }
+
+    void swap(flat_map &other) { data_.swap(other.data_); }
+
+    void clear() { data_.clear(); }
+
+    template <typename First, typename... Args>
+    std::pair<iterator, bool> emplace(First &&first, Args &&...args) {
+        KeyOrValueCompare comp;
+        auto lower_bound = std::lower_bound(data_.begin(), data_.end(), first, comp);
+        if (lower_bound == data_.end() || comp(first, *lower_bound))
+            return {
+                data_.emplace(lower_bound, std::forward<First>(first), std::forward<Args>(args)...),
+                true};
+
+        return {lower_bound, false};
+    }
+
+    std::pair<iterator, bool> emplace() { return emplace(value_type()); }
+
+    template <typename First, typename... Args>
+    iterator emplace_hint(const_iterator hint, First &&first, Args &&...args) {
+        KeyOrValueCompare comp;
+        if (hint == cend() || comp(first, *hint)) {
+            if (hint == cbegin() || comp(*(hint - 1), first))
+                return data_.emplace(iterator_const_cast(hint), std::forward<First>(first),
+                                     std::forward<Args>(args)...);
+
+            return emplace(std::forward<First>(first), std::forward<Args>(args)...).first;
+        } else if (!comp(*hint, first)) {
+            return begin() + (hint - cbegin());
+        }
+
+        return emplace(std::forward<First>(first), std::forward<Args>(args)...).first;
+    }
+
+    iterator emplace_hint(const_iterator hint) { return emplace_hint(hint, value_type()); }
+
+    key_compare key_comp() const { return key_compare(); }
+    value_compare value_comp() const { return value_compare(); }
+
+    template <typename T>
+    iterator find(const T &key) {
+        return binary_find(begin(), end(), key, KeyOrValueCompare());
+    }
+    template <typename T>
+    const_iterator find(const T &key) const {
+        return binary_find(begin(), end(), key, KeyOrValueCompare());
+    }
+    template <typename T>
+    size_type count(const T &key) const {
+        return std::binary_search(begin(), end(), key, KeyOrValueCompare()) ? 1 : 0;
+    }
+    template <typename T>
+    iterator lower_bound(const T &key) {
+        return std::lower_bound(begin(), end(), key, KeyOrValueCompare());
+    }
+    template <typename T>
+    const_iterator lower_bound(const T &key) const {
+        return std::lower_bound(begin(), end(), key, KeyOrValueCompare());
+    }
+    template <typename T>
+    iterator upper_bound(const T &key) {
+        return std::upper_bound(begin(), end(), key, KeyOrValueCompare());
+    }
+    template <typename T>
+    const_iterator upper_bound(const T &key) const {
+        return std::upper_bound(begin(), end(), key, KeyOrValueCompare());
+    }
+    template <typename T>
+    std::pair<iterator, iterator> equal_range(const T &key) {
+        return std::equal_range(begin(), end(), key, KeyOrValueCompare());
+    }
+    template <typename T>
+    std::pair<const_iterator, const_iterator> equal_range(const T &key) const {
+        return std::equal_range(begin(), end(), key, KeyOrValueCompare());
+    }
+    allocator_type get_allocator() const { return data_.get_allocator(); }
+
+    bool operator==(const flat_map &other) const { return data_ == other.data_; }
+    bool operator!=(const flat_map &other) const { return !(*this == other); }
+    bool operator<(const flat_map &other) const { return data_ < other.data_; }
+    bool operator>(const flat_map &other) const { return other < *this; }
+    bool operator<=(const flat_map &other) const { return !(other < *this); }
+    bool operator>=(const flat_map &other) const { return !(*this < other); }
+
+ private:
+    Container data_;
+
+    iterator iterator_const_cast(const_iterator it) { return begin() + (it - cbegin()); }
+
+    struct KeyOrValueCompare {
+        template <typename T, typename U>
+        bool operator()(const T &lhs, const U &rhs) const {
+            return key_compare()(extract(lhs), extract(rhs));
+        }
+
+     private:
+        const key_type &extract(const value_type &v) const { return v.first; }
+
+        template <typename Key>
+        const Key &extract(const Key &k) const {
+            return k;
+        }
+    };
+
+    template <typename It, typename T, typename Comp>
+    static It binary_find(It begin, It end, const T &value, const Comp &cmp) {
+        auto lower_bound = std::lower_bound(begin, end, value, cmp);
+        if (lower_bound == end || cmp(value, *lower_bound)) return end;
+
+        return lower_bound;
+    }
+};
+
+template <typename K, typename V, typename C, typename Cont>
+void swap(flat_map<K, V, C, Cont> &lhs, flat_map<K, V, C, Cont> &rhs) {
+    lhs.swap(rhs);
+}
+
+}  // namespace P4
+
+#endif  // LIB_FLAT_MAP_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ set (GTEST_UNITTEST_SOURCES
   gtest/equiv_test.cpp
   gtest/exception_test.cpp
   gtest/expr_uses_test.cpp
+  gtest/flat_map.cpp
   gtest/format_test.cpp
   gtest/helpers.cpp
   gtest/hash.cpp

--- a/test/gtest/flat_map.cpp
+++ b/test/gtest/flat_map.cpp
@@ -1,0 +1,273 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "lib/flat_map.h"
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+#include "lib/map.h"
+
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+
+namespace P4::Test {
+
+TEST(FlatMap, RangeConstructor) {
+    flat_map<unsigned, unsigned>::value_type myMap[] = {{1, 1}, {1, 2}, {1, 3}, {2, 1}, {2, 2},
+                                                        {2, 3}, {3, 1}, {3, 2}, {3, 3}};
+
+    flat_map<unsigned, unsigned> first(std::begin(myMap), std::end(myMap));
+    EXPECT_THAT(first,
+                ElementsAre(std::make_pair(1, 1), std::make_pair(2, 1), std::make_pair(3, 1)));
+}
+
+TEST(FlatMap, InitializerListConstructor) {
+    flat_map<unsigned, unsigned> myMap(
+        {{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {1, 2}, {10, 10}, {8, 8}});
+    EXPECT_THAT(myMap, ElementsAre(std::make_pair(1, 1), std::make_pair(2, 2), std::make_pair(3, 3),
+                                   std::make_pair(4, 4), std::make_pair(5, 5), std::make_pair(8, 8),
+                                   std::make_pair(10, 10)));
+}
+
+TEST(FlatMap, InitializerListAssignment) {
+    flat_map<unsigned, unsigned> myMap;
+    myMap = {{1, 1}, {2, 2}};
+    EXPECT_THAT(myMap, ElementsAre(std::make_pair(1, 1), std::make_pair(2, 2)));
+}
+
+TEST(FlatMap, InsertFindSize) {
+    flat_map<unsigned, unsigned> s;
+    s.insert(std::make_pair(1, 1));
+    s.insert(std::make_pair(1, 1));
+    s.insert(std::make_pair(2, 2));
+
+    EXPECT_EQ(2u, s.size());
+    EXPECT_EQ(std::make_pair(1u, 1u), *s.find(1));
+    EXPECT_EQ(std::make_pair(2u, 2u), *s.find(2));
+    EXPECT_EQ(s.end(), s.find(7));
+}
+
+TEST(FlatMap, CopySwap) {
+    flat_map<unsigned, unsigned> original;
+    original.insert({1, 1});
+    original.insert({2, 2});
+    EXPECT_THAT(original, ElementsAre(std::make_pair(1, 1), std::make_pair(2, 2)));
+
+    flat_map<unsigned, unsigned> copy(original);
+    EXPECT_THAT(copy, ElementsAre(std::make_pair(1, 1), std::make_pair(2, 2)));
+
+    copy.erase(copy.begin());
+    copy.insert({10, 10});
+    EXPECT_THAT(copy, ElementsAre(std::make_pair(2, 2), std::make_pair(10, 10)));
+
+    original.swap(copy);
+    EXPECT_THAT(original, ElementsAre(std::make_pair(2, 2), std::make_pair(10, 10)));
+    EXPECT_THAT(copy, ElementsAre(std::make_pair(1, 1), std::make_pair(2, 2)));
+}
+
+// operator[](const Key&)
+TEST(FlatMap, SubscriptConstKey) {
+    flat_map<std::string, unsigned> m;
+
+    // Default construct elements that don't exist yet.
+    unsigned &s = m["a"];
+    EXPECT_EQ(0, s);
+    EXPECT_EQ(1u, m.size());
+
+    // The returned mapped reference should refer unsignedo the map.
+    s = 22;
+    EXPECT_EQ(22, m["a"]);
+
+    // Overwrite existing elements.
+    m["a"] = 44;
+    EXPECT_EQ(44, m["a"]);
+}
+
+// mapped_type& at(const Key&)
+// const mapped_type& at(const Key&) const
+TEST(FlatMap, At) {
+    flat_map<unsigned, std::string> m = {{1, "a"}, {2, "b"}};
+
+    // basic usage.
+    EXPECT_EQ("a", m.at(1));
+    EXPECT_EQ("b", m.at(2));
+
+    // const reference works.
+    const std::string &const_ref = std::as_const(m).at(1);
+    EXPECT_EQ("a", const_ref);
+
+    // reference works, can operate on the string.
+    m.at(1)[0] = 'x';
+    EXPECT_EQ("x", m.at(1));
+
+    // out-of-bounds will throw.
+    EXPECT_THROW(m.at(-1), std::out_of_range);
+    EXPECT_THROW({ m.at(-1)[0] = 'z'; }, std::out_of_range);
+
+    // heterogeneous look-up works.
+    flat_map<std::string, unsigned> m2 = {{"a", 1}, {"b", 2}};
+    EXPECT_EQ(1, m2.at(std::string_view("a")));
+    EXPECT_EQ(2, std::as_const(m2).at(std::string_view("b")));
+}
+
+TEST(FlatMap, MapEqual) {
+    flat_map<unsigned, unsigned> a;
+    flat_map<unsigned, unsigned> b;
+
+    EXPECT_EQ(a, b);
+
+    a[1] = 111;
+    a[2] = 222;
+    a[3] = 333;
+    a[4] = 444;
+
+    b[1] = 111;
+    b[2] = 222;
+    b[3] = 333;
+    b[4] = 444;
+
+    EXPECT_EQ(a, b);
+
+    a.erase(2);
+    b.erase(2);
+
+    EXPECT_EQ(a, b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_EQ(a, b);
+}
+
+TEST(FlatMap, MapNotEqual) {
+    flat_map<unsigned, unsigned> a;
+    flat_map<unsigned, unsigned> b;
+
+    EXPECT_EQ(a, b);
+
+    a[1] = 111;
+    a[2] = 222;
+    a[3] = 333;
+    a[4] = 444;
+
+    b[4] = 444;
+    b[3] = 333;
+    b[2] = 222;
+    b[1] = 111;
+
+    EXPECT_EQ(a, b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_EQ(a, b);
+
+    a[1] = 111;
+    a[2] = 222;
+
+    b[1] = 111;
+    b[2] = 222;
+    b[3] = 333;
+
+    EXPECT_NE(a, b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_EQ(a, b);
+
+    a[1] = 111;
+    a[2] = 222;
+    a[3] = 333;
+    a[4] = 444;
+
+    b[4] = 111;
+    b[3] = 222;
+    b[2] = 333;
+    b[1] = 444;
+
+    EXPECT_NE(a, b);
+
+    a.clear();
+    b.clear();
+
+    EXPECT_EQ(a, b);
+
+    a[1] = 111;
+    a[2] = 222;
+    a[3] = 333;
+    a[4] = 444;
+
+    b[1] = 111;
+    b[2] = 111;
+    b[3] = 111;
+    b[4] = 111;
+
+    EXPECT_NE(a, b);
+}
+
+TEST(FlatMap, InsertEmplaceErase) {
+    flat_map<unsigned, unsigned> om;
+    std::map<unsigned, unsigned> sm;
+
+    auto it = om.end();
+    for (auto v : {0, 1, 2, 3, 4, 5, 6, 7, 8}) {
+        sm.emplace(v, 2 * v);
+        std::pair<unsigned, unsigned> pair{v, 2 * v};
+        if (v % 2 == 0) {
+            if ((v / 2) % 2 == 0) {
+                it = om.insert(pair).first;
+            } else {
+                it = om.emplace(v, pair.second).first;
+            }
+        } else {
+            if ((v / 2) % 2 == 0) {
+                it = om.insert(std::move(pair)).first;
+            } else {
+                it = om.emplace(v, v * 2).first;
+            }
+        }
+    }
+
+    EXPECT_THAT(om, ElementsAreArray(sm.begin(), sm.end()));
+
+    it = std::next(om.begin(), 2);
+    om.erase(it);
+    sm.erase(std::next(sm.begin(), 2));
+
+    EXPECT_EQ(om.size(), sm.size());
+
+    EXPECT_THAT(om, ElementsAreArray(sm.begin(), sm.end()));
+}
+
+TEST(FlatMap, ExistingKey) {
+    flat_map<unsigned, std::string> myMap{{1, "One"}, {2, "Two"}, {3, "Three"}};
+
+    EXPECT_EQ(get(myMap, 1), "One");
+    EXPECT_EQ(get(myMap, 2), "Two");
+    EXPECT_EQ(get(myMap, 3), "Three");
+}
+
+TEST(FlatMap, NonExistingKey) {
+    flat_map<unsigned, std::string> myMap{{1, "One"}, {2, "Two"}, {3, "Three"}};
+
+    EXPECT_EQ(get(myMap, 4), "");
+}
+
+}  // namespace P4::Test


### PR DESCRIPTION
As stated in https://github.com/p4lang/p4c/issues/4872 we are seeing high peak memory usage during def-use run. def-use creates lots of temporary objects and expects GC to clean them. However, it seems this does not happen reliably and therefore the peak memory usage could be very high. Especially given that def-use internal state objects (`AllDefinitions`) could be quite large. This PR tries to improve this situation in many aspects:

 * Shrink the lifetime of transient objects (this seems to be enough to reduce the memory consumption in the downstream testcase from 16+ Gb down to 2 Gb)
 * Reduce the amount of leaks - less work for GC and in many cases less allocation as we are allocating transient things on stack
 * Some improvements in internal structures as well

As a result:
 - The peak memory allocation in #4872 dropped down to 2 Gb (due to `AllDefinitions` being cleared)
 - We are seeing nice improvements in `gtestp4c --gtest_filter=P4CParserUnroll.switch_20160512` testcase:

1. 2% runtime improvements with GC both on and off:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `gtestp4c-gc-main --gtest_filter=P4CParserUnroll.switch_20160512` | 4.506 ± 0.088 | 4.365 | 4.659 | 1.02 ± 0.03 |
| `gtestp4c-gc --gtest_filter=P4CParserUnroll.switch_20160512` | 4.418 ± 0.086 | 4.194 | 4.502 | 1.00 |

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `gtestp4c-nogc-main --gtest_filter=P4CParserUnroll.switch_20160512` | 3.041 ± 0.024 | 3.004 | 3.099 | 1.01 ± 0.01 |
| `gtestp4c-nogc --gtest_filter=P4CParserUnroll.switch_20160512` | 2.996 ± 0.032 | 2.964 | 3.095 | 1.00 |

But notice that GC takes 1.5 seconds out of overall 4.5 seconds runtime (!)

2. We reduced the amount of memory allocations by 10% as well.
Before:
![image](https://github.com/user-attachments/assets/8aa90f6b-f14a-43dc-98f5-9a0d586ab7d7)

After:
![image](https://github.com/user-attachments/assets/62df8fa1-13dc-48c8-9355-ea4032a7dcb1)

Notice that # of allocations reduced from 27.6M down to 25.7M, the peak memory consumption also reduced from 3.22 GB down to 3.15 Gb

