### PR TITLE
Only process `IR::Path`s inside of `IR::ParserState` contexts in `MoveInitializers`

### DIFF
--- a/frontends/p4/moveDeclarations.cpp
+++ b/frontends/p4/moveDeclarations.cpp
@@ -180,6 +180,8 @@ const IR::Node *MoveInitializers::postorder(IR::ParserState *state) {
 }
 
 const IR::Node *MoveInitializers::postorder(IR::Path *path) {
+    if (!findContext<IR::ParserState>()) return path;
+
     if (!oldStart || !loopsBackToStart || path->name != IR::ParserState::start) return path;
 
     // Only rename start state references if the parser contains initializing assignments


### PR DESCRIPTION
Fixes UB introduced by #4902