### PR TITLE
Fix warning about delete not matching new

### DIFF
--- a/backends/p4tools/p4tools.def
+++ b/backends/p4tools/p4tools.def
@@ -144,6 +144,7 @@ class Extracted_Varbits : Type_Bits {
  public:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
     /// The assigned size of this varbit (assigned by extract calls).
     int assignedSize;

--- a/ir/type.def
+++ b/ir/type.def
@@ -75,6 +75,7 @@ class Type_Any : Type, ITypeVar {
  protected:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
     static long nextId;
  public:
@@ -130,6 +131,7 @@ class Type_Boolean : Type_Base {
  protected:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
  public:
     static Type_Boolean get();
@@ -144,6 +146,7 @@ class Type_State : Type_Base {
  protected:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
  public:
     static Type_State get();
@@ -157,6 +160,7 @@ class Type_Bits : Type_Base {
  protected:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
  public:
     optional int size = 0;      // zero (only) for not-yet evaluated const expression
@@ -176,6 +180,7 @@ class Type_Varbits : Type_Base {
  protected:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
  public:
     optional int         size = 0;   // if zero it means "unknown"
@@ -251,6 +256,7 @@ class Type_InfInt : Type, ITypeVar {
  protected:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
     long declid = nextId++;
  private:
@@ -275,6 +281,7 @@ class Type_Dontcare : Type_Base {
  protected:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
  public:
     toString{ return "_"_cs; }
@@ -287,6 +294,7 @@ class Type_Void : Type_Base {
  protected:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
  public:
     toString{ return "void"_cs; }
@@ -299,6 +307,7 @@ class Type_MatchKind : Type_Base {
  protected:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
  public:
     toString{ return "match_kind"_cs; }
@@ -636,6 +645,7 @@ class Type_String : Type_Base {
  protected:
 #emit
     void *operator new(size_t size) { return ::operator new(size); }
+    void operator delete(void *p, size_t size) { return ::operator delete(p, size); }
 #end
  public:
     static Type_String get();


### PR DESCRIPTION
New gcc versions (11+) give a slew of warnings about a mismatched operator delete being called from a new expression.  This trivial change fixes those warnings.