### PR TITLE
extend type checking to mark extern function call that returns enum a…

### DIFF
--- a/frontends/p4/typeChecking/typeCheckExpr.cpp
+++ b/frontends/p4/typeChecking/typeCheckExpr.cpp
@@ -2158,11 +2158,20 @@ const IR::Node *TypeInferenceBase::postorder(const IR::MethodCallExpression *exp
             if (const auto *sc = returnType->to<IR::Type_SpecializedCanonical>())
                 baseReturnType = sc->baseType;
             const bool factoryOrStaticAssert =
-                baseReturnType->is<IR::Type_Extern>() || ef->method->name == "static_assert";
+                baseReturnType->is<IR::Type_Extern>() || ef->method->name == "static_assert" ||
+                baseReturnType->is<IR::Type_Enum>();
             if (constArgs && factoryOrStaticAssert) {
-                // factory extern function calls (those that return extern objects) with constant
-                // args are compile-time constants.
-                // The result of a static_assert call is also a compile-time constant.
+                // This condition checks for three specific cases:
+                // 1. Factory extern function calls (those that return extern objects)
+                // 2. Calls to static_assert
+                // 3. Functions that return enum types
+                // If all arguments are constant and one of these conditions is met,
+                // the result is considered a compile-time constant.
+                //
+                // For factory functions, this allows compile-time instantiation of extern objects.
+                // For static_assert, the result is always a compile-time constant.
+                // For enum types, this ensures that enum operations with constant inputs
+                // are evaluated at compile-time.
                 setCompileTimeConstant(expression);
                 setCompileTimeConstant(getOriginal<IR::Expression>());
             }

--- a/frontends/p4/typeChecking/typeCheckExpr.cpp
+++ b/frontends/p4/typeChecking/typeCheckExpr.cpp
@@ -2157,11 +2157,10 @@ const IR::Node *TypeInferenceBase::postorder(const IR::MethodCallExpression *exp
             const IR::Type *baseReturnType = returnType;
             if (const auto *sc = returnType->to<IR::Type_SpecializedCanonical>())
                 baseReturnType = sc->baseType;
-            const bool factoryOrStaticAssert =
-                baseReturnType->is<IR::Type_Extern>() || ef->method->name == "static_assert";
-            const bool hasPureAnnotation =
+            const bool factoryOrStaticAssertOrPureAnnot =
+                baseReturnType->is<IR::Type_Extern>() || ef->method->name == "static_assert" ||
                 ef->method->getAnnotation(IR::Annotation::pureAnnotation);
-            if (constArgs && (factoryOrStaticAssert || hasPureAnnotation)) {
+            if (constArgs && factoryOrStaticAssertOrPureAnnot) {
                 // factory extern function calls (those that return extern objects) with constant
                 // args are compile-time constants.
                 // The result of a static_assert call is also a compile-time constant

--- a/testdata/p4_16_samples/hashext3.p4
+++ b/testdata/p4_16_samples/hashext3.p4
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+enum HashAlgorithm_t {
+    IDENTITY,
+    RANDOM
+}
+
+extern HashAlgorithm_t identity_hash(bool msb, bool extend);
+extern HashAlgorithm_t random_hash(bool msb, bool extend);
+
+extern Hash<W> {
+    /// Constructor
+    /// @type_param W : width of the calculated hash.
+    /// @param algo : The default algorithm used for hash calculation.
+    Hash(HashAlgorithm_t algo);
+
+    /// Compute the hash for the given data.
+    /// @param data : The list of fields contributing to the hash.
+    /// @return The hash value.
+    W get<D>(in D data);
+}
+
+header h1_t {
+    bit<32>     f1;
+    bit<32>     f2;
+    bit<32>     f3;
+}
+
+struct hdrs {
+    h1_t        h1;
+    bit<16>     hash;
+}
+
+control test(inout hdrs hdr) {
+    apply {
+        hdr.hash = Hash<bit<16>>(random_hash(false, false)).get(hdr.h1);
+    }
+}

--- a/testdata/p4_16_samples/hashext3.p4
+++ b/testdata/p4_16_samples/hashext3.p4
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Barefoot Networks, Inc.
+Copyright 2024 Intel Corp.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ enum HashAlgorithm_t {
     RANDOM
 }
 
-extern HashAlgorithm_t identity_hash(bool msb, bool extend);
-extern HashAlgorithm_t random_hash(bool msb, bool extend);
+@pure extern HashAlgorithm_t identity_hash(bool msb, bool extend);
+@pure extern HashAlgorithm_t random_hash(bool msb, bool extend);
 
 extern Hash<W> {
     /// Constructor

--- a/testdata/p4_16_samples_outputs/hashext3-first.p4
+++ b/testdata/p4_16_samples_outputs/hashext3-first.p4
@@ -1,0 +1,29 @@
+enum HashAlgorithm_t {
+    IDENTITY,
+    RANDOM
+}
+
+extern HashAlgorithm_t identity_hash(bool msb, bool extend);
+extern HashAlgorithm_t random_hash(bool msb, bool extend);
+extern Hash<W> {
+    Hash(HashAlgorithm_t algo);
+    W get<D>(in D data);
+}
+
+header h1_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<32> f3;
+}
+
+struct hdrs {
+    h1_t    h1;
+    bit<16> hash;
+}
+
+control test(inout hdrs hdr) {
+    apply {
+        hdr.hash = Hash<bit<16>>(random_hash(false, false)).get<h1_t>(hdr.h1);
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/hashext3-first.p4
+++ b/testdata/p4_16_samples_outputs/hashext3-first.p4
@@ -3,8 +3,8 @@ enum HashAlgorithm_t {
     RANDOM
 }
 
-extern HashAlgorithm_t identity_hash(bool msb, bool extend);
-extern HashAlgorithm_t random_hash(bool msb, bool extend);
+@pure extern HashAlgorithm_t identity_hash(bool msb, bool extend);
+@pure extern HashAlgorithm_t random_hash(bool msb, bool extend);
 extern Hash<W> {
     Hash(HashAlgorithm_t algo);
     W get<D>(in D data);

--- a/testdata/p4_16_samples_outputs/hashext3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hashext3-frontend.p4
@@ -1,0 +1,23 @@
+enum HashAlgorithm_t {
+    IDENTITY,
+    RANDOM
+}
+
+extern HashAlgorithm_t identity_hash(bool msb, bool extend);
+extern HashAlgorithm_t random_hash(bool msb, bool extend);
+extern Hash<W> {
+    Hash(HashAlgorithm_t algo);
+    W get<D>(in D data);
+}
+
+header h1_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<32> f3;
+}
+
+struct hdrs {
+    h1_t    h1;
+    bit<16> hash;
+}
+

--- a/testdata/p4_16_samples_outputs/hashext3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/hashext3-frontend.p4
@@ -3,8 +3,8 @@ enum HashAlgorithm_t {
     RANDOM
 }
 
-extern HashAlgorithm_t identity_hash(bool msb, bool extend);
-extern HashAlgorithm_t random_hash(bool msb, bool extend);
+@pure extern HashAlgorithm_t identity_hash(bool msb, bool extend);
+@pure extern HashAlgorithm_t random_hash(bool msb, bool extend);
 extern Hash<W> {
     Hash(HashAlgorithm_t algo);
     W get<D>(in D data);

--- a/testdata/p4_16_samples_outputs/hashext3.p4
+++ b/testdata/p4_16_samples_outputs/hashext3.p4
@@ -3,8 +3,8 @@ enum HashAlgorithm_t {
     RANDOM
 }
 
-extern HashAlgorithm_t identity_hash(bool msb, bool extend);
-extern HashAlgorithm_t random_hash(bool msb, bool extend);
+@pure extern HashAlgorithm_t identity_hash(bool msb, bool extend);
+@pure extern HashAlgorithm_t random_hash(bool msb, bool extend);
 extern Hash<W> {
     Hash(HashAlgorithm_t algo);
     W get<D>(in D data);

--- a/testdata/p4_16_samples_outputs/hashext3.p4
+++ b/testdata/p4_16_samples_outputs/hashext3.p4
@@ -1,0 +1,29 @@
+enum HashAlgorithm_t {
+    IDENTITY,
+    RANDOM
+}
+
+extern HashAlgorithm_t identity_hash(bool msb, bool extend);
+extern HashAlgorithm_t random_hash(bool msb, bool extend);
+extern Hash<W> {
+    Hash(HashAlgorithm_t algo);
+    W get<D>(in D data);
+}
+
+header h1_t {
+    bit<32> f1;
+    bit<32> f2;
+    bit<32> f3;
+}
+
+struct hdrs {
+    h1_t    h1;
+    bit<16> hash;
+}
+
+control test(inout hdrs hdr) {
+    apply {
+        hdr.hash = Hash<bit<16>>(random_hash(false, false)).get(hdr.h1);
+    }
+}
+

--- a/testdata/p4_16_samples_outputs/hashext3.p4-stderr
+++ b/testdata/p4_16_samples_outputs/hashext3.p4-stderr
@@ -1,0 +1,4 @@
+hashext3.p4(48): [--Wwarn=unused] warning: Control test is not used; removing
+control test(inout hdrs hdr) {
+        ^^^^
+[--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/issue4661_pure_extern_function_const_args.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue4661_pure_extern_function_const_args.p4-stderr
@@ -1,0 +1,3 @@
+issue4661_pure_extern_function_const_args.p4(13): [--Wwarn=mismatch] warning: baz(): constant expression in switch
+        switch(baz()) {
+               ^^^^^


### PR DESCRIPTION
…s compile time constant

This is an regression fix related to https://github.com/p4lang/p4c/pull/4726

In tofino backend, we have a use case that requires treating extern function returning enum as a compile-time constant. Example in hashext3.p4