### PR TITLE
Prevent compiling backend tests if dependencies are not installed

### DIFF
--- a/backends/ebpf/CMakeLists.txt
+++ b/backends/ebpf/CMakeLists.txt
@@ -220,6 +220,33 @@ else()
     "'llvm-config' return value: ${LLVM_RET}" )
   set (SUPPORTS_KERNEL False)
 endif()
+# List of executables (e.g., programs)
+set(PROGRAMS scapy tcpdump pcap)
+
+set(LIBRARIES libpcap-dev gcc-multilib)
+
+# Check for each program (executable)
+foreach(PROG ${PROGRAMS})
+  find_program(${PROG}_FOUND ${PROG})
+  if (${PROG}_FOUND)
+    message(STATUS "Found program ${PROG} at ${${PROG}_FOUND}")
+  else()
+    message(WARNING "Missing program ${PROG}, disabling relevant tests."
+    " Please install ${PROG} and ensure it is in your PATH.")
+    set(TEST_DEPENDENCY_PRESENT False)
+  endif()
+endforeach()
+
+foreach(LIB ${LIBRARIES})
+  find_library(${LIB}_FOUND ${LIB} "${CMAKE_CURRENT_SOURCE_DIR}/runtime/usr/lib64/")
+  if (${LIB}_FOUND)
+    message(STATUS "Found library ${LIB} at ${${LIB}_FOUND}")
+  else()
+    message(WARNING "Missing library ${LIB}, disabling relevant tests."
+    " Please install ${LIB}.")
+    set(TEST_DEPENDENCY_PRESENT False)
+  endif()
+endforeach()
 
 # check for the libbpf library
 find_library(LIBBPF NAMES bpf HINTS "${CMAKE_CURRENT_SOURCE_DIR}/runtime/usr/lib64/")
@@ -232,25 +259,29 @@ else()
   set (SUPPORTS_KERNEL False)
 endif()
 
-# Only add the kernel tests if the two requirements are met
-if (SUPPORTS_KERNEL)
-  p4c_add_tests("ebpf-kernel" ${EBPF_DRIVER_KERNEL} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_KERNEL}")
-  p4c_add_tests("ebpf-kernel" ${EBPF_DRIVER_KERNEL} ${EBPF_KERNEL_TEST_SUITES} "${XFAIL_TESTS_KERNEL}")
-  # These are special tests with args that are not included
-  # in the default ebpf tests
-  p4c_add_test_with_args("ebpf-kernel" ${EBPF_DRIVER_KERNEL} FALSE "testdata/p4_16_samples/ebpf_conntrack_extern.p4" "testdata/p4_16_samples/ebpf_conntrack_extern.p4" "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-conntrack-ebpf.c" "")
-  p4c_add_test_with_args("ebpf-kernel" ${EBPF_DRIVER_KERNEL} FALSE "testdata/p4_16_samples/ebpf_checksum_extern.p4" "testdata/p4_16_samples/ebpf_checksum_extern.p4" "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-checksum-ebpf.c" "")
-endif()
-# ToDo Add check which verifies that BCC is installed
-# Ideally, this is done via check for the python package
-p4c_add_tests("ebpf-bcc" ${EBPF_DRIVER_BCC} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_BCC}")
-p4c_add_tests("ebpf" ${EBPF_DRIVER_TEST} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_TEST}")
-p4c_add_tests("ebpf-errors" ${EBPF_DRIVER_TEST} ${EBPF_ERRORS_SUITES} "${XFAIL_TESTS_TEST}")
+if(TEST_DEPENDENCY_PRESENT)
+  # Only add the kernel tests if the two requirements are met
+  if (SUPPORTS_KERNEL)
+    p4c_add_tests("ebpf-kernel" ${EBPF_DRIVER_KERNEL} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_KERNEL}")
+    p4c_add_tests("ebpf-kernel" ${EBPF_DRIVER_KERNEL} ${EBPF_KERNEL_TEST_SUITES} "${XFAIL_TESTS_KERNEL}")
+    # These are special tests with args that are not included
+    # in the default ebpf tests
+    p4c_add_test_with_args("ebpf-kernel" ${EBPF_DRIVER_KERNEL} FALSE "testdata/p4_16_samples/ebpf_conntrack_extern.p4" "testdata/p4_16_samples/ebpf_conntrack_extern.p4" "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-conntrack-ebpf.c" "")
+    p4c_add_test_with_args("ebpf-kernel" ${EBPF_DRIVER_KERNEL} FALSE "testdata/p4_16_samples/ebpf_checksum_extern.p4" "testdata/p4_16_samples/ebpf_checksum_extern.p4" "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-checksum-ebpf.c" "")
+  endif()
+  # ToDo Add check which verifies that BCC is installed
+  # Ideally, this is done via check for the python package
+  p4c_add_tests("ebpf-bcc" ${EBPF_DRIVER_BCC} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_BCC}")
+  p4c_add_tests("ebpf" ${EBPF_DRIVER_TEST} ${EBPF_TEST_SUITES} "${XFAIL_TESTS_TEST}")
+  p4c_add_tests("ebpf-errors" ${EBPF_DRIVER_TEST} ${EBPF_ERRORS_SUITES} "${XFAIL_TESTS_TEST}")
 
-# These are special tests with args that are not included in the default ebpf tests
-p4c_add_test_with_args("ebpf" ${EBPF_DRIVER_TEST} FALSE "testdata/p4_16_samples/ebpf_checksum_extern.p4" "testdata/p4_16_samples/ebpf_checksum_extern.p4" "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-checksum-ebpf.c" "")
-# FIXME:This does not work yet
-# We do not have support for dynamic addition of tables in the test framework
-p4c_add_test_with_args("ebpf" ${EBPF_DRIVER_TEST} TRUE "testdata/p4_16_samples/ebpf_conntrack_extern.p4" "testdata/p4_16_samples/ebpf_conntrack_extern.p4" "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-conntrack-ebpf.c" "")
+  # These are special tests with args that are not included in the default ebpf tests
+  p4c_add_test_with_args("ebpf" ${EBPF_DRIVER_TEST} FALSE "testdata/p4_16_samples/ebpf_checksum_extern.p4" "testdata/p4_16_samples/ebpf_checksum_extern.p4" "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-checksum-ebpf.c" "")
+  # FIXME:This does not work yet
+  # We do not have support for dynamic addition of tables in the test framework
+  p4c_add_test_with_args("ebpf" ${EBPF_DRIVER_TEST} TRUE "testdata/p4_16_samples/ebpf_conntrack_extern.p4" "testdata/p4_16_samples/ebpf_conntrack_extern.p4" "--extern-file ${P4C_SOURCE_DIR}/testdata/extern_modules/extern-conntrack-ebpf.c" "")
+else()
+  message(WARNING "Skipped adding Tests due to missing dependencies. Please install the dependencies and try again")
+endif()
 
 message(STATUS "Done with configuring BPF back end")


### PR DESCRIPTION
- The added code checks for required dependencies before adding tests.
- This makes sures the Test don't fail due to missing dependencies.

solves #4535 