### PR TITLE
Change tc template define

### DIFF
--- a/backends/tc/tc.def
+++ b/backends/tc/tc.def
@@ -622,7 +622,7 @@ class TCPipeline {
     }
     toString {
         std::string tcCode = absl::StrCat("#!/bin/bash -x\n",
-                                        "\nset -e\n", "\nTC=\"tc\"",
+                                        "\nset -e\n", "\n: \"${TC:=\"tc\"}\"",
                                         "\n$TC p4template create pipeline/", pipelineName.string_view(),
                                         " numtables ", numTables);
         if (!actionDefs.empty()) {

--- a/testdata/p4tc_samples_outputs/add_entry_1_example.template
+++ b/testdata/p4tc_samples_outputs/add_entry_1_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/add_entry_1_example numtables 1
 
 $TC p4template create action/add_entry_1_example/MainControlImpl/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/add_entry_3_example.template
+++ b/testdata/p4tc_samples_outputs/add_entry_3_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/add_entry_3_example numtables 1
 
 $TC p4template create action/add_entry_3_example/MainControlImpl/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/add_entry_example.template
+++ b/testdata/p4tc_samples_outputs/add_entry_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/add_entry_example numtables 2
 
 $TC p4template create action/add_entry_example/MainControlImpl/next_hop actid 1

--- a/testdata/p4tc_samples_outputs/calculator.template
+++ b/testdata/p4tc_samples_outputs/calculator.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/calculator numtables 1
 
 $TC p4template create action/calculator/MainControlImpl/operation_add actid 1

--- a/testdata/p4tc_samples_outputs/checksum.template
+++ b/testdata/p4tc_samples_outputs/checksum.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/checksum numtables 1
 
 $TC p4template create action/checksum/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/const_entries_range_mask.template
+++ b/testdata/p4tc_samples_outputs/const_entries_range_mask.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/const_entries_range_mask numtables 1
 
 $TC p4template create action/const_entries_range_mask/MainControlImpl/a actid 1

--- a/testdata/p4tc_samples_outputs/default_action_example.template
+++ b/testdata/p4tc_samples_outputs/default_action_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/default_action_example numtables 2
 
 $TC p4template create action/default_action_example/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/default_action_example_01.template
+++ b/testdata/p4tc_samples_outputs/default_action_example_01.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/default_action_example_01 numtables 2
 
 $TC p4template create action/default_action_example_01/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/default_action_with_param.template
+++ b/testdata/p4tc_samples_outputs/default_action_with_param.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/default_action_with_param numtables 2
 
 $TC p4template create action/default_action_with_param/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/default_action_with_param_01.template
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_01.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/default_action_with_param_01 numtables 2
 
 $TC p4template create action/default_action_with_param_01/MainControlImpl/next_hop actid 1

--- a/testdata/p4tc_samples_outputs/default_hit_const_example.template
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/default_hit_const_example numtables 1
 
 $TC p4template create action/default_hit_const_example/MainControlImpl/tcp_syn_packet actid 1

--- a/testdata/p4tc_samples_outputs/digest.template
+++ b/testdata/p4tc_samples_outputs/digest.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/digest numtables 1
 
 $TC p4template create action/digest/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/digest_01.template
+++ b/testdata/p4tc_samples_outputs/digest_01.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/digest_01 numtables 1
 
 $TC p4template create action/digest_01/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/direct_counter_example.template
+++ b/testdata/p4tc_samples_outputs/direct_counter_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/direct_counter_example numtables 1
 
 $TC p4template create action/direct_counter_example/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/direct_meter.template
+++ b/testdata/p4tc_samples_outputs/direct_meter.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/direct_meter numtables 1
 
 $TC p4template create action/direct_meter/ingress/meter_exec actid 1

--- a/testdata/p4tc_samples_outputs/direct_meter_color.template
+++ b/testdata/p4tc_samples_outputs/direct_meter_color.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/direct_meter_color numtables 1
 
 $TC p4template create action/direct_meter_color/ingress/meter_exec actid 1

--- a/testdata/p4tc_samples_outputs/drop_packet_example.template
+++ b/testdata/p4tc_samples_outputs/drop_packet_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/drop_packet_example numtables 1
 
 $TC p4template create action/drop_packet_example/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/global_action_example_01.template
+++ b/testdata/p4tc_samples_outputs/global_action_example_01.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/global_action_example_01 numtables 2
 
 $TC p4template create action/global_action_example_01/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/global_action_example_02.template
+++ b/testdata/p4tc_samples_outputs/global_action_example_02.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/global_action_example_02 numtables 2
 
 $TC p4template create action/global_action_example_02/drop actid 1

--- a/testdata/p4tc_samples_outputs/hash1.template
+++ b/testdata/p4tc_samples_outputs/hash1.template
@@ -2,6 +2,6 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/hash1 numtables 0
 $TC p4template update pipeline/hash1 state ready

--- a/testdata/p4tc_samples_outputs/indirect_counter_01_example.template
+++ b/testdata/p4tc_samples_outputs/indirect_counter_01_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/indirect_counter_01_example numtables 1
 
 $TC p4template create action/indirect_counter_01_example/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/internetchecksum_01.template
+++ b/testdata/p4tc_samples_outputs/internetchecksum_01.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/internetchecksum_01 numtables 1
 
 $TC p4template create action/internetchecksum_01/ingress/set_ipip_csum actid 1 \

--- a/testdata/p4tc_samples_outputs/ipip.template
+++ b/testdata/p4tc_samples_outputs/ipip.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/ipip numtables 1
 
 $TC p4template create action/ipip/Main/set_ipip actid 1 \

--- a/testdata/p4tc_samples_outputs/is_host_port.template
+++ b/testdata/p4tc_samples_outputs/is_host_port.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/is_host_port numtables 1
 
 $TC p4template create action/is_host_port/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/is_net_port.template
+++ b/testdata/p4tc_samples_outputs/is_net_port.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/is_net_port numtables 1
 
 $TC p4template create action/is_net_port/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/matchtype.template
+++ b/testdata/p4tc_samples_outputs/matchtype.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/matchtype numtables 4
 
 $TC p4template create action/matchtype/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/meter.template
+++ b/testdata/p4tc_samples_outputs/meter.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/meter numtables 1
 
 $TC p4template create action/meter/ingress/meter_exec actid 1

--- a/testdata/p4tc_samples_outputs/meter_color.template
+++ b/testdata/p4tc_samples_outputs/meter_color.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/meter_color numtables 1
 
 $TC p4template create action/meter_color/ingress/meter_exec actid 1

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example.template
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/mix_matchtype_example numtables 4
 
 $TC p4template create action/mix_matchtype_example/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01.template
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/multiple_tables_example_01 numtables 7
 
 $TC p4template create action/multiple_tables_example_01/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02.template
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/multiple_tables_example_02 numtables 7
 
 $TC p4template create action/multiple_tables_example_02/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/name_annotation_example.template
+++ b/testdata/p4tc_samples_outputs/name_annotation_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/name_annotation_example numtables 2
 
 $TC p4template create action/name_annotation_example/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/no_table_example.template
+++ b/testdata/p4tc_samples_outputs/no_table_example.template
@@ -2,6 +2,6 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/no_table_example numtables 0
 $TC p4template update pipeline/no_table_example state ready

--- a/testdata/p4tc_samples_outputs/noaction_example_01.template
+++ b/testdata/p4tc_samples_outputs/noaction_example_01.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/noaction_example_01 numtables 2
 
 $TC p4template create action/noaction_example_01/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/noaction_example_02.template
+++ b/testdata/p4tc_samples_outputs/noaction_example_02.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/noaction_example_02 numtables 2
 
 $TC p4template create action/noaction_example_02/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example.template
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/nummask_annotation_example numtables 1
 
 $TC p4template create action/nummask_annotation_example/MainControlImpl/tcp_syn_packet actid 1

--- a/testdata/p4tc_samples_outputs/send_to_port_example.template
+++ b/testdata/p4tc_samples_outputs/send_to_port_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/send_to_port_example numtables 1
 
 $TC p4template create action/send_to_port_example/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example.template
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/set_entry_timer_example numtables 2
 
 $TC p4template create action/set_entry_timer_example/MainControlImpl/next_hop actid 1

--- a/testdata/p4tc_samples_outputs/simple_exact_example.template
+++ b/testdata/p4tc_samples_outputs/simple_exact_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/simple_exact_example numtables 1
 
 $TC p4template create action/simple_exact_example/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/simple_extern_example.template
+++ b/testdata/p4tc_samples_outputs/simple_extern_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/simple_extern_example numtables 1
 
 $TC p4template create action/simple_extern_example/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/simple_lpm_example.template
+++ b/testdata/p4tc_samples_outputs/simple_lpm_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/simple_lpm_example numtables 1
 
 $TC p4template create action/simple_lpm_example/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/simple_ternary_example.template
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/simple_ternary_example numtables 1
 
 $TC p4template create action/simple_ternary_example/ingress/send_nh actid 1 \

--- a/testdata/p4tc_samples_outputs/size_param_example.template
+++ b/testdata/p4tc_samples_outputs/size_param_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/size_param_example numtables 2
 
 $TC p4template create action/size_param_example/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_01.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_01.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/tc_may_override_example_01 numtables 2
 
 $TC p4template create action/tc_may_override_example_01/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_02.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_02.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/tc_may_override_example_02 numtables 2
 
 $TC p4template create action/tc_may_override_example_02/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_03.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_03.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/tc_may_override_example_03 numtables 2
 
 $TC p4template create action/tc_may_override_example_03/MainControlImpl/next_hop actid 1

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_04.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_04.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/tc_may_override_example_04 numtables 2
 
 $TC p4template create action/tc_may_override_example_04/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_05.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_05.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/tc_may_override_example_05 numtables 2
 
 $TC p4template create action/tc_may_override_example_05/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_06.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_06.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/tc_may_override_example_06 numtables 2
 
 $TC p4template create action/tc_may_override_example_06/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_07.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_07.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/tc_may_override_example_07 numtables 2
 
 $TC p4template create action/tc_may_override_example_07/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_08.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_08.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/tc_may_override_example_08 numtables 2
 
 $TC p4template create action/tc_may_override_example_08/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_09.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_09.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/tc_may_override_example_09 numtables 2
 
 $TC p4template create action/tc_may_override_example_09/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/tc_type_annotation_example.template
+++ b/testdata/p4tc_samples_outputs/tc_type_annotation_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/tc_type_annotation_example numtables 2
 
 $TC p4template create action/tc_type_annotation_example/MainControlImpl/next_hop actid 1 \

--- a/testdata/p4tc_samples_outputs/test_ipv6_example.template
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example.template
@@ -2,7 +2,7 @@
 
 set -e
 
-TC="tc"
+: "${TC:="tc"}"
 $TC p4template create pipeline/test_ipv6_example numtables 1
 
 $TC p4template create action/test_ipv6_example/MainControlImpl/set_dst actid 1 \


### PR DESCRIPTION
To ease the usage of P4TC, allow users to overwrite the TC environment
variable in the template script. That way the template script's TC will
default to "tc", unless the user defines it to be something else.

For example:

export TC="/my/tc/path"
./myprog.template