### PR TITLE
Fix broken Tofino build.

### DIFF
--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -135,7 +135,7 @@ void Z3Solver::pop() {
 void Z3Solver::comment(cstring commentStr) {
     // GCC complains about an unused parameter here.
     (void)(commentStr);
-    Z3_LOG("additional comment:%s", commentStr);
+    Z3_LOG("additional comment:%v", commentStr);
 }
 
 void Z3Solver::seed(unsigned seed) {

--- a/backends/tofino/bf-p4c/arch/fromv1.0/checksum.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/checksum.cpp
@@ -23,7 +23,7 @@ namespace V1 {
 
 TranslateParserChecksums::TranslateParserChecksums(ProgramStructure *structure,
                                                    P4::ReferenceMap *refMap, P4::TypeMap *typeMap)
-    : parserGraphs(refMap, cstring()) {
+    : parserGraphs(refMap, false) {
     auto collectParserChecksums = new BFN::V1::CollectParserChecksums(refMap, typeMap);
     auto insertParserChecksums =
         new BFN::V1::InsertParserChecksums(this, collectParserChecksums, &parserGraphs, structure);

--- a/backends/tofino/bf-p4c/arch/fromv1.0/meter.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/meter.cpp
@@ -117,8 +117,8 @@ const IR::Statement *P4V1::MeterConverter::convertExternCall(P4V1::ProgramStruct
         BUG("Unknown method %s in meter", prim->name);
     }
     bool direct = ext->properties.get<IR::Property>("instance_count"_cs) == nullptr;
-    bool pre_color = strstr(prim->name, "pre_color");
-    bool with_or = strstr(prim->name, "with_or");
+    bool pre_color = strstr(prim->name.c_str(), "pre_color");
+    bool with_or = strstr(prim->name.c_str(), "with_or");
     if (prim->operands.size() != 2U + pre_color + !direct)
         error("Expected %d operands for %s", 1 + pre_color + !direct, prim);
     auto dest = conv.convert(prim->operands.at(1));

--- a/backends/tofino/bf-p4c/arch/fromv1.0/meter.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/meter.cpp
@@ -117,8 +117,8 @@ const IR::Statement *P4V1::MeterConverter::convertExternCall(P4V1::ProgramStruct
         BUG("Unknown method %s in meter", prim->name);
     }
     bool direct = ext->properties.get<IR::Property>("instance_count"_cs) == nullptr;
-    bool pre_color = prim->name.find("pre_color") != nullptr;
-    bool with_or = prim->name.find("with_or") != nullptr;
+    bool pre_color = prim->name.find("pre_color");
+    bool with_or = prim->name.find("with_or");
     if (prim->operands.size() != 2U + pre_color + !direct)
         error("Expected %d operands for %s", 1 + pre_color + !direct, prim);
     auto dest = conv.convert(prim->operands.at(1));

--- a/backends/tofino/bf-p4c/arch/fromv1.0/meter.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/meter.cpp
@@ -117,8 +117,8 @@ const IR::Statement *P4V1::MeterConverter::convertExternCall(P4V1::ProgramStruct
         BUG("Unknown method %s in meter", prim->name);
     }
     bool direct = ext->properties.get<IR::Property>("instance_count"_cs) == nullptr;
-    bool pre_color = strstr(prim->name.c_str(), "pre_color");
-    bool with_or = strstr(prim->name.c_str(), "with_or");
+    bool pre_color = prim->name.find("pre_color") != nullptr;
+    bool with_or = prim->name.find("with_or") != nullptr;
     if (prim->operands.size() != 2U + pre_color + !direct)
         error("Expected %d operands for %s", 1 + pre_color + !direct, prim);
     auto dest = conv.convert(prim->operands.at(1));

--- a/backends/tofino/bf-p4c/arch/fromv1.0/programStructure.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/programStructure.cpp
@@ -2664,7 +2664,7 @@ const IR::P4Program *TnaProgramStructure::create(Util::SourceInfo info) {
 FixChecksum::FixChecksum(TnaProgramStructure *structure) {
     CHECK_NULL(structure);
     refMap.setIsV1(true);
-    auto parserGraphs = new P4ParserGraphs(&refMap, cstring());
+    auto parserGraphs = new P4ParserGraphs(&refMap, false);
     addPasses({
         new P4::CreateBuiltins(),
         new P4::ResolveReferences(&refMap, true),  // check shadowing

--- a/backends/tofino/bf-p4c/arch/fromv1.0/stateful_alu.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/stateful_alu.cpp
@@ -859,7 +859,7 @@ IR::IndexedVector<IR::Node>::iterator find_in_scope(IR::Vector<IR::Node> *scope,
             }
         }
     }
-    BUG_CHECK("%s not in scope", name);
+    BUG_CHECK("%s not in scope", name.c_str());
     return scope->end();
 }
 

--- a/backends/tofino/bf-p4c/arch/fromv1.0/stateful_alu.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/stateful_alu.cpp
@@ -859,7 +859,7 @@ IR::IndexedVector<IR::Node>::iterator find_in_scope(IR::Vector<IR::Node> *scope,
             }
         }
     }
-    BUG_CHECK("%s not in scope", name.c_str());
+    BUG("%v not in scope", name);
     return scope->end();
 }
 

--- a/backends/tofino/bf-p4c/arch/v1model.cpp
+++ b/backends/tofino/bf-p4c/arch/v1model.cpp
@@ -320,7 +320,7 @@ class LoadTargetArchitecture : public Inspector {
         }
 #endif  // HAVE_JBAY
         else
-            BUG("Unsupported device id %s"_cs, Device::currentDevice());
+            BUG("Unsupported device id %s", Device::currentDevice());
         filenames.push_back("tofino/stratum.p4");
         filenames.push_back("tofino/p4_14_prim.p4");
 
@@ -482,7 +482,7 @@ class NormalizeProgram : public Transform {
         } else if (auto parser = node->to<IR::P4Parser>()) {
             list = parser->type->getApplyParameters();
         } else {
-            BUG("Unknown block type %1%"_cs, node);
+            BUG("Unknown block type %1%", node);
         }
 
         for (auto p : list->parameters) {
@@ -648,7 +648,7 @@ class AnalyzeProgram : public Inspector {
     void analyzeArchBlock(const IR::ToplevelBlock *blk, cstring name, cstring type) {
         auto main = blk->getMain();
         auto ctrl = main->findParameterValue(name);
-        ERROR_CHECK(ctrl != nullptr, "%1%: could not find parameter %2%"_cs, main, name);
+        ERROR_CHECK(ctrl != nullptr, "%1%: could not find parameter %2%", main, name.c_str());
         ERROR_CHECK(ctrl->is<BlockType>(), "%1%: main package match the expected model", main);
         auto block = ctrl->to<BlockType>()->container;
         BUG_CHECK(block != nullptr, "Unable to find %1% block in V1Switch", name);

--- a/backends/tofino/bf-p4c/asm.cpp
+++ b/backends/tofino/bf-p4c/asm.cpp
@@ -88,7 +88,7 @@ bool AsmOutput::preorder(const IR::BFN::Pipe *pipe) {
         auto outputDir = BFNContext::get().getOutputDirectory(cstring::empty, pipe_id);
         if (!outputDir) return false;
         cstring outputFile = outputDir + "/"_cs + options.programName + ".bfa"_cs;
-        std::ofstream out(outputFile, std::ios_base::out);
+        std::ofstream out(outputFile.c_str(), std::ios_base::out);
 
         MauAsmOutput *mauasm = nullptr;
         if (!mauasm) mauasm = new Tofino::MauAsmOutput(phv, pipe, nxt_tbl, power_and_mpr, options);

--- a/backends/tofino/bf-p4c/asm.cpp
+++ b/backends/tofino/bf-p4c/asm.cpp
@@ -85,10 +85,11 @@ bool AsmOutput::preorder(const IR::BFN::Pipe *pipe) {
     LOG1("ASM generation for successful compile? " << (_successfulCompile ? "true" : "false"));
 
     if (_successfulCompile) {
-        auto outputDir = BFNContext::get().getOutputDirectory(cstring::empty, pipe_id);
-        if (!outputDir) return false;
-        cstring outputFile = outputDir + "/"_cs + options.programName + ".bfa"_cs;
-        std::ofstream out(outputFile.c_str(), std::ios_base::out);
+        std::filesystem::path outputDir =
+            BFNContext::get().getOutputDirectory(cstring::empty, pipe_id).c_str();
+        if (outputDir.empty()) return false;
+        auto outputFile = (outputDir / options.programName.c_str()).replace_extension("bfa");
+        std::ofstream out(outputFile, std::ios_base::out);
 
         MauAsmOutput *mauasm = nullptr;
         if (!mauasm) mauasm = new Tofino::MauAsmOutput(phv, pipe, nxt_tbl, power_and_mpr, options);

--- a/backends/tofino/bf-p4c/backend.cpp
+++ b/backends/tofino/bf-p4c/backend.cpp
@@ -151,7 +151,7 @@ class CheckUnimplementedFeatures : public Inspector {
                       source.toString());
         else
             throw Util::CompilerUnimplemented(
-                source.sourceLine, source.fileName,
+                source.sourceLine, source.fileName.c_str(),
                 "Table entries are not yet implemented in this backend");
         return false;
     }
@@ -259,7 +259,7 @@ Backend::Backend(const BFN_Options &o, int pipe_id)
         new CollectPhvInfo(phv),
         new GatherReductionOrReqs(deps.red_info),
         new InstructionSelection(options, phv, deps.red_info),
-        new DumpPipe("After InstructionSelection"_cs),
+        new DumpPipe("After InstructionSelection"),
         new FindDependencyGraph(phv, deps, &options, "program_graph"_cs,
                                 "After Instruction Selection"_cs),
         options.decaf ? &decaf : nullptr,
@@ -275,7 +275,7 @@ Backend::Backend(const BFN_Options &o, int pipe_id)
         new AutoAlias(phv, *pragmaAlias, *noOverlay),
         new Alias(phv, *pragmaAlias),
         new CollectPhvInfo(phv),
-        new DumpPipe("After Alias"_cs),
+        new DumpPipe("After Alias"),
         // This is the backtracking point from table placement to PHV allocation. Based on a
         // container conflict-free PHV allocation, we generate a number of no-pack conflicts between
         // fields (these are fields written in different nonmutually exclusive actions in the same
@@ -284,7 +284,7 @@ Backend::Backend(const BFN_Options &o, int pipe_id)
         // metadata packing.
         &mau_backtracker,
         new ResolveSizeOfOperator(),
-        new DumpPipe("After ResolveSizeOfOperator"_cs),
+        new DumpPipe("After ResolveSizeOfOperator"),
         // Run after bridged metadata packing as bridged packing updates the parser state.
         new CollectPhvInfo(phv),
         new ParserCopyProp(phv),
@@ -353,7 +353,7 @@ Backend::Backend(const BFN_Options &o, int pipe_id)
         //                                        with table info
         //     Trivial PHV alloc => table alloc ==================> PHV alloc ===> redo table.
         new AddInitsInMAU(phv, mauInitFields, false),
-        new DumpPipe("Before phv_analysis"_cs),
+        new DumpPipe("Before phv_analysis"),
         new DumpTableFlowGraph(phv),
         options.alt_phv_alloc
             ? new PassManager({
@@ -445,7 +445,7 @@ Backend::Backend(const BFN_Options &o, int pipe_id)
         // tables to be split across stages.
         new GeneratePrimitiveInfo(phv, primNode),
         &table_alloc,
-        new DumpPipe("After TableAlloc"_cs),
+        new DumpPipe("After TableAlloc"),
         &table_summary,
         // Rerun defuse analysis here so that table placements are used to correctly calculate live
         // ranges output in the assembly.
@@ -462,7 +462,7 @@ Backend::Backend(const BFN_Options &o, int pipe_id)
                                : nullptr,
         new InstructionAdjustment(phv, deps.red_info),
         &nextTblProp,  // Must be run after all modifications to the table graph have finished!
-        new DumpPipe("Final table graph"_cs),
+        new DumpPipe("Final table graph"),
         new CheckFieldCorruption(defuse, phv, PHV_Analysis->get_pragmas()),
         new AdjustExtract(phv),
         phvLoggingDefUseInfo,

--- a/backends/tofino/bf-p4c/bf-p4c-options.h
+++ b/backends/tofino/bf-p4c/bf-p4c-options.h
@@ -167,6 +167,8 @@ class BFNContext : public virtual P4CContext {
     /// If the directory does not exists, it is created. If the
     /// creation fails print an error message and return an empty
     /// string.
+    /// FIXME: Make this return std::filesystem::path. There are quite a few invocations of this
+    /// function.
     cstring getOutputDirectory(const cstring &suffix = cstring(), int pipe_id = -1);
 
     /// identify the pipelines in the program and setup the _pipes map

--- a/backends/tofino/bf-p4c/common/bridged_packing.cpp
+++ b/backends/tofino/bf-p4c/common/bridged_packing.cpp
@@ -1024,7 +1024,7 @@ void CollectConstraints::end_apply() {
 
 void ConstraintSolver::add_field_alignment_constraints(cstring hdr, const PHV::Field *f,
                                                        int upper_bound) {
-    z3::expr v = context.bv_const(f->name, 16);
+    z3::expr v = context.bv_const(f->name.c_str(), 16);
 
     // lower bound for variable
     solver.add(v >= 0);
@@ -1059,8 +1059,8 @@ void ConstraintSolver::add_non_overlap_constraints(cstring hdr,
     using const_iterator = ordered_set<const PHV::Field *>::const_iterator;
     for (const_iterator it = fields.begin(); it != fields.end(); it++) {
         for (const_iterator it2 = it; ++it2 != fields.end();) {
-            z3::expr v1 = context.bv_const((*it)->name, 16);
-            z3::expr v2 = context.bv_const((*it2)->name, 16);
+            z3::expr v1 = context.bv_const((*it)->name.c_str(), 16);
+            z3::expr v2 = context.bv_const((*it2)->name.c_str(), 16);
             solver.add((v2 - v1 >= (*it)->size) || (v1 - v2 >= (*it2)->size));
 
             std::stringstream str;
@@ -1083,8 +1083,8 @@ void ConstraintSolver::add_extract_together_constraints(cstring hdr,
     for (const_iterator it = fields.begin(); it != fields.end(); it++) {
         for (const_iterator it2 = it; ++it2 != fields.end();) {
             if (phv.are_bridged_extracted_together(*it, *it2)) {
-                z3::expr v1 = context.bv_const((*it)->name, 16);
-                z3::expr v2 = context.bv_const((*it2)->name, 16);
+                z3::expr v1 = context.bv_const((*it)->name.c_str(), 16);
+                z3::expr v2 = context.bv_const((*it2)->name.c_str(), 16);
                 LOG6("Copack constraint: " << v1 << " and " << v2);
                 z3::expr pack_same_byte = (v1 / 8 == v2 / 8);
                 solver.add(pack_same_byte);
@@ -1114,8 +1114,8 @@ void ConstraintSolver::add_mutually_aligned_constraints(ordered_set<const PHV::F
     for (const_iterator it = fields.begin(); it != fields.end(); it++) {
         for (const_iterator it2 = it; ++it2 != fields.end();) {
             if (phv.are_mutually_aligned(*it, *it2)) {
-                z3::expr v1 = context.bv_const((*it)->name, 16);
-                z3::expr v2 = context.bv_const((*it2)->name, 16);
+                z3::expr v1 = context.bv_const((*it)->name.c_str(), 16);
+                z3::expr v2 = context.bv_const((*it2)->name.c_str(), 16);
                 LOG6("Mutually aligned constraint: " << v1 << " and " << v2);
                 solver.add(v1 % 8 == v2 % 8);
 
@@ -1137,8 +1137,8 @@ void ConstraintSolver::add_solitary_constraints(cstring hdr,
         if (!f1->is_solitary()) continue;
         for (auto f2 : fields) {
             if (f1->id == f2->id) continue;
-            z3::expr v1 = context.bv_const(f1->name, 16);
-            z3::expr v2 = context.bv_const(f2->name, 16);
+            z3::expr v1 = context.bv_const(f1->name.c_str(), 16);
+            z3::expr v2 = context.bv_const(f2->name.c_str(), 16);
             //
             //   byte1     byte2    byte3
             // |......22|...111..|22.......|
@@ -1175,7 +1175,7 @@ void ConstraintSolver::add_deparsed_to_tm_constraints(cstring hdr,
         if (f->size > 8) continue;
         if (!f->deparsed_to_tm()) continue;
         if (!f->no_split()) continue;
-        z3::expr v = context.bv_const(f->name, 16);
+        z3::expr v = context.bv_const(f->name.c_str(), 16);
         z3::expr mustFitSingleByte = ((v / 8) * 8) == (((v + f->size - 1) / 8) * 8);
         LOG6("NoSplit constraint: " << f);
         solver.add(mustFitSingleByte);
@@ -1193,7 +1193,7 @@ void ConstraintSolver::add_no_split_constraints(cstring hdr,
                                                 ordered_set<const PHV::Field *> &fields) {
     for (auto f : fields) {
         if (!f->no_split()) continue;
-        z3::expr v = context.bv_const(f->name, 16);
+        z3::expr v = context.bv_const(f->name.c_str(), 16);
         if (f->size <= 8) {
             if (f->no_split_container_size() != -1) continue;
             z3::expr mustFitSingleByte = ((v / 8) * 8) == (((v + f->size - 1) / 8) * 8);
@@ -1236,8 +1236,8 @@ void ConstraintSolver::add_no_split_constraints(cstring hdr,
             if (f1->id == f2->id) continue;
             // skip if f1 and f2 has a copack constraint
             if (phv.are_bridged_extracted_together(f1, f2)) continue;
-            z3::expr v1 = context.bv_const(f1->name, 16);
-            z3::expr v2 = context.bv_const(f2->name, 16);
+            z3::expr v1 = context.bv_const(f1->name.c_str(), 16);
+            z3::expr v2 = context.bv_const(f2->name.c_str(), 16);
 
             z3::expr upperBound = (v2 >= (((v1 + f1->no_split_container_size()) / 8) * 8));
             z3::expr lowerBound = (v2 + f2->size) <= ((v1 / 8) * 8);
@@ -1263,8 +1263,8 @@ void ConstraintSolver::add_no_pack_constraints(cstring hdr,
     for (const_iterator it = fields.begin(); it != fields.end(); it++) {
         for (const_iterator it2 = it; ++it2 != fields.end();) {
             if (phv.isFieldNoPack(*it, *it2)) {
-                z3::expr v1 = context.bv_const((*it)->name, 16);
-                z3::expr v2 = context.bv_const((*it2)->name, 16);
+                z3::expr v1 = context.bv_const((*it)->name.c_str(), 16);
+                z3::expr v2 = context.bv_const((*it2)->name.c_str(), 16);
                 LOG6("NoPack constraint: " << v1 << " and " << v2);
                 z3::expr noPack = (((v1 + (*it)->size) / 8) * 8) < ((v2 / 8) * 8) ||
                                   (((v2 + (*it2)->size) / 8) * 8) < ((v1 / 8) * 8);

--- a/backends/tofino/bf-p4c/common/extract_maupipe.cpp
+++ b/backends/tofino/bf-p4c/common/extract_maupipe.cpp
@@ -1297,7 +1297,7 @@ void AttachTables::InitializeStatefulAlus ::updateAttachedSalu(const IR::Declara
     if (ext->type->toString().startsWith("LearnAction")) salu->learn_action = true;
 
     auto prim = findContext<IR::MAU::Primitive>();
-    LOG6("  - " << (prim ? prim->name : "<no primitive>"));
+    LOG6("  - " << (prim ? prim->name.c_str() : "<no primitive>"));
     if (prim && prim->name.endsWith(".address")) {
         salu->chain_vpn = true;
         return;

--- a/backends/tofino/bf-p4c/common/parse_annotations.h
+++ b/backends/tofino/bf-p4c/common/parse_annotations.h
@@ -49,7 +49,7 @@ namespace BFN {
 class ParseAnnotations : public P4::ParseAnnotations {
  public:
     ParseAnnotations()
-        : P4::ParseAnnotations("BFN"_cs, true,
+        : P4::ParseAnnotations("BFN", true,
                                {
                                    // Ignore p4v annotations.
                                    PARSE_SKIP("assert"_cs),

--- a/backends/tofino/bf-p4c/control-plane/bfruntime_arch_handler.h
+++ b/backends/tofino/bf-p4c/control-plane/bfruntime_arch_handler.h
@@ -1735,11 +1735,10 @@ class BFRuntimeArchHandlerTofino final : public BFN::BFRuntimeArchHandlerCommon<
         auto *params = parser->getApplyParameters();
         for (auto p : *params) {
             if (p->type->toString() == "ingress_intrinsic_metadata_t") {
-                BUG_CHECK(
-                    ingressIntrinsicMdParamName.count(parserBlock) == 0 ||
-                        strcmp(ingressIntrinsicMdParamName[parserBlock], p->name.toString()) == 0,
-                    "%1%: Multiple names of intrinsic metadata found in this parser block",
-                    parser->getName());
+                BUG_CHECK(ingressIntrinsicMdParamName.count(parserBlock) == 0 ||
+                              ingressIntrinsicMdParamName[parserBlock] == p->name.toString(),
+                          "%1%: Multiple names of intrinsic metadata found in this parser block",
+                          parser->getName());
                 ingressIntrinsicMdParamName[parserBlock] = p->name;
                 break;
             }
@@ -1861,7 +1860,7 @@ class BFRuntimeArchHandlerTofino final : public BFN::BFRuntimeArchHandlerCommon<
                     BUG_CHECK(parser->is<IR::ParserBlock>(), "Expected ParserBlock");
                     auto parserBlock = parser->to<IR::ParserBlock>();
                     auto decl = parserBlock->node->to<IR::Declaration_Instance>();
-                    auto userName = (decl == nullptr) ? "" : decl->controlPlaneName();
+                    auto userName = (decl == nullptr) ? cstring::empty : decl->controlPlaneName();
 
                     auto choice = parserChoices.add_choices();
                     auto parserFullName = prefix(parsersName, parserName);
@@ -2431,7 +2430,7 @@ class BFRuntimeArchHandlerPSA final : public BFRuntimeArchHandlerCommon<Arch::PS
     }
 
     void addTableProperties(const P4RuntimeSymbolTableIface &symbols, p4configv1::P4Info *p4info,
-                            p4configv1::Table *table, const IR::TableBlock *tableBlock) {
+                            p4configv1::Table *table, const IR::TableBlock *tableBlock) override {
         CHECK_NULL(tableBlock);
         addTablePropertiesCommon(symbols, p4info, table, tableBlock, defaultPipeName);
     }

--- a/backends/tofino/bf-p4c/ir/dbprint-tofino.cpp
+++ b/backends/tofino/bf-p4c/ir/dbprint-tofino.cpp
@@ -37,7 +37,7 @@ void IR::MAU::Table::dbprint(std::ostream &out) const {
             out << gw.first;
         else
             out << "(miss)";
-        out << " => " << (gw.second ? gw.second : "run table");
+        out << " => " << (gw.second.isNullOrEmpty() ? "run table"_cs : gw.second);
     }
     for (auto &payload : gateway_payload) {
         out << endl << "payload " << payload.first << " => " << payload.second.first;
@@ -225,7 +225,7 @@ void IR::BFN::Transition::dbprint(std::ostream &out) const {
         out << endl;
     }
 
-    out << "goto " << (next ? next->name : "(end)");
+    out << "goto " << (next ? next->name : "(end)"_cs);
 }
 
 void IR::BFN::Select::dbprint(std::ostream &out) const {

--- a/backends/tofino/bf-p4c/ir/mau.cpp
+++ b/backends/tofino/bf-p4c/ir/mau.cpp
@@ -193,7 +193,7 @@ void Table::visit_gateway_inhibited(THIS *self, Visitor &v, payload_info_t &payl
             if (!current) current = &saved->flow_clone();
             if (auto *gwcf = dynamic_cast<::BFN::GatewayControlFlow *>(current))
                 gwcf->pre_visit_table_next(self, tag);
-            current->visit(self->next.at(tag), tag);
+            current->visit(self->next.at(tag), tag.c_str());
             if (payload_info.post_payload) {
                 if (current != payload_info.post_payload)
                     payload_info.post_payload->flow_merge(*current);
@@ -245,7 +245,7 @@ class SplitFlowVisitTableNext : public SplitFlowVisit_base {
 
             if (table->next.count(next_action_key)) {
                 if (!next_visitor) next_visitor = &saved->flow_clone();
-                next_visitor->visit(table->next.at(next_action_key), next_action_key,
+                next_visitor->visit(table->next.at(next_action_key), next_action_key.c_str(),
                                     start_index + idx);
             }
         }
@@ -625,7 +625,7 @@ bool IR::MAU::Table::hit_miss_p4() const {
 
 bool IR::MAU::Table::action_chain() const {
     for (auto &n : next) {
-        if (n.first[0] != '$') {
+        if (n.first.get(0) != '$') {
             return true;
         }
     }
@@ -683,7 +683,7 @@ bool IR::MAU::Table::has_non_exit_action() const {
 int IR::MAU::Table::action_next_paths() const {
     int action_paths = 0;
     for (auto &n : next) {
-        if (n.first == "$default" || n.first[0] != '$') action_paths++;
+        if (n.first == "$default" || n.first.get(0) != '$') action_paths++;
     }
     if (has_exit_action()) action_paths++;
     return action_paths;

--- a/backends/tofino/bf-p4c/ir/mau.cpp
+++ b/backends/tofino/bf-p4c/ir/mau.cpp
@@ -625,7 +625,7 @@ bool IR::MAU::Table::hit_miss_p4() const {
 
 bool IR::MAU::Table::action_chain() const {
     for (auto &n : next) {
-        if (n.first.get(0) != '$') {
+        if (!n.first.startsWith("$")) {
             return true;
         }
     }
@@ -683,7 +683,7 @@ bool IR::MAU::Table::has_non_exit_action() const {
 int IR::MAU::Table::action_next_paths() const {
     int action_paths = 0;
     for (auto &n : next) {
-        if (n.first == "$default" || n.first.get(0) != '$') action_paths++;
+        if (n.first == "$default" || !n.first.startsWith("$")) action_paths++;
     }
     if (has_exit_action()) action_paths++;
     return action_paths;

--- a/backends/tofino/bf-p4c/ir/parde.def
+++ b/backends/tofino/bf-p4c/ir/parde.def
@@ -219,7 +219,7 @@ class ExtractPhv : Extract {
 class ExtractClot : Extract {
     dbprint {
         out << "extract " << source << " to CLOT-allocated " << dest << " from "
-            << (original_state ? original_state->name : "(nullptr)");
+            << (original_state ? original_state->name : "(nullptr)"_cs);
     }
 
     validate {

--- a/backends/tofino/bf-p4c/lib/cmp.h
+++ b/backends/tofino/bf-p4c/lib/cmp.h
@@ -96,9 +96,7 @@ class LiftCompare : public LiftEqual<T>, public LiftLess<T> {
 template <class T>
 class ByNameLess {
  public:
-    bool operator()(const T &a, const T &b) const {
-        return std::strcmp(a.getName().name, b.getName().name) < 0;
-    }
+    bool operator()(const T &a, const T &b) const { return a.getName().name < b.getName().name; }
 
     bool operator()(const T *a, const T *b) const {
         // note: std::less is guaranteed to be defined for pointers, operator < is not

--- a/backends/tofino/bf-p4c/logging/manifest.cpp
+++ b/backends/tofino/bf-p4c/logging/manifest.cpp
@@ -310,7 +310,7 @@ void Manifest::OutputFiles::serialize(Writer &writer) const {
     writer.StartObject();  // Abe`s note: is this a bug?  I copied it verbatim from the legacy code.
     writer.Key("path");
     if (m_context)
-        writer.String(m_context);
+        writer.String(m_context.c_str());
     else
         writer.String("");
     writer.EndObject();
@@ -320,7 +320,7 @@ void Manifest::OutputFiles::serialize(Writer &writer) const {
         writer.Key("binary");
         writer.StartObject();
         writer.Key("path");
-        writer.String(m_context);
+        writer.String(m_context.c_str());
         writer.EndObject();
     }
 

--- a/backends/tofino/bf-p4c/logging/phv_logging.cpp
+++ b/backends/tofino/bf-p4c/logging/phv_logging.cpp
@@ -547,7 +547,7 @@ void PhvLogging::logNoSplitConstraint(ConstrainedField &field, const SourceLocat
 }
 
 void PhvLogging::logContainerSizeConstraint(ConstrainedField &field, const SourceLocation *srcLoc) {
-    auto &c = field.getContainerSize();
+    auto c = field.getContainerSize();
     if (c.hasConstraint()) {
         auto csc = new IntConstraint(c.getContainerSize(), int(ConstraintReason::ContainerSize),
                                      "ContainerSize", srcLoc);
@@ -811,7 +811,7 @@ const char *PhvLogging::getDeparserAccessType(const PHV::Field *f) const {
 
 std::string PhvLogging::stripDotPrefix(const cstring name) const {
     // Check if the name starts with a '.' and strip it
-    if (name[0] != '.') return name.c_str();
+    if (name.get(0) != '.') return name.c_str();
     return name.substr(1).c_str();
 }
 

--- a/backends/tofino/bf-p4c/logging/phv_logging.cpp
+++ b/backends/tofino/bf-p4c/logging/phv_logging.cpp
@@ -811,8 +811,8 @@ const char *PhvLogging::getDeparserAccessType(const PHV::Field *f) const {
 
 std::string PhvLogging::stripDotPrefix(const cstring name) const {
     // Check if the name starts with a '.' and strip it
-    if (name.get(0) != '.') return name.c_str();
-    return name.substr(1).c_str();
+    if (!name.startsWith(".")) return name.string();
+    return name.substr(1).string();
 }
 
 void PhvLogging::getAllDeparserUses(const PHV::Field *f,

--- a/backends/tofino/bf-p4c/logging/resources_parser.cpp
+++ b/backends/tofino/bf-p4c/logging/resources_parser.cpp
@@ -57,7 +57,7 @@ bool ParserResourcesLogging::preorder(const IR::BFN::LoweredParserState *state) 
     for (const auto *match : state->transitions) {
         LOG1("State Match: " << match);
         std::string nextStateName =
-            (match->next ? match->next->name : (match->loop ? match->loop : "END"));
+            (match->next ? match->next->name.c_str() : (match->loop ? match->loop.c_str() : "END"));
         nextStateName = stripThreadPrefix(nextStateName);
         auto states = logStateTransitionsByMatch(nextStateName, state, match);
         for (auto state : states) {

--- a/backends/tofino/bf-p4c/logging/resources_parser.cpp
+++ b/backends/tofino/bf-p4c/logging/resources_parser.cpp
@@ -57,7 +57,7 @@ bool ParserResourcesLogging::preorder(const IR::BFN::LoweredParserState *state) 
     for (const auto *match : state->transitions) {
         LOG1("State Match: " << match);
         std::string nextStateName =
-            (match->next ? match->next->name.c_str() : (match->loop ? match->loop.c_str() : "END"));
+            (match->next ? match->next->name.string() : (match->loop ? match->loop.string() : "END"));
         nextStateName = stripThreadPrefix(nextStateName);
         auto states = logStateTransitionsByMatch(nextStateName, state, match);
         for (auto state : states) {

--- a/backends/tofino/bf-p4c/logging/resources_parser.cpp
+++ b/backends/tofino/bf-p4c/logging/resources_parser.cpp
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* clang-format off */
-
 #include "backends/tofino/bf-p4c/device.h"
+// Device needs to be imported first.
 #include "resources_parser.h"
 
 namespace BFN {
@@ -31,7 +30,7 @@ bool ParserResourcesLogging::preorder(const IR::BFN::LoweredParser *parser) {
     const auto nStates = Device::pardeSpec().numTcamRows();
 
     BUG_CHECK(parsers[parser->name].phase0 == nullptr,
-            "phase0 for parser: %1% is already set unexpectedly!", parser->name);
+              "phase0 for parser: %1% is already set unexpectedly!", parser->name);
 
     if (parser->gress == INGRESS) {
         if (parser->phase0) {
@@ -56,8 +55,8 @@ bool ParserResourcesLogging::preorder(const IR::BFN::LoweredParserState *state) 
 
     for (const auto *match : state->transitions) {
         LOG1("State Match: " << match);
-        std::string nextStateName =
-            (match->next ? match->next->name.string() : (match->loop ? match->loop.string() : "END"));
+        std::string nextStateName = (match->next ? match->next->name.string()
+                                                 : (match->loop ? match->loop.string() : "END"));
         nextStateName = stripThreadPrefix(nextStateName);
         auto states = logStateTransitionsByMatch(nextStateName, state, match);
         for (auto state : states) {
@@ -87,13 +86,13 @@ ParserResourcesLogging::logStateTransitionsByMatch(const std::string &nextStateN
 
         CHECK_NULL(match);
         for (auto *stmt : match->extracts) {
-          CHECK_NULL(stmt);
+            CHECK_NULL(stmt);
 
             if (auto *extract = stmt->to<IR::BFN::LoweredExtractClot>()) {
                 if (extract->dest) {
                     parser_state_transition->append_clot_extracts(new ClotExtracts(
-                            extract->source->to<IR::BFN::LoweredPacketRVal>()->range.lo,
-                            extract->source->to<IR::BFN::LoweredPacketRVal>()->range.size(),
+                        extract->source->to<IR::BFN::LoweredPacketRVal>()->range.lo,
+                        extract->source->to<IR::BFN::LoweredPacketRVal>()->range.size(),
                         extract->dest->tag));
                 }
             }
@@ -151,8 +150,8 @@ void ParserResourcesLogging::logStateExtracts(const IR::BFN::LoweredParserMatch 
             BUG_CHECK(buffer || constVal, "Unknown extract primitive: %1%", prim);
 
             auto ex = new StateExtracts(bitWidth, destContainer, extractorId,
-                buffer ? new int(buffer->range.loByte()) : nullptr,
-                constVal ? new int(constVal->constant) : nullptr);
+                                        buffer ? new int(buffer->range.loByte()) : nullptr,
+                                        constVal ? new int(constVal->constant) : nullptr);
             result.push_back(ex);
         }
     }
@@ -188,8 +187,8 @@ void ParserResourcesLogging::logStateMatches(const IR::BFN::LoweredParserState *
         BUG_CHECK(constVal || pvs, "Unknown parser match value type: %1%", match->value);
 
         auto smo = new StateMatchesOn(bitWidth, hardwareId,
-            constVal ? getConstVal(constVal, bitWidth, shift) : "",
-            pvs ? pvs->name.c_str() : "");
+                                      constVal ? getConstVal(constVal, bitWidth, shift) : "",
+                                      pvs ? pvs->name.c_str() : "");
         result.push_back(smo);
     }
 }

--- a/backends/tofino/bf-p4c/mau/asm_output.cpp
+++ b/backends/tofino/bf-p4c/mau/asm_output.cpp
@@ -1078,10 +1078,11 @@ void MauAsmOutput::emit_table_format(std::ostream &out, indent_t indent,
                 for (size_t i = 0; i < bits.size(); i++) {
                     cstring name = format_name(type);
                     if (bits.size() > 1) name = name + std::to_string(i);
-                    fmt.emit(out, name, group, bits[i].first, bits[i].second - bits[i].first + 1);
+                    fmt.emit(out, name.c_str(), group, bits[i].first,
+                             bits[i].second - bits[i].first + 1);
                 }
             } else {
-                fmt.emit(out, format_name(type), group, bits);
+                fmt.emit(out, format_name(type).c_str(), group, bits);
             }
         }
 
@@ -1122,7 +1123,7 @@ void MauAsmOutput::emit_table_format(std::ostream &out, indent_t indent,
             } while (start_bit != -1);
         }
         bits.emplace_back(start, end);
-        fmt.emit(out, format_name(type), group, bits);
+        fmt.emit(out, format_name(type).c_str(), group, bits);
         group++;
     }
 

--- a/backends/tofino/bf-p4c/mau/gen_prim_json.cpp
+++ b/backends/tofino/bf-p4c/mau/gen_prim_json.cpp
@@ -186,7 +186,7 @@ void GeneratePrimitiveInfo::gen_action_json(const IR::MAU::Table *tbl, const IR:
                                 sact_update->emplace("operand_1_type"_cs, "memory");
                                 auto dst_name = (dst->name == "alu_lo")   ? "memory_lo"
                                                 : (dst->name == "alu_hi") ? "memory_hi"
-                                                                          : dst->name;
+                                                                          : dst->name.c_str();
                                 sact_update->emplace("operand_1_value"_cs, dst_name);
                                 salu_details->emplace("output_value"_cs, sact_update);
                             }

--- a/backends/tofino/bf-p4c/mau/instruction_selection.cpp
+++ b/backends/tofino/bf-p4c/mau/instruction_selection.cpp
@@ -1311,7 +1311,7 @@ static const IR::Type *stateful_type_for_primitive(const IR::MAU::Primitive *pri
         prim->name == "Lpf.execute" || prim->name == "DirectLpf.execute" ||
         prim->name == "Wred.execute" || prim->name == "DirectWred.execute")
         return IR::Type_Meter::get();
-    if (auto a = strstr(prim->name.c_str(), "Action")) {
+    if (auto a = prim->name.find("Action")) {
         if (a[6] == '.' || (std::isdigit(a[6]) && a[7] == '.')) return IR::Type_Register::get();
     }
     if (prim->name == "Register.clear" || prim->name == "DirectRegister.clear")
@@ -1325,7 +1325,7 @@ static ssize_t index_operand(const IR::MAU::Primitive *prim) {
     else if (prim->name.startsWith("Counter") || prim->name.startsWith("Meter") ||
              prim->name.endsWith("Action.execute"))
         return 1;
-    else if (strstr(prim->name.c_str(), "Action."))
+    else if (prim->name.find("Action.") != nullptr)
         return -1;
     else if (prim->name.startsWith("Lpf") || prim->name.startsWith("Wred"))
         return 2;

--- a/backends/tofino/bf-p4c/mau/instruction_selection.cpp
+++ b/backends/tofino/bf-p4c/mau/instruction_selection.cpp
@@ -1127,7 +1127,7 @@ static const IR::MAU::Instruction *fillInstDest(const IR::Expression *in,
     if (!tv) tv = sl ? sl->e0->to<IR::TempVar>() : nullptr;
     if (tv) {
         int id;
-        if (sscanf(tv->name, "$tmp%d", &id) > 0 && id == tv->uid) --tv->uid;
+        if (sscanf(tv->name.c_str(), "$tmp%d", &id) > 0 && id == tv->uid) --tv->uid;
         auto *rv = inst->clone();
         if (sl != nullptr) dest = MakeSlice(dest, 0, sl->type->width_bits() - 1);
         rv->operands[0] = dest;
@@ -1311,7 +1311,7 @@ static const IR::Type *stateful_type_for_primitive(const IR::MAU::Primitive *pri
         prim->name == "Lpf.execute" || prim->name == "DirectLpf.execute" ||
         prim->name == "Wred.execute" || prim->name == "DirectWred.execute")
         return IR::Type_Meter::get();
-    if (auto a = strstr(prim->name, "Action")) {
+    if (auto a = strstr(prim->name.c_str(), "Action")) {
         if (a[6] == '.' || (std::isdigit(a[6]) && a[7] == '.')) return IR::Type_Register::get();
     }
     if (prim->name == "Register.clear" || prim->name == "DirectRegister.clear")
@@ -1325,7 +1325,7 @@ static ssize_t index_operand(const IR::MAU::Primitive *prim) {
     else if (prim->name.startsWith("Counter") || prim->name.startsWith("Meter") ||
              prim->name.endsWith("Action.execute"))
         return 1;
-    else if (strstr(prim->name, "Action."))
+    else if (strstr(prim->name.c_str(), "Action."))
         return -1;
     else if (prim->name.startsWith("Lpf") || prim->name.startsWith("Wred"))
         return 2;

--- a/backends/tofino/bf-p4c/mau/mau_alloc.cpp
+++ b/backends/tofino/bf-p4c/mau/mau_alloc.cpp
@@ -48,10 +48,10 @@ TableAllocPass::TableAllocPass(const BFN_Options &options, PhvInfo &phv, Depende
          new TableFindSeqDependencies(phv), new CheckTableNameDuplicate,
          new FindDependencyGraph(phv, deps, &options, ""_cs, "Before Table Placement"_cs, &summary),
          new DumpJsonGraph(deps, jsonGraph, "Before Table Placement"_cs, false), &ignore, &mutex,
-         &action_mutex, siaa, new DumpPipe("Before TablePlacement"_cs),
+         &action_mutex, siaa, new DumpPipe("Before TablePlacement"),
          new TablePlacement(options, deps, mutex, phv, *lc, *siaa, att_info, summary,
                             mau_backtracker),
-         new DumpPipe("After TablePlacement"_cs),
+         new DumpPipe("After TablePlacement"),
          new FindDependencyGraph(phv, deps, &options, ""_cs, "After Table Placement"_cs, &summary),
          new TableDependencyGraphSummary(deps), new CheckTableNameDuplicate,
          new TableFindSeqDependencies(phv),  // not needed?

--- a/backends/tofino/bf-p4c/mau/simple_power_graph.cpp
+++ b/backends/tofino/bf-p4c/mau/simple_power_graph.cpp
@@ -127,7 +127,7 @@ void SimplePowerGraph::add_connection(UniqueId parent, ordered_set<UniqueId> act
 /**
  * Outputs the final placed table control flow graphs to a .dot file.
  */
-void SimplePowerGraph::to_dot(const std::filesystem::path& filename) {
+void SimplePowerGraph::to_dot(const std::filesystem::path &filename) {
     std::ofstream myfile;
     myfile.open(filename);
 

--- a/backends/tofino/bf-p4c/mau/simple_power_graph.cpp
+++ b/backends/tofino/bf-p4c/mau/simple_power_graph.cpp
@@ -129,7 +129,7 @@ void SimplePowerGraph::add_connection(UniqueId parent, ordered_set<UniqueId> act
  */
 void SimplePowerGraph::to_dot(cstring filename) {
     std::ofstream myfile;
-    myfile.open(filename);
+    myfile.open(filename.c_str());
 
     std::queue<Node *> queue;
     queue.push(get_root());

--- a/backends/tofino/bf-p4c/mau/simple_power_graph.cpp
+++ b/backends/tofino/bf-p4c/mau/simple_power_graph.cpp
@@ -127,9 +127,9 @@ void SimplePowerGraph::add_connection(UniqueId parent, ordered_set<UniqueId> act
 /**
  * Outputs the final placed table control flow graphs to a .dot file.
  */
-void SimplePowerGraph::to_dot(cstring filename) {
+void SimplePowerGraph::to_dot(const std::filesystem::path& filename) {
     std::ofstream myfile;
-    myfile.open(filename.c_str());
+    myfile.open(filename);
 
     std::queue<Node *> queue;
     queue.push(get_root());

--- a/backends/tofino/bf-p4c/mau/simple_power_graph.h
+++ b/backends/tofino/bf-p4c/mau/simple_power_graph.h
@@ -149,7 +149,7 @@ class SimplePowerGraph : public IHasDbPrint {
     /**
      * Output this graph to the dot file, as specified by the filename.
      */
-    void to_dot(cstring filename);
+    void to_dot(const std::filesystem::path &filename);
     /**
      * Returns a vector of reachable leaf nodes in the graph from the provided
      * Node for the given UniqueId.

--- a/backends/tofino/bf-p4c/mau/split_gateways.cpp
+++ b/backends/tofino/bf-p4c/mau/split_gateways.cpp
@@ -82,7 +82,7 @@ namespace P4 {
 std::ostream &operator<<(std::ostream &out,
                          const std::pair<const P4::IR::Expression *, cstring> &p) {
     if (p.first) out << *p.first << " => ";
-    out << (p.second ? p.second : "_");
+    out << (p.second ? p.second.c_str() : "_");
     return out;
 }
 }  // namespace P4

--- a/backends/tofino/bf-p4c/mau/stateful_alu.cpp
+++ b/backends/tofino/bf-p4c/mau/stateful_alu.cpp
@@ -362,16 +362,16 @@ bool CreateSaluInstruction::applyArg(const IR::PathExpression *pe, cstring field
             }
             if (!opcode) opcode = "alu_a"_cs;
             if (etype == OUTPUT) {
-                const char *pfx = "mem_"_cs;
+                const char *pfx = "mem_";
                 if (local) {
                     if (local->use == LocalVar::ALUHI) {
-                        pfx = "alu_"_cs;
+                        pfx = "alu_";
                     } else if (local->use == LocalVar::NONE) {
                         e = new IR::Constant(0);
                         break;
                     }
                 } else if (alu_write[field_idx]) {
-                    pfx = "alu_"_cs;
+                    pfx = "alu_";
                 }
                 name = pfx + name;
             } else if (etype == MINMAX_SRC)

--- a/backends/tofino/bf-p4c/mau/table_dependency_graph.cpp
+++ b/backends/tofino/bf-p4c/mau/table_dependency_graph.cpp
@@ -610,8 +610,8 @@ void DependencyGraph::to_json(Util::JsonObject *dgsJson, const FlowGraph &fg, cs
             BUG("Invalid dependency graph edge from %1% (gress = %2%) --> %3% (gress = %4%) ",
                 source->name, source->gress, target->name, target->gress);
         auto gress = source ? static_cast<int>(source->gress) : static_cast<int>(target->gress);
-        std::string src_name = std::string(source ? source->name : "SOURCE");
-        std::string dst_name = std::string(target ? target->name : "SINK");
+        std::string src_name = std::string(source ? source->name.c_str() : "SOURCE");
+        std::string dst_name = std::string(target ? target->name.c_str() : "SINK");
 
         edge.label = g[*edges];
         LOG5(src_name.c_str() << " --- " << dep_types(edge.label) << " --> " << dst_name.c_str());
@@ -667,8 +667,8 @@ void DependencyGraph::to_json(Util::JsonObject *dgsJson, const FlowGraph &fg, cs
             auto ftarget = boost::target(*fedges, fg.g);
             const IR::MAU::Table *source = fg.get_vertex(fsource);
             const IR::MAU::Table *target = fg.get_vertex(ftarget);
-            std::string src_name = std::string(source ? source->name : "SOURCE");
-            std::string tgt_name = std::string(target ? target->name : "SINK");
+            std::string src_name = std::string(source ? source->name.c_str() : "SOURCE");
+            std::string tgt_name = std::string(target ? target->name.c_str() : "SINK");
             if (!source && !target)
                 BUG_CHECK(source || target,
                           " Invalid dependency graph edge found with no"
@@ -849,7 +849,7 @@ class FindDataDependencyGraph::AddDependencies : public MauInspector, TofinoWrit
                 LOG5("\tAdd " << dep_types(dep) << " dependency from " << upstream_t->name << " to "
                               << table->name << " because of field " << field->name
                               << " for actions " << upstream_t_pair.second->name << " - "
-                              << (action_use_context ? action_use_context->name.toString()
+                              << (action_use_context ? action_use_context->name.toString().c_str()
                                                      : "nullptr"));
             } else {
                 LOG5("\tAdd " << dep_types(dep) << " dependency from " << upstream_t->name << " to "
@@ -1205,8 +1205,8 @@ bool FindDataDependencyGraph::preorder(const IR::MAU::TableSeq *seq) {
     visitAgain();
     const Context *ctxt = getContext();
     LOG5("\t TableSeq (" << seq->size()
-                         << ")   front: " << (seq->front() ? seq->front()->name : "null")
-                         << " back: " << (seq->back() ? seq->back()->name : "null"));
+                         << ")   front: " << (seq->front() ? seq->front()->name.c_str() : "null")
+                         << " back: " << (seq->back() ? seq->back()->name.c_str() : "null"));
 
     if (ctxt && ctxt->node->is<IR::BFN::Pipe>()) {
         LOG5("\t Hit Top of pipe - clearing access");
@@ -1261,7 +1261,7 @@ bool FindDataDependencyGraph::preorder(const IR::MAU::Table *t) {
 bool FindDataDependencyGraph::preorder(const IR::MAU::TableKey *read) {
     visitAgain();
     auto tbl = findContext<IR::MAU::Table>();
-    LOG5("\t TableKey for table " << (tbl ? tbl->name : "null"));
+    LOG5("\t TableKey for table " << (tbl ? tbl->name.c_str() : "null"));
     read->apply(UpdateAccess(*this, tbl));
     return false;
 }
@@ -1269,7 +1269,7 @@ bool FindDataDependencyGraph::preorder(const IR::MAU::TableKey *read) {
 bool FindDataDependencyGraph::preorder(const IR::MAU::Action *act) {
     visitAgain();
     auto tbl = findContext<IR::MAU::Table>();
-    LOG5("\t Action for table " << (tbl ? tbl->name : "null"));
+    LOG5("\t Action for table " << (tbl ? tbl->name.c_str() : "null"));
     act->apply(UpdateAccess(*this, tbl));
     return false;
 }
@@ -2087,8 +2087,8 @@ void FindDependencyGraph::add_logical_deps_from_control_deps(void) {
         auto target = boost::target(pair.second, dg.g);
         const IR::MAU::Table *tsource = dg.get_vertex(source);
         const IR::MAU::Table *ttarget = dg.get_vertex(target);
-        std::string src_name = std::string(tsource ? tsource->name : "SINK");
-        std::string dst_name = std::string(ttarget ? ttarget->name : "SINK");
+        std::string src_name = std::string(tsource ? tsource->name.c_str() : "SINK");
+        std::string dst_name = std::string(ttarget ? ttarget->name.c_str() : "SINK");
         LOG4("\t\tadd_dependency " << dep_types(dep) << " " << pair.first.first->name << "-"
                                    << pair.first.second->name << " due to original dependency on "
                                    << src_name << "->" << dst_name << " of type "
@@ -2430,7 +2430,7 @@ Visitor::profile_t FindDependencyGraph::init_apply(const IR::Node *node) {
     auto rv = Logging::PassManager::init_apply(node);
     if (!passContext.isNullOrEmpty())
         LOG1("FindDependencyGraph : " << passContext << " : "
-                                      << (summary ? summary->getActualStateStr() : " NA "));
+                                      << (summary ? summary->getActualStateStr().c_str() : " NA "));
     dg.clear();
     return rv;
 }

--- a/backends/tofino/bf-p4c/mau/table_dependency_graph.cpp
+++ b/backends/tofino/bf-p4c/mau/table_dependency_graph.cpp
@@ -610,8 +610,8 @@ void DependencyGraph::to_json(Util::JsonObject *dgsJson, const FlowGraph &fg, cs
             BUG("Invalid dependency graph edge from %1% (gress = %2%) --> %3% (gress = %4%) ",
                 source->name, source->gress, target->name, target->gress);
         auto gress = source ? static_cast<int>(source->gress) : static_cast<int>(target->gress);
-        std::string src_name = std::string(source ? source->name.c_str() : "SOURCE");
-        std::string dst_name = std::string(target ? target->name.c_str() : "SINK");
+        std::string src_name = std::string(source ? source->name.string() : "SOURCE");
+        std::string dst_name = std::string(target ? target->name.string() : "SINK");
 
         edge.label = g[*edges];
         LOG5(src_name.c_str() << " --- " << dep_types(edge.label) << " --> " << dst_name.c_str());
@@ -667,8 +667,8 @@ void DependencyGraph::to_json(Util::JsonObject *dgsJson, const FlowGraph &fg, cs
             auto ftarget = boost::target(*fedges, fg.g);
             const IR::MAU::Table *source = fg.get_vertex(fsource);
             const IR::MAU::Table *target = fg.get_vertex(ftarget);
-            std::string src_name = std::string(source ? source->name.c_str() : "SOURCE");
-            std::string tgt_name = std::string(target ? target->name.c_str() : "SINK");
+            std::string src_name = std::string(source ? source->name.string() : "SOURCE");
+            std::string tgt_name = std::string(target ? target->name.string() : "SINK");
             if (!source && !target)
                 BUG_CHECK(source || target,
                           " Invalid dependency graph edge found with no"

--- a/backends/tofino/bf-p4c/mau/table_flow_graph.cpp
+++ b/backends/tofino/bf-p4c/mau/table_flow_graph.cpp
@@ -35,15 +35,15 @@ std::ostream &operator<<(std::ostream &out, const FlowGraph &fg) {
         auto dst = boost::target(*edges, fg.g);
         const IR::MAU::Table *target = fg.get_vertex(dst);
         auto desc = fg.get_ctrl_dependency_info(*edges);
-        out << "    " << (source ? source->name : "DEPARSER")
+        out << "    " << (source ? source->name.c_str() : "DEPARSER")
             << (src == fg.v_source ? " (PARSER)" : "") << " -- " << desc << " --> "
-            << (target ? target->name : "DEPARSER") << std::endl;
+            << (target ? target->name.c_str() : "DEPARSER") << std::endl;
     }
     return out;
 }
 
 std::string FlowGraph::viz_node_name(const IR::MAU::Table *tbl) {
-    std::string name = std::string(tbl ? tbl->name : "DEPARSER");
+    std::string name = std::string(tbl ? tbl->name.c_str() : "DEPARSER");
     std::replace(name.begin(), name.end(), '-', '_');
     std::replace(name.begin(), name.end(), '.', '_');
     return name;
@@ -252,17 +252,17 @@ bool FindFlowGraph::preorder(const IR::MAU::Table *t) {
             // This will sometimes be null, which will cause an edge to be added to v_sink
             dst = next_table;
         }
-        auto dst_name = dst ? dst->name : "DEPARSER";
+        auto dst_name = dst ? dst->name.c_str() : "DEPARSER";
         LOG1("Parent : " << t->name << " --> " << action_name << " --> " << dst_name);
         fg.add_edge(t, dst, action_name);
     }
 
     // Add edge for t -> next_table, if needed.
-    LOG3("Table: " << t->name << " Next: " << (next_table ? next_table->name : "<null>"));
+    LOG3("Table: " << t->name << " Next: " << (next_table ? next_table->name.c_str() : "<null>"));
     auto n = next_incomplete(t);
     LOG3("next - " << n.first << ":" << n.second);
     if (n.first) {
-        auto dst_name = next_table ? next_table->name : "DEPARSER";
+        auto dst_name = next_table ? next_table->name.c_str() : "DEPARSER";
         LOG1("Parent : " << t->name << " --> " << n.second << " --> " << dst_name);
         // This will sometimes be null, which will cause an edge to be added to v_sink
         fg.add_edge(t, next_table, n.second);

--- a/backends/tofino/bf-p4c/mau/table_mutex.cpp
+++ b/backends/tofino/bf-p4c/mau/table_mutex.cpp
@@ -92,7 +92,7 @@ bool TablesMutuallyExclusive::miss_mutex_action_chain(const IR::MAU::Table *tbl,
         if (default_act->name.originalName == n.first) {
             name = n.first;
             return true;
-        } else if (n.first[0] != '$') {
+        } else if (n.first.get(0) != '$') {
             non_def_act_chains.insert(n.first);
         }
     }

--- a/backends/tofino/bf-p4c/mau/table_mutex.cpp
+++ b/backends/tofino/bf-p4c/mau/table_mutex.cpp
@@ -92,7 +92,7 @@ bool TablesMutuallyExclusive::miss_mutex_action_chain(const IR::MAU::Table *tbl,
         if (default_act->name.originalName == n.first) {
             name = n.first;
             return true;
-        } else if (n.first.get(0) != '$') {
+        } else if (!n.first.startsWith("$")) {
             non_def_act_chains.insert(n.first);
         }
     }

--- a/backends/tofino/bf-p4c/mau/table_summary.cpp
+++ b/backends/tofino/bf-p4c/mau/table_summary.cpp
@@ -472,9 +472,9 @@ void TableSummary::postorder(const IR::BFN::Pipe *pipe) {
     const auto print_table_placement_errors = [&]() {
         for (auto &msg : tablePlacementErrors) {
             if (msg.second)
-                error(msg.first);
+                error(msg.first.c_str());
             else
-                warning(msg.first);
+                warning(msg.first.c_str());
         }
     };
 
@@ -1097,7 +1097,7 @@ ordered_map<int, ordered_map<cstring, int>> TableSummary::collect_table_sram_all
                 // There are allocation for xxx$action xxx$tind. Here extracts the prefix, which is
                 // the table name.
                 for (; pos < tbl.size(); pos++) {
-                    if (tbl[pos] == '$') {
+                    if (tbl.get(pos) == '$') {
                         break;
                     }
                 }

--- a/backends/tofino/bf-p4c/mau/tofino/memories.cpp
+++ b/backends/tofino/bf-p4c/mau/tofino/memories.cpp
@@ -4390,7 +4390,7 @@ void Memories::update(cstring name, const Use &alloc) {
             // for result_buses
             if (u_type == UPDATE_RESULT_BUS && name == use) collision = false;
 
-            if (collision) BUG_CHECK("conflicting memory use between %s and %s", use, name);
+            if (collision) BUG_CHECK("conflicting memory use between %s and %s", use.c_str(), name);
         }
         use = name;
     });

--- a/backends/tofino/bf-p4c/mau/validate_actions.cpp
+++ b/backends/tofino/bf-p4c/mau/validate_actions.cpp
@@ -53,14 +53,10 @@ Visitor::profile_t ValidateActions::init_apply(const IR::Node *root) {
 }
 
 void ValidateActions::end_apply() {
-    cstring error_message;
-    if (phv_alloc)
-        error_message =
-            cstring("PHV allocation creates an invalid container action within a Tofino ALU");
-    else
-        error_message = cstring(
-            "Instruction selection creates an instruction that the rest of the compiler cannot "
-            "correctly interpret");
+    const char *error_message =
+        phv_alloc ? "PHV allocation creates an invalid container action within a Tofino ALU"
+                  : "Instruction selection creates an instruction that the rest of the compiler "
+                    "cannot correctly interpret";
     if (error_found) {
         error(error_message);
     } else if (warning_found) {

--- a/backends/tofino/bf-p4c/mau/walk_power_graph.cpp
+++ b/backends/tofino/bf-p4c/mau/walk_power_graph.cpp
@@ -788,8 +788,8 @@ void WalkPowerGraph::create_mau_power_json(const IR::Node *root) {
     auto logDir =
         BFNContext::get().getOutputDirectory("logs"_cs, root->to<IR::BFN::Pipe>()->canon_id());
     if (!logDir) return;
-    cstring powerFile = logDir + "/power.json"_cs;
-    logger_ = new PowerLogging(powerFile, Logging::Logger::buildDate(), BF_P4C_VERSION,
+    cstring powerFile = logDir + "/power.json";
+    logger_ = new PowerLogging(powerFile.c_str(), Logging::Logger::buildDate(), BF_P4C_VERSION,
                                BackendOptions().programName + ".p4", RunId::getId(),
                                POWER_SCHEMA_VERSION);
 

--- a/backends/tofino/bf-p4c/midend/collect_pipelines.cpp
+++ b/backends/tofino/bf-p4c/midend/collect_pipelines.cpp
@@ -75,7 +75,7 @@ bool CollectPipelines::Pipe::operator==(const Pipe &other) const {
 }
 
 bool CollectPipelines::Pipe::operator<(const Pipe &other) const {
-    return (dec && other.dec && std::strcmp(dec->getName().name, other.dec->getName().name) < 0) ||
+    return (dec && other.dec && dec->getName().name == other.dec->getName().name) ||
            dec < other.dec;
 }
 

--- a/backends/tofino/bf-p4c/midend/move_to_egress.cpp
+++ b/backends/tofino/bf-p4c/midend/move_to_egress.cpp
@@ -42,11 +42,11 @@ MoveToEgress::MoveToEgress(BFN::EvaluatorPass *ev)
               auto main = toplevel->getMain();
               for (auto &pkg : main->constantValue) {
                   LOG2(pkg.first->toString()
-                       << " : " << (pkg.second ? pkg.second->toString() : "nullptr"));
+                       << " : " << (pkg.second ? pkg.second->toString().c_str() : "nullptr"));
                   if (auto pb = pkg.second ? pkg.second->to<IR::PackageBlock>() : nullptr) {
                       for (auto &p : pb->constantValue) {
                           LOG2("  " << p.first->toString() << " : "
-                                    << (p.second ? p.second->toString() : "nullptr"));
+                                    << (p.second ? p.second->toString().c_str() : "nullptr"));
                           if (p.second) {
                               auto name = p.first->toString();
                               if (name == "ingress_parser")

--- a/backends/tofino/bf-p4c/midend/parser_enforce_depth_req.cpp
+++ b/backends/tofino/bf-p4c/midend/parser_enforce_depth_req.cpp
@@ -1221,7 +1221,7 @@ ParserEnforceDepthReq::ParserEnforceDepthReq(P4::ReferenceMap *rm, BFN::Evaluato
             auto main = toplevel->getMain();
             for (auto &pkg : main->constantValue) {
                 LOG2(pkg.first->toString()
-                     << " : " << (pkg.second ? pkg.second->toString() : "nullptr"));
+                     << " : " << (pkg.second ? pkg.second->toString().c_str() : "nullptr"));
                 if (auto pb = pkg.second ? pkg.second->to<IR::PackageBlock>() : nullptr) {
                     const IR::P4Parser *ip = nullptr;
                     const IR::P4Parser *ep = nullptr;
@@ -1231,7 +1231,7 @@ ParserEnforceDepthReq::ParserEnforceDepthReq(P4::ReferenceMap *rm, BFN::Evaluato
                     const IR::P4Control *ed = nullptr;
                     for (auto &p : pb->constantValue) {
                         LOG2("  " << p.first->toString() << " : "
-                                  << (p.second ? p.second->toString() : "nullptr"));
+                                  << (p.second ? p.second->toString().c_str() : "nullptr"));
                         if (p.second) {
                             auto name = p.first->toString();
                             if (name == "ingress_parser") {

--- a/backends/tofino/bf-p4c/p4c-barefoot.cpp
+++ b/backends/tofino/bf-p4c/p4c-barefoot.cpp
@@ -167,8 +167,7 @@ class GenerateOutputs : public PassManager {
     /// Output a skeleton context.json in case compilation fails.
     /// It is required by all our tools. If the assembler can get far enough, it will overwrite it.
     void outputContext() {
-        cstring ctxtFileName = _outputDir + "/context.json"_cs;
-        std::ofstream ctxtFile(ctxtFileName);
+        std::ofstream ctxtFile(_outputDir + "/context.json");
         rapidjson::StringBuffer sb;
         rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(sb);
         writer.StartObject();
@@ -230,8 +229,8 @@ class GenerateOutputs : public PassManager {
     }
 
     void end_apply() override {
-        cstring outputFile = _outputDir + "/"_cs + _options.programName + ".bfa"_cs;
-        std::ofstream ctxt_stream(outputFile, std::ios_base::app);
+        std::ofstream ctxt_stream(_outputDir + "/" + _options.programName + ".bfa",
+                                  std::ios_base::app);
 
         Logging::Manifest &manifest = Logging::Manifest::getManifest();
         if (_success) {
@@ -239,7 +238,7 @@ class GenerateOutputs : public PassManager {
             cstring primitivesFile = _outputDir + "/"_cs + _options.programName + ".prim.json"_cs;
             LOG2("ASM generation for primitives: " << primitivesFile);
             ctxt_stream << "primitives: \"" << _options.programName << ".prim.json\"" << std::endl;
-            std::ofstream prim(primitivesFile);
+            std::ofstream prim(primitivesFile.c_str());
             _primitives.serialize(prim);
             prim << std::endl << std::flush;
 
@@ -247,7 +246,7 @@ class GenerateOutputs : public PassManager {
             cstring dynHashFile = _outputDir + "/"_cs + _options.programName + ".dynhash.json"_cs;
             LOG2("ASM generation for dynamic hash: " << dynHashFile);
             ctxt_stream << "dynhash: \"" << _options.programName << ".dynhash.json\"" << std::endl;
-            std::ofstream dynhash(dynHashFile);
+            std::ofstream dynhash(dynHashFile.c_str());
             dynhash << _dynhash << std::endl << std::flush;
         }
         if (_options.debugInfo) {  // Generate graphs only if invoked with -g
@@ -257,7 +256,7 @@ class GenerateOutputs : public PassManager {
                 cstring depFileName = "dep"_cs;
                 cstring depFile = graphsDir + "/"_cs + depFileName + ".json"_cs;
                 LOG2("Dependency graph json generation for P4i: " << depFile);
-                std::ofstream dep(depFile);
+                std::ofstream dep(depFile.c_str());
                 _depgraph.serialize(dep);
                 // relative path to the output directory
                 // TBD: In manifest, add an option to indicate a program graph

--- a/backends/tofino/bf-p4c/p4c-barefoot.cpp
+++ b/backends/tofino/bf-p4c/p4c-barefoot.cpp
@@ -249,7 +249,7 @@ class GenerateOutputs : public PassManager {
                 (_outputDir / _options.programName.string()).replace_extension("dynhash.json");
             LOG2("ASM generation for dynamic hash: " << dynHashFile);
             ctxt_stream << "dynhash: \"" << _options.programName << ".dynhash.json\"" << std::endl;
-            std::ofstream dynhash(dynHashFile.string());
+            std::ofstream dynhash(dynHashFile);
             dynhash << _dynhash << std::endl << std::flush;
         }
         if (_options.debugInfo) {  // Generate graphs only if invoked with -g

--- a/backends/tofino/bf-p4c/p4c-barefoot.cpp
+++ b/backends/tofino/bf-p4c/p4c-barefoot.cpp
@@ -158,7 +158,7 @@ class GenerateOutputs : public PassManager {
     const BFN_Options &_options;
     int _pipeId;
     bool _success;
-    std::string _outputDir;
+    std::filesystem::path _outputDir;
 
     BFN::DynamicHashJson _dynhash;
     const Util::JsonObject &_primitives;
@@ -167,7 +167,7 @@ class GenerateOutputs : public PassManager {
     /// Output a skeleton context.json in case compilation fails.
     /// It is required by all our tools. If the assembler can get far enough, it will overwrite it.
     void outputContext() {
-        std::ofstream ctxtFile(_outputDir + "/context.json");
+        std::ofstream ctxtFile(_outputDir / "context.json");
         rapidjson::StringBuffer sb;
         rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(sb);
         writer.StartObject();
@@ -229,34 +229,38 @@ class GenerateOutputs : public PassManager {
     }
 
     void end_apply() override {
-        std::ofstream ctxt_stream(_outputDir + "/" + _options.programName + ".bfa",
-                                  std::ios_base::app);
+        std::ofstream ctxt_stream(
+            (_outputDir / _options.programName.string()).replace_extension("bfa"),
+            std::ios_base::app);
 
         Logging::Manifest &manifest = Logging::Manifest::getManifest();
         if (_success) {
             // Always output primitives json file (info used by model for logging actions)
-            cstring primitivesFile = _outputDir + "/"_cs + _options.programName + ".prim.json"_cs;
+            auto primitivesFile =
+                (_outputDir / _options.programName.string()).replace_extension("prim.json");
             LOG2("ASM generation for primitives: " << primitivesFile);
             ctxt_stream << "primitives: \"" << _options.programName << ".prim.json\"" << std::endl;
-            std::ofstream prim(primitivesFile.c_str());
+            std::ofstream prim(primitivesFile);
             _primitives.serialize(prim);
             prim << std::endl << std::flush;
 
             // Output dynamic hash json file
-            cstring dynHashFile = _outputDir + "/"_cs + _options.programName + ".dynhash.json"_cs;
+            auto dynHashFile =
+                (_outputDir / _options.programName.string()).replace_extension("dynhash.json");
             LOG2("ASM generation for dynamic hash: " << dynHashFile);
             ctxt_stream << "dynhash: \"" << _options.programName << ".dynhash.json\"" << std::endl;
-            std::ofstream dynhash(dynHashFile.c_str());
+            std::ofstream dynhash(dynHashFile.string());
             dynhash << _dynhash << std::endl << std::flush;
         }
         if (_options.debugInfo) {  // Generate graphs only if invoked with -g
-            auto graphsDir = BFNContext::get().getOutputDirectory("graphs"_cs, _pipeId);
+            std::filesystem::path graphsDir =
+                BFNContext::get().getOutputDirectory("graphs"_cs, _pipeId).string();
             // Output dependency graph json file
             if (_depgraph.size() > 0) {
                 cstring depFileName = "dep"_cs;
-                cstring depFile = graphsDir + "/"_cs + depFileName + ".json"_cs;
+                auto depFile = (graphsDir / depFileName.string()).replace_extension("json");
                 LOG2("Dependency graph json generation for P4i: " << depFile);
-                std::ofstream dep(depFile.c_str());
+                std::ofstream dep(depFile);
                 _depgraph.serialize(dep);
                 // relative path to the output directory
                 // TBD: In manifest, add an option to indicate a program graph
@@ -288,8 +292,9 @@ class GenerateOutputs : public PassManager {
           _primitives(p),
           _depgraph(d) {
         setStopOnError(false);
-        _outputDir = BFNContext::get().getOutputDirectory(""_cs, pipeId);
+        _outputDir = BFNContext::get().getOutputDirectory(""_cs, pipeId).c_str();
         if (_outputDir == "") exit(1);
+        // FIXME: Make this a std::filesystem::path.
         auto logsDir = BFNContext::get().getOutputDirectory("logs"_cs, pipeId);
         std::string phvLogFile(logsDir + "/phv.json");
         std::string resourcesLogFile(logsDir + "/resources.json");

--- a/backends/tofino/bf-p4c/parde/allocate_parser_match_register.cpp
+++ b/backends/tofino/bf-p4c/parde/allocate_parser_match_register.cpp
@@ -348,8 +348,8 @@ struct DelayDefs : public ParserModifier {
             auto orig_shift = trans->shift;
             trans->shift = static_cast<unsigned>(static_cast<int>(trans->shift) + adj);
             LOG3("Adjust shift on transition from "
-                 << state->name << " to " << (trans->next ? trans->next->name : "DONE") << " by "
-                 << adj << ": orig=" << orig_shift << " new=" << trans->shift);
+                 << state->name << " to " << (trans->next ? trans->next->name.c_str() : "DONE")
+                 << " by " << adj << ": orig=" << orig_shift << " new=" << trans->shift);
         }
 
         return true;
@@ -702,7 +702,7 @@ class MatcherAllocator : public Visitor {
             for (auto &[def, next_states] : delay_def_info)
                 for (auto *ns : next_states)
                     prev_delay_defs[std::make_pair(def->state->name, def->rval->range)].emplace(
-                        ns ? ns->name : "NULL");
+                        ns ? ns->name.c_str() : "NULL");
 
         result.transition_saves.clear();
         result.transition_scratches.clear();

--- a/backends/tofino/bf-p4c/parde/check_parser_multi_write.cpp
+++ b/backends/tofino/bf-p4c/parde/check_parser_multi_write.cpp
@@ -158,39 +158,41 @@ struct InferWriteMode : public ParserTransform {
                   /* 1 */ first_valid(c_field->getSourceInfo(), example->curr->getSourceInfo()),
                   /* 2 */ c_field->toString(),
                   /* 3 */ field_to_states.write_to_state.at(example->curr),
-                  /* 4 */ example->prev.size() > 1 ? "s"_cs : ""_cs,
-                  /* 5 */ on_loop && example->prev.size() > 1 ? " including assignment"_cs : ""_cs,
-                  /* 6 */ on_loop ? " in the same state due to a loop"_cs : ""_cs,
+                  /* 4 */ example->prev.size() > 1 ? "s"_cs : cstring::empty,
+                  /* 5 */ on_loop && example->prev.size() > 1 ? " including assignment"_cs
+                                                              : cstring::empty,
+                  /* 6 */ on_loop ? " in the same state due to a loop"_cs : cstring::empty,
                   /* 7 */ example->prev.size() - int(on_loop) > 0
                       ? "See the following errors for the list of previous assignments. "_cs
-                      : ""_cs,
+                      : cstring::empty,
                   /* 8 */ example->is_rewritten_always
                       ? "\nThe field will either always be assigned multiple times or there "_cs +
                             "is a loopback in the parser that always reassigns the field."_cs
-                      : ""_cs,
+                      : cstring::empty,
                   /* 9 */ example->curr->is<IR::BFN::ChecksumVerify>()
                       ? CHECKSUM_VERIFY_OR_SUGGESTION
-                      : ""_cs);
+                      : "");
         } else {
-            warning(
-                ErrorType::WARN_UNSUPPORTED,
-                "%1%%2% is assigned in state %3% but has also previous assignment%4%%5%%6%. %7%"
-                "This re-assignment is not supported by Tofino.%8%%9%",
-                /* 1 */ first_valid(c_field->getSourceInfo(), example->curr->getSourceInfo()),
-                /* 2 */ c_field->toString(),
-                /* 3 */ field_to_states.write_to_state.at(example->curr),
-                /* 4 */ example->prev.size() > 1 ? "s"_cs : ""_cs,
-                /* 5 */ on_loop && example->prev.size() > 1 ? " including assignment"_cs : ""_cs,
-                /* 6 */ on_loop ? " in the same state due to a loop"_cs : ""_cs,
-                /* 7 */ example->prev.size() - int(on_loop) > 0
-                    ? "See the following errors for the list of previous assignments. "_cs
-                    : ""_cs,
-                /* 8 */ example->is_rewritten_always
-                    ? "\nThe field will either always be assigned multiple times or there "_cs +
-                          "is a loopback in the parser that always reassigns the field."_cs
-                    : ""_cs,
-                /* 9 */ example->curr->is<IR::BFN::ChecksumVerify>() ? CHECKSUM_VERIFY_OR_SUGGESTION
-                                                                     : ""_cs);
+            warning(ErrorType::WARN_UNSUPPORTED,
+                    "%1%%2% is assigned in state %3% but has also previous assignment%4%%5%%6%. %7%"
+                    "This re-assignment is not supported by Tofino.%8%%9%",
+                    /* 1 */ first_valid(c_field->getSourceInfo(), example->curr->getSourceInfo()),
+                    /* 2 */ c_field->toString(),
+                    /* 3 */ field_to_states.write_to_state.at(example->curr),
+                    /* 4 */ example->prev.size() > 1 ? "s"_cs : cstring::empty,
+                    /* 5 */ on_loop && example->prev.size() > 1 ? " including assignment"_cs
+                                                                : cstring::empty,
+                    /* 6 */ on_loop ? " in the same state due to a loop"_cs : cstring::empty,
+                    /* 7 */ example->prev.size() - int(on_loop) > 0
+                        ? "See the following errors for the list of previous assignments. "_cs
+                        : cstring::empty,
+                    /* 8 */ example->is_rewritten_always
+                        ? "\nThe field will either always be assigned multiple times or there "_cs +
+                              "is a loopback in the parser that always reassigns the field."_cs
+                        : cstring::empty,
+                    /* 9 */ example->curr->is<IR::BFN::ChecksumVerify>()
+                        ? CHECKSUM_VERIFY_OR_SUGGESTION
+                        : "");
         }
         for (auto p : example->prev) {
             if (p == example->curr) continue;  // skip printing the looped assignment again

--- a/backends/tofino/bf-p4c/parde/clot/allocate_clot.cpp
+++ b/backends/tofino/bf-p4c/parde/clot/allocate_clot.cpp
@@ -90,7 +90,7 @@ class GreedyClotAllocator : public Visitor {
                     cstring name = field->name;
                     cstring field_name = cstring(name.findlast('.') + 1);
                     cstring header_name = field->header();
-                    header_name = header_name.before(strrchr(header_name, '['));
+                    header_name = header_name.before(strrchr(header_name.c_str(), '['));
                     cstring new_field_name = header_name + "["_cs +
                                              cstring::to_cstring(*stack_index + stack_offset) +
                                              "]." + field_name;
@@ -828,7 +828,7 @@ class GreedyClotAllocator : public Visitor {
     /// Get the element index for a field
     std::optional<unsigned> get_element_index(const PHV::Field *field) {
         cstring header_name = field->header();
-        const char *index_pos = strrchr(header_name, '[');
+        const char *index_pos = strrchr(header_name.c_str(), '[');
         if (index_pos) {
             size_t idx_start = index_pos - header_name.c_str() + 1;
             size_t idx_len = header_name.size() - idx_start - 1;
@@ -1201,7 +1201,7 @@ class GreedyClotAllocator : public Visitor {
             for (const auto *field : Keys(extracts)) {
                 if (auto stack_index = get_element_index(field)) {
                     cstring header_name = field->header();
-                    header_name = header_name.before(strrchr(header_name, '['));
+                    header_name = header_name.before(strrchr(header_name.c_str(), '['));
                     pseudoheader_stacks[header_name].emplace(*stack_index, pseudoheader);
                     LOG5("Pseudoheader " << pseudoheader->id << " extracts " << header_name << "["
                                          << *stack_index << "]");

--- a/backends/tofino/bf-p4c/parde/clot/clot_candidate.cpp
+++ b/backends/tofino/bf-p4c/parde/clot/clot_candidate.cpp
@@ -229,7 +229,7 @@ std::string ClotCandidate::print() const {
             else
                 attr = "unused";
 
-            tp.addRow({std::string(first_extract_info ? parser_state->name : ""),
+            tp.addRow({std::string(first_extract_info ? parser_state->name : cstring::empty),
                        std::string(slice->shortString()), bits.str(), attr});
             first_extract_info = false;
 

--- a/backends/tofino/bf-p4c/parde/clot/clot_candidate.cpp
+++ b/backends/tofino/bf-p4c/parde/clot/clot_candidate.cpp
@@ -229,7 +229,7 @@ std::string ClotCandidate::print() const {
             else
                 attr = "unused";
 
-            tp.addRow({std::string(first_extract_info ? parser_state->name : cstring::empty),
+            tp.addRow({first_extract_info ? parser_state->name.string() : "",
                        std::string(slice->shortString()), bits.str(), attr});
             first_extract_info = false;
 

--- a/backends/tofino/bf-p4c/parde/extract_parser.cpp
+++ b/backends/tofino/bf-p4c/parde/extract_parser.cpp
@@ -1852,7 +1852,7 @@ void ExtractParser::end_apply() {
 /// intrinsic metadata extraction logic based on the target device (tofino/jbay).
 ProcessParde::ProcessParde(const IR::BFN::Pipe *rv, bool useV1model)
     : Logging::PassManager("parser"_cs, Logging::Mode::AUTO) {
-    setName("ProcessParde"_cs);
+    setName("ProcessParde");
     addPasses({
         new AddParserMetadata(rv, useV1model),
         new AddDeparserMetadata(rv),

--- a/backends/tofino/bf-p4c/parde/lower_parser.cpp
+++ b/backends/tofino/bf-p4c/parde/lower_parser.cpp
@@ -213,7 +213,7 @@ struct RemoveNegativeDeposits : public ParserTransform {
         new_tr->shift = tr->shift - 1;
         auto ps = findContext<IR::BFN::ParserState>();
         LOG4("RemoveNegativeDeposits: Transition from "
-             << (ps ? ps->name : "--unknown--") << " to " << tr->next->name
+             << (ps ? ps->name.c_str() : "--unknown--") << " to " << tr->next->name.c_str()
              << " changed shift: " << tr->shift << "->" << new_tr->shift);
         return new_tr;
     }
@@ -238,7 +238,7 @@ struct RemoveNegativeDeposits : public ParserTransform {
             if (!tr->next || !found.states_to_shift.count(tr->next->name)) {
                 new_tr->shift = tr->shift - shift_amt / 8;
                 LOG4("RemoveNegativeDeposits: Transition from "
-                     << ps->name << " to " << (tr->next ? tr->next->name : "--END--")
+                     << ps->name << " to " << (tr->next ? tr->next->name.c_str() : "--END--")
                      << " changed: " << tr->shift << "->" << new_tr->shift);
             }
             new_tr->saves = *(new_tr->saves.apply(ShiftPacketRVal(shift_amt)));

--- a/backends/tofino/bf-p4c/parde/parser_dominator_builder.cpp
+++ b/backends/tofino/bf-p4c/parde/parser_dominator_builder.cpp
@@ -78,8 +78,8 @@ ParserDominatorBuilder::StateImmediateDominatorMap ParserDominatorBuilder::index
             dominator = rpg.vertex_to_state.at(kv.second);
         }
         idom_state[state] = dominator;
-        LOG7(TAB1 << ((state) ? state->name : "END OF PARSER") << " --> "
-                  << ((dominator) ? dominator->name : "END OF PARSER"));
+        LOG7(TAB1 << ((state) ? state->name.c_str() : "END OF PARSER") << " --> "
+                  << ((dominator) ? dominator->name.c_str() : "END OF PARSER"));
     }
     return idom_state;
 }

--- a/backends/tofino/bf-p4c/parde/parser_info.h
+++ b/backends/tofino/bf-p4c/parde/parser_info.h
@@ -97,7 +97,7 @@ class ReversibleParserGraph {
         if (state != nullptr && !gress) gress = state->gress;
 
         if (contains(state)) {
-            LOG1("State " << ((state) ? state->name : "END"_cs) << " already exists");
+            LOG1("State " << ((state) ? state->name.c_str() : "END") << " already exists");
             return state_to_vertex.at(state);
         }
 

--- a/backends/tofino/bf-p4c/parde/parser_info.h
+++ b/backends/tofino/bf-p4c/parde/parser_info.h
@@ -97,7 +97,7 @@ class ReversibleParserGraph {
         if (state != nullptr && !gress) gress = state->gress;
 
         if (contains(state)) {
-            LOG1("State " << ((state) ? state->name : "END") << " already exists");
+            LOG1("State " << ((state) ? state->name : "END"_cs) << " already exists");
             return state_to_vertex.at(state);
         }
 

--- a/backends/tofino/bf-p4c/parde/phase0.cpp
+++ b/backends/tofino/bf-p4c/parde/phase0.cpp
@@ -91,7 +91,7 @@ std::ostream &operator<<(std::ostream &out, const P4::IR::BFN::Phase0 *p0) {
         BUG_CHECK(phase0Range.contains(fieldRange),
                   "Phase 0 allocation %1% overflows the phase 0 region %2% for "
                   "field %3%",
-                  fieldRange, phase0Range, field.isPadding() ? "(padding)" : field.source);
+                  fieldRange, phase0Range, field.isPadding() ? "(padding)" : field.source.c_str());
 
         posBits += field.width;
         if (field.isPadding()) continue;

--- a/backends/tofino/bf-p4c/parde/resolve_negative_extract.h
+++ b/backends/tofino/bf-p4c/parde/resolve_negative_extract.h
@@ -566,7 +566,7 @@ struct ResolveNegativeExtract : public PassManager {
                     LOG4("Adding transition { "
                          << succ_tr->value << " } shift value " << new_shift << " B from state "
                          << state_succ->name << " to state "
-                         << (succ_tr->next != nullptr ? succ_tr->next->name : "EXIT"));
+                         << (succ_tr->next != nullptr ? succ_tr->next->name.c_str() : "EXIT"));
                 }
             }
         }

--- a/backends/tofino/bf-p4c/phv/add_initialization.cpp
+++ b/backends/tofino/bf-p4c/phv/add_initialization.cpp
@@ -548,14 +548,14 @@ class AddDarkInitialization : public Transform {
             const PHV::Field *f = phv.field(prim->operands[0], &range);
             PHV::FieldSlice slice(f, range);
             if (dests.count(slice)) {
-                LOG4("Ignoring already added initialization " << slice << " to action "
-                                                              << action->name << " and table "
-                                                              << (tbl ? tbl->name : "NO TABLE"));
+                LOG4("Ignoring already added initialization "
+                     << slice << " to action " << action->name << " and table "
+                     << (tbl ? tbl->name.c_str() : "NO TABLE"));
                 continue;
             }
             action->action.push_back(prim);
             LOG4("Adding instruction " << prim << " to action " << action->name << " and table "
-                                       << (tbl ? tbl->name : "NO TABLE"));
+                                       << (tbl ? tbl->name.c_str() : "NO TABLE"));
         }
         return action;
     }

--- a/backends/tofino/bf-p4c/phv/analysis/header_mutex.cpp
+++ b/backends/tofino/bf-p4c/phv/analysis/header_mutex.cpp
@@ -830,7 +830,7 @@ ordered_set<std::pair<cstring, cstring>> ExcludeMAUNotMutexHeaders::process_set_
                     std::string tmp{header.c_str()};
                     auto begin = tmp.find("[");
                     auto end = tmp.find("]");
-                    if (!header.find(substring) || begin == std::string::npos ||
+                    if (!header.find(substring.c_str()) || begin == std::string::npos ||
                         end == std::string::npos)
                         return;
                     int index = std::stoi(tmp.substr(begin + 1, end - (begin + 1)));
@@ -921,7 +921,7 @@ std::string ExcludeMAUNotMutexHeaders::get_active_headers_change_table(
         TablePrinter::Align::LEFT);
     for (size_t i = 0; i < header_info.all_headers.size(); i++) {
         auto header_name = header_info.get_header_name(i);
-        if (!header_name.find(gress)) continue;
+        if (!header_name.find(gress.c_str())) continue;
 
         auto header_index = i * state_size;
         auto begin_state =

--- a/backends/tofino/bf-p4c/phv/analysis/header_mutex.h
+++ b/backends/tofino/bf-p4c/phv/analysis/header_mutex.h
@@ -85,7 +85,7 @@ class AddParserHeadersToHeaderMutexMatrix : public BuildMutex {
         return !field || field->pov || field->metadata;
     }
 
-    void mark(const PHV::Field *field);
+    void mark(const PHV::Field *field) override;
 
     profile_t init_apply(const IR::Node *root) override;
     bool preorder(const IR::MAU::TableSeq *) override { return false; }

--- a/backends/tofino/bf-p4c/phv/phv_fields.cpp
+++ b/backends/tofino/bf-p4c/phv/phv_fields.cpp
@@ -1034,9 +1034,9 @@ void PHV::Field::updateAlignment(PHV::AlignmentReason reason, const FieldAlignme
         auto alignmentSourceStr = [&](const FieldAlignment &alignment,
                                       const Util::SourceInfo &srcInfo) {
             std::stringstream ss;
-            ss << (srcInfo.isValid() ? srcInfo.toPositionString() : "Source unknown")
+            ss << (srcInfo.isValid() ? srcInfo.toPositionString() : "Source unknown"_cs)
                << ": alignment = " << alignment.align << " (little endian)" << std::endl
-               << (srcInfo.isValid() ? srcInfo.toSourceFragment() : "");
+               << (srcInfo.isValid() ? srcInfo.toSourceFragment() : cstring::empty);
             return ss.str();
         };
         std::stringstream inferredAlignments;

--- a/backends/tofino/bf-p4c/phv/phv_spec.cpp
+++ b/backends/tofino/bf-p4c/phv/phv_spec.cpp
@@ -729,10 +729,10 @@ void PhvSpec::applyGlobalPragmas(const std::vector<const IR::Annotation *> &glob
         PHV::Container startRange, prev;
         bool negate = false;
         for (auto *tok : annot->body) {
-            PHV::Container c(tok->text, false);
+            PHV::Container c(tok->text.c_str(), false);
             if (startRange) {
                 if (tok->token_type == P4::P4Parser::token_type::TOK_INTEGER)
-                    c = PHV::Container(startRange.type(), atoi(tok->text));
+                    c = PHV::Container(startRange.type(), atoi(tok->text.c_str()));
                 if (!c || c.type() != startRange.type() || startRange.index() > c.index()) {
                     error(ErrorType::ERR_INVALID, "invalid container range %2%-%3% in %1%", annot,
                           startRange, tok->text);

--- a/backends/tofino/bf-p4c/phv/pragma/pa_alias.cpp
+++ b/backends/tofino/bf-p4c/phv/pragma/pa_alias.cpp
@@ -81,7 +81,7 @@ std::optional<std::pair<const PHV::Field *, const PHV::Field *>> PragmaAlias::ma
                    "@pragma pa_alias for fields %1% and %2% ignored because "
                    "field %1% already aliases with a different field %3%",
                    field1->name, field2->name,
-                   (aliasMap.count(field1->name) ? aliasMap[field1->name].field : ""));
+                   (aliasMap.count(field1->name) ? aliasMap[field1->name].field : cstring::empty));
         return std::nullopt;
     }
 
@@ -90,7 +90,7 @@ std::optional<std::pair<const PHV::Field *, const PHV::Field *>> PragmaAlias::ma
                    "@pragma pa_alias for fields %1% and %2% ignored because "
                    "field %2% already aliases with a different field %3%",
                    field1->name, field2->name,
-                   (aliasMap.count(field2->name) ? aliasMap[field2->name].field : ""));
+                   (aliasMap.count(field2->name) ? aliasMap[field2->name].field : cstring::empty));
         return std::nullopt;
     }
 
@@ -164,11 +164,12 @@ std::optional<std::pair<const PHV::Field *, const PHV::Field *>> PragmaAlias::ma
               "aliasSrc");
 
     if (fieldsWithAliasingDst[aliasSrc->id]) {
-        WARN_CHECK(suppressWarning,
-                   "@pragma pa_alias for fields %1% and %2% ignored because "
-                   "field %2% already aliases with a different field %3%",
-                   aliasDest->name, aliasSrc->name,
-                   (aliasMap.count(aliasSrc->name) ? aliasMap[aliasSrc->name].field : ""));
+        WARN_CHECK(
+            suppressWarning,
+            "@pragma pa_alias for fields %1% and %2% ignored because "
+            "field %2% already aliases with a different field %3%",
+            aliasDest->name, aliasSrc->name,
+            (aliasMap.count(aliasSrc->name) ? aliasMap[aliasSrc->name].field : cstring::empty));
         return std::nullopt;
     }
 

--- a/backends/tofino/bf-p4c/phv/pragma/pa_byte_pack.cpp
+++ b/backends/tofino/bf-p4c/phv/pragma/pa_byte_pack.cpp
@@ -140,7 +140,7 @@ bool PragmaBytePack::preorder(const IR::BFN::Pipe *pipe) {
         if (!ignore) {
             auto rst = add_packing_constraint(pack);
             if (!rst.ok()) {
-                error(cstring(*rst.error + ", %1%"), *pack.src_info);
+                error("%1%, %2%", *rst.error, *pack.src_info);
             }
         }
     }

--- a/backends/tofino/bf-p4c/phv/utils/utils.cpp
+++ b/backends/tofino/bf-p4c/phv/utils/utils.cpp
@@ -97,7 +97,7 @@ static const char *fieldName(const PHV::AllocSlice &slice) {
     if (!slice.field()) return "no_name";
     if (auto *t = slice.field()->name.findlast('.')) return t + 1;
     if (auto *t = slice.field()->name.findlast(':')) return t + 1;
-    return slice.field()->name;
+    return slice.field()->name.c_str();
 }
 
 std::ostream &operator<<(std::ostream &out, const PHV::ActionSet &actions) {
@@ -1312,7 +1312,7 @@ std::optional<le_bitrange> PHV::AlignedCluster::validContainerStartRange(
     LOG5("\tField slice " << slice << " to be placed in container size " << container_size
                           << " slices has "
                           << (slice.validContainerRange() == ZeroToMax()
-                                  ? "no"
+                                  ? "no"_cs
                                   : cstring::to_cstring(slice.validContainerRange()))
                           << " alignment requirement.");
 
@@ -1730,7 +1730,7 @@ PHV::SuperCluster::SliceList *PHV::SuperCluster::findLinkedWideArithSliceList(
                     LOG7("   Looking for slice list " << list);
                     LOG7("      slice_lsb2 = " << slice_lsb2);
                     if (fs2.field()->bit_used_in_wide_arith(slice_lsb2)) {
-                        if (0 == std::strcmp(fs.field()->name, fs2.field()->name)) {
+                        if (fs.field()->name == fs2.field()->name) {
                             if (lo_slice && (slice_lsb + 32) == slice_lsb2)
                                 return list;
                             else if (!lo_slice && (slice_lsb - 32) == slice_lsb2)

--- a/backends/tofino/bf-p4c/phv/v2/copacker.cpp
+++ b/backends/tofino/bf-p4c/phv/v2/copacker.cpp
@@ -333,8 +333,8 @@ CoPacker::CoPackHintOrErr CoPacker::gen_move_copack(const Allocation &allocated_
         }
         LOG5("Found move (dest, src) pair: "
              << dest << " = " << src_fs.shortString() << "@"
-             << (src_container != std::nullopt ? cstring::to_cstring(*src_container) : "*") << "["
-             << src_start_idx << ":" << src_start_idx + src_fs.size() - 1 << "]");
+             << (src_container != std::nullopt ? cstring::to_cstring(*src_container).c_str() : "*")
+             << "[" << src_start_idx << ":" << src_start_idx + src_fs.size() - 1 << "]");
         // compute number of bits that source will be right shifted, wrap-around considered.
         const int this_src_right_shift_bits =
             n_wrap_around_right_shift_bits(src_start_idx, dest.container_slice().lo, c.size());

--- a/lib/error.h
+++ b/lib/error.h
@@ -53,14 +53,6 @@ inline void error(const char *format, Args &&...args) {
     auto action = context.getDefaultErrorDiagnosticAction();
     context.errorReporter().diagnose(action, nullptr, format, "", std::forward<Args>(args)...);
 }
-
-template <typename... Args>
-inline void error(cstring format, Args &&...args) {
-    auto &context = BaseCompileContext::get();
-    auto action = context.getDefaultErrorDiagnosticAction();
-    context.errorReporter().diagnose(action, nullptr, format.c_str(), "",
-                                     std::forward<Args>(args)...);
-}
 #endif
 
 /// Report errors of type kind. Requires that the node argument have source info.
@@ -99,15 +91,6 @@ void error(const char *format, const T *node, Args &&...args) {
     error(ErrorType::LEGACY_ERROR, format, node, std::forward<Args>(args)...);
 }
 
-/// Convert errors that have a first argument as a node with source info to errors with kind
-/// This allows incremental migration toward minimizing the number of errors and warnings
-/// reported when passes are repeated, as typed errors are filtered.
-// LEGACY: once we transition to error types, this should be deprecated
-template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
-void error(cstring format, const T *node, Args &&...args) {
-    error(ErrorType::LEGACY_ERROR, format.c_str(), node, std::forward<Args>(args)...);
-}
-
 /// The const ref variant of the above
 // LEGACY: once we transition to error types, this should be deprecated
 template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T> && !std::is_pointer_v<T>>,
@@ -134,16 +117,6 @@ inline void warning(const char *format, Args &&...args) {
     auto action = context.getDefaultWarningDiagnosticAction();
     context.errorReporter().diagnose(action, nullptr, format, "", std::forward<Args>(args)...);
 }
-
-/// Report a warning with the given message.
-template <typename... Args>
-inline void warning(cstring format, Args &&...args) {
-    auto &context = BaseCompileContext::get();
-    auto action = context.getDefaultWarningDiagnosticAction();
-    context.errorReporter().diagnose(action, nullptr, format.c_str(), "",
-                                     std::forward<Args>(args)...);
-}
-
 #endif
 
 /// Report warnings of type kind. Requires that the node argument have source info.

--- a/lib/error.h
+++ b/lib/error.h
@@ -53,6 +53,14 @@ inline void error(const char *format, Args &&...args) {
     auto action = context.getDefaultErrorDiagnosticAction();
     context.errorReporter().diagnose(action, nullptr, format, "", std::forward<Args>(args)...);
 }
+
+template <typename... Args>
+inline void error(cstring format, Args &&...args) {
+    auto &context = BaseCompileContext::get();
+    auto action = context.getDefaultErrorDiagnosticAction();
+    context.errorReporter().diagnose(action, nullptr, format.c_str(), "",
+                                     std::forward<Args>(args)...);
+}
 #endif
 
 /// Report errors of type kind. Requires that the node argument have source info.
@@ -91,6 +99,15 @@ void error(const char *format, const T *node, Args &&...args) {
     error(ErrorType::LEGACY_ERROR, format, node, std::forward<Args>(args)...);
 }
 
+/// Convert errors that have a first argument as a node with source info to errors with kind
+/// This allows incremental migration toward minimizing the number of errors and warnings
+/// reported when passes are repeated, as typed errors are filtered.
+// LEGACY: once we transition to error types, this should be deprecated
+template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T>>, class... Args>
+void error(cstring format, const T *node, Args &&...args) {
+    error(ErrorType::LEGACY_ERROR, format.c_str(), node, std::forward<Args>(args)...);
+}
+
 /// The const ref variant of the above
 // LEGACY: once we transition to error types, this should be deprecated
 template <class T, typename = std::enable_if_t<Util::has_SourceInfo_v<T> && !std::is_pointer_v<T>>,
@@ -117,6 +134,16 @@ inline void warning(const char *format, Args &&...args) {
     auto action = context.getDefaultWarningDiagnosticAction();
     context.errorReporter().diagnose(action, nullptr, format, "", std::forward<Args>(args)...);
 }
+
+/// Report a warning with the given message.
+template <typename... Args>
+inline void warning(cstring format, Args &&...args) {
+    auto &context = BaseCompileContext::get();
+    auto action = context.getDefaultWarningDiagnosticAction();
+    context.errorReporter().diagnose(action, nullptr, format.c_str(), "",
+                                     std::forward<Args>(args)...);
+}
+
 #endif
 
 /// Report warnings of type kind. Requires that the node argument have source info.

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -103,6 +103,13 @@ class CompilerBug final : public P4CExceptionBase {
         message = absl::StrCat("In file: ", file, ":", line, "\n", cerr_colorize(ANSI_RED),
                                "Compiler Bug", cerr_clear_colors(), ": ", message);
     }
+
+    template <typename... Args>
+    CompilerBug(int line, cstring file, const char *format, Args &&...args)
+        : P4CExceptionBase(format, std::forward<Args>(args)...) {
+        message = absl::StrCat("In file: ", file, ":", line, "\n", cerr_colorize(ANSI_RED),
+                               "Compiler Bug", cerr_clear_colors(), ": ", message);
+    }
 };
 
 /// This class indicates an unimplemented feature in the compiler
@@ -118,6 +125,14 @@ class CompilerUnimplemented final : public P4CExceptionBase {
 
     template <typename... Args>
     CompilerUnimplemented(int line, const char *file, const char *format, Args &&...args)
+        : P4CExceptionBase(format, std::forward<Args>(args)...) {
+        message =
+            absl::StrCat("In file: ", file, ":", line, "\n", cerr_colorize(ANSI_BLUE),
+                         "Unimplemented compiler support", cerr_clear_colors(), ": ", message);
+    }
+
+    template <typename... Args>
+    CompilerUnimplemented(int line, cstring file, const char *format, Args &&...args)
         : P4CExceptionBase(format, std::forward<Args>(args)...) {
         message =
             absl::StrCat("In file: ", file, ":", line, "\n", cerr_colorize(ANSI_BLUE),

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -103,13 +103,6 @@ class CompilerBug final : public P4CExceptionBase {
         message = absl::StrCat("In file: ", file, ":", line, "\n", cerr_colorize(ANSI_RED),
                                "Compiler Bug", cerr_clear_colors(), ": ", message);
     }
-
-    template <typename... Args>
-    CompilerBug(int line, cstring file, const char *format, Args &&...args)
-        : P4CExceptionBase(format, std::forward<Args>(args)...) {
-        message = absl::StrCat("In file: ", file, ":", line, "\n", cerr_colorize(ANSI_RED),
-                               "Compiler Bug", cerr_clear_colors(), ": ", message);
-    }
 };
 
 /// This class indicates an unimplemented feature in the compiler
@@ -125,14 +118,6 @@ class CompilerUnimplemented final : public P4CExceptionBase {
 
     template <typename... Args>
     CompilerUnimplemented(int line, const char *file, const char *format, Args &&...args)
-        : P4CExceptionBase(format, std::forward<Args>(args)...) {
-        message =
-            absl::StrCat("In file: ", file, ":", line, "\n", cerr_colorize(ANSI_BLUE),
-                         "Unimplemented compiler support", cerr_clear_colors(), ": ", message);
-    }
-
-    template <typename... Args>
-    CompilerUnimplemented(int line, cstring file, const char *format, Args &&...args)
         : P4CExceptionBase(format, std::forward<Args>(args)...) {
         message =
             absl::StrCat("In file: ", file, ":", line, "\n", cerr_colorize(ANSI_BLUE),


### PR DESCRIPTION
Fix the Tofino build which was broken with #4971. 

The majority of the fixes are simple `char *` conversions. In many places this could be improved by not using cstring at all. 

The most important changes are the addition of error and exception helpers which support cstring. I could probably add more functions here. Or do not add them at all and demand explicit conversion.

