### PR TITLE
I believe package python3-devel is required on Fedora Linux to ...

### DIFF
--- a/tools/install_fedora_deps.sh
+++ b/tools/install_fedora_deps.sh
@@ -49,6 +49,7 @@ sudo dnf install -y -q \
     python3 \
     python3-pip \
     python3-thrift \
+    python3-devel \
     readline-devel \
     tcpdump \
     thrift-devel \


### PR DESCRIPTION
... build Python packages like grpcio from source.