### PR TITLE
set PathExpression type in ExpandLookahead

### DIFF
--- a/midend/expandLookahead.cpp
+++ b/midend/expandLookahead.cpp
@@ -94,7 +94,7 @@ DoExpandLookahead::ExpansionInfo *DoExpandLookahead::convertLookahead(
     ta->push_back(bittype);
     auto mc = new IR::MethodCallExpression(expression->srcInfo, expression->method->clone(), ta,
                                            expression->arguments);
-    auto pathe = new IR::PathExpression(name);
+    auto pathe = new IR::PathExpression(bittype, name);
     auto lookupCall = new IR::AssignmentStatement(expression->srcInfo, pathe, mc);
     auto result = new ExpansionInfo;
     result->statement = lookupCall;


### PR DESCRIPTION
Don't leave the PathExpression as Type_Unknown when expanding a lookahead.

Fixes an issue I hit in Tofino code where an expanded lookahead triggers a failure in another pass because `width_bits()` is called on a Type_Unknown object.