### PR TITLE
Framework for copy-on-write visitors (WIP)

### DIFF
--- a/backends/tofino/bf-p4c/common/check_for_unimplemented_features.cpp
+++ b/backends/tofino/bf-p4c/common/check_for_unimplemented_features.cpp
@@ -21,7 +21,7 @@
 #include "lib/error_reporter.h"
 
 std::optional<const IR::Operation_Binary *> CheckOperations::getSrcBinop(
-    const IR::MAU::Primitive *prim) const {
+    const IR::MAU::MauPrimitive *prim) const {
     prim = prim->apply(RemoveCasts());
     if (prim->name != "modify_field") return std::nullopt;
     if (prim->operands.size() < 2) return std::nullopt;
@@ -29,7 +29,7 @@ std::optional<const IR::Operation_Binary *> CheckOperations::getSrcBinop(
     return std::nullopt;
 }
 
-bool CheckOperations::isModBitMask(const IR::MAU::Primitive *prim) const {
+bool CheckOperations::isModBitMask(const IR::MAU::MauPrimitive *prim) const {
     auto *binop = getSrcBinop(prim).value_or(nullptr);
     if (!binop || binop->getStringOp() != "|") return false;
     auto leftBinop = binop->left->to<IR::Operation_Binary>();
@@ -38,7 +38,7 @@ bool CheckOperations::isModBitMask(const IR::MAU::Primitive *prim) const {
     return leftBinop->getStringOp() == "&" && rightBinop->getStringOp() == "&";
 }
 
-bool CheckOperations::preorder(const IR::MAU::Primitive *prim) {
+bool CheckOperations::preorder(const IR::MAU::MauPrimitive *prim) {
     if (isModBitMask(prim))
         error("The following operation is not yet supported: %1%", prim->srcInfo);
     return true;

--- a/backends/tofino/bf-p4c/common/check_for_unimplemented_features.h
+++ b/backends/tofino/bf-p4c/common/check_for_unimplemented_features.h
@@ -41,17 +41,17 @@ class CheckOperations : public Inspector {
 
     /// @returns BOP in modify_field(x, BOP), if BOP is a binary operation
     /// expression.
-    std::optional<const IR::Operation_Binary *> getSrcBinop(const IR::MAU::Primitive *p) const;
+    std::optional<const IR::Operation_Binary *> getSrcBinop(const IR::MAU::MauPrimitive *p) const;
 
     /// @returns true if @p is a P4_16 encoding of a P4_14 funnel shift
     /// operation, eg. modify_field(x, (y ++ z) >> n).
-    bool isFunnelShift(const IR::MAU::Primitive *p) const;
+    bool isFunnelShift(const IR::MAU::MauPrimitive *p) const;
 
     /// @returns true if @p is a P4_16 encoding of a P4_14 bitmasked modify_field
     /// operation, eg. modify_field(x, val, 0xAA).
-    bool isModBitMask(const IR::MAU::Primitive *p) const;
+    bool isModBitMask(const IR::MAU::MauPrimitive *p) const;
 
-    bool preorder(const IR::MAU::Primitive *) override;
+    bool preorder(const IR::MAU::MauPrimitive *) override;
 };
 
 class CheckForUnimplementedFeatures : public PassManager {

--- a/backends/tofino/bf-p4c/common/extract_maupipe.cpp
+++ b/backends/tofino/bf-p4c/common/extract_maupipe.cpp
@@ -242,10 +242,10 @@ class ConvertMethodCalls : public MauTransform {
         return prim;
     }
 
-    const IR::MAU::Primitive *postorder(IR::MAU::Primitive *prim) {
+    const IR::MAU::MauPrimitive *postorder(IR::MAU::MauPrimitive *prim) {
         if (prim->name == "method_call_init") {
             BUG_CHECK(prim->operands.size() == 1, "method call initialization failed");
-            if (auto *p = prim->operands.at(0)->to<IR::MAU::Primitive>())
+            if (auto *p = prim->operands.at(0)->to<IR::MAU::MauPrimitive>())
                 return p;
             else if (prim->operands.at(0)->is<IR::Member>())
                 // comes from a bare "isValid" call -- is a noop
@@ -379,7 +379,8 @@ class ActionBodySetup : public Inspector {
         if (!af->exitAction) {
             cstring pname = "modify_field"_cs;
             if (assign->left->type->is<IR::Type_Header>()) pname = "copy_header"_cs;
-            auto prim = new IR::MAU::Primitive(assign->srcInfo, pname, assign->left, assign->right);
+            auto prim =
+                new IR::MAU::MauPrimitive(assign->srcInfo, pname, assign->left, assign->right);
             prim->in_hash = InHashAnnot();
             af->action.push_back(prim);
         }
@@ -388,7 +389,7 @@ class ActionBodySetup : public Inspector {
     bool preorder(const IR::MethodCallStatement *mc) override {
         if (!af->exitAction) {
             auto mc_init =
-                new IR::MAU::Primitive(mc->srcInfo, "method_call_init"_cs, mc->methodCall);
+                new IR::MAU::MauPrimitive(mc->srcInfo, "method_call_init"_cs, mc->methodCall);
             af->action.push_back(mc_init);
         }
         return false;
@@ -1293,7 +1294,7 @@ void AttachTables::InitializeStatefulAlus ::updateAttachedSalu(const IR::Declara
     }
     if (ext->type->toString().startsWith("LearnAction")) salu->learn_action = true;
 
-    auto prim = findContext<IR::MAU::Primitive>();
+    auto prim = findContext<IR::MAU::MauPrimitive>();
     LOG6("  - " << (prim ? prim->name.c_str() : "<no primitive>"));
     if (prim && prim->name.endsWith(".address")) {
         salu->chain_vpn = true;
@@ -1340,7 +1341,7 @@ void AttachTables::InitializeStatefulAlus::postorder(const IR::GlobalRef *gref) 
  * Gathers information about register params and checks
  * that they are used in a single stateful ALU.
  */
-bool AttachTables::InitializeRegisterParams::preorder(const IR::MAU::Primitive *prim) {
+bool AttachTables::InitializeRegisterParams::preorder(const IR::MAU::MauPrimitive *prim) {
     if (prim->name != "RegisterParam.read") return true;
     const IR::Declaration_Instance *reg_param_decl = nullptr;
     if (auto *gr = prim->operands.at(0)->to<IR::GlobalRef>())

--- a/backends/tofino/bf-p4c/common/extract_maupipe.h
+++ b/backends/tofino/bf-p4c/common/extract_maupipe.h
@@ -126,7 +126,7 @@ class AttachTables : public PassManager {
         ordered_map<const IR::Declaration_Instance *,
                     IR::MAU::StatefulAlu *>
             param_salus;  // RegisterParam -> StatefulAlu
-        bool preorder(const IR::MAU::Primitive *prim) override;
+        bool preorder(const IR::MAU::MauPrimitive *prim) override;
         void end_apply() override;
 
      public:

--- a/backends/tofino/bf-p4c/common/field_defuse.cpp
+++ b/backends/tofino/bf-p4c/common/field_defuse.cpp
@@ -384,13 +384,13 @@ bool FieldDefUse::preorder(const IR::MAU::Action *act) {
     return false;
 }
 
-bool FieldDefUse::preorder(const IR::MAU::Primitive *prim) {
+bool FieldDefUse::preorder(const IR::MAU::MauPrimitive *prim) {
     // TODO: consider h.f1 = h.f1 + 1; When we visit it,
     // we should first visit the source on the RHS, as how hardware does.
     // The h.f1 on RHS is an use of previous def, and the one on LHS is a
     // write that clears the previous defs from this point.
     // TODO: The long-term fix for this is to change the order of visiting when
-    // visiting IR::MAU::Primitive to the evaluation order defined in spec,
+    // visiting IR::MAU::MauPrimitive to the evaluation order defined in spec,
     // to make control flow visit correct.
     LOG6("FieldDefUse preorder Primitive : " << prim << IndentCtl::indent);
     if (prim->operands.size() > 0) {

--- a/backends/tofino/bf-p4c/common/field_defuse.h
+++ b/backends/tofino/bf-p4c/common/field_defuse.h
@@ -155,7 +155,7 @@ class FieldDefUse : public BFN::ControlFlowVisitor, public Inspector, TofinoWrit
     bool preorder(const IR::BFN::LoweredParser *p) override;
     bool preorder(const IR::MAU::Table *t) override;
     void postorder(const IR::MAU::Table *t) override;
-    bool preorder(const IR::MAU::Primitive *prim) override;
+    bool preorder(const IR::MAU::MauPrimitive *prim) override;
     bool preorder(const IR::MAU::Action *p) override;
     bool preorder(const IR::MAU::StatefulAlu *prim) override;
     bool preorder(const IR::Expression *e) override;

--- a/backends/tofino/bf-p4c/common/header_stack.cpp
+++ b/backends/tofino/bf-p4c/common/header_stack.cpp
@@ -51,7 +51,7 @@ void CollectHeaderStackInfo::postorder(IR::HeaderStack *hs) {
         i.inThread[INGRESS] = false;
 }
 
-void CollectHeaderStackInfo::postorder(IR::MAU::Primitive *prim) {
+void CollectHeaderStackInfo::postorder(IR::MAU::MauPrimitive *prim) {
     if (prim->name == "push_front" || prim->name == "pop_front") {
         LOG3("CollectHeaderStackInfo: visiting " << prim);
         BUG_CHECK(prim->operands.size() == 2, "wrong number of operands to %s", prim);
@@ -147,8 +147,8 @@ IR::Node *RemovePushInitialization::preorder(IR::MAU::Action *act) {
     // then cleared when an initialization is found.
     ordered_map<cstring, bitvec> pushed_inits;
 
-    ordered_map<cstring, const IR::MAU::Primitive *> push_prims;
-    IR::Vector<IR::MAU::Primitive> to_keep;
+    ordered_map<cstring, const IR::MAU::MauPrimitive *> push_prims;
+    IR::Vector<IR::MAU::MauPrimitive> to_keep;
 
     for (auto *prim : act->action) {
         to_keep.push_back(prim);

--- a/backends/tofino/bf-p4c/common/header_stack.h
+++ b/backends/tofino/bf-p4c/common/header_stack.h
@@ -39,7 +39,7 @@ struct CollectHeaderStackInfo : public Modifier {
  private:
     Visitor::profile_t init_apply(const IR::Node *root) override;
     void postorder(IR::HeaderStack *stack) override;
-    void postorder(IR::MAU::Primitive *primitive) override;
+    void postorder(IR::MAU::MauPrimitive *primitive) override;
     void postorder(IR::BFN::Pipe *pipe) override;
 
     BFN::HeaderStackInfo *stacks;

--- a/backends/tofino/bf-p4c/ir/gateway_control_flow.h
+++ b/backends/tofino/bf-p4c/ir/gateway_control_flow.h
@@ -56,6 +56,9 @@ class GatewayControlFlow : public virtual ControlFlowVisitor {
 
  public:
     virtual void pre_visit_table_next(const IR::MAU::Table *tbl, cstring tags) = 0;
+    void pre_visit_table_next(IR::COWptr<IR::MAU::Table> tbl, cstring tags) {
+        pre_visit_table_next(tbl.get(), tags);
+    }
 };
 
 }  // end namespace BFN

--- a/backends/tofino/bf-p4c/ir/mau.cpp
+++ b/backends/tofino/bf-p4c/ir/mau.cpp
@@ -37,6 +37,7 @@ namespace MAU {
 // function templates to be in the same compilation unit.
 void Table::visit_children(Visitor &v, const char *n) { visit_children(this, v, n); }
 void Table::visit_children(Visitor &v, const char *n) const { visit_children(this, v, n); }
+void Table::COWref::visit_children(Visitor &v, const char *n) { Table::visit_children(this, v, n); }
 
 /**
  * The potential control flow(s) through an IR::MAU::Table object are quite complex, which
@@ -167,7 +168,7 @@ void Table::visit_gateway_inhibited(THIS *self, Visitor &v, const char *,
     std::set<cstring> gw_tags_seen;
     bool fallen_through = false;
     for (auto &gw : self->gateway_rows) {
-        auto tag = gw.second;
+        cstring tag = gw.second;
         if (!tag || gw_tags_seen.count(tag)) continue;
 
         gw_tags_seen.emplace(tag);

--- a/backends/tofino/bf-p4c/ir/mau.cpp
+++ b/backends/tofino/bf-p4c/ir/mau.cpp
@@ -37,7 +37,9 @@ namespace MAU {
 // function templates to be in the same compilation unit.
 void Table::visit_children(Visitor &v, const char *n) { visit_children(this, v, n); }
 void Table::visit_children(Visitor &v, const char *n) const { visit_children(this, v, n); }
-void Table::COWref::visit_children(Visitor &v, const char *n) { Table::visit_children(this, v, n); }
+void Table::COWref::visit_children(Visitor &v, const char *n) const {
+    Table::visit_children(this, v, n);
+}
 
 /**
  * The potential control flow(s) through an IR::MAU::Table object are quite complex, which

--- a/backends/tofino/bf-p4c/ir/mau.def
+++ b/backends/tofino/bf-p4c/ir/mau.def
@@ -169,7 +169,7 @@ class Table : BFN::Unit, IAnnotated  {
         int   total_actions                = 0;
         int   sel_len_bits                 = 0;
         int   proxy_hash_width             = 0;
-        HashFunction proxy_hash_algorithm  = {};
+        MAU::HashFunction proxy_hash_algorithm  = {};
         inline IndirectAddress meter_addr  = {};
         inline IndirectAddress stats_addr  = {};
         inline IndirectAddress action_addr = {};
@@ -779,7 +779,7 @@ class TableSeq {
 #apply
 }
 
-class Primitive : IR::Primitive {
+class MauPrimitive : IR::Primitive {
     bool in_hash = false;
 #emit
     using IR::Primitive::Primitive;
@@ -789,18 +789,18 @@ class Primitive : IR::Primitive {
 }
 
 /// A primitive function, optionally annotated with its front end type.
-class TypedPrimitive : Primitive {
+class TypedPrimitive : MauPrimitive {
 #nodbprint
 #noconstructor
     IR::Type method_type;
 
     std::map<unsigned, cstring> op_names;
     TypedPrimitive(cstring name)
-    : Primitive(name), method_type(nullptr) { }
+    : MauPrimitive(name), method_type(nullptr) { }
     TypedPrimitive(Util::SourceInfo srcInfo, const IR::Type* return_type, const IR::Type* m_type, cstring name)
-    : Primitive(srcInfo, return_type, name), method_type(m_type) { }
+    : MauPrimitive(srcInfo, return_type, name), method_type(m_type) { }
 
-    visit_children { Primitive::visit_children(v, n); }
+    visit_children { MauPrimitive::visit_children(v, n); }
 }
 
 /// A single MAU instruction.  For the most part instructions look exactly like Primitives,
@@ -808,20 +808,20 @@ class TypedPrimitive : Primitive {
 /// destination and two sources as an "add" primitive, with the additional constraints that
 /// the dest and first source are PHV while second source can be PHV, action bus, or constant.
 /// We convert the primitive into an instruction when we check those constraints
-class Instruction : Primitive {
+class Instruction : MauPrimitive {
 #nodbprint
 #emit
-    using Primitive::Primitive;
+    using MauPrimitive::MauPrimitive;
 #end
     // This is a vector, filled after BackendCopyPropagation, indicating which operands
     // have been copy propagated from an earlier instruction.  Copy propagated operands
     // don't have to be checked in order to guarantee parallelism
     bitvec copy_propagated = {};
-    Instruction(const Primitive &p) : Primitive(p) {}
-    Instruction(cstring op, const std::vector<Expression> &args) : Primitive(op) {
+    Instruction(const MauPrimitive &p) : MauPrimitive(p) {}
+    Instruction(cstring op, const std::vector<Expression> &args) : MauPrimitive(op) {
         for (auto a : args) operands.push_back(a); }
     Instruction(Util::SourceInfo si, cstring op, const std::vector<Expression> &args)
-        : Primitive(si, op) { for (auto a : args) operands.push_back(a); }
+        : MauPrimitive(si, op) { for (auto a : args) operands.push_back(a); }
     bool isOutput(int operand_index) const override { return operand_index == 0; }
     virtual Expression getOutput() const { return operands.empty() ? nullptr : operands.at(0); }
     validate { BUG_CHECK(name, "empty name in instruction"); }
@@ -884,7 +884,7 @@ class StatefulCounter : Expression {
 class StatefulCall {
     // This will always be null after InstructionSelection is complete.  Everything
     // currently used for DefUse analysis is saved within the rest of the call
-    optional NullOK Primitive prim = nullptr;
+    optional NullOK MauPrimitive prim = nullptr;
     AttachedMemory  attached_callee;
     optional NullOK Expression index = nullptr;
 }
@@ -898,7 +898,7 @@ abstract VLIWInstruction {
 class Action : VLIWInstruction, IAnnotated {
     optional ID                 name;
     unsigned                    handle = 0;
-    inline Vector<Primitive>    action = {};
+    inline Vector<MauPrimitive> action = {};
     safe_vector<ActionArg>      args = {};
     optional inline Vector<Annotation> annotations;
     bool init_default = false;

--- a/backends/tofino/bf-p4c/mau/action_analysis.cpp
+++ b/backends/tofino/bf-p4c/mau/action_analysis.cpp
@@ -455,7 +455,7 @@ bool ActionAnalysis::preorder(const IR::Cast *) {
     BUG("No casts should ever reach this point in the Tofino backend");
 }
 
-bool ActionAnalysis::preorder(const IR::MAU::Primitive *prim) {
+bool ActionAnalysis::preorder(const IR::MAU::MauPrimitive *prim) {
     LOG4("ActionAnalysis preorder on Primitive : " << *prim);
     BUG("%s: Primitive %s was not correctly converted in Instruction Selection", prim->srcInfo,
         prim);

--- a/backends/tofino/bf-p4c/mau/action_analysis.h
+++ b/backends/tofino/bf-p4c/mau/action_analysis.h
@@ -588,7 +588,7 @@ class ActionAnalysis : public MauInspector, TofinoWriteContext {
     bool preorder(const IR::MAU::Instruction *) override;
     bool preorder(const IR::MAU::StatefulCall *) override;
     bool preorder(const IR::MAU::StatefulCounter *sc) override;
-    bool preorder(const IR::MAU::Primitive *) override;
+    bool preorder(const IR::MAU::MauPrimitive *) override;
     void postorder(const IR::MAU::Instruction *) override;
     void postorder(const IR::MAU::Action *) override;
     bool preorder(const IR::BFN::ReinterpretCast *cast) override;

--- a/backends/tofino/bf-p4c/mau/adjust_byte_count.cpp
+++ b/backends/tofino/bf-p4c/mau/adjust_byte_count.cpp
@@ -69,7 +69,7 @@ const IR::MAU::Meter *AdjustByteCountSetup::Update::preorder(IR::MAU::Meter *met
     return meter;
 }
 
-bool AdjustByteCountSetup::Scan::preorder(const IR::MAU::Primitive *prim) {
+bool AdjustByteCountSetup::Scan::preorder(const IR::MAU::MauPrimitive *prim) {
     LOG1("Primitive : " << prim);
 
     const IR::MAU::AttachedMemory *obj = nullptr;

--- a/backends/tofino/bf-p4c/mau/adjust_byte_count.h
+++ b/backends/tofino/bf-p4c/mau/adjust_byte_count.h
@@ -40,7 +40,7 @@ class AdjustByteCountSetup : public PassManager {
 
      public:
         explicit Scan(AdjustByteCountSetup &self) : self(self) {}
-        bool preorder(const IR::MAU::Primitive *prim) override;
+        bool preorder(const IR::MAU::MauPrimitive *prim) override;
     };
 
     class Update : public MauTransform {

--- a/backends/tofino/bf-p4c/mau/attached_info.h
+++ b/backends/tofino/bf-p4c/mau/attached_info.h
@@ -200,7 +200,7 @@ class HasAttachedMemory : public MauInspector {
     bool preorder(const IR::MAU::AttachedMemory *am) {
         unsigned mask = 1U;
         const Visitor::Context *ctxt = nullptr;
-        if (findContext<IR::MAU::Primitive>(ctxt)) {
+        if (findContext<IR::MAU::MauPrimitive>(ctxt)) {
             BUG_CHECK(ctxt->child_index >= 0 && ctxt->child_index < 32, "mask overflow");
             mask <<= ctxt->child_index;
         }

--- a/backends/tofino/bf-p4c/mau/instruction_adjustment.cpp
+++ b/backends/tofino/bf-p4c/mau/instruction_adjustment.cpp
@@ -54,7 +54,7 @@
  *
  *  In this example, it is possible to carry tmp0/1 on 32, 16 or 8-bit field.
  */
-static void split_shl_instruction(IR::Vector<IR::MAU::Primitive> *split,
+static void split_shl_instruction(IR::Vector<IR::MAU::MauPrimitive> *split,
                                   std::vector<le_bitrange> &slices, const PHV::Field *field,
                                   IR::MAU::Instruction *inst) {
     std::queue<le_bitrange> slices_q;
@@ -194,7 +194,7 @@ static void split_shl_instruction(IR::Vector<IR::MAU::Primitive> *split,
  *
  *  In this example, it is possible to carry tmp0/1 on 32, 16 or 8-bit field.
  */
-static void split_shr_instruction(IR::Vector<IR::MAU::Primitive> *split,
+static void split_shr_instruction(IR::Vector<IR::MAU::MauPrimitive> *split,
                                   std::vector<le_bitrange> &slices, const PHV::Field *field,
                                   IR::MAU::Instruction *inst, bool signed_opcode) {
     std::queue<le_bitrange> slices_q;
@@ -484,7 +484,7 @@ const IR::Node *SplitInstructions::preorder(IR::MAU::Instruction *inst) {
     BUG_CHECK(opcode != "saddu" && opcode != "sadds" && opcode != "ssubu" && opcode != "ssubs",
               "Saturating arithmetic operations cannot be split");
 
-    auto split = new IR::Vector<IR::MAU::Primitive>();
+    auto split = new IR::Vector<IR::MAU::MauPrimitive>();
 
     if (opcode == "shl") {
         split_shl_instruction(split, slices, field, inst);
@@ -579,7 +579,7 @@ const IR::MAU::Instruction *ConstantsToActionData::preorder(IR::MAU::Instruction
 
 const IR::MAU::ActionArg *ConstantsToActionData::preorder(IR::MAU::ActionArg *arg) { return arg; }
 
-const IR::MAU::Primitive *ConstantsToActionData::preorder(IR::MAU::Primitive *prim) {
+const IR::MAU::MauPrimitive *ConstantsToActionData::preorder(IR::MAU::MauPrimitive *prim) {
     prune();
     return prim;
 }
@@ -929,7 +929,7 @@ const IR::Constant *MergeInstructions::preorder(IR::Constant *cst) {
     return cst;
 }
 
-const IR::MAU::Primitive *MergeInstructions::preorder(IR::MAU::Primitive *prim) {
+const IR::MAU::MauPrimitive *MergeInstructions::preorder(IR::MAU::MauPrimitive *prim) {
     prune();
     return prim;
 }

--- a/backends/tofino/bf-p4c/mau/instruction_adjustment.h
+++ b/backends/tofino/bf-p4c/mau/instruction_adjustment.h
@@ -171,7 +171,7 @@ class ConstantsToActionData : public MauTransform, TofinoWriteContext {
     const IR::Constant *preorder(IR::Constant *) override;
     const IR::Slice *preorder(IR::Slice *) override;
     void analyze_phv_field(IR::Expression *);
-    const IR::MAU::Primitive *preorder(IR::MAU::Primitive *) override;
+    const IR::MAU::MauPrimitive *preorder(IR::MAU::MauPrimitive *) override;
     const IR::MAU::Instruction *postorder(IR::MAU::Instruction *) override;
     const IR::MAU::Action *postorder(IR::MAU::Action *) override;
 
@@ -250,7 +250,7 @@ class MergeInstructions : public MauTransform, TofinoWriteContext {
     const IR::MAU::ActionDataConstant *preorder(IR::MAU::ActionDataConstant *) override;
     const IR::MAU::ActionArg *preorder(IR::MAU::ActionArg *) override;
     const IR::Constant *preorder(IR::Constant *) override;
-    const IR::MAU::Primitive *preorder(IR::MAU::Primitive *) override;
+    const IR::MAU::MauPrimitive *preorder(IR::MAU::MauPrimitive *) override;
 
     const IR::MAU::AttachedOutput *preorder(IR::MAU::AttachedOutput *ao) override;
     const IR::MAU::StatefulAlu *preorder(IR::MAU::StatefulAlu *salu) override;

--- a/backends/tofino/bf-p4c/mau/instruction_selection.h
+++ b/backends/tofino/bf-p4c/mau/instruction_selection.h
@@ -34,7 +34,7 @@ using namespace P4;
  * calls.  Eventually someone has to write a pass to do this conversion.
  */
 class UnimplementedRegisterMethodCalls : public MauInspector {
-    bool preorder(const IR::MAU::Primitive *prim) override;
+    bool preorder(const IR::MAU::MauPrimitive *prim) override;
 
  public:
     UnimplementedRegisterMethodCalls() {}
@@ -90,8 +90,8 @@ class HashGenSetup : public PassManager {
         bool preorder(const IR::Concat *) override;
         bool preorder(const IR::Expression *) override;
         bool preorder(const IR::Constant *) override;
-        bool preorder(const IR::MAU::Primitive *) override;
-        void postorder(const IR::MAU::Primitive *) override;
+        bool preorder(const IR::MAU::MauPrimitive *) override;
+        void postorder(const IR::MAU::MauPrimitive *) override;
 
         void check_for_symmetric(const IR::Declaration_Instance *decl, const IR::ListExpression *le,
                                  IR::MAU::HashFunction hf, LTBitMatrix *sym_keys);
@@ -140,14 +140,14 @@ class HashGenSetup : public PassManager {
  *  IR node could be necessary.
  */
 class Synth2PortSetup : public MauTransform {
-    safe_vector<const IR::MAU::Primitive *> stateful;
+    safe_vector<const IR::MAU::MauPrimitive *> stateful;
     std::set<UniqueAttachedId> per_flow_enables;
     std::map<UniqueAttachedId, IR::MAU::MeterType> meter_types;
 
     safe_vector<IR::MAU::Instruction *> created_instrs;
 
     const IR::MAU::Action *preorder(IR::MAU::Action *) override;
-    const IR::Node *postorder(IR::MAU::Primitive *) override;
+    const IR::Node *postorder(IR::MAU::MauPrimitive *) override;
     const IR::MAU::Action *postorder(IR::MAU::Action *) override;
 
     void clear_action() {
@@ -214,7 +214,7 @@ class DoInstructionSelection : public MauTransform, TofinoWriteContext {
     const IR::Expression *postorder(IR::Mux *) override;
     const IR::Slice *postorder(IR::Slice *) override;
     const IR::Expression *postorder(IR::BoolLiteral *) override;
-    const IR::Node *postorder(IR::MAU::Primitive *) override;
+    const IR::Node *postorder(IR::MAU::MauPrimitive *) override;
     const IR::MAU::Instruction *postorder(IR::MAU::Instruction *i) override { return i; }
 
     bool checkPHV(const IR::Expression *);
@@ -278,7 +278,7 @@ class StatefulAttachmentSetup : public PassManager {
         bool preorder(const IR::TempVar *) override;
         bool preorder(const IR::MAU::HashDist *) override;
         void postorder(const IR::MAU::Instruction *) override;
-        void postorder(const IR::MAU::Primitive *) override;
+        void postorder(const IR::MAU::MauPrimitive *) override;
         void postorder(const IR::MAU::Table *) override;
         void setup_index_operand(const IR::Expression *index_expr,
                                  const IR::MAU::Synth2Port *synth2port, const IR::MAU::Table *tbl,
@@ -302,8 +302,8 @@ class StatefulAttachmentSetup : public PassManager {
     };
 
     const IR::MAU::HashDist *find_hash_dist(const IR::Expression *expr,
-                                            const IR::MAU::Primitive *prim);
-    IR::MAU::HashDist *create_hash_dist(const IR::Expression *e, const IR::MAU::Primitive *prim);
+                                            const IR::MAU::MauPrimitive *prim);
+    IR::MAU::HashDist *create_hash_dist(const IR::Expression *e, const IR::MAU::MauPrimitive *prim);
 
  public:
     explicit StatefulAttachmentSetup(const PhvInfo &p) : phv(p) {
@@ -333,7 +333,7 @@ class BackendCopyPropagation : public MauTransform, TofinoWriteContext {
     };
     ordered_map<const PHV::Field *, safe_vector<FieldImpact>> copy_propagation_replacements;
     bool elem_copy_propagated = false;
-    IR::Vector<IR::MAU::Primitive> *split_set = nullptr;
+    IR::Vector<IR::MAU::MauPrimitive> *split_set = nullptr;
 
     const IR::Node *preorder(IR::Node *n) override {
         visitOnce();
@@ -576,12 +576,12 @@ class MeterSetup : public PassManager {
 
     class Scan : public MauInspector {
         MeterSetup &self;
-        void find_input(const IR::MAU::Primitive *);
-        void find_pre_color(const IR::MAU::Primitive *);
+        void find_input(const IR::MAU::MauPrimitive *);
+        void find_pre_color(const IR::MAU::MauPrimitive *);
         const IR::Expression *convert_cast_to_slice(const IR::Expression *);
         profile_t init_apply(const IR::Node *root) override;
         bool preorder(const IR::MAU::Instruction *) override;
-        bool preorder(const IR::MAU::Primitive *) override;
+        bool preorder(const IR::MAU::MauPrimitive *) override;
 
      public:
         explicit Scan(MeterSetup &self) : self(self) {}

--- a/backends/tofino/bf-p4c/mau/push_pop.h
+++ b/backends/tofino/bf-p4c/mau/push_pop.h
@@ -123,44 +123,44 @@ class HeaderPushPop : public MauTransform {
         return pipe;
     }
 
-    void copy_hdr(IR::Vector<IR::MAU::Primitive> *rv, const IR::Type_StructLike *hdr,
+    void copy_hdr(IR::Vector<IR::MAU::MauPrimitive> *rv, const IR::Type_StructLike *hdr,
                   const IR::HeaderRef *to, const IR::HeaderRef *from) {
         for (auto field : hdr->fields) {
             auto dst = new IR::Member(field->type, to, field->name);
             auto src = new IR::Member(field->type, from, field->name);
-            rv->push_back(new IR::MAU::Primitive("modify_field"_cs, dst, src));
+            rv->push_back(new IR::MAU::MauPrimitive("modify_field"_cs, dst, src));
         }
     }
     IR::Node *do_push(const IR::HeaderRef *stack, int count) {
         auto &info = stacks->at(stack->toString());
-        auto *rv = new IR::Vector<IR::MAU::Primitive>;
+        auto *rv = new IR::Vector<IR::MAU::MauPrimitive>;
         for (int i = info.size - 1; i >= count; --i)
             copy_hdr(rv, stack->baseRef()->type,
                      new IR::HeaderStackItemRef(stack, new IR::Constant(i)),
                      new IR::HeaderStackItemRef(stack, new IR::Constant(i - count)));
         auto *valid = new IR::Member(IR::Type::Bits::get(info.size + info.maxpop + info.maxpush),
                                      stack, "$stkvalid");
-        rv->push_back(new IR::MAU::Primitive(
+        rv->push_back(new IR::MAU::MauPrimitive(
             "modify_field"_cs, MakeSlice(valid, info.maxpop, info.maxpop + info.size - 1),
             MakeSlice(valid, info.maxpop + count, info.maxpop + info.size + count - 1)));
         return rv;
     }
     IR::Node *do_pop(const IR::HeaderRef *stack, int count) {
         auto &info = stacks->at(stack->toString());
-        auto *rv = new IR::Vector<IR::MAU::Primitive>;
+        auto *rv = new IR::Vector<IR::MAU::MauPrimitive>;
         for (int i = count; i < info.size; ++i)
             copy_hdr(rv, stack->baseRef()->type,
                      new IR::HeaderStackItemRef(stack, new IR::Constant(i - count)),
                      new IR::HeaderStackItemRef(stack, new IR::Constant(i)));
         auto *valid = new IR::Member(IR::Type::Bits::get(info.size + info.maxpop + info.maxpush),
                                      stack, "$stkvalid");
-        rv->push_back(new IR::MAU::Primitive(
+        rv->push_back(new IR::MAU::MauPrimitive(
             "modify_field"_cs, MakeSlice(valid, info.maxpop, info.maxpop + info.size - 1),
             MakeSlice(valid, info.maxpop - count, info.maxpop + info.size - count - 1)));
         return rv;
     }
 
-    IR::Node *preorder(IR::MAU::Primitive *prim) override {
+    IR::Node *preorder(IR::MAU::MauPrimitive *prim) override {
         BUG_CHECK(stacks != nullptr,
                   "No HeaderStackInfo; was HeaderPushPop "
                   "applied to a non-Pipe node?");

--- a/backends/tofino/bf-p4c/mau/stateful_alu.cpp
+++ b/backends/tofino/bf-p4c/mau/stateful_alu.cpp
@@ -989,7 +989,7 @@ static double (*fn[2][3])(double) = {{sqrt, mul, sqr}, {rsqrt, div, rsqr}};
 static double fn_max[2][3] = {{1.36930639376291528364, 1.875, 3.515625},
                               {1.41421356237309504880, 1.0, 1.0}};
 
-bool CreateSaluInstruction::preorder(const IR::MAU::Primitive *prim) {
+bool CreateSaluInstruction::preorder(const IR::MAU::MauPrimitive *prim) {
     cstring method;
     if (const char *p = prim->name.find('.')) {
         method = cstring(p + 1);
@@ -2386,7 +2386,7 @@ bool CheckStatefulAlu::preorder(IR::MAU::StatefulAlu *salu) {
         }
         // Validate that each operand are not larger than the stateful ALU can support based on
         // the register size selected.
-        for (const IR::MAU::Primitive *act_prim : salu_action->action) {
+        for (const IR::MAU::MauPrimitive *act_prim : salu_action->action) {
             // Min and Max instruction can operate on 128 bit input even if the stateful ALU
             // operate in 8 or 16 bit mode. Just ignore this corner case for now in this
             // preemptive error reporting.
@@ -2426,7 +2426,7 @@ void CheckStatefulAlu::postorder(IR::MAU::SaluInstruction *si) {
     }
 }
 
-bool CheckStatefulAlu::preorder(IR::MAU::Primitive *prim) {
+bool CheckStatefulAlu::preorder(IR::MAU::MauPrimitive *prim) {
     if (!findContext<IR::MAU::SaluAction>()) {
         return true;
     }
@@ -2625,10 +2625,10 @@ const IR::Expression *FixupStatefulAlu::UpdateEncodings::preorder(IR::Member *ex
     if (!enum_type || !self.encodings.count(enum_type)) return exp;
     if (!exp->expr->is<IR::TypeNameExpression>()) return exp;
     auto encoding = self.encodings.at(enum_type).encoding;
-    const IR::MAU::Primitive *prim;
+    const IR::MAU::MauPrimitive *prim;
     if (getParent<IR::AssignmentStatement>() || getParent<IR::BFN::SavedRVal>()) {
         // ok
-    } else if ((prim = getParent<IR::MAU::Primitive>()) && prim->name == "modify_field") {
+    } else if ((prim = getParent<IR::MAU::MauPrimitive>()) && prim->name == "modify_field") {
         // ok
     } else {
         error(ErrorType::ERR_UNSUPPORTED, "%1%: unexpected enum reference", exp);

--- a/backends/tofino/bf-p4c/mau/stateful_alu.h
+++ b/backends/tofino/bf-p4c/mau/stateful_alu.h
@@ -31,7 +31,7 @@
  *       represented by a register action in P4 code and IR::MAU::SaluAction IR node
  *       * The SALU VLIW instruction contains instructions for particular units
  *         (four sub-ALUs, two comparators, output sub-ALU) represented by primitives
- *         (IR::MAU::Primitive) both in backend and assembler.
+ *         (IR::MAU::MauPrimitive) both in backend and assembler.
  *   * Register file:
  *     * Four rows, each one is 32b (Tofino) / 34b (Tofino 2) register
  *       represented by a register parameter in P4 code and IR::MAU::SaluRegfileRow IR node
@@ -268,7 +268,7 @@ class CreateSaluInstruction : public Inspector {
     bool preorder(const IR::BoolLiteral *) override;
     bool preorder(const IR::AttribLocal *) override { BUG("unconverted p4_14"); }
     bool preorder(const IR::Slice *) override;
-    bool preorder(const IR::MAU::Primitive *) override;
+    bool preorder(const IR::MAU::MauPrimitive *) override;
     bool preorder(const IR::MAU::SaluRegfileRow *) override;
     bool preorder(const IR::Operation::Relation *, cstring op, bool eq);
     bool preorder(const IR::Equ *r) override { return preorder(r, "equ"_cs, true); }
@@ -350,7 +350,7 @@ class CheckStatefulAlu : public MauModifier {
 
     bool preorder(IR::MAU::StatefulAlu *) override;
     bool preorder(IR::MAU::SaluFunction *) override;
-    bool preorder(IR::MAU::Primitive *) override;
+    bool preorder(IR::MAU::MauPrimitive *) override;
 
     /**
      * @brief Check that register params and large constants used in register actions associated

--- a/backends/tofino/bf-p4c/mau/table_placement.cpp
+++ b/backends/tofino/bf-p4c/mau/table_placement.cpp
@@ -5836,7 +5836,7 @@ bool MergeAlwaysRunActions::Scan::preorder(const IR::MAU::Table *tbl) {
     return true;
 }
 
-bool MergeAlwaysRunActions::Scan::preorder(const IR::MAU::Primitive *prim) {
+bool MergeAlwaysRunActions::Scan::preorder(const IR::MAU::MauPrimitive *prim) {
     auto *tbl = findContext<IR::MAU::Table>();
     if (tbl != nullptr && tbl->is_always_run_action()) {
         for (uint32_t idx = 0; idx < prim->operands.size(); ++idx) {

--- a/backends/tofino/bf-p4c/mau/table_placement.h
+++ b/backends/tofino/bf-p4c/mau/table_placement.h
@@ -362,7 +362,7 @@ class MergeAlwaysRunActions : public PassManager {
     class Scan : public MauInspector {
         MergeAlwaysRunActions &self;
         bool preorder(const IR::MAU::Table *) override;
-        bool preorder(const IR::MAU::Primitive *) override;
+        bool preorder(const IR::MAU::MauPrimitive *) override;
         void end_apply() override;
 
      public:

--- a/backends/tofino/bf-p4c/parde/add_metadata_pov.h
+++ b/backends/tofino/bf-p4c/parde/add_metadata_pov.h
@@ -37,16 +37,16 @@ class AddMetadataPOV : public Transform {
     const IR::BFN::Deparser *dp = nullptr;
 
     bool equiv(const IR::Expression *a, const IR::Expression *b);
-    static IR::MAU::Primitive *create_pov_write(const IR::Expression *povBit, bool validate);
-    IR::Node *insert_deparser_param_pov_write(const IR::MAU::Primitive *p, bool validate);
-    IR::Node *insert_deparser_digest_pov_write(const IR::MAU::Primitive *p, bool validate);
-    IR::Node *insert_field_pov_read(const IR::MAU::Primitive *p);
+    static IR::MAU::MauPrimitive *create_pov_write(const IR::Expression *povBit, bool validate);
+    IR::Node *insert_deparser_param_pov_write(const IR::MAU::MauPrimitive *p, bool validate);
+    IR::Node *insert_deparser_digest_pov_write(const IR::MAU::MauPrimitive *p, bool validate);
+    IR::Node *insert_field_pov_read(const IR::MAU::MauPrimitive *p);
 
     IR::BFN::Pipe *preorder(IR::BFN::Pipe *pipe) override;
 
     IR::BFN::DeparserParameter *postorder(IR::BFN::DeparserParameter *param) override;
     IR::BFN::Digest *postorder(IR::BFN::Digest *digest) override;
-    IR::Node *postorder(IR::MAU::Primitive *p) override;
+    IR::Node *postorder(IR::MAU::MauPrimitive *p) override;
     IR::Node *postorder(IR::BFN::Extract *e) override;
 
  public:

--- a/backends/tofino/bf-p4c/parde/reset_invalidated_checksum_headers.h
+++ b/backends/tofino/bf-p4c/parde/reset_invalidated_checksum_headers.h
@@ -81,7 +81,7 @@ struct CollectInvalidatedHeaders : public Inspector {
         const std::map<const PHV::Field *, std::set<const PHV::Field *>> &pov_bit_to_fields)
         : phv(phv), pov_bit_to_fields(pov_bit_to_fields) {}
 
-    bool preorder(const IR::MAU::Primitive *p) override {
+    bool preorder(const IR::MAU::MauPrimitive *p) override {
         auto table = findContext<IR::MAU::Table>();
         auto gress = table->gress;
 

--- a/backends/tofino/bf-p4c/phv/add_initialization.cpp
+++ b/backends/tofino/bf-p4c/phv/add_initialization.cpp
@@ -173,7 +173,7 @@ Visitor::profile_t ComputeDarkInitialization::init_apply(const IR::Node *root) {
 
 void ComputeDarkInitialization::computeInitInstruction(const PHV::AllocSlice &slice,
                                                        const IR::MAU::Action *action) {
-    const IR::MAU::Primitive *prim;
+    const IR::MAU::MauPrimitive *prim;
     if (slice.getInitPrimitive().destAssignedToZero()) {
         LOG4("\tAdd initialization from zero in action " << action->name << " for: " << slice);
         prim = fieldToExpr.generateInitInstruction(slice);
@@ -515,10 +515,10 @@ void ComputeDarkInitialization::end_apply() {
 
 // Retrieve primitives for @tbl/@act hash key
 // -----
-const ordered_set<const IR::MAU::Primitive *>
+const ordered_set<const IR::MAU::MauPrimitive *>
 ComputeDarkInitialization::getInitializationInstructions(const IR::MAU::Table *tbl,
                                                          const IR::MAU::Action *act) const {
-    static ordered_set<const IR::MAU::Primitive *> rv;
+    static ordered_set<const IR::MAU::MauPrimitive *> rv;
     cstring key = getKey(tbl, act);
     if (!actionToInsertedInsts.count(key)) return rv;
     return actionToInsertedInsts.at(key);

--- a/backends/tofino/bf-p4c/phv/add_initialization.h
+++ b/backends/tofino/bf-p4c/phv/add_initialization.h
@@ -105,7 +105,7 @@ class ComputeDarkInitialization : public Inspector {
     const MapFieldToExpr &fieldToExpr;
     const DependencyGraph &dg;
 
-    ordered_map<cstring, ordered_set<const IR::MAU::Primitive *>> actionToInsertedInsts;
+    ordered_map<cstring, ordered_set<const IR::MAU::MauPrimitive *>> actionToInsertedInsts;
     ordered_map<const PHV::DarkInitEntry, IR::MAU::Table *> darkInitToARA;
 
     void computeInitInstruction(const PHV::AllocSlice &slice, const IR::MAU::Action *act);
@@ -140,7 +140,7 @@ class ComputeDarkInitialization : public Inspector {
                                        const MapFieldToExpr &e, const DependencyGraph &g)
         : phv(p), tableActionsMap(m), fieldToExpr(e), dg(g) {}
 
-    const ordered_set<const IR::MAU::Primitive *> getInitializationInstructions(
+    const ordered_set<const IR::MAU::MauPrimitive *> getInitializationInstructions(
         const IR::MAU::Table *tbl, const IR::MAU::Action *act) const;
 };
 

--- a/backends/tofino/bf-p4c/phv/analysis/header_mutex.cpp
+++ b/backends/tofino/bf-p4c/phv/analysis/header_mutex.cpp
@@ -218,7 +218,7 @@ bool FindPovAndParserErrorInMau::is_original_parser_err_field(const PHV::Field *
 }
 
 const PHV::Field *FindPovAndParserErrorInMau::get_assigned_field() {
-    const auto *primitive = findContext<IR::MAU::Primitive>();
+    const auto *primitive = findContext<IR::MAU::MauPrimitive>();
     if (!primitive) return nullptr;
 
     const PHV::Field *field = get_phv_field(primitive->operands[0]);
@@ -761,30 +761,30 @@ Visitor::profile_t ExcludeMAUNotMutexHeaders::init_apply(const IR::Node *root) {
     return rv;
 }
 
-bool ExcludeMAUNotMutexHeaders::is_set(const IR::MAU::Primitive *primitive) {
+bool ExcludeMAUNotMutexHeaders::is_set(const IR::MAU::MauPrimitive *primitive) {
     return (primitive->name == "set" && primitive->operands.size() > 1);
 }
 
-bool ExcludeMAUNotMutexHeaders::is_set_header_pov(const IR::MAU::Primitive *primitive) {
+bool ExcludeMAUNotMutexHeaders::is_set_header_pov(const IR::MAU::MauPrimitive *primitive) {
     if (!is_set(primitive)) return false;
     const PHV::Field *field = get_phv_field(primitive->operands[0]);
     return (field && field->header() && field->pov);
 }
 
-bool ExcludeMAUNotMutexHeaders::is_set_header_valid(const IR::MAU::Primitive *primitive) {
+bool ExcludeMAUNotMutexHeaders::is_set_header_valid(const IR::MAU::MauPrimitive *primitive) {
     const IR::Constant *constant =
         (is_set_header_pov(primitive)) ? primitive->operands[1]->to<IR::Constant>() : nullptr;
     return (constant && constant->value == 1);
 }
 
-bool ExcludeMAUNotMutexHeaders::is_set_header_invalid(const IR::MAU::Primitive *primitive) {
+bool ExcludeMAUNotMutexHeaders::is_set_header_invalid(const IR::MAU::MauPrimitive *primitive) {
     const IR::Constant *constant =
         (is_set_header_pov(primitive)) ? primitive->operands[1]->to<IR::Constant>() : nullptr;
     return (constant && constant->value == 0);
 }
 
 bool ExcludeMAUNotMutexHeaders::is_set_header_pov_to_other_header_pov(
-    const IR::MAU::Primitive *primitive) {
+    const IR::MAU::MauPrimitive *primitive) {
     const PHV::Field *field =
         (is_set_header_pov(primitive)) ? get_phv_field(primitive->operands[1]) : nullptr;
     return (field && field->header() && field->pov);

--- a/backends/tofino/bf-p4c/phv/analysis/header_mutex.h
+++ b/backends/tofino/bf-p4c/phv/analysis/header_mutex.h
@@ -334,11 +334,11 @@ class ExcludeMAUNotMutexHeaders : public MauInspector,
     }
 
     bool is_header(const PHV::Field *field) { return field && field->header() && !field->metadata; }
-    bool is_set(const IR::MAU::Primitive *primitive);
-    bool is_set_header_pov(const IR::MAU::Primitive *primitive);
-    bool is_set_header_valid(const IR::MAU::Primitive *primitive);
-    bool is_set_header_invalid(const IR::MAU::Primitive *primitive);
-    bool is_set_header_pov_to_other_header_pov(const IR::MAU::Primitive *primitive);
+    bool is_set(const IR::MAU::MauPrimitive *primitive);
+    bool is_set_header_pov(const IR::MAU::MauPrimitive *primitive);
+    bool is_set_header_valid(const IR::MAU::MauPrimitive *primitive);
+    bool is_set_header_invalid(const IR::MAU::MauPrimitive *primitive);
+    bool is_set_header_pov_to_other_header_pov(const IR::MAU::MauPrimitive *primitive);
     void init_active_headers();
     void init_extracted_headers();
     void init_not_extracted_headers();

--- a/backends/tofino/bf-p4c/phv/analysis/mutex_overlay.cpp
+++ b/backends/tofino/bf-p4c/phv/analysis/mutex_overlay.cpp
@@ -265,7 +265,7 @@ Visitor::profile_t MarkMutexPragmaFields::init_apply(const IR::Node *root) {
     return Inspector::init_apply(root);
 }
 
-bool FindAddedHeaderFields::preorder(const IR::MAU::Primitive *prim) {
+bool FindAddedHeaderFields::preorder(const IR::MAU::MauPrimitive *prim) {
     LOG5("Prim name: " << prim->name);
     // If this is a well-formed field modification...
     if (prim->name == "set" && prim->operands.size() > 1) {

--- a/backends/tofino/bf-p4c/phv/analysis/mutex_overlay.h
+++ b/backends/tofino/bf-p4c/phv/analysis/mutex_overlay.h
@@ -175,7 +175,7 @@ class FindAddedHeaderFields : public MauInspector {
         rv.clear();
         return Inspector::init_apply(root);
     }
-    bool preorder(const IR::MAU::Primitive *prim) override;
+    bool preorder(const IR::MAU::MauPrimitive *prim) override;
     void markFields(const IR::HeaderRef *hr);
 
  public:

--- a/frontends/p4-14/ir-v1.def
+++ b/frontends/p4-14/ir-v1.def
@@ -163,7 +163,7 @@ class If :  Expression {
     NullOK Vector<Expression>    ifFalse;
     visit_children {
         v.visit(pred, "pred");
-        SplitFlowVisit<Vector<Expression>>(v, ifTrue, ifFalse).run_visit();
+        SplitFlowVisit<If, Vector<Expression>>(v, ifTrue, ifFalse).run_visit();
         Expression::visit_children(v, n);
     }
 }
@@ -253,6 +253,10 @@ class CalculatedField : IAnnotated {
         ID                      name;
         Expression              cond;
         update_or_verify() { }  // FIXME -- needed by umpack_json(safe_vector) -- should not be
+        visit_children {
+            (void)n;
+            v.visit(cond, name.name.c_str());
+        }
     }
     safe_vector<update_or_verify> specs = {};
     optional inline Vector<Annotation> annotations;
@@ -261,7 +265,7 @@ class CalculatedField : IAnnotated {
     visit_children {
         (void)n;
         v.visit(field, "field");
-        for (auto &s : specs) v.visit(s.cond, s.name.name.c_str());
+        for (auto &s : specs) s.visit_children(v, "specs");
         v.visit(annotations, "annotations"); }
 }
 

--- a/frontends/p4/removeReturns.cpp
+++ b/frontends/p4/removeReturns.cpp
@@ -9,7 +9,7 @@
 
 namespace P4 {
 
-bool MoveToElseAfterBranch::preorder(IR::BlockStatement *block) {
+bool MoveToElseAfterBranch::preorder(IR::COWptr<IR::BlockStatement> block) {
     movedToIfBranch = false;
     for (auto it = block->components.begin(); it != block->components.end();) {
         if (movedToIfBranch)
@@ -21,7 +21,8 @@ bool MoveToElseAfterBranch::preorder(IR::BlockStatement *block) {
     return false;
 }
 
-bool MoveToElseAfterBranch::moveFromParentTo(const IR::Statement *&child) {
+template <class T>
+bool MoveToElseAfterBranch::moveFromParentTo(T &child) {
     auto parent = getParent<IR::BlockStatement>();
     size_t next = getContext()->child_index + 1;
     if (!parent || next >= parent->components.size()) {
@@ -32,9 +33,9 @@ bool MoveToElseAfterBranch::moveFromParentTo(const IR::Statement *&child) {
     IR::BlockStatement *modified = nullptr;
     if (!child)
         modified = new IR::BlockStatement;
-    else if (auto *t = child->to<IR::BlockStatement>())
+    else if (auto *t = child->template to<IR::BlockStatement>())
         modified = t->clone();
-    else if (child->is<IR::EmptyStatement>())
+    else if (child->template is<IR::EmptyStatement>())
         modified = new IR::BlockStatement;
     else
         modified = new IR::BlockStatement({child});
@@ -44,7 +45,7 @@ bool MoveToElseAfterBranch::moveFromParentTo(const IR::Statement *&child) {
     return true;
 }
 
-bool MoveToElseAfterBranch::preorder(IR::IfStatement *ifStmt) {
+bool MoveToElseAfterBranch::preorder(IR::COWptr<IR::IfStatement> ifStmt) {
     hasJumped = false;
     bool movedCode = false;
     visit(ifStmt->ifTrue, "ifTrue", 1);
@@ -63,11 +64,11 @@ bool MoveToElseAfterBranch::preorder(IR::IfStatement *ifStmt) {
     return false;
 }
 
-bool MoveToElseAfterBranch::preorder(IR::SwitchStatement *swch) {
+bool MoveToElseAfterBranch::preorder(IR::COWptr<IR::SwitchStatement> swch) {
     // TBD: if there is exactly one case that falls through (all others end with a branch)
     // then we could move subsequent code into that case, as it done with 'if'
     bool canFallThrough = false;
-    for (auto &c : swch->cases) {
+    for (auto c : swch->cases) {
         hasJumped = false;
         visit(c, "cases");
         canFallThrough |= !hasJumped;
@@ -76,7 +77,7 @@ bool MoveToElseAfterBranch::preorder(IR::SwitchStatement *swch) {
     return false;
 }
 
-void MoveToElseAfterBranch::postorder(IR::LoopStatement *) {
+void MoveToElseAfterBranch::postorder(IR::COWptr<IR::LoopStatement>) {
     // after a loop body is never unreachable
     hasJumped = false;
 }

--- a/frontends/p4/removeReturns.h
+++ b/frontends/p4/removeReturns.h
@@ -56,7 +56,7 @@ introduce a boolean flag and extra tests to remove those branches.
 precondition:
     switchAddDefault pass has run to ensure switch statements cover all cases
 */
-class MoveToElseAfterBranch : public Modifier {
+class MoveToElseAfterBranch : public COWModifier {
     /* This pass does not use (inherit from) ControlFlowVisitor, even though it is doing
      * control flow analysis, as it turns out to be more efficient to do it directly here
      * by overloading the branching constructs (if/switch/loops) and not cloning the visitor,
@@ -71,22 +71,23 @@ class MoveToElseAfterBranch : public Modifier {
      * indicating that it needs to be removed from the BlockStatment */
     bool movedToIfBranch = false;
 
-    bool preorder(IR::BlockStatement *) override;
-    bool moveFromParentTo(const IR::Statement *&child);
-    bool preorder(IR::IfStatement *) override;
-    bool preorder(IR::SwitchStatement *) override;
-    void postorder(IR::LoopStatement *) override;
+    bool preorder(IR::COWptr<IR::BlockStatement>) override;
+    template <class T>
+    bool moveFromParentTo(T &child);
+    bool preorder(IR::COWptr<IR::IfStatement>) override;
+    bool preorder(IR::COWptr<IR::SwitchStatement>) override;
+    void postorder(IR::COWptr<IR::LoopStatement>) override;
     bool branch() {
         hasJumped = true;
         // no need to visit children
         return false;
     }
-    bool preorder(IR::BreakStatement *) override { return branch(); }
-    bool preorder(IR::ContinueStatement *) override { return branch(); }
-    bool preorder(IR::ExitStatement *) override { return branch(); }
-    bool preorder(IR::ReturnStatement *) override { return branch(); }
+    bool preorder(IR::COWptr<IR::BreakStatement>) override { return branch(); }
+    bool preorder(IR::COWptr<IR::ContinueStatement>) override { return branch(); }
+    bool preorder(IR::COWptr<IR::ExitStatement>) override { return branch(); }
+    bool preorder(IR::COWptr<IR::ReturnStatement>) override { return branch(); }
     // Only visit statements, skip all expressions
-    bool preorder(IR::Expression *) override { return false; }
+    bool preorder(IR::COWptr<IR::Expression>) override { return false; }
 
  public:
     MoveToElseAfterBranch() {}

--- a/ir/copy_on_write_inl.h
+++ b/ir/copy_on_write_inl.h
@@ -203,13 +203,13 @@ struct COWref_subfield<T, std::vector<U>, COW, X, field>
     using COWref_base<T, std::vector<U>,
                       COWref_subfield<T, std::vector<U>, COW, X, field>>::operator=;
     const std::vector<U> &get() const {
-        return (reinterpret_cast<const COW *>(this)->get()).*field;
+        return std::launder(reinterpret_cast<const COW *>(this))->get().*field;
     }
     const std::vector<U> &getOrig() const {
-        return (reinterpret_cast<const COW *>(this)->getOrig()).*field;
+        return std::launder(reinterpret_cast<const COW *>(this))->getOrig().*field;
     }
     std::vector<U> &modify() const {
-        return (reinterpret_cast<const COW *>(this)->modify()).*field;
+        return std::launder(reinterpret_cast<const COW *>(this))->modify().*field;
     }
 
     void visit_children(Visitor &v, const char *name = nullptr) const {
@@ -246,11 +246,15 @@ struct COWref_subfield<T, Vector<U>, COW, X, field>
           COW_iterator<T, Vector<U>, U, COWref_subfield<T, Vector<U>, COW, X, field>>> {
     COWinfo<T> *info;
     using COWref_base<T, Vector<U>, COWref_subfield<T, Vector<U>, COW, X, field>>::operator=;
-    const Vector<U> &get() const { return (reinterpret_cast<const COW *>(this)->get()).*field; }
-    const Vector<U> &getOrig() const {
-        return (reinterpret_cast<const COW *>(this)->getOrig()).*field;
+    const Vector<U> &get() const {
+        return std::launder(reinterpret_cast<const COW *>(this))->get().*field;
     }
-    Vector<U> &modify() const { return (reinterpret_cast<const COW *>(this)->modify()).*field; }
+    const Vector<U> &getOrig() const {
+        return std::launder(reinterpret_cast<const COW *>(this))->getOrig().*field;
+    }
+    Vector<U> &modify() const {
+        return std::launder(reinterpret_cast<const COW *>(this))->modify().*field;
+    }
 
     void visit_children(Visitor &v, const char *name = nullptr) const {
         auto res = visit_safe_vector(get(), "Vector", v, name);
@@ -466,26 +470,28 @@ struct COW_element_ref<T, C, std::pair<U, V>, COW>
 };
 
 template <class T, class C, class U, class COW>
-requires std::derived_from<typename U::template COW_nested<T, COW_element_ref<T, C, U, COW>>,
-                           COW_nested_class>
-struct COW_element_ref<T, C, U, COW> : public COWref_base<T, U, COW_element_ref<T, C, U, COW>>,
-    public U::template COW_nested<T, COW_element_ref<T, C, U, COW>>
-{
+    requires std::derived_from<typename U::template COW_nested<T, COW_element_ref<T, C, U, COW>>,
+                               COW_nested_class>
+struct COW_element_ref<T, C, U, COW>
+    : public COWref_base<T, U, COW_element_ref<T, C, U, COW>>,
+      public U::template COW_nested<T, COW_element_ref<T, C, U, COW>> {
     mutable bool is_const;
     union {
         typename C::const_iterator ci;
         mutable typename C::iterator ni;
     };
     COW_element_ref(COW r, typename C::const_iterator i)
-      : U::template COW_nested<T, COW_element_ref<T, C, U, COW>>(r.info), is_const(true), ci(i) {}
+        : U::template COW_nested<T, COW_element_ref<T, C, U, COW>>(r.info), is_const(true), ci(i) {}
     COW_element_ref(COW r, typename C::iterator i)
-      : U::template COW_nested<T, COW_element_ref<T, C, U, COW>>(r.info), is_const(false), ni(i) {}
+        : U::template COW_nested<T, COW_element_ref<T, C, U, COW>>(r.info),
+          is_const(false),
+          ni(i) {}
     void clone_fixup() const {
         if (is_const) {
             // messy problem -- need to clone (iff not yet cloned) and then find the
             // corresponding iterator in the clone
-            auto i = reinterpret_cast<const COW *>(this)->modify().begin();
-            auto &orig_vec = reinterpret_cast<const COW *>(this)->getOrig();
+            auto i = std::launder(reinterpret_cast<const COW *>(this))->modify().begin();
+            auto &orig_vec = std::launder(reinterpret_cast<const COW *>(this))->getOrig();
             for (auto oi = orig_vec.begin(); oi != ci; ++oi, ++i)
                 BUG_CHECK(oi != orig_vec.end(), "Invalid iterator in clone_fixup");
             ni = i;
@@ -494,20 +500,19 @@ struct COW_element_ref<T, C, U, COW> : public COWref_base<T, U, COW_element_ref<
     }
     using COWref_base<T, U, COW_element_ref<T, C, U, COW>>::operator=;
     const U &get() const {
-        if (is_const && reinterpret_cast<const COW *>(this)->isCloned()) clone_fixup();
+        if (is_const && isCloned()) clone_fixup();
         return *ci;
     }
     const U &getOrig() const {
         if (is_const) return *ci;
         BUG("getOrig on cloned COW_element_ref");
     }
-    bool isCloned() const { return reinterpret_cast<const COW *>(this)->isCloned(); }
+    bool isCloned() const { return std::launder(reinterpret_cast<const COW *>(this))->isCloned(); }
     U &modify() const {
         clone_fixup();
         return *ni;
     }
 };
-
 
 // specialization for maps with value type pair
 template <class T, class C, class K, class U, class V, class COW>
@@ -581,8 +586,8 @@ struct COW_map_value_ref<T, C, K, std::vector<U>, COW>
             this->is_const = false;
         }
     }
-    using COWref_base<T, std::vector<U>,
-                      COW_map_value_ref<T, C, K, std::vector<U>, COW>>::operator=;
+    using COWref_base<T, std::vector<U>, COW_map_value_ref<T, C, K, std::vector<U>, COW>>::operator=
+        ;
     const std::vector<U> &get() const {
         if (this->is_const && this->isCloned()) clone_fixup();
         return this->ci->second;
@@ -636,8 +641,9 @@ struct COW_array_element_ref : public COWref_base<T, U, COW_array_element_ref<T,
 };
 
 template <class T, typename U, size_t N, U (T::*field)[N]>
-requires std::derived_from<
-    typename U::template COW_nested<T, COW_array_element_ref<T, U, N, field>>, COW_nested_class>
+    requires std::derived_from<
+                 typename U::template COW_nested<T, COW_array_element_ref<T, U, N, field>>,
+                 COW_nested_class>
 struct COW_array_element_ref<T, U, N, field>
     : public COWref_base<T, U, COW_array_element_ref<T, U, N, field>>,
       public U::template COW_nested<T, COW_array_element_ref<T, U, N, field>> {
@@ -647,11 +653,13 @@ struct COW_array_element_ref<T, U, N, field>
         mutable U *ni;
     };
     COW_array_element_ref(COWinfo<T> *inf, const U *i)
-      : U::template COW_nested<T, COW_array_element_ref<T, U, N, field>>(inf),
-        is_const(true), ci(i) {}
+        : U::template COW_nested<T, COW_array_element_ref<T, U, N, field>>(inf),
+          is_const(true),
+          ci(i) {}
     COW_array_element_ref(COWinfo<T> *inf, U *i)
-      : U::template COW_nested<T, COW_array_element_ref<T, U, N, field>>(inf),
-      is_const(false), ni(i) {}
+        : U::template COW_nested<T, COW_array_element_ref<T, U, N, field>>(inf),
+          is_const(false),
+          ni(i) {}
     void clone_fixup() const {
         if (is_const) {
             // messy problem -- need to clone (iff not yet cloned) and then find the
@@ -683,9 +691,9 @@ struct COW_array_iterator {
     COW_array_element_ref<T, U, N, field> ref;
     COW_array_iterator(COWinfo<T> *inf, const U *i) : ref(inf, i) {}
     COW_array_iterator(COWinfo<T> *inf, U *i) : ref(inf, i) {}
-    template<class COW>  // requires COWref<COW>
+    template <class COW>  // requires COWref<COW>
     COW_array_iterator(COW r, const U *i) : ref(r.info, i) {}
-    template<class COW>  // requires COWref<COW>
+    template <class COW>  // requires COWref<COW>
     COW_array_iterator(COW r, U *i) : ref(r.info, i) {}
 
     COW_array_iterator &operator++() {

--- a/ir/copy_on_write_inl.h
+++ b/ir/copy_on_write_inl.h
@@ -1,0 +1,741 @@
+/*
+Copyright 2024 NVIDIA CORPORATION.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef IR_COPY_ON_WRITE_INL_H_
+#define IR_COPY_ON_WRITE_INL_H_
+
+/* template methods declared in "copy_on_write_ptr.h" that can't be defined there
+ * due to order-of-declaration issues. */
+
+// Really only need Visitor::Context here -- split that out into a separate header?
+#include "ir/visitor.h"
+#include "lib/ordered_map.h"
+
+namespace P4::IR {
+
+template <class T>
+const T *COWinfo<T>::get() const {
+    if (clone) return clone->checkedTo<T>();
+    return orig->checkedTo<T>();
+}
+
+template <class T>
+const T *COWinfo<T>::getOrig() const {
+    return orig->checkedTo<T>();
+}
+
+template <class T>
+T *COWinfo<T>::mkClone() {
+    if (!clone) ctxt->node = clone = orig->clone();
+    return clone->checkedTo<T>();
+}
+
+template <class T>
+T *COWinfo<T>::getClone() const {
+    BUG_CHECK(clone != nullptr, "Not yet cloned in getClone");
+    return clone->checkedTo<T>();
+}
+
+/* COW reference to an element from a container.  Used by COWfieldref specializations
+ * of safe_vector, std::vector, Vector, IndexedVector, and NameMap */
+template <class T, class C, class U, class COW>
+struct COW_element_ref : public COWref_base<T, U, COW_element_ref<T, C, U, COW>> {
+    union {
+        COWinfo<T> *info;
+        COW ref;
+    };
+    mutable bool is_const;
+    union {
+        typename C::const_iterator ci;
+        mutable typename C::iterator ni;
+    };
+    COW_element_ref(COW r, typename C::const_iterator i) : ref(r), is_const(true), ci(i) {}
+    COW_element_ref(COW r, typename C::iterator i) : ref(r), is_const(false), ni(i) {}
+    void clone_fixup() const {
+        if (is_const) {
+            // messy problem -- need to clone (iff not yet cloned) and then find the
+            // corresponding iterator in the clone
+            auto i = ref.modify().begin();
+            auto &orig_vec = ref.getOrig();
+            for (auto oi = orig_vec.begin(); oi != ci; ++oi, ++i)
+                BUG_CHECK(oi != orig_vec.end(), "Invalid iterator in clone_fixup");
+            ni = i;
+            is_const = false;
+        }
+    }
+    using COWref_base<T, U, COW_element_ref<T, C, U, COW>>::operator=;
+    const U &get() const {
+        if (is_const && ref.isCloned()) clone_fixup();
+        return *ci;
+    }
+    const U &getOrig() const {
+        if (is_const) return *ci;
+        BUG("getOrig on cloned COW_element_ref");
+    }
+    bool isCloned() const { return ref.isCloned(); }
+    U &modify() const {
+        clone_fixup();
+        return *ni;
+    }
+};
+
+template <class T, class C, class U, class COW>
+struct COW_iterator {
+    COW_element_ref<T, C, U, COW> ref;
+    COW_iterator(COW r, typename C::const_iterator i) : ref(r, i) {}
+    COW_iterator(COW r, typename C::iterator i) : ref(r, i) {}
+    COW_iterator &operator++() {
+        ++ref.ci;
+        return *this;
+    }
+    COW_iterator operator++(int) {
+        COW_iterator<T, C, U, COW> rv = *this;
+        ++ref.ci;
+        return rv;
+    }
+    COW_iterator &operator--() {
+        --ref.ci;
+        return *this;
+    }
+    COW_iterator operator--(int) {
+        COW_iterator<T, C, U, COW> rv = *this;
+        --ref.ci;
+        return rv;
+    }
+    bool operator==(const COW_iterator<T, C, U, COW> &i) const {
+        if (ref.is_const != i.ref.is_const) {
+            ref.clone_fixup();
+            i.ref.clone_fixup();
+        }
+        return ref.ci == i.ref.ci;
+    }
+    bool operator!=(const COW_iterator<T, C, U, COW> &i) const {
+        if (ref.is_const != i.ref.is_const) {
+            ref.clone_fixup();
+            i.ref.clone_fixup();
+        }
+        return ref.ci != i.ref.ci;
+    }
+    const COW_element_ref<T, C, U, COW> &operator*() const { return ref; }
+};
+
+template <class T, class U, class REF, class ITER>
+struct COW_iterableref_base : public COWref_base<T, U, REF> {
+    using iterator = ITER;
+    iterator begin() const {
+        const REF *self = static_cast<const REF *>(this);
+        if (self->info->isCloned())
+            return iterator(*self, std::begin(self->modify()));
+        else
+            return iterator(*self, std::begin(self->get()));
+    }
+    iterator end() const {
+        const REF *self = static_cast<const REF *>(this);
+        if (self->info->isCloned())
+            return iterator(*self, std::end(self->modify()));
+        else
+            return iterator(*self, std::end(self->get()));
+    }
+    iterator erase(iterator i) const {
+        const REF *self = static_cast<const REF *>(this);
+        i.ref.clone_fixup();
+        U &vec = self->modify();
+        return iterator(*self, vec.erase(i.ref.ni));
+    }
+    // FIXME should add insert/append/prepend/emplace_back specializations
+};
+
+/* specialization for safe_vector */
+template <class T, typename U, safe_vector<U> T::*field>
+struct COWfieldref<T, safe_vector<U>, field>
+    : public COW_iterableref_base<
+          T, safe_vector<U>, COWfieldref<T, safe_vector<U>, field>,
+          COW_iterator<T, safe_vector<U>, U, COWfieldref<T, safe_vector<U>, field>>> {
+    COWinfo<T> *info;
+    using COWref_base<T, safe_vector<U>, COWfieldref<T, safe_vector<U>, field>>::operator=;
+    const safe_vector<U> &get() const { return info->get()->*field; }
+    const safe_vector<U> &getOrig() const { return info->getOrig()->*field; }
+    safe_vector<U> &modify() const { return info->mkClone()->*field; }
+
+    void visit_children(Visitor &v, const char *name = nullptr) const {
+        auto res = visit_safe_vector(get(), "safe_vector", v, name);
+        if (res != get()) modify() = std::move(res);
+    }
+};
+
+/* specializations for std::vector */
+template <class T, typename U, std::vector<U> T::*field>
+struct COWfieldref<T, std::vector<U>, field>
+    : public COW_iterableref_base<
+          T, std::vector<U>, COWfieldref<T, std::vector<U>, field>,
+          COW_iterator<T, std::vector<U>, U, COWfieldref<T, std::vector<U>, field>>> {
+    COWinfo<T> *info;
+    using COWref_base<T, std::vector<U>, COWfieldref<T, std::vector<U>, field>>::operator=;
+    const std::vector<U> &get() const { return info->get()->*field; }
+    const std::vector<U> &getOrig() const { return info->getOrig()->*field; }
+    std::vector<U> &modify() const { return info->mkClone()->*field; }
+
+    void visit_children(Visitor &v, const char *name = nullptr) const {
+        auto res = visit_safe_vector(get(), "vector", v, name);
+        if (res != get()) modify() = std::move(res);
+    }
+};
+
+template <class T, class U, class COW, class X, std::vector<U> X::*field>
+struct COWref_subfield<T, std::vector<U>, COW, X, field>
+    : public COW_iterableref_base<
+          T, std::vector<U>, COWref_subfield<T, std::vector<U>, COW, X, field>,
+          COW_iterator<T, std::vector<U>, U, COWref_subfield<T, std::vector<U>, COW, X, field>>> {
+    COWinfo<T> *info;
+    using COWref_base<T, std::vector<U>,
+                      COWref_subfield<T, std::vector<U>, COW, X, field>>::operator=;
+    const std::vector<U> &get() const {
+        return (reinterpret_cast<const COW *>(this)->get()).*field;
+    }
+    const std::vector<U> &getOrig() const {
+        return (reinterpret_cast<const COW *>(this)->getOrig()).*field;
+    }
+    std::vector<U> &modify() const {
+        return (reinterpret_cast<const COW *>(this)->modify()).*field;
+    }
+
+    void visit_children(Visitor &v, const char *name = nullptr) const {
+        auto res = visit_safe_vector(get(), "vector", v, name);
+        if (res != get()) modify() = std::move(res);
+    }
+};
+
+/* specializations for IR::Vector */
+template <class T, typename U, Vector<U> T::*field>
+struct COWfieldref<T, Vector<U>, field>
+    : public COW_iterableref_base<
+          T, Vector<U>, COWfieldref<T, Vector<U>, field>,
+          COW_iterator<T, Vector<U>, const U *, COWfieldref<T, Vector<U>, field>>> {
+    COWinfo<T> *info;
+    using COWref_base<T, Vector<U>, COWfieldref<T, Vector<U>, field>>::operator=;
+    const Vector<U> &get() const { return info->get()->*field; }
+    const Vector<U> &getOrig() const { return info->getOrig()->*field; }
+    Vector<U> &modify() const { return info->mkClone()->*field; }
+
+    void visit_children(Visitor &v, const char *name = nullptr) const {
+        auto res = visit_safe_vector(get().get_contents(), "Vector", v, name);
+        if (res != get().get_contents()) modify().replace_contents(std::move(res));
+    }
+    void parallel_visit_children(Visitor &v, const char * = nullptr) const {
+        SplitFlowVisitVector(v, *this);
+    }
+};
+
+template <class T, class U, class COW, class X, Vector<U> X::*field>
+struct COWref_subfield<T, Vector<U>, COW, X, field>
+    : public COW_iterableref_base<
+          T, Vector<U>, COWref_subfield<T, Vector<U>, COW, X, field>,
+          COW_iterator<T, Vector<U>, U, COWref_subfield<T, Vector<U>, COW, X, field>>> {
+    COWinfo<T> *info;
+    using COWref_base<T, Vector<U>, COWref_subfield<T, Vector<U>, COW, X, field>>::operator=;
+    const Vector<U> &get() const { return (reinterpret_cast<const COW *>(this)->get()).*field; }
+    const Vector<U> &getOrig() const {
+        return (reinterpret_cast<const COW *>(this)->getOrig()).*field;
+    }
+    Vector<U> &modify() const { return (reinterpret_cast<const COW *>(this)->modify()).*field; }
+
+    void visit_children(Visitor &v, const char *name = nullptr) const {
+        auto res = visit_safe_vector(get(), "Vector", v, name);
+        if (res != get()) modify() = std::move(res);
+    }
+    void parallel_visit_children(Visitor &v, const char * = nullptr) const {
+        SplitFlowVisitVector(v, *this);
+    }
+};
+
+/* specializations for IR::IndexedVector */
+template <class T, typename U, IndexedVector<U> T::*field>
+struct COWfieldref<T, IndexedVector<U>, field>
+    : public COW_iterableref_base<
+          T, IndexedVector<U>, COWfieldref<T, IndexedVector<U>, field>,
+          COW_iterator<T, IndexedVector<U>, const U *, COWfieldref<T, IndexedVector<U>, field>>> {
+    COWinfo<T> *info;
+    using COWref_base<T, IndexedVector<U>, COWfieldref<T, IndexedVector<U>, field>>::operator=;
+    const IndexedVector<U> &get() const { return info->get()->*field; }
+    const IndexedVector<U> &getOrig() const { return info->getOrig()->*field; }
+    IndexedVector<U> &modify() const { return info->mkClone()->*field; }
+
+    void visit_children(Visitor &v, const char *name = nullptr) const {
+        auto res = visit_safe_vector(get().get_contents(), "IndexedVector", v, name);
+        if (res != get().get_contents()) modify().replace_contents(std::move(res));
+    }
+};
+
+/* specializations for IR::NameMap */
+template <class T, typename U, template <class K, class V, class COMP, class ALLOC> class MAP,
+          NameMap<U, MAP> T::*field>
+struct COWfieldref<T, NameMap<U, MAP>, field>
+    : public COW_iterableref_base<
+          T, NameMap<U, MAP>, COWfieldref<T, NameMap<U, MAP>, field>,
+          COW_iterator<T, NameMap<U, MAP>, const U *, COWfieldref<T, NameMap<U, MAP>, field>>> {
+    COWinfo<T> *info;
+    using COWref_base<T, NameMap<U, MAP>, COWfieldref<T, NameMap<U, MAP>, field>>::operator=;
+    const NameMap<U, MAP> &get() const { return info->get()->*field; }
+    const NameMap<U, MAP> &getOrig() const { return info->getOrig()->*field; }
+    NameMap<U, MAP> &modify() const { return info->mkClone()->*field; }
+
+    void visit_children(Visitor &v, const char *name = nullptr) const {
+        auto res = get().visit_symbols(v, name);
+        if (!get().match_contents(res)) modify().replace_contents(std::move(res));
+    }
+};
+
+// FIXME -- need NodeMap specializations if any backend ever uses that template
+
+template <class T, class C, class K, class V, class COW>
+struct COW_map_value_ref : public COWref_base<T, V, COW_map_value_ref<T, C, K, V, COW>> {
+    union {
+        COWinfo<T> *info;
+        COW ref;
+    };
+    mutable bool is_const;
+    union {
+        typename C::const_iterator ci;
+        mutable typename C::iterator ni;
+    };
+    COW_map_value_ref(COW r, typename C::const_iterator i) : ref(r), is_const(true), ci(i) {}
+    COW_map_value_ref(COW r, typename C::iterator i) : ref(r), is_const(false), ni(i) {}
+    void clone_fixup() const {
+        if (this->is_const) {
+            // messy problem -- need to clone (iff not yet cloned) and then find the
+            // corresponding iterator in the clone.  If the element has been removed
+            // in the clone, we end up returning end(), which may or may not be ok
+            this->ni = this->ref.modify().find(this->ci->first);
+            this->is_const = false;
+        }
+    }
+    using COWref_base<T, V, COW_map_value_ref<T, C, K, V, COW>>::operator=;
+    const V &get() const {
+        if (this->is_const && this->isCloned()) clone_fixup();
+        return this->ci->second;
+    }
+    const V &getOrig() const {
+        if (this->is_const) return this->ci->second;
+        BUG("getOrig on cloned COW_map_value_ref");
+    }
+    V &modify() const {
+        clone_fixup();
+        return this->ni->second;
+    }
+};
+
+/* specializations for std::map */
+template <class T, class KEY, class VAL, class COMP, class ALLOC,
+          std::map<KEY, VAL, COMP, ALLOC> T::*field>
+struct COWfieldref<T, std::map<KEY, VAL, COMP, ALLOC>, field>
+    : public COW_iterableref_base<
+          T, std::map<KEY, VAL, COMP, ALLOC>,
+          COWfieldref<T, std::map<KEY, VAL, COMP, ALLOC>, field>,
+          COW_iterator<T, std::map<KEY, VAL, COMP, ALLOC>, std::pair<const KEY, VAL>,
+                       COWfieldref<T, std::map<KEY, VAL, COMP, ALLOC>, field>>> {
+    COWinfo<T> *info;
+    using THIS = COWfieldref<T, std::map<KEY, VAL, COMP, ALLOC>, field>;
+    using COWref_base<T, std::map<KEY, VAL, COMP, ALLOC>, THIS>::operator=;
+    const std::map<KEY, VAL, COMP, ALLOC> &get() const { return info->get()->*field; }
+    const std::map<KEY, VAL, COMP, ALLOC> &getOrig() const { return info->getOrig()->*field; }
+    std::map<KEY, VAL, COMP, ALLOC> &modify() const { return info->mkClone()->*field; }
+
+    COW_map_value_ref<T, std::map<KEY, VAL, COMP, ALLOC>, KEY, VAL, THIS> at(const KEY &k) const {
+        auto it = get().find(k);
+        if (it == get().end()) get().at(k);  // throw exception
+        return COW_map_value_ref<T, std::map<KEY, VAL, COMP, ALLOC>, KEY, VAL, THIS>(*this, it);
+    }
+    size_t count(const KEY &k) const { return get().count(k); }
+};
+
+/* specializations for ordered_map */
+template <class T, class KEY, class VAL, class COMP, class ALLOC,
+          ordered_map<KEY, VAL, COMP, ALLOC> T::*field>
+struct COWfieldref<T, ordered_map<KEY, VAL, COMP, ALLOC>, field>
+    : public COW_iterableref_base<
+          T, ordered_map<KEY, VAL, COMP, ALLOC>,
+          COWfieldref<T, ordered_map<KEY, VAL, COMP, ALLOC>, field>,
+          COW_iterator<T, ordered_map<KEY, VAL, COMP, ALLOC>, std::pair<const KEY, VAL>,
+                       COWfieldref<T, ordered_map<KEY, VAL, COMP, ALLOC>, field>>> {
+    COWinfo<T> *info;
+    using THIS = COWfieldref<T, ordered_map<KEY, VAL, COMP, ALLOC>, field>;
+    using COWref_base<T, ordered_map<KEY, VAL, COMP, ALLOC>, THIS>::operator=;
+    const ordered_map<KEY, VAL, COMP, ALLOC> &get() const { return info->get()->*field; }
+    const ordered_map<KEY, VAL, COMP, ALLOC> &getOrig() const { return info->getOrig()->*field; }
+    ordered_map<KEY, VAL, COMP, ALLOC> &modify() const { return info->mkClone()->*field; }
+
+    COW_map_value_ref<T, ordered_map<KEY, VAL, COMP, ALLOC>, KEY, VAL, THIS> at(
+        const KEY &k) const {
+        auto it = get().find(k);
+        if (it == get().end()) get().at(k);  // throw exception
+        return COW_map_value_ref<T, ordered_map<KEY, VAL, COMP, ALLOC>, KEY, VAL, THIS>(*this, it);
+    }
+    size_t count(const KEY &k) const { return get().count(k); }
+};
+
+#if 0
+/* specialization for std::variant */
+template <class T, class... TYPES, std::variant<TYPES...> T::*field>
+struct COWfieldref<T, std::variant<TYPES...>, field> {
+    COWinfo<T>        *info;
+
+    size_t index() const { return info->get()->*field.index(); }
+    // FIXME -- what do we need here?  Do we need a specialization of std::visit?
+};
+#endif
+
+/* specialization for pairs */
+template <class T, typename U, typename V, std::pair<U, V> T::*field>
+struct COWfieldref<T, std::pair<U, V>, field>
+    : public COWref_base<T, std::pair<U, V>, COWfieldref<T, std::pair<U, V>, field>> {
+    union {
+        COWinfo<T> *info;
+        COWref_subfield<T, U, COWfieldref<T, std::pair<U, V>, field>, std::pair<U, V>,
+                        &std::pair<U, V>::first>
+            first;
+        COWref_subfield<T, V, COWfieldref<T, std::pair<U, V>, field>, std::pair<U, V>,
+                        &std::pair<U, V>::second>
+            second;
+    };
+    using COWref_base<T, std::pair<U, V>, COWfieldref<T, std::pair<U, V>, field>>::operator=;
+    const std::pair<U, V> &get() const { return info->get()->*field; }
+    const std::pair<U, V> &getOrig() const { return info->getOrig()->*field; }
+    std::pair<U, V> &modify() const { return info->mkClone()->*field; }
+};
+
+/* specialization for a vector<pair> element */
+template <class T, class C, class U, class V, class COW>
+struct COW_element_ref<T, C, std::pair<U, V>, COW>
+    : public COWref_base<T, std::pair<U, V>, COW_element_ref<T, C, std::pair<U, V>, COW>> {
+    union {
+        COWinfo<T> *info;
+        COW ref;
+        COWref_subfield<T, U, COW_element_ref<T, C, std::pair<U, V>, COW>, std::pair<U, V>,
+                        &std::pair<U, V>::first>
+            first;
+        COWref_subfield<T, V, COW_element_ref<T, C, std::pair<U, V>, COW>, std::pair<U, V>,
+                        &std::pair<U, V>::second>
+            second;
+    };
+    mutable bool is_const;
+    union {
+        typename C::const_iterator ci;
+        mutable typename C::iterator ni;
+    };
+    COW_element_ref(COW r, typename C::const_iterator i) : ref(r), is_const(true), ci(i) {}
+    COW_element_ref(COW r, typename C::iterator i) : ref(r), is_const(false), ni(i) {}
+    void clone_fixup() const {
+        if (is_const) {
+            // messy problem -- need to clone (iff not yet cloned) and then find the
+            // corresponding iterator in the clone
+            auto i = ref.modify().begin();
+            auto &orig_vec = ref.getOrig();
+            for (auto oi = orig_vec.begin(); oi != ci; ++oi, ++i)
+                BUG_CHECK(oi != orig_vec.end(), "Invalid iterator in clone_fixup");
+            ni = i;
+            is_const = false;
+        }
+    }
+    using COWref_base<T, std::pair<U, V>, COW_element_ref<T, C, std::pair<U, V>, COW>>::operator=;
+    const std::pair<U, V> &get() const {
+        if (is_const && ref.isCloned()) clone_fixup();
+        return *ci;
+    }
+    const std::pair<U, V> &getOrig() const {
+        if (is_const) return *ci;
+        BUG("getOrig on cloned COW_element_ref");
+    }
+    bool isCloned() const { return ref.isCloned(); }
+    std::pair<U, V> &modify() const {
+        clone_fixup();
+        return *ni;
+    }
+};
+
+template <class T, class C, class U, class COW>
+requires std::derived_from<typename U::template COW_nested<T, COW_element_ref<T, C, U, COW>>,
+                           COW_nested_class>
+struct COW_element_ref<T, C, U, COW> : public COWref_base<T, U, COW_element_ref<T, C, U, COW>>,
+    public U::template COW_nested<T, COW_element_ref<T, C, U, COW>>
+{
+    mutable bool is_const;
+    union {
+        typename C::const_iterator ci;
+        mutable typename C::iterator ni;
+    };
+    COW_element_ref(COW r, typename C::const_iterator i)
+      : U::template COW_nested<T, COW_element_ref<T, C, U, COW>>(r.info), is_const(true), ci(i) {}
+    COW_element_ref(COW r, typename C::iterator i)
+      : U::template COW_nested<T, COW_element_ref<T, C, U, COW>>(r.info), is_const(false), ni(i) {}
+    void clone_fixup() const {
+        if (is_const) {
+            // messy problem -- need to clone (iff not yet cloned) and then find the
+            // corresponding iterator in the clone
+            auto i = reinterpret_cast<const COW *>(this)->modify().begin();
+            auto &orig_vec = reinterpret_cast<const COW *>(this)->getOrig();
+            for (auto oi = orig_vec.begin(); oi != ci; ++oi, ++i)
+                BUG_CHECK(oi != orig_vec.end(), "Invalid iterator in clone_fixup");
+            ni = i;
+            is_const = false;
+        }
+    }
+    using COWref_base<T, U, COW_element_ref<T, C, U, COW>>::operator=;
+    const U &get() const {
+        if (is_const && reinterpret_cast<const COW *>(this)->isCloned()) clone_fixup();
+        return *ci;
+    }
+    const U &getOrig() const {
+        if (is_const) return *ci;
+        BUG("getOrig on cloned COW_element_ref");
+    }
+    bool isCloned() const { return reinterpret_cast<const COW *>(this)->isCloned(); }
+    U &modify() const {
+        clone_fixup();
+        return *ni;
+    }
+};
+
+
+// specialization for maps with value type pair
+template <class T, class C, class K, class U, class V, class COW>
+struct COW_map_value_ref<T, C, K, std::pair<U, V>, COW>
+    : public COWref_base<T, std::pair<U, V>, COW_map_value_ref<T, C, K, std::pair<U, V>, COW>> {
+    union {
+        COWinfo<T> *info;
+        COW ref;
+        COWref_subfield<T, U, COW_map_value_ref<T, C, K, std::pair<U, V>, COW>, std::pair<U, V>,
+                        &std::pair<U, V>::first>
+            first;
+        COWref_subfield<T, V, COW_map_value_ref<T, C, K, std::pair<U, V>, COW>, std::pair<U, V>,
+                        &std::pair<U, V>::second>
+            second;
+    };
+    mutable bool is_const;
+    union {
+        typename C::const_iterator ci;
+        mutable typename C::iterator ni;
+    };
+    COW_map_value_ref(COW r, typename C::const_iterator i) : ref(r), is_const(true), ci(i) {}
+    COW_map_value_ref(COW r, typename C::iterator i) : ref(r), is_const(false), ni(i) {}
+    void clone_fixup() const {
+        if (this->is_const) {
+            // messy problem -- need to clone (iff not yet cloned) and then find the
+            // corresponding iterator in the clone.  If the element has been removed
+            // in the clone, we end up returning end(), which may or may not be ok
+            this->ni = this->ref.modify().find(this->ci->first);
+            this->is_const = false;
+        }
+    }
+    using COWref_base<T, std::pair<U, V>,
+                      COW_map_value_ref<T, C, K, std::pair<U, V>, COW>>::operator=;
+    const std::pair<U, V> &get() const {
+        if (this->is_const && this->isCloned()) clone_fixup();
+        return this->ci->second;
+    }
+    const std::pair<U, V> &getOrig() const {
+        if (this->is_const) return this->ci->second;
+        BUG("getOrig on cloned COW_map_value_ref");
+    }
+    std::pair<U, V> &modify() const {
+        clone_fixup();
+        return this->ni->second;
+    }
+};
+
+// specialization for maps with value type vector
+template <class T, class C, class K, class U, class COW>
+struct COW_map_value_ref<T, C, K, std::vector<U>, COW>
+    : public COW_iterableref_base<
+          T, std::vector<U>, COW_map_value_ref<T, C, K, std::vector<U>, COW>,
+          COW_iterator<T, std::vector<U>, U, COW_map_value_ref<T, C, K, std::vector<U>, COW>>> {
+    union {
+        COWinfo<T> *info;
+        COW ref;
+    };
+    mutable bool is_const;
+    union {
+        typename C::const_iterator ci;
+        mutable typename C::iterator ni;
+    };
+    COW_map_value_ref(COW r, typename C::const_iterator i) : ref(r), is_const(true), ci(i) {}
+    COW_map_value_ref(COW r, typename C::iterator i) : ref(r), is_const(false), ni(i) {}
+    void clone_fixup() const {
+        if (this->is_const) {
+            // messy problem -- need to clone (iff not yet cloned) and then find the
+            // corresponding iterator in the clone.  If the element has been removed
+            // in the clone, we end up returning end(), which may or may not be ok
+            this->ni = this->ref.modify().find(this->ci->first);
+            this->is_const = false;
+        }
+    }
+    using COWref_base<T, std::vector<U>,
+                      COW_map_value_ref<T, C, K, std::vector<U>, COW>>::operator=;
+    const std::vector<U> &get() const {
+        if (this->is_const && this->isCloned()) clone_fixup();
+        return this->ci->second;
+    }
+    const std::vector<U> &getOrig() const {
+        if (this->is_const) return this->ci->second;
+        BUG("getOrig on cloned COW_map_value_ref");
+    }
+    std::vector<U> &modify() const {
+        clone_fixup();
+        return this->ni->second;
+    }
+};
+
+/* COW reference to an element from an array.  Used by COWfieldref specializations for arrays */
+// FIXME -- figure out how to combine/factor this with COW_element_ref
+template <class T, typename U, size_t N, U (T::*field)[N]>
+struct COW_array_element_ref : public COWref_base<T, U, COW_array_element_ref<T, U, N, field>> {
+    COWinfo<T> *info;
+    mutable bool is_const;
+    union {
+        const U *ci;
+        mutable U *ni;
+    };
+    COW_array_element_ref(COWinfo<T> *inf, const U *i) : info(inf), is_const(true), ci(i) {}
+    COW_array_element_ref(COWinfo<T> *inf, U *i) : info(inf), is_const(false), ni(i) {}
+    void clone_fixup() const {
+        if (is_const) {
+            // messy problem -- need to clone (iff not yet cloned) and then find the
+            // corresponding iterator in the clone
+            U *i = info->mkClone()->*field;
+            const U *orig_vec = info->getOrig()->*field;
+            BUG_CHECK(ci >= orig_vec && ci <= orig_vec + N, "Invalid iterator in clone_fixup");
+            ni = i + (ci - orig_vec);
+            is_const = false;
+        }
+    }
+    using COWref_base<T, U, COW_array_element_ref<T, U, N, field>>::operator=;
+    const U &get() const {
+        if (is_const && info->isCloned()) clone_fixup();
+        return *ci;
+    }
+    const U &getOrig() const {
+        if (is_const) return *ci;
+        BUG("getOrig on cloned COW_array_element_ref");
+    }
+    U &modify() const {
+        clone_fixup();
+        return *ni;
+    }
+};
+
+template <class T, typename U, size_t N, U (T::*field)[N]>
+requires std::derived_from<
+    typename U::template COW_nested<T, COW_array_element_ref<T, U, N, field>>, COW_nested_class>
+struct COW_array_element_ref<T, U, N, field>
+    : public COWref_base<T, U, COW_array_element_ref<T, U, N, field>>,
+      public U::template COW_nested<T, COW_array_element_ref<T, U, N, field>> {
+    mutable bool is_const;
+    union {
+        const U *ci;
+        mutable U *ni;
+    };
+    COW_array_element_ref(COWinfo<T> *inf, const U *i)
+      : U::template COW_nested<T, COW_array_element_ref<T, U, N, field>>(inf),
+        is_const(true), ci(i) {}
+    COW_array_element_ref(COWinfo<T> *inf, U *i)
+      : U::template COW_nested<T, COW_array_element_ref<T, U, N, field>>(inf),
+      is_const(false), ni(i) {}
+    void clone_fixup() const {
+        if (is_const) {
+            // messy problem -- need to clone (iff not yet cloned) and then find the
+            // corresponding iterator in the clone
+            U *i = this->info->mkClone()->*field;
+            const U *orig_vec = this->info->getOrig()->*field;
+            BUG_CHECK(ci >= orig_vec && ci <= orig_vec + N, "Invalid iterator in clone_fixup");
+            ni = i + (ci - orig_vec);
+            is_const = false;
+        }
+    }
+    using COWref_base<T, U, COW_array_element_ref<T, U, N, field>>::operator=;
+    const U &get() const {
+        if (is_const && this->info->isCloned()) clone_fixup();
+        return *ci;
+    }
+    const U &getOrig() const {
+        if (is_const) return *ci;
+        BUG("getOrig on cloned COW_array_element_ref");
+    }
+    U &modify() const {
+        clone_fixup();
+        return *ni;
+    }
+};
+
+template <class T, typename U, size_t N, U (T::*field)[N]>
+struct COW_array_iterator {
+    COW_array_element_ref<T, U, N, field> ref;
+    COW_array_iterator(COWinfo<T> *inf, const U *i) : ref(inf, i) {}
+    COW_array_iterator(COWinfo<T> *inf, U *i) : ref(inf, i) {}
+    template<class COW>  // requires COWref<COW>
+    COW_array_iterator(COW r, const U *i) : ref(r.info, i) {}
+    template<class COW>  // requires COWref<COW>
+    COW_array_iterator(COW r, U *i) : ref(r.info, i) {}
+
+    COW_array_iterator &operator++() {
+        ++ref.ci;
+        return *this;
+    }
+    COW_array_iterator operator++(int) {
+        COW_array_iterator<T, U, N, field> rv = *this;
+        ++ref.ci;
+        return rv;
+    }
+    COW_array_iterator &operator--() {
+        --ref.ci;
+        return *this;
+    }
+    COW_array_iterator operator--(int) {
+        COW_array_iterator<T, U, N, field> rv = *this;
+        --ref.ci;
+        return rv;
+    }
+    bool operator==(COW_array_iterator<T, U, N, field> &i) {
+        if (ref.is_const != i.ref.is_const) {
+            ref.clone_fixup();
+            i.ref.clone_fixup();
+        }
+        return ref.ci == i.ref.ci;
+    }
+    bool operator!=(COW_array_iterator<T, U, N, field> &i) {
+        if (ref.is_const != i.ref.is_const) {
+            ref.clone_fixup();
+            i.ref.clone_fixup();
+        }
+        return ref.ci != i.ref.ci;
+    }
+    COW_array_element_ref<T, U, N, field> &operator*() { return ref; }
+};
+
+/* specialization for array */
+template <class T, typename U, size_t N, U (T::*field)[N]>
+struct COWfieldref<T, U[N], field>
+    : public COW_iterableref_base<T, U[N], COWfieldref<T, U[N], field>,
+                                  COW_array_iterator<T, U, N, field>> {
+    typedef U array[N];
+    COWinfo<T> *info;
+    using COWref_base<T, U[N], COWfieldref<T, U[N], field>>::operator=;
+    const array &get() const { return info->get()->*field; }
+    const array &getOrig() const { return info->getOrig()->*field; }
+    array &modify() const { return info->mkClone()->*field; }
+};
+
+}  // namespace P4::IR
+
+#endif /* IR_COPY_ON_WRITE_INL_H_ */

--- a/ir/copy_on_write_ptr.h
+++ b/ir/copy_on_write_ptr.h
@@ -109,17 +109,19 @@ struct COWref_subfield : public COWref_base<T, U, COWref_subfield<T, U, COW, X, 
     // FIXME -- should be `union { COWinfo<T> *info; COW ref; };`, but that causes errors
     // about incomplete types when trying to instantiate specializations.
     using COWref_base<T, U, COWref_subfield<T, U, COW, X, field>>::operator=;
-    const U &get() const { return (reinterpret_cast<const COW *>(this)->get()).*field; }
-    const U &getOrig() const { return (reinterpret_cast<const COW *>(this)->getOrig()).*field; }
-    U &modify() const { return (reinterpret_cast<const COW *>(this)->modify()).*field; }
+    const U &get() const { return std::launder(reinterpret_cast<const COW *>(this))->get().*field; }
+    const U &getOrig() const {
+        return std::launder(reinterpret_cast<const COW *>(this))->getOrig().*field;
+    }
+    U &modify() const { return std::launder(reinterpret_cast<const COW *>(this))->modify().*field; }
 };
 
 /* a nested IR class defined in ir-generated.h -- base class marker for template speciaizations */
 struct COW_nested_class {};
 
 template <class T, typename U, U T::*field>
-requires std::derived_from<typename U::template COW_nested<T, COWfieldref<T, U, field>>,
-                           COW_nested_class>
+    requires std::derived_from<typename U::template COW_nested<T, COWfieldref<T, U, field>>,
+                               COW_nested_class>
 struct COWfieldref<T, U, field> : public COWref_base<T, U, COWfieldref<T, U, field>>,
                                   public U::template COW_nested<T, COWfieldref<T, U, field>> {
     using COWref_base<T, U, COWfieldref<T, U, field>>::operator=;
@@ -138,23 +140,26 @@ class COWptr {
     explicit COWptr(COWNode_info *p) : info(static_cast<COWinfo<T> *>(p)) {
         BUG_CHECK(info->get()->template is<T>(), "incorrect type in COWptr ctor");
     }
-    typename T::COWref getRef() const { return typename T::COWref(info); }
+    const typename T::COWref *getRef() const {
+        return std::launder(reinterpret_cast<const T::COWref *>(this));
+    }
 
  public:
     COWptr() = default;
     COWptr(const COWptr &) = default;
     COWptr(COWptr &&) = default;
-    COWptr(const T::COWref *r) : info(r->info) {}               // NOLINT(runtime/explicit)
+    COWptr(const T::COWref *r) : info(r->info) {}  // NOLINT(runtime/explicit)
     template <typename U>
-    requires std::derived_from<U, T> COWptr(const COWptr<U> &a) : COWptr(a.info) {}
+        requires std::derived_from<U, T>
+    COWptr(const COWptr<U> &a) : COWptr(a.info) {}
     ~COWptr() = default;
     COWptr &operator=(const COWptr &) = default;
     COWptr &operator=(COWptr &&) = default;
 
     const T *get() const { return info->get(); }
     operator const T *() const { return get(); }
-    typename T::COWref operator->() const { return getRef(); }
-    typename T::COWref operator*() const { return getRef(); }
+    const typename T::COWref *operator->() const { return getRef(); }
+    const typename T::COWref &operator*() const { return *getRef(); }
     void visit_children(Visitor &v, const char *name = nullptr) const {
         get()->COWref_visit_children(info, v, name);
     }

--- a/ir/copy_on_write_ptr.h
+++ b/ir/copy_on_write_ptr.h
@@ -1,0 +1,177 @@
+/*
+Copyright 2024 NVIDIA CORPORATION.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef IR_COPY_ON_WRITE_PTR_H_
+#define IR_COPY_ON_WRITE_PTR_H_
+
+#include "lib/exceptions.h"
+
+namespace P4 {
+
+class COWModifier;
+class COWTransform;
+class Visitor;
+struct Visitor_Context;
+
+namespace IR {
+
+class Node;
+
+template <typename T>
+concept COWref = requires(T r) {
+    r.set(r.get());
+    r.modify() = r.get();
+    // also requires `this == &this->info` where `this->info` is a `COWinfo<X> *`
+    // where X is some IR::Node subclass
+};
+
+class COWNode_info {
+ protected:
+    const Node *orig;
+    Node *clone;
+    Visitor_Context *ctxt;
+
+    COWNode_info() = delete;
+    COWNode_info(const COWNode_info &) = delete;
+    COWNode_info(const Node *n, Visitor_Context *c) : orig(n), clone(nullptr), ctxt(c) {}
+};
+
+template <class T>
+class COWinfo : public COWNode_info {
+ public:
+    const T *get() const;
+    const T *getOrig() const;
+    T *mkClone();
+    T *getClone() const;
+    bool isCloned() const { return clone != nullptr; }
+
+ private:
+    friend COWModifier;
+    friend COWTransform;
+    COWinfo(const T *n, Visitor_Context *c) : COWNode_info(n, c) {}
+    void transform_to(const T *n) {
+        orig = n;
+        clone = nullptr;
+    }
+};
+
+// CRTP base class for all classes that implement concept COWref<U>
+template <class T, class U, class REF>
+// requires REF inherits from COWref_base, and has COWinfo<T> *info;
+struct COWref_base {
+    operator const U &() const { return static_cast<const REF *>(this)->get(); }
+    const U &operator=(const U &val) const {
+        const REF *self = static_cast<const REF *>(this);
+        if (!self->info->isCloned() && self->get() == val) return val;
+        return self->modify() = val;
+    }
+    const U &operator=(U &&val) const {
+        const REF *self = static_cast<const REF *>(this);
+        if (!self->info->isCloned() && self->get() == val) return val;
+        return self->modify() = std::move(val);
+    }
+    bool isCloned() const { return static_cast<const REF *>(this)->info->isCloned(); }
+    void set(const U &val) const { *this = val; }
+    void visit_children(Visitor &v, const char *name = nullptr) const {
+        static_cast<const REF *>(this)->get().visit_children(v, name);
+    }
+    const U &operator->() const { return static_cast<const REF *>(this)->get(); }
+};
+
+/* basic COWref reference to a field of a COW object */
+template <class T, typename U, U T::*field>
+struct COWfieldref : public COWref_base<T, U, COWfieldref<T, U, field>> {
+    COWinfo<T> *info;
+    using COWref_base<T, U, COWfieldref<T, U, field>>::operator=;
+    const U &get() const { return info->get()->*field; }
+    const U &getOrig() const { return info->getOrig()->*field; }
+    U &modify() const { return info->mkClone()->*field; }
+};
+
+/* COWref reference to a field of a COWref */
+template <class T, class U, class COW, class X, U X::*field>
+// requires COWref<COW>
+struct COWref_subfield : public COWref_base<T, U, COWref_subfield<T, U, COW, X, field>> {
+    COWinfo<T> *info;
+    // FIXME -- should be `union { COWinfo<T> *info; COW ref; };`, but that causes errors
+    // about incomplete types when trying to instantiate specializations.
+    using COWref_base<T, U, COWref_subfield<T, U, COW, X, field>>::operator=;
+    const U &get() const { return (reinterpret_cast<const COW *>(this)->get()).*field; }
+    const U &getOrig() const { return (reinterpret_cast<const COW *>(this)->getOrig()).*field; }
+    U &modify() const { return (reinterpret_cast<const COW *>(this)->modify()).*field; }
+};
+
+/* a nested IR class defined in ir-generated.h -- base class marker for template speciaizations */
+struct COW_nested_class {};
+
+template <class T, typename U, U T::*field>
+requires std::derived_from<typename U::template COW_nested<T, COWfieldref<T, U, field>>,
+                           COW_nested_class>
+struct COWfieldref<T, U, field> : public COWref_base<T, U, COWfieldref<T, U, field>>,
+                                  public U::template COW_nested<T, COWfieldref<T, U, field>> {
+    using COWref_base<T, U, COWfieldref<T, U, field>>::operator=;
+};
+
+template <class T>
+class COWptr {
+    COWinfo<T> *info;
+
+    template <class U>
+    friend class COWptr;
+    friend COWModifier;
+    friend COWTransform;
+    friend T;
+    explicit COWptr(COWinfo<T> *p) : info(p) {}
+    explicit COWptr(COWNode_info *p) : info(static_cast<COWinfo<T> *>(p)) {
+        BUG_CHECK(info->get()->template is<T>(), "incorrect type in COWptr ctor");
+    }
+    typename T::COWref getRef() const { return typename T::COWref(info); }
+
+ public:
+    COWptr() = default;
+    COWptr(const COWptr &) = default;
+    COWptr(COWptr &&) = default;
+    COWptr(const T::COWref *r) : info(r->info) {}               // NOLINT(runtime/explicit)
+    template <typename U>
+    requires std::derived_from<U, T> COWptr(const COWptr<U> &a) : COWptr(a.info) {}
+    ~COWptr() = default;
+    COWptr &operator=(const COWptr &) = default;
+    COWptr &operator=(COWptr &&) = default;
+
+    const T *get() const { return info->get(); }
+    operator const T *() const { return get(); }
+    typename T::COWref operator->() const { return getRef(); }
+    typename T::COWref operator*() const { return getRef(); }
+    void visit_children(Visitor &v, const char *name = nullptr) const {
+        get()->COWref_visit_children(info, v, name);
+    }
+    bool apply_visitor_preorder(COWModifier &v) const {
+        return get()->apply_visitor_preorder(info, v);
+    }
+    void apply_visitor_postorder(COWModifier &v) const { get()->apply_visitor_postorder(info, v); }
+    const IR::Node *apply_visitor_preorder(COWTransform &v) const {
+        return get()->apply_visitor_preorder(info, v);
+    }
+    const IR::Node *apply_visitor_postorder(COWTransform &v) const {
+        return get()->apply_visitor_postorder(info, v);
+    }
+};
+
+}  // namespace IR
+
+}  // namespace P4
+
+#endif /* IR_COPY_ON_WRITE_PTR_H_ */

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -503,7 +503,7 @@ class Mux : Operation_Ternary {
     visit_children {
         (void)n;
         v.visit(e0, "e0");
-        SplitFlowVisit<Expression>(v, e1, e2).run_visit(); }
+        SplitFlowVisit<Mux, Expression>(v, e1, e2).run_visit(); }
     inline Mux { if (type->is<Type::Unknown>() && e1 && e2 && e1->type == e2->type) type = e1->type; }
 }
 
@@ -542,7 +542,7 @@ class SelectExpression : Expression {
     visit_children {
         (void)n;
         v.visit(select, "select");
-        SplitFlowVisitVector<SelectCase>(v, selectCases).run_visit(); }
+        SplitFlowVisitVector(v, selectCases, "selectCases"); }
 }
 
 class MethodCallExpression : Expression {

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -180,6 +180,11 @@ class IndexedVector : public Vector<T> {
         Vector<T>::push_back(a);
         insertInMap(a);
     }
+    void replace_contents(safe_vector<const T *> &&n) {
+        clear();
+        Vector<T>::replace_contents(std::move(n));
+        for (auto *e : *this) insertInMap(e);
+    }
 
     IRNODE_SUBCLASS(IndexedVector)
     IRNODE_DECLARE_APPLY_OVERLOAD(IndexedVector)
@@ -209,6 +214,7 @@ class IndexedVector : public Vector<T> {
     static cstring static_type_name() { return "IndexedVector<" + T::static_type_name() + ">"; }
     void visit_children(Visitor &v, const char *name) override;
     void visit_children(Visitor &v, const char *name) const override;
+    void COWref_visit_children(COWNode_info *, Visitor &, const char *) const override;
 
     void toJSON(JSONGenerator &json) const override;
     static Node *fromJSON(JSONLoader &json);

--- a/ir/inode.h
+++ b/ir/inode.h
@@ -53,12 +53,23 @@ class INode : public Util::IHasSourceInfo, public IHasDbPrint, public ICastable 
     std::enable_if_t<!has_static_type_name_v<T>, const T *> checkedTo() const {
         return ICastable::checkedTo<T>();
     }
+    template <typename T>
+    std::enable_if_t<!has_static_type_name_v<T>, T *> checkedTo() {
+        return ICastable::checkedTo<T>();
+    }
 
     // alternative checkedTo implementation that produces slightly better error message
     // due to node_type_name() / static_type_name() being available
     template <typename T>
     std::enable_if_t<has_static_type_name_v<T>, const T *> checkedTo() const {
         const auto *result = to<T>();
+        BUG_CHECK(result, "Cast failed: %1% with type %2% is not a %3%.", this, node_type_name(),
+                  T::static_type_name());
+        return result;
+    }
+    template <typename T>
+    std::enable_if_t<has_static_type_name_v<T>, T *> checkedTo() {
+        auto *result = to<T>();
         BUG_CHECK(result, "Cast failed: %1% with type %2% is not a %3%.", this, node_type_name(),
                   T::static_type_name());
         return result;

--- a/ir/ir-inline.h
+++ b/ir/ir-inline.h
@@ -27,113 +27,153 @@ limitations under the License.
 
 namespace P4 {
 
-#define DEFINE_APPLY_FUNCTIONS(CLASS, TEMPLATE, TT, INLINE)                                       \
-    TEMPLATE INLINE bool IR::CLASS TT::apply_visitor_preorder(Modifier &v) {                      \
-        Node::traceVisit("Mod pre");                                                              \
-        return v.preorder(this);                                                                  \
-    }                                                                                             \
-    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_postorder(Modifier &v) {                     \
-        Node::traceVisit("Mod post");                                                             \
-        v.postorder(this);                                                                        \
-    }                                                                                             \
-    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Modifier &v, const Node *n) const {  \
-        Node::traceVisit("Mod revisit");                                                          \
-        v.revisit(this, n);                                                                       \
-    }                                                                                             \
-    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(Modifier &v) const {            \
-        Node::traceVisit("Mod loop_revisit");                                                     \
-        v.loop_revisit(this);                                                                     \
-    }                                                                                             \
-    TEMPLATE INLINE bool IR::CLASS TT::apply_visitor_preorder(Inspector &v) const {               \
-        Node::traceVisit("Insp pre");                                                             \
-        return v.preorder(this);                                                                  \
-    }                                                                                             \
-    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_postorder(Inspector &v) const {              \
-        Node::traceVisit("Insp post");                                                            \
-        v.postorder(this);                                                                        \
-    }                                                                                             \
-    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Inspector &v) const {                \
-        Node::traceVisit("Insp revisit");                                                         \
-        v.revisit(this);                                                                          \
-    }                                                                                             \
-    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(Inspector &v) const {           \
-        Node::traceVisit("Insp loop_revisit");                                                    \
-        v.loop_revisit(this);                                                                     \
-    }                                                                                             \
-    TEMPLATE INLINE const IR::Node *IR::CLASS TT::apply_visitor_preorder(Transform &v) {          \
-        Node::traceVisit("Trans pre");                                                            \
-        return v.preorder(this);                                                                  \
-    }                                                                                             \
-    TEMPLATE INLINE const IR::Node *IR::CLASS TT::apply_visitor_postorder(Transform &v) {         \
-        Node::traceVisit("Trans post");                                                           \
-        return v.postorder(this);                                                                 \
-    }                                                                                             \
-    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Transform &v, const Node *n) const { \
-        Node::traceVisit("Trans revisit");                                                        \
-        v.revisit(this, n);                                                                       \
-    }                                                                                             \
-    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(Transform &v) const {           \
-        Node::traceVisit("Trans loop_revisit");                                                   \
-        v.loop_revisit(this);                                                                     \
+#define DEFINE_APPLY_FUNCTIONS(CLASS, TEMPLATE, TT, INLINE)                                        \
+    TEMPLATE INLINE bool IR::CLASS TT::apply_visitor_preorder(Modifier &v) {                       \
+        Node::traceVisit("Mod pre");                                                               \
+        return v.preorder(this);                                                                   \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_postorder(Modifier &v) {                      \
+        Node::traceVisit("Mod post");                                                              \
+        v.postorder(this);                                                                         \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Modifier &v, const Node *n) const {   \
+        Node::traceVisit("Mod revisit");                                                           \
+        v.revisit(this, n);                                                                        \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(Modifier &v) const {             \
+        Node::traceVisit("Mod loop_revisit");                                                      \
+        v.loop_revisit(this);                                                                      \
+    }                                                                                              \
+    TEMPLATE INLINE bool IR::CLASS TT::apply_visitor_preorder(COWNode_info *info, COWModifier &v)  \
+        const {                                                                                    \
+        Node::traceVisit("Mod pre (COW)");                                                         \
+        return v.preorder(IR::COWptr<IR::CLASS TT>(info));                                         \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_postorder(COWNode_info *info, COWModifier &v) \
+        const {                                                                                    \
+        Node::traceVisit("Mod post (COW)");                                                        \
+        v.postorder(IR::COWptr<IR::CLASS TT>(info));                                               \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(COWModifier &v, const Node *n)        \
+        const {                                                                                    \
+        Node::traceVisit("Mod revisit (COW)");                                                     \
+        v.revisit(this, n);                                                                        \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(COWModifier &v) const {          \
+        Node::traceVisit("Mod loop_revisit (COW)");                                                \
+        v.loop_revisit(this);                                                                      \
+    }                                                                                              \
+    TEMPLATE INLINE bool IR::CLASS TT::apply_visitor_preorder(Inspector &v) const {                \
+        Node::traceVisit("Insp pre");                                                              \
+        return v.preorder(this);                                                                   \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_postorder(Inspector &v) const {               \
+        Node::traceVisit("Insp post");                                                             \
+        v.postorder(this);                                                                         \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Inspector &v) const {                 \
+        Node::traceVisit("Insp revisit");                                                          \
+        v.revisit(this);                                                                           \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(Inspector &v) const {            \
+        Node::traceVisit("Insp loop_revisit");                                                     \
+        v.loop_revisit(this);                                                                      \
+    }                                                                                              \
+    TEMPLATE INLINE const IR::Node *IR::CLASS TT::apply_visitor_preorder(Transform &v) {           \
+        Node::traceVisit("Trans pre");                                                             \
+        return v.preorder(this);                                                                   \
+    }                                                                                              \
+    TEMPLATE INLINE const IR::Node *IR::CLASS TT::apply_visitor_postorder(Transform &v) {          \
+        Node::traceVisit("Trans post");                                                            \
+        return v.postorder(this);                                                                  \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(Transform &v, const Node *n) const {  \
+        Node::traceVisit("Trans revisit");                                                         \
+        v.revisit(this, n);                                                                        \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(Transform &v) const {            \
+        Node::traceVisit("Trans loop_revisit");                                                    \
+        v.loop_revisit(this);                                                                      \
+    }                                                                                              \
+    TEMPLATE INLINE const IR::Node *IR::CLASS TT::apply_visitor_preorder(COWNode_info *info,       \
+                                                                         COWTransform &v) const {  \
+        Node::traceVisit("Trans pre (COW)");                                                       \
+        return v.preorder(IR::COWptr<IR::CLASS TT>(info));                                         \
+    }                                                                                              \
+    TEMPLATE INLINE const IR::Node *IR::CLASS TT::apply_visitor_postorder(COWNode_info *info,      \
+                                                                          COWTransform &v) const { \
+        Node::traceVisit("Trans post (COW)");                                                      \
+        return v.postorder(IR::COWptr<IR::CLASS TT>(info));                                        \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_revisit(COWTransform &v, const Node *n)       \
+        const {                                                                                    \
+        Node::traceVisit("Trans revisit (COW)");                                                   \
+        v.revisit(this, n);                                                                        \
+    }                                                                                              \
+    TEMPLATE INLINE void IR::CLASS TT::apply_visitor_loop_revisit(COWTransform &v) const {         \
+        Node::traceVisit("Trans loop_revisit (COW)");                                              \
+        v.loop_revisit(this);                                                                      \
     }
 
 IRNODE_ALL_TEMPLATES(DEFINE_APPLY_FUNCTIONS, inline)
 
 template <class T>
-void IR::Vector<T>::visit_children(Visitor &v, const char *name) {
-    for (auto i = vec.begin(); i != vec.end();) {
-        const IR::Node *n = v.apply_visitor(*i, name);
-        if (!n && *i) {
-            i = erase(i);
-            continue;
-        }
-        CHECK_NULL(n);
-        if (n == *i) {
-            i++;
-            continue;
-        }
+void IR::merge_into_safe_vector(safe_vector<const T *> &rv, const IR::Node *n, const char *clss) {
+    if (n) {
         if (auto l = n->to<Vector<T>>()) {
-            i = erase(i);
-            i = insert(i, l->vec.begin(), l->vec.end());
-            i += l->vec.size();
-            continue;
-        }
-        if (const auto *v = n->to<VectorBase>()) {
-            if (v->empty()) {
-                i = erase(i);
-            } else {
-                i = insert(i, v->size() - 1, nullptr);
-                for (const auto *el : *v) {
-                    CHECK_NULL(el);
-                    if (auto e = el->template to<T>()) {
-                        *i++ = e;
-                    } else {
-                        BUG("visitor returned invalid type %s for Vector<%s>", el->node_type_name(),
-                            T::static_type_name());
-                    }
+            rv.insert(rv.end(), l->begin(), l->end());
+        } else if (const auto *v = n->to<VectorBase>()) {
+            for (const auto *el : *v) {
+                CHECK_NULL(el);
+                if (auto e = el->template to<T>()) {
+                    rv.push_back(e);
+                } else {
+                    BUG("visitor returned invalid type %s for %s<%s>", el->node_type_name(), clss,
+                        T::static_type_name());
                 }
             }
-            continue;
+        } else if (auto e = n->to<T>()) {
+            rv.push_back(e);
+        } else {
+            BUG("visitor returned invalid type %s for %s<%s>", n->node_type_name(), clss,
+                T::static_type_name());
         }
-        if (auto e = n->to<T>()) {
-            *i++ = e;
-            continue;
-        }
-        BUG("visitor returned invalid type %s for Vector<%s>", n->node_type_name(),
-            T::static_type_name());
     }
+}
+template <class T>
+safe_vector<const T *> IR::visit_safe_vector(const safe_vector<const T *> &vec, const char *clss,
+                                             Visitor &v, const char *name) {
+    safe_vector<const T *> rv;
+    for (const T *el : vec) {
+        const IR::Node *n = v.apply_visitor(el, name);
+        merge_into_safe_vector(rv, n, clss);
+    }
+    return rv;
+}
+
+template <class T>
+void IR::Vector<T>::visit_children(Visitor &v, const char *name) {
+    auto res = visit_safe_vector(vec, "Vector", v, name);
+    if (res != vec) replace_contents(std::move(res));
 }
 template <class T>
 void IR::Vector<T>::visit_children(Visitor &v, const char *name) const {
     for (auto &a : vec) v.visit(a, name);
 }
 template <class T>
-void IR::Vector<T>::parallel_visit_children(Visitor &v, const char *) {
-    SplitFlowVisitVector<T>(v, *this).run_visit();
+void IR::Vector<T>::COWref_visit_children(COWNode_info *info, Visitor &v, const char *name) const {
+    IR::COWinfo<IR::Vector<T>> *p = static_cast<IR::COWinfo<IR::Vector<T>> *>(info);
+    auto res = visit_safe_vector(this->get_contents(), "Vector", v, name);
+    if (res != p->get()->get_contents()) p->mkClone()->replace_contents(std::move(res));
+}
+
+template <class T>
+void IR::Vector<T>::parallel_visit_children(Visitor &v, const char *name) {
+    SplitFlowVisitVector(v, *this, name);
 }
 template <class T>
-void IR::Vector<T>::parallel_visit_children(Visitor &v, const char *) const {
-    SplitFlowVisitVector<T>(v, *this).run_visit();
+void IR::Vector<T>::parallel_visit_children(Visitor &v, const char *name) const {
+    SplitFlowVisitVector(v, *this, name);
 }
 IRNODE_DEFINE_APPLY_OVERLOAD(Vector, template <class T>, <T>)
 template <class T>
@@ -150,35 +190,21 @@ std::ostream &operator<<(std::ostream &out, const IR::Vector<IR::Annotation> &v)
 
 template <class T>
 void IR::IndexedVector<T>::visit_children(Visitor &v, const char *name) {
-    for (auto i = begin(); i != end();) {
-        auto n = v.apply_visitor(*i, name);
-        if (!n && *i) {
-            i = erase(i);
-            continue;
-        }
-        CHECK_NULL(n);
-        if (n == *i) {
-            i++;
-            continue;
-        }
-        if (auto l = n->template to<Vector<T>>()) {
-            i = erase(i);
-            i = insert(i, l->begin(), l->end());
-            i += l->Vector<T>::size();
-            continue;
-        }
-        if (auto e = n->template to<T>()) {
-            i = replace(i, e);
-            continue;
-        }
-        BUG("visitor returned invalid type %s for IndexedVector<%s>", n->node_type_name(),
-            T::static_type_name());
-    }
+    auto res = visit_safe_vector(this->get_contents(), "IndexedVector", v, name);
+    if (res != this->get_contents()) replace_contents(std::move(res));
 }
 template <class T>
 void IR::IndexedVector<T>::visit_children(Visitor &v, const char *name) const {
     for (auto &a : *this) v.visit(a, name);
 }
+template <class T>
+void IR::IndexedVector<T>::COWref_visit_children(COWNode_info *info, Visitor &v,
+                                                 const char *name) const {
+    IR::COWinfo<IR::Vector<T>> *p = static_cast<IR::COWinfo<IR::Vector<T>> *>(info);
+    auto res = visit_safe_vector(this->get_contents(), "IndexedVector", v, name);
+    if (res != p->get()->get_contents()) p->mkClone()->replace_contents(std::move(res));
+}
+
 template <class T>
 void IR::IndexedVector<T>::toJSON(JSONGenerator &json) const {
     Vector<T>::toJSON(json);
@@ -219,38 +245,32 @@ static inline void namemap_insert_helper(typename ordered_map<cstring, T>::itera
 template <class T, template <class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
           class COMP /*= std::less<cstring>*/,
           class ALLOC /*= std::allocator<std::pair<const cstring, const T*>>*/>
-void IR::NameMap<T, MAP, COMP, ALLOC>::visit_children(Visitor &v, const char *) {
+auto IR::NameMap<T, MAP, COMP, ALLOC>::visit_symbols(Visitor &v, const char *) const -> map_t {
     map_t new_symbols;
-    for (auto i = symbols.begin(); i != symbols.end();) {
-        const IR::Node *n = v.apply_visitor(i->second, i->first.c_str());
-        if (!n && i->second) {
-            i = symbols.erase(i);
-            continue;
-        }
-        CHECK_NULL(n);
-        if (n == i->second) {
-            i++;
-            continue;
-        }
-        if (auto m = n->to<NameMap>()) {
-            namemap_insert_helper(i, m->symbols.begin(), m->symbols.end(), symbols, new_symbols);
-            i = symbols.erase(i);
-            continue;
-        }
+    for (auto [name_, sym] : symbols) {
+        // gcc bug?  auto seems to infer a const type for name_, which is wrong.  Second
+        // auto correctly infers non-const type.
+        auto name = name_;
+        const IR::Node *n = v.apply_visitor(sym, name.c_str());
+        if (!n) continue;
         if (auto s = n->to<T>()) {
-            if (match_name(i->first, s)) {
-                i->second = s;
-                i++;
-            } else {
-                namemap_insert_helper(i, cstring(obj_name(s)), std::move(s), symbols, new_symbols);
-                i = symbols.erase(i);
-            }
-            continue;
+            if (!match_name(name, s)) name = obj_name(s);
+            new_symbols.emplace(name, s);
+        } else if (auto m = n->to<NameMap>()) {
+            for (auto [n2, s2] : *m) new_symbols.emplace(n2, s2);
+        } else {
+            BUG("visitor returned invalid type %s for NameMap<%s>", n->node_type_name(),
+                T::static_type_name());
         }
-        BUG("visitor returned invalid type %s for NameMap<%s>", n->node_type_name(),
-            T::static_type_name());
     }
-    symbols.insert(new_symbols.begin(), new_symbols.end());
+    return new_symbols;
+}
+template <class T, template <class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
+          class COMP /*= std::less<cstring>*/,
+          class ALLOC /*= std::allocator<std::pair<const cstring, const T*>>*/>
+void IR::NameMap<T, MAP, COMP, ALLOC>::visit_children(Visitor &v, const char *name) {
+    map_t res = visit_symbols(v, name);
+    if (!match_contents(res)) replace_contents(std::move(res));
 }
 template <class T, template <class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
           class COMP /*= std::less<cstring>*/,
@@ -260,6 +280,16 @@ void IR::NameMap<T, MAP, COMP, ALLOC>::visit_children(Visitor &v, const char *) 
         v.visit(k.second, k.first.c_str());
     }
 }
+template <class T, template <class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
+          class COMP /*= std::less<cstring>*/,
+          class ALLOC /*= std::allocator<std::pair<const cstring, const T*>>*/>
+void IR::NameMap<T, MAP, COMP, ALLOC>::COWref_visit_children(COWNode_info *info, Visitor &v,
+                                                             const char *name) const {
+    auto *p = static_cast<IR::COWinfo<IR::NameMap<T, MAP, COMP, ALLOC>> *>(info);
+    map_t res = visit_symbols(v, name);
+    if (!p->get()->match_contents(res)) p->mkClone()->replace_contents(std::move(res));
+}
+
 template <class T, template <class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
           class COMP /*= std::less<cstring>*/,
           class ALLOC /*= std::allocator<std::pair<cstring, const T*>>*/>

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -501,7 +501,7 @@ class IfStatement : Statement {
     visit_children {
         (void)n;
         v.visit(condition, "condition");
-        SplitFlowVisit<Statement>(v, ifTrue, ifFalse).run_visit(); }
+        SplitFlowVisit<IfStatement, Statement>(v, ifTrue, ifFalse).run_visit(); }
 }
 
 class BreakStatement : Statement {
@@ -563,7 +563,7 @@ class SwitchStatement : Statement {
     visit_children {
         (void)n;
         v.visit(expression, "expression");
-        SplitFlowVisit<SwitchCase> split(v);
+        SplitFlowVisit<SwitchStatement, SwitchCase> split(v);
         for (auto &c : cases) split.addNode(c);
         split.run_visit(); }
 }
@@ -588,7 +588,7 @@ class ForStatement : LoopStatement {
         return init.getDeclarations(); }
     visit_children;
 #emit
-    // template single implementation of const vs non-const ForStatement
+    // template single implementation of const vs non-const vs COWref ForStatement
     template<class THIS> static void visit_children(THIS *, Visitor &v);
 #end
 }
@@ -613,7 +613,7 @@ class ForInStatement : LoopStatement {
         return new Util::EmptyEnumerator<const IDeclaration *>(); }
     visit_children;
 #emit
-    // template single implementation of const vs non-const ForInStatement
+    // template single implementation of const vs non-const vs COWref ForInStatement
     template<class THIS> static void visit_children(THIS *, Visitor &v);
 #end
 }

--- a/ir/loop-visitor.cpp
+++ b/ir/loop-visitor.cpp
@@ -45,6 +45,9 @@ void IR::ForStatement::visit_children(THIS *self, Visitor &v) {
 
 void IR::ForStatement::visit_children(Visitor &v, const char *) { visit_children(this, v); }
 void IR::ForStatement::visit_children(Visitor &v, const char *) const { visit_children(this, v); }
+void IR::ForStatement::COWref::visit_children(Visitor &v, const char *) {
+    IR::ForStatement::visit_children(this, v);
+}
 
 template <class THIS>
 void IR::ForInStatement::visit_children(THIS *self, Visitor &v) {
@@ -71,6 +74,9 @@ void IR::ForInStatement::visit_children(THIS *self, Visitor &v) {
 }
 void IR::ForInStatement::visit_children(Visitor &v, const char *) { visit_children(this, v); }
 void IR::ForInStatement::visit_children(Visitor &v, const char *) const { visit_children(this, v); }
+void IR::ForInStatement::COWref::visit_children(Visitor &v, const char *) {
+    IR::ForInStatement::visit_children(this, v);
+}
 
 void IR::BreakStatement::visit_children(Visitor &v, const char *) const {
     if (auto *cfv = v.controlFlowVisitor()) {

--- a/ir/loop-visitor.cpp
+++ b/ir/loop-visitor.cpp
@@ -45,7 +45,7 @@ void IR::ForStatement::visit_children(THIS *self, Visitor &v) {
 
 void IR::ForStatement::visit_children(Visitor &v, const char *) { visit_children(this, v); }
 void IR::ForStatement::visit_children(Visitor &v, const char *) const { visit_children(this, v); }
-void IR::ForStatement::COWref::visit_children(Visitor &v, const char *) {
+void IR::ForStatement::COWref::visit_children(Visitor &v, const char *) const {
     IR::ForStatement::visit_children(this, v);
 }
 
@@ -74,7 +74,7 @@ void IR::ForInStatement::visit_children(THIS *self, Visitor &v) {
 }
 void IR::ForInStatement::visit_children(Visitor &v, const char *) { visit_children(this, v); }
 void IR::ForInStatement::visit_children(Visitor &v, const char *) const { visit_children(this, v); }
-void IR::ForInStatement::COWref::visit_children(Visitor &v, const char *) {
+void IR::ForInStatement::COWref::visit_children(Visitor &v, const char *) const {
     IR::ForInStatement::visit_children(this, v);
 }
 

--- a/ir/node.h
+++ b/ir/node.h
@@ -149,8 +149,8 @@ class Node : public virtual INode {
     union COWref {
         COWfieldref<Node, Util::SourceInfo, &Node::srcInfo> srcInfo;
         COWref(COWNode_info *i) { _info = i; }
-        COWref *operator->() { return this; }
-        void visit_children(Visitor &, const char * /*name*/ = nullptr) {}
+        // COWref *operator->() { return this; }
+        void visit_children(Visitor &, const char * /*name*/ = nullptr) const {}
 
      private:
         COWNode_info *_info;

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -362,12 +362,22 @@ Visitor::profile_t Modifier::init_apply(const IR::Node *root) {
     visited = std::make_shared<ChangeTracker>(forceClone);
     return rv;
 }
+Visitor::profile_t COWModifier::init_apply(const IR::Node *root) {
+    auto rv = Visitor::init_apply(root);
+    visited = std::make_shared<ChangeTracker>(forceClone);
+    return rv;
+}
 Visitor::profile_t Inspector::init_apply(const IR::Node *root) {
     auto rv = Visitor::init_apply(root);
     visited = std::make_shared<Tracker>();
     return rv;
 }
 Visitor::profile_t Transform::init_apply(const IR::Node *root) {
+    auto rv = Visitor::init_apply(root);
+    visited = std::make_shared<ChangeTracker>(forceClone);
+    return rv;
+}
+Visitor::profile_t COWTransform::init_apply(const IR::Node *root) {
     auto rv = Visitor::init_apply(root);
     visited = std::make_shared<ChangeTracker>(forceClone);
     return rv;
@@ -399,11 +409,15 @@ Visitor::profile_t::~profile_t() {
 
 void Inspector::visitOnce() const { visited->visitOnce(getOriginal()); }
 void Modifier::visitOnce() const { visited->visitOnce(getOriginal()); }
+void COWModifier::visitOnce() const { visited->visitOnce(getOriginal()); }
 void Transform::visitOnce() const { visited->visitOnce(getOriginal()); }
+void COWTransform::visitOnce() const { visited->visitOnce(getOriginal()); }
 
 void Inspector::visitAgain() const { visited->visitAgain(getOriginal()); }
 void Modifier::visitAgain() const { visited->visitAgain(getOriginal()); }
+void COWModifier::visitAgain() const { visited->visitAgain(getOriginal()); }
 void Transform::visitAgain() const { visited->visitAgain(getOriginal()); }
+void COWTransform::visitAgain() const { visited->visitAgain(getOriginal()); }
 
 void Visitor::print_context() const {
     std::ostream &out = std::cout;
@@ -425,7 +439,15 @@ void Modifier::visitor_const_error() {
     BUG("Modifier called const visit function -- missing template "
         "instantiation in gen-tree-macro.h?");
 }
+void COWModifier::visitor_const_error() {
+    BUG("Modifier called const visit function -- missing template "
+        "instantiation in gen-tree-macro.h?");
+}
 void Transform::visitor_const_error() {
+    BUG("Transform called const visit function -- missing template "
+        "instantiation in gen-tree-macro.h?");
+}
+void COWTransform::visitor_const_error() {
     BUG("Transform called const visit function -- missing template "
         "instantiation in gen-tree-macro.h?");
 }
@@ -495,6 +517,43 @@ const IR::Node *Modifier::apply_visitor(const IR::Node *n, const char *name) {
                     if (onNodeTransformedHook) onNodeTransformedHook(n, copy);
                     n = copy;
                 }
+                break;
+            }
+        }
+    }
+    if (ctxt)
+        ctxt->child_index++;
+    else
+        visited.reset();
+    return n;
+}
+
+const IR::Node *COWModifier::apply_visitor(const IR::Node *n, const char *name) {
+    if (ctxt && name) ctxt->child_name = name;
+    if (n) {
+        PushContext local(ctxt, n);
+        switch (visited->try_start(n, visitDagOnce)) {
+            case VisitStatus::Busy:
+                n->apply_visitor_loop_revisit(*this);
+                // FIXME -- should have a way of updating the node?  Needs to be decided
+                // by the visitor somehow, but it is tough
+                break;
+            case VisitStatus::Done:
+                n->apply_visitor_revisit(*this, visited->result(n));
+                n = visited->result(n);
+                break;
+            default: {  // New or Revisit
+                IR::COWinfo<IR::Node> clone_info(n, &local.current);
+                IR::COWptr<IR::Node> cloner(&clone_info);
+                if (!dontForwardChildrenBeforePreorder) {
+                    ForwardChildren forward_children(*visited);
+                    cloner.visit_children(forward_children, name);
+                }
+                if (cloner.apply_visitor_preorder(*this)) {
+                    cloner.visit_children(*this, name);
+                    cloner.apply_visitor_postorder(*this);
+                }
+                if (visited->finish(n, cloner)) (n = cloner)->validate();
                 break;
             }
         }
@@ -605,12 +664,77 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
     return n;
 }
 
+const IR::Node *COWTransform::apply_visitor(const IR::Node *n, const char *name) {
+    if (ctxt) ctxt->child_name = name;
+    if (n) {
+        PushContext local(ctxt, n);
+        switch (visited->try_start(n, visitDagOnce)) {
+            case VisitStatus::Busy:
+                n->apply_visitor_loop_revisit(*this);
+                // FIXME -- should have a way of updating the node?  Needs to be decided
+                // by the visitor somehow, but it is tough
+                break;
+            case VisitStatus::Done:
+                n->apply_visitor_revisit(*this, visited->result(n));
+                n = visited->result(n);
+                break;
+            default: {  // New or Revisit
+                IR::COWinfo<IR::Node> clone_info(n, &local.current);
+                IR::COWptr<IR::Node> cloner(&clone_info);
+                if (!dontForwardChildrenBeforePreorder) {
+                    ForwardChildren forward_children(*visited);
+                    cloner.visit_children(forward_children, name);
+                }
+                bool save_prune_flag = prune_flag;
+                prune_flag = false;
+                const IR::Node *preorder_result = cloner.apply_visitor_preorder(*this);
+                if (preorder_result != cloner.get()) {
+                    if (!preorder_result) {
+                        clone_info.transform_to(preorder_result);
+                        prune_flag = true;
+                    } else if (visited->done(preorder_result)) {
+                        clone_info.transform_to(visited->result(preorder_result));
+                        prune_flag = true;
+                    } else {
+                        auto status =
+                            visited->try_start(preorder_result, visited->shouldVisitOnce(n));
+                        // Sanity check for IR loops.  Not needed any more?
+                        if (status == VisitStatus::Busy) BUG("IR loop detected ");
+                        clone_info.transform_to(preorder_result);
+                        local.current.node = preorder_result;
+                    }
+                }
+                if (!prune_flag) {
+                    cloner.visit_children(*this, name);
+                    const IR::Node *final_result = cloner.apply_visitor_postorder(*this);
+                    if (final_result != cloner.get()) {
+                        clone_info.transform_to(final_result);
+                        local.current.node = final_result;
+                    }
+                }
+                prune_flag = save_prune_flag;
+                if (visited->finish(n, cloner) && (n = cloner)) n->validate();
+                break;
+            }
+        }
+    }
+    if (ctxt)
+        ctxt->child_index++;
+    else
+        visited.reset();
+    return n;
+}
+
 void Inspector::revisit_visited() { visited->revisit_visited(); }
 bool Inspector::visit_in_progress(const IR::Node *n) const { return visited->busy(n); }
 void Modifier::revisit_visited() { visited->revisit_visited(); }
 bool Modifier::visit_in_progress(const IR::Node *n) const { return visited->busy(n); }
+void COWModifier::revisit_visited() { visited->revisit_visited(); }
+bool COWModifier::visit_in_progress(const IR::Node *n) const { return visited->busy(n); }
 void Transform::revisit_visited() { visited->revisit_visited(); }
 bool Transform::visit_in_progress(const IR::Node *n) const { return visited->busy(n); }
+void COWTransform::revisit_visited() { visited->revisit_visited(); }
+bool COWTransform::visit_in_progress(const IR::Node *n) const { return visited->busy(n); }
 
 #define DEFINE_VISIT_FUNCTIONS(CLASS, BASE)                                                        \
     bool Modifier::preorder(IR::CLASS *n) { return preorder(static_cast<IR::BASE *>(n)); }         \
@@ -619,6 +743,16 @@ bool Transform::visit_in_progress(const IR::Node *n) const { return visited->bus
         revisit(static_cast<const IR::BASE *>(o), static_cast<const IR::BASE *>(n));               \
     }                                                                                              \
     void Modifier::loop_revisit(const IR::CLASS *o) {                                              \
+        loop_revisit(static_cast<const IR::BASE *>(o));                                            \
+    }                                                                                              \
+    bool COWModifier::preorder(IR::COWptr<IR::CLASS> n) {                                          \
+        return preorder(IR::COWptr<IR::BASE>(n));                                                  \
+    }                                                                                              \
+    void COWModifier::postorder(IR::COWptr<IR::CLASS> n) { postorder(IR::COWptr<IR::BASE>(n)); }   \
+    void COWModifier::revisit(const IR::CLASS *o, const IR::CLASS *n) {                            \
+        revisit(static_cast<const IR::BASE *>(o), static_cast<const IR::BASE *>(n));               \
+    }                                                                                              \
+    void COWModifier::loop_revisit(const IR::CLASS *o) {                                           \
         loop_revisit(static_cast<const IR::BASE *>(o));                                            \
     }                                                                                              \
     bool Inspector::preorder(const IR::CLASS *n) {                                                 \
@@ -639,6 +773,18 @@ bool Transform::visit_in_progress(const IR::Node *n) const { return visited->bus
         return revisit(static_cast<const IR::BASE *>(o), n);                                       \
     }                                                                                              \
     void Transform::loop_revisit(const IR::CLASS *o) {                                             \
+        return loop_revisit(static_cast<const IR::BASE *>(o));                                     \
+    }                                                                                              \
+    const IR::Node *COWTransform::preorder(IR::COWptr<IR::CLASS> n) {                              \
+        return preorder(IR::COWptr<IR::BASE>(n));                                                  \
+    }                                                                                              \
+    const IR::Node *COWTransform::postorder(IR::COWptr<IR::CLASS> n) {                             \
+        return postorder(IR::COWptr<IR::BASE>(n));                                                 \
+    }                                                                                              \
+    void COWTransform::revisit(const IR::CLASS *o, const IR::Node *n) {                            \
+        return revisit(static_cast<const IR::BASE *>(o), n);                                       \
+    }                                                                                              \
+    void COWTransform::loop_revisit(const IR::CLASS *o) {                                          \
         return loop_revisit(static_cast<const IR::BASE *>(o));                                     \
     }
 
@@ -739,8 +885,18 @@ bool Modifier::check_clone(const Visitor *v) {
     BUG_CHECK(t && t->visited == visited, "Clone failed to copy base object");
     return Visitor::check_clone(v);
 }
+bool COWModifier::check_clone(const Visitor *v) {
+    auto *t = dynamic_cast<const COWModifier *>(v);
+    BUG_CHECK(t && t->visited == visited, "Clone failed to copy base object");
+    return Visitor::check_clone(v);
+}
 bool Transform::check_clone(const Visitor *v) {
     auto *t = dynamic_cast<const Transform *>(v);
+    BUG_CHECK(t && t->visited == visited, "Clone failed to copy base object");
+    return Visitor::check_clone(v);
+}
+bool COWTransform::check_clone(const Visitor *v) {
+    auto *t = dynamic_cast<const COWTransform *>(v);
     BUG_CHECK(t && t->visited == visited, "Clone failed to copy base object");
     return Visitor::check_clone(v);
 }
@@ -857,8 +1013,8 @@ std::ostream &operator<<(std::ostream &out, const ControlFlowVisitor::flow_join_
     out << Brief;
     for (auto &i : info.parents) {
         out << Log::endl
-            << "  " << *i.first << " [" << i.first->id << "] " << "exist=" << i.second.exist
-            << " visited=" << i.second.visited;
+            << "  " << *i.first << " [" << i.first->id << "] "
+            << "exist=" << i.second.exist << " visited=" << i.second.visited;
     }
     dbsetflags(out, flags);
 #endif

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -168,7 +168,7 @@ class Visitor {
         n.visit_children(*this, name);
     }
     template <class COW>
-    requires IR::COWref<COW> && std::convertible_to<COW, const IR::Node *>
+        requires IR::COWref<COW> && std::convertible_to<COW, const IR::Node *>
     void visit(COW ref, const char *name = 0, int cidx = -1) {
         auto o = ref.get();
         if (cidx >= 0 && ctxt) ctxt->child_index = cidx;
@@ -955,7 +955,6 @@ void SplitFlowVisitVector(Visitor &v,
 
     COWvec_subf(v, vec, name).run_visit();
 }
-
 
 class Backtrack : public virtual Visitor {
  public:

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include <utility>
 
 #include "absl/time/time.h"
+#include "ir/copy_on_write_ptr.h"
 #include "ir/gen-tree-macro.h"
 #include "ir/ir-tree-macros.h"
 #include "ir/node.h"
@@ -127,11 +128,11 @@ class Visitor {
         if (t != n) visitor_const_error();
     }
     void visit(const IR::Node *&n, const char *name, int cidx) {
-        ctxt->child_index = cidx;
+        if (ctxt) ctxt->child_index = cidx;
         n = apply_visitor(n, name);
     }
     void visit(const IR::Node *const &n, const char *name, int cidx) {
-        ctxt->child_index = cidx;
+        if (ctxt) ctxt->child_index = cidx;
         auto t = apply_visitor(n, name);
         if (t != n) visitor_const_error();
     }
@@ -166,6 +167,40 @@ class Visitor {
         }
         n.visit_children(*this, name);
     }
+    template <class COW>
+    requires IR::COWref<COW> && std::convertible_to<COW, const IR::Node *>
+    void visit(COW ref, const char *name = 0, int cidx = -1) {
+        auto o = ref.get();
+        if (cidx >= 0 && ctxt) ctxt->child_index = cidx;
+        const IR::Node *n = apply_visitor(o, name);
+        if (n != o) {
+            if (!n)
+                ref.set(nullptr);
+            else if (auto c = n->to<std::decay_t<decltype(*o)>>())
+                ref.set(c);
+            else
+                BUG("visitor returned invalid type %s for %s", n->node_type_name(),
+                    o->static_type_name());
+        }
+    }
+    template <class T, class N>
+    void visit(std::pair<IR::COWinfo<T> *, const N * T::*> &ref, const char *name = 0,
+               int cidx = -1) {
+        auto o = ref.first->get()->*ref.second;
+        if (cidx >= 0 && ctxt) ctxt->child_index = cidx;
+        const IR::Node *n = apply_visitor(o, name);
+        if (n != o) {
+            auto &dest = ref.first->mkClone()->*ref.second;
+            if (!n)
+                dest = nullptr;
+            else if (auto c = n->to<N>())
+                dest = c;
+            else
+                BUG("visitor returned invalid type %s for %s", n->node_type_name(),
+                    N::static_type_name());
+        }
+    }
+
     template <class T>
     void parallel_visit(IR::Vector<T> &v, const char *name = 0) {
         if (name && ctxt) ctxt->child_name = name;
@@ -378,7 +413,9 @@ class Visitor {
     const Context *ctxt = nullptr;  // should be readonly to subclasses
     friend class Inspector;
     friend class Modifier;
+    friend class COWModifier;
     friend class Transform;
+    friend class COWTransform;
     friend class ControlFlowVisitor;
 };
 
@@ -410,6 +447,34 @@ class Modifier : public virtual Visitor {
         const std::function<void(const IR::Node *from, const IR::Node *to)> &hook) {
         onNodeTransformedHook = hook;
     }
+
+ protected:
+    bool forceClone = false;  // force clone whole tree even if unchanged
+};
+
+class COWModifier : public virtual Visitor {
+    std::shared_ptr<ChangeTracker> visited;
+    void visitor_const_error() override;
+    bool check_clone(const Visitor *) override;
+
+ public:
+    profile_t init_apply(const IR::Node *root) override;
+    const IR::Node *apply_visitor(const IR::Node *n, const char *name = 0) override;
+    virtual bool preorder(IR::COWptr<IR::Node>) { return true; }
+    virtual void postorder(IR::COWptr<IR::Node>) {}
+    virtual void revisit(const IR::Node *, const IR::Node *) {}
+    virtual void loop_revisit(const IR::Node *) { BUG("IR loop detected"); }
+#define DECLARE_VISIT_FUNCTIONS(CLASS, BASE)                    \
+    virtual bool preorder(IR::COWptr<IR::CLASS>);               \
+    virtual void postorder(IR::COWptr<IR::CLASS>);              \
+    virtual void revisit(const IR::CLASS *, const IR::CLASS *); \
+    virtual void loop_revisit(const IR::CLASS *);
+    IRNODE_ALL_SUBCLASSES(DECLARE_VISIT_FUNCTIONS)
+#undef DECLARE_VISIT_FUNCTIONS
+    void revisit_visited();
+    bool visit_in_progress(const IR::Node *) const;
+    void visitOnce() const override;
+    void visitAgain() const override;
 
  protected:
     bool forceClone = false;  // force clone whole tree even if unchanged
@@ -470,6 +535,42 @@ class Transform : public virtual Visitor {
         const std::function<void(const IR::Node *from, const IR::Node *to)> &hook) {
         onNodeTransformedHook = hook;
     }
+
+ protected:
+    const IR::Node *transform_child(const IR::Node *child) {
+        auto *rv = apply_visitor(child);
+        prune_flag = true;
+        return rv;
+    }
+    bool forceClone = false;  // force clone whole tree even if unchanged
+};
+
+class COWTransform : public virtual Visitor {
+    std::shared_ptr<ChangeTracker> visited;
+    bool prune_flag = false;
+    void visitor_const_error() override;
+    bool check_clone(const Visitor *) override;
+
+ public:
+    profile_t init_apply(const IR::Node *root) override;
+    const IR::Node *apply_visitor(const IR::Node *, const char *name = 0) override;
+    virtual const IR::Node *preorder(IR::COWptr<IR::Node> n) { return n; }
+    virtual const IR::Node *postorder(IR::COWptr<IR::Node> n) { return n; }
+    virtual void revisit(const IR::Node *, const IR::Node *) {}
+    virtual void loop_revisit(const IR::Node *) { BUG("IR loop detected"); }
+#define DECLARE_VISIT_FUNCTIONS(CLASS, BASE)                   \
+    virtual const IR::Node *preorder(IR::COWptr<IR::CLASS>);   \
+    virtual const IR::Node *postorder(IR::COWptr<IR::CLASS>);  \
+    virtual void revisit(const IR::CLASS *, const IR::Node *); \
+    virtual void loop_revisit(const IR::CLASS *);
+    IRNODE_ALL_SUBCLASSES(DECLARE_VISIT_FUNCTIONS)
+#undef DECLARE_VISIT_FUNCTIONS
+    void revisit_visited();
+    bool visit_in_progress(const IR::Node *) const;
+    void visitOnce() const override;
+    void visitAgain() const override;
+    // can only be called usefully from a 'preorder' function (directly or indirectly)
+    void prune() { prune_flag = true; }
 
  protected:
     const IR::Node *transform_child(const IR::Node *child) {
@@ -670,15 +771,17 @@ class SplitFlowVisit_base {
     friend void dump(const SplitFlowVisit_base *);
 };
 
-template <class N>
+template <class T, class N>
 class SplitFlowVisit : public SplitFlowVisit_base {
     std::vector<const N **> nodes;
     std::vector<const N *const *> const_nodes;
+    std::vector<std::pair<IR::COWinfo<T> *, const N * T::*>> cow_nodes;
 
  public:
     explicit SplitFlowVisit(Visitor &v) : SplitFlowVisit_base(v) {}
     void addNode(const N *&node) {
         BUG_CHECK(const_nodes.empty(), "Mixing const and non-const in SplitFlowVisit");
+        BUG_CHECK(cow_nodes.empty(), "Mixing COW and non-const in SplitFlowVisit");
         BUG_CHECK(visitors.size() == nodes.size(), "size mismatch in SplitFlowVisit");
         BUG_CHECK(visit_next == 0, "Can't addNode to SplitFlowVisit after visiting started");
         visitors.push_back(visitors.empty() ? &v : &v.flow_clone());
@@ -686,10 +789,20 @@ class SplitFlowVisit : public SplitFlowVisit_base {
     }
     void addNode(const N *const &node) {
         BUG_CHECK(nodes.empty(), "Mixing const and non-const in SplitFlowVisit");
+        BUG_CHECK(cow_nodes.empty(), "Mixing COW and const in SplitFlowVisit");
         BUG_CHECK(visitors.size() == const_nodes.size(), "size mismatch in SplitFlowVisit");
         BUG_CHECK(visit_next == 0, "Can't addNode to SplitFlowVisit after visiting started");
         visitors.push_back(visitors.empty() ? &v : &v.flow_clone());
         const_nodes.emplace_back(&node);
+    }
+    template <const N *T::*field>
+    void addNode(IR::COWfieldref<T, const N *, field> &f) {
+        BUG_CHECK(const_nodes.empty(), "Mixing COW and const in SplitFlowVisit");
+        BUG_CHECK(nodes.empty(), "Mixing COW and non-const in SplitFlowVisit");
+        BUG_CHECK(visitors.size() == cow_nodes.size(), "size mismatch in SplitFlowVisit");
+        BUG_CHECK(visit_next == 0, "Can't addNode to SplitFlowVisit after visiting started");
+        visitors.push_back(visitors.empty() ? &v : &v.flow_clone());
+        cow_nodes.emplace_back(std::make_pair(f.info, field));
     }
     template <class T1, class T2, class... Args>
     void addNode(T1 &&t1, T2 &&t2, Args &&...args) {
@@ -704,10 +817,12 @@ class SplitFlowVisit : public SplitFlowVisit_base {
         if (!finished()) {
             BUG_CHECK(!paused, "trying to visit paused split_flow_visitor");
             int idx = visit_next++;
-            if (nodes.empty())
+            if (!const_nodes.empty())
                 visitors.at(idx)->visit(*const_nodes.at(idx), nullptr, start_index + idx);
-            else
+            else if (!nodes.empty())
                 visitors.at(idx)->visit(*nodes.at(idx), nullptr, start_index + idx);
+            else if (!cow_nodes.empty())
+                visitors.at(idx)->visit(cow_nodes.at(idx), nullptr, start_index + idx);
         }
     }
     void dbprint(std::ostream &out) const override {
@@ -715,76 +830,132 @@ class SplitFlowVisit : public SplitFlowVisit_base {
     }
 };
 
-template <class N>
-class SplitFlowVisitVector : public SplitFlowVisit_base {
-    IR::Vector<N> *vec = nullptr;
-    const IR::Vector<N> *const_vec = nullptr;
-    std::vector<const IR::Node *> result;
+class SplitFlowVisitVector_base : public SplitFlowVisit_base {
+ protected:
+    const char *name = nullptr;
+    SplitFlowVisitVector_base(Visitor &v, const char *name) : SplitFlowVisit_base(v), name(name) {}
     void init_visit(size_t size) {
         if (size > 0) visitors.push_back(&v);
         while (visitors.size() < size) visitors.push_back(&v.flow_clone());
-    }
-
- public:
-    SplitFlowVisitVector(Visitor &v, IR::Vector<N> &vec) : SplitFlowVisit_base(v), vec(&vec) {
-        result.resize(vec.size());
-        init_visit(vec.size());
-    }
-    SplitFlowVisitVector(Visitor &v, const IR::Vector<N> &vec)
-        : SplitFlowVisit_base(v), const_vec(&vec) {
-        init_visit(vec.size());
-    }
-    void do_visit() override {
-        if (!finished()) {
-            BUG_CHECK(!paused, "trying to visit paused split_flow_visitor");
-            int idx = visit_next++;
-            if (vec)
-                result[idx] = visitors.at(idx)->apply_visitor(vec->at(idx));
-            else
-                visitors.at(idx)->visit(const_vec->at(idx), nullptr, start_index + idx);
-        }
-    }
-    void run_visit() override {
-        SplitFlowVisit_base::run_visit();
-        if (vec) {
-            int idx = 0;
-            for (auto i = vec->begin(); i != vec->end(); ++idx) {
-                if (!result[idx] && *i) {
-                    i = vec->erase(i);
-                } else if (result[idx] == *i) {
-                    ++i;
-                } else if (auto l = result[idx]->template to<IR::Vector<N>>()) {
-                    i = vec->erase(i);
-                    i = vec->insert(i, l->begin(), l->end());
-                    i += l->size();
-                } else if (auto v = result[idx]->template to<IR::VectorBase>()) {
-                    if (v->empty()) {
-                        i = vec->erase(i);
-                    } else {
-                        i = vec->insert(i, v->size() - 1, nullptr);
-                        for (auto el : *v) {
-                            CHECK_NULL(el);
-                            if (auto e = el->template to<N>())
-                                *i++ = e;
-                            else
-                                BUG("visitor returned invalid type %s for Vector<%s>",
-                                    el->node_type_name(), N::static_type_name());
-                        }
-                    }
-                } else if (auto e = result[idx]->template to<N>()) {
-                    *i++ = e;
-                } else {
-                    CHECK_NULL(result[idx]);
-                    BUG("visitor returned invalid type %s for Vector<%s>",
-                        result[idx]->node_type_name(), N::static_type_name());
-                }
-            }
-        }
     }
     void dbprint(std::ostream &out) const override {
         out << "SplitFlowVisitVector processed " << visit_next << " of " << visitors.size();
     }
 };
+
+// SplitFlowVisitVector functions overloaded to infer the vector type/kind from the arguments
+// different kinds of vectors (const/non-const/copy-on-write) need different handling so
+// have slightly different local classes to deal with it
+template <class T>
+void SplitFlowVisitVector(Visitor &v, IR::Vector<T> &vec, const char *name = nullptr) {
+    class ncVec : public SplitFlowVisitVector_base {
+        IR::Vector<T> *vec = nullptr;
+        safe_vector<const T *> result;
+
+     public:
+        ncVec(Visitor &v, IR::Vector<T> &vec, const char *name)
+            : SplitFlowVisitVector_base(v, name), vec(&vec) {
+            init_visit(vec.size());
+        }
+        void do_visit() override {
+            if (finished()) return;
+            BUG_CHECK(!paused, "trying to visit paused split_flow_visitor");
+            int idx = visit_next++;
+            const IR::Node *n = visitors.at(idx)->apply_visitor(vec->at(idx), name);
+            IR::merge_into_safe_vector(result, n, "Vector");
+        }
+        void run_visit() override {
+            SplitFlowVisit_base::run_visit();
+            if (result != vec->get_contents()) vec->replace_contents(std::move(result));
+        }
+    };
+
+    ncVec(v, vec, name).run_visit();
+}
+
+template <class T>
+void SplitFlowVisitVector(Visitor &v, const IR::Vector<T> &vec, const char *name = nullptr) {
+    class constVec : public SplitFlowVisitVector_base {
+        const IR::Vector<T> *const_vec = nullptr;
+
+     public:
+        constVec(Visitor &v, const IR::Vector<T> &vec, const char *name)
+            : SplitFlowVisitVector_base(v, name), const_vec(&vec) {
+            init_visit(vec.size());
+        }
+        void do_visit() override {
+            if (finished()) return;
+            BUG_CHECK(!paused, "trying to visit paused split_flow_visitor");
+            int idx = visit_next++;
+            visitors.at(idx)->visit(const_vec->at(idx), name, start_index + idx);
+        }
+    };
+
+    constVec(v, vec, name).run_visit();
+}
+
+template <class T, class U, IR::Vector<U> T::*field>
+void SplitFlowVisitVector(Visitor &v, const IR::COWfieldref<T, IR::Vector<U>, field> &vec,
+                          const char *name = nullptr) {
+    class COWvec : public SplitFlowVisitVector_base {
+        const IR::COWfieldref<T, IR::Vector<U>, field> &vec;
+        safe_vector<const U *> result;
+
+     public:
+        COWvec(Visitor &v, const IR::COWfieldref<T, IR::Vector<U>, field> &vec, const char *name)
+            : SplitFlowVisitVector_base(v, name), vec(vec) {
+            init_visit(vec.get().size());
+        }
+
+        void do_visit() override {
+            if (finished()) return;
+            BUG_CHECK(!paused, "trying to visit paused split_flow_visitor");
+            int idx = visit_next++;
+            const IR::Node *n = visitors.at(idx)->apply_visitor(vec.get().at(idx), name);
+            IR::merge_into_safe_vector(result, n, "Vector");
+        }
+        void run_visit() override {
+            SplitFlowVisit_base::run_visit();
+            auto old = vec.get().get_contents();
+            if (result != old) vec.modify().replace_contents(std::move(result));
+        }
+    };
+
+    COWvec(v, vec, name).run_visit();
+}
+
+template <class T, class U, class COW, class X, IR::Vector<U> X::*field>
+void SplitFlowVisitVector(Visitor &v,
+                          const IR::COWref_subfield<T, IR::Vector<U>, COW, X, field> &vec,
+                          const char *name = nullptr) {
+    class COWvec_subf : public SplitFlowVisitVector_base {
+        const IR::COWref_subfield<T, IR::Vector<U>, COW, X, field> &vec;
+        safe_vector<const U *> result;
+
+     public:
+        COWvec_subf(Visitor &v, const IR::COWref_subfield<T, IR::Vector<U>, COW, X, field> &vec,
+                    const char *name)
+            : SplitFlowVisitVector_base(v, name), vec(vec) {
+            init_visit(vec.get().size());
+        }
+
+        void do_visit() override {
+            if (finished()) return;
+            BUG_CHECK(!paused, "trying to visit paused split_flow_visitor");
+            int idx = visit_next++;
+            const IR::Node *n = visitors.at(idx)->apply_visitor(vec.get().at(idx), name);
+            IR::merge_into_safe_vector(result, n, "Vector");
+        }
+        void run_visit() override {
+            SplitFlowVisit_base::run_visit();
+            auto old = vec.get().get_contents();
+            if (result != old) vec.modify().replace_contents(std::move(result));
+        }
+    };
+
+    COWvec_subf(v, vec, name).run_visit();
+}
+
 
 class Backtrack : public virtual Visitor {
  public:

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -514,9 +514,9 @@ void IrClass::outputCOWref(std::ostream &out) const {
     out << indent << "operator COWptr<" << name << ">() const { return COWptr<" << name
         << ">(info); }\n";
     out << indent << "operator const " << name << " *() const { return info->get(); }\n";
+    out << indent << "const COWref *operator->() const { return this; }\n";
 #endif
-    out << indent << "COWref *operator->() { return this; }\n";
-    out << indent << "void visit_children(Visitor &, const char *);\n";
+    out << indent << "void visit_children(Visitor &, const char *) const;\n";
     outputCOWmethodrefs(
         IrElement::Public, out,
         {"visit_children"_cs, "COWref::visit_children"_cs, "COWref_visit_children"_cs});
@@ -543,11 +543,13 @@ void IrClass::outputCOWnested(std::ostream &out, IrNamespace *containedIn) const
     }
     out << indent << "};\n";
     out << indent << "const " << qname
-        << " &get() const { return reinterpret_cast<const COW *>(this)->get(); }\n";
+        << " &get() const { return std::launder(reinterpret_cast<const COW *>(this))->get(); }\n";
     out << indent << "const " << qname
-        << " &getOrig() const { return reinterpret_cast<const COW *>(this)->getOrig(); }\n";
+        << " &getOrig() const { return std::launder(reinterpret_cast<const COW "
+           "*>(this))->getOrig(); }\n";
     out << indent << qname
-        << " &modify() const { return reinterpret_cast<const COW *>(this)->modify(); }\n";
+        << " &modify() const { return std::launder(reinterpret_cast<const COW *>(this))->modify(); "
+           "}\n";
     out << IrElement::Protected;
     out << indent << "COW_nested() = delete;\n";
     out << indent << "COW_nested(const COW_nested &) = default;\n";

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -156,6 +156,7 @@ void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &i
         << "#include <map>\n\n"
         << "#include \"lib/big_int.h\"        // IWYU pragma: keep\n"
         << "// Special IR classes and types\n"
+        << "#include \"ir/copy_on_write_ptr.h\"  // IWYU pragma: keep\n"
         << "#include \"ir/dbprint.h\"         // IWYU pragma: keep\n"
         << "#include \"ir/id.h\"              // IWYU pragma: keep\n"
         << "#include \"ir/indexed_vector.h\"  // IWYU pragma: keep\n"
@@ -163,6 +164,8 @@ void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &i
         << "#include \"ir/node.h\"            // IWYU pragma: keep\n"
         << "#include \"ir/nodemap.h\"         // IWYU pragma: keep\n"
         << "#include \"ir/vector.h\"          // IWYU pragma: keep\n"
+        << "// copy_on_write_inl.h must be after vector.h and indexed_vector.h\n"
+        << "#include \"ir/copy_on_write_inl.h\"  // IWYU pragma: keep\n"
         << "#include \"lib/ordered_map.h\"    // IWYU pragma: keep\n"
         << std::endl
         << "namespace P4 {\n"
@@ -215,6 +218,8 @@ void IrDefinitions::generate(std::ostream &t, std::ostream &out, std::ostream &i
         e->generate_hdr(out);
         e->generate_impl(impl);
     }
+
+    for (auto cls : *getClasses()) cls->outputCOWref(out);
 
     out << "#endif /* " << macroname << " */" << std::endl;
 
@@ -354,6 +359,7 @@ void IrMethod::generate_proto(std::ostream &out, bool fullname, bool defaults) c
 }
 
 void IrMethod::generate_hdr(std::ostream &out) const {
+    if (COWrefMethod) return;
     if (srcInfo.isValid()) out << LineDirective(srcInfo);
     out << IrClass::indent;
     if (isStatic) out << "static ";
@@ -366,7 +372,7 @@ void IrMethod::generate_hdr(std::ostream &out) const {
     else
         out << ' ' << body;
     out << std::endl;
-    if (name == "visit_children") {
+    if (constAndNonconst) {
         out << IrClass::indent;
         generate_proto(out, false, isUser);
         out << " const";
@@ -381,10 +387,14 @@ void IrMethod::generate_hdr(std::ostream &out) const {
 
 void IrMethod::generate_impl(std::ostream &out) const {
     if (!inImpl || !body) return;
+    if (COWrefMethod) {
+        // skip these
+        if (clss->kind != NodeKind::Concrete && clss->kind != NodeKind::Template) return;
+    }
     out << LineDirective(srcInfo);
     generate_proto(out, true, false);
     out << " " << body << std::endl;
-    if (name == "visit_children") {
+    if (constAndNonconst) {
         out << LineDirective(srcInfo);
         generate_proto(out, true, false);
         out << " const " << body << std::endl;
@@ -439,6 +449,113 @@ cstring IrClass::qualified_name(const IrNamespace *in) const {
     return rv;
 }
 
+IrElement::access_t IrClass::outputCOWfieldrefs(std::ostream &out) const {
+    auto access = IrElement::Private;
+    if (concreteParent) {
+        access = concreteParent->outputCOWfieldrefs(out);
+    } else {
+        out << (access = IrElement::Public);
+        out << indent << "COWfieldref<Node, Util::SourceInfo, &Node::srcInfo> srcInfo;\n";
+    }
+    for (auto e : elements) {
+        if (auto *fld = e->to<IrField>()) {
+            if (fld->isStatic) continue;
+            if (e->access != access) out << (access = e->access);
+            out << indent << "COWfieldref<" << name << ", " << fld->typeName() << ", &" << name
+                << "::" << fld->name << "> " << fld->name << ";\n";
+        }
+    }
+    return access;
+}
+
+IrElement::access_t IrClass::outputCOWmethodrefs(IrElement::access_t access, std::ostream &out,
+                                                 std::unordered_set<cstring> overridden) const {
+    std::unordered_set<cstring> override_parent = overridden;
+    for (auto e : elements) {
+        if (auto *m = e->to<IrMethod>()) {
+            if (m->isStatic) continue;
+            if (m->name == name) continue;  // constructor
+            if (overridden.count(m->name)) continue;
+            override_parent.insert(m->name);
+            if (e->access != access) out << (access = e->access);
+            out << indent;
+            m->generate_proto(out, false, true);
+            out << " { return info->" << (m->isConst ? "get" : "mkClone") << "()->" << m->name
+                << "(";
+            const char *sep = "";
+            for (auto *a : m->args) {
+                out << sep << a->name;
+                sep = ", ";
+            }
+            out << "); }\n";
+        }
+    }
+    if (concreteParent) return concreteParent->outputCOWmethodrefs(access, out, override_parent);
+    return access;
+}
+
+void IrClass::outputCOWref(std::ostream &out) const {
+    if (kind != NodeKind::Concrete && kind != NodeKind::Template) return;
+    out << "namespace P4::IR {" << std::endl;
+    enter_namespace(out, containedIn);
+    for (auto e : elements) {
+        if (auto *nc = e->to<IrClass>()) {
+            nc->outputCOWnested(out, containedIn ? containedIn : &IrNamespace::global());
+        }
+    }
+    out << "union " << name << "::COWref {\n";
+    out << indent << "friend class COWptr<" << name << ">;\n";
+    out << IrElement::Private;
+    out << indent << "COWNode_info *_info;\n";
+    out << indent << "COWinfo<" << name << "> *info;\n";
+    if (outputCOWfieldrefs(out) != IrElement::Public) out << IrElement::Public;
+    out << indent << "COWref(COWNode_info *i) { _info = i; }\n";
+#if 0
+    out << indent << "operator COWptr<" << name << ">() const { return COWptr<" << name
+        << ">(info); }\n";
+    out << indent << "operator const " << name << " *() const { return info->get(); }\n";
+#endif
+    out << indent << "COWref *operator->() { return this; }\n";
+    out << indent << "void visit_children(Visitor &, const char *);\n";
+    outputCOWmethodrefs(
+        IrElement::Public, out,
+        {"visit_children"_cs, "COWref::visit_children"_cs, "COWref_visit_children"_cs});
+    out << "};\n";
+    exit_namespace(out, containedIn);
+    out << "}  // namespace P4::IR" << std::endl;
+}
+
+void IrClass::outputCOWnested(std::ostream &out, IrNamespace *containedIn) const {
+    std::stringstream COWfieldref;
+    cstring qname = qualified_name(containedIn);
+    out << "template <class T, class COW>\n";
+    out << "class " << qname << "::COW_nested : public P4::IR::COW_nested_class {\n";
+    out << IrElement::Public;  // FIXME can't mix public and private in an anonymous union,
+                               // so the whole thing must be public
+    out << indent << "union {\n";
+    out << indent << indent << "COWinfo<T> *info;\n";
+    for (auto e : elements) {
+        if (auto *fld = e->to<IrField>()) {
+            if (fld->isStatic) continue;
+            out << indent << indent << "COWref_subfield<T, " << fld->typeName() << ", COW, "
+                << qname << ", &" << qname << "::" << fld->name << "> " << fld->name << ";\n";
+        }
+    }
+    out << indent << "};\n";
+    out << indent << "const " << qname
+        << " &get() const { return reinterpret_cast<const COW *>(this)->get(); }\n";
+    out << indent << "const " << qname
+        << " &getOrig() const { return reinterpret_cast<const COW *>(this)->getOrig(); }\n";
+    out << indent << qname
+        << " &modify() const { return reinterpret_cast<const COW *>(this)->modify(); }\n";
+    out << IrElement::Protected;
+    out << indent << "COW_nested() = delete;\n";
+    out << indent << "COW_nested(const COW_nested &) = default;\n";
+    out << indent << "COW_nested(COW_nested &&) = default;\n";
+    out << indent << "COW_nested(COWinfo<T> *i) { info = i; }\n";
+    out << "};\n";
+}
+
 void IrClass::generate_hdr(std::ostream &out) const {
     if (kind != NodeKind::Nested) {
         out << "namespace P4::IR {" << std::endl;
@@ -449,7 +566,10 @@ void IrClass::generate_hdr(std::ostream &out) const {
 
     bool concreteParent = false;
     for (auto p : parentClasses) {
-        if (p->kind != NodeKind::Interface) concreteParent = true;
+        if (p->kind != NodeKind::Interface) {
+            BUG_CHECK(!concreteParent && p == this->concreteParent, "inconsisten concreteParent");
+            concreteParent = true;
+        }
     }
 
     const char *sep = " : ";
@@ -478,6 +598,12 @@ void IrClass::generate_hdr(std::ostream &out) const {
     if (kind != NodeKind::Interface && kind != NodeKind::Nested)
         out << indent << "IRNODE" << (kind == NodeKind::Abstract ? "_ABSTRACT" : "") << "_SUBCLASS("
             << name << ")" << std::endl;
+
+    if (kind == NodeKind::Concrete || kind == NodeKind::Template) {
+        out << indent << "union COWref;\n";
+    }
+    if (kind == NodeKind::Nested)
+        out << indent << "template<class T, class COW> class COW_nested;\n";
 
     auto *irNamespace = IrNamespace::get(nullptr, "IR"_cs);
     if (kind != NodeKind::Nested) {
@@ -695,6 +821,16 @@ void IrField::generate_impl(std::ostream &) const {
     // FIXME -- for now statics are manually generated elsewhere
 }
 
+cstring IrField::typeName() const {
+    std::stringstream ss;
+    const IrClass *cls = type->resolve(clss ? clss->containedIn : nullptr);
+    if (cls != nullptr && !isInline) ss << "const ";
+    ss << type->toString();
+    if (cls != nullptr && !isInline) ss << "*";
+    ss << type->declSuffix();
+    return ss.str();
+}
+
 ////////////////////////////////////////////////////////////////////////////////////
 
 void IrVariantField::resolve() {
@@ -730,6 +866,8 @@ void IrVariantField::generate(std::ostream &out, bool asField) const {
         out << std::endl;
     }
 }
+
+cstring IrVariantField::typeName() const { return name + "_variant"; }
 
 ////////////////////////////////////////////////////////////////////////////////////
 

--- a/tools/ir-generator/irclass.h
+++ b/tools/ir-generator/irclass.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <map>
 #include <set>
 #include <stdexcept>
+#include <unordered_set>
 #include <vector>
 
 #include "lib/cstring.h"
@@ -130,6 +131,7 @@ class IrMethod : public IrElement {
     cstring body;
     bool inImpl = false, isConst = false, isOverride = false, isStatic = false, isVirtual = false,
          isUser = false, isFriend = false;
+    bool constAndNonconst = false, COWrefMethod = false;
     IrMethod(Util::SourceInfo info, cstring name, cstring body)
         : IrElement(info), name(name), body(body) {}
     IrMethod(Util::SourceInfo info, cstring name) : IrElement(info), name(name) {}
@@ -180,6 +182,7 @@ class IrField : public IrElement {
     void generate_hdr(std::ostream &out) const override { generate(out, true); }
     void generate_impl(std::ostream &) const override;
     cstring toString() const override { return name; }
+    virtual cstring typeName() const;
 
  protected:
     void resolveType(const Type *type);
@@ -194,6 +197,7 @@ class IrVariantField : public IrField {
 
     void resolve() override;
     void generate(std::ostream &out, bool asField) const override;
+    cstring typeName() const override;
 };
 
 class ConstFieldInitializer : public IrElement {
@@ -345,6 +349,10 @@ class IrClass : public IrElement {
     void generate_hdr(std::ostream &out) const override;
     void generate_impl(std::ostream &out) const override;
     void generateTreeMacro(std::ostream &out) const;
+    access_t outputCOWfieldrefs(std::ostream &out) const;
+    access_t outputCOWmethodrefs(access_t, std::ostream &out, std::unordered_set<cstring>) const;
+    void outputCOWref(std::ostream &out) const;
+    void outputCOWnested(std::ostream &out, IrNamespace *containedIn) const;
     void resolve() override;
     cstring toString() const override { return name; }
     std::string fullName() const;

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -12,17 +12,19 @@ namespace P4 {
 
 enum flags {
     // flags that control the creation of auto-created methods
-    EXTEND = 1,          // call the creation function to extend even when user-defined
-    IN_IMPL = 2,         // output in the implementation file, not the header
-    OVERRIDE = 4,        // give an 'override' tag (overrides something in IR::Node)
-    NOT_DEFAULT = 8,     // don't create if not user-defined
-    CONCRETE_ONLY = 16,  // don't create in abstract classes
-    CONST = 32,          // give a 'const' tag
-    CLASSREF = 64,       // add an argument `const CLASS &a'
-    INCL_NESTED = 128,   // create even in nested (non-Node sublass) classes
-    CONSTRUCTOR = 256,   // is a constructor
-    FACTORY = 512,       // factory (static) method
-    FRIEND = 1024        // friend function, not a method
+    EXTEND = 1,                 // call the creation function to extend even when user-defined
+    IN_IMPL = 2,                // output in the implementation file, not the header
+    OVERRIDE = 4,               // give an 'override' tag (overrides something in IR::Node)
+    NOT_DEFAULT = 8,            // don't create if not user-defined
+    CONCRETE_ONLY = 16,         // don't create in abstract classes
+    CONST = 32,                 // give a 'const' tag
+    CLASSREF = 64,              // add an argument `const CLASS &a'
+    INCL_NESTED = 128,          // create even in nested (non-Node sublass) classes
+    CONSTRUCTOR = 256,          // is a constructor
+    FACTORY = 512,              // factory (static) method
+    FRIEND = 1024,              // friend function, not a method
+    CONST_AND_NONCONST = 2048,  // generate twice, with and without const tag
+    COWREF_METHOD = 4096,       // part of COWref nested class
 };
 
 const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
@@ -162,11 +164,60 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
           buf << LineDirective(true) << cl->indent << "return out; }";
           return {buf};
       }}},
+    {"COWref::visit_children"_cs,
+     {&NamedType::Void(),
+      {new IrField(&ReferenceType::VisitorRef, "v"_cs),
+       new IrField(new PointerType(&NamedType::Char(), true), "n"_cs, "nullptr"_cs)},
+      IN_IMPL + OVERRIDE + COWREF_METHOD,
+      [](IrClass *cl, Util::SourceInfo, cstring) -> cstring {
+          std::stringstream buf;
+          buf << "{" << std::endl;
+          // Silence "not used" warnings in case of name `n` is not used
+          buf << cl->indent << "(void)n;" << std::endl;
+          if (auto parent = cl->getParent())
+              buf << cl->indent << "reinterpret_cast<" << parent->qualified_name(cl->containedIn)
+                  << "::COWref *>(this)->visit_children(v, n);" << std::endl;
+          for (auto f : *cl->getFields()) {
+              if (f->type) {
+                  if (f->type->resolve(cl->containedIn) == nullptr)
+                      // This is not an IR pointer
+                      continue;
+                  if (f->isInline)
+                      buf << cl->indent << f->name << ".visit_children(v, \"" << f->name << "\");"
+                          << std::endl;
+                  else
+                      buf << cl->indent << "v.visit(" << f->name << ", \"" << f->name << "\");"
+                          << std::endl;
+              } else {
+                  const auto *varF = f->to<IrVariantField>();
+                  buf << cl->indent << "std::visit([&](auto &&variant) {\n"
+                      << cl->indent << cl->indent << "using T = std::decay_t<decltype(variant)>;\n";
+                  bool first = true;
+                  for (const auto *type : *varF->types) {
+                      buf << cl->indent << cl->indent
+                          << (first ? "if constexpr (std::is_same_v<T, "
+                                    : "else if constexpr (std::is_same_v<T,")
+                          << type->toString() << ">) {";
+                      if (type->resolve(cl->containedIn)) {
+                          buf << " v.visit(variant, \"" << f->name << "::" << type->toString()
+                              << "\"); ";
+                      }
+                      buf << "}\n";
+                      first = false;
+                  }
+                  buf << cl->indent << cl->indent
+                      << R"(else { BUG("Unexpected variant field"); } }, )" << f->name << ".get());"
+                      << std::endl;
+              }
+          }
+          buf << "}";
+          return buf;
+      }}},
     {"visit_children"_cs,
      {&NamedType::Void(),
       {new IrField(&ReferenceType::VisitorRef, "v"_cs),
        new IrField(new PointerType(&NamedType::Char(), true), "n"_cs, "nullptr"_cs)},
-      IN_IMPL + OVERRIDE,
+      IN_IMPL + OVERRIDE + CONST_AND_NONCONST,
       [](IrClass *cl, Util::SourceInfo, cstring) -> cstring {
           bool needed = false;
           std::stringstream buf;
@@ -213,6 +264,35 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
           }
           buf << "}";
           return needed ? buf : cstring();
+      }}},
+    {"COWref_visit_children"_cs,
+     {&NamedType::Void(),
+      {new IrField(new PointerType(&NamedType::COWNode_info()), "info"_cs),
+       new IrField(&ReferenceType::VisitorRef, "v"_cs),
+       new IrField(new PointerType(&NamedType::Char(), true), "n"_cs)},
+      CONST + IN_IMPL + OVERRIDE + CONCRETE_ONLY,
+      [](IrClass *cl, Util::SourceInfo, cstring) -> cstring {
+          bool needed = false;
+          for (auto f : *cl->getFields()) {
+              if (f->type) {
+                  if (f->type->resolve(cl->containedIn)) {
+                      needed = true;
+                      break;
+                  }
+              } else {
+                  const auto *varF = f->to<IrVariantField>();
+                  if (!varF->types->empty()) {
+                      needed = true;
+                      break;
+                  }
+              }
+          }
+          if (!needed) return cstring();
+          std::stringstream buf;
+          buf << "{" << std::endl;
+          buf << cl->indent << "COWref(info).visit_children(v, n);" << std::endl;
+          buf << "}";
+          return buf;
       }}},
     {"validate"_cs,
      {&NamedType::Void(),
@@ -385,6 +465,22 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
       [](IrClass *, Util::SourceInfo, cstring) -> cstring { return cstring(); }}},
 };
 
+static cstring rewriteCOWMethodBody(cstring body) {
+    std::string rv;
+    const char *p = body.c_str();
+    while (const char *vccall = std::strstr(p, "::visit_children(")) {
+        const char *t = vccall;
+        while (t > p && (std::isalnum(t[-1]) || t[-1] == '_' || t[-1] == ':')) t--;
+        rv.append(p, t - p);
+        rv.append("reinterpret_cast<");
+        rv.append(t, vccall - t);
+        rv.append("::COWref *>(this)->");
+        p = vccall + 2;
+    }
+    rv.append(p);
+    return rv;
+}
+
 void IrClass::generateMethods() {
     if (this == nodeClass() || this == vectorClass()) return;
     if (kind != NodeKind::Interface) {
@@ -397,24 +493,37 @@ void IrClass::generateMethods() {
                     ->where([&def](IrElement *el) { return el->to<IrNo>()->text == def.first; })
                     ->any())
                 continue;
+            auto name = def.first;
+            if (def.second.flags & COWREF_METHOD) {
+                auto *p = name.find("::");
+                BUG_CHECK(p, "%s is not a COWref method", name);
+                name = cstring(p + 2);
+            }
             IrMethod *exist = dynamic_cast<IrMethod *>(
                 Util::enumerate(elements)
                     ->where([](IrElement *el) { return el->is<IrMethod>(); })
-                    ->where([&def](IrElement *el) { return el->to<IrMethod>()->name == def.first; })
+                    ->where([name](IrElement *el) { return el->to<IrMethod>()->name == name; })
                     ->nextOrDefault());
-            if (exist && !(def.second.flags & EXTEND)) continue;
             cstring body;
-            if (exist)
-                body = def.second.create(this, exist->srcInfo, exist->body);
-            else
-                body = def.second.create(this, Util::SourceInfo(), cstring());
+            Util::SourceInfo srcInfo;
+            if (exist) {
+                srcInfo = exist->srcInfo;
+                if (def.second.flags & COWREF_METHOD) {
+                    if (exist->body) body = rewriteCOWMethodBody(exist->body);
+                    exist = nullptr;
+                } else if (!(def.second.flags & EXTEND))
+                    continue;
+                else
+                    body = def.second.create(this, srcInfo, exist->body);
+            } else
+                body = def.second.create(this, srcInfo, cstring());
             if (body) {
                 if (!body.size()) body = nullptr;
                 if (exist) {
                     exist->body = body;
                     if (def.second.flags & FRIEND) exist->isFriend = true;
                 } else {
-                    auto *m = new IrMethod(def.first, body);
+                    auto *m = new IrMethod(srcInfo, def.first, body);
                     if (def.second.flags & FRIEND) m->isFriend = true;
                     m->clss = this;
                     if (!(def.second.flags & CONSTRUCTOR) || !shouldSkip("method_constructor"_cs)) {
@@ -483,6 +592,8 @@ void IrClass::generateMethods() {
         if (info.flags & CONST) m->isConst = true;
         if ((info.flags & OVERRIDE) && kind != NodeKind::Nested) m->isOverride = true;
         if (info.flags & FACTORY) m->isStatic = true;
+        if (info.flags & CONST_AND_NONCONST) m->constAndNonconst = true;
+        if (info.flags & COWREF_METHOD) m->COWrefMethod = true;
     }
     if (ctor) elements.erase(find(elements, ctor));
     if (kind != NodeKind::Interface && !shouldSkip("constructor"_cs)) {

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -168,15 +168,16 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
      {&NamedType::Void(),
       {new IrField(&ReferenceType::VisitorRef, "v"_cs),
        new IrField(new PointerType(&NamedType::Char(), true), "n"_cs, "nullptr"_cs)},
-      IN_IMPL + OVERRIDE + COWREF_METHOD,
+      CONST + IN_IMPL + OVERRIDE + COWREF_METHOD,
       [](IrClass *cl, Util::SourceInfo, cstring) -> cstring {
           std::stringstream buf;
           buf << "{" << std::endl;
           // Silence "not used" warnings in case of name `n` is not used
           buf << cl->indent << "(void)n;" << std::endl;
           if (auto parent = cl->getParent())
-              buf << cl->indent << "reinterpret_cast<" << parent->qualified_name(cl->containedIn)
-                  << "::COWref *>(this)->visit_children(v, n);" << std::endl;
+              buf << cl->indent << "std::launder(reinterpret_cast<const "
+                  << parent->qualified_name(cl->containedIn)
+                  << "::COWref *>(this))->visit_children(v, n);" << std::endl;
           for (auto f : *cl->getFields()) {
               if (f->type) {
                   if (f->type->resolve(cl->containedIn) == nullptr)
@@ -472,9 +473,9 @@ static cstring rewriteCOWMethodBody(cstring body) {
         const char *t = vccall;
         while (t > p && (std::isalnum(t[-1]) || t[-1] == '_' || t[-1] == ':')) t--;
         rv.append(p, t - p);
-        rv.append("reinterpret_cast<");
+        rv.append("std::launder(reinterpret_cast<const ");
         rv.append(t, vccall - t);
-        rv.append("::COWref *>(this)->");
+        rv.append("::COWref *>(this))->");
         p = vccall + 2;
     }
     rv.append(p);

--- a/tools/ir-generator/type.cpp
+++ b/tools/ir-generator/type.cpp
@@ -136,6 +136,11 @@ NamedType &NamedType::Char() {
     return nt;
 }
 
+NamedType &NamedType::COWNode_info() {
+    static NamedType nt("COWNode_info"_cs);
+    return nt;
+}
+
 cstring NamedType::toString() const {
     if (resolved) return resolved->fullName();
     if (!lookup && name == "ID") return "IR::ID"_cs;  // hack -- ID is in namespace P4::IR

--- a/tools/ir-generator/type.h
+++ b/tools/ir-generator/type.h
@@ -112,6 +112,7 @@ class NamedType : public Type {
     static NamedType &JSONLoader();
     static NamedType &JSONObject();
     static NamedType &SourceInfo();
+    static NamedType &COWNode_info();
 };
 
 class TemplateInstantiation : public Type {


### PR DESCRIPTION
This is still very much a work in progress (doesn't even build at the moment due to order-of-declaration issues), but is complete enough to show my thinking.

The idea here is address #4418 (excessive cloning in Transform/Modifier visitors) by doing lazy clones -- nodes are only cloned when they are modified (true copy on write), by giving the preorder/postorder methods "smart" pointers that manage the cloning when fields are actually modified.  This uses the ir generator to make special COWref reference objects for each IR class that understand the fields in the IR class and can be assigned to as if they were instances of the class, managing the cloning on demand.

Since we've been saying we're going to update to requiring C++20, this uses C++20 concepts in a number of places to simplify the overloading.