### PR TITLE
Fix parser symbolic interpreter to evaluate StringLiteral

### DIFF
--- a/test/gtest/parser_unroll.cpp
+++ b/test/gtest/parser_unroll.cpp
@@ -147,4 +147,11 @@ TEST_F(P4CParserUnroll, header_union) {
     ASSERT_EQ(parsers.first->states.size(), parsers.second->states.size());
 }
 
+TEST_F(P4CParserUnroll, stringTypes) {
+    auto parsers = loadExample("issue4932.p4");
+    ASSERT_TRUE(parsers.first);
+    ASSERT_TRUE(parsers.second);
+    ASSERT_EQ(parsers.first->states.size(), parsers.second->states.size());
+}
+
 }  // namespace P4::Test

--- a/testdata/p4_16_samples/issue4932.p4
+++ b/testdata/p4_16_samples/issue4932.p4
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+extern void log(string msg);
+
+parser SimpleParser();
+package SimpleArch(SimpleParser p);
+
+parser ParserImpl()
+{
+    state start {
+        log("Log message" ++ " text");
+        transition accept;
+    }
+}
+
+SimpleArch(ParserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4932-first.p4
+++ b/testdata/p4_16_samples_outputs/issue4932-first.p4
@@ -1,0 +1,11 @@
+extern void log(string msg);
+parser SimpleParser();
+package SimpleArch(SimpleParser p);
+parser ParserImpl() {
+    state start {
+        log("Log message text");
+        transition accept;
+    }
+}
+
+SimpleArch(ParserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4932-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue4932-frontend.p4
@@ -1,0 +1,11 @@
+extern void log(string msg);
+parser SimpleParser();
+package SimpleArch(SimpleParser p);
+parser ParserImpl() {
+    state start {
+        log("Log message text");
+        transition accept;
+    }
+}
+
+SimpleArch(ParserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4932-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue4932-midend.p4
@@ -1,0 +1,11 @@
+extern void log(string msg);
+parser SimpleParser();
+package SimpleArch(SimpleParser p);
+parser ParserImpl() {
+    state start {
+        log("Log message text");
+        transition accept;
+    }
+}
+
+SimpleArch(ParserImpl()) main;

--- a/testdata/p4_16_samples_outputs/issue4932.p4
+++ b/testdata/p4_16_samples_outputs/issue4932.p4
@@ -1,0 +1,11 @@
+extern void log(string msg);
+parser SimpleParser();
+package SimpleArch(SimpleParser p);
+parser ParserImpl() {
+    state start {
+        log("Log message" ++ " text");
+        transition accept;
+    }
+}
+
+SimpleArch(ParserImpl()) main;


### PR DESCRIPTION
Add support for StringLiteral in ExpressionEvaluator. Fixes #4932