### PR TITLE
Make number of masks default to 1 for exact tables 

### DIFF
--- a/backends/tc/tc.def
+++ b/backends/tc/tc.def
@@ -351,9 +351,14 @@ class TCTable {
                         "\n\ttblid ", tableID, " \\",
                         "\n\ttype ", printMatchType(matchType).string_view(), " \\",
                         "\n\tkeysz ", keySize,
-                        " nummasks ", numMask,
                         " permissions ", permissions.string_view(),
                         " tentries ", tableEntriesCount);
+        if (matchType == TC::EXACT_TYPE) {
+            absl::StrAppend(&tcTable, " nummasks ", TC::DEFAULT_KEY_MASK_EXACT);
+        } else {
+            absl::StrAppend(&tcTable, " nummasks ", TC::DEFAULT_KEY_MASK);
+        }
+
         if (isTableAddOnMiss && timerProfiles > defaultTimerProfiles) {
             absl::StrAppend(&tcTable, " num_timer_profiles ", timerProfiles);
         }

--- a/backends/tc/tc_defines.h
+++ b/backends/tc/tc_defines.h
@@ -21,6 +21,7 @@ namespace P4::TC {
 
 inline constexpr auto DEFAULT_TABLE_ENTRIES = 1024;
 inline constexpr auto DEFAULT_KEY_MASK = 8;
+inline constexpr auto DEFAULT_KEY_MASK_EXACT = 1;
 inline constexpr auto PORTID_BITWIDTH = 32;
 inline constexpr auto DEFAULT_KEY_ID = 1;
 inline constexpr auto DEFAULT_METADATA_ID = 1;

--- a/testdata/p4tc_samples_outputs/add_entry_1_example.template
+++ b/testdata/p4tc_samples_outputs/add_entry_1_example.template
@@ -19,7 +19,7 @@ $TC p4template update action/add_entry_1_example/MainControlImpl/dflt_route_drop
 $TC p4template create table/add_entry_1_example/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x38e6 tentries 1024 \
+	keysz 64 permissions 0x38e6 tentries 1024 nummasks 1 \
 	table_acts act name add_entry_1_example/MainControlImpl/next_hop \
 	act name add_entry_1_example/MainControlImpl/send_nh \
 	act name add_entry_1_example/MainControlImpl/dflt_route_drop

--- a/testdata/p4tc_samples_outputs/add_entry_3_example.template
+++ b/testdata/p4tc_samples_outputs/add_entry_3_example.template
@@ -19,7 +19,7 @@ $TC p4template update action/add_entry_3_example/MainControlImpl/dflt_route_drop
 $TC p4template create table/add_entry_3_example/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x38a6 tentries 1024 \
+	keysz 64 permissions 0x38a6 tentries 1024 nummasks 1 \
 	table_acts act name add_entry_3_example/MainControlImpl/next_hop \
 	act name add_entry_3_example/MainControlImpl/send_nh \
 	act name add_entry_3_example/MainControlImpl/dflt_route_drop

--- a/testdata/p4tc_samples_outputs/add_entry_example.template
+++ b/testdata/p4tc_samples_outputs/add_entry_example.template
@@ -17,7 +17,7 @@ $TC p4template update action/add_entry_example/MainControlImpl/next_hop1 state a
 $TC p4template create table/add_entry_example/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3de6 tentries 1024 \
+	keysz 64 permissions 0x3de6 tentries 1024 nummasks 1 \
 	table_acts act name add_entry_example/MainControlImpl/next_hop \
 	act name add_entry_example/MainControlImpl/dflt_route_drop
 $TC p4template update table/add_entry_example/MainControlImpl/ipv4_tbl_1 default_miss_action action add_entry_example/MainControlImpl/next_hop
@@ -25,7 +25,7 @@ $TC p4template update table/add_entry_example/MainControlImpl/ipv4_tbl_1 default
 $TC p4template create table/add_entry_example/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3de6 tentries 1024 \
+	keysz 72 permissions 0x3de6 tentries 1024 nummasks 1 \
 	table_acts act name add_entry_example/MainControlImpl/next_hop1 \
 	act name add_entry_example/MainControlImpl/dflt_route_drop
 $TC p4template update table/add_entry_example/MainControlImpl/ipv4_tbl_2 default_miss_action action add_entry_example/MainControlImpl/next_hop1

--- a/testdata/p4tc_samples_outputs/calculator.template
+++ b/testdata/p4tc_samples_outputs/calculator.template
@@ -26,7 +26,7 @@ $TC p4template update action/calculator/MainControlImpl/operation_drop state act
 $TC p4template create table/calculator/MainControlImpl/calculate \
 	tblid 1 \
 	type exact \
-	keysz 8 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 8 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name calculator/MainControlImpl/operation_add \
 	act name calculator/MainControlImpl/operation_sub \
 	act name calculator/MainControlImpl/operation_and \

--- a/testdata/p4tc_samples_outputs/checksum.template
+++ b/testdata/p4tc_samples_outputs/checksum.template
@@ -17,7 +17,7 @@ $TC p4template update action/checksum/ingress/drop state active
 $TC p4template create table/checksum/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 262144 \
+	keysz 32 permissions 0x3da4 tentries 262144 nummasks 1 \
 	table_acts act name checksum/ingress/send_nh \
 	act name checksum/ingress/drop
 $TC p4template update table/checksum/ingress/nh_table default_miss_action permissions 0x1024 action checksum/ingress/drop

--- a/testdata/p4tc_samples_outputs/const_entries_range_mask.template
+++ b/testdata/p4tc_samples_outputs/const_entries_range_mask.template
@@ -15,7 +15,7 @@ $TC p4template update action/const_entries_range_mask/MainControlImpl/a_with_con
 $TC p4template create table/const_entries_range_mask/MainControlImpl/t_range \
 	tblid 1 \
 	type ternary \
-	keysz 8 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 8 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name const_entries_range_mask/MainControlImpl/a \
 	act name const_entries_range_mask/MainControlImpl/a_with_control_params
 $TC p4template update table/const_entries_range_mask/MainControlImpl/t_range default_miss_action action const_entries_range_mask/MainControlImpl/a

--- a/testdata/p4tc_samples_outputs/default_action_example.template
+++ b/testdata/p4tc_samples_outputs/default_action_example.template
@@ -18,7 +18,7 @@ $TC p4template update action/default_action_example/MainControlImpl/drop state a
 $TC p4template create table/default_action_example/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name default_action_example/MainControlImpl/next_hop \
 	act name default_action_example/MainControlImpl/default_route_drop
 $TC p4template update table/default_action_example/MainControlImpl/ipv4_tbl_1 default_miss_action action default_action_example/MainControlImpl/default_route_drop
@@ -26,7 +26,7 @@ $TC p4template update table/default_action_example/MainControlImpl/ipv4_tbl_1 de
 $TC p4template create table/default_action_example/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name default_action_example/MainControlImpl/next_hop \
 	act name default_action_example/MainControlImpl/drop
 $TC p4template update table/default_action_example/MainControlImpl/ipv4_tbl_2 default_miss_action action default_action_example/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/default_action_example_01.template
+++ b/testdata/p4tc_samples_outputs/default_action_example_01.template
@@ -15,7 +15,7 @@ $TC p4template update action/default_action_example_01/MainControlImpl/default_r
 $TC p4template create table/default_action_example_01/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name default_action_example_01/MainControlImpl/next_hop \
 	act name default_action_example_01/MainControlImpl/default_route_drop \
 	act name NoAction flags defaultonly
@@ -23,6 +23,6 @@ $TC p4template create table/default_action_example_01/MainControlImpl/ipv4_tbl_1
 $TC p4template create table/default_action_example_01/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name NoAction flags defaultonly
 $TC p4template update pipeline/default_action_example_01 state ready

--- a/testdata/p4tc_samples_outputs/default_action_with_param.template
+++ b/testdata/p4tc_samples_outputs/default_action_with_param.template
@@ -18,7 +18,7 @@ $TC p4template update action/default_action_with_param/MainControlImpl/drop stat
 $TC p4template create table/default_action_with_param/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name default_action_with_param/MainControlImpl/next_hop \
 	act name default_action_with_param/MainControlImpl/dflt_route_drop
 $TC p4template update table/default_action_with_param/MainControlImpl/ipv4_tbl_1 default_miss_action action default_action_with_param/MainControlImpl/next_hop param vport 8
@@ -26,7 +26,7 @@ $TC p4template update table/default_action_with_param/MainControlImpl/ipv4_tbl_1
 $TC p4template create table/default_action_with_param/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name default_action_with_param/MainControlImpl/next_hop \
 	act name default_action_with_param/MainControlImpl/drop
 $TC p4template update table/default_action_with_param/MainControlImpl/ipv4_tbl_2 default_miss_action action default_action_with_param/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/default_action_with_param_01.template
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_01.template
@@ -17,7 +17,7 @@ $TC p4template update action/default_action_with_param_01/MainControlImpl/drop s
 $TC p4template create table/default_action_with_param_01/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name default_action_with_param_01/MainControlImpl/next_hop flags defaultonly \
 	act name default_action_with_param_01/MainControlImpl/dflt_route_drop
 $TC p4template update table/default_action_with_param_01/MainControlImpl/ipv4_tbl_1 default_miss_action action default_action_with_param_01/MainControlImpl/next_hop
@@ -25,7 +25,7 @@ $TC p4template update table/default_action_with_param_01/MainControlImpl/ipv4_tb
 $TC p4template create table/default_action_with_param_01/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name default_action_with_param_01/MainControlImpl/next_hop flags defaultonly \
 	act name default_action_with_param_01/MainControlImpl/drop
 $TC p4template update table/default_action_with_param_01/MainControlImpl/ipv4_tbl_2 default_miss_action action default_action_with_param_01/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/default_hit_const_example.template
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example.template
@@ -17,7 +17,7 @@ $TC p4template update action/default_hit_const_example/MainControlImpl/tcp_other
 $TC p4template create table/default_hit_const_example/MainControlImpl/set_ct_options \
 	tblid 1 \
 	type ternary \
-	keysz 8 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 8 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name default_hit_const_example/MainControlImpl/tcp_syn_packet \
 	act name default_hit_const_example/MainControlImpl/tcp_fin_or_rst_packet \
 	act name default_hit_const_example/MainControlImpl/tcp_other_packets

--- a/testdata/p4tc_samples_outputs/digest.template
+++ b/testdata/p4tc_samples_outputs/digest.template
@@ -23,7 +23,7 @@ control_path tc_key index ptype bit32 id 1 param srcAddr ptype macaddr id 2 para
 $TC p4template create table/digest/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 2048 \
+	keysz 32 permissions 0x3da4 tentries 2048 nummasks 1 \
 	table_acts act name digest/ingress/send_nh \
 	act name digest/ingress/drop
 $TC p4template update table/digest/ingress/nh_table default_miss_action permissions 0x1024 action digest/ingress/drop

--- a/testdata/p4tc_samples_outputs/digest_01.template
+++ b/testdata/p4tc_samples_outputs/digest_01.template
@@ -23,7 +23,7 @@ control_path tc_key index ptype bit32 id 1 param data ptype bit32 id 2
 $TC p4template create table/digest_01/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 2048 \
+	keysz 32 permissions 0x3da4 tentries 2048 nummasks 1 \
 	table_acts act name digest_01/ingress/send_nh \
 	act name digest_01/ingress/drop
 $TC p4template update table/digest_01/ingress/nh_table default_miss_action permissions 0x1024 action digest_01/ingress/drop

--- a/testdata/p4tc_samples_outputs/direct_counter_example.template
+++ b/testdata/p4tc_samples_outputs/direct_counter_example.template
@@ -25,7 +25,7 @@ control_path tc_key index ptype bit32 id 1 param pkts ptype bit64 id 2
 $TC p4template create table/direct_counter_example/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 2048 \
+	keysz 32 permissions 0x3da4 tentries 2048 nummasks 1 \
 	pna_direct_counter DirectCounter/ingress.global_counter \
 	table_acts act name direct_counter_example/ingress/send_nh \
 	act name direct_counter_example/ingress/drop

--- a/testdata/p4tc_samples_outputs/direct_meter.template
+++ b/testdata/p4tc_samples_outputs/direct_meter.template
@@ -22,7 +22,7 @@ control_path tc_key index ptype bit32 id 1 param cir ptype bit64 id 2 param cbs 
 $TC p4template create table/direct_meter/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 2048 \
+	keysz 32 permissions 0x3da4 tentries 2048 nummasks 1 \
 	pna_direct_meter DirectMeter/ingress.global_meter \
 	table_acts act name direct_meter/ingress/meter_exec \
 	act name direct_meter/ingress/drop

--- a/testdata/p4tc_samples_outputs/direct_meter_color.template
+++ b/testdata/p4tc_samples_outputs/direct_meter_color.template
@@ -22,7 +22,7 @@ control_path tc_key index ptype bit32 id 1 param cir ptype bit64 id 2 param cbs 
 $TC p4template create table/direct_meter_color/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 2048 \
+	keysz 32 permissions 0x3da4 tentries 2048 nummasks 1 \
 	pna_direct_meter DirectMeter/ingress.global_meter \
 	table_acts act name direct_meter_color/ingress/meter_exec \
 	act name direct_meter_color/ingress/drop

--- a/testdata/p4tc_samples_outputs/drop_packet_example.template
+++ b/testdata/p4tc_samples_outputs/drop_packet_example.template
@@ -15,7 +15,7 @@ $TC p4template update action/drop_packet_example/MainControlImpl/default_route_d
 $TC p4template create table/drop_packet_example/MainControlImpl/ipv4_tbl \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name drop_packet_example/MainControlImpl/next_hop \
 	act name drop_packet_example/MainControlImpl/default_route_drop
 $TC p4template update table/drop_packet_example/MainControlImpl/ipv4_tbl default_miss_action action drop_packet_example/MainControlImpl/default_route_drop

--- a/testdata/p4tc_samples_outputs/global_action_example_01.template
+++ b/testdata/p4tc_samples_outputs/global_action_example_01.template
@@ -22,7 +22,7 @@ $TC p4template update action/global_action_example_01/ingress/drop state active
 $TC p4template create table/global_action_example_01/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 262144 \
+	keysz 32 permissions 0x3da4 tentries 262144 nummasks 1 \
 	table_acts act name global_action_example_01/send_nh \
 	act name global_action_example_01/ingress/drop
 $TC p4template update table/global_action_example_01/ingress/nh_table default_miss_action permissions 0x1024 action global_action_example_01/ingress/drop
@@ -30,7 +30,7 @@ $TC p4template update table/global_action_example_01/ingress/nh_table default_mi
 $TC p4template create table/global_action_example_01/ingress/nh_table2 \
 	tblid 2 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 262144 \
+	keysz 32 permissions 0x3da4 tentries 262144 nummasks 1 \
 	table_acts act name global_action_example_01/ingress/send_nh \
 	act name global_action_example_01/ingress/drop
 $TC p4template update table/global_action_example_01/ingress/nh_table2 default_miss_action permissions 0x1024 action global_action_example_01/ingress/drop

--- a/testdata/p4tc_samples_outputs/global_action_example_02.template
+++ b/testdata/p4tc_samples_outputs/global_action_example_02.template
@@ -20,7 +20,7 @@ $TC p4template update action/global_action_example_02/ingress/drop state active
 $TC p4template create table/global_action_example_02/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 262144 \
+	keysz 32 permissions 0x3da4 tentries 262144 nummasks 1 \
 	table_acts act name global_action_example_02/ingress/send_nh \
 	act name global_action_example_02/drop
 $TC p4template update table/global_action_example_02/ingress/nh_table default_miss_action permissions 0x1024 action global_action_example_02/drop
@@ -28,7 +28,7 @@ $TC p4template update table/global_action_example_02/ingress/nh_table default_mi
 $TC p4template create table/global_action_example_02/ingress/nh_table2 \
 	tblid 2 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 262144 \
+	keysz 32 permissions 0x3da4 tentries 262144 nummasks 1 \
 	table_acts act name global_action_example_02/ingress/send_nh \
 	act name global_action_example_02/ingress/drop
 $TC p4template update table/global_action_example_02/ingress/nh_table2 default_miss_action permissions 0x1024 action global_action_example_02/ingress/drop

--- a/testdata/p4tc_samples_outputs/indirect_counter_01_example.template
+++ b/testdata/p4tc_samples_outputs/indirect_counter_01_example.template
@@ -24,7 +24,7 @@ control_path tc_key index ptype bit32 id 1 param pkts ptype bit64 id 2
 $TC p4template create table/indirect_counter_01_example/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 2048 \
+	keysz 32 permissions 0x3da4 tentries 2048 nummasks 1 \
 	table_acts act name indirect_counter_01_example/ingress/send_nh \
 	act name indirect_counter_01_example/ingress/drop
 $TC p4template update table/indirect_counter_01_example/ingress/nh_table default_miss_action permissions 0x1024 action indirect_counter_01_example/ingress/drop

--- a/testdata/p4tc_samples_outputs/internetchecksum_01.template
+++ b/testdata/p4tc_samples_outputs/internetchecksum_01.template
@@ -22,7 +22,7 @@ $TC p4template update action/internetchecksum_01/ingress/drop state active
 $TC p4template create table/internetchecksum_01/ingress/fwd_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name internetchecksum_01/ingress/set_ipip_csum \
 	act name internetchecksum_01/ingress/set_nh \
 	act name internetchecksum_01/ingress/drop

--- a/testdata/p4tc_samples_outputs/ipip.template
+++ b/testdata/p4tc_samples_outputs/ipip.template
@@ -22,7 +22,7 @@ $TC p4template update action/ipip/Main/drop state active
 $TC p4template create table/ipip/Main/fwd_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name ipip/Main/set_ipip \
 	act name ipip/Main/set_nh \
 	act name ipip/Main/drop

--- a/testdata/p4tc_samples_outputs/is_host_port.template
+++ b/testdata/p4tc_samples_outputs/is_host_port.template
@@ -17,7 +17,7 @@ $TC p4template update action/is_host_port/ingress/drop state active
 $TC p4template create table/is_host_port/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 262144 \
+	keysz 32 permissions 0x3da4 tentries 262144 nummasks 1 \
 	table_acts act name is_host_port/ingress/send_nh \
 	act name is_host_port/ingress/drop
 $TC p4template update table/is_host_port/ingress/nh_table default_miss_action permissions 0x1024 action is_host_port/ingress/drop

--- a/testdata/p4tc_samples_outputs/is_net_port.template
+++ b/testdata/p4tc_samples_outputs/is_net_port.template
@@ -17,7 +17,7 @@ $TC p4template update action/is_net_port/ingress/drop state active
 $TC p4template create table/is_net_port/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 262144 \
+	keysz 32 permissions 0x3da4 tentries 262144 nummasks 1 \
 	table_acts act name is_net_port/ingress/send_nh \
 	act name is_net_port/ingress/drop
 $TC p4template update table/is_net_port/ingress/nh_table default_miss_action permissions 0x1024 action is_net_port/ingress/drop

--- a/testdata/p4tc_samples_outputs/matchtype.template
+++ b/testdata/p4tc_samples_outputs/matchtype.template
@@ -18,7 +18,7 @@ $TC p4template update action/matchtype/MainControlImpl/drop state active
 $TC p4template create table/matchtype/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name matchtype/MainControlImpl/next_hop \
 	act name matchtype/MainControlImpl/default_route_drop
 $TC p4template update table/matchtype/MainControlImpl/ipv4_tbl_1 default_miss_action action matchtype/MainControlImpl/default_route_drop
@@ -26,7 +26,7 @@ $TC p4template update table/matchtype/MainControlImpl/ipv4_tbl_1 default_miss_ac
 $TC p4template create table/matchtype/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type ternary \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name matchtype/MainControlImpl/next_hop \
 	act name matchtype/MainControlImpl/drop
 $TC p4template update table/matchtype/MainControlImpl/ipv4_tbl_2 default_miss_action action matchtype/MainControlImpl/drop
@@ -34,7 +34,7 @@ $TC p4template update table/matchtype/MainControlImpl/ipv4_tbl_2 default_miss_ac
 $TC p4template create table/matchtype/MainControlImpl/ipv4_tbl_3 \
 	tblid 3 \
 	type ternary \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name matchtype/MainControlImpl/next_hop \
 	act name matchtype/MainControlImpl/drop
 $TC p4template update table/matchtype/MainControlImpl/ipv4_tbl_3 default_miss_action action matchtype/MainControlImpl/drop
@@ -42,7 +42,7 @@ $TC p4template update table/matchtype/MainControlImpl/ipv4_tbl_3 default_miss_ac
 $TC p4template create table/matchtype/MainControlImpl/ipv4_tbl_4 \
 	tblid 4 \
 	type lpm \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name matchtype/MainControlImpl/next_hop \
 	act name matchtype/MainControlImpl/drop
 $TC p4template update table/matchtype/MainControlImpl/ipv4_tbl_4 default_miss_action action matchtype/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/meter.template
+++ b/testdata/p4tc_samples_outputs/meter.template
@@ -21,7 +21,7 @@ control_path tc_key index ptype bit32 id 1 param cir ptype rate id 2 param cbs p
 $TC p4template create table/meter/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 2048 \
+	keysz 32 permissions 0x3da4 tentries 2048 nummasks 1 \
 	table_acts act name meter/ingress/meter_exec \
 	act name meter/ingress/drop
 $TC p4template update table/meter/ingress/nh_table default_miss_action permissions 0x1024 action meter/ingress/drop

--- a/testdata/p4tc_samples_outputs/meter_color.template
+++ b/testdata/p4tc_samples_outputs/meter_color.template
@@ -21,7 +21,7 @@ control_path tc_key index ptype bit32 id 1 param cir ptype bit64 id 2 param cbs 
 $TC p4template create table/meter_color/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 2048 \
+	keysz 32 permissions 0x3da4 tentries 2048 nummasks 1 \
 	table_acts act name meter_color/ingress/meter_exec \
 	act name meter_color/ingress/drop
 $TC p4template update table/meter_color/ingress/nh_table default_miss_action permissions 0x1024 action meter_color/ingress/drop

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example.template
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example.template
@@ -18,7 +18,7 @@ $TC p4template update action/mix_matchtype_example/MainControlImpl/drop state ac
 $TC p4template create table/mix_matchtype_example/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name mix_matchtype_example/MainControlImpl/next_hop \
 	act name mix_matchtype_example/MainControlImpl/default_route_drop
 $TC p4template update table/mix_matchtype_example/MainControlImpl/ipv4_tbl_1 default_miss_action action mix_matchtype_example/MainControlImpl/default_route_drop
@@ -26,7 +26,7 @@ $TC p4template update table/mix_matchtype_example/MainControlImpl/ipv4_tbl_1 def
 $TC p4template create table/mix_matchtype_example/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type ternary \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name mix_matchtype_example/MainControlImpl/next_hop \
 	act name mix_matchtype_example/MainControlImpl/drop
 $TC p4template update table/mix_matchtype_example/MainControlImpl/ipv4_tbl_2 default_miss_action action mix_matchtype_example/MainControlImpl/drop
@@ -34,7 +34,7 @@ $TC p4template update table/mix_matchtype_example/MainControlImpl/ipv4_tbl_2 def
 $TC p4template create table/mix_matchtype_example/MainControlImpl/ipv4_tbl_3 \
 	tblid 3 \
 	type ternary \
-	keysz 40 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 40 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name mix_matchtype_example/MainControlImpl/next_hop \
 	act name mix_matchtype_example/MainControlImpl/drop
 $TC p4template update table/mix_matchtype_example/MainControlImpl/ipv4_tbl_3 default_miss_action action mix_matchtype_example/MainControlImpl/drop
@@ -42,7 +42,7 @@ $TC p4template update table/mix_matchtype_example/MainControlImpl/ipv4_tbl_3 def
 $TC p4template create table/mix_matchtype_example/MainControlImpl/ipv4_tbl_4 \
 	tblid 4 \
 	type lpm \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name mix_matchtype_example/MainControlImpl/next_hop \
 	act name mix_matchtype_example/MainControlImpl/drop
 $TC p4template update table/mix_matchtype_example/MainControlImpl/ipv4_tbl_4 default_miss_action action mix_matchtype_example/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01.template
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01.template
@@ -31,7 +31,7 @@ $TC p4template update action/multiple_tables_example_01/MainControlImpl/tcp_othe
 $TC p4template create table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name multiple_tables_example_01/MainControlImpl/next_hop \
 	act name multiple_tables_example_01/MainControlImpl/default_route_drop
 $TC p4template update table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_1 default_miss_action action multiple_tables_example_01/MainControlImpl/default_route_drop
@@ -39,7 +39,7 @@ $TC p4template update table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_
 $TC p4template create table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name multiple_tables_example_01/MainControlImpl/next_hop \
 	act name multiple_tables_example_01/MainControlImpl/drop
 $TC p4template update table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_2 default_miss_action action multiple_tables_example_01/MainControlImpl/drop
@@ -47,7 +47,7 @@ $TC p4template update table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_
 $TC p4template create table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_3 \
 	tblid 3 \
 	type exact \
-	keysz 67 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 67 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name multiple_tables_example_01/MainControlImpl/sendtoport \
 	act name multiple_tables_example_01/MainControlImpl/drop \
 	act name NoAction flags defaultonly
@@ -55,7 +55,7 @@ $TC p4template create table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_
 $TC p4template create table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_4 \
 	tblid 4 \
 	type exact \
-	keysz 77 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 77 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name multiple_tables_example_01/MainControlImpl/sendtoport \
 	act name multiple_tables_example_01/MainControlImpl/drop \
 	act name NoAction
@@ -63,13 +63,13 @@ $TC p4template create table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_
 $TC p4template create table/multiple_tables_example_01/MainControlImpl/ipv4_tbl_5 \
 	tblid 5 \
 	type exact \
-	keysz 13 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 13 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name NoAction
 
 $TC p4template create table/multiple_tables_example_01/MainControlImpl/set_ct_options \
 	tblid 6 \
 	type ternary \
-	keysz 8 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 8 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name multiple_tables_example_01/MainControlImpl/tcp_syn_packet \
 	act name multiple_tables_example_01/MainControlImpl/tcp_fin_or_rst_packet \
 	act name multiple_tables_example_01/MainControlImpl/tcp_other_packets
@@ -78,7 +78,7 @@ $TC p4template update table/multiple_tables_example_01/MainControlImpl/set_ct_op
 $TC p4template create table/multiple_tables_example_01/MainControlImpl/set_all_options \
 	tblid 7 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name multiple_tables_example_01/MainControlImpl/next_hop \
 	act name multiple_tables_example_01/MainControlImpl/default_route_drop \
 	act name multiple_tables_example_01/MainControlImpl/tcp_syn_packet \

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02.template
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02.template
@@ -30,7 +30,7 @@ $TC p4template update action/multiple_tables_example_02/MainControlImpl/tcp_othe
 $TC p4template create table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name multiple_tables_example_02/MainControlImpl/next_hop flags tableonly \
 	act name multiple_tables_example_02/MainControlImpl/default_route_drop
 $TC p4template update table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_1 default_miss_action action multiple_tables_example_02/MainControlImpl/default_route_drop
@@ -38,7 +38,7 @@ $TC p4template update table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_
 $TC p4template create table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name multiple_tables_example_02/MainControlImpl/next_hop \
 	act name multiple_tables_example_02/MainControlImpl/drop flags defaultonly
 $TC p4template update table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_2 default_miss_action action multiple_tables_example_02/MainControlImpl/drop
@@ -46,7 +46,7 @@ $TC p4template update table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_
 $TC p4template create table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_3 \
 	tblid 3 \
 	type exact \
-	keysz 67 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 67 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name multiple_tables_example_02/MainControlImpl/sendtoport \
 	act name multiple_tables_example_02/MainControlImpl/drop \
 	act name NoAction flags defaultonly
@@ -54,7 +54,7 @@ $TC p4template create table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_
 $TC p4template create table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_4 \
 	tblid 4 \
 	type exact \
-	keysz 77 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 77 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name multiple_tables_example_02/MainControlImpl/sendtoport \
 	act name multiple_tables_example_02/MainControlImpl/drop \
 	act name NoAction
@@ -62,13 +62,13 @@ $TC p4template create table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_
 $TC p4template create table/multiple_tables_example_02/MainControlImpl/ipv4_tbl_5 \
 	tblid 5 \
 	type exact \
-	keysz 13 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 13 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name NoAction
 
 $TC p4template create table/multiple_tables_example_02/MainControlImpl/set_ct_options \
 	tblid 6 \
 	type ternary \
-	keysz 8 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 8 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name multiple_tables_example_02/MainControlImpl/tcp_syn_packet \
 	act name multiple_tables_example_02/MainControlImpl/tcp_fin_or_rst_packet \
 	act name multiple_tables_example_02/MainControlImpl/tcp_other_packets
@@ -77,7 +77,7 @@ $TC p4template update table/multiple_tables_example_02/MainControlImpl/set_ct_op
 $TC p4template create table/multiple_tables_example_02/MainControlImpl/set_all_options \
 	tblid 7 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name multiple_tables_example_02/MainControlImpl/next_hop \
 	act name multiple_tables_example_02/MainControlImpl/default_route_drop \
 	act name multiple_tables_example_02/MainControlImpl/tcp_syn_packet \

--- a/testdata/p4tc_samples_outputs/name_annotation_example.template
+++ b/testdata/p4tc_samples_outputs/name_annotation_example.template
@@ -18,7 +18,7 @@ $TC p4template update action/name_annotation_example/MainControlImpl/drop state 
 $TC p4template create table/name_annotation_example/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name name_annotation_example/MainControlImpl/next_hop \
 	act name name_annotation_example/MainControlImpl/default_route_drop
 $TC p4template update table/name_annotation_example/MainControlImpl/ipv4_tbl_1 default_miss_action action name_annotation_example/MainControlImpl/default_route_drop
@@ -26,7 +26,7 @@ $TC p4template update table/name_annotation_example/MainControlImpl/ipv4_tbl_1 d
 $TC p4template create table/name_annotation_example/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name name_annotation_example/MainControlImpl/next_hop \
 	act name name_annotation_example/MainControlImpl/drop
 $TC p4template update table/name_annotation_example/MainControlImpl/ipv4_tbl_2 default_miss_action action name_annotation_example/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/noaction_example_01.template
+++ b/testdata/p4tc_samples_outputs/noaction_example_01.template
@@ -22,7 +22,7 @@ $TC p4template update action/noaction_example_01/MainControlImpl/drop state acti
 $TC p4template create table/noaction_example_01/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name noaction_example_01/MainControlImpl/next_hop \
 	act name noaction_example_01/MainControlImpl/default_route_drop
 $TC p4template update table/noaction_example_01/MainControlImpl/ipv4_tbl_1 default_miss_action action noaction_example_01/MainControlImpl/default_route_drop
@@ -30,7 +30,7 @@ $TC p4template update table/noaction_example_01/MainControlImpl/ipv4_tbl_1 defau
 $TC p4template create table/noaction_example_01/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 67 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 67 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name noaction_example_01/MainControlImpl/sendtoport \
 	act name noaction_example_01/MainControlImpl/drop \
 	act name NoAction

--- a/testdata/p4tc_samples_outputs/noaction_example_02.template
+++ b/testdata/p4tc_samples_outputs/noaction_example_02.template
@@ -15,7 +15,7 @@ $TC p4template update action/noaction_example_02/MainControlImpl/default_route_d
 $TC p4template create table/noaction_example_02/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name noaction_example_02/MainControlImpl/next_hop \
 	act name noaction_example_02/MainControlImpl/default_route_drop
 $TC p4template update table/noaction_example_02/MainControlImpl/ipv4_tbl_1 default_miss_action action noaction_example_02/MainControlImpl/default_route_drop
@@ -23,6 +23,6 @@ $TC p4template update table/noaction_example_02/MainControlImpl/ipv4_tbl_1 defau
 $TC p4template create table/noaction_example_02/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 3 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 3 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name NoAction
 $TC p4template update pipeline/noaction_example_02 state ready

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example.template
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example.template
@@ -17,7 +17,7 @@ $TC p4template update action/nummask_annotation_example/MainControlImpl/tcp_othe
 $TC p4template create table/nummask_annotation_example/MainControlImpl/set_ct_options \
 	tblid 1 \
 	type lpm \
-	keysz 8 nummasks 64 permissions 0x3da4 tentries 1024 \
+	keysz 8 permissions 0x3da4 tentries 1024 nummasks 8 \
 	table_acts act name nummask_annotation_example/MainControlImpl/tcp_syn_packet \
 	act name nummask_annotation_example/MainControlImpl/tcp_fin_or_rst_packet \
 	act name nummask_annotation_example/MainControlImpl/tcp_other_packets

--- a/testdata/p4tc_samples_outputs/send_to_port_example.template
+++ b/testdata/p4tc_samples_outputs/send_to_port_example.template
@@ -21,7 +21,7 @@ control_path tc_key index ptype bit32 id 1 param a_value ptype bit32 id 2
 $TC p4template create table/send_to_port_example/MainControlImpl/ipv4_tbl \
 	tblid 1 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name send_to_port_example/MainControlImpl/next_hop \
 	act name send_to_port_example/MainControlImpl/default_route_drop
 $TC p4template update table/send_to_port_example/MainControlImpl/ipv4_tbl default_miss_action permissions 0x1024 action send_to_port_example/MainControlImpl/default_route_drop

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example.template
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example.template
@@ -17,7 +17,7 @@ $TC p4template update action/set_entry_timer_example/MainControlImpl/drop state 
 $TC p4template create table/set_entry_timer_example/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name set_entry_timer_example/MainControlImpl/next_hop \
 	act name set_entry_timer_example/MainControlImpl/default_route_drop
 $TC p4template update table/set_entry_timer_example/MainControlImpl/ipv4_tbl_1 default_miss_action action set_entry_timer_example/MainControlImpl/default_route_drop
@@ -25,7 +25,7 @@ $TC p4template update table/set_entry_timer_example/MainControlImpl/ipv4_tbl_1 d
 $TC p4template create table/set_entry_timer_example/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name set_entry_timer_example/MainControlImpl/next_hop \
 	act name set_entry_timer_example/MainControlImpl/drop
 $TC p4template update table/set_entry_timer_example/MainControlImpl/ipv4_tbl_2 default_miss_action action set_entry_timer_example/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/simple_exact_example.template
+++ b/testdata/p4tc_samples_outputs/simple_exact_example.template
@@ -17,7 +17,7 @@ $TC p4template update action/simple_exact_example/ingress/drop state active
 $TC p4template create table/simple_exact_example/ingress/nh_table \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x18a6 tentries 262144 \
+	keysz 32 permissions 0x18a6 tentries 262144 nummasks 1 \
 	table_acts act name simple_exact_example/ingress/send_nh \
 	act name simple_exact_example/ingress/drop
 $TC p4template update table/simple_exact_example/ingress/nh_table default_miss_action permissions 0x1024 action simple_exact_example/ingress/drop

--- a/testdata/p4tc_samples_outputs/simple_extern_example.template
+++ b/testdata/p4tc_samples_outputs/simple_extern_example.template
@@ -31,7 +31,7 @@ control_path tc_key index ptype bit32 id 1 param protocol ptype bit8 id 2 param 
 $TC p4template create table/simple_extern_example/ingress/nh_table \
 	tblid 1 \
 	type lpm \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 262144 \
+	keysz 32 permissions 0x3da4 tentries 262144 nummasks 8 \
 	table_acts act name simple_extern_example/ingress/ext_reg \
 	act name simple_extern_example/ingress/send_nh \
 	act name simple_extern_example/ingress/drop

--- a/testdata/p4tc_samples_outputs/simple_lpm_example.template
+++ b/testdata/p4tc_samples_outputs/simple_lpm_example.template
@@ -17,7 +17,7 @@ $TC p4template update action/simple_lpm_example/ingress/drop state active
 $TC p4template create table/simple_lpm_example/ingress/nh_table \
 	tblid 1 \
 	type lpm \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 262144 \
+	keysz 32 permissions 0x3da4 tentries 262144 nummasks 8 \
 	table_acts act name simple_lpm_example/ingress/send_nh \
 	act name simple_lpm_example/ingress/drop
 $TC p4template update table/simple_lpm_example/ingress/nh_table default_miss_action permissions 0x1024 action simple_lpm_example/ingress/drop

--- a/testdata/p4tc_samples_outputs/simple_ternary_example.template
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example.template
@@ -17,7 +17,7 @@ $TC p4template update action/simple_ternary_example/ingress/drop state active
 $TC p4template create table/simple_ternary_example/ingress/nh_table \
 	tblid 1 \
 	type ternary \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 262144 \
+	keysz 64 permissions 0x3da4 tentries 262144 nummasks 8 \
 	table_acts act name simple_ternary_example/ingress/send_nh \
 	act name simple_ternary_example/ingress/drop
 $TC p4template update table/simple_ternary_example/ingress/nh_table default_miss_action permissions 0x1024 action simple_ternary_example/ingress/drop

--- a/testdata/p4tc_samples_outputs/size_param_example.template
+++ b/testdata/p4tc_samples_outputs/size_param_example.template
@@ -22,7 +22,7 @@ $TC p4template update action/size_param_example/MainControlImpl/drop state activ
 $TC p4template create table/size_param_example/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name size_param_example/MainControlImpl/next_hop \
 	act name size_param_example/MainControlImpl/default_route_drop
 $TC p4template update table/size_param_example/MainControlImpl/ipv4_tbl_1 default_miss_action action size_param_example/MainControlImpl/default_route_drop
@@ -30,7 +30,7 @@ $TC p4template update table/size_param_example/MainControlImpl/ipv4_tbl_1 defaul
 $TC p4template create table/size_param_example/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 67 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 67 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name size_param_example/MainControlImpl/sendtoport \
 	act name size_param_example/MainControlImpl/drop
 $TC p4template update table/size_param_example/MainControlImpl/ipv4_tbl_2 default_miss_action action size_param_example/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_01.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_01.template
@@ -18,7 +18,7 @@ $TC p4template update action/tc_may_override_example_01/MainControlImpl/drop sta
 $TC p4template create table/tc_may_override_example_01/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_01/MainControlImpl/next_hop \
 	act name tc_may_override_example_01/MainControlImpl/default_route_drop
 $TC p4template update table/tc_may_override_example_01/MainControlImpl/ipv4_tbl_1 default_miss_action action tc_may_override_example_01/MainControlImpl/next_hop param vport flags runtime
@@ -26,7 +26,7 @@ $TC p4template update table/tc_may_override_example_01/MainControlImpl/ipv4_tbl_
 $TC p4template create table/tc_may_override_example_01/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_01/MainControlImpl/next_hop \
 	act name tc_may_override_example_01/MainControlImpl/drop
 $TC p4template update table/tc_may_override_example_01/MainControlImpl/ipv4_tbl_2 default_hit_action permissions 0x1024 action tc_may_override_example_01/MainControlImpl/next_hop param vport flags runtime

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_02.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_02.template
@@ -18,7 +18,7 @@ $TC p4template update action/tc_may_override_example_02/MainControlImpl/drop sta
 $TC p4template create table/tc_may_override_example_02/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_02/MainControlImpl/next_hop \
 	act name tc_may_override_example_02/MainControlImpl/dflt_route_drop
 $TC p4template update table/tc_may_override_example_02/MainControlImpl/ipv4_tbl_1 default_miss_action action tc_may_override_example_02/MainControlImpl/dflt_route_drop
@@ -26,7 +26,7 @@ $TC p4template update table/tc_may_override_example_02/MainControlImpl/ipv4_tbl_
 $TC p4template create table/tc_may_override_example_02/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_02/MainControlImpl/next_hop \
 	act name tc_may_override_example_02/MainControlImpl/drop
 $TC p4template update table/tc_may_override_example_02/MainControlImpl/ipv4_tbl_2 default_miss_action action tc_may_override_example_02/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_03.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_03.template
@@ -17,7 +17,7 @@ $TC p4template update action/tc_may_override_example_03/MainControlImpl/drop sta
 $TC p4template create table/tc_may_override_example_03/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_03/MainControlImpl/next_hop flags defaultonly \
 	act name tc_may_override_example_03/MainControlImpl/dflt_route_drop
 $TC p4template update table/tc_may_override_example_03/MainControlImpl/ipv4_tbl_1 default_miss_action action tc_may_override_example_03/MainControlImpl/next_hop
@@ -25,7 +25,7 @@ $TC p4template update table/tc_may_override_example_03/MainControlImpl/ipv4_tbl_
 $TC p4template create table/tc_may_override_example_03/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_03/MainControlImpl/next_hop flags defaultonly \
 	act name tc_may_override_example_03/MainControlImpl/drop
 $TC p4template update table/tc_may_override_example_03/MainControlImpl/ipv4_tbl_2 default_miss_action action tc_may_override_example_03/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_04.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_04.template
@@ -18,7 +18,7 @@ $TC p4template update action/tc_may_override_example_04/MainControlImpl/drop sta
 $TC p4template create table/tc_may_override_example_04/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_04/MainControlImpl/next_hop \
 	act name tc_may_override_example_04/MainControlImpl/default_route_drop
 $TC p4template update table/tc_may_override_example_04/MainControlImpl/ipv4_tbl_1 default_miss_action action tc_may_override_example_04/MainControlImpl/next_hop param ipv4addr flags runtime
@@ -26,7 +26,7 @@ $TC p4template update table/tc_may_override_example_04/MainControlImpl/ipv4_tbl_
 $TC p4template create table/tc_may_override_example_04/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_04/MainControlImpl/next_hop \
 	act name tc_may_override_example_04/MainControlImpl/drop
 $TC p4template update table/tc_may_override_example_04/MainControlImpl/ipv4_tbl_2 default_miss_action action tc_may_override_example_04/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_05.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_05.template
@@ -18,7 +18,7 @@ $TC p4template update action/tc_may_override_example_05/MainControlImpl/drop sta
 $TC p4template create table/tc_may_override_example_05/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_05/MainControlImpl/next_hop \
 	act name tc_may_override_example_05/MainControlImpl/default_route_drop
 $TC p4template update table/tc_may_override_example_05/MainControlImpl/ipv4_tbl_1 default_miss_action action tc_may_override_example_05/MainControlImpl/next_hop param vport flags runtime
@@ -26,7 +26,7 @@ $TC p4template update table/tc_may_override_example_05/MainControlImpl/ipv4_tbl_
 $TC p4template create table/tc_may_override_example_05/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_05/MainControlImpl/next_hop \
 	act name tc_may_override_example_05/MainControlImpl/drop
 $TC p4template update table/tc_may_override_example_05/MainControlImpl/ipv4_tbl_2 default_miss_action action tc_may_override_example_05/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_06.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_06.template
@@ -18,7 +18,7 @@ $TC p4template update action/tc_may_override_example_06/MainControlImpl/drop sta
 $TC p4template create table/tc_may_override_example_06/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_06/MainControlImpl/next_hop \
 	act name tc_may_override_example_06/MainControlImpl/default_route_drop
 $TC p4template update table/tc_may_override_example_06/MainControlImpl/ipv4_tbl_1 default_miss_action action tc_may_override_example_06/MainControlImpl/next_hop param vport flags runtime
@@ -26,7 +26,7 @@ $TC p4template update table/tc_may_override_example_06/MainControlImpl/ipv4_tbl_
 $TC p4template create table/tc_may_override_example_06/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_06/MainControlImpl/next_hop \
 	act name tc_may_override_example_06/MainControlImpl/drop
 $TC p4template update table/tc_may_override_example_06/MainControlImpl/ipv4_tbl_2 default_miss_action action tc_may_override_example_06/MainControlImpl/next_hop param vport flags runtime

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_07.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_07.template
@@ -18,7 +18,7 @@ $TC p4template update action/tc_may_override_example_07/MainControlImpl/drop sta
 $TC p4template create table/tc_may_override_example_07/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_07/MainControlImpl/next_hop \
 	act name tc_may_override_example_07/MainControlImpl/dflt_route_drop
 $TC p4template update table/tc_may_override_example_07/MainControlImpl/ipv4_tbl_1 default_miss_action action tc_may_override_example_07/MainControlImpl/next_hop param vport flags runtime
@@ -26,7 +26,7 @@ $TC p4template update table/tc_may_override_example_07/MainControlImpl/ipv4_tbl_
 $TC p4template create table/tc_may_override_example_07/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_07/MainControlImpl/next_hop \
 	act name tc_may_override_example_07/MainControlImpl/dflt_route_drop \
 	act name tc_may_override_example_07/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_08.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_08.template
@@ -18,7 +18,7 @@ $TC p4template update action/tc_may_override_example_08/MainControlImpl/drop sta
 $TC p4template create table/tc_may_override_example_08/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_08/MainControlImpl/next_hop \
 	act name tc_may_override_example_08/MainControlImpl/dflt_route_drop
 $TC p4template update table/tc_may_override_example_08/MainControlImpl/ipv4_tbl_1 default_miss_action action tc_may_override_example_08/MainControlImpl/next_hop param vport flags runtime
@@ -26,7 +26,7 @@ $TC p4template update table/tc_may_override_example_08/MainControlImpl/ipv4_tbl_
 $TC p4template create table/tc_may_override_example_08/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_08/MainControlImpl/next_hop \
 	act name tc_may_override_example_08/MainControlImpl/dflt_route_drop \
 	act name tc_may_override_example_08/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_09.template
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_09.template
@@ -18,7 +18,7 @@ $TC p4template update action/tc_may_override_example_09/MainControlImpl/drop sta
 $TC p4template create table/tc_may_override_example_09/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 64 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 64 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_09/MainControlImpl/next_hop \
 	act name tc_may_override_example_09/MainControlImpl/dflt_route_drop
 $TC p4template update table/tc_may_override_example_09/MainControlImpl/ipv4_tbl_1 default_miss_action action tc_may_override_example_09/MainControlImpl/next_hop param vport flags runtime
@@ -26,7 +26,7 @@ $TC p4template update table/tc_may_override_example_09/MainControlImpl/ipv4_tbl_
 $TC p4template create table/tc_may_override_example_09/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 72 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 72 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_may_override_example_09/MainControlImpl/next_hop \
 	act name tc_may_override_example_09/MainControlImpl/dflt_route_drop \
 	act name tc_may_override_example_09/MainControlImpl/drop

--- a/testdata/p4tc_samples_outputs/tc_type_annotation_example.template
+++ b/testdata/p4tc_samples_outputs/tc_type_annotation_example.template
@@ -16,7 +16,7 @@ $TC p4template update action/tc_type_annotation_example/MainControlImpl/default_
 $TC p4template create table/tc_type_annotation_example/MainControlImpl/ipv4_tbl_1 \
 	tblid 1 \
 	type exact \
-	keysz 32 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 32 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name tc_type_annotation_example/MainControlImpl/next_hop \
 	act name tc_type_annotation_example/MainControlImpl/default_route_drop \
 	act name NoAction flags defaultonly
@@ -24,6 +24,6 @@ $TC p4template create table/tc_type_annotation_example/MainControlImpl/ipv4_tbl_
 $TC p4template create table/tc_type_annotation_example/MainControlImpl/ipv4_tbl_2 \
 	tblid 2 \
 	type exact \
-	keysz 3 nummasks 8 permissions 0x3da4 tentries 1024 \
+	keysz 3 permissions 0x3da4 tentries 1024 nummasks 1 \
 	table_acts act name NoAction
 $TC p4template update pipeline/tc_type_annotation_example state ready

--- a/testdata/p4tc_samples_outputs/test_ipv6_example.template
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example.template
@@ -12,7 +12,7 @@ $TC p4template update action/test_ipv6_example/MainControlImpl/set_dst state act
 $TC p4template create table/test_ipv6_example/MainControlImpl/tbl_default \
 	tblid 1 \
 	type exact \
-	keysz 128 nummasks 8 permissions 0x3da4 tentries 100 \
+	keysz 128 permissions 0x3da4 tentries 100 nummasks 1 \
 	table_acts act name test_ipv6_example/MainControlImpl/set_dst \
 	act name NoAction
 $TC p4template update table/test_ipv6_example/MainControlImpl/tbl_default default_miss_action action test_ipv6_example/MainControlImpl/set_dst param addr6 0xffff111122223333444455556666aaaa


### PR DESCRIPTION
Since exact tables only have `1` mask, the default number of masks for exact tables should be `1` instead of `8`