### PR TITLE
Fix Fedora CI build.

### DIFF
--- a/.github/workflows/ci-test-fedora.yml
+++ b/.github/workflows/ci-test-fedora.yml
@@ -21,6 +21,8 @@ jobs:
     container:
       image: registry.fedoraproject.org/fedora:latest
       options: --privileged
+      env:
+        IN_DOCKER: "TRUE"
     env:
       CTEST_PARALLEL_LEVEL: 4
     steps:
@@ -47,6 +49,6 @@ jobs:
           cmake --build build -- -j $(nproc)
 
       - name: Run p4c tests (Fedora Linux)
-        # Need to use sudo for the eBPF kernel tests.
-        run: sudo -E ctest --output-on-failure --schedule-random
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"; ctest --output-on-failure --schedule-random
         working-directory: ./build

--- a/tools/install_fedora_deps.sh
+++ b/tools/install_fedora_deps.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-set -e
+# Script for building P4C on Fedora for continuous integration builds.
+
+set -e  # Exit on error.
+set -x  # Make command execution verbose
+
+# In Docker builds, sudo is not available. So make it a noop.
+if [ "$IN_DOCKER" == "TRUE" ]; then
+  echo "Executing within docker container."
+  function sudo() { command "$@"; }
+fi
 
 sudo dnf install -y -q \
     automake \
@@ -47,12 +56,12 @@ sudo dnf install -y -q \
     zlib-devel \
     ninja-build
 
-sudo pip3 install ply ptf scapy==2.5.0 wheel
+pip3 install --user ply ptf scapy==2.5.0 wheel
 
 # Install dependencies for the BMv2 PTF runner and P4Runtime.
-sudo pip3 install --upgrade protobuf==3.20.3
-sudo pip3 install --upgrade googleapis-common-protos==1.61.0
-sudo pip3 install --upgrade grpcio==1.59.2
+pip3 install --user --upgrade protobuf==3.20.3
+pip3 install --user --upgrade googleapis-common-protos==1.61.0
+pip3 install --user --upgrade grpcio==1.59.2
 
 MAKEFLAGS="-j$(nproc)"
 export MAKEFLAGS


### PR DESCRIPTION
The Fedora installation is failing because execution of sudo is not viable any more in the installation script. Let's see whether this workaround can fix it. 
This is the error that occurs within Docker:
```
 sudo: PAM account management error: Authentication service cannot retrieve authentication info
sudo: a password is required
```