### PR TITLE
Reorder subdirectory additions in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,10 @@ set(P4RUNTIME_STD_DIR ${p4runtime_SOURCE_DIR}/proto CACHE INTERNAL
 )
 ########################################## P4Runtime End ##########################################
 
+add_subdirectory (frontends)
+add_subdirectory (midend)
+add_subdirectory (control-plane)
+
 file (GLOB p4c_extensions RELATIVE ${P4C_SOURCE_DIR}/extensions ${P4C_SOURCE_DIR}/extensions/*)
 MESSAGE ("-- Available extensions ${p4c_extensions}")
 foreach (ext ${p4c_extensions})
@@ -449,10 +453,6 @@ foreach (ext ${p4c_extensions})
     endif()
   endif()
 endforeach(ext)
-
-add_subdirectory (frontends)
-add_subdirectory (midend)
-add_subdirectory (control-plane)
 
 # With the current implementation of ir-generator, all targets share the
 # same ir-generated.h and ir-generated.cpp file, which means all targets


### PR DESCRIPTION
Move add_subdirectory commands for frontends, midend, and control-plane before the extension processing loop. This ensures that classes declared in ir-generated.h from the frontends is available when processing extensions.