### PR TITLE
Remove conflicting and outdated CPack licensing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,8 @@ endif()
 
 if (NOT $ENV{P4C_VERSION} STREQUAL "")
   # Allow the version to be set from outside
-  set (P4C_VERSION $ENV{P4C_VERSION})
+  set (P4C_SEM_VERSION_STRING $ENV{P4C_VERSION})
+  set (P4C_VERSION ${P4C_SEM_VERSION_STRING})
 else()
   # Semantic version numbering: <major>.<minor>.<patch>[-rcX]
   # Examples: 0.5.1, 1.0.0-rc1, 1.0.1-alpha
@@ -92,12 +93,6 @@ else()
     OUTPUT_STRIP_TRAILING_WHITESPACE
     RESULT_VARIABLE rc
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-  string (REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)([-0-9a-z\\.]*).*"
-    __p4c_version ${P4C_SEM_VERSION_STRING})
-  set (P4C_VERSION_MAJOR ${CMAKE_MATCH_1})
-  set (P4C_VERSION_MINOR ${CMAKE_MATCH_2})
-  set (P4C_VERSION_PATCH ${CMAKE_MATCH_3})
-  set (P4C_VERSION_RC ${CMAKE_MATCH_4})
   execute_process (COMMAND git rev-parse --short HEAD
     OUTPUT_VARIABLE P4C_GIT_SHA
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -105,6 +100,12 @@ else()
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
   set (P4C_VERSION "${P4C_SEM_VERSION_STRING} (SHA: ${P4C_GIT_SHA} BUILD: ${CMAKE_BUILD_TYPE})")
 endif()
+string (REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)([-0-9a-z\\.]*).*"
+  __p4c_version ${P4C_SEM_VERSION_STRING})
+set (P4C_VERSION_MAJOR ${CMAKE_MATCH_1})
+set (P4C_VERSION_MINOR ${CMAKE_MATCH_2})
+set (P4C_VERSION_PATCH ${CMAKE_MATCH_3})
+set (P4C_VERSION_RC ${CMAKE_MATCH_4})
 
 # P4 General Utilities
 include(P4CUtils)
@@ -116,7 +117,6 @@ include(CheckIncludeFile)
 include(CheckIncludeFileCXX)
 include(CheckFunctionExists)
 include(FindPythonModule)
-include(CPack)
 # TODO: Remove this deprecated include eventually.
 include(UnifiedBuild)
 
@@ -667,7 +667,7 @@ if (ENABLE_DOCS AND DOXYGEN_FOUND)
     DESTINATION ${P4C_ARTIFACTS_OUTPUT_DIRECTORY}/docs)
 endif()
 
-# Packaging:
+######################################## Packaging BEGIN ########################################
 SET(CPACK_SOURCE_GENERATOR "TXZ")
 SET(CPACK_SOURCE_PACKAGE_FILE_NAME
    "p4c-${P4C_SEM_VERSION_STRING}")
