### PR TITLE
Add abseil string helpers

### DIFF
--- a/backends/bmv2/common/JsonObjects.cpp
+++ b/backends/bmv2/common/JsonObjects.cpp
@@ -109,7 +109,7 @@ void JsonObjects::add_meta_info() {
 /// @param fields a JsonArray for the fields in the header
 unsigned JsonObjects::add_header_type(const cstring &name, Util::JsonArray *&fields,
                                       unsigned max_length) {
-    std::string sname(name, name.size());
+    std::string sname = name.string();
     auto header_type_id_it = header_type_id.find(sname);
     if (header_type_id_it != header_type_id.end()) {
         return header_type_id_it->second;
@@ -131,7 +131,7 @@ unsigned JsonObjects::add_header_type(const cstring &name, Util::JsonArray *&fie
 }
 
 unsigned JsonObjects::add_union_type(const cstring &name, Util::JsonArray *&fields) {
-    std::string sname(name, name.size());
+    std::string sname = name.string();
     auto it = union_type_id.find(sname);
     if (it != union_type_id.end()) return it->second;
     auto union_type = new Util::JsonObject();
@@ -150,7 +150,7 @@ unsigned JsonObjects::add_union_type(const cstring &name, Util::JsonArray *&fiel
 }
 
 unsigned JsonObjects::add_header_type(const cstring &name) {
-    std::string sname(name, name.size());
+    std::string sname = name.string();
     auto header_type_id_it = header_type_id.find(sname);
     if (header_type_id_it != header_type_id.end()) {
         return header_type_id_it->second;

--- a/backends/bmv2/common/annotations.h
+++ b/backends/bmv2/common/annotations.h
@@ -28,7 +28,7 @@ using namespace P4::literals;
 class ParseAnnotations : public P4::ParseAnnotations {
  public:
     ParseAnnotations()
-        : P4::ParseAnnotations("BMV2"_cs, false,
+        : P4::ParseAnnotations("BMV2", false,
                                {
                                    PARSE_EMPTY("metadata"_cs),
                                    PARSE_EXPRESSION_LIST("field_list"_cs),

--- a/backends/bmv2/common/header.cpp
+++ b/backends/bmv2/common/header.cpp
@@ -290,7 +290,7 @@ void HeaderConverter::addHeaderType(const IR::Type_StructLike *st) {
         if (auto aliasAnnotation = f->getAnnotation("alias"_cs)) {
             auto container = new Util::JsonArray();
             auto alias = new Util::JsonArray();
-            auto target_name = "";
+            cstring target_name;
             if (BMV2Context::get().options().loadIRFromJson == false) {
                 target_name = aliasAnnotation->expr.front()->to<IR::StringLiteral>()->value;
             } else {

--- a/backends/bmv2/common/midend.h
+++ b/backends/bmv2/common/midend.h
@@ -33,7 +33,7 @@ class EnumOn32Bits : public P4::ChooseEnumRepresentation {
     bool convert(const IR::Type_Enum *type) const override {
         if (type->srcInfo.isValid()) {
             auto sourceFile = type->srcInfo.getSourceFile();
-            if (sourceFile.endsWith(filename.string_view()))
+            if (sourceFile.endsWith(filename))
                 // Don't convert any of the standard enums
                 return false;
         }

--- a/backends/bmv2/pna_nic/midend.cpp
+++ b/backends/bmv2/pna_nic/midend.cpp
@@ -78,7 +78,7 @@ class PnaEnumOn32Bits : public P4::ChooseEnumRepresentation {
         if (type->name == "PNA_MeterColor_t") return true;
         if (type->srcInfo.isValid()) {
             auto sourceFile = type->srcInfo.getSourceFile();
-            if (sourceFile.endsWith(filename.string_view()))
+            if (sourceFile.endsWith(filename))
                 // Don't convert any of the standard enums
                 return false;
         }

--- a/backends/bmv2/pna_nic/pnaProgramStructure.h
+++ b/backends/bmv2/pna_nic/pnaProgramStructure.h
@@ -39,14 +39,13 @@ class PnaProgramStructure : public P4::PortableProgramStructure {
 
     /// Checks if a string is of type PNA_CounterType_t returns true
     /// if it is, false otherwise.
-    static bool isCounterMetadata(cstring ptName) { return !strcmp(ptName, "PNA_CounterType_t"); }
+    static bool isCounterMetadata(cstring ptName) { return ptName == "PNA_CounterType_t"; }
 
     /// Checks if a string is a pna metadata returns true
     /// if it is, false otherwise.
     static bool isStandardMetadata(cstring ptName) {
-        return (!strcmp(ptName, "pna_main_parser_input_metadata_t") ||
-                !strcmp(ptName, "pna_main_input_metadata_t") ||
-                !strcmp(ptName, "pna_main_output_metadata_t"));
+        return ptName == "pna_main_parser_input_metadata_t" ||
+               ptName == "pna_main_input_metadata_t" || ptName == "pna_main_output_metadata_t";
     }
 };
 

--- a/backends/bmv2/psa_switch/midend.cpp
+++ b/backends/bmv2/psa_switch/midend.cpp
@@ -78,7 +78,7 @@ class PsaEnumOn32Bits : public P4::ChooseEnumRepresentation {
         if (type->name == "PSA_MeterColor_t") return true;
         if (type->srcInfo.isValid()) {
             auto sourceFile = type->srcInfo.getSourceFile();
-            if (sourceFile.endsWith(filename.string_view()))
+            if (sourceFile.endsWith(filename))
                 // Don't convert any of the standard enums
                 return false;
         }

--- a/backends/common/psaProgramStructure.h
+++ b/backends/common/psaProgramStructure.h
@@ -44,18 +44,18 @@ class PsaProgramStructure : public PortableProgramStructure {
 
     /// Checks if a string is of type PSA_CounterType_t returns true
     /// if it is, false otherwise.
-    static bool isCounterMetadata(cstring ptName) { return !strcmp(ptName, "PSA_CounterType_t"); }
+    static bool isCounterMetadata(cstring ptName) { return ptName == "PSA_CounterType_t"; }
 
     /// Checks if a string is a psa metadata returns true
     /// if it is, false otherwise.
     static bool isStandardMetadata(cstring ptName) {
-        return (!strcmp(ptName, "psa_ingress_parser_input_metadata_t") ||
-                !strcmp(ptName, "psa_egress_parser_input_metadata_t") ||
-                !strcmp(ptName, "psa_ingress_input_metadata_t") ||
-                !strcmp(ptName, "psa_ingress_output_metadata_t") ||
-                !strcmp(ptName, "psa_egress_input_metadata_t") ||
-                !strcmp(ptName, "psa_egress_deparser_input_metadata_t") ||
-                !strcmp(ptName, "psa_egress_output_metadata_t"));
+        return (ptName == "psa_ingress_parser_input_metadata_t" ||
+                ptName == "psa_egress_parser_input_metadata_t" ||
+                ptName == "psa_ingress_input_metadata_t" ||
+                ptName == "psa_ingress_output_metadata_t" ||
+                ptName == "psa_egress_input_metadata_t" ||
+                ptName == "psa_egress_deparser_input_metadata_t" ||
+                ptName == "psa_egress_output_metadata_t");
     }
 };
 

--- a/backends/dpdk/control-plane/bfruntime_arch_handler.h
+++ b/backends/dpdk/control-plane/bfruntime_arch_handler.h
@@ -147,7 +147,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
         }
         auto *externType = p4info->add_externs();
         externType->set_extern_type_id(static_cast<p4rt_id_t>(typeId));
-        externType->set_extern_type_name(typeName);
+        externType->set_extern_type_name(typeName.string_view());
         return externType;
     }
 
@@ -161,8 +161,8 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
         auto *externInstance = externType->add_instances();
         auto *pre = externInstance->mutable_preamble();
         pre->set_id(symbols.getId(typeId, name));
-        pre->set_name(prefix(pipeName, name));
-        pre->set_alias(symbols.getAlias(name));
+        pre->set_name(prefix(pipeName, name).string_view());
+        pre->set_alias(symbols.getAlias(name).string_view());
         Helpers::addAnnotations(pre, annotations);
         Helpers::addDocumentation(pre, annotations);
         externInstance->mutable_info()->PackFrom(message);
@@ -237,7 +237,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
         auto pipeName = getBlockNamePrefix(tableBlock);
         auto *pre = table->mutable_preamble();
         if (pre->name() == tableDeclaration->controlPlaneName())
-            pre->set_name(prefix(pipeName, pre->name()));
+            pre->set_name(prefix(pipeName, pre->name()).string_view());
     }
 
     void addExternInstance(const P4RuntimeSymbolTableIface &symbols, p4configv1::P4Info *p4info,
@@ -261,7 +261,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
             for (auto &extType : *p4info->mutable_action_profiles()) {
                 auto *pre = extType.mutable_preamble();
                 if (pre->name() == decl->controlPlaneName()) {
-                    pre->set_name(prefix(pipeName, pre->name()));
+                    pre->set_name(prefix(pipeName, pre->name()).string_view());
                     break;
                 }
             }
@@ -269,7 +269,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
             for (auto &extType : *p4info->mutable_action_profiles()) {
                 auto *pre = extType.mutable_preamble();
                 if (pre->name() == decl->controlPlaneName()) {
-                    pre->set_name(prefix(pipeName, pre->name()));
+                    pre->set_name(prefix(pipeName, pre->name()).string_view());
                     break;
                 }
             }
@@ -277,7 +277,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
             for (auto &extType : *p4info->mutable_meters()) {
                 auto *pre = extType.mutable_preamble();
                 if (pre->name() == decl->controlPlaneName()) {
-                    pre->set_name(prefix(pipeName, pre->name()));
+                    pre->set_name(prefix(pipeName, pre->name()).string_view());
                     break;
                 }
             }
@@ -285,7 +285,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
             for (auto &extType : *p4info->mutable_counters()) {
                 auto *pre = extType.mutable_preamble();
                 if (pre->name() == decl->controlPlaneName()) {
-                    pre->set_name(prefix(pipeName, pre->name()));
+                    pre->set_name(prefix(pipeName, pre->name()).string_view());
                     break;
                 }
             }
@@ -293,7 +293,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
             for (auto &extType : *p4info->mutable_registers()) {
                 auto *pre = extType.mutable_preamble();
                 if (pre->name() == decl->controlPlaneName()) {
-                    pre->set_name(prefix(pipeName, pre->name()));
+                    pre->set_name(prefix(pipeName, pre->name()).string_view());
                     break;
                 }
             }

--- a/backends/dpdk/control-plane/bfruntime_arch_handler.h
+++ b/backends/dpdk/control-plane/bfruntime_arch_handler.h
@@ -147,7 +147,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
         }
         auto *externType = p4info->add_externs();
         externType->set_extern_type_id(static_cast<p4rt_id_t>(typeId));
-        externType->set_extern_type_name(typeName.string_view());
+        externType->set_extern_type_name(typeName);
         return externType;
     }
 
@@ -161,8 +161,8 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
         auto *externInstance = externType->add_instances();
         auto *pre = externInstance->mutable_preamble();
         pre->set_id(symbols.getId(typeId, name));
-        pre->set_name(prefix(pipeName, name).string_view());
-        pre->set_alias(symbols.getAlias(name).string_view());
+        pre->set_name(prefix(pipeName, name));
+        pre->set_alias(symbols.getAlias(name));
         Helpers::addAnnotations(pre, annotations);
         Helpers::addDocumentation(pre, annotations);
         externInstance->mutable_info()->PackFrom(message);
@@ -237,7 +237,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
         auto pipeName = getBlockNamePrefix(tableBlock);
         auto *pre = table->mutable_preamble();
         if (pre->name() == tableDeclaration->controlPlaneName())
-            pre->set_name(prefix(pipeName, pre->name()).string_view());
+            pre->set_name(prefix(pipeName, pre->name()));
     }
 
     void addExternInstance(const P4RuntimeSymbolTableIface &symbols, p4configv1::P4Info *p4info,
@@ -261,7 +261,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
             for (auto &extType : *p4info->mutable_action_profiles()) {
                 auto *pre = extType.mutable_preamble();
                 if (pre->name() == decl->controlPlaneName()) {
-                    pre->set_name(prefix(pipeName, pre->name()).string_view());
+                    pre->set_name(prefix(pipeName, pre->name()));
                     break;
                 }
             }
@@ -269,7 +269,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
             for (auto &extType : *p4info->mutable_action_profiles()) {
                 auto *pre = extType.mutable_preamble();
                 if (pre->name() == decl->controlPlaneName()) {
-                    pre->set_name(prefix(pipeName, pre->name()).string_view());
+                    pre->set_name(prefix(pipeName, pre->name()));
                     break;
                 }
             }
@@ -277,7 +277,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
             for (auto &extType : *p4info->mutable_meters()) {
                 auto *pre = extType.mutable_preamble();
                 if (pre->name() == decl->controlPlaneName()) {
-                    pre->set_name(prefix(pipeName, pre->name()).string_view());
+                    pre->set_name(prefix(pipeName, pre->name()));
                     break;
                 }
             }
@@ -285,7 +285,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
             for (auto &extType : *p4info->mutable_counters()) {
                 auto *pre = extType.mutable_preamble();
                 if (pre->name() == decl->controlPlaneName()) {
-                    pre->set_name(prefix(pipeName, pre->name()).string_view());
+                    pre->set_name(prefix(pipeName, pre->name()));
                     break;
                 }
             }
@@ -293,7 +293,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
             for (auto &extType : *p4info->mutable_registers()) {
                 auto *pre = extType.mutable_preamble();
                 if (pre->name() == decl->controlPlaneName()) {
-                    pre->set_name(prefix(pipeName, pre->name()).string_view());
+                    pre->set_name(prefix(pipeName, pre->name()));
                     break;
                 }
             }

--- a/backends/dpdk/dpdkAsmOpt.cpp
+++ b/backends/dpdk/dpdkAsmOpt.cpp
@@ -425,7 +425,7 @@ void EmitDpdkTableConfig::addAction(const IR::Expression *actionRef, P4::Referen
         actionName = newNameMap[actionDecl->name.name];
     else
         actionName = actionDecl->name.name;
-    print(actionName.string_view(), " ");
+    print(actionName, " ");
     if (actionDecl->parameters->parameters.size() == 1) {
         std::vector<cstring> paramNames;
         std::vector<big_int> argVals;
@@ -458,7 +458,7 @@ void EmitDpdkTableConfig::addAction(const IR::Expression *actionRef, P4::Referen
         }
 
         for (size_t i = 0; i < argVals.size(); i++) {
-            print(paramNames[i].string_view(), " ");
+            print(paramNames[i], " ");
             print(argVals[i], " ");
         }
     }

--- a/backends/dpdk/dpdkHelpers.cpp
+++ b/backends/dpdk/dpdkHelpers.cpp
@@ -1530,9 +1530,9 @@ void ConvertStatementToDpdk::add128bitwiseInstr(const IR::Expression *src1Op,
     const IR::Type_Header *Type_Header = nullptr;
     const IR::Type_Header *Type_Tmp = nullptr;
     for (auto header : structure->header_types) {
-        if (strcmp(header.first, "_p4c_sandbox_header_t") == 0) {
+        if (header.first == "_p4c_sandbox_header_t") {
             Type_Header = header.second;
-        } else if (strcmp(header.first, "_p4c_tmp128_t") == 0) {
+        } else if (header.first == "_p4c_tmp128_t") {
             Type_Tmp = header.second;
         }
     }
@@ -1637,7 +1637,7 @@ void ConvertStatementToDpdk::add128ComparisonInstr(cstring true_label, const IR:
     }
     const IR::Type_Header *Type_Header = nullptr;
     for (auto header : structure->header_types) {
-        if (strcmp(header.first, "_p4c_sandbox_header_t") == 0) {
+        if (header.first == "_p4c_sandbox_header_t") {
             Type_Header = header.second;
         }
     }
@@ -1700,9 +1700,9 @@ void ConvertStatementToDpdk::add128bitComplInstr(const IR::Expression *dst,
     const IR::Type_Header *Type_Header = nullptr;
     const IR::Type_Header *Type_Tmp = nullptr;
     for (auto header : structure->header_types) {
-        if (strcmp(header.first, "_p4c_sandbox_header_t") == 0) {
+        if (header.first == "_p4c_sandbox_header_t") {
             Type_Header = header.second;
-        } else if (strcmp(header.first, "_p4c_tmp128_t") == 0) {
+        } else if (header.first == "_p4c_tmp128_t") {
             Type_Tmp = header.second;
         }
     }

--- a/backends/dpdk/dpdkProgramStructure.cpp
+++ b/backends/dpdk/dpdkProgramStructure.cpp
@@ -242,14 +242,12 @@ void InspectDpdkProgram::addTypesAndInstances(const IR::Type_StructLike *type, b
 }
 
 bool InspectDpdkProgram::isStandardMetadata(cstring ptName) {
-    // FIXME: do we really need strcmp here?
-    return (!strcmp(ptName, "psa_ingress_parser_input_metadata_t") ||
-            !strcmp(ptName, "psa_egress_parser_input_metadata_t") ||
-            !strcmp(ptName, "psa_ingress_input_metadata_t") ||
-            !strcmp(ptName, "psa_ingress_output_metadata_t") ||
-            !strcmp(ptName, "psa_egress_input_metadata_t") ||
-            !strcmp(ptName, "psa_egress_deparser_input_metadata_t") ||
-            !strcmp(ptName, "psa_egress_output_metadata_t"));
+    return (ptName == "psa_ingress_parser_input_metadata_t" ||
+            ptName == "psa_egress_parser_input_metadata_t") ||
+           ptName == "psa_ingress_input_metadata_t" || ptName == "psa_ingress_output_metadata_t" ||
+           ptName == "psa_egress_input_metadata_t" ||
+           ptName == "psa_egress_deparser_input_metadata_t" ||
+           ptName == "psa_egress_output_metadata_t";
 }
 
 bool InspectDpdkProgram::preorder(const IR::Declaration_Variable *dv) {

--- a/backends/ebpf/codeGen.cpp
+++ b/backends/ebpf/codeGen.cpp
@@ -39,14 +39,14 @@ bool CodeGenInspector::preorder(const IR::Constant *expression) {
     cstring str = EBPFInitializerUtils::genHexStr(expression->value, width, expression);
     builder->append("{ ");
     for (size_t i = 0; i < str.size() / 2; ++i)
-        builder->appendFormat("0x%s, ", str.substr(2 * i, 2));
+        builder->appendFormat("0x%v, ", str.substr(2 * i, 2));
     builder->append("}");
 
     return false;
 }
 
 bool CodeGenInspector::preorder(const IR::StringLiteral *expression) {
-    builder->appendFormat("\"%s\"", expression->toString());
+    builder->appendFormat("\"%v\"", expression->toString());
     return true;
 }
 
@@ -491,7 +491,7 @@ void CodeGenInspector::emitAndConvertByteOrder(const IR::Expression *expr, cstri
         loadSize = 64;
     }
     unsigned shift = loadSize - widthToEmit;
-    builder->appendFormat("%s(", emit);
+    builder->appendFormat("%v(", emit);
     visit(expr);
     if (shift != 0 && byte_order == "HOST") builder->appendFormat(" << %d", shift);
     builder->append(")");

--- a/backends/ebpf/ebpfControl.cpp
+++ b/backends/ebpf/ebpfControl.cpp
@@ -142,8 +142,7 @@ bool ControlBodyTranslator::preorder(const IR::MethodCallExpression *expression)
         // Action arguments have been eliminated by the mid-end.
         BUG_CHECK(expression->arguments->size() == 0, "%1%: unexpected arguments for action call",
                   expression);
-        cstring msg =
-            absl::StrFormat("Control: explicit calling action %s()", ac->action->name.name);
+        cstring msg = absl::StrFormat("Control: explicit calling action %v()", ac->action->name);
         builder->target->emitTraceMessage(builder, msg.c_str());
         visit(ac->action->body);
         return false;
@@ -165,9 +164,9 @@ void ControlBodyTranslator::compileEmitField(const IR::Expression *expr, cstring
     if (!swap.isNullOrEmpty()) {
         builder->emitIndent();
         visit(expr);
-        builder->appendFormat(".%s = %s(", field.c_str(), swap);
+        builder->appendFormat(".%v = %v(", field, swap);
         visit(expr);
-        builder->appendFormat(".%s)", field.c_str());
+        builder->appendFormat(".%v)", field);
         builder->endOfStatement(true);
     }
 
@@ -304,7 +303,7 @@ void ControlBodyTranslator::processApply(const P4::ApplyMethod *method) {
     auto table = control->getTable(method->object->getName().name);
     BUG_CHECK(table != nullptr, "No table for %1%", method->expr);
 
-    msgStr = absl::StrFormat("Control: applying %s", method->object->getName().name);
+    msgStr = absl::StrFormat("Control: applying %v", method->object->getName());
     builder->target->emitTraceMessage(builder, msgStr.c_str());
 
     builder->emitIndent();
@@ -393,7 +392,7 @@ void ControlBodyTranslator::processApply(const P4::ApplyMethod *method) {
     builder->blockEnd(true);
     builder->blockEnd(true);
 
-    msgStr = absl::StrFormat("Control: %s applied", method->object->getName().name);
+    msgStr = absl::StrFormat("Control: %v applied", method->object->getName());
     builder->target->emitTraceMessage(builder, msgStr.c_str());
 }
 
@@ -595,8 +594,7 @@ void EBPFControl::emitDeclaration(CodeBuilder *builder, const IR::Declaration *d
                     // Therefore, this piece of code zero-initialize structures
                     // that might be used as keys.
                     builder->emitIndent();
-                    builder->appendFormat("__builtin_memset((void *) &%s, 0, sizeof(",
-                                          vd->name.name);
+                    builder->appendFormat("__builtin_memset((void *) &%v, 0, sizeof(", vd->name);
                     etype->declare(builder, cstring::empty, false);
                     builder->append("))");
                     builder->endOfStatement(true);

--- a/backends/ebpf/ebpfDeparser.cpp
+++ b/backends/ebpf/ebpfDeparser.cpp
@@ -201,13 +201,13 @@ void DeparserHdrEmitTranslator::emitField(CodeBuilder *builder, cstring field,
             visit(hdrExpr);
             builder->appendFormat(".%s", field.c_str());
             builder->endOfStatement(true);
-            msgStr = absl::StrFormat("Deparser: emitting field %s=0x%%llx (%u bits)", field,
+            msgStr = absl::StrFormat("Deparser: emitting field %v=0x%%llx (%u bits)", field,
                                      widthToEmit);
             builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, "tmp");
             builder->blockEnd(true);
         }
     } else {
-        msgStr = absl::StrFormat("Deparser: emitting field %s (%u bits)", field, widthToEmit);
+        msgStr = absl::StrFormat("Deparser: emitting field %v (%u bits)", field, widthToEmit);
         builder->target->emitTraceMessage(builder, msgStr.c_str());
     }
 
@@ -229,9 +229,9 @@ void DeparserHdrEmitTranslator::emitField(CodeBuilder *builder, cstring field,
     if (!swap.isNullOrEmpty()) {
         builder->emitIndent();
         visit(hdrExpr);
-        builder->appendFormat(".%s = %s(", field, swap);
+        builder->appendFormat(".%v = %v(", field, swap);
         visit(hdrExpr);
-        builder->appendFormat(".%s", field);
+        builder->appendFormat(".%v", field);
         if (shift != 0) builder->appendFormat(" << %d", shift);
         builder->append(")");
         builder->endOfStatement(true);
@@ -244,7 +244,7 @@ void DeparserHdrEmitTranslator::emitField(CodeBuilder *builder, cstring field,
         builder->emitIndent();
         builder->appendFormat("%s = ((char*)(&", program->byteVar.c_str());
         visit(hdrExpr);
-        builder->appendFormat(".%s))[%d]", field, i);
+        builder->appendFormat(".%v))[%d]", field, i);
         builder->endOfStatement(true);
         unsigned freeBits = alignment != 0 ? (8 - alignment) : 8;
         bitsInCurrentByte = left >= 8 ? 8 : left;
@@ -371,14 +371,14 @@ void EBPFDeparser::emit(CodeBuilder *builder) {
     emitBufferAdjusts(builder);
 
     builder->emitIndent();
-    builder->appendFormat("%s = %s;", program->packetStartVar,
+    builder->appendFormat("%v = %v;", program->packetStartVar,
                           builder->target->dataOffset(program->model.CPacketName.toString()));
     builder->newline();
     builder->emitIndent();
-    builder->appendFormat("%s = %s;", program->headerStartVar, program->packetStartVar);
+    builder->appendFormat("%v = %v;", program->headerStartVar, program->packetStartVar);
     builder->newline();
     builder->emitIndent();
-    builder->appendFormat("%s = %s;", program->packetEndVar,
+    builder->appendFormat("%v = %v;", program->packetEndVar,
                           builder->target->dataEnd(program->model.CPacketName.toString()));
     builder->newline();
 

--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -209,7 +209,7 @@ void EBPFStructType::emitInitializer(CodeBuilder *builder) {
     if (type->is<IR::Type_Struct>() || type->is<IR::Type_HeaderUnion>()) {
         for (auto f : fields) {
             builder->emitIndent();
-            builder->appendFormat(".%s = ", f->field->name.name);
+            builder->appendFormat(".%v = ", f->field->name);
             f->type->emitInitializer(builder);
             builder->append(",");
             builder->newline();

--- a/backends/ebpf/psa/ebpfPsaControl.cpp
+++ b/backends/ebpf/psa/ebpfPsaControl.cpp
@@ -48,7 +48,7 @@ bool ControlBodyTranslatorPSA::preorder(const IR::AssignmentStatement *a) {
                    ext->originalExternType->name.name == "DirectMeter") {
             // It is just for trace message before meter execution
             cstring name = EBPFObject::externalName(ext->object);
-            auto msgStr = absl::StrFormat("Executing meter: %s", name);
+            auto msgStr = absl::StrFormat("Executing meter: %v", name);
             builder->target->emitTraceMessage(builder, msgStr.c_str());
         }
     }

--- a/backends/ebpf/psa/ebpfPsaDeparser.cpp
+++ b/backends/ebpf/psa/ebpfPsaDeparser.cpp
@@ -201,7 +201,7 @@ void XDPIngressDeparserPSA::emitPreDeparser(CodeBuilder *builder) {
     cstring conditionSendToTC =
         "if (%s->clone || %s->multicast_group != 0 ||"
         " (!%s->drop && %s->egress_port == 0 && !%s->resubmit && %s->multicast_group == 0)) "_cs;
-    conditionSendToTC = conditionSendToTC.replace("%s", istd->name.name.string_view());
+    conditionSendToTC = conditionSendToTC.replace("%s", istd->name.name);
     builder->append(conditionSendToTC);
     builder->blockStart();
     builder->emitIndent();

--- a/backends/ebpf/psa/ebpfPsaDeparser.cpp
+++ b/backends/ebpf/psa/ebpfPsaDeparser.cpp
@@ -30,8 +30,7 @@ void DeparserBodyTranslatorPSA::processFunction(const P4::ExternFunction *functi
     auto dprs = deparser->to<EBPFDeparserPSA>();
     CHECK_NULL(dprs);
     if (function->method->name.name == "psa_resubmit") {
-        builder->appendFormat("(!%s->drop && %s->resubmit)", dprs->istd->name.name,
-                              dprs->istd->name.name);
+        builder->appendFormat("(!%v->drop && %v->resubmit)", dprs->istd->name, dprs->istd->name);
     }
 }
 
@@ -141,19 +140,19 @@ void TCIngressDeparserPSA::emitPreDeparser(CodeBuilder *builder) {
     builder->emitIndent();
 
     // clone support
-    builder->appendFormat("if (%s->clone) ", istd->name.name);
+    builder->appendFormat("if (%v->clone) ", istd->name);
     builder->blockStart();
     builder->emitIndent();
     builder->appendFormat(
-        "do_packet_clones(%s, &clone_session_tbl, %s->clone_session_id,"
+        "do_packet_clones(%s, &clone_session_tbl, %v->clone_session_id,"
         " CLONE_I2E, 1);",
-        program->model.CPacketName.str(), istd->name.name);
+        program->model.CPacketName.str(), istd->name);
     builder->newline();
     builder->blockEnd(true);
 
     // early drop
     builder->emitIndent();
-    builder->appendFormat("if (%s->drop) ", istd->name.name);
+    builder->appendFormat("if (%v->drop) ", istd->name);
     builder->blockStart();
     builder->target->emitTraceMessage(builder, "PreDeparser: dropping packet..");
     builder->emitIndent();
@@ -162,7 +161,7 @@ void TCIngressDeparserPSA::emitPreDeparser(CodeBuilder *builder) {
 
     // if packet should be resubmitted, we skip deparser
     builder->emitIndent();
-    builder->appendFormat("if (%s->resubmit) ", istd->name.name);
+    builder->appendFormat("if (%v->resubmit) ", istd->name);
     builder->blockStart();
     builder->target->emitTraceMessage(builder,
                                       "PreDeparser: resubmitting packet, "
@@ -170,7 +169,7 @@ void TCIngressDeparserPSA::emitPreDeparser(CodeBuilder *builder) {
     builder->emitIndent();
     CHECK_NULL(program);
     auto pipeline = program->checkedTo<EBPFPipeline>();
-    builder->appendFormat("%s->packet_path = RESUBMIT;", pipeline->compilerGlobalMetadata);
+    builder->appendFormat("%v->packet_path = RESUBMIT;", pipeline->compilerGlobalMetadata);
     builder->newline();
     builder->emitIndent();
     builder->appendLine("return TC_ACT_UNSPEC;");
@@ -181,13 +180,13 @@ void TCIngressDeparserPSA::emitPreDeparser(CodeBuilder *builder) {
 void TCIngressDeparserForTrafficManagerPSA::emitPreDeparser(CodeBuilder *builder) {
     // clone support
     builder->emitIndent();
-    builder->appendFormat("if (%s.clone) ", this->istd->name.name);
+    builder->appendFormat("if (%v.clone) ", this->istd->name);
     builder->blockStart();
     builder->emitIndent();
     builder->appendFormat(
-        "do_packet_clones(%s, &clone_session_tbl, %s.clone_session_id,"
+        "do_packet_clones(%s, &clone_session_tbl, %v.clone_session_id,"
         " CLONE_I2E, 1);",
-        program->model.CPacketName.str(), this->istd->name.name);
+        program->model.CPacketName.str(), this->istd->name);
     builder->newline();
     builder->blockEnd(true);
 }
@@ -208,14 +207,14 @@ void XDPIngressDeparserPSA::emitPreDeparser(CodeBuilder *builder) {
     builder->emitIndent();
     builder->appendLine("struct xdp2tc_metadata xdp2tc_md = {};");
     builder->emitIndent();
-    builder->appendFormat("xdp2tc_md.headers = *%s", this->parserHeaders->name.name);
+    builder->appendFormat("xdp2tc_md.headers = *%v", this->parserHeaders->name);
 
     builder->endOfStatement(true);
     builder->emitIndent();
-    builder->appendFormat("xdp2tc_md.ostd = *%s", this->istd->name.name);
+    builder->appendFormat("xdp2tc_md.ostd = *%v", this->istd->name);
     builder->endOfStatement(true);
     builder->emitIndent();
-    builder->appendFormat("xdp2tc_md.packetOffsetInBits = 8 * PTR_DIFF_BYTES(%s, %s)",
+    builder->appendFormat("xdp2tc_md.packetOffsetInBits = 8 * PTR_DIFF_BYTES(%v, %v)",
                           this->program->headerStartVar, this->program->packetStartVar);
     builder->endOfStatement(true);
     builder->append(
@@ -260,11 +259,11 @@ void XDPIngressDeparserPSA::emitPreDeparser(CodeBuilder *builder) {
     }
     builder->target->emitTraceMessage(builder, "Sending packet up to TC for cloning or to kernel");
     builder->emitIndent();
-    builder->appendFormat("return %s", builder->target->forwardReturnCode());
+    builder->appendFormat("return %v", builder->target->forwardReturnCode());
     builder->endOfStatement(true);
     builder->blockEnd(true);
     builder->emitIndent();
-    builder->appendFormat("if (%s->drop) ", istd->name.name);
+    builder->appendFormat("if (%v->drop) ", istd->name);
     builder->blockStart();
     builder->target->emitTraceMessage(builder, "PreDeparser: dropping packet..");
     builder->emitIndent();
@@ -273,13 +272,13 @@ void XDPIngressDeparserPSA::emitPreDeparser(CodeBuilder *builder) {
 
     // if packet should be resubmitted, we skip deparser
     builder->emitIndent();
-    builder->appendFormat("if (%s->resubmit) ", istd->name.name);
+    builder->appendFormat("if (%v->resubmit) ", istd->name);
     builder->blockStart();
     builder->target->emitTraceMessage(builder,
                                       "PreDeparser: resubmitting packet, "
                                       "skipping deparser..");
     builder->emitIndent();
-    builder->appendFormat("%s->packet_path = RESUBMIT;",
+    builder->appendFormat("%v->packet_path = RESUBMIT;",
                           program->to<EBPFPipeline>()->compilerGlobalMetadata);
     builder->newline();
     builder->emitIndent();
@@ -290,7 +289,7 @@ void XDPIngressDeparserPSA::emitPreDeparser(CodeBuilder *builder) {
 // =====================XDPEgressDeparserPSA=============================
 void XDPEgressDeparserPSA::emitPreDeparser(CodeBuilder *builder) {
     builder->emitIndent();
-    builder->appendFormat("if (%s.drop) ", istd->name.name);
+    builder->appendFormat("if (%v.drop) ", istd->name);
     builder->blockStart();
     builder->target->emitTraceMessage(builder, "PreDeparser: dropping packet..");
     builder->emitIndent();

--- a/backends/ebpf/psa/ebpfPsaGen.cpp
+++ b/backends/ebpf/psa/ebpfPsaGen.cpp
@@ -46,7 +46,7 @@ class PSAErrorCodesGen : public Inspector {
             }
 
             builder->emitIndent();
-            builder->appendFormat("static const ParserError_t %s = %d", decl->name.name, id);
+            builder->appendFormat("static const ParserError_t %v = %d", decl->name, id);
             builder->endOfStatement(true);
 
             // Type ParserError_t is u8, which can have values from 0 to 255.
@@ -567,7 +567,7 @@ void PSAArchXDP::emitInitializerSection(CodeBuilder *builder) const {
 void PSAArchXDP::emitXDP2TCInternalStructures(CodeBuilder *builder) const {
     builder->appendFormat(
         "struct xdp2tc_metadata {\n"
-        "    struct %s headers;\n"
+        "    struct %v headers;\n"
         "    struct psa_ingress_output_metadata_t ostd;\n"
         "    __u32 packetOffsetInBits;\n"
         "    __u16 pkt_ether_type;\n"

--- a/backends/ebpf/psa/ebpfPsaTable.cpp
+++ b/backends/ebpf/psa/ebpfPsaTable.cpp
@@ -613,16 +613,16 @@ void EBPFTablePSA::emitMapUpdateTraceMsg(CodeBuilder *builder, cstring mapName,
     builder->emitIndent();
     builder->appendFormat("if (%s) ", returnCode.c_str());
     builder->blockStart();
-    cstring msgStr =
+    auto msgStr =
         absl::StrFormat("Map initializer: Error while map (%v) update, code: %s", mapName, "%d");
-    builder->target->emitTraceMessage(builder, msgStr, 1, returnCode.c_str());
+    builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, returnCode.c_str());
 
     builder->blockEnd(false);
     builder->append(" else ");
 
     builder->blockStart();
     msgStr = absl::StrFormat("Map initializer: Map (%v) update succeed", mapName);
-    builder->target->emitTraceMessage(builder, msgStr);
+    builder->target->emitTraceMessage(builder, msgStr.c_str());
     builder->blockEnd(true);
 }
 

--- a/backends/ebpf/psa/externs/ebpfPsaCounter.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaCounter.cpp
@@ -260,7 +260,7 @@ void EBPFCounterPSA::emitCounterUpdate(CodeBuilder *builder, const cstring targe
 
     if (type == CounterType::BYTES || type == CounterType::PACKETS_AND_BYTES) {
         builder->emitIndent();
-        builder->appendFormat("__sync_fetch_and_add(&(%sbytes), %s)", targetWAccess.c_str(),
+        builder->appendFormat("__sync_fetch_and_add(&(%vbytes), %v)", targetWAccess,
                               program->lengthVar);
         builder->endOfStatement(true);
 

--- a/backends/ebpf/psa/externs/ebpfPsaDigest.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaDigest.cpp
@@ -82,7 +82,7 @@ class EBPFDigestPSAValueVisitor : public CodeGenInspector {
 
         for (const auto *f : se->components) {
             auto type = typeMap->getType(f->expression);
-            cstring path = absl::StrFormat("%s.%s", tmpVar, f->name.name);
+            cstring path = absl::StrFormat("%v.%v", tmpVar, f->name);
             codegen->emitAssignStatement(type, nullptr, path, f->expression);
             builder->newline();
         }
@@ -123,7 +123,7 @@ void EBPFDigestPSA::emitTypes(CodeBuilder *builder) {
 }
 
 void EBPFDigestPSA::emitInstance(CodeBuilder *builder) const {
-    builder->appendFormat("REGISTER_TABLE_NO_KEY_TYPE(%s, BPF_MAP_TYPE_QUEUE, 0, ", instanceName);
+    builder->appendFormat("REGISTER_TABLE_NO_KEY_TYPE(%v, BPF_MAP_TYPE_QUEUE, 0, ", instanceName);
 
     if (valueTypeName.isNullOrEmpty()) {
         valueType->declare(builder, cstring::empty, false);
@@ -151,7 +151,7 @@ void EBPFDigestPSA::processMethod(CodeBuilder *builder, cstring method,
 void EBPFDigestPSA::emitPushElement(CodeBuilder *builder, const IR::Expression *elem,
                                     Inspector *codegen) const {
     builder->emitIndent();
-    builder->appendFormat("bpf_map_push_elem(&%s, &", instanceName);
+    builder->appendFormat("bpf_map_push_elem(&%v, &", instanceName);
     codegen->visit(elem);
     builder->append(", BPF_EXIST)");
     builder->endOfStatement(true);
@@ -159,7 +159,7 @@ void EBPFDigestPSA::emitPushElement(CodeBuilder *builder, const IR::Expression *
 
 void EBPFDigestPSA::emitPushElement(CodeBuilder *builder, cstring elem) const {
     builder->emitIndent();
-    builder->appendFormat("bpf_map_push_elem(&%s, &%s, BPF_EXIST)", instanceName, elem);
+    builder->appendFormat("bpf_map_push_elem(&%v, &%v, BPF_EXIST)", instanceName, elem);
     builder->endOfStatement(true);
 }
 

--- a/backends/ebpf/psa/externs/ebpfPsaMeter.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaMeter.cpp
@@ -169,12 +169,12 @@ void EBPFMeterPSA::emitExecute(CodeBuilder *builder, const P4::ExternMethod *met
     }
 
     if (type == BYTES) {
-        builder->appendFormat("meter_execute_bytes%s(&%s, &%s, ", functionNameSuffix, instanceName,
-                              pipeline->lengthVar.c_str());
+        builder->appendFormat("meter_execute_bytes%v(&%v, &%v, ", functionNameSuffix, instanceName,
+                              pipeline->lengthVar);
         this->emitIndex(builder, method, translator);
         builder->appendFormat(", &%s", pipeline->timestampVar.c_str());
     } else {
-        builder->appendFormat("meter_execute_packets%s(&%s, ", functionNameSuffix, instanceName);
+        builder->appendFormat("meter_execute_packets%v(&%v, ", functionNameSuffix, instanceName);
         this->emitIndex(builder, method, translator);
         builder->appendFormat(", &%s", pipeline->timestampVar.c_str());
     }
@@ -215,12 +215,11 @@ void EBPFMeterPSA::emitDirectExecute(CodeBuilder *builder, const P4::ExternMetho
     cstring lockVar = valuePtr + "->" + spinlockField;
     cstring valueMeter = valuePtr + "->" + instanceName;
     if (type == BYTES) {
-        builder->appendFormat("meter_execute_bytes_value%s(&%s, &%s, &%s, &%s", functionNameSuffix,
-                              valueMeter, lockVar, pipeline->lengthVar.c_str(),
-                              pipeline->timestampVar.c_str());
+        builder->appendFormat("meter_execute_bytes_value%v(&%v, &%v, &%v, &%v", functionNameSuffix,
+                              valueMeter, lockVar, pipeline->lengthVar, pipeline->timestampVar);
     } else {
-        builder->appendFormat("meter_execute_packets_value%s(&%s, &%s, &%s", functionNameSuffix,
-                              valueMeter, lockVar, pipeline->timestampVar.c_str());
+        builder->appendFormat("meter_execute_packets_value%v(&%v, &%v, &%v", functionNameSuffix,
+                              valueMeter, lockVar, pipeline->timestampVar);
     }
 
     if (method->expr->arguments->size() == 1) {

--- a/backends/ebpf/psa/externs/ebpfPsaRegister.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaRegister.cpp
@@ -136,7 +136,7 @@ void EBPFRegisterPSA::emitInitializer(CodeBuilder *builder) {
     builder->emitIndent();
     builder->appendFormat("if (%s) ", ret.c_str());
     builder->blockStart();
-    cstring msgStr = absl::StrFormat("Map initializer: Error while map (%s) update, code: %s",
+    cstring msgStr = absl::StrFormat("Map initializer: Error while map (%v) update, code: %s",
                                      instanceName, "%d");
     builder->target->emitTraceMessage(builder, msgStr, 1, ret.c_str());
 
@@ -231,7 +231,7 @@ void EBPFRegisterPSA::emitRegisterWrite(CodeBuilder *builder, const P4::ExternMe
     builder->emitIndent();
     builder->appendFormat("if (%s) ", ret.c_str());
     builder->blockStart();
-    msgStr = absl::StrFormat("Register: Error while map (%s) update, code: %s", instanceName, "%d");
+    msgStr = absl::StrFormat("Register: Error while map (%v) update, code: %s", instanceName, "%d");
     builder->target->emitTraceMessage(builder, msgStr, 1, ret.c_str());
 
     builder->blockEnd(true);

--- a/backends/ebpf/psa/externs/ebpfPsaRegister.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaRegister.cpp
@@ -136,9 +136,9 @@ void EBPFRegisterPSA::emitInitializer(CodeBuilder *builder) {
     builder->emitIndent();
     builder->appendFormat("if (%s) ", ret.c_str());
     builder->blockStart();
-    cstring msgStr = absl::StrFormat("Map initializer: Error while map (%v) update, code: %s",
-                                     instanceName, "%d");
-    builder->target->emitTraceMessage(builder, msgStr, 1, ret.c_str());
+    auto msgStr = absl::StrFormat("Map initializer: Error while map (%v) update, code: %s",
+                                  instanceName, "%d");
+    builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, ret.c_str());
 
     builder->blockEnd(true);
 
@@ -216,7 +216,7 @@ void EBPFRegisterPSA::emitRegisterRead(CodeBuilder *builder, const P4::ExternMet
 
 void EBPFRegisterPSA::emitRegisterWrite(CodeBuilder *builder, const P4::ExternMethod *method,
                                         ControlBodyTranslatorPSA *translator) {
-    cstring msgStr = absl::StrFormat("Register: writing %s", instanceName.c_str());
+    auto msgStr = absl::StrFormat("Register: writing %s", instanceName.c_str());
     builder->target->emitTraceMessage(builder, msgStr.c_str());
 
     builder->emitIndent();
@@ -232,7 +232,7 @@ void EBPFRegisterPSA::emitRegisterWrite(CodeBuilder *builder, const P4::ExternMe
     builder->appendFormat("if (%s) ", ret.c_str());
     builder->blockStart();
     msgStr = absl::StrFormat("Register: Error while map (%v) update, code: %s", instanceName, "%d");
-    builder->target->emitTraceMessage(builder, msgStr, 1, ret.c_str());
+    builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, ret.c_str());
 
     builder->blockEnd(true);
 }

--- a/backends/ebpf/psa/externs/ebpfPsaTableImplementation.cpp
+++ b/backends/ebpf/psa/externs/ebpfPsaTableImplementation.cpp
@@ -279,7 +279,7 @@ void EBPFActionSelectorPSA::emitInitializer(CodeBuilder *builder) {
         if (action->name.originalName == P4::P4CoreLibrary::instance().noAction.name) {
             builder->append(".action = 0,");
         } else {
-            builder->appendFormat(".action = %s,", p4ActionToActionIDName(action));
+            builder->appendFormat(".action = %v,", p4ActionToActionIDName(action));
         }
         builder->newline();
         builder->blockEnd(false);

--- a/backends/ebpf/psa/xdpHelpProgram.h
+++ b/backends/ebpf/psa/xdpHelpProgram.h
@@ -104,7 +104,7 @@ class XDPHelpProgram : public EBPFProgram {
     void emit(CodeBuilder *builder) {
         builder->target->emitCodeSection(builder, sectionName);
         builder->emitIndent();
-        builder->appendFormat("int %s(struct xdp_md *%s)", functionName, model.CPacketName.str());
+        builder->appendFormat("int %v(struct xdp_md *%s)", functionName, model.CPacketName.str());
         builder->spc();
         builder->blockStart();
         builder->emitIndent();

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -258,8 +258,7 @@ class XdpTarget : public KernelSamplesTarget {
                           cstring offsetVar) const override;
     void emitMain(Util::SourceCodeBuilder *builder, cstring functionName,
                   cstring argName) const override {
-        builder->appendFormat("int %s(%s *%s)", functionName.c_str(), packetDescriptorType(),
-                              argName.c_str());
+        builder->appendFormat("int %v(%v *%v)", functionName, packetDescriptorType(), argName);
     }
 };
 

--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -447,7 +447,7 @@ bool Z3Translator::preorder(const IR::BoolLiteral *boolLiteral) {
 }
 
 bool Z3Translator::preorder(const IR::StringLiteral *stringLiteral) {
-    result = solver.get().ctx().string_val(stringLiteral->value);
+    result = solver.get().ctx().string_val(stringLiteral->value.c_str());
     return false;
 }
 

--- a/backends/p4tools/modules/smith/common/declarations.cpp
+++ b/backends/p4tools/modules/smith/common/declarations.cpp
@@ -206,19 +206,14 @@ IR::Type *DeclarationGenerator::genDerivedTypeDeclaration() { return genHeaderTy
 
 IR::IndexedVector<IR::Declaration_ID> DeclarationGenerator::genIdentifierList(size_t len) {
     IR::IndexedVector<IR::Declaration_ID> declIds;
-    std::set<cstring> declIdsName;
+    std::unordered_set<cstring> declIdsName;
 
     for (size_t i = 0; i < len; i++) {
-        cstring name = getRandomString(2);
-        auto *declId = new IR::Declaration_ID(name);
+        std::string name = getRandomString(2);
+        auto [_, inserted] = declIdsName.insert(name);
+        if (!inserted) continue;
 
-        if (declIdsName.find(name) != declIdsName.end()) {
-            delete name;
-            delete declId;
-            continue;
-        }
-
-        declIds.push_back(declId);
+        declIds.push_back(new IR::Declaration_ID(name));
     }
 
     return declIds;
@@ -226,40 +221,30 @@ IR::IndexedVector<IR::Declaration_ID> DeclarationGenerator::genIdentifierList(si
 
 IR::IndexedVector<IR::SerEnumMember> DeclarationGenerator::genSpecifiedIdentifier(size_t len) {
     IR::IndexedVector<IR::SerEnumMember> members;
-    std::set<cstring> membersName;
+    std::unordered_set<cstring> membersName;
 
     for (size_t i = 0; i < len; i++) {
         cstring name = getRandomString(2);
+        auto [_, inserted] = membersName.insert(name);
+        if (!inserted) continue;
+
         IR::Expression *ex = P4Tools::P4Smith::ExpressionGenerator::genIntLiteral();
-
-        if (membersName.find(name) != membersName.end()) {
-            delete ex;
-            continue;
-        }
-
-        auto *member = new IR::SerEnumMember(name, ex);
-
-        members.push_back(member);
+        members.push_back(new IR::SerEnumMember(name, ex));
     }
 
     return members;
 }
 IR::IndexedVector<IR::SerEnumMember> DeclarationGenerator::genSpecifiedIdentifierList(size_t len) {
     IR::IndexedVector<IR::SerEnumMember> members;
-    std::set<cstring> membersName;
+    std::unordered_set<cstring> membersName;
 
     for (size_t i = 0; i < len; i++) {
         cstring name = getRandomString(2);
+        auto [_, inserted] = membersName.insert(name);
+        if (!inserted) continue;
+
         IR::Expression *ex = target().expressionGenerator().genIntLiteral();
-
-        if (membersName.find(name) != membersName.end()) {
-            delete ex;
-            continue;
-        }
-
-        auto *member = new IR::SerEnumMember(name, ex);
-
-        members.push_back(member);
+        members.push_back(new IR::SerEnumMember(name, ex));
     }
 
     return members;

--- a/backends/p4tools/modules/smith/common/expressions.cpp
+++ b/backends/p4tools/modules/smith/common/expressions.cpp
@@ -1203,7 +1203,7 @@ IR::Expression *ExpressionGenerator::editHdrStack(cstring lval) {
         auto subStr = *sIter;
         const auto *hdrBrkt = subStr.find('[');
         if (hdrBrkt != nullptr) {
-            auto stackStr = subStr.substr(static_cast<size_t>(hdrBrkt - subStr + 1));
+            auto stackStr = subStr.substr(static_cast<size_t>(hdrBrkt - subStr.c_str() + 1));
             const auto *stackSzEnd = stackStr.find(']');
             if (stackSzEnd == nullptr) {
                 BUG("There should be a closing bracket.");

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
@@ -130,7 +130,7 @@ const IR::Expression *makeConstant(Token input, const IdenitifierTypeMap &typeMa
         for (const auto &[identifier, keyType] : typeMap) {
             auto annoSize = identifier.size();
             auto tokenLength = inputStr.length();
-            if (inputStr.compare(tokenLength - annoSize, annoSize, identifier) != 0) {
+            if (inputStr.compare(tokenLength - annoSize, annoSize, identifier.string_view()) != 0) {
                 continue;
             }
             if (const auto *bit = keyType->to<IR::Type_Bits>()) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
@@ -130,7 +130,7 @@ const IR::Expression *makeConstant(Token input, const IdenitifierTypeMap &typeMa
         for (const auto &[identifier, keyType] : typeMap) {
             auto annoSize = identifier.size();
             auto tokenLength = inputStr.length();
-            if (inputStr.compare(tokenLength - annoSize, annoSize, identifier.string_view()) != 0) {
+            if (inputStr.compare(tokenLength - annoSize, annoSize, identifier) != 0) {
                 continue;
             }
             if (const auto *bit = keyType->to<IR::Type_Bits>()) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.cpp
@@ -326,7 +326,7 @@ std::vector<Token> combineTokensToNames(const std::vector<Token> &inputVector) {
         } else {
             if (txt.size() > 0) {
                 cstring buf(txt);
-                result.emplace_back(Token::Kind::Text, buf, buf.size());
+                result.emplace_back(Token::Kind::Text, buf);
                 txt = "";
             }
             result.push_back(input);
@@ -362,7 +362,7 @@ std::vector<Token> combineTokensToNumbers(std::vector<Token> input) {
 
             if (str.rfind("0x", 0) == 0 || str.rfind("0X", 0) == 0) {
                 cstring cstr = str;
-                result.emplace_back(Token::Kind::Number, cstr, cstr.size());
+                result.emplace_back(Token::Kind::Number, cstr);
                 continue;
             }
 
@@ -380,14 +380,14 @@ std::vector<Token> combineTokensToNumbers(std::vector<Token> input) {
             numb += std::string(input[i].lexeme());
             if (i + 1 == input.size()) {
                 cstring cstr(numb);
-                result.emplace_back(Token::Kind::Number, cstr, cstr.size());
+                result.emplace_back(Token::Kind::Number, cstr);
                 numb = "";
                 continue;
             }
         } else {
             if (numb.size() > 0) {
                 cstring cstr(numb);
-                result.emplace_back(Token::Kind::Number, cstr, cstr.size());
+                result.emplace_back(Token::Kind::Number, cstr);
                 numb = "";
             }
             result.push_back(input[i]);
@@ -416,26 +416,26 @@ std::vector<Token> combineTokensToTableKeys(std::vector<Token> input, cstring ta
         auto substr = str.substr(0, str.find("::mask"));
         if (substr != str) {
             cstring cstr = tableName + "_mask_" + substr;
-            result.emplace_back(Token::Kind::Text, cstr, cstr.size());
+            result.emplace_back(Token::Kind::Text, cstr);
             continue;
         }
         substr = str.substr(0, str.find("::prefix_length"));
         if (substr != str) {
             cstring cstr = tableName + "_lpm_prefix_" + substr;
-            result.emplace_back(Token::Kind::Text, cstr, cstr.size());
+            result.emplace_back(Token::Kind::Text, cstr);
             continue;
         }
 
         substr = str.substr(0, str.find("::priority"));
         if (substr != str) {
             cstring cstr = tableName + "_priority";
-            result.emplace_back(Token::Kind::Priority, cstr, cstr.size());
+            result.emplace_back(Token::Kind::Priority, cstr);
             continue;
         }
 
         if (str.find("isValid") != std::string::npos) {
             cstring cstr = tableName + "_key_" + str;
-            result.emplace_back(Token::Kind::Text, cstr, cstr.size());
+            result.emplace_back(Token::Kind::Text, cstr);
             idx += 2;
             continue;
         }
@@ -443,12 +443,12 @@ std::vector<Token> combineTokensToTableKeys(std::vector<Token> input, cstring ta
         substr = str.substr(0, str.find("::value"));
         if (substr != str) {
             cstring cstr = tableName + "_key_" + substr;
-            result.emplace_back(Token::Kind::Text, cstr, cstr.size());
+            result.emplace_back(Token::Kind::Text, cstr);
             continue;
         }
 
         cstring cstr = tableName + "_key_" + str;
-        result.emplace_back(Token::Kind::Text, cstr, cstr.size());
+        result.emplace_back(Token::Kind::Text, cstr);
     }
     return result;
 }
@@ -481,7 +481,7 @@ std::vector<Token> removeComments(const std::vector<Token> &input) {
 std::vector<const IR::Expression *> AssertsParser::genIRStructs(cstring tableName,
                                                                 cstring restrictionString,
                                                                 const IdenitifierTypeMap &typeMap) {
-    Lexer lex(restrictionString);
+    Lexer lex(restrictionString.c_str());
     std::vector<Token> tmp;
     for (auto token = lex.next(); !token.isOneOf(Token::Kind::End, Token::Kind::Unknown);
          token = lex.next()) {

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.h
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_asserts_parser.h
@@ -84,6 +84,8 @@ class Token {
     Token(Kind kind, const char *beg, std::size_t len) noexcept
         : m_kind{kind}, m_lexeme(beg, len) {}
 
+    Token(Kind kind, std::string_view lexeme) noexcept : m_kind{kind}, m_lexeme(lexeme) {}
+
     Token(Kind kind, const char *beg, const char *end) noexcept
         : m_kind{kind}, m_lexeme(beg, std::distance(beg, end)) {}
 

--- a/backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.cpp
+++ b/backends/p4tools/modules/testgen/targets/bmv2/p4_refers_to_parser.cpp
@@ -110,7 +110,7 @@ const IR::SymbolicVariable *RefersToParser::getReferencedKey(const IR::P4Control
     const IR::IDeclaration *tableDeclaration = nullptr;
     for (const auto *decl : *ctrlContext.getDeclarations()) {
         auto declName = decl->controlPlaneName();
-        if (declName.endsWith(tableReference.string_view())) {
+        if (declName.endsWith(tableReference)) {
             tableDeclaration = decl;
             break;
         }

--- a/backends/tc/backend.cpp
+++ b/backends/tc/backend.cpp
@@ -712,8 +712,8 @@ cstring ConvertToBackendIR::HandleTableAccessPermission(const IR::P4Table *t) {
         }
     }
     // FIXME: refactor not to require cstring
-    auto access_cp = GetAccessNumericValue(control_path.string_view());
-    auto access_dp = GetAccessNumericValue(data_path.string_view());
+    auto access_cp = GetAccessNumericValue(control_path);
+    auto access_dp = GetAccessNumericValue(data_path);
     auto access_permisson = (access_cp << 7) | access_dp;
     std::stringstream value;
     value << "0x" << std::hex << access_permisson;
@@ -847,8 +847,8 @@ cstring ConvertToBackendIR::processExternPermission(const IR::Type_Extern *ext) 
     if (data_path.isNullOrEmpty()) {
         data_path = cstring(DEFAULT_EXTERN_DATA_PATH_ACCESS);
     }
-    auto access_cp = GetAccessNumericValue(control_path.string_view());
-    auto access_dp = GetAccessNumericValue(data_path.string_view());
+    auto access_cp = GetAccessNumericValue(control_path);
+    auto access_dp = GetAccessNumericValue(data_path);
     auto access_permisson = (access_cp << 7) | access_dp;
     std::stringstream value;
     value << "0x" << std::hex << access_permisson;

--- a/backends/tc/ebpfCodeGen.cpp
+++ b/backends/tc/ebpfCodeGen.cpp
@@ -136,7 +136,7 @@ void PNAEbpfGenerator::emitP4TCActionParam(EBPF::CodeBuilder *builder) const {
                 cstring placeholder = tblName + "_" + defaultActionName + "_" + paramName;
                 cstring typeName = param->paramDetail->getParamType();
                 builder->emitIndent();
-                builder->appendFormat("%s %s", typeName, placeholder);
+                builder->appendFormat("%v %v", typeName, placeholder);
                 builder->endOfStatement(true);
             }
         }
@@ -151,7 +151,7 @@ void PNAEbpfGenerator::emitP4TCActionParam(EBPF::CodeBuilder *builder) const {
                 cstring placeholder = tblName + "_" + defaultActionName + "_" + paramName;
                 cstring typeName = param->paramDetail->getParamType();
                 builder->emitIndent();
-                builder->appendFormat("%s %s", typeName, placeholder);
+                builder->appendFormat("%v %v", typeName, placeholder);
                 builder->endOfStatement(true);
             }
         }
@@ -183,7 +183,7 @@ void PNAArchTC::emit(EBPF::CodeBuilder *builder) const {
      * 2. Include header file.
      */
     cstring headerFile = getProgramName() + "_parser.h";
-    builder->appendFormat("#include \"%s\"", headerFile);
+    builder->appendFormat("#include \"%v\"", headerFile);
     builder->newline();
     /*
      * 3. Headers, structs
@@ -222,7 +222,7 @@ void PNAArchTC::emitParser(EBPF::CodeBuilder *builder) const {
      */
     xdp->emitGeneratedComment(builder);
     cstring headerFile = getProgramName() + "_parser.h";
-    builder->appendFormat("#include \"%s\"", headerFile);
+    builder->appendFormat("#include \"%v\"", headerFile);
     builder->newline();
     builder->newline();
     builder->appendLine("struct p4tc_filter_fields p4tc_filter_fields;");
@@ -260,11 +260,11 @@ void TCIngressPipelinePNA::emit(EBPF::CodeBuilder *builder) {
     // FIXME: use Target to generate metadata type
     cstring func_name = (name == "tc-parse") ? "run_parser"_cs : "process"_cs;
     builder->appendFormat(
-        "int %s(%s *%s, %s %s *%s, "
-        "struct pna_global_metadata *%s",
+        "int %v(%v *%s, %v %v *%v, "
+        "struct pna_global_metadata *%v",
         func_name, builder->target->packetDescriptorType(), model.CPacketName.str(),
         parser->headerType->as<EBPF::EBPFStructType>().kind,
-        parser->headerType->as<EBPF::EBPFStructType>().name, parser->headers->name.name,
+        parser->headerType->as<EBPF::EBPFStructType>().name, parser->headers->name,
         compilerGlobalMetadata);
 
     builder->append(")");
@@ -290,7 +290,7 @@ void TCIngressPipelinePNA::emit(EBPF::CodeBuilder *builder) {
         builder->newline();
         builder->emitIndent();
         builder->emitIndent();
-        builder->appendFormat("return %s;", dropReturnCode());
+        builder->appendFormat("return %v;", dropReturnCode());
         builder->newline();
         builder->emitIndent();
         builder->appendFormat("unsigned %s = hdrMd->%s;", offsetVar.c_str(), offsetVar.c_str());
@@ -307,10 +307,10 @@ void TCIngressPipelinePNA::emit(EBPF::CodeBuilder *builder) {
 
     if (name == "tc-parse") {
         msgStr = absl::StrFormat(
-            "%s parser: parsing new packet, input_port=%%d, path=%%d, "
+            "%v parser: parsing new packet, input_port=%%d, path=%%d, "
             "pkt_len=%%d",
             sectionName);
-        varStr = absl::StrFormat("%s->packet_path", compilerGlobalMetadata);
+        varStr = absl::StrFormat("%v->packet_path", compilerGlobalMetadata);
         builder->target->emitTraceMessage(builder, msgStr.c_str(), 3, inputPortVar.c_str(), varStr,
                                           lengthVar.c_str());
 
@@ -327,21 +327,21 @@ void TCIngressPipelinePNA::emit(EBPF::CodeBuilder *builder) {
     if (name == "tc-ingress") {
         // CONTROL
         builder->blockStart();
-        msgStr = absl::StrFormat("%s control: packet processing started", sectionName);
+        msgStr = absl::StrFormat("%v control: packet processing started", sectionName);
         builder->target->emitTraceMessage(builder, msgStr.c_str());
         ((EBPFControlPNA *)control)->emitExternDefinition(builder);
         control->emit(builder);
         builder->blockEnd(true);
-        msgStr = absl::StrFormat("%s control: packet processing finished", sectionName);
+        msgStr = absl::StrFormat("%v control: packet processing finished", sectionName);
         builder->target->emitTraceMessage(builder, msgStr.c_str());
 
         // DEPARSER
         builder->emitIndent();
         builder->blockStart();
-        msgStr = absl::StrFormat("%s deparser: packet deparsing started", sectionName);
+        msgStr = absl::StrFormat("%v deparser: packet deparsing started", sectionName);
         builder->target->emitTraceMessage(builder, msgStr.c_str());
         deparser->emit(builder);
-        msgStr = absl::StrFormat("%s deparser: packet deparsing finished", sectionName);
+        msgStr = absl::StrFormat("%v deparser: packet deparsing finished", sectionName);
         builder->target->emitTraceMessage(builder, msgStr.c_str());
         builder->blockEnd(true);
     }
@@ -359,7 +359,7 @@ void TCIngressPipelinePNA::emit(EBPF::CodeBuilder *builder) {
     if (name == "tc-ingress") {
         builder->target->emitCodeSection(builder, sectionName);
         builder->emitIndent();
-        builder->appendFormat("int %s(%s *%s)", functionName,
+        builder->appendFormat("int %v(%v *%s)", functionName,
                               builder->target->packetDescriptorType(), model.CPacketName.str());
         builder->spc();
 
@@ -374,12 +374,12 @@ void TCIngressPipelinePNA::emit(EBPF::CodeBuilder *builder) {
         builder->appendFormat("int ret = %d;", actUnspecCode);
         builder->newline();
         builder->emitIndent();
-        builder->appendFormat("ret = %s(skb, ", func_name);
+        builder->appendFormat("ret = %v(skb, ", func_name);
 
-        builder->appendFormat("(%s %s *) %s, %s);",
+        builder->appendFormat("(%v %v *) %v, %v);",
                               parser->headerType->as<EBPF::EBPFStructType>().kind,
                               parser->headerType->as<EBPF::EBPFStructType>().name,
-                              parser->headers->name.name, compilerGlobalMetadata);
+                              parser->headers->name, compilerGlobalMetadata);
 
         builder->newline();
         builder->emitIndent();
@@ -397,7 +397,7 @@ void TCIngressPipelinePNA::emit(EBPF::CodeBuilder *builder) {
         builder->newline();
         builder->target->emitCodeSection(builder, sectionName);
         builder->emitIndent();
-        builder->appendFormat("int %s(%s *%s)", functionName,
+        builder->appendFormat("int %v(%v *%s)", functionName,
                               builder->target->packetDescriptorType(), model.CPacketName.str());
         builder->spc();
 
@@ -405,7 +405,7 @@ void TCIngressPipelinePNA::emit(EBPF::CodeBuilder *builder) {
 
         builder->emitIndent();
         builder->appendFormat(
-            "struct pna_global_metadata *%s = (struct pna_global_metadata *) skb->cb;",
+            "struct pna_global_metadata *%v = (struct pna_global_metadata *) skb->cb;",
             compilerGlobalMetadata);
         builder->newline();
 
@@ -416,12 +416,12 @@ void TCIngressPipelinePNA::emit(EBPF::CodeBuilder *builder) {
         builder->appendFormat("int ret = %d;", actUnspecCode);
         builder->newline();
         builder->emitIndent();
-        builder->appendFormat("ret = %s(skb, ", func_name);
+        builder->appendFormat("ret = %v(skb, ", func_name);
 
-        builder->appendFormat("(%s %s *) %s, %s);",
+        builder->appendFormat("(%v %v *) %v, %v);",
                               parser->headerType->as<EBPF::EBPFStructType>().kind,
                               parser->headerType->as<EBPF::EBPFStructType>().name,
-                              parser->headers->name.name, compilerGlobalMetadata);
+                              parser->headers->name, compilerGlobalMetadata);
 
         builder->newline();
         builder->emitIndent();
@@ -442,7 +442,7 @@ void TCIngressPipelinePNA::emit(EBPF::CodeBuilder *builder) {
 void TCIngressPipelinePNA::emitGlobalMetadataInitializer(EBPF::CodeBuilder *builder) {
     builder->emitIndent();
     builder->appendFormat(
-        "struct pna_global_metadata *%s = (struct pna_global_metadata *) skb->cb;",
+        "struct pna_global_metadata *%v = (struct pna_global_metadata *) skb->cb;",
         compilerGlobalMetadata);
     builder->newline();
 
@@ -459,7 +459,7 @@ void TCIngressPipelinePNA::emitGlobalMetadataInitializer(EBPF::CodeBuilder *buil
     // workaround to make TC protocol-independent, DO NOT REMOVE
     builder->emitIndent();
     // replace ether_type only if a packet comes from XDP
-    builder->appendFormat("if (!%s->recirculated) ", compilerGlobalMetadata);
+    builder->appendFormat("if (!%v->recirculated) ", compilerGlobalMetadata);
     builder->blockStart();
     builder->emitIndent();
     builder->appendFormat("compiler_meta__->mark = %u", packetMark);
@@ -482,7 +482,7 @@ void TCIngressPipelinePNA::emitGlobalMetadataInitializer(EBPF::CodeBuilder *buil
 
 void TCIngressPipelinePNA::emitTrafficManager(EBPF::CodeBuilder *builder) {
     builder->emitIndent();
-    builder->appendFormat("if (!%s->drop && %s->egress_port == 0) ", compilerGlobalMetadata,
+    builder->appendFormat("if (!%v->drop && %v->egress_port == 0) ", compilerGlobalMetadata,
                           compilerGlobalMetadata);
     builder->blockStart();
     builder->target->emitTraceMessage(builder, "IngressTM: Sending packet up to the kernel stack");
@@ -501,13 +501,13 @@ void TCIngressPipelinePNA::emitTrafficManager(EBPF::CodeBuilder *builder) {
     builder->endOfStatement(true);
     builder->blockEnd(true);
 
-    cstring eg_port = absl::StrFormat("%s->egress_port", compilerGlobalMetadata);
+    cstring eg_port = absl::StrFormat("%v->egress_port", compilerGlobalMetadata);
     cstring cos =
-        absl::StrFormat("%s.class_of_service", control->outputStandardMetadata->name.name);
+        absl::StrFormat("%v.class_of_service", control->outputStandardMetadata->name.name);
     builder->target->emitTraceMessage(
         builder, "IngressTM: Sending packet out of port %d with priority %d", 2, eg_port, cos);
     builder->emitIndent();
-    builder->appendFormat("return bpf_redirect(%s->egress_port, 0)", compilerGlobalMetadata);
+    builder->appendFormat("return bpf_redirect(%v->egress_port, 0)", compilerGlobalMetadata);
     builder->endOfStatement(true);
 }
 
@@ -636,7 +636,7 @@ void PnaStateTranslationVisitor::compileExtractField(const IR::Expression *expr,
         }
     }
 
-    msgStr = absl::StrFormat("Parser: extracting field %s", fieldName);
+    msgStr = absl::StrFormat("Parser: extracting field %v", fieldName);
     builder->target->emitTraceMessage(builder, msgStr.c_str());
 
     if (widthToExtract <= 64) {
@@ -666,15 +666,14 @@ void PnaStateTranslationVisitor::compileExtractField(const IR::Expression *expr,
         if (noEndiannessConversion) {
             builder->appendFormat("__builtin_memcpy(&");
             visit(expr);
-            builder->appendFormat(".%s, %s + BYTES(%s), %d)", fieldName,
-                                  program->packetStartVar.c_str(), program->offsetVar.c_str(),
-                                  widthToExtract / 8);
+            builder->appendFormat(".%v, %v + BYTES(%v), %d)", fieldName, program->packetStartVar,
+                                  program->offsetVar, widthToExtract / 8);
         } else {
             visit(expr);
-            builder->appendFormat(".%s = (", fieldName);
+            builder->appendFormat(".%v = (", fieldName);
             type->emit(builder);
-            builder->appendFormat(")((%s(%s, BYTES(%s))", helper, program->packetStartVar.c_str(),
-                                  program->offsetVar.c_str());
+            builder->appendFormat(")((%s(%v, BYTES(%v))", helper, program->packetStartVar,
+                                  program->offsetVar);
             if (shift != 0) builder->appendFormat(" >> %d", shift);
             builder->append(")");
             if (widthToExtract != loadSize) {
@@ -753,13 +752,13 @@ void PnaStateTranslationVisitor::compileExtractField(const IR::Expression *expr,
                 }
             }
         }
-        cstring tmp = absl::StrFormat("(unsigned long long) %s.%s", exprStr, fieldName);
+        cstring tmp = absl::StrFormat("(unsigned long long) %v.%v", exprStr, fieldName);
 
         msgStr =
-            absl::StrFormat("Parser: extracted %s=0x%%llx (%u bits)", fieldName, widthToExtract);
+            absl::StrFormat("Parser: extracted %v=0x%%llx (%u bits)", fieldName, widthToExtract);
         builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, tmp.c_str());
     } else {
-        msgStr = absl::StrFormat("Parser: extracted %s (%u bits)", fieldName, widthToExtract);
+        msgStr = absl::StrFormat("Parser: extracted %v (%u bits)", fieldName, widthToExtract);
         builder->target->emitTraceMessage(builder, msgStr.c_str());
     }
 
@@ -785,9 +784,8 @@ bool PnaStateTranslationVisitor::preorder(const IR::Member *m) {
 }
 
 void PnaStateTranslationVisitor::compileLookahead(const IR::Expression *destination) {
-    cstring msgStr = absl::StrFormat("Parser: lookahead for %s %s",
-                                     state->parser->typeMap->getType(destination)->toString(),
-                                     destination->toString());
+    cstring msgStr = absl::StrFormat("Parser: lookahead for %v %v",
+                                     state->parser->typeMap->getType(destination), destination);
     builder->target->emitTraceMessage(builder, msgStr.c_str());
 
     builder->emitIndent();
@@ -863,7 +861,7 @@ void EBPFTablePNA::emitKeyType(EBPF::CodeBuilder *builder) {
     if (isTernaryTable()) {
         // generate mask key
         builder->emitIndent();
-        builder->appendFormat("#define MAX_%s_MASKS %u", keyTypeName.toUpper(),
+        builder->appendFormat("#define MAX_%v_MASKS %u", keyTypeName.toUpper(),
                               program->options.maxTernaryMasks);
         builder->newline();
 
@@ -939,7 +937,7 @@ void EBPFTablePNA::emitValueStructStructure(EBPF::CodeBuilder *builder) {
 cstring EBPFTablePNA::p4ActionToActionIDName(const IR::P4Action *action) const {
     cstring actionName = EBPFObject::externalName(action);
     cstring tableInstance = dataMapName;
-    return absl::StrFormat("%s_ACT_%s", tableInstance.toUpper(), actionName.toUpper());
+    return absl::StrFormat("%v_ACT_%v", tableInstance.toUpper(), actionName.toUpper());
 }
 
 void EBPFTablePNA::emitActionArguments(EBPF::CodeBuilder *builder, const IR::P4Action *action,
@@ -982,24 +980,23 @@ void EBPFTablePNA::emitAction(EBPF::CodeBuilder *builder, cstring valueName,
         cstring name = EBPF::EBPFObject::externalName(action), msgStr, convStr;
         builder->emitIndent();
         cstring actionName = p4ActionToActionIDName(action);
-        builder->appendFormat("case %s: ", actionName);
+        builder->appendFormat("case %v: ", actionName);
         builder->newline();
         builder->increaseIndent();
 
-        msgStr = absl::StrFormat("Control: executing action %s", name);
+        msgStr = absl::StrFormat("Control: executing action %v", name);
         builder->target->emitTraceMessage(builder, msgStr.c_str());
         for (auto param : *(action->parameters)) {
             auto etype = EBPF::EBPFTypeFactory::instance->create(param->type);
             unsigned width = etype->as<EBPF::IHasWidth>().widthInBits();
 
             if (width <= 64) {
-                convStr = absl::StrFormat("(unsigned long long) (%s->u.%s.%s)", valueName, name,
-                                          param->toString());
-                msgStr = absl::StrFormat("Control: param %s=0x%%llx (%d bits)", param->toString(),
-                                         width);
+                convStr =
+                    absl::StrFormat("(unsigned long long) (%v->u.%v.%v)", valueName, name, param);
+                msgStr = absl::StrFormat("Control: param %v=0x%%llx (%d bits)", param, width);
                 builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, convStr.c_str());
             } else {
-                msgStr = absl::StrFormat("Control: param %s (%d bits)", param->toString(), width);
+                msgStr = absl::StrFormat("Control: param %v (%d bits)", param, width);
                 builder->target->emitTraceMessage(builder, msgStr.c_str());
             }
         }
@@ -1080,9 +1077,9 @@ void EBPFTablePNA::emitAction(EBPF::CodeBuilder *builder, cstring valueName,
         cstring noActionName = P4::P4CoreLibrary::instance().noAction.name;
         cstring tableInstance = dataMapName;
         cstring actionName =
-            absl::StrFormat("%s_ACT_%s", tableInstance.toUpper(), noActionName.toUpper());
+            absl::StrFormat("%v_ACT_%v", tableInstance.toUpper(), noActionName.toUpper());
         builder->emitIndent();
-        builder->appendFormat("case %s: ", actionName);
+        builder->appendFormat("case %v: ", actionName);
         builder->newline();
         builder->increaseIndent();
         builder->emitIndent();
@@ -1138,17 +1135,17 @@ void EBPFTablePNA::emitValueActionIDNames(EBPF::CodeBuilder *builder) {
             noActionGenerated = true;
         unsigned int action_idx = tcIR->getActionId(tcIR->externalName(action));
         builder->emitIndent();
-        builder->appendFormat("#define %s %d", p4ActionToActionIDName(action), action_idx);
+        builder->appendFormat("#define %v %d", p4ActionToActionIDName(action), action_idx);
         builder->newline();
     }
     if (!noActionGenerated) {
         cstring noActionName = P4::P4CoreLibrary::instance().noAction.name;
         cstring tableInstance = dataMapName;
         cstring actionName =
-            absl::StrFormat("%s_ACT_%s", tableInstance.toUpper(), noActionName.toUpper());
+            absl::StrFormat("%v_ACT_%v", tableInstance.toUpper(), noActionName.toUpper());
         unsigned int action_idx = tcIR->getActionId(noActionName);
         builder->emitIndent();
-        builder->appendFormat("#define %s %d", actionName, action_idx);
+        builder->appendFormat("#define %v %d", actionName, action_idx);
         builder->newline();
     }
     builder->emitIndent();
@@ -1191,7 +1188,7 @@ void IngressDeparserPNA::emitPreDeparser(EBPF::CodeBuilder *builder) {
     builder->emitIndent();
     CHECK_NULL(program);
     auto pipeline = program->checkedTo<EBPF::EBPFPipeline>();
-    builder->appendFormat("if (%s->drop) ", pipeline->compilerGlobalMetadata);
+    builder->appendFormat("if (%v->drop) ", pipeline->compilerGlobalMetadata);
     builder->blockStart();
     builder->target->emitTraceMessage(builder, "PreDeparser: dropping packet..");
     builder->emitIndent();
@@ -1231,11 +1228,11 @@ void IngressDeparserPNA::emit(EBPF::CodeBuilder *builder) {
 
     emitBufferAdjusts(builder);
     builder->emitIndent();
-    builder->appendFormat("%s = %s;", program->packetStartVar,
+    builder->appendFormat("%v = %v;", program->packetStartVar,
                           builder->target->dataOffset(program->model.CPacketName.toString()));
     builder->newline();
     builder->emitIndent();
-    builder->appendFormat("%s = %s;", program->packetEndVar,
+    builder->appendFormat("%v = %v;", program->packetEndVar,
                           builder->target->dataEnd(program->model.CPacketName.toString()));
     builder->newline();
 
@@ -1749,19 +1746,19 @@ void ControlBodyTranslatorPNA::processFunction(const P4::ExternFunction *functio
                                         actionName);
                         }
                         builder->emitIndent();
-                        builder->appendFormat("update_act_bpf_val->u.%s.%s = ", actionExtName,
-                                              param->toString());
+                        builder->appendFormat("update_act_bpf_val->u.%v.%v = ", actionExtName,
+                                              param);
                         visit(components.at(index)->expression);
                         builder->endOfStatement();
                         builder->newline();
                     }
                     builder->emitIndent();
-                    builder->appendFormat("update_act_bpf_val->action = %s;",
+                    builder->appendFormat("update_act_bpf_val->action = %v;",
                                           table->p4ActionToActionIDName(action));
                     builder->newline();
                 } else {
                     builder->emitIndent();
-                    builder->appendFormat("update_act_bpf.act_id = %s;",
+                    builder->appendFormat("update_act_bpf.act_id = %v;",
                                           table->p4ActionToActionIDName(action));
                     builder->newline();
                 }
@@ -1818,7 +1815,7 @@ void ControlBodyTranslatorPNA::processApply(const P4::ApplyMethod *method) {
     auto table = control->getTable(method->object->getName().name);
     BUG_CHECK(table != nullptr, "No table for %1%", method->expr);
 
-    msgStr = absl::StrFormat("Control: applying %s", method->object->getName().name);
+    msgStr = absl::StrFormat("Control: applying %v", method->object->getName());
     builder->target->emitTraceMessage(builder, msgStr.c_str());
 
     builder->emitIndent();
@@ -1918,10 +1915,10 @@ void ControlBodyTranslatorPNA::processApply(const P4::ApplyMethod *method) {
 
             cstring msgStr, varStr;
             if (memcpy) {
-                msgStr = absl::StrFormat("Control: key %s", c->expression->toString());
+                msgStr = absl::StrFormat("Control: key %v", c->expression);
                 builder->target->emitTraceMessage(builder, msgStr.c_str());
             } else {
-                msgStr = absl::StrFormat("Control: key %s=0x%%llx", c->expression->toString());
+                msgStr = absl::StrFormat("Control: key %v=0x%%llx", c->expression);
                 varStr = absl::StrFormat("(unsigned long long) %s.%s", keyname.c_str(),
                                          fieldName.c_str());
                 builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, varStr.c_str());
@@ -1981,7 +1978,7 @@ void ControlBodyTranslatorPNA::processApply(const P4::ApplyMethod *method) {
     toDereference.clear();
     builder->blockEnd(true);
 
-    msgStr = absl::StrFormat("Control: %s applied", method->object->getName().name);
+    msgStr = absl::StrFormat("Control: %v applied", method->object->getName());
     builder->target->emitTraceMessage(builder, msgStr.c_str());
 }
 
@@ -2109,9 +2106,9 @@ cstring ActionTranslationVisitorPNA::getParamInstanceName(const IR::Expression *
 
     if (isDefaultAction) {
         cstring actionName = action->name.originalName;
-        auto paramStr = absl::StrFormat("p4tc_filter_fields.%s_%s_%s",
-                                        table->table->container->name.originalName, actionName,
-                                        expression->toString());
+        auto paramStr =
+            absl::StrFormat("p4tc_filter_fields.%v_%v_%v",
+                            table->table->container->name.originalName, actionName, expression);
         return paramStr;
     } else {
         return EBPF::ActionTranslationVisitor::getParamInstanceName(expression);
@@ -2289,13 +2286,13 @@ void DeparserHdrEmitTranslatorPNA::emitField(EBPF::CodeBuilder *builder, cstring
             visit(hdrExpr);
             builder->appendFormat(".%s", field.c_str());
             builder->endOfStatement(true);
-            msgStr = absl::StrFormat("Deparser: emitting field %s=0x%%llx (%u bits)", field,
+            msgStr = absl::StrFormat("Deparser: emitting field %v=0x%%llx (%u bits)", field,
                                      widthToEmit);
             builder->target->emitTraceMessage(builder, msgStr.c_str(), 1, "tmp");
             builder->blockEnd(true);
         }
     } else {
-        msgStr = absl::StrFormat("Deparser: emitting field %s (%u bits)", field, widthToEmit);
+        msgStr = absl::StrFormat("Deparser: emitting field %v (%u bits)", field, widthToEmit);
         builder->target->emitTraceMessage(builder, msgStr.c_str());
     }
 
@@ -2317,9 +2314,9 @@ void DeparserHdrEmitTranslatorPNA::emitField(EBPF::CodeBuilder *builder, cstring
     if (!swap.isNullOrEmpty() && !noEndiannessConversion) {
         builder->emitIndent();
         visit(hdrExpr);
-        builder->appendFormat(".%s = %s(", field, swap);
+        builder->appendFormat(".%v = %v(", field, swap);
         visit(hdrExpr);
-        builder->appendFormat(".%s", field);
+        builder->appendFormat(".%v", field);
         if (shift != 0) builder->appendFormat(" << %d", shift);
         builder->append(")");
         builder->endOfStatement(true);
@@ -2332,7 +2329,7 @@ void DeparserHdrEmitTranslatorPNA::emitField(EBPF::CodeBuilder *builder, cstring
         builder->emitIndent();
         builder->appendFormat("%s = ((char*)(&", program->byteVar.c_str());
         visit(hdrExpr);
-        builder->appendFormat(".%s))[%d]", field, i);
+        builder->appendFormat(".%v))[%d]", field, i);
         builder->endOfStatement(true);
         unsigned freeBits = alignment != 0 ? (8 - alignment) : 8;
         bitsInCurrentByte = left >= 8 ? 8 : left;

--- a/backends/tc/ebpfCodeGen.h
+++ b/backends/tc/ebpfCodeGen.h
@@ -76,7 +76,7 @@ class PNAErrorCodesGen : public Inspector {
             }
 
             builder->emitIndent();
-            builder->appendFormat("static const ParserError_t %s = %d", decl->name.name, id);
+            builder->appendFormat("static const ParserError_t %v = %d", decl->name, id);
             builder->endOfStatement(true);
 
             // type ParserError_t is u8, which can have values from 0 to 255

--- a/backends/tc/pnaProgramStructure.h
+++ b/backends/tc/pnaProgramStructure.h
@@ -89,16 +89,15 @@ class PnaProgramStructure : public P4::ProgramStructure {
      * Checks if a string is of type PNA_CounterType_t returns true
      * if it is, false otherwise.
      */
-    static bool isCounterMetadata(cstring ptName) { return !strcmp(ptName, "PNA_CounterType_t"); }
+    static bool isCounterMetadata(cstring ptName) { return ptName == "PNA_CounterType_t"; }
 
     /**
      * Checks if a string is a psa metadata returns true
      * if it is, false otherwise.
      */
     static bool isStandardMetadata(cstring ptName) {
-        return (!strcmp(ptName, "pna_main_parser_input_metadata_t") ||
-                !strcmp(ptName, "pna_main_input_metadata_t") ||
-                !strcmp(ptName, "pna_main_output_metadata_t"));
+        return ptName == "pna_main_parser_input_metadata_t" ||
+               ptName == "pna_main_input_metadata_t" || ptName == "pna_main_output_metadata_t";
     }
 };
 

--- a/backends/tc/tc.def
+++ b/backends/tc/tc.def
@@ -108,7 +108,7 @@ class TCActionParam {
         return paramType;
     }
     toString {
-        std::string tcActionParam = absl::StrCat("\n\tparam ", paramName.string_view(), " type ");
+        std::string tcActionParam = absl::StrCat("\n\tparam ", paramName, " type ");
         switch(dataType) {
             case TC::BIT_TYPE :
                 absl::StrAppend(&tcActionParam, "bit", bitSize);
@@ -154,9 +154,9 @@ class TCDefaultActionParam {
         defaultValue = nullptr;
     }
     toString {
-        std::string tcActionParam = absl::StrCat(" ", paramDetail->paramName.string_view());
+        std::string tcActionParam = absl::StrCat(" ", paramDetail->paramName);
         if (defaultValue != nullptr)
-            absl::StrAppend(&tcActionParam, " ", defaultValue.string_view());
+            absl::StrAppend(&tcActionParam, " ", defaultValue);
         return tcActionParam;
     }
     dbprint { out << toString(); }
@@ -171,8 +171,7 @@ class TCAction {
         if (actionName == "NoAction") {
             return actionName;
         }
-        std::string tcAction = absl::StrCat(pipelineName.string_view(), "/", actionName.string_view());
-        return tcAction;
+        return absl::StrCat(pipelineName, "/", actionName);
     }
     cstring getActionName() const {
         return actionName;
@@ -192,16 +191,16 @@ class TCAction {
         actId = 0;
     }
     toString {
-        std::string tcAction = absl::StrCat("\n$TC p4template create action/", pipelineName.string_view(), "/", actionName.string_view());
+        std::string tcAction = absl::StrCat("\n$TC p4template create action/", pipelineName, "/", actionName);
         if (actId != 0) {
             absl::StrAppend(&tcAction, " actid ", actId);
         }
         if (!actionParams.empty()) {
             for (auto actParam : actionParams) {
-                absl::StrAppend(&tcAction, " \\", actParam->toString().string_view());
+                absl::StrAppend(&tcAction, " \\", actParam);
             }
         }
-        absl::StrAppend(&tcAction, "\n$TC p4template update action/", pipelineName.string_view(), "/", actionName.string_view(), " state active");
+        absl::StrAppend(&tcAction, "\n$TC p4template update action/", pipelineName, "/", actionName, " state active");
 
         return tcAction;
     }
@@ -216,7 +215,7 @@ class TCEntry {
     }
     toString {
         std::string tcEntry = "";
-        for(auto k : keys) {
+        for (auto k : keys) {
             tcEntry = absl::StrJoin({tcEntry, k.first.string(), k.second.string()}, " ");
         }
         return tcEntry;
@@ -347,11 +346,11 @@ class TCTable {
     }
     toString {
         std::string tcTable = absl::StrCat("\n$TC p4template create table/",
-                        pipelineName.string_view(), "/", controlName.string_view(), "/", tableName.string_view(), " \\",
+                        pipelineName, "/", controlName, "/", tableName, " \\",
                         "\n\ttblid ", tableID, " \\",
-                        "\n\ttype ", printMatchType(matchType).string_view(), " \\",
+                        "\n\ttype ", printMatchType(matchType), " \\",
                         "\n\tkeysz ", keySize,
-                        " permissions ", permissions.string_view(),
+                        " permissions ", permissions,
                         " tentries ", tableEntriesCount);
         if (matchType == TC::EXACT_TYPE) {
             absl::StrAppend(&tcTable, " nummasks ", TC::DEFAULT_KEY_MASK_EXACT);
@@ -363,16 +362,16 @@ class TCTable {
             absl::StrAppend(&tcTable, " num_timer_profiles ", timerProfiles);
         }
         if (isDirectCounter) {
-            absl::StrAppend(&tcTable, " \\\n\tpna_direct_counter DirectCounter/", directCounterInstance.string_view());
+            absl::StrAppend(&tcTable, " \\\n\tpna_direct_counter DirectCounter/", directCounterInstance);
         }
         if (isDirectMeter) {
-            absl::StrAppend(&tcTable, " \\\n\tpna_direct_meter DirectMeter/", directMeterInstance.string_view());
+            absl::StrAppend(&tcTable, " \\\n\tpna_direct_meter DirectMeter/", directMeterInstance);
         }
 
         if (!actionList.empty()) {
             absl::StrAppend(&tcTable, " \\", "\n\ttable_acts ");
             for (auto iter = actionList.begin(); iter != actionList.end(); iter++) {
-                absl::StrAppend(&tcTable, "act name ", iter->first->getName().string_view());
+                absl::StrAppend(&tcTable, "act name ", iter->first->getName());
                 if (iter->second == TC::TABLEONLY) {
                     absl::StrAppend(&tcTable, " flags tableonly");
                 } else if (iter->second == TC::DEFAULTONLY) {
@@ -384,43 +383,43 @@ class TCTable {
             }
         }
         if (defaultHitAction != nullptr) {
-            absl::StrAppend(&tcTable, "\n$TC p4template update table/", pipelineName.string_view(),
-                      "/", controlName.string_view(), "/", tableName.string_view(),
+            absl::StrAppend(&tcTable, "\n$TC p4template update table/", pipelineName,
+                      "/", controlName, "/", tableName,
                       " default_hit_action");
             if (isDefaultHitConst) {
                 absl::StrAppend(&tcTable, " permissions 0x1024");
             }
-            absl::StrAppend(&tcTable, " action ", defaultHitAction->getName().string_view());
+            absl::StrAppend(&tcTable, " action ", defaultHitAction->getName());
             if (!defaultHitActionParams.empty())
                 absl::StrAppend(&tcTable, " param");
             for (auto param : defaultHitActionParams)
-                absl::StrAppend(&tcTable, param->toString().string_view());
+                absl::StrAppend(&tcTable, param);
             if (isTcMayOverrideHit)
                 absl::StrAppend(&tcTable, " flags runtime");
         }
         if (defaultMissAction != nullptr) {
-            absl::StrAppend(&tcTable, "\n$TC p4template update table/", pipelineName.string_view(),
-                      "/", controlName.string_view(), "/", tableName.string_view(),
+            absl::StrAppend(&tcTable, "\n$TC p4template update table/", pipelineName,
+                      "/", controlName, "/", tableName,
                       " default_miss_action");
             if (isDefaultMissConst) {
                 absl::StrAppend(&tcTable, " permissions 0x1024");
             }
-            absl::StrAppend(&tcTable, " action ", defaultMissAction->getName().string_view());
+            absl::StrAppend(&tcTable, " action ", defaultMissAction->getName());
             if (!defaultMissActionParams.empty())
                 absl::StrAppend(&tcTable, " param");
             for (auto param : defaultMissActionParams)
-                absl::StrAppend(&tcTable, param->toString().string_view());
+                absl::StrAppend(&tcTable, param);
             if (isTcMayOverrideMiss)
                 absl::StrAppend(&tcTable, " flags runtime");
         }
         if (const_entries.size() != 0) {
             for (auto entry : const_entries) {
-                absl::StrAppend(&tcTable, "\n$TC p4template create table/", pipelineName.string_view(),
-                                "/", controlName.string_view(), "/", tableName.string_view(),
-                                " entry", entry->toString().string_view(),
+                absl::StrAppend(&tcTable, "\n$TC p4template create table/", pipelineName,
+                                "/", controlName, "/", tableName,
+                                " entry", entry,
                                 " permissions 0x1024",
-                                " action ", pipelineName.string_view(),
-                                "/", controlName.string_view(), "/", entry->getActionName().string_view());
+                                " action ", pipelineName,
+                                "/", controlName, "/", entry->getActionName());
             }
         }
         return tcTable;
@@ -451,7 +450,7 @@ class TCKey {
         emitValue = true;
     }
     toString {
-        std::string tckeyInstance = absl::StrCat(" ", keyAttribute.string_view(), " ", keyName.string_view(), " ptype ", type.string_view());
+        std::string tckeyInstance = absl::StrCat(" ", keyAttribute, " ", keyName, " ptype ", type);
         if (emitID) {
             absl::StrAppend(&tckeyInstance, " id ", keyID);
         }
@@ -510,7 +509,7 @@ class TCExternInstance {
         numelemns = ne;
     } 
     toString {
-        std::string tcExternInstance = absl::StrCat(instanceName.string_view(), " instid ", instanceID, " \\");
+        std::string tcExternInstance = absl::StrCat(instanceName, " instid ", instanceID, " \\");
         if (isNumelemns) {
             absl::StrAppend(&tcExternInstance, "\ntc_numel ", numelemns, " \\");
         }
@@ -520,14 +519,14 @@ class TCExternInstance {
         if (isConstructorKeys) {
             absl::StrAppend(&tcExternInstance, "\nconstructor");
             for (auto field : constructorKeys) {
-                absl::StrAppend(&tcExternInstance, field->toString().string_view());
+                absl::StrAppend(&tcExternInstance, field);
             }
             absl::StrAppend(&tcExternInstance, " \\");
         }
         if (isControlPath) {
             absl::StrAppend(&tcExternInstance, "\ncontrol_path");
             for (auto field : controlKeys) {
-                absl::StrAppend(&tcExternInstance, field->toString().string_view());
+                absl::StrAppend(&tcExternInstance, field);
             }
         }
         return tcExternInstance;
@@ -563,16 +562,16 @@ class TCExtern {
         return nullptr;
     }
     toString {
-        std::string tcExtern = absl::StrCat("\n$TC p4template create extern/", "root/", externName.string_view(),
-                                            " extid ", externID.string_view(), " numinstances ", numinstances, " tc_acl " + acl_permisson);
+        std::string tcExtern = absl::StrCat("\n$TC p4template create extern/", "root/", externName,
+                                            " extid ", externID, " numinstances ", numinstances, " tc_acl " + acl_permisson);
         if (has_exec_method) {
              absl::StrAppend(&tcExtern, " has_exec_method");
         }
         for (unsigned iter = 0; iter < numinstances; iter++) {
-            absl::StrAppend(&tcExtern, "\n\n$TC p4template create extern_inst/", pipelineName.string_view(),
-                      "/", externName.string_view(), "/");
+            absl::StrAppend(&tcExtern, "\n\n$TC p4template create extern_inst/", pipelineName,
+                      "/", externName, "/");
             if (externInstances.size() > iter)
-                absl::StrAppend(&tcExtern, externInstances[iter]->toString().string_view());
+                absl::StrAppend(&tcExtern, externInstances[iter]->toString());
         }
         return tcExtern;
     }
@@ -628,34 +627,34 @@ class TCPipeline {
     toString {
         std::string tcCode = absl::StrCat("#!/bin/bash -x\n",
                                         "\nset -e\n", "\n: \"${TC:=\"tc\"}\"",
-                                        "\n$TC p4template create pipeline/", pipelineName.string_view(),
+                                        "\n$TC p4template create pipeline/", pipelineName,
                                         " numtables ", numTables);
         if (!actionDefs.empty()) {
             for (auto a : actionDefs) {
-                absl::StrAppend(&tcCode, "\n", a->toString().string_view());
+                absl::StrAppend(&tcCode, "\n", a);
             }
         }
         if (!externDefs.empty()) {
             for (auto e : externDefs) {
-                absl::StrAppend(&tcCode, "\n", e->toString().string_view());
+                absl::StrAppend(&tcCode, "\n", e);
             }
         }
         if (!tableDefs.empty()) {
             for (auto t : tableDefs) {
-                absl::StrAppend(&tcCode, "\n", t->toString().string_view());
+                absl::StrAppend(&tcCode, "\n", t);
             }
         }
         if (preaction != nullptr) {
-            absl::StrAppend(&tcCode, "\n", preaction->toString().string_view(),
-                            "\n$TC p4template update pipeline/", pipelineName.string_view(),
-                            " preactions action ", pipelineName.string_view(), "/preaction");
+            absl::StrAppend(&tcCode, "\n", preaction,
+                            "\n$TC p4template update pipeline/", pipelineName,
+                            " preactions action ", pipelineName, "/preaction");
         }
         if (postaction != nullptr) {
-            absl::StrAppend(&tcCode, "\n", postaction->toString().string_view(),
-                            "\n$TC p4template update pipeline/", pipelineName.string_view(),
-                            " postactions action ", pipelineName.string_view(), "/postaction");
+            absl::StrAppend(&tcCode, "\n", postaction,
+                            "\n$TC p4template update pipeline/", pipelineName,
+                            " postactions action ", pipelineName, "/postaction");
         }
-        absl::StrAppend(&tcCode, "\n$TC p4template update pipeline/", pipelineName.string_view(), " state ready");
+        absl::StrAppend(&tcCode, "\n$TC p4template update pipeline/", pipelineName, " state ready");
         return tcCode;
     }
     dbprint { out << toString(); }

--- a/backends/tc/tcExterns.cpp
+++ b/backends/tc/tcExterns.cpp
@@ -29,7 +29,7 @@ void EBPFRegisterPNA::emitInitializer(EBPF::CodeBuilder *builder, const P4::Exte
     builder->emitIndent();
     auto extId = translator->tcIR->getExternId(externName);
     BUG_CHECK(!extId.isNullOrEmpty(), "Extern ID not found");
-    builder->appendFormat("ext_params.ext_id = %s;", extId);
+    builder->appendFormat("ext_params.ext_id = %v;", extId);
     builder->newline();
     builder->emitIndent();
     auto instId = translator->tcIR->getExternInstanceId(externName, this->instanceName);
@@ -151,7 +151,7 @@ void EBPFCounterPNA::emitCount(EBPF::CodeBuilder *builder, const P4::ExternMetho
     builder->emitIndent();
     auto extId = translator->tcIR->getExternId(externName);
     BUG_CHECK(!extId.isNullOrEmpty(), "Extern ID not found");
-    builder->appendFormat("ext_params.ext_id = %s;", extId);
+    builder->appendFormat("ext_params.ext_id = %v;", extId);
     builder->newline();
     builder->emitIndent();
     auto instId = translator->tcIR->getExternInstanceId(externName, instanceName);
@@ -350,7 +350,7 @@ void InternetChecksumAlgorithmPNA::updateChecksum(EBPF::CodeBuilder *builder,
                     auto etype = EBPF::EBPFTypeFactory::instance->create(field->type);
                     builder->emitIndent();
                     etype->declare(builder, field_temp, false);
-                    builder->appendFormat(" = %s(", getConvertByteOrderFunction(width, "HOST"_cs));
+                    builder->appendFormat(" = %v(", getConvertByteOrderFunction(width, "HOST"_cs));
                     visitor->visit(field);
                     builder->appendLine(");");
                 }
@@ -366,7 +366,7 @@ void InternetChecksumAlgorithmPNA::updateChecksum(EBPF::CodeBuilder *builder,
                     remainingBits -= bitsToRead;
                     builder->append("(");
                     if (fieldByteOrder == "NETWORK"_cs) {
-                        builder->appendFormat("%s", field_temp);
+                        builder->appendFormat("%v", field_temp);
                     } else {
                         visitor->visit(field);
                     }
@@ -375,7 +375,7 @@ void InternetChecksumAlgorithmPNA::updateChecksum(EBPF::CodeBuilder *builder,
                 } else if (bitsToRead == remainingBits) {
                     remainingBits = 0;
                     if (fieldByteOrder == "NETWORK"_cs) {
-                        builder->appendFormat("%s", field_temp);
+                        builder->appendFormat("%v", field_temp);
                     } else {
                         visitor->visit(field);
                     }
@@ -385,7 +385,7 @@ void InternetChecksumAlgorithmPNA::updateChecksum(EBPF::CodeBuilder *builder,
                     remainingBits = 0;
                     builder->append("(");
                     if (fieldByteOrder == "NETWORK"_cs) {
-                        builder->appendFormat("%s", field_temp);
+                        builder->appendFormat("%v", field_temp);
                     } else {
                         visitor->visit(field);
                     }
@@ -444,7 +444,7 @@ void EBPFDigestPNA::emitInitializer(EBPF::CodeBuilder *builder) const {
     builder->emitIndent();
     auto extId = tcIR->getExternId(externName);
     BUG_CHECK(!extId.isNullOrEmpty(), "Extern ID not found");
-    builder->appendFormat("ext_params.ext_id = %s;", extId);
+    builder->appendFormat("ext_params.ext_id = %v;", extId);
     builder->newline();
     builder->emitIndent();
     auto instId = tcIR->getExternInstanceId(externName, instanceName);
@@ -507,7 +507,7 @@ void CRCChecksumAlgorithmPNA::emitAddData(EBPF::CodeBuilder *builder,
     for (auto field : arguments) {
         builder->newline();
         builder->emitIndent();
-        builder->appendFormat("%s(&", kfunc);
+        builder->appendFormat("%v(&", kfunc);
         visitor->visit(field);
         builder->append(", sizeof(");
         visitor->visit(field);
@@ -516,9 +516,9 @@ void CRCChecksumAlgorithmPNA::emitAddData(EBPF::CodeBuilder *builder,
             visitor->visit(expr->arguments->at(0));
             builder->append(", ");
             visitor->visit(expr->arguments->at(2));
-            builder->appendFormat(", %s);", registerVar);
+            builder->appendFormat(", %v);", registerVar);
         } else {
-            builder->appendFormat("), %s);", registerVar);
+            builder->appendFormat("), %v);", registerVar);
         }
     }
 }
@@ -542,7 +542,7 @@ void EBPFDigestPNA::emitPushElement(EBPF::CodeBuilder *builder, cstring elem) co
     emitInitializer(builder);
     builder->newline();
     builder->emitIndent();
-    builder->appendFormat("__builtin_memcpy(ext_params.in_params, &%s, sizeof(", elem);
+    builder->appendFormat("__builtin_memcpy(ext_params.in_params, &%v, sizeof(", elem);
     this->valueType->declare(builder, cstring::empty, false);
     builder->append("));");
     builder->newline();
@@ -559,11 +559,11 @@ void EBPFMeterPNA::emitInitializer(EBPF::CodeBuilder *builder, const ConvertToBa
     builder->emitIndent();
     auto extId = tcIR->getExternId(externName);
     BUG_CHECK(!extId.isNullOrEmpty(), "Extern ID not found");
-    builder->appendFormat("ext_params.ext_id = %s;", extId);
+    builder->appendFormat("ext_params.ext_id = %v;", extId);
     builder->newline();
     cstring ext_flags = isDirect ? "P4TC_EXT_METER_DIRECT"_cs : "P4TC_EXT_METER_INDIRECT"_cs;
     builder->emitIndent();
-    builder->appendFormat("ext_params.flags = %s;", ext_flags);
+    builder->appendFormat("ext_params.flags = %v;", ext_flags);
 }
 
 void EBPFMeterPNA::emitExecute(EBPF::CodeBuilder *builder, const P4::ExternMethod *method,
@@ -597,7 +597,7 @@ void EBPFMeterPNA::emitExecute(EBPF::CodeBuilder *builder, const P4::ExternMetho
         etype->declare(builder, color_aware, true);
         builder->appendLine(" = (u32 *)ext_params.in_params;");
         builder->emitIndent();
-        builder->appendFormat("*%s = ", color_aware);
+        builder->appendFormat("*%v = ", color_aware);
         translator->visit(value);
         builder->endOfStatement();
     }
@@ -655,7 +655,7 @@ void EBPFMeterPNA::emitDirectMeterExecute(EBPF::CodeBuilder *builder,
         etype->declare(builder, color_aware, true);
         builder->appendLine(" = (u32 *)ext_params.in_params;");
         builder->emitIndent();
-        builder->appendFormat("*%s = ", color_aware);
+        builder->appendFormat("*%v = ", color_aware);
         translator->visit(value);
         builder->endOfStatement();
     }

--- a/backends/tofino/bf-p4c/ir/mau.cpp
+++ b/backends/tofino/bf-p4c/ir/mau.cpp
@@ -309,7 +309,7 @@ void Table::visit_match_table(THIS *self, Visitor &v, payload_info_t &payload_in
         auto exit_visitor = &saved->flow_clone();
         if (payload_info.action_info.count(action_name))
             exit_visitor->flow_merge(*payload_info.action_info.at(action_name).flow_state);
-        exit_visitor->visit(action, "actions"_cs);
+        exit_visitor->visit(action, "actions");
         exit_visitor->flow_merge_global_to("-EXIT-"_cs);
     }
 
@@ -345,7 +345,7 @@ void Table::visit_match_table(THIS *self, Visitor &v, payload_info_t &payload_in
         }
 
         // Visit the action.
-        current->visit(action, "actions"_cs);
+        current->visit(action, "actions");
 
         // Figure out which keys in the next_visitors table need updating.
         if (pinfo) {

--- a/backends/tofino/bf-p4c/ir/tofino.def
+++ b/backends/tofino/bf-p4c/ir/tofino.def
@@ -157,27 +157,27 @@ class BFN::Pipe {
     visit_children {
         if (auto *th = dynamic_cast<ThreadVisitor *>(&v)) {
             if (th->thread == GHOST) {
-                v.visit(ghost_thread.ghost_parser, "ghost_parser"_cs);
-                v.visit(ghost_thread.ghost_mau, "ghost_mau"_cs);
+                v.visit(ghost_thread.ghost_parser, "ghost_parser");
+                v.visit(ghost_thread.ghost_mau, "ghost_mau");
             } else {
                 thread[th->thread].parsers.parallel_visit_children(v);
                 ControlFlowVisitor::GuardGlobal guard_except(v, "-EXIT-"_cs);
-                v.visit(thread[th->thread].mau, "mau"_cs);
+                v.visit(thread[th->thread].mau, "mau");
                 v.flow_merge_global_from("-EXIT-"_cs);
-                v.visit(ghost_thread.ghost_parser, "ghost_parser"_cs);
-                v.visit(ghost_thread.ghost_mau, "ghost_mau"_cs);
-                v.visit(thread[th->thread].deparser, "deparser"_cs); }
+                v.visit(ghost_thread.ghost_parser, "ghost_parser");
+                v.visit(ghost_thread.ghost_mau, "ghost_mau");
+                v.visit(thread[th->thread].deparser, "deparser"); }
         } else {
             // FIXME -- doesn't do flow_clone/merge properly, but fixing will
             // break ParserGraph (at least) as it doesn't do merge properly
             for (auto &th : thread) {
                 th.parsers.parallel_visit_children(v);
                 ControlFlowVisitor::GuardGlobal guard_except(v, "-EXIT-"_cs);
-                v.visit(th.mau, "mau"_cs);
+                v.visit(th.mau, "mau");
                 v.flow_merge_global_from("-EXIT-"_cs);
-                v.visit(th.deparser, "deparser"_cs); }
-            v.visit(ghost_thread.ghost_parser, "ghost_parser"_cs);
-            v.visit(ghost_thread.ghost_mau, "ghost_mau"_cs); } }
+                v.visit(th.deparser, "deparser"); }
+            v.visit(ghost_thread.ghost_parser, "ghost_parser");
+            v.visit(ghost_thread.ghost_mau, "ghost_mau"); } }
 }
 
 // A path that may span more than two pipeline gresses, depending on how the
@@ -198,15 +198,15 @@ class BFN::BridgePath : BFN::Pipe {
         for (auto &th : threads.at(INGRESS)) {
             th.parsers.parallel_visit_children(v);
             ControlFlowVisitor::GuardGlobal guard_except(v, "-EXIT-"_cs);
-            v.visit(th.mau, "mau"_cs);
+            v.visit(th.mau, "mau");
             v.flow_merge_global_from("-EXIT-"_cs);
-            v.visit(th.deparser, "deparser"_cs); }
+            v.visit(th.deparser, "deparser"); }
         for (auto &th : threads.at(EGRESS)) {
             th.parsers.parallel_visit_children(v);
             ControlFlowVisitor::GuardGlobal guard_except(v, "-EXIT-"_cs);
-            v.visit(th.mau, "mau"_cs);
+            v.visit(th.mau, "mau");
             v.flow_merge_global_from("-EXIT-"_cs);
-            v.visit(th.deparser, "deparser"_cs); } }
+            v.visit(th.deparser, "deparser"); } }
 }
 
 // BFN::Toplevel stores the midend and backend representation of a P4Program.

--- a/backends/tofino/bf-p4c/midend/defuse.cpp
+++ b/backends/tofino/bf-p4c/midend/defuse.cpp
@@ -106,7 +106,7 @@ class ComputeDefUse::SetupJoinPoints : public ControlFlowVisitor::SetupJoinPoint
         LOG6("SetupJoinPoints(P4Parser " << p->name << ")" << indent);
         LOG8("    " << Log::indent << Log::indent << *p << Log::unindent << Log::unindent);
         if (auto start = p->states.getDeclaration<IR::ParserState>("start"_cs))
-            visit(start, "start"_cs);
+            visit(start, "start");
         return false;
     }
     bool preorder(const IR::P4Control *) override { return false; }
@@ -220,7 +220,7 @@ bool ComputeDefUse::preorder(const IR::P4Control *c) {
         if (p->direction == IR::Direction::In || p->direction == IR::Direction::InOut)
             def_info[p].defs.insert(getLoc(p));
     state = NORMAL;
-    visit(c->body, "body"_cs);  // just visit the body; tables/actions will be visited when applied
+    visit(c->body, "body");  // just visit the body; tables/actions will be visited when applied
     for (auto *p : c->getApplyParameters()->parameters)
         if (p->direction == IR::Direction::Out || p->direction == IR::Direction::InOut)
             add_uses(getLoc(p), def_info[p]);
@@ -233,7 +233,7 @@ bool ComputeDefUse::preorder(const IR::P4Table *tbl) {
     if (state == SKIPPING) return false;
     IndentCtl::TempIndent indent;
     LOG5("ComputeDefUse(P4Table " << tbl->name << ")" << indent);
-    if (auto key = tbl->getKey()) visit(key, "key"_cs);
+    if (auto key = tbl->getKey()) visit(key, "key");
     if (auto actions = tbl->getActionList()) {
         parallel_visit(actions->actionList, "actions");
     } else {
@@ -247,7 +247,7 @@ bool ComputeDefUse::preorder(const IR::P4Action *act) {
     for (auto *p : *act->parameters) def_info[p].defs.insert(getLoc(p));
     IndentCtl::TempIndent indent;
     LOG5("ComputeDefUse(P4Action " << act->name << ")" << indent);
-    visit(act->body, "body"_cs);
+    visit(act->body, "body");
     return false;
 }
 
@@ -260,7 +260,7 @@ bool ComputeDefUse::preorder(const IR::P4Parser *p) {
             def_info[a].defs.insert(getLoc(a));
     state = NORMAL;
     if (auto start = p->states.getDeclaration<IR::ParserState>("start"_cs)) {
-        visit(start, "start"_cs);
+        visit(start, "start");
     } else {
         BUG("No start state in %s", p);
     }

--- a/backends/tofino/bf-p4c/phv/phv_fields.h
+++ b/backends/tofino/bf-p4c/phv/phv_fields.h
@@ -282,7 +282,7 @@ class Field : public LiftLess<Field> {
     bitvec getStartBits(PHV::Size size) const;
 
     /// @returns the header to which this field belongs.
-    cstring header() const { return name.before(strrchr(name, '.')); }
+    cstring header() const { return name.before(strrchr(name.c_str(), '.')); }
 
  private:
     /// When set, use this name rather than PHV::Field::name when generating

--- a/backends/ubpf/target.cpp
+++ b/backends/ubpf/target.cpp
@@ -53,7 +53,7 @@ void UbpfTarget::emitTableDecl(Util::SourceCodeBuilder *builder, cstring tblName
                                EBPF::TableKind tableKind, cstring keyType, cstring valueType,
                                unsigned size) const {
     builder->append("struct ");
-    builder->appendFormat("ubpf_map_def %s = ", tblName);
+    builder->appendFormat("ubpf_map_def %v = ", tblName);
     builder->spc();
     builder->blockStart();
 
@@ -69,15 +69,15 @@ void UbpfTarget::emitTableDecl(Util::SourceCodeBuilder *builder, cstring tblName
     }
 
     builder->emitIndent();
-    builder->appendFormat(".type = %s,", type);
+    builder->appendFormat(".type = %v,", type);
     builder->newline();
 
     builder->emitIndent();
-    builder->appendFormat(".key_size = sizeof(%s),", keyType);
+    builder->appendFormat(".key_size = sizeof(%v),", keyType);
     builder->newline();
 
     builder->emitIndent();
-    builder->appendFormat(".value_size = sizeof(%s),", valueType);
+    builder->appendFormat(".value_size = sizeof(%v),", valueType);
 
     builder->newline();
 

--- a/backends/ubpf/ubpfControl.cpp
+++ b/backends/ubpf/ubpfControl.cpp
@@ -35,10 +35,10 @@ UBPFControlBodyTranslator::UBPFControlBodyTranslator(const UBPFControl *control)
 
 void UBPFControlBodyTranslator::processFunction(const P4::ExternFunction *function) {
     if (function->method->name.name == control->program->model.drop.name) {
-        builder->appendFormat("%s = false", control->passVariable);
+        builder->appendFormat("%v = false", control->passVariable);
         return;
     } else if (function->method->name.name == control->program->model.pass.name) {
-        builder->appendFormat("%s = true", control->passVariable);
+        builder->appendFormat("%v = true", control->passVariable);
         return;
     } else if (function->method->name.name == control->program->model.ubpf_time_get_ns.name) {
         builder->append(control->program->model.ubpf_time_get_ns.name + "()");
@@ -56,7 +56,7 @@ void UBPFControlBodyTranslator::processFunction(const P4::ExternFunction *functi
         auto algorithmType = algorithmTypeArgument->member.name;
 
         if (algorithmType == control->program->model.hashAlgorithm.lookup3.name) {
-            builder->appendFormat(" = ubpf_hash(&%s, sizeof(%s))", hashKeyInstanceName,
+            builder->appendFormat(" = ubpf_hash(&%v, sizeof(%v))", hashKeyInstanceName,
                                   hashKeyInstanceName);
         } else {
             ::P4::error(ErrorType::ERR_UNSUPPORTED, "%1%: Not supported hash algorithm type",
@@ -129,7 +129,7 @@ cstring UBPFControlBodyTranslator::createHashKeyInstance(const P4::ExternFunctio
         if (!f->type)  // If nullptr it's a padding.
             continue;
         builder->emitIndent();
-        builder->appendFormat("%s.%s = ", hashKeyInstance, f->name);
+        builder->appendFormat("%v.%v = ", hashKeyInstance, f->name);
         auto c = dataArgument->components.at(idx);
         visit(c);
         builder->endOfStatement(true);
@@ -358,7 +358,7 @@ bool UBPFControlBodyTranslator::emitRegisterRead(const IR::AssignmentStatement *
 
     builder->newline();
     builder->emitIndent();
-    builder->appendFormat("if (%s != NULL) ", tmp);
+    builder->appendFormat("if (%v != NULL) ", tmp);
     builder->blockStart();
 
     builder->emitIndent();

--- a/backends/ubpf/ubpfDeparser.cpp
+++ b/backends/ubpf/ubpfDeparser.cpp
@@ -141,9 +141,9 @@ void UBPFDeparserTranslationVisitor::compileEmitField(const IR::Expression *expr
     if (!swap.isNullOrEmpty()) {
         builder->emitIndent();
         visit(expr);
-        builder->appendFormat(".%s = %s(", field.c_str(), swap);
+        builder->appendFormat(".%v = %v(", field, swap);
         visit(expr);
-        builder->appendFormat(".%s", field.c_str());
+        builder->appendFormat(".%v", field);
         if (shift != 0) builder->appendFormat(" << %d", shift);
         builder->append(")");
         builder->endOfStatement(true);

--- a/backends/ubpf/ubpfParser.cpp
+++ b/backends/ubpf/ubpfParser.cpp
@@ -128,7 +128,7 @@ bool UBPFStateTranslationVisitor::preorder(const IR::ParserState *parserState) {
 bool UBPFStateTranslationVisitor::preorder(const IR::SelectCase *selectCase) {
     builder->emitIndent();
     if (auto mask = selectCase->keyset->to<IR::Mask>()) {
-        builder->appendFormat("if ((%s", selectValue);
+        builder->appendFormat("if ((%v", selectValue);
         builder->append(" & ");
         visit(mask->right);
         builder->append(") == (");
@@ -137,7 +137,7 @@ bool UBPFStateTranslationVisitor::preorder(const IR::SelectCase *selectCase) {
         visit(mask->right);
         builder->append("))");
     } else {
-        builder->appendFormat("if (%s", selectValue);
+        builder->appendFormat("if (%v", selectValue);
         builder->append(" == ");
         visit(selectCase->keyset);
         builder->append(")");
@@ -162,13 +162,13 @@ bool UBPFStateTranslationVisitor::preorder(const IR::SelectExpression *expressio
     etype->declare(builder, selectValue, false);
     builder->endOfStatement(true);
     builder->emitIndent();
-    builder->appendFormat("%s = ", selectValue);
+    builder->appendFormat("%v = ", selectValue);
     visit(expression->select);
     builder->endOfStatement(true);
     for (auto e : expression->selectCases) visit(e);
 
     builder->emitIndent();
-    builder->appendFormat("else goto %s;", IR::ParserState::reject.c_str());
+    builder->appendFormat("else goto %v;", IR::ParserState::reject);
     builder->newline();
     return false;
 }

--- a/backends/ubpf/ubpfProgram.cpp
+++ b/backends/ubpf/ubpfProgram.cpp
@@ -97,7 +97,7 @@ void UBPFProgram::emitC(UbpfCodeBuilder *builder, const std::filesystem::path &h
     emitLocalVariables(builder);
     builder->newline();
     builder->emitIndent();
-    builder->appendFormat("goto %s;", IR::ParserState::start.c_str());
+    builder->appendFormat("goto %v;", IR::ParserState::start);
     builder->newline();
 
     parser->emit(builder);
@@ -105,23 +105,23 @@ void UBPFProgram::emitC(UbpfCodeBuilder *builder, const std::filesystem::path &h
     emitPipeline(builder);
 
     builder->emitIndent();
-    builder->appendFormat("%s:\n", endLabel.c_str());
+    builder->appendFormat("%v:\n", endLabel);
     builder->emitIndent();
     builder->blockStart();
     deparser->emit(builder);
     builder->blockEnd(true);
 
     builder->emitIndent();
-    builder->appendFormat("if (%s)\n", control->passVariable);
+    builder->appendFormat("if (%v)\n", control->passVariable);
     builder->increaseIndent();
     builder->emitIndent();
-    builder->appendFormat("return %s;\n", builder->target->forwardReturnCode().c_str());
+    builder->appendFormat("return %v;\n", builder->target->forwardReturnCode());
     builder->decreaseIndent();
     builder->emitIndent();
     builder->appendLine("else");
     builder->increaseIndent();
     builder->emitIndent();
-    builder->appendFormat("return %s;\n", builder->target->dropReturnCode().c_str());
+    builder->appendFormat("return %v;\n", builder->target->dropReturnCode());
     builder->decreaseIndent();
     builder->blockEnd(true);
 }
@@ -267,11 +267,11 @@ void UBPFProgram::emitLocalVariables(EBPF::CodeBuilder *builder) {
     builder->newline();
 
     builder->emitIndent();
-    builder->appendFormat("uint8_t %s = 1;", control->passVariable);
+    builder->appendFormat("uint8_t %v = 1;", control->passVariable);
     builder->newline();
 
     builder->emitIndent();
-    builder->appendFormat("uint8_t %s = 0;", control->hitVariable);
+    builder->appendFormat("uint8_t %v = 0;", control->hitVariable);
     builder->newline();
 
     builder->emitIndent();

--- a/backends/ubpf/ubpfTable.cpp
+++ b/backends/ubpf/ubpfTable.cpp
@@ -86,10 +86,10 @@ class UbpfActionTranslationVisitor : public EBPF::CodeGenInspector {
         auto ef = mi->to<P4::ExternFunction>();
         if (ef != nullptr) {
             if (ef->method->name.name == program->model.drop.name) {
-                builder->appendFormat("%s = false", program->control->passVariable);
+                builder->appendFormat("%v = false", program->control->passVariable);
                 return false;
             } else if (ef->method->name.name == program->model.pass.name) {
-                builder->appendFormat("%s = true", program->control->passVariable);
+                builder->appendFormat("%v = true", program->control->passVariable);
                 return false;
             } else if (ef->method->name.name == program->model.ubpf_time_get_ns.name) {
                 builder->emitIndent();
@@ -484,8 +484,8 @@ void UBPFTable::emitInitializer(EBPF::CodeBuilder *builder) {
     builder->endOfStatement(true);
 
     builder->emitIndent();
-    builder->appendFormat("INIT_UBPF_TABLE(\"%s\", sizeof(%s), sizeof(%s));", defaultTable,
-                          program->zeroKey.c_str(), value);
+    builder->appendFormat("INIT_UBPF_TABLE(\"%v\", sizeof(%v), sizeof(%v));", defaultTable,
+                          program->zeroKey, value);
     builder->newline();
 
     builder->emitIndent();

--- a/backends/ubpf/ubpfType.cpp
+++ b/backends/ubpf/ubpfType.cpp
@@ -252,14 +252,14 @@ void UBPFListType::emitInitializer(EBPF::CodeBuilder *builder) {
     for (auto f : elements) {
         if (!f->is<Padding>()) continue;
         builder->emitIndent();
-        builder->appendFormat(".%s = {0},", f->to<Padding>()->name);
+        builder->appendFormat(".%v = {0},", f->to<Padding>()->name);
         builder->newline();
     }
     builder->blockEnd(false);
 }
 
 void UBPFListType::emitPadding(EBPF::CodeBuilder *builder, UBPF::UBPFListType::Padding *pad) {
-    builder->appendFormat("uint8_t %s[%u]", pad->name, pad->widthInBytes);
+    builder->appendFormat("uint8_t %v[%u]", pad->name, pad->widthInBytes);
 }
 
 /***

--- a/control-plane/p4RuntimeArchHandler.cpp
+++ b/control-plane/p4RuntimeArchHandler.cpp
@@ -142,7 +142,7 @@ void serializeStructuredExpression(const IR::Expression *expr, p4configv1::Expre
     } else if (expr->is<IR::BoolLiteral>()) {
         sExpr->set_bool_value(expr->to<IR::BoolLiteral>()->value);
     } else if (expr->is<IR::StringLiteral>()) {
-        sExpr->set_string_value(expr->to<IR::StringLiteral>()->value.string_view());
+        sExpr->set_string_value(expr->to<IR::StringLiteral>()->value);
     } else {
         // guaranteed by the type checker.
         BUG("%1%: structured annotation expression must be a compile-time value", expr);
@@ -150,13 +150,13 @@ void serializeStructuredExpression(const IR::Expression *expr, p4configv1::Expre
 }
 
 void serializeStructuredKVPair(const IR::NamedExpression *kv, p4configv1::KeyValuePair *sKV) {
-    sKV->set_key(kv->name.string_view());
+    sKV->set_key(kv->name.name);
     serializeStructuredExpression(kv->expression, sKV->mutable_value());
 }
 
 void serializeOneStructuredAnnotation(const IR::Annotation *annotation,
                                       p4configv1::StructuredAnnotation *structuredAnnotation) {
-    structuredAnnotation->set_name(annotation->name.string_view());
+    structuredAnnotation->set_name(annotation->name.name);
     switch (annotation->annotationKind()) {
         case IR::Annotation::Kind::StructuredEmpty:
             // nothing to do, body oneof should be empty.

--- a/control-plane/p4RuntimeArchHandler.cpp
+++ b/control-plane/p4RuntimeArchHandler.cpp
@@ -142,7 +142,7 @@ void serializeStructuredExpression(const IR::Expression *expr, p4configv1::Expre
     } else if (expr->is<IR::BoolLiteral>()) {
         sExpr->set_bool_value(expr->to<IR::BoolLiteral>()->value);
     } else if (expr->is<IR::StringLiteral>()) {
-        sExpr->set_string_value(expr->to<IR::StringLiteral>()->value);
+        sExpr->set_string_value(expr->to<IR::StringLiteral>()->value.string_view());
     } else {
         // guaranteed by the type checker.
         BUG("%1%: structured annotation expression must be a compile-time value", expr);
@@ -150,13 +150,13 @@ void serializeStructuredExpression(const IR::Expression *expr, p4configv1::Expre
 }
 
 void serializeStructuredKVPair(const IR::NamedExpression *kv, p4configv1::KeyValuePair *sKV) {
-    sKV->set_key(kv->name.name);
+    sKV->set_key(kv->name.string_view());
     serializeStructuredExpression(kv->expression, sKV->mutable_value());
 }
 
 void serializeOneStructuredAnnotation(const IR::Annotation *annotation,
                                       p4configv1::StructuredAnnotation *structuredAnnotation) {
-    structuredAnnotation->set_name(annotation->name.name);
+    structuredAnnotation->set_name(annotation->name.string_view());
     switch (annotation->annotationKind()) {
         case IR::Annotation::Kind::StructuredEmpty:
             // nothing to do, body oneof should be empty.

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -321,7 +321,7 @@ void addDocumentation(Message *message, const IR::IAnnotated *annotated) {
             auto brief = annotation->expr[0]->to<IR::StringLiteral>();
             // guaranteed by ParseAnnotations pass
             CHECK_NULL(brief);
-            doc.set_brief(brief->value);
+            doc.set_brief(brief->value.string_view());
             hasDoc = true;
             continue;
         }
@@ -329,7 +329,7 @@ void addDocumentation(Message *message, const IR::IAnnotated *annotated) {
             auto description = annotation->expr[0]->to<IR::StringLiteral>();
             // guaranteed by ParseAnnotations pass
             CHECK_NULL(description);
-            doc.set_description(description->value);
+            doc.set_description(description->value.string_view());
             hasDoc = true;
             continue;
         }
@@ -346,8 +346,8 @@ void setPreamble(::p4::config::v1::Preamble *preamble, p4rt_id_t id, cstring nam
                  const IR::IAnnotated *annotated, UnaryPredicate p) {
     CHECK_NULL(preamble);
     preamble->set_id(id);
-    preamble->set_name(name);
-    preamble->set_alias(alias);
+    preamble->set_name(name.string_view());
+    preamble->set_alias(alias.string_view());
     addAnnotations(preamble, annotated, p);
     addDocumentation(preamble, annotated);
 }

--- a/control-plane/p4RuntimeArchHandler.h
+++ b/control-plane/p4RuntimeArchHandler.h
@@ -321,7 +321,7 @@ void addDocumentation(Message *message, const IR::IAnnotated *annotated) {
             auto brief = annotation->expr[0]->to<IR::StringLiteral>();
             // guaranteed by ParseAnnotations pass
             CHECK_NULL(brief);
-            doc.set_brief(brief->value.string_view());
+            doc.set_brief(brief->value);
             hasDoc = true;
             continue;
         }
@@ -329,7 +329,7 @@ void addDocumentation(Message *message, const IR::IAnnotated *annotated) {
             auto description = annotation->expr[0]->to<IR::StringLiteral>();
             // guaranteed by ParseAnnotations pass
             CHECK_NULL(description);
-            doc.set_description(description->value.string_view());
+            doc.set_description(description->value);
             hasDoc = true;
             continue;
         }
@@ -346,8 +346,8 @@ void setPreamble(::p4::config::v1::Preamble *preamble, p4rt_id_t id, cstring nam
                  const IR::IAnnotated *annotated, UnaryPredicate p) {
     CHECK_NULL(preamble);
     preamble->set_id(id);
-    preamble->set_name(name.string_view());
-    preamble->set_alias(alias.string_view());
+    preamble->set_name(name);
+    preamble->set_alias(alias);
     addAnnotations(preamble, annotated, p);
     addDocumentation(preamble, annotated);
 }

--- a/control-plane/p4RuntimeArchStandard.h
+++ b/control-plane/p4RuntimeArchStandard.h
@@ -874,8 +874,7 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
             setCounterCommon(symbols, counter, id, counterInstance);
             counter->set_size(counterInstance.size);
             if (counterInstance.index_type_name) {
-                counter->mutable_index_type_name()->set_name(
-                    counterInstance.index_type_name.string_view());
+                counter->mutable_index_type_name()->set_name(counterInstance.index_type_name);
             }
         }
     }
@@ -904,8 +903,7 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
             setMeterCommon(symbols, meter, id, meterInstance);
             meter->set_size(meterInstance.size);
             if (meterInstance.index_type_name) {
-                meter->mutable_index_type_name()->set_name(
-                    meterInstance.index_type_name.string_view());
+                meter->mutable_index_type_name()->set_name(meterInstance.index_type_name);
             }
         }
     }
@@ -919,8 +917,7 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
         register_->set_size(registerInstance.size);
         register_->mutable_type_spec()->CopyFrom(*registerInstance.typeSpec);
         if (registerInstance.index_type_name) {
-            register_->mutable_index_type_name()->set_name(
-                registerInstance.index_type_name.string_view());
+            register_->mutable_index_type_name()->set_name(registerInstance.index_type_name);
         }
     }
 

--- a/control-plane/p4RuntimeArchStandard.h
+++ b/control-plane/p4RuntimeArchStandard.h
@@ -874,7 +874,8 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
             setCounterCommon(symbols, counter, id, counterInstance);
             counter->set_size(counterInstance.size);
             if (counterInstance.index_type_name) {
-                counter->mutable_index_type_name()->set_name(counterInstance.index_type_name);
+                counter->mutable_index_type_name()->set_name(
+                    counterInstance.index_type_name.string_view());
             }
         }
     }
@@ -903,7 +904,8 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
             setMeterCommon(symbols, meter, id, meterInstance);
             meter->set_size(meterInstance.size);
             if (meterInstance.index_type_name) {
-                meter->mutable_index_type_name()->set_name(meterInstance.index_type_name);
+                meter->mutable_index_type_name()->set_name(
+                    meterInstance.index_type_name.string_view());
             }
         }
     }
@@ -917,7 +919,8 @@ class P4RuntimeArchHandlerCommon : public P4RuntimeArchHandlerIface {
         register_->set_size(registerInstance.size);
         register_->mutable_type_spec()->CopyFrom(*registerInstance.typeSpec);
         if (registerInstance.index_type_name) {
-            register_->mutable_index_type_name()->set_name(registerInstance.index_type_name);
+            register_->mutable_index_type_name()->set_name(
+                registerInstance.index_type_name.string_view());
         }
     }
 

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -562,7 +562,7 @@ class P4RuntimeAnalyzer {
             auto paramName = actionParam->controlPlaneName();
             auto id = idAllocator.getId(actionParam);
             param->set_id(id);
-            param->set_name(paramName.string_view());
+            param->set_name(paramName);
             addAnnotations(param, actionParam->to<IR::IAnnotated>());
             addDocumentation(param, actionParam->to<IR::IAnnotated>());
 
@@ -586,7 +586,7 @@ class P4RuntimeAnalyzer {
             auto type_name = getTypeName(paramType, typeMap);
             if (type_name) {
                 auto namedType = param->mutable_type_name();
-                namedType->set_name(type_name.string_view());
+                namedType->set_name(type_name);
             } else if (auto e = paramType->to<IR::Type_Enum>()) {
                 param->mutable_type_name()->set_name(std::string(e->controlPlaneName()));
             }
@@ -626,7 +626,7 @@ class P4RuntimeAnalyzer {
             auto fieldName = headerField->controlPlaneName();
             auto id = idAllocator.getId(headerField);
             metadata->set_id(id);
-            metadata->set_name(fieldName.string_view());
+            metadata->set_name(fieldName);
             addAnnotations(metadata, headerField->to<IR::IAnnotated>());
 
             auto fieldType = typeMap->getType(headerField, true);
@@ -643,7 +643,7 @@ class P4RuntimeAnalyzer {
             auto type_name = getTypeName(fieldType, typeMap);
             if (type_name) {
                 auto namedType = metadata->mutable_type_name();
-                namedType->set_name(type_name.string_view());
+                namedType->set_name(type_name);
             }
         }
     }
@@ -729,17 +729,17 @@ class P4RuntimeAnalyzer {
         for (const auto &field : matchFields) {
             auto match_field = table->add_match_fields();
             match_field->set_id(field.id);
-            match_field->set_name(field.name.string_view());
+            match_field->set_name(field.name);
             addAnnotations(match_field, field.annotations);
             addDocumentation(match_field, field.annotations);
             match_field->set_bitwidth(field.bitwidth);
             if (field.type != MatchField::MatchTypes::UNSPECIFIED)
                 match_field->set_match_type(field.type);
             else
-                match_field->set_other_match_type(field.other_match_type.string_view());
+                match_field->set_other_match_type(field.other_match_type);
             if (field.type_name) {
                 auto namedType = match_field->mutable_type_name();
-                namedType->set_name(field.type_name.string_view());
+                namedType->set_name(field.type_name);
             }
         }
 
@@ -840,7 +840,7 @@ class P4RuntimeAnalyzer {
             if (matchType != MatchField::MatchTypes::UNSPECIFIED)
                 match->set_match_type(*matchType);
             else
-                match->set_other_match_type(matchTypeName.string_view());
+                match->set_other_match_type(matchTypeName);
         };
 
         // TODO(antonin): handle new types
@@ -872,7 +872,7 @@ class P4RuntimeAnalyzer {
                 auto *match = vs->add_match();
                 auto fieldId = idAllocator.getId(f);
                 match->set_id(fieldId);
-                match->set_name(f->controlPlaneName().string_view());
+                match->set_name(f->controlPlaneName());
                 match->set_bitwidth(fType->width_bits());
                 setMatchType(f, match);
                 // add annotations save for the @match one
@@ -896,7 +896,7 @@ class P4RuntimeAnalyzer {
             for (auto f : fields) {
                 auto *match = vs->add_match();
                 match->set_id(index++);
-                match->set_name(f->controlPlaneName().string_view());
+                match->set_name(f->controlPlaneName());
                 match->set_bitwidth(fType->width_bits());
                 match->set_match_type(MatchField::MatchTypes::EXACT);
             }
@@ -933,7 +933,7 @@ class P4RuntimeAnalyzer {
         CHECK_NULL(decl);
         auto *pkginfo = p4Info->mutable_pkg_info();
 
-        pkginfo->set_arch(arch.string_view());
+        pkginfo->set_arch(arch);
 
         std::set<cstring> keysVisited;
 

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -562,7 +562,7 @@ class P4RuntimeAnalyzer {
             auto paramName = actionParam->controlPlaneName();
             auto id = idAllocator.getId(actionParam);
             param->set_id(id);
-            param->set_name(paramName);
+            param->set_name(paramName.string_view());
             addAnnotations(param, actionParam->to<IR::IAnnotated>());
             addDocumentation(param, actionParam->to<IR::IAnnotated>());
 
@@ -586,7 +586,7 @@ class P4RuntimeAnalyzer {
             auto type_name = getTypeName(paramType, typeMap);
             if (type_name) {
                 auto namedType = param->mutable_type_name();
-                namedType->set_name(type_name);
+                namedType->set_name(type_name.string_view());
             } else if (auto e = paramType->to<IR::Type_Enum>()) {
                 param->mutable_type_name()->set_name(std::string(e->controlPlaneName()));
             }
@@ -626,7 +626,7 @@ class P4RuntimeAnalyzer {
             auto fieldName = headerField->controlPlaneName();
             auto id = idAllocator.getId(headerField);
             metadata->set_id(id);
-            metadata->set_name(fieldName);
+            metadata->set_name(fieldName.string_view());
             addAnnotations(metadata, headerField->to<IR::IAnnotated>());
 
             auto fieldType = typeMap->getType(headerField, true);
@@ -643,7 +643,7 @@ class P4RuntimeAnalyzer {
             auto type_name = getTypeName(fieldType, typeMap);
             if (type_name) {
                 auto namedType = metadata->mutable_type_name();
-                namedType->set_name(type_name);
+                namedType->set_name(type_name.string_view());
             }
         }
     }
@@ -729,17 +729,17 @@ class P4RuntimeAnalyzer {
         for (const auto &field : matchFields) {
             auto match_field = table->add_match_fields();
             match_field->set_id(field.id);
-            match_field->set_name(field.name);
+            match_field->set_name(field.name.string_view());
             addAnnotations(match_field, field.annotations);
             addDocumentation(match_field, field.annotations);
             match_field->set_bitwidth(field.bitwidth);
             if (field.type != MatchField::MatchTypes::UNSPECIFIED)
                 match_field->set_match_type(field.type);
             else
-                match_field->set_other_match_type(field.other_match_type);
+                match_field->set_other_match_type(field.other_match_type.string_view());
             if (field.type_name) {
                 auto namedType = match_field->mutable_type_name();
-                namedType->set_name(field.type_name);
+                namedType->set_name(field.type_name.string_view());
             }
         }
 
@@ -840,7 +840,7 @@ class P4RuntimeAnalyzer {
             if (matchType != MatchField::MatchTypes::UNSPECIFIED)
                 match->set_match_type(*matchType);
             else
-                match->set_other_match_type(matchTypeName);
+                match->set_other_match_type(matchTypeName.string_view());
         };
 
         // TODO(antonin): handle new types
@@ -872,7 +872,7 @@ class P4RuntimeAnalyzer {
                 auto *match = vs->add_match();
                 auto fieldId = idAllocator.getId(f);
                 match->set_id(fieldId);
-                match->set_name(f->controlPlaneName());
+                match->set_name(f->controlPlaneName().string_view());
                 match->set_bitwidth(fType->width_bits());
                 setMatchType(f, match);
                 // add annotations save for the @match one
@@ -896,7 +896,7 @@ class P4RuntimeAnalyzer {
             for (auto f : fields) {
                 auto *match = vs->add_match();
                 match->set_id(index++);
-                match->set_name(f->controlPlaneName());
+                match->set_name(f->controlPlaneName().string_view());
                 match->set_bitwidth(fType->width_bits());
                 match->set_match_type(MatchField::MatchTypes::EXACT);
             }
@@ -933,7 +933,7 @@ class P4RuntimeAnalyzer {
         CHECK_NULL(decl);
         auto *pkginfo = p4Info->mutable_pkg_info();
 
-        pkginfo->set_arch(arch);
+        pkginfo->set_arch(arch.string_view());
 
         std::set<cstring> keysVisited;
 

--- a/control-plane/typeSpecConverter.cpp
+++ b/control-plane/typeSpecConverter.cpp
@@ -131,15 +131,15 @@ bool TypeSpecConverter::preorder(const IR::Type_Name *type) {
     auto decl = refMap->getDeclaration(type->path, true);
     auto name = decl->controlPlaneName();
     if (decl->is<IR::Type_Struct>()) {
-        typeSpec->mutable_struct_()->set_name(name.string_view());
+        typeSpec->mutable_struct_()->set_name(name);
     } else if (decl->is<IR::Type_Header>()) {
-        typeSpec->mutable_header()->set_name(name.string_view());
+        typeSpec->mutable_header()->set_name(name);
     } else if (decl->is<IR::Type_HeaderUnion>()) {
-        typeSpec->mutable_header_union()->set_name(name.string_view());
+        typeSpec->mutable_header_union()->set_name(name);
     } else if (decl->is<IR::Type_Enum>()) {
-        typeSpec->mutable_enum_()->set_name(name.string_view());
+        typeSpec->mutable_enum_()->set_name(name);
     } else if (decl->is<IR::Type_SerEnum>()) {
-        typeSpec->mutable_serializable_enum()->set_name(name.string_view());
+        typeSpec->mutable_serializable_enum()->set_name(name);
     } else if (decl->is<IR::Type_Error>()) {
         // enable "error" field in P4DataTypeSpec's type_spec oneof
         (void)typeSpec->mutable_error();
@@ -154,7 +154,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Name *type) {
         map.emplace(type, typeSpec);
         return false;
     } else if (decl->is<IR::Type_Newtype>()) {
-        typeSpec->mutable_new_type()->set_name(name.string_view());
+        typeSpec->mutable_new_type()->set_name(name);
     } else {
         BUG("Unexpected named type %1%", type);
     }
@@ -244,11 +244,11 @@ bool TypeSpecConverter::preorder(const IR::Type_Stack *type) {
 
     if (decl->is<IR::Type_Header>()) {
         auto headerStackTypeSpec = typeSpec->mutable_header_stack();
-        headerStackTypeSpec->mutable_header()->set_name(name.string_view());
+        headerStackTypeSpec->mutable_header()->set_name(name);
         headerStackTypeSpec->set_size(size);
     } else if (decl->is<IR::Type_HeaderUnion>()) {
         auto headerUnionStackTypeSpec = typeSpec->mutable_header_union_stack();
-        headerUnionStackTypeSpec->mutable_header_union()->set_name(name.string_view());
+        headerUnionStackTypeSpec->mutable_header_union()->set_name(name);
         headerUnionStackTypeSpec->set_size(size);
     } else {
         BUG("Unexpected declaration %1%", decl);
@@ -270,7 +270,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Struct *type) {
                 auto fTypeSpec = map.at(fType);
                 CHECK_NULL(fTypeSpec);
                 auto member = structTypeSpec->add_members();
-                member->set_name(f->controlPlaneName().string_view());
+                member->set_name(f->controlPlaneName());
                 member->mutable_type_spec()->CopyFrom(*fTypeSpec);
             }
             (*structs)[name] = *structTypeSpec;
@@ -296,7 +296,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Header *type) {
                           "Only bitstring fields expected in flattened header type %1%",
                           flattenedHeaderType);
                 auto member = headerTypeSpec->add_members();
-                member->set_name(f->controlPlaneName().string_view());
+                member->set_name(f->controlPlaneName());
                 member->mutable_type_spec()->CopyFrom(fTypeSpec->bitstring());
             }
             (*headers)[name] = *headerTypeSpec;
@@ -320,7 +320,7 @@ bool TypeSpecConverter::preorder(const IR::Type_HeaderUnion *type) {
                 BUG_CHECK(fTypeSpec->has_header(),
                           "Only header fields expected in header union declaration %1%", type);
                 auto member = headerUnionTypeSpec->add_members();
-                member->set_name(f->controlPlaneName().string_view());
+                member->set_name(f->controlPlaneName());
                 member->mutable_header()->CopyFrom(fTypeSpec->header());
             }
             (*headerUnions)[name] = *headerUnionTypeSpec;
@@ -338,7 +338,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Enum *type) {
             auto enumTypeSpec = new p4configv1::P4EnumTypeSpec();
             for (auto m : type->members) {
                 auto member = enumTypeSpec->add_members();
-                member->set_name(m->controlPlaneName().string_view());
+                member->set_name(m->controlPlaneName());
             }
             (*enums)[name] = *enumTypeSpec;
         }
@@ -358,7 +358,7 @@ bool TypeSpecConverter::preorder(const IR::Type_SerEnum *type) {
             bitTypeSpec->set_bitwidth(width);
             for (auto m : type->members) {
                 auto member = enumTypeSpec->add_members();
-                member->set_name(m->controlPlaneName().string_view());
+                member->set_name(m->controlPlaneName());
                 if (!m->value->is<IR::Constant>()) {
                     ::P4::error(ErrorType::ERR_UNSUPPORTED, "%1% unsupported SerEnum member value",
                                 m->value);
@@ -378,8 +378,7 @@ bool TypeSpecConverter::preorder(const IR::Type_SerEnum *type) {
 bool TypeSpecConverter::preorder(const IR::Type_Error *type) {
     if (p4RtTypeInfo && !p4RtTypeInfo->has_error()) {
         auto errorTypeSpec = p4RtTypeInfo->mutable_error();
-        for (auto m : type->members)
-            errorTypeSpec->add_members(m->controlPlaneName().string_view());
+        for (auto m : type->members) errorTypeSpec->add_members(m->controlPlaneName());
     }
     map.emplace(type, nullptr);
     return false;

--- a/control-plane/typeSpecConverter.cpp
+++ b/control-plane/typeSpecConverter.cpp
@@ -131,15 +131,15 @@ bool TypeSpecConverter::preorder(const IR::Type_Name *type) {
     auto decl = refMap->getDeclaration(type->path, true);
     auto name = decl->controlPlaneName();
     if (decl->is<IR::Type_Struct>()) {
-        typeSpec->mutable_struct_()->set_name(name);
+        typeSpec->mutable_struct_()->set_name(name.string_view());
     } else if (decl->is<IR::Type_Header>()) {
-        typeSpec->mutable_header()->set_name(name);
+        typeSpec->mutable_header()->set_name(name.string_view());
     } else if (decl->is<IR::Type_HeaderUnion>()) {
-        typeSpec->mutable_header_union()->set_name(name);
+        typeSpec->mutable_header_union()->set_name(name.string_view());
     } else if (decl->is<IR::Type_Enum>()) {
-        typeSpec->mutable_enum_()->set_name(name);
+        typeSpec->mutable_enum_()->set_name(name.string_view());
     } else if (decl->is<IR::Type_SerEnum>()) {
-        typeSpec->mutable_serializable_enum()->set_name(name);
+        typeSpec->mutable_serializable_enum()->set_name(name.string_view());
     } else if (decl->is<IR::Type_Error>()) {
         // enable "error" field in P4DataTypeSpec's type_spec oneof
         (void)typeSpec->mutable_error();
@@ -154,7 +154,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Name *type) {
         map.emplace(type, typeSpec);
         return false;
     } else if (decl->is<IR::Type_Newtype>()) {
-        typeSpec->mutable_new_type()->set_name(name);
+        typeSpec->mutable_new_type()->set_name(name.string_view());
     } else {
         BUG("Unexpected named type %1%", type);
     }
@@ -244,11 +244,11 @@ bool TypeSpecConverter::preorder(const IR::Type_Stack *type) {
 
     if (decl->is<IR::Type_Header>()) {
         auto headerStackTypeSpec = typeSpec->mutable_header_stack();
-        headerStackTypeSpec->mutable_header()->set_name(name);
+        headerStackTypeSpec->mutable_header()->set_name(name.string_view());
         headerStackTypeSpec->set_size(size);
     } else if (decl->is<IR::Type_HeaderUnion>()) {
         auto headerUnionStackTypeSpec = typeSpec->mutable_header_union_stack();
-        headerUnionStackTypeSpec->mutable_header_union()->set_name(name);
+        headerUnionStackTypeSpec->mutable_header_union()->set_name(name.string_view());
         headerUnionStackTypeSpec->set_size(size);
     } else {
         BUG("Unexpected declaration %1%", decl);
@@ -270,7 +270,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Struct *type) {
                 auto fTypeSpec = map.at(fType);
                 CHECK_NULL(fTypeSpec);
                 auto member = structTypeSpec->add_members();
-                member->set_name(f->controlPlaneName());
+                member->set_name(f->controlPlaneName().string_view());
                 member->mutable_type_spec()->CopyFrom(*fTypeSpec);
             }
             (*structs)[name] = *structTypeSpec;
@@ -296,7 +296,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Header *type) {
                           "Only bitstring fields expected in flattened header type %1%",
                           flattenedHeaderType);
                 auto member = headerTypeSpec->add_members();
-                member->set_name(f->controlPlaneName());
+                member->set_name(f->controlPlaneName().string_view());
                 member->mutable_type_spec()->CopyFrom(fTypeSpec->bitstring());
             }
             (*headers)[name] = *headerTypeSpec;
@@ -320,7 +320,7 @@ bool TypeSpecConverter::preorder(const IR::Type_HeaderUnion *type) {
                 BUG_CHECK(fTypeSpec->has_header(),
                           "Only header fields expected in header union declaration %1%", type);
                 auto member = headerUnionTypeSpec->add_members();
-                member->set_name(f->controlPlaneName());
+                member->set_name(f->controlPlaneName().string_view());
                 member->mutable_header()->CopyFrom(fTypeSpec->header());
             }
             (*headerUnions)[name] = *headerUnionTypeSpec;
@@ -338,7 +338,7 @@ bool TypeSpecConverter::preorder(const IR::Type_Enum *type) {
             auto enumTypeSpec = new p4configv1::P4EnumTypeSpec();
             for (auto m : type->members) {
                 auto member = enumTypeSpec->add_members();
-                member->set_name(m->controlPlaneName());
+                member->set_name(m->controlPlaneName().string_view());
             }
             (*enums)[name] = *enumTypeSpec;
         }
@@ -358,7 +358,7 @@ bool TypeSpecConverter::preorder(const IR::Type_SerEnum *type) {
             bitTypeSpec->set_bitwidth(width);
             for (auto m : type->members) {
                 auto member = enumTypeSpec->add_members();
-                member->set_name(m->controlPlaneName());
+                member->set_name(m->controlPlaneName().string_view());
                 if (!m->value->is<IR::Constant>()) {
                     ::P4::error(ErrorType::ERR_UNSUPPORTED, "%1% unsupported SerEnum member value",
                                 m->value);
@@ -378,7 +378,8 @@ bool TypeSpecConverter::preorder(const IR::Type_SerEnum *type) {
 bool TypeSpecConverter::preorder(const IR::Type_Error *type) {
     if (p4RtTypeInfo && !p4RtTypeInfo->has_error()) {
         auto errorTypeSpec = p4RtTypeInfo->mutable_error();
-        for (auto m : type->members) errorTypeSpec->add_members(m->controlPlaneName());
+        for (auto m : type->members)
+            errorTypeSpec->add_members(m->controlPlaneName().string_view());
     }
     map.emplace(type, nullptr);
     return false;

--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -328,9 +328,9 @@ ParserOptions::ParserOptions(std::string_view defaultMessage) : Util::Options(de
         "when it can inline the subparser's states only once for multiple\n"
         "invocations of the same subparser instance.");
     registerOption(
-        "--doNotEmitIncludes", "condition",
-        [this](const char *arg) {
-            noIncludes = cstring(arg);
+        "--doNotEmitIncludes", nullptr,
+        [this](const char *) {
+            noIncludes = true;
             return true;
         },
         "[Compiler debugging] If true do not generate #include statements\n");
@@ -481,7 +481,7 @@ void ParserOptions::dumpPass(const char *manager, unsigned seq, const char *pass
     for (auto s : top4) {
         bool match = false;
         try {
-            auto sRegex = std::regex(s, std::regex::ECMAScript | std::regex::icase);
+            auto sRegex = std::regex(s.c_str(), std::regex::ECMAScript | std::regex::icase);
             // We use std::regex_search instead of std::regex_match.
             // std::regex_match compares the regex against the entire string.
             // std::regex_search checks if the regex is contained as substring.

--- a/frontends/p4-14/ir-v1.def
+++ b/frontends/p4-14/ir-v1.def
@@ -252,7 +252,7 @@ class CalculatedField : IAnnotated {
     Annotations getAnnotations() const override { return annotations; }
     visit_children {
         v.visit(field, "field");
-        for (auto &s : specs) v.visit(s.cond, s.name.name);
+        for (auto &s : specs) v.visit(s.cond, s.name.name.c_str());
         v.visit(annotations, "annotations"); }
 }
 

--- a/frontends/p4-14/typecheck.cpp
+++ b/frontends/p4-14/typecheck.cpp
@@ -257,7 +257,7 @@ class TypeCheck::AssignInitialTypes : public Transform {
     }
 
     const IR::Node *postorder(IR::Member *ref) override {
-        if (ref->member.toString()[0] == '$') {
+        if (ref->member.toString().startsWith("$")) {
             if (ref->member == "$valid") setType(ref, IR::Type::Boolean::get());
         } else if (auto ht = ref->expr->type->to<IR::Type_StructLike>()) {
             auto f = ht->getField(ref->member);

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -65,7 +65,7 @@ StorageLocation *StorageFactory::create(const IR::Type *type, cstring name) cons
         auto *result = construct<TupleLocation>(type, name);
         size_t index = 0;
         for (const auto *t : bl->components) {
-            cstring fieldName = absl::StrCat(name.string_view(), "[", index, "]");
+            cstring fieldName = absl::StrCat(name, "[", index, "]");
             auto *sl = create(t, fieldName);
             result->createElement(index, sl);
             index++;
@@ -103,11 +103,11 @@ StorageLocation *StorageFactory::create(const IR::Type *type, cstring name) cons
     } else if (auto st = type->to<IR::Type_Stack>()) {
         auto *result = construct<ArrayLocation>(st, name);
         for (unsigned i = 0; i < st->getSize(); i++) {
-            auto *sl = create(st->elementType, absl::StrCat(name.string_view(), "[", i, "]"));
+            auto *sl = create(st->elementType, absl::StrCat(name, "[", i, "]"));
             result->createElement(i, sl);
         }
         result->setLastIndexField(
-            create(IR::Type_Bits::get(32), absl::StrCat(name.string_view(), ".", indexFieldName)));
+            create(IR::Type_Bits::get(32), absl::StrCat(name, ".", indexFieldName)));
         return result;
     }
 

--- a/frontends/p4/localizeActions.cpp
+++ b/frontends/p4/localizeActions.cpp
@@ -73,7 +73,7 @@ bool FindGlobalActionUses::preorder(const IR::PathExpression *path) {
     auto control = findContext<IR::P4Control>();
     if (control != nullptr) {
         if (repl->getReplacement(action, control) != nullptr) return false;
-        auto newName = nameGen.newName(action->name.name.string_view());
+        auto newName = nameGen.newName(action->name.string_view());
         ParamCloner cloner;
         auto replBody = cloner.clone<IR::BlockStatement>(action->body);
         auto params = cloner.clone<IR::ParameterList>(action->parameters);
@@ -163,7 +163,7 @@ bool FindRepeatedActionUses::preorder(const IR::PathExpression *expression) {
     LOG1(dbp(expression) << " used by " << dbp(actionUser));
     auto replacement = repl->getActionUser(action, actionUser);
     if (replacement == nullptr) {
-        auto newName = nameGen.newName(action->name.name.string_view());
+        auto newName = nameGen.newName(action->name.string_view());
         ParamCloner cloner;
         auto replBody = cloner.clone<IR::BlockStatement>(action->body);
         auto annos = action->annotations;

--- a/frontends/p4/staticAssert.h
+++ b/frontends/p4/staticAssert.h
@@ -66,7 +66,7 @@ class DoStaticAssert : public Transform, public ResolutionContext {
                             auto msg = subst.lookup(param);
                             CHECK_NULL(msg);
                             if (const auto *sl = msg->expression->to<IR::StringLiteral>()) {
-                                message = sl->value.string_view();
+                                message = sl->value;
                             }
                         }
                         ::P4::error(ErrorType::ERR_EXPECTED, "%1%: %2%", method, message);

--- a/frontends/p4/typeChecking/typeCheckDecl.cpp
+++ b/frontends/p4/typeChecking/typeCheckDecl.cpp
@@ -379,15 +379,13 @@ static bool checkEnumValueInitializer(const IR::Type_Bits *type, const IR::Expre
             if (!type->isSigned && constant->value < low) {
                 extraMsg = absl::Substitute(
                     "the value $0 is negative, but the underlying type $1 is unsigned",
-                    P4::Util::toString(constant->value, 0, type->isSigned).string_view(),
-                    type->toString().string_view());
+                    P4::Util::toString(constant->value, 0, type->isSigned), type->toString());
             } else {
                 extraMsg = absl::Substitute(
                     "the value $0 requires $1 bits but the underlying "
                     "$2 type $3 only contains $4 bits",
-                    P4::Util::toString(constant->value, 0, type->isSigned).string_view(), required,
-                    (type->isSigned ? "signed" : "unsigned"), type->toString().string_view(),
-                    type->size);
+                    P4::Util::toString(constant->value, 0, type->isSigned), required,
+                    (type->isSigned ? "signed" : "unsigned"), type->toString(), type->size);
             }
             P4::error(ErrorType::ERR_TYPE_ERROR,
                       "%1%: Serialized enum constant value %2% is out of bounds of the underlying "

--- a/frontends/p4/typeChecking/typeConstraints.cpp
+++ b/frontends/p4/typeChecking/typeConstraints.cpp
@@ -74,7 +74,8 @@ bool TypeConstraints::solve(const BinaryConstraint *constraint) {
             LOG3("Binding " << leftTv << " => " << right);
             auto error = currentSubstitution->compose(leftTv, right);
             if (!error.isNullOrEmpty())
-                return constraint->reportError(getCurrentSubstitution(), error, leftTv, right);
+                return constraint->reportError(getCurrentSubstitution(), error.c_str(), leftTv,
+                                               right);
             return true;
         } else {
             add(constraint->create(leftSubst, constraint->right));
@@ -91,7 +92,8 @@ bool TypeConstraints::solve(const BinaryConstraint *constraint) {
             LOG3("Binding " << rightTv << " => " << left);
             auto error = currentSubstitution->compose(rightTv, left);
             if (!error.isNullOrEmpty())
-                return constraint->reportError(getCurrentSubstitution(), error, rightTv, left);
+                return constraint->reportError(getCurrentSubstitution(), error.c_str(), rightTv,
+                                               left);
             return true;
         } else {
             add(constraint->create(constraint->left, rightSubst));
@@ -124,7 +126,7 @@ std::string TypeConstraint::localError(Explain *explainer) const {
     if (errFormat.isNullOrEmpty()) return "";
 
     std::string message, explanation;
-    boost::format fmt = boost::format(errFormat);
+    boost::format fmt = boost::format(errFormat.c_str());
     switch (errArguments.size()) {
         case 0:
             message = boost::str(fmt);

--- a/frontends/p4/uniqueNames.h
+++ b/frontends/p4/uniqueNames.h
@@ -97,7 +97,7 @@ class FindSymbols : public Inspector {
     }
 
     void doDecl(const IR::Declaration *decl) {
-        cstring newName = nameGen.newName(decl->getName().name.string_view());
+        cstring newName = nameGen.newName(decl->getName().string_view());
         renameMap->setNewName(decl, newName);
     }
     void postorder(const IR::Declaration_Variable *decl) override { doDecl(decl); }
@@ -170,7 +170,7 @@ class FindParameters : public Inspector {
 
     void doParameters(const IR::ParameterList *pl) {
         for (auto p : pl->parameters) {
-            cstring newName = nameGen.newName(p->name.name.string_view());
+            cstring newName = nameGen.newName(p->name.string_view());
             renameMap->setNewName(p, newName);
         }
     }

--- a/frontends/parsers/parserDriver.cpp
+++ b/frontends/parsers/parserDriver.cpp
@@ -181,7 +181,7 @@ const T *P4ParserDriver::parse(P4AnnotationLexer::Type type, const Util::SourceI
     LOG3("Parsing P4-16 annotation " << srcInfo);
 
     P4AnnotationLexer lexer(type, srcInfo, body);
-    if (!parse(lexer, srcInfo.getSourceFile().string_view())) {
+    if (!parse(lexer, srcInfo.getSourceFile())) {
         return nullptr;
     }
 

--- a/ir/base.def
+++ b/ir/base.def
@@ -193,11 +193,11 @@ class Path {
     bool isDontCare() const { return name.isDontCare(); }
     toString{
         // This is the ORIGINAL name the user used
-        return absl::StrCat(absolute ? "." : "", name.toString().string_view());
+        return absl::StrCat(absolute ? "." : "", name.toString());
     }
     cstring asString() const {
         // The CURRENT internal name
-        return absl::StrCat(absolute ? "." : "", name.string_view());
+        return absl::StrCat(absolute ? "." : "", name);
     }
     dbprint { out << name; }
     validate { BUG_CHECK(!name.name.isNullOrEmpty(), "Empty path"); }
@@ -288,7 +288,7 @@ class Annotation {
     static const cstring matchAnnotation;  /// Match annotation (for value sets).
     static const cstring fieldListAnnotation;  /// Used for recirculate, etc.
     static const cstring debugLoggingAnnotation;  /// Used by compiler implementer to limit debug log to the annotated IR context.
-    toString{ return absl::StrCat("@", name.string_view()); }
+    toString{ return absl::StrCat("@", name); }
     validate{
         BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name");
         BUG_CHECK(!(needsParsing && !expr.empty()),
@@ -395,8 +395,8 @@ class Argument {
     toString{
         std::string result = "";
         if (!name.name.isNullOrEmpty())
-            absl::StrAppend(&result, name.toString().string_view(), " = ");
-        return absl::StrCat(result, expression->toString().string_view());
+            absl::StrAppend(&result, name, " = ");
+        return absl::StrCat(result, expression);
     }
 }
 

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -293,7 +293,7 @@ class BoolLiteral : Literal {
 class StringLiteral : Literal {
     cstring value;
     validate{ if (value.isNull()) BUG("null StringLiteral"); }
-    toString{ return absl::StrCat("\"", value.escapeJson().string_view(), "\""); }
+    toString{ return absl::StrCat("\"", value.escapeJson(), "\""); }
     StringLiteral(ID v) : Literal(v.srcInfo), value(v.name) {}
 #emit
     operator IR::ID() const { return IR::ID(srcInfo, value); }
@@ -333,9 +333,7 @@ abstract AbstractSlice : Operation_Ternary {
 class Slice : AbstractSlice {
     precedence = DBPrint::Prec_Postfix;
     stringOp = "[:]";
-    toString{ return absl::StrCat(e0->toString().string_view(),
-                                  "[", e1->toString().string_view(), ":",
-                                       e2->toString().string_view(), "]"); }
+    toString{ return absl::StrCat(e0, "[", e1, ":", e2, "]"); }
     // After type checking e1 and e2 will be constants
     unsigned getH() const override { return e1->checkedTo<IR::Constant>()->asUnsigned(); }
     unsigned getL() const override { return e2->checkedTo<IR::Constant>()->asUnsigned(); }
@@ -353,9 +351,7 @@ class Slice : AbstractSlice {
 class PlusSlice : AbstractSlice {
     precedence = DBPrint::Prec_Postfix;
     stringOp = "[+:]";
-    toString{ return absl::StrCat(e0->toString().string_view(),
-                                  "[", e1->toString().string_view(), "+:",
-                                       e2->toString().string_view(), "]"); }
+    toString{ return absl::StrCat(e0, "[", e1, "+:", e2, "]"); }
     unsigned getH() const override {
         BUG_CHECK(e1->is<IR::Constant>(), "non-const PlusSlice not handled");
         return e1->to<IR::Constant>()->asUnsigned() + e2->checkedTo<IR::Constant>()->asUnsigned() - 1; }
@@ -376,7 +372,7 @@ class Member : Operation_Unary {
     int lsb() const;
     int msb() const;
     stringOp = ".";
-    toString{ return absl::StrCat(expr->toString().string_view(), ".", member.string_view()); }
+    toString{ return absl::StrCat(expr, ".", member); }
 }
 
 class Concat : Operation_Binary {
@@ -396,7 +392,7 @@ class ArrayIndex : Operation_Binary {
     ArrayIndex {
         if (auto st = left ? left->type->to<IR::Type_Stack>() : nullptr)
             type = st->elementType; }
-    toString{ return absl::StrCat(left->toString().string_view(), "[", right->toString().string_view(), "]"); }
+    toString{ return absl::StrCat(left, "[", right, "]"); }
 }
 
 class Range : Operation_Binary {
@@ -440,7 +436,7 @@ class Cast : Operation_Unary {
     /// type, and 'type' will only be updated later when type inferencing occurs
     precedence = DBPrint::Prec_Prefix;
     stringOp = "(cast)";
-    toString{ return absl::StrCat("(", destType->toString().string_view(), ")", expr->toString().string_view()); }
+    toString{ return absl::StrCat("(", destType, ")", expr); }
     validate{ BUG_CHECK(!destType->is<Type_Unknown>(), "%1%: Cannot cast to unknown type", this); }
 }
 
@@ -464,10 +460,10 @@ class MethodCallExpression : Expression {
     optional Vector<Argument>   arguments = new Vector<Argument>;
     toString {
         return
-            absl::StrCat(method->toString().string_view(), "(",
+            absl::StrCat(method, "(",
                          absl::StrJoin(*arguments, ", ",
                                        [](std::string *out, const Argument *arg) {
-                                           absl::StrAppend(out, arg->toString().string_view());
+                                           absl::StrAppend(out, arg);
                                        }),
                          ")");
     }
@@ -510,7 +506,7 @@ class BaseListExpression : Expression {
             absl::StrCat("{ ",
                          absl::StrJoin(components, ", ",
                                        [](std::string *out, const Expression *comp)  {
-                                           absl::StrAppend(out, comp->toString().string_view());
+                                           absl::StrAppend(out, comp);
                                        }),
                          " }");
     }
@@ -564,10 +560,7 @@ class StructExpression : Expression {
             absl::StrCat("{ ",
                          absl::StrJoin(components, ", ",
                                        [](std::string *out, const NamedExpression *comp)  {
-                                           absl::StrAppend(out,
-                                                           comp->toString().string_view(),
-                                                           " = ",
-                                                           comp->expression->toString().string_view());
+                                           absl::StrAppend(out, comp, " = ", comp->expression);
                                        }),
                          " }");
     }
@@ -652,7 +645,7 @@ class SymbolicVariable : Expression {
         return label < other.label;
     }
 
-    toString { return absl::StrCat("|", label.string_view(), "(", type->toString().string_view(), ")|"); }
+    toString { return absl::StrCat("|", label, "(", type, ")|"); }
 
     dbprint { out << "|" + label +"(" << type << ")|"; }
 }

--- a/ir/id.h
+++ b/ir/id.h
@@ -67,6 +67,8 @@ struct ID : Util::IHasSourceInfo, public IHasDbPrint {
     Util::SourceInfo getSourceInfo() const override { return srcInfo; }
     cstring toString() const override { return originalName.isNullOrEmpty() ? name : originalName; }
 
+    /// Helper to simplify usage of ID in Abseil functions (e.g. StrCat / StrFormat, etc.) without
+    /// explicit string_view conversion.
     template <typename Sink>
     friend void AbslStringify(Sink &sink, const ID &id) {
         sink.Append(id.string_view());

--- a/ir/id.h
+++ b/ir/id.h
@@ -38,9 +38,10 @@ struct ID : Util::IHasSourceInfo, public IHasDbPrint {
     ID(Util::SourceInfo si, cstring n) : srcInfo(si), name(n), originalName(n) {
         if (n.isNullOrEmpty()) BUG("Identifier with no name");
     }
+    // FIXME: Replace with single string_view constructor
     ID(const char *n) : ID(Util::SourceInfo(), cstring(n)) {}  // NOLINT(runtime/explicit)
     ID(cstring n) : ID(Util::SourceInfo(), n) {}               // NOLINT(runtime/explicit)
-    ID(std::string n) : ID(Util::SourceInfo(), n) {}           // NOLINT(runtime/explicit)
+    ID(const std::string &n) : ID(Util::SourceInfo(), n) {}    // NOLINT(runtime/explicit)
     ID(cstring n, cstring old) : ID(Util::SourceInfo(), n, old) {}
     void dbprint(std::ostream &out) const override {
         out << name;
@@ -65,6 +66,11 @@ struct ID : Util::IHasSourceInfo, public IHasDbPrint {
     bool isDontCare() const { return name == "_"; }
     Util::SourceInfo getSourceInfo() const override { return srcInfo; }
     cstring toString() const override { return originalName.isNullOrEmpty() ? name : originalName; }
+
+    template <typename Sink>
+    friend void AbslStringify(Sink &sink, const ID &id) {
+        sink.Append(id.string_view());
+    }
 };
 
 }  // namespace P4::IR

--- a/ir/id.h
+++ b/ir/id.h
@@ -59,7 +59,7 @@ struct ID : Util::IHasSourceInfo, public IHasDbPrint {
     bool operator!=(const char *a) const { return name != a; }
     /// Defer to cstring's notion of less, which is a lexicographical and not a pointer comparison.
     bool operator<(const char *a) const { return name < a; }
-    explicit operator bool() const { return name.c_str(); }
+    explicit operator bool() const { return name.c_str() != nullptr; }
     operator cstring() const { return name; }
     std::string string() const { return name.string(); }
     std::string_view string_view() const { return name.string_view(); }

--- a/ir/id.h
+++ b/ir/id.h
@@ -59,7 +59,7 @@ struct ID : Util::IHasSourceInfo, public IHasDbPrint {
     bool operator!=(const char *a) const { return name != a; }
     /// Defer to cstring's notion of less, which is a lexicographical and not a pointer comparison.
     bool operator<(const char *a) const { return name < a; }
-    explicit operator bool() const { return name; }
+    explicit operator bool() const { return name.c_str(); }
     operator cstring() const { return name; }
     std::string string() const { return name.string(); }
     std::string_view string_view() const { return name.string_view(); }

--- a/ir/ir-inline.h
+++ b/ir/ir-inline.h
@@ -235,7 +235,7 @@ template <class T, template <class K, class V, class COMP, class ALLOC> class MA
 void IR::NameMap<T, MAP, COMP, ALLOC>::visit_children(Visitor &v) {
     map_t new_symbols;
     for (auto i = symbols.begin(); i != symbols.end();) {
-        const IR::Node *n = v.apply_visitor(i->second, i->first);
+        const IR::Node *n = v.apply_visitor(i->second, i->first.c_str());
         if (!n && i->second) {
             i = symbols.erase(i);
             continue;
@@ -270,7 +270,7 @@ template <class T, template <class K, class V, class COMP, class ALLOC> class MA
           class ALLOC /*= std::allocator<std::pair<cstring, const T*>>*/>
 void IR::NameMap<T, MAP, COMP, ALLOC>::visit_children(Visitor &v) const {
     for (auto &k : symbols) {
-        v.visit(k.second, k.first);
+        v.visit(k.second, k.first.c_str());
     }
 }
 template <class T, template <class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -454,7 +454,7 @@ class ReturnStatement : Statement {
     NullOK Expression expression;
     toString{ return absl::StrCat("return ",
                                   (expression ?
-                                   expression->toString().string_view() : "")); }
+                                   expression->toString() : "")); }
 }
 
 class EmptyStatement : Statement {
@@ -464,9 +464,7 @@ class EmptyStatement : Statement {
 class AssignmentStatement : Statement {
     Expression left;
     Expression right;
-    toString{ return absl::StrCat(left->toString().string_view(),
-                                  " = ",
-                                  right->toString().string_view()); }
+    toString{ return absl::StrCat(left, " = ", right); }
 }
 
 class IfStatement : Statement {

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -454,7 +454,7 @@ class ReturnStatement : Statement {
     NullOK Expression expression;
     toString{ return absl::StrCat("return ",
                                   (expression ?
-                                   expression->toString() : "")); }
+                                   expression->toString() : ""_cs)); }
 }
 
 class EmptyStatement : Statement {

--- a/ir/node.h
+++ b/ir/node.h
@@ -165,6 +165,11 @@ class Node : public virtual INode {
 
     bool operator!=(const Node &n) const { return !operator==(n); }
 
+    template <typename Sink>
+    friend void AbslStringify(Sink &sink, const IR::Node *n) {
+        sink.Append(n->toString());
+    }
+
     DECLARE_TYPEINFO_WITH_TYPEID(Node, NodeKind::Node, INode);
 };
 

--- a/ir/node.h
+++ b/ir/node.h
@@ -165,6 +165,9 @@ class Node : public virtual INode {
 
     bool operator!=(const Node &n) const { return !operator==(n); }
 
+    /// Helper to simplify usage of nodes in Abseil functions (e.g. StrCat / StrFormat, etc.)
+    /// without explicit string_view conversion. Note that this calls Node::toString() so might
+    /// not be always appropriate for user-visible messages / strings.
     template <typename Sink>
     friend void AbslStringify(Sink &sink, const IR::Node *n) {
         sink.Append(n->toString());

--- a/ir/type.def
+++ b/ir/type.def
@@ -575,7 +575,7 @@ class Type_Stack : Type_Indexed, Type {
         return
             absl::StrCat(elementType,
                          "[",
-                         sizeKnown() ? size->toString() : "?",
+                         sizeKnown() ? size->toString() : "?"_cs,
                          "]"); }
     dbprint{ out << elementType << "[" << size << "]"; }
     bool sizeKnown() const;

--- a/ir/type.def
+++ b/ir/type.def
@@ -108,7 +108,7 @@ class Type_Any : Type, ITypeVar {
 class Type_Fragment : Type {
     Type type;
     dbprint { out << "FRAGMENT(" << type << ")"; }
-    toString { return absl::StrCat("FRAGMENT(", type->toString().string_view(), ")"); }
+    toString { return absl::StrCat("FRAGMENT(", type, ")"); }
     const Type* getP4Type() const override { return nullptr; }
 }
 
@@ -121,7 +121,7 @@ class Type_Fragment : Type {
 /// by type-checking.
 class Type_Type : Type {
     Type type;
-    toString { return absl::StrCat("Type(", type->toString().string_view(), ")"); }
+    toString { return absl::StrCat("Type(", type, ")"); }
     dbprint { out << "Type(" << type << ")"; }
     const Type* getP4Type() const override { return type; }
     validate { BUG_CHECK(!type->is<IR::Type_Type>(), "%1%: nested Type_Type", type); }
@@ -172,7 +172,7 @@ class Type_Bits : Type_Base {
     cstring baseName() const { return isSigned ? "int"_cs : "bit"_cs; }
     int width_bits() const override { return size; }
 
-    toString{ return absl::StrCat(baseName().string_view(), "<", size, ">"); }
+    toString{ return absl::StrCat(baseName(), "<", size, ">"); }
     dbprint { out << toString(); }
 }
 
@@ -231,7 +231,7 @@ class ParameterList : ISimpleNamespace {
     toString {
         return absl::StrJoin(parameters, ", ",
                              [](std::string *out, const auto *p) {
-                                 absl::StrAppend(out, p->toString().string_view());
+                                 absl::StrAppend(out, p);
                              });
     }
 #emit
@@ -334,7 +334,7 @@ class TypeParameters : ISimpleNamespace {
         return absl::StrCat("<",
                             absl::StrJoin(parameters, ", ",
                                           [](std::string *out, const auto *p) {
-                                              absl::StrAppend(out, p->toString().string_view());
+                                              absl::StrAppend(out, p);
                                           }),
                             ">");
     }
@@ -439,7 +439,7 @@ class Type_Header : Type_StructLike {
 class Type_Set : Type {
     Type elementType;
     dbprint{ Node::dbprint(out); out << "<" << elementType << ">"; }
-    toString { return absl::StrCat("set<", elementType->toString().string_view(), ">"); }
+    toString { return absl::StrCat("set<", elementType, ">"); }
     const Type* getP4Type() const override { return nullptr; }
     int width_bits() const override {
         /// returning the width of the set elements, not the set itself, which doesn't
@@ -473,7 +473,7 @@ abstract Type_BaseList : Type, Type_Indexed {
                          "<",
                          absl::StrJoin(components, ", ",
                                        [](std::string *out, const auto *t) {
-                                           absl::StrAppend(out, t->toString().string_view());
+                                           absl::StrAppend(out, t);
                                        }),
                          ">");
     }
@@ -504,7 +504,7 @@ class Type_P4List : Type {
     Type elementType;
     const Type* getP4Type() const override;
     toString{
-        return absl::StrCat("list<", elementType->toString().string_view(), ">");
+        return absl::StrCat("list<", elementType, ">");
     }
 }
 
@@ -573,9 +573,9 @@ class Type_Stack : Type_Indexed, Type {
     Expression  size;
     toString{
         return
-            absl::StrCat(elementType->toString().string_view(),
+            absl::StrCat(elementType,
                          "[",
-                         sizeKnown() ? size->toString().string_view() : "?",
+                         sizeKnown() ? size->toString() : "?",
                          "]"); }
     dbprint{ out << elementType << "[" << size << "]"; }
     bool sizeKnown() const;
@@ -604,11 +604,11 @@ class Type_Specialized : Type {
     const Type* getP4Type() const override;
     toString{
         return
-            absl::StrCat(baseType->toString().string_view(),
+            absl::StrCat(baseType,
                          "<",
                          absl::StrJoin(*arguments, ", ",
                                        [](std::string *out, const auto *t) {
-                                           absl::StrAppend(out, t->toString().string_view());
+                                           absl::StrAppend(out, t);
                                        }),
                          ">");
     }

--- a/lib/bug_helper.h
+++ b/lib/bug_helper.h
@@ -36,7 +36,7 @@ namespace detail {
 static inline std::pair<std::string_view, std::string> getPositionTail(const Util::SourceInfo &info,
                                                                        std::string_view position,
                                                                        std::string_view tail) {
-    std::string_view posString = info.toPositionString().string_view();
+    std::string_view posString = info.toPositionString();
     std::string outTail(tail);
     if (position.empty()) {
         position = posString;

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -309,6 +309,8 @@ class cstring {
     /// Append this many spaces after each newline (and before the first string).
     cstring indent(size_t amount) const;
 
+    /// Helper to simplify usage of cstring in Abseil functions (e.g. StrCat / StrFormat, etc.)
+    /// without explicit string_view conversion.
     template <typename Sink>
     friend void AbslStringify(Sink &sink, cstring s) {
         sink.Append(s.string_view());

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -183,7 +183,7 @@ class cstring {
 
     char get(unsigned index) const { return (index < size()) ? str[index] : 0; }
     const char *c_str() const { return str; }
-    operator const char *() const { return str; }
+    explicit operator const char *() const { return str; }
 
     std::string string() const { return str ? std::string(str) : std::string(""); }
     explicit operator std::string() const { return string(); }

--- a/lib/cstring.h
+++ b/lib/cstring.h
@@ -118,7 +118,7 @@ class cstring {
 
     // construct cstring from std::string_view. Do not use if possible, this is linear
     // time operation if string not exists in table, because the underlying string must be copied.
-    explicit cstring(std::string_view string) {  // NOLINT(runtime/explicit)
+    explicit cstring(std::string_view string) {
         construct_from_shared(string.data(), string.length());
     }
 
@@ -178,7 +178,7 @@ class cstring {
 
     template <typename Iter>
     cstring(Iter begin, Iter end) {
-        *this = std::string(begin, end);
+        *this = cstring(std::string(begin, end));
     }
 
     char get(unsigned index) const { return (index < size()) ? str[index] : 0; }
@@ -191,7 +191,7 @@ class cstring {
     std::string_view string_view() const {
         return str ? std::string_view(str) : std::string_view("");
     }
-    explicit operator std::string_view() const { return string_view(); }
+    operator std::string_view() const { return string_view(); }
 
     // Size tests. Constant time except for size(), which is linear time.
     size_t size() const {
@@ -202,6 +202,7 @@ class cstring {
     }
     bool isNull() const { return str == nullptr; }
     bool isNullOrEmpty() const { return str == nullptr ? true : str[0] == 0; }
+    explicit operator bool() const { return str; }
 
     // iterate over characters
     const char *begin() const { return str; }
@@ -307,6 +308,11 @@ class cstring {
     cstring capitalize() const;
     /// Append this many spaces after each newline (and before the first string).
     cstring indent(size_t amount) const;
+
+    template <typename Sink>
+    friend void AbslStringify(Sink &sink, cstring s) {
+        sink.Append(s.string_view());
+    }
 };
 
 inline bool operator==(const char *a, cstring b) { return b == a; }
@@ -350,19 +356,19 @@ inline std::string operator+(char a, cstring b) {
 }
 
 inline cstring cstring::operator+=(cstring a) {
-    *this = *this + a;
+    *this = cstring(*this + a);
     return *this;
 }
 inline cstring cstring::operator+=(const char *a) {
-    *this = *this + a;
+    *this = cstring(*this + a);
     return *this;
 }
 inline cstring cstring::operator+=(std::string a) {
-    *this = *this + a;
+    *this = cstring(*this + a);
     return *this;
 }
 inline cstring cstring::operator+=(char a) {
-    *this = *this + a;
+    *this = cstring(*this + a);
     return *this;
 }
 
@@ -382,7 +388,7 @@ cstring cstring::make_unique(const T &inuse, cstring base, int &counter, char se
     cstring rv = base;
     do {
         snprintf(suffix, sizeof(suffix) / sizeof(suffix[0]), "%c%d", sep, counter++);
-        rv = base + suffix;
+        rv = cstring(base + (const char *)suffix);
     } while (inuse.count(rv));
     return rv;
 }
@@ -394,7 +400,7 @@ cstring cstring::make_unique(const T &inuse, cstring base, char sep) {
 }
 
 inline std::ostream &operator<<(std::ostream &out, cstring s) {
-    return out << (s ? s.c_str() : "<null>");
+    return out << (s.isNull() ? "<null>" : s.string_view());
 }
 
 }  // namespace P4

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -114,8 +114,8 @@ class ErrorReporter {
         if (!node || error_reported(errorCode, node->getSourceInfo())) return;
 
         if (cstring name = get_error_name(errorCode))
-            diagnose(getDiagnosticAction(errorCode, name, action), name, format, suffix, node,
-                     std::forward<Args>(args)...);
+            diagnose(getDiagnosticAction(errorCode, name, action), name.c_str(), format, suffix,
+                     node, std::forward<Args>(args)...);
         else
             diagnose(action, nullptr, format, suffix, node, std::forward<Args>(args)...);
     }
@@ -124,7 +124,7 @@ class ErrorReporter {
     void diagnose(DiagnosticAction action, const int errorCode, const char *format,
                   const char *suffix, Args &&...args) {
         if (cstring name = get_error_name(errorCode))
-            diagnose(getDiagnosticAction(errorCode, name, action), name, format, suffix,
+            diagnose(getDiagnosticAction(errorCode, name, action), name.c_str(), format, suffix,
                      std::forward<Args>(args)...);
         else
             diagnose(action, nullptr, format, suffix, std::forward<Args>(args)...);

--- a/lib/json.cpp
+++ b/lib/json.cpp
@@ -187,7 +187,7 @@ JsonObject *JsonObject::emplace(std::string_view label, IJson *value) {
         throw std::logic_error(
             absl::StrCat("Attempt to add to json object a value "
                          "for a label which already exists ",
-                         label, " ", s.string_view()));
+                         label, " ", s));
     }
     base::emplace(label, value);
     return this;

--- a/lib/options.cpp
+++ b/lib/options.cpp
@@ -77,7 +77,7 @@ std::vector<const char *> *Util::Options::process(int argc, char *const argv[]) 
 
             // If there's no such option, try single-character options.
             if (option == nullptr && opt.size() > 2) {
-                arg = opt.substr(2);
+                arg = opt.substr(2).c_str();
                 opt = opt.substr(0, 2);
                 option = get(options, opt);
             }
@@ -91,7 +91,7 @@ std::vector<const char *> *Util::Options::process(int argc, char *const argv[]) 
         }
 
         if (option == nullptr) {
-            remainingOptions.push_back(opt);
+            remainingOptions.push_back(opt.c_str());
         } else {
             if (option->argName != nullptr && arg == nullptr &&
                 !(option->flags & OptionFlags::OptionalArgument)) {
@@ -137,7 +137,7 @@ void Util::Options::usage() {
     for (const auto &o : optionOrder) {
         auto option = get(options, o);
         CHECK_NULL(option);
-        size_t len = strlen(o);
+        size_t len = o.size();
         if (option->flags & OptionFlags::Hide) continue;
         *outStream << option->option;
         if (option->argName != nullptr) {

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -58,14 +58,11 @@ SourceInfo::SourceInfo(const InputSources *sources, SourcePosition start, Source
 }
 
 cstring SourceInfo::toString() const {
-    return absl::StrFormat("(%s)-(%s)", start.toString().string_view(),
-                           end.toString().string_view());
+    return absl::StrFormat("(%v)-(%v)", start.toString(), end.toString());
 }
 
 std::ostream &operator<<(std::ostream &os, const SourceInfo &info) {
-    // FIXME: implement abseil stringify to skip cstring conversion here
-    os << absl::StrFormat("(%s)-(%s)", info.start.toString().string_view(),
-                          info.end.toString().string_view());
+    os << absl::StrFormat("(%v)-(%v)", info.start, info.end);
     return os;
 }
 
@@ -312,7 +309,7 @@ cstring InputSources::toDebugString() const {
     builder << "---------------" << std::endl;
     for (const auto &lf : line_file_map)
         builder << lf.first << ": " << lf.second.toString() << std::endl;
-    return builder.str();
+    return {builder};
 }
 
 ///////////////////////////////////////////////////
@@ -360,9 +357,7 @@ cstring SourceInfo::getLineNum() const {
 
 ////////////////////////////////////////////////////////
 
-cstring SourceFileLine::toString() const {
-    return absl::StrFormat("%s(%d)", fileName.string_view(), sourceLine);
-}
+cstring SourceFileLine::toString() const { return absl::StrFormat("%v(%d)", fileName, sourceLine); }
 
 }  // namespace P4::Util
 

--- a/lib/source_file.cpp
+++ b/lib/source_file.cpp
@@ -183,7 +183,7 @@ SourceFileLine InputSources::getSourceLine(unsigned line) const {
     // So we have to subtract one to get the real line number.
     const auto nominalLine = line - it->first + it->second.sourceLine;
     const auto realLine = nominalLine > 0 ? nominalLine - 1 : 0;
-    return SourceFileLine(it->second.fileName.string_view(), realLine);
+    return SourceFileLine(it->second.fileName, realLine);
 }
 
 unsigned InputSources::getCurrentLineNumber() const { return contents.size(); }

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include <string_view>
 #include <vector>
 
+#include "absl/strings/str_format.h"
 #include "cstring.h"
 #include "stringify.h"
 
@@ -102,6 +103,11 @@ class SourcePosition final {
     unsigned getLineNumber() const { return lineNumber; }
 
     unsigned getColumnNumber() const { return columnNumber; }
+
+    template <typename Sink>
+    friend void AbslStringify(Sink &sink, const SourcePosition &p) {
+        absl::Format(&sink, "%d:%d", p.lineNumber, p.columnNumber);
+    }
 
  private:
     // Input sources where this character position is interpreted.
@@ -259,7 +265,7 @@ class Comment final : IHasDbPrint, IHasSourceInfo {
     cstring toString() const override {
         std::stringstream str;
         dbprint(str);
-        return str.str();
+        return {str};
     }
     void dbprint(std::ostream &out) const override {
         if (singleLine)

--- a/lib/stringify.h
+++ b/lib/stringify.h
@@ -89,7 +89,7 @@ inline constexpr bool has_toString_v = has_toString<T>::value;
 
 template <typename T, typename = decltype(std::to_string(std::declval<T>()))>
 cstring toString(T value) {
-    return std::to_string(value);
+    return cstring(std::to_string(value));
 }
 
 template <typename T>

--- a/midend/expr_uses.h
+++ b/midend/expr_uses.h
@@ -31,7 +31,7 @@ class exprUses : public Inspector {
     const char *search_tail = nullptr;  // pointer into look_for for partial match
     bool result = false;
     bool preorder(const IR::Path *p) override {
-        if (look_for.startsWith(p->name.name.string_view())) {
+        if (look_for.startsWith(p->name.name)) {
             search_tail = look_for.c_str() + p->name.name.size();
             if (*search_tail == 0 || *search_tail == '.' || *search_tail == '[') result = true;
         }
@@ -46,7 +46,7 @@ class exprUses : public Inspector {
     void postorder(const IR::Member *m) override {
         if (result && search_tail && *search_tail) {
             if (*search_tail == '.') search_tail++;
-            if (cstring(search_tail).startsWith(m->member.name.string_view())) {
+            if (cstring(search_tail).startsWith(m->member.name)) {
                 search_tail += m->member.name.size();
                 if (*search_tail == 0 || *search_tail == '.' || *search_tail == '[') return;
             }

--- a/midend/fillEnumMap.cpp
+++ b/midend/fillEnumMap.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 namespace P4 {
 
 const IR::Node *FillEnumMap::preorder(IR::Type_Enum *type) {
-    if (strstr(type->srcInfo.filename, "v1model") == nullptr) {
+    if (type->srcInfo.filename.find("v1model") == nullptr) {
         unsigned long long count = type->members.size();
         unsigned long long width = policy->enumSize(count);
         auto r = new EnumRepresentation(type->srcInfo, width);

--- a/midend/flattenInterfaceStructs.cpp
+++ b/midend/flattenInterfaceStructs.cpp
@@ -74,7 +74,7 @@ const IR::Node *ReplaceStructs::postorder(IR::Member *expression) {
     std::string prefix;
     while (auto mem = e->to<IR::Member>()) {
         e = mem->expr;
-        prefix = absl::StrCat(".", mem->member.string_view(), prefix);
+        prefix = absl::StrCat(".", mem->member, prefix);
     }
     auto pe = e->to<IR::PathExpression>();
     if (pe == nullptr) return expression;

--- a/midend/global_copyprop.cpp
+++ b/midend/global_copyprop.cpp
@@ -28,8 +28,8 @@ static cstring lValueName(const IR::Expression *exp) {
 /// Test to see if names denote overlapping locations.
 bool names_overlap(cstring name1, cstring name2) {
     if (name1 == name2) return true;
-    if (name1.startsWith(name2.string_view()) && strchr(".[", name1.get(name2.size()))) return true;
-    if (name2.startsWith(name1.string_view()) && strchr(".[", name2.get(name1.size()))) return true;
+    if (name1.startsWith(name2) && strchr(".[", name1.get(name2.size()))) return true;
+    if (name2.startsWith(name1) && strchr(".[", name2.get(name1.size()))) return true;
     return false;
 }
 

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -234,8 +234,8 @@ bool DoLocalCopyPropagation::operator==(const ControlFlowVisitor &a_) const {
 /// test to see if names denote overlapping locations
 bool DoLocalCopyPropagation::name_overlap(cstring name1, cstring name2) {
     if (name1 == name2) return true;
-    if (name1.startsWith(name2.string_view()) && strchr(".[", name1.get(name2.size()))) return true;
-    if (name2.startsWith(name1.string_view()) && strchr(".[", name2.get(name1.size()))) return true;
+    if (name1.startsWith(name2) && strchr(".[", name1.get(name2.size()))) return true;
+    if (name2.startsWith(name1) && strchr(".[", name2.get(name1.size()))) return true;
     return false;
 }
 
@@ -259,8 +259,7 @@ void DoLocalCopyPropagation::forOverlapAvail(cstring name,
         if (it != available.end()) fn(it->first, &it->second);
     }
     for (auto it = available.upper_bound(name); it != available.end(); ++it) {
-        if (!it->first.startsWith(name.string_view()) || !strchr(".[", it->first.get(name.size())))
-            break;
+        if (!it->first.startsWith(name) || !strchr(".[", it->first.get(name.size()))) break;
         fn(it->first, &it->second);
     }
 }

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -491,7 +491,7 @@ IR::ForInStatement *DoLocalCopyPropagation::preorder(IR::ForInStatement *s) {
 }
 
 bool isAsync(const IR::Vector<IR::Method> methods, cstring callee, cstring caller) {
-    if (callee[0] == '.') callee = callee.substr(1);
+    if (callee.startsWith(".")) callee = callee.substr(1);
     for (auto *m : methods) {
         if (m->name != callee) continue;
         auto sync = m->getAnnotation(IR::Annotation::synchronousAnnotation);

--- a/midend/nestedStructs.cpp
+++ b/midend/nestedStructs.cpp
@@ -25,7 +25,7 @@ void ComplexValues::explode(std::string_view prefix, const IR::Type_Struct *type
                             IR::Vector<T> *result) {
     CHECK_NULL(type);
     for (const auto *f : type->fields) {
-        std::string fname = absl::StrCat(prefix, "_", f->name.string_view());
+        std::string fname = absl::StrCat(prefix, "_", f->name);
         auto ftype = typeMap->getType(f, true);
         if (isNestedStruct(ftype)) {
             auto submap = new FieldsMap(ftype);

--- a/midend/parserUnroll.h
+++ b/midend/parserUnroll.h
@@ -151,7 +151,7 @@ class ParserStructure {
     std::map<cstring, size_t> callsIndexes;  // map for curent calls of state insite current one
     void setParser(const IR::P4Parser *parser) {
         CHECK_NULL(parser);
-        callGraph = new StateCallGraph(parser->name.name.string_view());
+        callGraph = new StateCallGraph(parser->name.name);
         this->parser = parser;
         start = nullptr;
     }

--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -272,7 +272,7 @@ method
                 yyerror("'%s' invalid on method", IrMethod::modifier(mod)); }
       optArgList ')' optConst optOverride body
           { ($$ = $<irMethod>5)->body = $10;
-            if (!$10 || $10[0] == '=') {
+            if (!$10 || $10.startsWith("=")) {
                 if (!$$->inImpl)
                     yyerror("inline method %s with no body", $3);
                 $$->inImpl = false; }
@@ -361,7 +361,7 @@ nonRefType
     | lookup_scope IDENTIFIER           { $$ = new NamedType(@2, $1, $2); }
     | lookup_scope OPTIONAL             { $$ = new NamedType(@2, $1, "optional"_cs); }
     | nonRefType '<' type_args '>'      { $$ = new TemplateInstantiation(@1+@4, $1, *$3); }
-    | nonRefType '[' INTEGER ']'        { $$ = new ArrayType(@1+@4, $1, atoi($3)); }
+    | nonRefType '[' INTEGER ']'        { $$ = new ArrayType(@1+@4, $1, atoi($3.c_str())); }
     ;
 
 type: nonRefType

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -71,7 +71,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
           }
           buf << ";" << std::endl;
           buf << cl->indent << "}";
-          return buf.str();
+          return {buf};
       }}},
     {"equiv"_cs,
      {&NamedType::Bool(),
@@ -126,7 +126,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
               buf << ";" << std::endl;
           }
           buf << cl->indent << "}";
-          return buf.str();
+          return {buf};
       }}},
     {"operator<<"_cs,
      {&ReferenceType::OstreamRef,
@@ -137,7 +137,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
           buf << "{";
           if (body) buf << LineDirective(srcInfo, true) << body;
           buf << LineDirective(true) << cl->indent << "return out; }";
-          return buf.str();
+          return {buf};
       }}},
     {"visit_children"_cs,
      {&NamedType::Void(),
@@ -162,7 +162,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
               needed = true;
           }
           buf << "}";
-          return needed ? buf.str() : cstring();
+          return needed ? buf : cstring();
       }}},
     {"validate"_cs,
      {&NamedType::Void(),
@@ -189,7 +189,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
               needed = true;
           }
           buf << " }";
-          return needed ? buf.str() : cstring();
+          return needed ? buf : cstring();
       }}},
     {"node_type_name"_cs,
      {&NamedType::Cstring(),
@@ -198,7 +198,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
       [](IrClass *cl, Util::SourceInfo, cstring) -> cstring {
           std::stringstream buf;
           buf << "{ return \"" << cl->containedIn << cl->name << "\"_cs; }";
-          return buf.str();
+          return {buf};
       }}},
     {"dbprint"_cs,
      {&NamedType::Void(),
@@ -227,7 +227,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
               }
           }
           buf << "}";
-          return needed ? buf.str() : cstring();
+          return needed ? buf : cstring();
       }}},
     {"toJSON"_cs,
      {&NamedType::Void(),
@@ -247,7 +247,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
                   << "\\\" : \" << " << "this->" << f->name << ";" << std::endl;
           }
           buf << "}";
-          return buf.str();
+          return {buf};
       }}},
     {nullptr,
      {nullptr,
@@ -264,7 +264,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
                   << std::endl;
           }
           buf << "}";
-          return buf.str();
+          return {buf};
       }}},
     {"fromJSON"_cs,
      {nullptr,
@@ -275,7 +275,7 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
       [](IrClass *cl, Util::SourceInfo, cstring) -> cstring {
           std::stringstream buf;
           buf << "{ return new " << cl->name << "(json); }";
-          return buf.str();
+          return {buf};
       }}},
     {"toString"_cs,
      {&NamedType::Cstring(),

--- a/tools/ir-generator/type.h
+++ b/tools/ir-generator/type.h
@@ -68,7 +68,7 @@ struct LookupScope : public Util::IHasSourceInfo {
     Util::SourceInfo getSourceInfo() const override { return srcInfo; }
     cstring toString() const override {
         if (global) return "IR::"_cs;
-        return absl::StrCat(in ? in->toString() : "", name, "::");
+        return absl::StrCat(in ? in->toString() : ""_cs, name, "::");
     }
     IrNamespace *resolve(const IrNamespace *) const;
     bool operator==(const LookupScope &l) const {

--- a/tools/ir-generator/type.h
+++ b/tools/ir-generator/type.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <vector>
 
+#include "absl/strings/str_cat.h"
 #include "lib/cstring.h"
 #include "lib/source_file.h"
 
@@ -67,7 +68,7 @@ struct LookupScope : public Util::IHasSourceInfo {
     Util::SourceInfo getSourceInfo() const override { return srcInfo; }
     cstring toString() const override {
         if (global) return "IR::"_cs;
-        return (in ? in->toString() + name : name) + "::"_cs;
+        return absl::StrCat(in ? in->toString() : "", name, "::");
     }
     IrNamespace *resolve(const IrNamespace *) const;
     bool operator==(const LookupScope &l) const {


### PR DESCRIPTION
Add abseil string manipulator helpers for
  - cstring
  - IR::Node
  - IR::ID

This improves the code itself as we no longer need to do explicit .toString() / .string_view() calls. Also, this prints directly to sink, providing some performance improvements.