### PR TITLE
Miscellaneous small Tofino fixes for compilation.

### DIFF
--- a/backends/tofino/bf-p4c/CMakeLists.txt
+++ b/backends/tofino/bf-p4c/CMakeLists.txt
@@ -28,7 +28,6 @@ set(BF_P4C_UNIFIED_SOURCE_CHUNK_SIZE "5" CACHE STRING
     "Target unified compilation chunk size for bf-p4c (an integer or ALL)")
 
 find_package (Boost REQUIRED COMPONENTS graph)
-add_definitions("-DBOOST_NO_ARGUMENT_DEPENDENT_LOOKUP")
 if (ENABLE_BAREFOOT_INTERNAL)
   add_definitions("-DBAREFOOT_INTERNAL=1")
 endif()
@@ -998,7 +997,6 @@ target_link_libraries (bfp4c tofinobackend bfn_p4runtime
 # XXX These compile definitions and include directories should be inherited
 # XXX from bfp4c's dependencies, but these CMake files aren't very modular.
 target_compile_definitions(bfp4c
-  INTERFACE "-DBOOST_NO_ARGUMENT_DEPENDENT_LOOKUP"
   INTERFACE "-DMAX_LOGGING_LEVEL=${MAX_LOGGING_LEVEL}"
   INTERFACE "-DEVENT_LOG_SCHEMA_VERSION=\"${EVENT_LOG_SCHEMA_VERSION}\""
   INTERFACE "-DPHV_SCHEMA_VERSION=\"${PHV_SCHEMA_VERSION}\""

--- a/backends/tofino/bf-p4c/arch/arch.cpp
+++ b/backends/tofino/bf-p4c/arch/arch.cpp
@@ -376,7 +376,7 @@ const IR::Node *DoRewriteControlAndParserBlocks::postorder(IR::Declaration_Insta
     auto newArgs = new IR::Vector<IR::Argument>();
     int index = 0;
     for (auto arg : *decl->arguments) {
-        const auto newName = ::get(block_name_map, std::make_pair(decl->name, index));
+        const auto newName = P4::get(block_name_map, std::make_pair(decl->name, index));
         CHECK_NULL(newName);
         const auto *typeRef = new IR::Type_Name(IR::ID(newName, nullptr));
         const auto *cc = arg->expression->to<IR::ConstructorCallExpression>();

--- a/backends/tofino/bf-p4c/arch/fromv1.0/programStructure.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/programStructure.cpp
@@ -266,7 +266,7 @@ const IR::Declaration_Instance *TnaProgramStructure::convert(const IR::Register 
     } else if (reg->width > 0) {
         regElementType = IR::Type_Bits::get(reg->width);
     } else if (reg->layout) {
-        cstring newName = ::get(registerLayoutType, reg->layout);
+        cstring newName = P4::get(registerLayoutType, reg->layout);
         if (newName.isNullOrEmpty()) newName = reg->layout;
         regElementType = new IR::Type_Name(new IR::Path(newName));
     } else {

--- a/backends/tofino/bf-p4c/arch/fromv1.0/v1_converters.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/v1_converters.cpp
@@ -23,6 +23,7 @@
 #include "bf-p4c/arch/bridge_metadata.h"
 #include "bf-p4c/common/utils.h"
 #include "bf-p4c/device.h"
+#include "lib/map.h"
 #include "lib/ordered_map.h"
 #include "v1_program_structure.h"
 
@@ -544,7 +545,7 @@ const IR::Node *EgressParserConverter::postorder(IR::P4Parser *node) {
 
 const IR::Node *TypeNameExpressionConverter::postorder(IR::Type_Name *node) {
     auto path = node->path->to<IR::Path>();
-    if (auto newName = ::get(enumsToTranslate, path->name)) {
+    if (auto newName = P4::get(enumsToTranslate, path->name)) {
         if (!structure->enums.count(newName)) {
             BUG("Cannot translation for type ", node);
             return node;
@@ -557,7 +558,7 @@ const IR::Node *TypeNameExpressionConverter::postorder(IR::Type_Name *node) {
 const IR::Node *TypeNameExpressionConverter::postorder(IR::TypeNameExpression *node) {
     auto typeName = node->typeName->to<IR::Type_Name>();
     auto path = typeName->path->to<IR::Path>();
-    if (auto newType = ::get(structure->enums, path->name)) {
+    if (auto newType = P4::get(structure->enums, path->name)) {
         node->type = newType;
     }
     return node;
@@ -566,7 +567,7 @@ const IR::Node *TypeNameExpressionConverter::postorder(IR::TypeNameExpression *n
 const IR::Node *TypeNameExpressionConverter::postorder(IR::Member *node) {
     if (!node->expr->is<IR::TypeNameExpression>()) return node;
     auto name = node->member;
-    if (auto newName = ::get(fieldsToTranslate, name))
+    if (auto newName = P4::get(fieldsToTranslate, name))
         return new IR::Member(node->srcInfo, node->expr, newName);
     return node;
 }

--- a/backends/tofino/bf-p4c/control-plane/bfruntime_arch_handler.h
+++ b/backends/tofino/bf-p4c/control-plane/bfruntime_arch_handler.h
@@ -247,7 +247,7 @@ struct ActionProfile {
                                         // profile declaration.
 
     p4rt_id_t getId(const P4RuntimeSymbolTableIface &symbols,
-                    const cstring blockPrefix = ""_cs) const {
+                    const cstring blockPrefix = cstring::empty) const {
         auto symName = prefix(blockPrefix, name);
         return symbols.getId(SymbolType::P4RT_ACTION_PROFILE(), symName);
     }
@@ -267,7 +267,7 @@ struct ActionSelector {
     bool selSuffix;
 
     p4rt_id_t getId(const P4RuntimeSymbolTableIface &symbols,
-                    const cstring blockPrefix = ""_cs) const {
+                    const cstring blockPrefix = cstring::empty) const {
         auto symName = prefix(blockPrefix, name);
         auto symSelectorName = (selSuffix) ? symName + "_sel" : symName;
         if (actionProfileName) {
@@ -687,7 +687,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
     }
 
     cstring getControlPlaneName(const IR::Block *block, const IR::IDeclaration *decl) {
-        auto declName = decl ? decl->controlPlaneName() : ""_cs;
+        auto declName = decl ? decl->controlPlaneName() : cstring::empty;
         return getFullyQualifiedName(block, declName);
     }
 
@@ -708,8 +708,8 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
     // CTXT JSON : ig_pipe0.prsr0
     cstring getFullyQualifiedName(const IR::Block *block, const cstring name,
                                   bool skip_control_plane_name = false) {
-        cstring block_name = ""_cs;
-        cstring control_plane_name = ""_cs;
+        cstring block_name = cstring::empty;
+        cstring control_plane_name = cstring::empty;
         cstring full_name = getBlockNamePrefix(block);
         if (!skip_control_plane_name) {
             if (auto cont = block->getContainer()) {
@@ -846,7 +846,8 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
 
     void addTablePropertiesCommon(const P4RuntimeSymbolTableIface &symbols,
                                   p4configv1::P4Info *p4info, p4configv1::Table *table,
-                                  const IR::TableBlock *tableBlock, cstring blockPrefix = "") {
+                                  const IR::TableBlock *tableBlock,
+                                  cstring blockPrefix = cstring::empty) {
         CHECK_NULL(tableBlock);
         auto tableDeclaration = tableBlock->container;
 
@@ -952,7 +953,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
 
     void addExternInstanceCommon(const P4RuntimeSymbolTableIface &symbols,
                                  p4configv1::P4Info *p4info, const IR::ExternBlock *externBlock,
-                                 cstring pipeName = ""_cs) {
+                                 cstring pipeName = cstring::empty) {
         Log::TempIndent indent;
         LOG1("Adding Extern Instances for pipe " << pipeName << indent);
         auto decl = externBlock->node->to<IR::Declaration_Instance>();
@@ -1240,7 +1241,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
     }
 
     void addDigest(const P4RuntimeSymbolTableIface &symbols, p4configv1::P4Info *p4Info,
-                   const Digest &digestInstance, cstring pipeName = "") {
+                   const Digest &digestInstance, cstring pipeName = cstring::empty) {
         ::barefoot::Digest digest;
         digest.mutable_type_spec()->CopyFrom(*digestInstance.typeSpec);
         auto digestName = prefix(pipeName, digestInstance.name);
@@ -1250,7 +1251,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
     }
 
     void addDynHash(const P4RuntimeSymbolTableIface &symbols, p4configv1::P4Info *p4Info,
-                    const DynHash &dynHashInstance, cstring pipeName = "") {
+                    const DynHash &dynHashInstance, cstring pipeName = cstring::empty) {
         ::barefoot::DynHash dynHash;
         dynHash.set_hash_width(dynHashInstance.hashWidth);
         dynHash.mutable_type_spec()->CopyFrom(*dynHashInstance.typeSpec);
@@ -1268,7 +1269,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
     // For Registers, the table name should have the associated pipe prefix but
     // the data field names should not since they have local scope.
     void addRegister(const P4RuntimeSymbolTableIface &symbols, p4configv1::P4Info *p4Info,
-                     const Register &registerInstance, cstring pipeName = "") {
+                     const Register &registerInstance, cstring pipeName = cstring::empty) {
         auto registerName = prefix(pipeName, registerInstance.name);
         if (registerInstance.size == 0) {
             ::barefoot::DirectRegister register_;
@@ -1299,7 +1300,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
 
     void addCounter(const P4RuntimeSymbolTableIface &symbols, p4configv1::P4Info *p4Info,
                     const Helpers::Counterlike<ArchCounterExtern> &counterInstance,
-                    const cstring blockPrefix = "") {
+                    const cstring blockPrefix = cstring::empty) {
         if (counterInstance.table) {
             ::barefoot::DirectCounter counter;
             setCounterCommon(&counter, counterInstance);
@@ -1340,7 +1341,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
 
     void addMeter(const P4RuntimeSymbolTableIface &symbols, p4configv1::P4Info *p4Info,
                   const Helpers::Counterlike<ArchMeterExtern> &meterInstance,
-                  const cstring blockPrefix = "") {
+                  const cstring blockPrefix = cstring::empty) {
         auto meterName = prefix(blockPrefix, meterInstance.name);
         if (meterInstance.table) {
             ::barefoot::DirectMeter meter;
@@ -1365,7 +1366,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
     }
 
     void addActionProfile(const P4RuntimeSymbolTableIface &symbols, p4configv1::P4Info *p4Info,
-                          const ActionProfile &actionProfile, cstring pipeName = "") {
+                          const ActionProfile &actionProfile, cstring pipeName = cstring::empty) {
         ::barefoot::ActionProfile profile;
         profile.set_size(actionProfile.size);
         auto actionProfileName = prefix(pipeName, actionProfile.name);
@@ -1385,7 +1386,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
 
     virtual void addActionSelector(const P4RuntimeSymbolTableIface &symbols,
                                    p4configv1::P4Info *p4Info, const ActionSelector &actionSelector,
-                                   cstring blockPrefix = "") {
+                                   cstring blockPrefix = cstring::empty) {
         ::barefoot::ActionSelector selector;
         selector.set_max_group_size(actionSelector.maxGroupSize);
         selector.set_num_groups(actionSelector.numGroups);
@@ -1654,7 +1655,7 @@ class BFRuntimeArchHandlerTofino final : public BFN::BFRuntimeArchHandlerCommon<
 
     cstring getBlockNamePrefix(const IR::Block *blk) override {
         if (blockNamePrefixMap.count(blk) > 0) return blockNamePrefixMap[blk];
-        return ""_cs;
+        return cstring::empty;
     }
 
     void collectExternInstance(P4RuntimeSymbolTableIface *symbols,
@@ -1770,7 +1771,8 @@ class BFRuntimeArchHandlerTofino final : public BFN::BFRuntimeArchHandlerCommon<
                 BUG_CHECK(gress->is<IR::ControlBlock>(), "Expected control");
                 auto control = gress->to<IR::ControlBlock>();
                 if (blockNamePrefixMap.count(control) > 0) pipeName = blockNamePrefixMap[control];
-                snapshotInfo.emplace(control, SnapshotInfo{pipeName, gressName, 0u, ""_cs, {}});
+                snapshotInfo.emplace(control,
+                                     SnapshotInfo{pipeName, gressName, 0u, cstring::empty, {}});
                 LOG3("Adding SnapshotInfo for " << control->getName() << " " << gressName
                                                 << " on pipe " << pipeName);
             }
@@ -2332,7 +2334,8 @@ class BFRuntimeArchHandlerTofino final : public BFN::BFRuntimeArchHandlerCommon<
     // For RegisterParams, the table name should have the associated pipe prefix but
     // the data field names should not since they have local scope.
     void addRegisterParam(const P4RuntimeSymbolTableIface &symbols, p4configv1::P4Info *p4Info,
-                          const RegisterParam &registerParamInstance, cstring pipeName = ""_cs) {
+                          const RegisterParam &registerParamInstance,
+                          cstring pipeName = cstring::empty) {
         p4rt_id_t tableId = 0;
         if (registerParam2register.count(registerParamInstance.name) > 0)
             tableId =

--- a/backends/tofino/bf-p4c/ir/mau.cpp
+++ b/backends/tofino/bf-p4c/ir/mau.cpp
@@ -332,7 +332,7 @@ void Table::visit_match_table(THIS *self, Visitor &v, payload_info_t &payload_in
 
         if (action->exitAction) continue;
 
-        auto *pinfo = ::getref(payload_info.action_info, action_name);
+        auto *pinfo = P4::getref(payload_info.action_info, action_name);
         if (!action->hit_allowed && !action->default_allowed) {
             // can't be invoked from the match table
             if (pinfo)

--- a/backends/tofino/bf-p4c/mau/add_always_run.cpp
+++ b/backends/tofino/bf-p4c/mau/add_always_run.cpp
@@ -140,7 +140,7 @@ bool AddAlwaysRun::PrepareToAdd::preorder(const IR::MAU::Table *table) {
     // Ensure we re-visit this table if we encounter it again elsewhere in the IR.
     visitAgain();
 
-    auto *curMin = ::get(minSubsequentTables, table);
+    auto *curMin = P4::get(minSubsequentTables, table);
     if (self.compare(subsequentTable, curMin) < 0) curMin = subsequentTable;
     minSubsequentTables[table] = curMin;
 

--- a/backends/tofino/bf-p4c/mau/instruction_selection.cpp
+++ b/backends/tofino/bf-p4c/mau/instruction_selection.cpp
@@ -1723,7 +1723,7 @@ const IR::MAU::StatefulCall *StatefulAttachmentSetup::Update::preorder(
     auto *orig_call = getOriginal()->to<IR::MAU::StatefulCall>();
 
     StatefulCallKey sck = std::make_pair(orig_call, tbl);
-    if (auto expr = ::get(self.update_calls, sck)) call->index = expr;
+    if (auto expr = P4::get(self.update_calls, sck)) call->index = expr;
 
     auto prim = call->prim;
     BUG_CHECK(prim->operands.size() >= 1, "Invalid primitive %s", prim);
@@ -1751,7 +1751,7 @@ const IR::MAU::BackendAttached *StatefulAttachmentSetup::Update::preorder(
     IR::MAU::BackendAttached *ba) {
     auto *tbl = findOrigCtxt<IR::MAU::Table>();
     HashDistKey hdk = std::make_pair(ba->attached, tbl);
-    if (auto hd = ::get(self.update_hd, hdk)) {
+    if (auto hd = P4::get(self.update_hd, hdk)) {
         ba->hash_dist = hd;
     }
     use_t use = IR::MAU::StatefulUse::NO_USE;

--- a/backends/tofino/bf-p4c/mau/mau_power.cpp
+++ b/backends/tofino/bf-p4c/mau/mau_power.cpp
@@ -25,6 +25,7 @@
 #include "bf-p4c/device.h"
 #include "bf-p4c/mau/memories.h"
 #include "lib/hex.h"
+#include "lib/map.h"
 
 namespace MauPower {
 
@@ -101,7 +102,7 @@ bool MauFeatures::requires_dep_asm(gress_t g, int stage) const {
 }
 
 mau_dep_t MauFeatures::get_dependency_for_gress_stage(gress_t g, int stage) const {
-    return ::get(stage_dep_to_previous_[g], stage, DEP_MATCH);
+    return P4::get(stage_dep_to_previous_[g], stage, DEP_MATCH);
 }
 void MauFeatures::set_dependency_for_gress_stage(gress_t g, int stage, mau_dep_t dep) {
     stage_dep_to_previous_[g][stage] = dep;

--- a/backends/tofino/bf-p4c/mau/simple_power_graph.cpp
+++ b/backends/tofino/bf-p4c/mau/simple_power_graph.cpp
@@ -347,7 +347,7 @@ double SimplePowerGraph::visit_node_power(Node *n, const std::map<UniqueId, Powe
         }
         double edge_power = 0.0;
         for (auto uid : edge_worst_path) {
-            if (auto pma = ::getref(tma, uid)) {
+            if (auto pma = P4::getref(tma, uid)) {
                 edge_power += pma->compute_table_power(Device::numPipes());
                 // LOG5("\tEdge Power (" << uid << ") :"
                 // << pma->compute_table_power(Device::numPipes()));
@@ -369,7 +369,7 @@ double SimplePowerGraph::visit_node_power(Node *n, const std::map<UniqueId, Powe
             }
         }
     }
-    if (auto pma = ::getref(tma, n->unique_id_))
+    if (auto pma = P4::getref(tma, n->unique_id_))
         worst_power += pma->compute_table_power(Device::numPipes());
     computed_power_.emplace(n->id_, worst_power);
     worst_path.insert(n->unique_id_);

--- a/backends/tofino/bf-p4c/phv/phv_fields.cpp
+++ b/backends/tofino/bf-p4c/phv/phv_fields.cpp
@@ -667,18 +667,18 @@ std::set<int> PhvInfo::minStages(const IR::MAU::Table *table) {
     if (LOGGING(6)) {
         std::stringstream ss;
         ss << " Reading stage(s) for table " << table->name << " = ";
-        for (auto stg : ::get(table_to_min_stages, TableSummary::getTableName(table)))
+        for (auto stg : P4::get(table_to_min_stages, TableSummary::getTableName(table)))
             ss << stg << " ";
         LOG6(ss.str());
     }
 
-    return ::get(table_to_min_stages, TableSummary::getTableName(table));
+    return P4::get(table_to_min_stages, TableSummary::getTableName(table));
 }
 
 std::set<int> PhvInfo::physicalStages(const IR::MAU::Table *table) {
     std::set<int> rv;
     if (table_to_physical_stages.count(TableSummary::getTableIName(table)))
-        rv = ::get(table_to_physical_stages, TableSummary::getTableIName(table));
+        rv = P4::get(table_to_physical_stages, TableSummary::getTableIName(table));
     return rv;
 }
 


### PR DESCRIPTION
`BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP` was removed from main P4C a while ago. 