### PR TITLE
In BMv2, Translate architecture-dependent boolean parameter to JSON expression

### DIFF
--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -280,8 +280,20 @@ void ExpressionConverter::postorder(const IR::Member *expression) {
     auto param = enclosingParamReference(expression->expr);
     if (param != nullptr) {
         // convert architecture-dependent parameter
-        if (auto result = convertParam(param, fieldName)) {
-            mapExpression(expression, result);
+        if (auto tmpResult = convertParam(param, fieldName)) {
+            // If architecture-dependent parameter is a boolean
+            if (type->is<IR::Type_Boolean>()) {
+                auto result = new Util::JsonObject();
+                result->emplace("type", "expression");
+                auto e = new Util::JsonObject();
+                result->emplace("value", e);
+                e->emplace("op", "d2b");  // data to Boolean cast
+                e->emplace("left", Util::JsonValue::null);
+                e->emplace("right", tmpResult);
+                mapExpression(expression, result);
+            } else {
+                mapExpression(expression, tmpResult);
+            }
             return;
         }
         // convert normal parameters


### PR DESCRIPTION
Tried to solve the bug mentioned in the issue: https://github.com/p4lang/p4c/issues/4985.

https://github.com/p4lang/p4c/blob/b35c89b07215cbaff51b79ac659cd10065099104/backends/bmv2/pna_nic/pnaNic.h#L60-L68
In the above code, If the parameter is part of architecture's standard metadata, it generates the JSON expression like:

```
"expression" : {
  "type" : "field",
  "value" : ["pna_main_input_metadata", "recirculated"]
}
```

Tried to tackle the case of a parameter being both architecture-dependent and a boolean.