@@ -676,4 +676,35 @@ SET(CPACK_SOURCE_IGNORE_FILES
 
 ADD_CUSTOM_TARGET(dist COMMAND ${CMAKE_MAKE_PROGRAM} clean package_source)
 
+set (CPACK_RESOURCE_FILE_LICENSE "${P4C_SOURCE_DIR}/LICENSES/Apache-2.0.txt")
+
+set (CPACK_GENERATOR "TBZ2")
+set (CPACK_PACKAGE_NAME "p4c")
+set (CPACK_PACKAGE_VERSION_MAJOR ${P4C_VERSION_MAJOR})
+set (CPACK_PACKAGE_VERSION_MINOR ${P4C_VERSION_MINOR})
+set (CPACK_PACKAGE_VERSION_PATCH ${P4C_VERSION_PATCH})
+set (CPACK_PACKAGE_VERSION "${P4C_SEM_VERSION_STRING}")
+set (CPACK_PACKAGE_CONTACT "P4 Language Organization <info@p4.org>")
+set (CPACK_PACKAGE_VENDOR "P4 Language Organization")
+set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "P4C compilers for P4_14 and P4_16")
+set (CPACK_PACKAGE_DESCRIPTION "p4c is a reference compiler for the P4 programming language.
+ It supports both P4-14 and P4-16; you can find more information about P4
+ and the specifications for both versions of the language at http://p4.org.
+
+ p4c is modular; it provides a standard frontend and midend which can be
+ combined with a target-specific backend to create a complete P4 compiler.
+ The goal is to make adding new backends easy.")
+set (CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/p4lang/p4c")
+set (CPACK_PROJECT_CONFIG_FILE "${P4C_SOURCE_DIR}/cmake/CPackOptions.cmake")
+# Match the package name used by the debian/ packaging.
+set (CPACK_DEBIAN_PACKAGE_NAME "p4lang-p4c")
+set (CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://github.com/p4lang/p4c")
+# The p4c driver is a Python script, which SHLIBDEPS cannot detect.
+set (CPACK_DEBIAN_PACKAGE_DEPENDS "python3")
+set (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+set (CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
+set (CPACK_STRIP_FILES TRUE)
+
+include (CPack)
+######################################## Packaging End ########################################
 endif (NOT FORMATTING_ONLY)

--- a/backends/p4fmt/CMakeLists.txt
+++ b/backends/p4fmt/CMakeLists.txt
@@ -19,6 +19,9 @@ add_executable(p4fmt ${FMT_SRCS})
 target_link_libraries(p4fmt ${P4C_LIBRARIES} ${P4C_LIB_DEPS})
 add_dependencies(p4fmt frontend)
 
+install (TARGETS p4fmt
+  RUNTIME DESTINATION ${P4C_RUNTIME_OUTPUT_DIRECTORY})
+
 add_custom_target(p4formatter
         COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/p4fmt ${P4C_BINARY_DIR}/p4fmt
 )

--- a/backends/tofino/CMakeLists.txt
+++ b/backends/tofino/CMakeLists.txt
@@ -174,20 +174,6 @@ if (ENABLE_DOXYGEN)
   endif()
 endif()
 
-set (CPACK_GENERATOR "TBZ2")
-set (CPACK_PACKAGE_NAME "p4c")
-set (CPACK_PACKAGE_VERSION_MAJOR ${BFN_P4C_VERSION_MAJOR})
-set (CPACK_PACKAGE_VERSION_MINOR ${BFN_P4C_VERSION_MINOR})
-set (CPACK_PACKAGE_VERSION_PATCH ${BFN_P4C_VERSION_PATCH})
-set (CPACK_PACKAGE_VERSION "${BFN_P4C_VERSION}")
-set (CPACK_PACKAGE_CONTACT "Barefoot Networks, Inc. <p4c@barefootnetworks.com>")
-set (CPACK_PACKAGE_VENDOR "Barefoot Networks, Inc.")
-set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "P4C compilers for P4_14 and P4_16")
-set (CPACK_PACKAGE_DESCRIPTION "P4C compilers for the Barefoot Networks Tofino architecture")
-set (CPACK_PROJECT_CONFIG_FILE "${BFN_P4C_SOURCE_DIR}/CPackOptions.cmake")
-set (CPACK_STRIP_FILES TRUE)
-
-include (CPack)
 
 set (BF_P4C_IR_DEF_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/bf-p4c/ir/tofino.def

--- a/backends/tofino/scripts/format-project-for-p4c.py
+++ b/backends/tofino/scripts/format-project-for-p4c.py
@@ -34,7 +34,6 @@ def copy_directories_and_files(source, dest):
         'LICENSE',
         'README',
         'bootstrap_bfn_env.sh',
-        'CPackOptions.cmake',
         'LICENSE.in',
         'README.md',
         'bootstrap_bfn_compilers.sh',

--- a/cmake/CPackOptions.cmake
+++ b/cmake/CPackOptions.cmake
@@ -19,5 +19,4 @@ if (CPACK_GENERATOR MATCHES "DEB")
     set (CPACK_DEBIAN_PACKAGE_ARCHITECTURE "i386")
   endif()
 
-  set (CPACK_DEBIAN_PACKAGE_DEPENDS "cpp (>= 4.8), libboost-iostreams1.58.0, libgmp10, libgmpxx4ldbl, libgc1c2, libstdc++6, libc6, libbz2-1.0, libssl1.0.0, python (>= 2.7)")
 endif()


### PR DESCRIPTION
Now that Tofino is part of the open-source compiler this license packaging is no longer relevant, in fact it conflicts with the CPack licensing of the parent compiler. 