### PR TITLE
Add @likely/@unlikely annotations for blocks

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -1122,7 +1122,8 @@ class FilterLikelyAnnot : public Transform {
         prune();
         if (annot->name == IR::Annotation::likelyAnnotation) return nullptr;
         if (annot->name == IR::Annotation::unlikelyAnnotation) {
-            warning(ErrorType::WARN_IGNORE, "ignoring %1% on always taken statement", annot);
+            // FIXME -- disable this warning due to worries it will trigger too often
+            warning(ErrorType::WARN_BRANCH_HINT, "ignoring %1% on always taken statement", annot);
             return nullptr;
         }
         return annot;
@@ -1134,13 +1135,15 @@ const IR::Node *DoConstantFolding::postorder(IR::IfStatement *ifstmt) {
         if (cond->value) {
             if (auto blk = ifstmt->ifFalse ? ifstmt->ifFalse->to<IR::BlockStatement>() : nullptr) {
                 if (auto annot = blk->getAnnotation(IR::Annotation::likelyAnnotation))
-                    warning(ErrorType::WARN_IGNORE, "ignoring %1% on never taken statement", annot);
+                    warning(ErrorType::WARN_BRANCH_HINT, "ignoring %1% on never taken statement",
+                            annot);
             }
             return ifstmt->ifTrue->apply(FilterLikelyAnnot());
         } else {
             if (auto blk = ifstmt->ifTrue->to<IR::BlockStatement>()) {
                 if (auto annot = blk->getAnnotation(IR::Annotation::likelyAnnotation))
-                    warning(ErrorType::WARN_IGNORE, "ignoring %1% on never taken statement", annot);
+                    warning(ErrorType::WARN_BRANCH_HINT, "ignoring %1% on never taken statement",
+                            annot);
             }
             if (ifstmt->ifFalse == nullptr) {
                 return new IR::EmptyStatement(ifstmt->srcInfo);

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -1132,8 +1132,16 @@ class FilterLikelyAnnot : public Transform {
 const IR::Node *DoConstantFolding::postorder(IR::IfStatement *ifstmt) {
     if (auto cond = ifstmt->condition->to<IR::BoolLiteral>()) {
         if (cond->value) {
+            if (auto blk = ifstmt->ifFalse ? ifstmt->ifFalse->to<IR::BlockStatement>() : nullptr) {
+                if (auto annot = blk->getAnnotation(IR::Annotation::likelyAnnotation))
+                    warning(ErrorType::WARN_IGNORE, "ignoring %1% on never taken statement", annot);
+            }
             return ifstmt->ifTrue->apply(FilterLikelyAnnot());
         } else {
+            if (auto blk = ifstmt->ifTrue->to<IR::BlockStatement>()) {
+                if (auto annot = blk->getAnnotation(IR::Annotation::likelyAnnotation))
+                    warning(ErrorType::WARN_IGNORE, "ignoring %1% on never taken statement", annot);
+            }
             if (ifstmt->ifFalse == nullptr) {
                 return new IR::EmptyStatement(ifstmt->srcInfo);
             } else {

--- a/frontends/p4/dontcareArgs.h
+++ b/frontends/p4/dontcareArgs.h
@@ -40,7 +40,8 @@ class DontcareArgs : public Transform, public ResolutionContext {
         IR::IndexedVector<IR::StatOrDecl> body;
         for (auto d : toAdd) body.push_back(d);
         body.append(function->body->components);
-        function->body = new IR::BlockStatement(function->body->srcInfo, body);
+        function->body =
+            new IR::BlockStatement(function->body->srcInfo, function->body->annotations, body);
         toAdd.clear();
         return function;
     }
@@ -48,7 +49,8 @@ class DontcareArgs : public Transform, public ResolutionContext {
         IR::IndexedVector<IR::StatOrDecl> body;
         for (auto d : toAdd) body.push_back(d);
         body.append(action->body->components);
-        action->body = new IR::BlockStatement(action->body->srcInfo, body);
+        action->body =
+            new IR::BlockStatement(action->body->srcInfo, action->body->annotations, body);
         toAdd.clear();
         return action;
     }

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -21,13 +21,15 @@ namespace P4 {
 ParseAnnotations::HandlerMap ParseAnnotations::standardHandlers() {
     return {
         // These annotations have empty bodies.
-        PARSE_EMPTY(IR::Annotation::tableOnlyAnnotation),
+        PARSE_EMPTY(IR::Annotation::atomicAnnotation),
         PARSE_EMPTY(IR::Annotation::defaultOnlyAnnotation),
         PARSE_EMPTY(IR::Annotation::hiddenAnnotation),
-        PARSE_EMPTY(IR::Annotation::atomicAnnotation),
+        PARSE_EMPTY(IR::Annotation::likelyAnnotation),
+        PARSE_EMPTY(IR::Annotation::noSideEffectsAnnotation),
         PARSE_EMPTY(IR::Annotation::optionalAnnotation),
         PARSE_EMPTY(IR::Annotation::pureAnnotation),
-        PARSE_EMPTY(IR::Annotation::noSideEffectsAnnotation),
+        PARSE_EMPTY(IR::Annotation::tableOnlyAnnotation),
+        PARSE_EMPTY(IR::Annotation::unlikelyAnnotation),
         PARSE_EMPTY("disable_optimization"_cs),
         PARSE_EMPTY("unroll"_cs),
         PARSE_EMPTY("nounroll"_cs),

--- a/frontends/p4/removeParameters.cpp
+++ b/frontends/p4/removeParameters.cpp
@@ -155,7 +155,8 @@ const IR::Node *DoRemoveActionParameters::postorder(IR::P4Action *action) {
     body.append(postamble);
 
     action->parameters = new IR::ParameterList(action->parameters->srcInfo, std::move(leftParams));
-    action->body = new IR::BlockStatement(action->body->srcInfo, std::move(body));
+    action->body =
+        new IR::BlockStatement(action->body->srcInfo, action->body->annotations, std::move(body));
     LOG1("To replace " << dbp(action));
     result->push_back(action);
     return result;

--- a/frontends/p4/removeReturns.cpp
+++ b/frontends/p4/removeReturns.cpp
@@ -215,7 +215,7 @@ const IR::Node *DoRemoveReturns::preorder(IR::ExitStatement *statement) {
 }
 
 const IR::Node *DoRemoveReturns::preorder(IR::BlockStatement *statement) {
-    auto block = new IR::BlockStatement;
+    auto block = new IR::BlockStatement(statement->srcInfo, statement->annotations);
     auto currentBlock = block;
     TernaryBool ret = TernaryBool::No;
     for (auto s : statement->components) {

--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -580,7 +580,7 @@ const IR::Node *DoSimplifyExpressions::preorder(IR::MethodCallExpression *mce) {
 
 const IR::Node *DoSimplifyExpressions::postorder(IR::Function *function) {
     if (toInsert.empty()) return function;
-    auto body = new IR::BlockStatement(function->body->srcInfo);
+    auto body = new IR::BlockStatement(function->body->srcInfo, function->body->annotations);
     for (auto a : toInsert) body->push_back(a);
     for (auto s : function->body->components) body->push_back(s);
     function->body = body;
@@ -604,7 +604,7 @@ const IR::Node *DoSimplifyExpressions::postorder(IR::P4Control *control) {
 
 const IR::Node *DoSimplifyExpressions::postorder(IR::P4Action *action) {
     if (toInsert.empty()) return action;
-    auto body = new IR::BlockStatement(action->body->srcInfo);
+    auto body = new IR::BlockStatement(action->body->srcInfo, action->body->annotations);
     for (auto a : toInsert) body->push_back(a);
     for (auto s : action->body->components) body->push_back(s);
     action->body = body;

--- a/frontends/p4/simplify.cpp
+++ b/frontends/p4/simplify.cpp
@@ -27,11 +27,8 @@ const IR::Node *DoSimplifyControlFlow::postorder(IR::BlockStatement *statement) 
         !(foldInlinedFrom && statement->hasOnlyAnnotation(IR::Annotation::inlinedFromAnnotation))) {
         if (auto *pblk = getParent<IR::BlockStatement>()) {
             for (auto *annot : statement->annotations) {
-                if (auto *p = pblk->getAnnotation(annot->name)) {
-                    if (!p->equiv(*annot)) return statement;
-                } else {
+                if (auto *p = pblk->getAnnotation(annot->name); !p || !p->equiv(*annot))
                     return statement;
-                }
             }
         } else {
             return statement;

--- a/ir/annotations.cpp
+++ b/ir/annotations.cpp
@@ -39,6 +39,8 @@ const cstring IR::Annotation::fieldListAnnotation = "field_list"_cs;
 const cstring IR::Annotation::debugLoggingAnnotation = "__debug"_cs;
 const cstring IR::Annotation::disableOptimizationAnnotation = "disable_optimization"_cs;
 const cstring IR::Annotation::inlinedFromAnnotation = "inlinedFrom"_cs;
+const cstring IR::Annotation::likelyAnnotation = "likely"_cs;
+const cstring IR::Annotation::unlikelyAnnotation = "unlikely"_cs;
 
 namespace Annotations {
 void addIfNew(Vector<Annotation> &annotations, cstring name, const Expression *expr,

--- a/ir/base.def
+++ b/ir/base.def
@@ -291,7 +291,8 @@ class Annotation {
     static const cstring debugLoggingAnnotation;  /// Used by compiler implementer to limit debug log to the annotated IR context.
     static const cstring disableOptimizationAnnotation; /// annotation to disable certain optimization
     static const cstring inlinedFromAnnotation; /// annotation to mark block of inlined function
-
+    static const cstring likelyAnnotation;  /// annotation for likely taken blocks/branchs
+    static const cstring unlikelyAnnotation;  /// annotation for likely not taken blocks/branchs
     toString{ return absl::StrCat("@", name); }
     validate{
         BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name");

--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <map>
 
+#include "error_reporter.h"
 #include "lib/cstring.h"
 
 namespace P4 {
@@ -71,6 +72,7 @@ const int ErrorType::WARN_ENTRIES_OUT_OF_ORDER = 1022;
 const int ErrorType::WARN_MULTI_HDR_EXTRACT = 1023;
 const int ErrorType::WARN_EXPRESSION = 1024;
 const int ErrorType::WARN_DUPLICATE = 1025;
+const int ErrorType::WARN_BRANCH_HINT = 1026;
 
 // ------ Info messages -----------
 const int ErrorType::INFO_INFERRED = WARN_MAX + 1;
@@ -124,9 +126,16 @@ std::map<int, cstring> ErrorCatalog::errorCatalog = {
     {ErrorType::WARN_MULTI_HDR_EXTRACT, "multi_header_extract"_cs},
     {ErrorType::WARN_EXPRESSION, "expr"_cs},
     {ErrorType::WARN_DUPLICATE, "duplicate"_cs},
+    {ErrorType::WARN_BRANCH_HINT, "branch"_cs},
 
     // Info messages
     {ErrorType::INFO_INFERRED, "inferred"_cs},
     {ErrorType::INFO_PROGRESS, "progress"_cs}};
+
+void ErrorCatalog::initReporter(ErrorReporter &reporter) {
+    // by default, ignore warnings about branch hints -- user can turn them
+    // on with --Wwarn=branch
+    reporter.setDiagnosticAction("branch"_cs, DiagnosticAction::Ignore);
+}
 
 }  // namespace P4

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -28,6 +28,8 @@ namespace P4 {
 
 using MessageType = ErrorMessage::MessageType;
 
+class ErrorReporter;
+
 /// enumerate supported errors
 /// It is a class and not an enum class because in C++11 you can't extend an enum class
 class ErrorType {
@@ -85,6 +87,7 @@ class ErrorType {
     static const int WARN_MULTI_HDR_EXTRACT;        // same header may be extracted more than once
     static const int WARN_EXPRESSION;               // expression related warnings
     static const int WARN_DUPLICATE;                // duplicate objects
+    static const int WARN_BRANCH_HINT;              // branch frequency/likely hints
     // Backends should extend this class with additional warnings in the range 1500-2141.
     static const int WARN_MIN_BACKEND = 1500;  // first allowed backend warning code
     static const int WARN_MAX = 2141;          // last allowed warning code
@@ -154,6 +157,8 @@ class ErrorCatalog {
 
         return error;
     }
+
+    void initReporter(ErrorReporter &reporter);
 
  private:
     ErrorCatalog() {}

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -91,6 +91,7 @@ class ErrorReporter {
           defaultInfoDiagnosticAction(DiagnosticAction::Info),
           defaultWarningDiagnosticAction(DiagnosticAction::Warn) {
         outputstream = &std::cerr;
+        ErrorCatalog::getCatalog().initReporter(*this);
     }
     virtual ~ErrorReporter() = default;
 

--- a/midend/flattenUnions.cpp
+++ b/midend/flattenUnions.cpp
@@ -169,7 +169,7 @@ const IR::Node *HandleValidityHeaderUnion::postorder(IR::MethodCallStatement *mc
 
 const IR::Node *HandleValidityHeaderUnion::postorder(IR::P4Action *action) {
     if (toInsert.empty()) return action;
-    auto body = new IR::BlockStatement(action->body->srcInfo);
+    auto body = new IR::BlockStatement(action->body->srcInfo, action->body->annotations);
     for (auto a : toInsert) body->push_back(a);
     for (auto s : action->body->components) body->push_back(s);
     action->body = body;
@@ -380,7 +380,7 @@ const IR::Node *DoFlattenHeaderUnion::postorder(IR::P4Action *action) {
             }
         }
     }
-    auto body = new IR::BlockStatement(action->body->srcInfo);
+    auto body = new IR::BlockStatement(action->body->srcInfo, action->body->annotations);
     for (auto a : actiondecls) body->push_back(a);
     action->body = body;
     return action;

--- a/midend/removeExits.cpp
+++ b/midend/removeExits.cpp
@@ -128,7 +128,7 @@ const IR::Node *DoRemoveExits::preorder(IR::P4Control *control) {
 }
 
 const IR::Node *DoRemoveExits::preorder(IR::BlockStatement *statement) {
-    auto block = new IR::BlockStatement;
+    auto block = new IR::BlockStatement(statement->srcInfo, statement->annotations);
     auto currentBlock = block;
     TernaryBool ret = TernaryBool::No;
     for (auto s : statement->components) {

--- a/testdata/p4_16_samples/annotation-likely.p4
+++ b/testdata/p4_16_samples/annotation-likely.p4
@@ -1,5 +1,7 @@
 #include <core.p4>
 
+@command_line("--Wwarn=branch")
+
 struct Headers {
     bit<8> a;
     bit<8> b;

--- a/testdata/p4_16_samples/annotation-likely.p4
+++ b/testdata/p4_16_samples/annotation-likely.p4
@@ -1,0 +1,22 @@
+#include <core.p4>
+
+struct Headers {
+    bit<8> a;
+    bit<8> b;
+}
+
+control ingress(inout Headers h) {
+    apply {
+        if (true) @likely {
+            h.a = 0;
+        }
+        if (true) @unlikely {
+            h.b = 0;
+        }
+    }
+}
+
+control c<T>(inout T d);
+package top<T>(c<T> _c);
+
+top(ingress()) main;

--- a/testdata/p4_16_samples/annotation-likely.p4
+++ b/testdata/p4_16_samples/annotation-likely.p4
@@ -13,6 +13,9 @@ control ingress(inout Headers h) {
         if (true) @unlikely {
             h.b = 0;
         }
+        if (h.a != h.a) @likely {
+            h.b = 1;
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/annotation-likely-first.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely-first.p4
@@ -1,0 +1,17 @@
+#include <core.p4>
+
+struct Headers {
+    bit<8> a;
+    bit<8> b;
+}
+
+control ingress(inout Headers h) {
+    apply {
+        h.a = 8w0;
+        h.b = 8w0;
+    }
+}
+
+control c<T>(inout T d);
+package top<T>(c<T> _c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_samples_outputs/annotation-likely-first.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely-first.p4
@@ -1,6 +1,6 @@
 #include <core.p4>
 
-struct Headers {
+@command_line("--Wwarn=branch") struct Headers {
     bit<8> a;
     bit<8> b;
 }

--- a/testdata/p4_16_samples_outputs/annotation-likely-first.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely-first.p4
@@ -9,6 +9,9 @@ control ingress(inout Headers h) {
     apply {
         h.a = 8w0;
         h.b = 8w0;
+        if (h.a != h.a) @likely {
+            h.b = 8w1;
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/annotation-likely-frontend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely-frontend.p4
@@ -1,0 +1,17 @@
+#include <core.p4>
+
+struct Headers {
+    bit<8> a;
+    bit<8> b;
+}
+
+control ingress(inout Headers h) {
+    apply {
+        h.a = 8w0;
+        h.b = 8w0;
+    }
+}
+
+control c<T>(inout T d);
+package top<T>(c<T> _c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_samples_outputs/annotation-likely-frontend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely-frontend.p4
@@ -1,6 +1,6 @@
 #include <core.p4>
 
-struct Headers {
+@command_line("--Wwarn=branch") struct Headers {
     bit<8> a;
     bit<8> b;
 }

--- a/testdata/p4_16_samples_outputs/annotation-likely-frontend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely-frontend.p4
@@ -9,6 +9,9 @@ control ingress(inout Headers h) {
     apply {
         h.a = 8w0;
         h.b = 8w0;
+        if (h.a != h.a) @likely {
+            h.b = 8w1;
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/annotation-likely-midend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely-midend.p4
@@ -1,23 +1,23 @@
 #include <core.p4>
 
-struct Headers {
+@command_line("--Wwarn=branch") struct Headers {
     bit<8> a;
     bit<8> b;
 }
 
 control ingress(inout Headers h) {
-    @hidden action annotationlikely11() {
+    @hidden action annotationlikely13() {
         h.a = 8w0;
         h.b = 8w0;
     }
-    @hidden table tbl_annotationlikely11 {
+    @hidden table tbl_annotationlikely13 {
         actions = {
-            annotationlikely11();
+            annotationlikely13();
         }
-        const default_action = annotationlikely11();
+        const default_action = annotationlikely13();
     }
     apply {
-        tbl_annotationlikely11.apply();
+        tbl_annotationlikely13.apply();
     }
 }
 

--- a/testdata/p4_16_samples_outputs/annotation-likely-midend.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely-midend.p4
@@ -1,0 +1,26 @@
+#include <core.p4>
+
+struct Headers {
+    bit<8> a;
+    bit<8> b;
+}
+
+control ingress(inout Headers h) {
+    @hidden action annotationlikely11() {
+        h.a = 8w0;
+        h.b = 8w0;
+    }
+    @hidden table tbl_annotationlikely11 {
+        actions = {
+            annotationlikely11();
+        }
+        const default_action = annotationlikely11();
+    }
+    apply {
+        tbl_annotationlikely11.apply();
+    }
+}
+
+control c<T>(inout T d);
+package top<T>(c<T> _c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_samples_outputs/annotation-likely.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely.p4
@@ -1,6 +1,6 @@
 #include <core.p4>
 
-struct Headers {
+@command_line("--Wwarn=branch") struct Headers {
     bit<8> a;
     bit<8> b;
 }

--- a/testdata/p4_16_samples_outputs/annotation-likely.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely.p4
@@ -1,0 +1,21 @@
+#include <core.p4>
+
+struct Headers {
+    bit<8> a;
+    bit<8> b;
+}
+
+control ingress(inout Headers h) {
+    apply {
+        if (true) @likely {
+            h.a = 0;
+        }
+        if (true) @unlikely {
+            h.b = 0;
+        }
+    }
+}
+
+control c<T>(inout T d);
+package top<T>(c<T> _c);
+top(ingress()) main;

--- a/testdata/p4_16_samples_outputs/annotation-likely.p4
+++ b/testdata/p4_16_samples_outputs/annotation-likely.p4
@@ -13,6 +13,9 @@ control ingress(inout Headers h) {
         if (true) @unlikely {
             h.b = 0;
         }
+        if (h.a != h.a) @likely {
+            h.b = 1;
+        }
     }
 }
 

--- a/testdata/p4_16_samples_outputs/annotation-likely.p4-stderr
+++ b/testdata/p4_16_samples_outputs/annotation-likely.p4-stderr
@@ -1,3 +1,6 @@
 annotation-likely.p4(13): [--Wwarn=ignore] warning: ignoring @unlikely on always taken statement
         if (true) @unlikely {
                   ^
+annotation-likely.p4(16): [--Wwarn=ignore] warning: ignoring @likely on never taken statement
+        if (h.a != h.a) @likely {
+                        ^

--- a/testdata/p4_16_samples_outputs/annotation-likely.p4-stderr
+++ b/testdata/p4_16_samples_outputs/annotation-likely.p4-stderr
@@ -1,0 +1,3 @@
+annotation-likely.p4(13): [--Wwarn=ignore] warning: ignoring @unlikely on always taken statement
+        if (true) @unlikely {
+                  ^

--- a/testdata/p4_16_samples_outputs/annotation-likely.p4-stderr
+++ b/testdata/p4_16_samples_outputs/annotation-likely.p4-stderr
@@ -1,6 +1,6 @@
-annotation-likely.p4(13): [--Wwarn=ignore] warning: ignoring @unlikely on always taken statement
+annotation-likely.p4(15): [--Wwarn=branch] warning: ignoring @unlikely on always taken statement
         if (true) @unlikely {
                   ^
-annotation-likely.p4(16): [--Wwarn=ignore] warning: ignoring @likely on never taken statement
+annotation-likely.p4(18): [--Wwarn=branch] warning: ignoring @likely on never taken statement
         if (h.a != h.a) @likely {
                         ^

--- a/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
+++ b/testdata/p4_16_samples_outputs/fabric_20190420/fabric-midend.p4
@@ -411,7 +411,9 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     }
     @name("FabricIngress.forwarding.bridging_counter") direct_counter(CounterType.packets_and_bytes) forwarding_bridging_counter;
     @name("FabricIngress.forwarding.set_next_id_bridging") action forwarding_set_next_id_bridging_0(@name("next_id") bit<32> next_id_0) {
-        fabric_metadata._next_id10 = next_id_0;
+        @hidden @inlinedFrom("forwarding_set_next_id") {
+            fabric_metadata._next_id10 = next_id_0;
+        }
         forwarding_bridging_counter.count();
     }
     @name("FabricIngress.forwarding.bridging") table forwarding_bridging {
@@ -430,7 +432,9 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     @name("FabricIngress.forwarding.mpls_counter") direct_counter(CounterType.packets_and_bytes) forwarding_mpls_counter;
     @name("FabricIngress.forwarding.pop_mpls_and_next") action forwarding_pop_mpls_and_next_0(@name("next_id") bit<32> next_id_6) {
         fabric_metadata._mpls_label5 = 20w0;
-        fabric_metadata._next_id10 = next_id_6;
+        @hidden @inlinedFrom("forwarding_set_next_id") {
+            fabric_metadata._next_id10 = next_id_6;
+        }
         forwarding_mpls_counter.count();
     }
     @name("FabricIngress.forwarding.mpls") table forwarding_mpls {
@@ -447,7 +451,9 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     }
     @name("FabricIngress.forwarding.routing_v4_counter") direct_counter(CounterType.packets_and_bytes) forwarding_routing_v4_counter;
     @name("FabricIngress.forwarding.set_next_id_routing_v4") action forwarding_set_next_id_routing_v4_0(@name("next_id") bit<32> next_id_7) {
-        fabric_metadata._next_id10 = next_id_7;
+        @hidden @inlinedFrom("forwarding_set_next_id") {
+            fabric_metadata._next_id10 = next_id_7;
+        }
         forwarding_routing_v4_counter.count();
     }
     @name("FabricIngress.forwarding.nop_routing_v4") action forwarding_nop_routing_v4_0() {
@@ -533,7 +539,9 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     }
     @name("FabricIngress.next.xconnect_counter") direct_counter(CounterType.packets_and_bytes) next_xconnect_counter;
     @name("FabricIngress.next.output_xconnect") action next_output_xconnect_0(@name("port_num") bit<9> port_num) {
-        standard_metadata.egress_spec = port_num;
+        @hidden @inlinedFrom("next_output") {
+            standard_metadata.egress_spec = port_num;
+        }
         next_xconnect_counter.count();
     }
     @name("FabricIngress.next.set_next_id_xconnect") action next_set_next_id_xconnect_0(@name("next_id") bit<32> next_id_9) {
@@ -557,20 +565,42 @@ control FabricIngress(inout parsed_headers_t hdr, inout fabric_metadata_t fabric
     @max_group_size(16) @name("FabricIngress.next.hashed_selector") action_selector(HashAlgorithm.crc16, 32w1024, 32w16) next_hashed_selector;
     @name("FabricIngress.next.hashed_counter") direct_counter(CounterType.packets_and_bytes) next_hashed_counter;
     @name("FabricIngress.next.output_hashed") action next_output_hashed_0(@name("port_num") bit<9> port_num_0) {
-        standard_metadata.egress_spec = port_num_0;
+        @hidden @inlinedFrom("next_output") {
+            standard_metadata.egress_spec = port_num_0;
+        }
         next_hashed_counter.count();
     }
     @name("FabricIngress.next.routing_hashed") action next_routing_hashed_0(@name("port_num") bit<9> port_num_1, @name("smac") bit<48> smac, @name("dmac") bit<48> dmac) {
-        hdr.ethernet.src_addr = smac;
-        hdr.ethernet.dst_addr = dmac;
-        standard_metadata.egress_spec = port_num_1;
+        @hidden @inlinedFrom("next_routing") {
+            @hidden @inlinedFrom("next_rewrite_smac") {
+                hdr.ethernet.src_addr = smac;
+            }
+            @hidden @inlinedFrom("next_rewrite_dmac") {
+                hdr.ethernet.dst_addr = dmac;
+            }
+            @hidden @inlinedFrom("next_output") {
+                standard_metadata.egress_spec = port_num_1;
+            }
+        }
         next_hashed_counter.count();
     }
     @name("FabricIngress.next.mpls_routing_hashed") action next_mpls_routing_hashed_0(@name("port_num") bit<9> port_num_2, @name("smac") bit<48> smac_0, @name("dmac") bit<48> dmac_0, @name("label") bit<20> label_0) {
-        fabric_metadata._mpls_label5 = label_0;
-        hdr.ethernet.src_addr = smac_0;
-        hdr.ethernet.dst_addr = dmac_0;
-        standard_metadata.egress_spec = port_num_2;
+        @hidden @inlinedFrom("next_mpls_routing") {
+            @hidden @inlinedFrom("next_set_mpls_label") {
+                fabric_metadata._mpls_label5 = label_0;
+            }
+            @hidden @inlinedFrom("next_routing") {
+                @hidden @inlinedFrom("next_rewrite_smac") {
+                    hdr.ethernet.src_addr = smac_0;
+                }
+                @hidden @inlinedFrom("next_rewrite_dmac") {
+                    hdr.ethernet.dst_addr = dmac_0;
+                }
+                @hidden @inlinedFrom("next_output") {
+                    standard_metadata.egress_spec = port_num_2;
+                }
+            }
+        }
         next_hashed_counter.count();
     }
     @name("FabricIngress.next.hashed") table next_hashed {

--- a/testdata/p4_16_samples_outputs/omec/up4-midend.p4
+++ b/testdata/p4_16_samples_outputs/omec/up4-midend.p4
@@ -431,27 +431,35 @@ control PreQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta
         const default_action = do_drop_1();
     }
     @name("PreQosPipe.uplink_term_fwd") action uplink_term_fwd(@name("ctr_idx") bit<32> ctr_idx_0, @name("tc") bit<2> tc_2, @name("app_meter_idx") bit<32> app_meter_idx) {
-        local_meta.ctr_idx = ctr_idx_0;
-        local_meta.terminations_hit = true;
+        @hidden @inlinedFrom("common_term") {
+            local_meta.ctr_idx = ctr_idx_0;
+            local_meta.terminations_hit = true;
+        }
         local_meta.app_meter_idx_internal = app_meter_idx;
         local_meta.tc = tc_2;
     }
     @name("PreQosPipe.uplink_term_drop") action uplink_term_drop(@name("ctr_idx") bit<32> ctr_idx_5) {
-        local_meta.ctr_idx = ctr_idx_5;
-        local_meta.terminations_hit = true;
+        @hidden @inlinedFrom("common_term") {
+            local_meta.ctr_idx = ctr_idx_5;
+            local_meta.terminations_hit = true;
+        }
         local_meta.needs_dropping = true;
     }
     @name("PreQosPipe.downlink_term_fwd") action downlink_term_fwd(@name("ctr_idx") bit<32> ctr_idx_6, @name("teid") bit<32> teid_1, @name("qfi") bit<6> qfi_1, @name("tc") bit<2> tc_3, @name("app_meter_idx") bit<32> app_meter_idx_2) {
-        local_meta.ctr_idx = ctr_idx_6;
-        local_meta.terminations_hit = true;
+        @hidden @inlinedFrom("common_term") {
+            local_meta.ctr_idx = ctr_idx_6;
+            local_meta.terminations_hit = true;
+        }
         local_meta.tunnel_out_teid = teid_1;
         local_meta.tunnel_out_qfi = qfi_1;
         local_meta.app_meter_idx_internal = app_meter_idx_2;
         local_meta.tc = tc_3;
     }
     @name("PreQosPipe.downlink_term_drop") action downlink_term_drop(@name("ctr_idx") bit<32> ctr_idx_7) {
-        local_meta.ctr_idx = ctr_idx_7;
-        local_meta.terminations_hit = true;
+        @hidden @inlinedFrom("common_term") {
+            local_meta.ctr_idx = ctr_idx_7;
+            local_meta.terminations_hit = true;
+        }
         local_meta.needs_dropping = true;
     }
     @name("PreQosPipe.terminations_uplink") table terminations_uplink_0 {
@@ -510,78 +518,86 @@ control PreQosPipe(inout parsed_headers_t hdr, inout local_metadata_t local_meta
         default_action = NoAction_2();
     }
     @name("PreQosPipe.do_gtpu_tunnel") action do_gtpu_tunnel() {
-        hdr.inner_udp = hdr.udp;
-        hdr.udp.setInvalid();
-        hdr.inner_tcp = hdr.tcp;
-        hdr.tcp.setInvalid();
-        hdr.inner_icmp = hdr.icmp;
-        hdr.icmp.setInvalid();
-        hdr.udp.setValid();
-        hdr.udp.sport = local_meta.tunnel_out_udp_sport;
-        hdr.udp.dport = 16w2152;
-        hdr.udp.len = hdr.ipv4.total_len + 16w16;
-        hdr.udp.checksum = 16w0;
-        hdr.inner_ipv4 = hdr.ipv4;
-        hdr.ipv4.setValid();
-        hdr.ipv4.version = 4w4;
-        hdr.ipv4.ihl = 4w5;
-        hdr.ipv4.dscp = 6w0;
-        hdr.ipv4.ecn = 2w0;
-        hdr.ipv4.total_len = hdr.ipv4.total_len + 16w36;
-        hdr.ipv4.identification = 16w0x1513;
-        hdr.ipv4.flags = 3w0;
-        hdr.ipv4.frag_offset = 13w0;
-        hdr.ipv4.ttl = 8w64;
-        hdr.ipv4.proto = 8w17;
-        hdr.ipv4.src_addr = local_meta.tunnel_out_src_ipv4_addr;
-        hdr.ipv4.dst_addr = local_meta.tunnel_out_dst_ipv4_addr;
-        hdr.ipv4.checksum = 16w0;
-        hdr.gtpu.setValid();
-        hdr.gtpu.version = 3w0x1;
-        hdr.gtpu.pt = 1w0x1;
-        hdr.gtpu.spare = 1w0;
-        hdr.gtpu.ex_flag = 1w0;
-        hdr.gtpu.seq_flag = 1w0;
-        hdr.gtpu.npdu_flag = 1w0;
-        hdr.gtpu.msgtype = 8w255;
-        hdr.gtpu.msglen = hdr.inner_ipv4.total_len;
-        hdr.gtpu.teid = local_meta.tunnel_out_teid;
+        @hidden @inlinedFrom("_udp_encap") {
+            hdr.inner_udp = hdr.udp;
+            hdr.udp.setInvalid();
+            hdr.inner_tcp = hdr.tcp;
+            hdr.tcp.setInvalid();
+            hdr.inner_icmp = hdr.icmp;
+            hdr.icmp.setInvalid();
+            hdr.udp.setValid();
+            hdr.udp.sport = local_meta.tunnel_out_udp_sport;
+            hdr.udp.dport = 16w2152;
+            hdr.udp.len = hdr.ipv4.total_len + 16w16;
+            hdr.udp.checksum = 16w0;
+            hdr.inner_ipv4 = hdr.ipv4;
+            hdr.ipv4.setValid();
+            hdr.ipv4.version = 4w4;
+            hdr.ipv4.ihl = 4w5;
+            hdr.ipv4.dscp = 6w0;
+            hdr.ipv4.ecn = 2w0;
+            hdr.ipv4.total_len = hdr.ipv4.total_len + 16w36;
+            hdr.ipv4.identification = 16w0x1513;
+            hdr.ipv4.flags = 3w0;
+            hdr.ipv4.frag_offset = 13w0;
+            hdr.ipv4.ttl = 8w64;
+            hdr.ipv4.proto = 8w17;
+            hdr.ipv4.src_addr = local_meta.tunnel_out_src_ipv4_addr;
+            hdr.ipv4.dst_addr = local_meta.tunnel_out_dst_ipv4_addr;
+            hdr.ipv4.checksum = 16w0;
+        }
+        @hidden @inlinedFrom("_gtpu_encap") {
+            hdr.gtpu.setValid();
+            hdr.gtpu.version = 3w0x1;
+            hdr.gtpu.pt = 1w0x1;
+            hdr.gtpu.spare = 1w0;
+            hdr.gtpu.ex_flag = 1w0;
+            hdr.gtpu.seq_flag = 1w0;
+            hdr.gtpu.npdu_flag = 1w0;
+            hdr.gtpu.msgtype = 8w255;
+            hdr.gtpu.msglen = hdr.inner_ipv4.total_len;
+            hdr.gtpu.teid = local_meta.tunnel_out_teid;
+        }
     }
     @name("PreQosPipe.do_gtpu_tunnel_with_psc") action do_gtpu_tunnel_with_psc() {
-        hdr.inner_udp = hdr.udp;
-        hdr.udp.setInvalid();
-        hdr.inner_tcp = hdr.tcp;
-        hdr.tcp.setInvalid();
-        hdr.inner_icmp = hdr.icmp;
-        hdr.icmp.setInvalid();
-        hdr.udp.setValid();
-        hdr.udp.sport = local_meta.tunnel_out_udp_sport;
-        hdr.udp.dport = 16w2152;
-        hdr.udp.len = hdr.ipv4.total_len + 16w24;
-        hdr.udp.checksum = 16w0;
-        hdr.inner_ipv4 = hdr.ipv4;
-        hdr.ipv4.setValid();
-        hdr.ipv4.version = 4w4;
-        hdr.ipv4.ihl = 4w5;
-        hdr.ipv4.dscp = 6w0;
-        hdr.ipv4.ecn = 2w0;
-        hdr.ipv4.total_len = hdr.ipv4.total_len + 16w44;
-        hdr.ipv4.identification = 16w0x1513;
-        hdr.ipv4.flags = 3w0;
-        hdr.ipv4.frag_offset = 13w0;
-        hdr.ipv4.ttl = 8w64;
-        hdr.ipv4.proto = 8w17;
-        hdr.ipv4.src_addr = local_meta.tunnel_out_src_ipv4_addr;
-        hdr.ipv4.dst_addr = local_meta.tunnel_out_dst_ipv4_addr;
-        hdr.ipv4.checksum = 16w0;
-        hdr.gtpu.setValid();
-        hdr.gtpu.version = 3w0x1;
-        hdr.gtpu.pt = 1w0x1;
-        hdr.gtpu.spare = 1w0;
-        hdr.gtpu.seq_flag = 1w0;
-        hdr.gtpu.npdu_flag = 1w0;
-        hdr.gtpu.msgtype = 8w255;
-        hdr.gtpu.teid = local_meta.tunnel_out_teid;
+        @hidden @inlinedFrom("_udp_encap") {
+            hdr.inner_udp = hdr.udp;
+            hdr.udp.setInvalid();
+            hdr.inner_tcp = hdr.tcp;
+            hdr.tcp.setInvalid();
+            hdr.inner_icmp = hdr.icmp;
+            hdr.icmp.setInvalid();
+            hdr.udp.setValid();
+            hdr.udp.sport = local_meta.tunnel_out_udp_sport;
+            hdr.udp.dport = 16w2152;
+            hdr.udp.len = hdr.ipv4.total_len + 16w24;
+            hdr.udp.checksum = 16w0;
+            hdr.inner_ipv4 = hdr.ipv4;
+            hdr.ipv4.setValid();
+            hdr.ipv4.version = 4w4;
+            hdr.ipv4.ihl = 4w5;
+            hdr.ipv4.dscp = 6w0;
+            hdr.ipv4.ecn = 2w0;
+            hdr.ipv4.total_len = hdr.ipv4.total_len + 16w44;
+            hdr.ipv4.identification = 16w0x1513;
+            hdr.ipv4.flags = 3w0;
+            hdr.ipv4.frag_offset = 13w0;
+            hdr.ipv4.ttl = 8w64;
+            hdr.ipv4.proto = 8w17;
+            hdr.ipv4.src_addr = local_meta.tunnel_out_src_ipv4_addr;
+            hdr.ipv4.dst_addr = local_meta.tunnel_out_dst_ipv4_addr;
+            hdr.ipv4.checksum = 16w0;
+        }
+        @hidden @inlinedFrom("_gtpu_encap") {
+            hdr.gtpu.setValid();
+            hdr.gtpu.version = 3w0x1;
+            hdr.gtpu.pt = 1w0x1;
+            hdr.gtpu.spare = 1w0;
+            hdr.gtpu.seq_flag = 1w0;
+            hdr.gtpu.npdu_flag = 1w0;
+            hdr.gtpu.msgtype = 8w255;
+            hdr.gtpu.teid = local_meta.tunnel_out_teid;
+        }
         hdr.gtpu.msglen = hdr.inner_ipv4.total_len + 16w8;
         hdr.gtpu.ex_flag = 1w1;
         hdr.gtpu_options.setValid();


### PR DESCRIPTION
These will generally be used by backends and simply passed through the frontend/midend, so not much is needed here.

Perhaps some frontend passes (in particular,  DoSimplifyControlFlow in frontends/p4/simplify.cpp) could be extended to understand these -- currently, any annotations on a block will inhibit combining the blocks, whereas `@likely`/`@unlikely` on a block should not inhibit combining it with a block with no annotation (the annotation should be on the resulting combined block).

See discussion in https://github.com/p4lang/p4-spec/issues/1308