### PR TITLE
[P4Testgen] Move newline stripping from trace to TestFramework

### DIFF
--- a/backends/p4tools/common/lib/trace_event_types.cpp
+++ b/backends/p4tools/common/lib/trace_event_types.cpp
@@ -277,9 +277,7 @@ const Emit *Emit::evaluate(const Model &model, bool doComplete) const {
         model.evaluateStructExpr(emitHeader, doComplete)->checkedTo<IR::HeaderExpression>());
 }
 
-void Emit::print(std::ostream &os) const {
-    os << "[Emit]: " << emitHeader;
-}
+void Emit::print(std::ostream &os) const { os << "[Emit]: " << emitHeader; }
 
 /* =============================================================================================
  *   Packet

--- a/backends/p4tools/common/lib/trace_event_types.cpp
+++ b/backends/p4tools/common/lib/trace_event_types.cpp
@@ -63,20 +63,9 @@ const Expression *Expression::evaluate(const Model &model, bool doComplete) cons
     return new Expression(evaluatedValue, label);
 }
 
-static std::string dbFormatWithoutNewline(const P4::IHasDbPrint *value)
-{
-    std::stringstream str;
-    value->dbprint(str);
-    auto expString = str.str();
-    expString.erase(std::remove(expString.begin(), expString.end(), '\n'), expString.cend());
-    return expString;
-}
-
 void Expression::print(std::ostream &os) const {
-    // Convert the assignment to a string and strip any new lines.
-    // TODO: Maybe there is a better way to format newlines?
     Generic::print(os);
-    os << ": " << dbFormatWithoutNewline(value);
+    os << ": " << value;
 }
 
 /* =============================================================================================
@@ -144,7 +133,7 @@ void IfStatementCondition::print(std::ostream &os) const {
     } else {
         os << "[P4Testgen If Statement]:";
     }
-    os << " Condition: " << dbFormatWithoutNewline(preEvalCond);
+    os << " Condition: " << preEvalCond;
     const auto *boolResult = postEvalCond->checkedTo<IR::BoolLiteral>()->value ? "true" : "false";
     os << " Result: " << boolResult;
 }
@@ -189,19 +178,12 @@ const AssignmentStatement *AssignmentStatement::evaluate(const Model &model,
 
 void AssignmentStatement::print(std::ostream &os) const {
     const auto &srcInfo = stmt.getSourceInfo();
-    // Convert the assignment to a string and strip any new lines.
-    // TODO: Maybe there is a better way to format newlines?
-    std::stringstream assignStream;
-    stmt.dbprint(assignStream);
-    auto assignString = assignStream.str();
-    assignString.erase(std::remove(assignString.begin(), assignString.end(), '\n'),
-                       assignString.cend());
     if (srcInfo.isValid()) {
         auto fragment = srcInfo.toSourceFragment(false);
         fragment = fragment.trim();
-        os << "[AssignmentStatement]: " << fragment << "| Computed: " << assignString;
+        os << "[AssignmentStatement]: " << fragment << "| Computed: " << stmt;
     } else {
-        os << "[P4Testgen AssignmentStatement]: " << assignString;
+        os << "[P4Testgen AssignmentStatement]: " << stmt;
     }
 }
 

--- a/backends/p4tools/common/lib/trace_event_types.cpp
+++ b/backends/p4tools/common/lib/trace_event_types.cpp
@@ -63,15 +63,20 @@ const Expression *Expression::evaluate(const Model &model, bool doComplete) cons
     return new Expression(evaluatedValue, label);
 }
 
+static std::string dbFormatWithoutNewline(const P4::IHasDbPrint *value)
+{
+    std::stringstream str;
+    value->dbprint(str);
+    auto expString = str.str();
+    expString.erase(std::remove(expString.begin(), expString.end(), '\n'), expString.cend());
+    return expString;
+}
+
 void Expression::print(std::ostream &os) const {
     // Convert the assignment to a string and strip any new lines.
     // TODO: Maybe there is a better way to format newlines?
-    std::stringstream exprStream;
-    value->dbprint(exprStream);
-    auto expString = exprStream.str();
-    expString.erase(std::remove(expString.begin(), expString.end(), '\n'), expString.cend());
     Generic::print(os);
-    os << ": " << expString;
+    os << ": " << dbFormatWithoutNewline(value);
 }
 
 /* =============================================================================================
@@ -137,9 +142,9 @@ void IfStatementCondition::print(std::ostream &os) const {
     if (srcInfo.isValid()) {
         os << "[If Statement]: " << srcInfo.toBriefSourceFragment();
     } else {
-        os << "[P4Testgen If Statement]: " << preEvalCond;
+        os << "[P4Testgen If Statement]:";
     }
-    os << " Condition: " << preEvalCond;
+    os << " Condition: " << dbFormatWithoutNewline(preEvalCond);
     const auto *boolResult = postEvalCond->checkedTo<IR::BoolLiteral>()->value ? "true" : "false";
     os << " Result: " << boolResult;
 }

--- a/backends/p4tools/common/lib/trace_event_types.cpp
+++ b/backends/p4tools/common/lib/trace_event_types.cpp
@@ -76,15 +76,10 @@ MethodCall::MethodCall(const IR::MethodCallExpression *call) : call(call) {}
 
 void MethodCall::print(std::ostream &os) const {
     const auto &srcInfo = call->getSourceInfo();
-    // Convert the method call to a string and strip any new lines.
-    std::stringstream callStream;
-    call->dbprint(callStream);
-    auto callString = callStream.str();
-    callString.erase(std::remove(callString.begin(), callString.end(), '\n'), callString.cend());
     if (srcInfo.isValid()) {
-        os << "[MethodCall]: " << callString;
+        os << "[MethodCall]: " << call;
     } else {
-        os << "[P4Testgen MethodCall]: " << callString;
+        os << "[P4Testgen MethodCall]: " << call;
     }
 }
 
@@ -283,14 +278,7 @@ const Emit *Emit::evaluate(const Model &model, bool doComplete) const {
 }
 
 void Emit::print(std::ostream &os) const {
-    // Convert the header expression to a string and strip any new lines.
-    // TODO: Maybe there is a better way to format newlines?
-    std::stringstream assignStream;
-    emitHeader->dbprint(assignStream);
-    auto headerString = assignStream.str();
-    headerString.erase(std::remove(headerString.begin(), headerString.end(), '\n'),
-                       headerString.cend());
-    os << "[Emit]: " << headerString;
+    os << "[Emit]: " << emitHeader;
 }
 
 /* =============================================================================================

--- a/backends/p4tools/modules/testgen/lib/test_framework.h
+++ b/backends/p4tools/modules/testgen/lib/test_framework.h
@@ -49,7 +49,7 @@ std::vector<const ConcreteTest *> convertAbstractTestsToConcreteTests(
 /// framework.
 using OptionalFilePath = std::optional<std::filesystem::path>;
 
-/// THe default base class for the various test frameworks. Every test framework has a test
+/// The default base class for the various test frameworks. Every test framework has a test
 /// name and a seed associated with it. Also contains a variety of common utility functions.
 class TestFramework {
  private:
@@ -61,14 +61,20 @@ class TestFramework {
     explicit TestFramework(const TestBackendConfiguration &testBackendConfiguration);
 
     /// Converts the traces of this test into a string representation and Inja object.
-    static inja::json getTrace(const TestSpec *testSpec) {
+    /// @param stripNewline  Currently most test frameworks don't handle newlines in the trace well,
+    ///                      therefore we strip them by default.
+    static inja::json getTrace(const TestSpec *testSpec, bool stripNewline = true) {
         inja::json traceList = inja::json::array();
         const auto *traces = testSpec->getTraces();
         if (traces != nullptr) {
             for (const auto &trace : *traces) {
                 std::stringstream ss;
                 ss << trace;
-                traceList.push_back(ss.str());
+                std::string traceStr = ss.str();
+                if (stripNewline) {
+                    traceStr.erase(std::remove(traceStr.begin(), traceStr.end(), '\n'), traceStr.cend());
+                }
+                traceList.push_back(traceStr);
             }
         }
         return traceList;

--- a/backends/p4tools/modules/testgen/lib/test_framework.h
+++ b/backends/p4tools/modules/testgen/lib/test_framework.h
@@ -72,7 +72,8 @@ class TestFramework {
                 ss << trace;
                 std::string traceStr = ss.str();
                 if (stripNewline) {
-                    traceStr.erase(std::remove(traceStr.begin(), traceStr.end(), '\n'), traceStr.cend());
+                    traceStr.erase(std::remove(traceStr.begin(), traceStr.end(), '\n'),
+                                   traceStr.cend());
                 }
                 traceList.push_back(traceStr);
             }

--- a/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/expr_stepper.cpp
@@ -459,12 +459,9 @@ const Bmv2V1ModelExprStepper::ExternMethodImpls<Bmv2V1ModelExprStepper>
 
              // Strip any newlines in the value we want to record.
              value->dbprint(assignStream);
-             auto assignString = assignStream.str();
-             assignString.erase(std::remove(assignString.begin(), assignString.end(), '\n'),
-                                assignString.cend());
 
              auto &nextState = stepper.state.clone();
-             nextState.add(*new TraceEvents::Generic(assignString));
+             nextState.add(*new TraceEvents::Generic(assignStream.str()));
              nextState.popBody();
              stepper.result->emplace_back(nextState);
          }},


### PR DESCRIPTION
... I think this makes more sense. There is nothing saying traces can't contain newlines, or that the newline can only occur from a limited set of expressions. But test frameworks (presumably both STF and PTF, due to their comment styles) have problems with it. So I move newline stripping to `TestFramework`. This should resolve the problem found in #4943.