### PR TITLE
fixing build error: undefined symbol: void boost::hash_combine

### DIFF
--- a/ir/expression.cpp
+++ b/ir/expression.cpp
@@ -16,6 +16,8 @@ limitations under the License.
 
 #include <ostream>
 
+#include <boost/functional/hash.hpp>
+
 #include "absl/container/flat_hash_map.h"
 #include "ir/id.h"
 #include "ir/indexed_vector.h"


### PR DESCRIPTION
I'm unable to build p4c on Ubuntu 20.04 without this change.

This is the error message.

```
ld.lld: error: undefined symbol: void boost::hash_combine<unsigned long long>(unsigned long&, unsigned long long const&)                                                           
>>> referenced by expression.cpp                                                                                                                                                   >>>               expression.cpp.o:(P4::IR::Constant::get(P4::IR::Type const*, boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long long> >, (boost::multiprecision::expression_template_option)1>, P4::Util::SourceInfo)) in archive ../../ir/libir.a                                                                                                                                          >>> referenced by expression.cpp                                                                                                                                                   >>>               expression.cpp.o:(absl::lts_20240116::container_internal::raw_hash_set<absl::lts_20240116::container_internal::FlatHashMapPolicy<std::tuple<int, unsigned long, bool, boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long long> >, (boost::multiprecision::expression_template_option)1> >, P4::IR::Constant const*>, P4::Util::Hash, std::equal_to<std::tuple<int, unsigned long, bool, boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long long> >, (boost::multiprecision::expression_template_option)1> > >, std::allocator<std::pair<std::tuple<int, unsigned long, bool, boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long long> >, (boost::multiprecision::expression_template_option)1> > const, P4::IR::Constant const*> > >::hash_slot_fn(void*, void*)) in archive ../../ir/libir.a     >>> referenced by expression.cpp                                                                                                                                                   >>>               expression.cpp.o:(absl::lts_20240116::container_internal::raw_hash_set<absl::lts_20240116::container_internal::FlatHashMapPolicy<std::tuple<int, unsigned long, bool, boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long long> >, (boost::multiprecision::expression_template_option)1> >, P4::IR::Constant const*>, P4::Util::Hash, std::equal_to<std::tuple<int, unsigned long, bool, boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long long> >, (boost::multiprecision::expression_template_option)1> > >, std::allocator<std::pair<std::tuple<int, unsigned long, bool, boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long long> >, (boost::multiprecision::expression_template_option)1> > const, P4::IR::Constant const*> > >::resize(unsigned long)) in archive ../../ir/libir.a 
```