### PR TITLE
Add Vector::dbprint

### DIFF
--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "ir/vector.h"
 #include "lib/enumerator.h"
 #include "lib/error.h"
+#include "lib/indent.h"
 #include "lib/map.h"
 #include "lib/null.h"
 #include "lib/safe_vector.h"
@@ -219,6 +220,14 @@ class IndexedVector : public Vector<T> {
             BUG_CHECK(it != declarations.end() && it->second->getNode() == el->getNode(),
                       "invalid element %1%", el);
         }
+    }
+
+    void dbprint(std::ostream &out) const override {
+        out << "{" << IndentCtl::indent;
+        for (auto p : *this) {
+            out << " " << p;
+        }
+        out << IndentCtl::unindent << " }";
     }
 
     DECLARE_TYPEINFO_WITH_DISCRIMINATOR(IndexedVector<T>, NodeDiscriminator::IndexedVectorT, T,

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -21,7 +21,6 @@ limitations under the License.
 #include "ir/vector.h"
 #include "lib/enumerator.h"
 #include "lib/error.h"
-#include "lib/indent.h"
 #include "lib/map.h"
 #include "lib/null.h"
 #include "lib/safe_vector.h"
@@ -220,14 +219,6 @@ class IndexedVector : public Vector<T> {
             BUG_CHECK(it != declarations.end() && it->second->getNode() == el->getNode(),
                       "invalid element %1%", el);
         }
-    }
-
-    void dbprint(std::ostream &out) const override {
-        out << "{" << IndentCtl::indent;
-        for (auto p : *this) {
-            out << " " << p;
-        }
-        out << IndentCtl::unindent << " }";
     }
 
     DECLARE_TYPEINFO_WITH_DISCRIMINATOR(IndexedVector<T>, NodeDiscriminator::IndexedVectorT, T,

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include "ir/node.h"
 #include "lib/enumerator.h"
+#include "lib/indent.h"
 #include "lib/null.h"
 #include "lib/safe_vector.h"
 
@@ -206,6 +207,14 @@ class Vector : public VectorBase {
     Util::Enumerator<const S *> *only() const {
         return getEnumerator()->template as<const S *>()->where(
             [](const T *d) { return d != nullptr; });
+    }
+
+    void dbprint(std::ostream &out) const override {
+        out << "{" << IndentCtl::indent;
+        for (auto p : *this) {
+            out << " " << p;
+        }
+        out << IndentCtl::unindent << " }";
     }
 
     DECLARE_TYPEINFO_WITH_DISCRIMINATOR(Vector<T>, NodeDiscriminator::VectorT, T, VectorBase);


### PR DESCRIPTION
`IR::Vector` and `IR::IndexedVector` are often used in other IR nodes (such us `BlockStatement` or `P4Control`), and therefore is often processed by passes. However, up until now it had only un-useful default debug printer. This PR adds simple debug printer for indexed vector. It is mainly useful in debugger, in tests to add context to failed assertion, or in `LOG*` functions.