### PR TITLE
search for includes in share/p4c

### DIFF
--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -382,9 +382,12 @@ std::vector<const char *> *ParserOptions::process(int argc, char *const argv[]) 
     this->exe_name = cstring(executablePath.stem().c_str());
 
     searchForIncludePath(p4_14includePath,
-                         {"p4_14include"_cs, "../p4_14include"_cs, "../../p4_14include"_cs},
+                         {"p4_14include"_cs, "../p4_14include"_cs, "../../p4_14include"_cs,
+                          "../share/p4c/p4include"_cs},
                          executablePath);
-    searchForIncludePath(p4includePath, {"p4include"_cs, "../p4include"_cs, "../../p4include"_cs},
+    searchForIncludePath(p4includePath,
+                         {"p4include"_cs, "../p4include"_cs, "../../p4include"_cs,
+                          "../share/p4c/p4_14include"_cs},
                          executablePath);
 
     auto *remainingOptions = Util::Options::process(argc, argv);


### PR DESCRIPTION
Generally the compiler is run via the p4c driver which sets up the include path properly, but sometimes one wants to run the executable directly.  If it is installed in a `bin` directory somewhere, the standard include files will likely be in `share/p4c/p4include`, so this change looks there as well as where it was looking.