### PR TITLE
Remove some trivial leaks in codebase

### DIFF
--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -1032,39 +1032,37 @@ bool ComputeWriteSet::preorder(const IR::P4Action *action) {
     auto saveReturned = returnedDefinitions;
     returnedDefinitions = new Definitions();
 
-    auto decls = new IR::IndexedVector<IR::Declaration>();
+    IR::IndexedVector<IR::Declaration> decls;
     // We assume that there are no declarations in inner scopes
     // inside the action body.
     for (auto s : action->body->components) {
-        if (s->is<IR::Declaration>()) decls->push_back(s->to<IR::Declaration>());
+        if (s->is<IR::Declaration>()) decls.push_back(s->to<IR::Declaration>());
     }
     ProgramPoint pt(callingContext, action);
-    enterScope(action->parameters, decls, pt, false);
+    enterScope(action->parameters, &decls, pt, false);
     visit(action->body);
     currentDefinitions = currentDefinitions->joinDefinitions(returnedDefinitions);
     setDefinitions(currentDefinitions, action->body, true);  // overwrite
-    exitScope(action->parameters, decls, pt);
+    exitScope(action->parameters, &decls, pt);
     returnedDefinitions = saveReturned;
     return false;
 }
 
 namespace {
 class GetDeclarations : public Inspector {
-    IR::IndexedVector<IR::Declaration> *declarations;
+    IR::IndexedVector<IR::Declaration> declarations;
     bool preorder(const IR::Declaration_Variable *declaration) override {
-        declarations->push_back(declaration);
+        declarations.push_back(declaration);
         return true;
     }
     bool preorder(const IR::Declaration_Instance *declaration) override {
-        declarations->push_back(declaration);
+        declarations.push_back(declaration);
         return true;
     }
 
  public:
-    GetDeclarations() : declarations(new IR::IndexedVector<IR::Declaration>()) {
-        setName("GetDeclarations");
-    }
-    static IR::IndexedVector<IR::Declaration> *get(const IR::Node *node, const Visitor *calledBy) {
+    GetDeclarations() { setName("GetDeclarations"); }
+    static IR::IndexedVector<IR::Declaration> get(const IR::Node *node, const Visitor *calledBy) {
         GetDeclarations gd;
         gd.setCalledBy(calledBy);
         (void)node->apply(gd);
@@ -1085,7 +1083,7 @@ bool ComputeWriteSet::preorder(const IR::Function *function) {
     auto point = ProgramPoint(callingContext, function);
     auto locals = GetDeclarations::get(function->body, this);
     auto saveReturned = returnedDefinitions;
-    enterScope(function->type->parameters, locals, point, false);
+    enterScope(function->type->parameters, &locals, point, false);
 
     returnedDefinitions = new Definitions();
     visit(function->body);
@@ -1095,7 +1093,7 @@ bool ComputeWriteSet::preorder(const IR::Function *function) {
     else
         LOG3("CWS @" << point.after() << " with " << currentDefinitions->size() << " defs");
     allDefinitions->setDefinitionsAt(point.after(), currentDefinitions, false);
-    exitScope(function->type->parameters, locals, point);
+    exitScope(function->type->parameters, &locals, point);
 
     returnedDefinitions = saveReturned;
     LOG3("Done " << dbp(function));

--- a/frontends/p4/def_use.cpp
+++ b/frontends/p4/def_use.cpp
@@ -779,7 +779,7 @@ std::size_t P4::loc_t::hash() const {
 // In this case parentLoc is the loc of n's direct parent.
 const P4::loc_t *ComputeWriteSet::getLoc(const IR::Node *n, const loc_t *parentLoc) {
     loc_t tmp{n, parentLoc};
-    return &*cached_locs.insert(tmp).first;
+    return &*cached_locs->insert(tmp).first;
 }
 
 // Returns program location given the context of the currently being visited node.
@@ -787,7 +787,7 @@ const P4::loc_t *ComputeWriteSet::getLoc(const IR::Node *n, const loc_t *parentL
 const P4::loc_t *ComputeWriteSet::getLoc(const Visitor::Context *ctxt) {
     if (!ctxt) return nullptr;
     loc_t tmp{ctxt->node, getLoc(ctxt->parent)};
-    return &*cached_locs.insert(tmp).first;
+    return &*cached_locs->insert(tmp).first;
 }
 
 // Returns program location of a child node n, given the context of the
@@ -798,7 +798,7 @@ const P4::loc_t *ComputeWriteSet::getLoc(const IR::Node *n, const Visitor::Conte
         if (p->node == n) return getLoc(p);
     auto rv = getLoc(ctxt);
     loc_t tmp{n, rv};
-    return &*cached_locs.insert(tmp).first;
+    return &*cached_locs->insert(tmp).first;
 }
 
 // Symbolic execution of the parser

--- a/frontends/p4/moveDeclarations.cpp
+++ b/frontends/p4/moveDeclarations.cpp
@@ -21,12 +21,12 @@ namespace P4 {
 const IR::Node *MoveDeclarations::postorder(IR::P4Action *action) {
     if (findContext<IR::P4Control>() == nullptr) {
         // Else let the parent control get these
-        auto body = new IR::IndexedVector<IR::StatOrDecl>();
+        IR::IndexedVector<IR::StatOrDecl> body;
         auto m = getMoves();
-        body->insert(body->end(), m->begin(), m->end());
-        body->append(action->body->components);
-        action->body =
-            new IR::BlockStatement(action->body->srcInfo, action->body->annotations, *body);
+        body.insert(body.end(), m->begin(), m->end());
+        body.append(action->body->components);
+        action->body = new IR::BlockStatement(action->body->srcInfo, action->body->annotations,
+                                              std::move(body));
         pop();
     }
     return action;
@@ -34,33 +34,33 @@ const IR::Node *MoveDeclarations::postorder(IR::P4Action *action) {
 
 const IR::Node *MoveDeclarations::postorder(IR::P4Control *control) {
     LOG1("Visiting " << control << " toMove " << toMove.size());
-    auto decls = new IR::IndexedVector<IR::Declaration>();
+    IR::IndexedVector<IR::Declaration> decls;
     for (auto decl : *getMoves()) {
         LOG1("Moved " << decl);
-        decls->push_back(decl);
+        decls.push_back(decl);
     }
-    decls->append(control->controlLocals);
-    control->controlLocals = *decls;
+    decls.append(control->controlLocals);
+    control->controlLocals = std::move(decls);
     pop();
     return control;
 }
 
 const IR::Node *MoveDeclarations::postorder(IR::P4Parser *parser) {
-    auto newStateful = new IR::IndexedVector<IR::Declaration>();
-    newStateful->append(*getMoves());
-    newStateful->append(parser->parserLocals);
-    parser->parserLocals = *newStateful;
+    IR::IndexedVector<IR::Declaration> newStateful;
+    newStateful.append(*getMoves());
+    newStateful.append(parser->parserLocals);
+    parser->parserLocals = std::move(newStateful);
     pop();
     return parser;
 }
 
 const IR::Node *MoveDeclarations::postorder(IR::Function *function) {
-    auto body = new IR::IndexedVector<IR::StatOrDecl>();
+    IR::IndexedVector<IR::StatOrDecl> body;
     auto m = getMoves();
-    body->insert(body->end(), m->begin(), m->end());
-    body->append(function->body->components);
-    function->body =
-        new IR::BlockStatement(function->body->srcInfo, function->body->annotations, *body);
+    body.insert(body.end(), m->begin(), m->end());
+    body.append(function->body->components);
+    function->body = new IR::BlockStatement(function->body->srcInfo, function->body->annotations,
+                                            std::move(body));
     pop();
     return function;
 }

--- a/frontends/p4/moveDeclarations.cpp
+++ b/frontends/p4/moveDeclarations.cpp
@@ -22,8 +22,8 @@ const IR::Node *MoveDeclarations::postorder(IR::P4Action *action) {
     if (findContext<IR::P4Control>() == nullptr) {
         // Else let the parent control get these
         IR::IndexedVector<IR::StatOrDecl> body;
-        auto m = getMoves();
-        body.insert(body.end(), m->begin(), m->end());
+        const auto &m = getMoves();
+        body.insert(body.end(), m.begin(), m.end());
         body.append(action->body->components);
         action->body = new IR::BlockStatement(action->body->srcInfo, action->body->annotations,
                                               std::move(body));
@@ -35,7 +35,7 @@ const IR::Node *MoveDeclarations::postorder(IR::P4Action *action) {
 const IR::Node *MoveDeclarations::postorder(IR::P4Control *control) {
     LOG1("Visiting " << control << " toMove " << toMove.size());
     IR::IndexedVector<IR::Declaration> decls;
-    for (auto decl : *getMoves()) {
+    for (auto decl : getMoves()) {
         LOG1("Moved " << decl);
         decls.push_back(decl);
     }
@@ -47,7 +47,7 @@ const IR::Node *MoveDeclarations::postorder(IR::P4Control *control) {
 
 const IR::Node *MoveDeclarations::postorder(IR::P4Parser *parser) {
     IR::IndexedVector<IR::Declaration> newStateful;
-    newStateful.append(*getMoves());
+    newStateful.append(getMoves());
     newStateful.append(parser->parserLocals);
     parser->parserLocals = std::move(newStateful);
     pop();
@@ -56,8 +56,8 @@ const IR::Node *MoveDeclarations::postorder(IR::P4Parser *parser) {
 
 const IR::Node *MoveDeclarations::postorder(IR::Function *function) {
     IR::IndexedVector<IR::StatOrDecl> body;
-    auto m = getMoves();
-    body.insert(body.end(), m->begin(), m->end());
+    const auto &m = getMoves();
+    body.insert(body.end(), m.begin(), m.end());
     body.append(function->body->components);
     function->body = new IR::BlockStatement(function->body->srcInfo, function->body->annotations,
                                             std::move(body));

--- a/frontends/p4/moveDeclarations.h
+++ b/frontends/p4/moveDeclarations.h
@@ -36,17 +36,22 @@ class MoveDeclarations : public Transform {
 
     /// List of lists of declarations to move, one list per
     /// control/parser/action.
-    std::vector<IR::Vector<IR::Declaration> *> toMove;
-    void push() { toMove.push_back(new IR::Vector<IR::Declaration>()); }
+    // FIXME: Do we really need IR::Vector here?
+    std::vector<IR::Vector<IR::Declaration>> toMove;
+    void push() { toMove.emplace_back(); }
     void pop() {
         BUG_CHECK(!toMove.empty(), "Empty move stack");
         toMove.pop_back();
     }
-    IR::Vector<IR::Declaration> *getMoves() const {
+    const IR::Vector<IR::Declaration> &getMoves() const {
         BUG_CHECK(!toMove.empty(), "Empty move stack");
         return toMove.back();
     }
-    void addMove(const IR::Declaration *decl) { getMoves()->push_back(decl); }
+    IR::Vector<IR::Declaration> &getMoves() {
+        BUG_CHECK(!toMove.empty(), "Empty move stack");
+        return toMove.back();
+    }
+    void addMove(const IR::Declaration *decl) { getMoves().push_back(decl); }
 
  public:
     explicit MoveDeclarations(bool parsersOnly = false) : parsersOnly(parsersOnly) {

--- a/frontends/p4/parserControlFlow.cpp
+++ b/frontends/p4/parserControlFlow.cpp
@@ -57,17 +57,12 @@ const IR::Node *DoRemoveParserControlFlow::postorder(IR::ParserState *state) {
             }
 
             // left-over
-            auto vec = new IR::Vector<IR::Expression>();
-            vec->push_back(ifstat->condition);
             auto trueCase = new IR::SelectCase(new IR::BoolLiteral(true),
                                                new IR::PathExpression(IR::ID(trueName, nullptr)));
             auto falseCase = new IR::SelectCase(new IR::BoolLiteral(false),
                                                 new IR::PathExpression(IR::ID(falseName, nullptr)));
-            auto cases = new IR::Vector<IR::SelectCase>();
-            cases->push_back(trueCase);
-            cases->push_back(falseCase);
-            currentState->selectExpression =
-                new IR::SelectExpression(new IR::ListExpression(*vec), std::move(*cases));
+            currentState->selectExpression = new IR::SelectExpression(
+                new IR::ListExpression({ifstat->condition}), {trueCase, falseCase});
 
             currentState->components = currentComponents;
             currentComponents.clear();

--- a/frontends/p4/parserControlFlow.cpp
+++ b/frontends/p4/parserControlFlow.cpp
@@ -64,14 +64,14 @@ const IR::Node *DoRemoveParserControlFlow::postorder(IR::ParserState *state) {
             currentState->selectExpression = new IR::SelectExpression(
                 new IR::ListExpression({ifstat->condition}), {trueCase, falseCase});
 
-            currentState->components = currentComponents;
+            currentState->components = std::move(currentComponents);
             currentComponents.clear();
             currentState = new IR::ParserState(joinName, origSelect);  // may be overriten
         } else {
             currentComponents.push_back(c);
         }
     }
-    currentState->components = currentComponents;
+    currentState->components = std::move(currentComponents);
 
     if (states->empty()) return state;
     states->push_back(currentState);

--- a/frontends/p4/removeReturns.cpp
+++ b/frontends/p4/removeReturns.cpp
@@ -197,18 +197,16 @@ const IR::Node *DoRemoveReturns::preorder(IR::P4Control *control) {
 
 const IR::Node *DoRemoveReturns::preorder(IR::ReturnStatement *statement) {
     set(TernaryBool::Yes);
-    auto vec = new IR::IndexedVector<IR::StatOrDecl>();
+    IR::IndexedVector<IR::StatOrDecl> vec;
 
     auto left = new IR::PathExpression(IR::Type::Boolean::get(), returnVar);
-    vec->push_back(
-        new IR::AssignmentStatement(statement->srcInfo, left, new IR::BoolLiteral(true)));
+    vec.push_back(new IR::AssignmentStatement(statement->srcInfo, left, new IR::BoolLiteral(true)));
     if (statement->expression != nullptr) {
         left = new IR::PathExpression(statement->expression->type, returnedValue);
-        vec->push_back(
-            new IR::AssignmentStatement(statement->srcInfo, left, statement->expression));
+        vec.push_back(new IR::AssignmentStatement(statement->srcInfo, left, statement->expression));
     }
-    if (findContext<IR::LoopStatement>()) vec->push_back(new IR::BreakStatement);
-    return new IR::BlockStatement(*vec);
+    if (findContext<IR::LoopStatement>()) vec.push_back(new IR::BreakStatement);
+    return new IR::BlockStatement(std::move(vec));
 }
 
 const IR::Node *DoRemoveReturns::preorder(IR::ExitStatement *statement) {

--- a/frontends/p4/setHeaders.cpp
+++ b/frontends/p4/setHeaders.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 namespace P4 {
 
 void DoSetHeaders::generateSetValid(const IR::Expression *dest, const IR::Expression *src,
-                                    const IR::Type *destType, IR::Vector<IR::StatOrDecl> *insert) {
+                                    const IR::Type *destType, IR::Vector<IR::StatOrDecl> &insert) {
     auto structType = destType->to<IR::Type_StructLike>();
     if (structType == nullptr) return;
 
@@ -34,7 +34,7 @@ void DoSetHeaders::generateSetValid(const IR::Expression *dest, const IR::Expres
         auto mc =
             new IR::MethodCallExpression(dest->srcInfo, method, new IR::Vector<IR::Argument>());
         auto stat = new IR::MethodCallStatement(mc->srcInfo, mc);
-        insert->push_back(stat);
+        insert.push_back(stat);
         return;
     }
 
@@ -63,12 +63,12 @@ void DoSetHeaders::generateSetValid(const IR::Expression *dest, const IR::Expres
 }
 
 const IR::Node *DoSetHeaders::postorder(IR::AssignmentStatement *statement) {
-    auto vec = new IR::IndexedVector<IR::StatOrDecl>();
+    IR::IndexedVector<IR::StatOrDecl> vec;
     auto destType = typeMap->getType(statement->left, true);
     generateSetValid(statement->left, statement->right, destType, vec);
-    if (vec->empty()) return statement;
-    vec->push_back(statement);
-    return new IR::BlockStatement(statement->srcInfo, *vec);
+    if (vec.empty()) return statement;
+    vec.push_back(statement);
+    return new IR::BlockStatement(statement->srcInfo, vec);
 }
 
 }  // namespace P4

--- a/frontends/p4/setHeaders.h
+++ b/frontends/p4/setHeaders.h
@@ -50,7 +50,7 @@ class DoSetHeaders final : public Transform {
 
     bool containsHeaderType(const IR::Type *type);
     void generateSetValid(const IR::Expression *dest, const IR::Expression *src,
-                          const IR::Type *destType, IR::Vector<IR::StatOrDecl> *insert);
+                          const IR::Type *destType, IR::Vector<IR::StatOrDecl> &insert);
 
  public:
     explicit DoSetHeaders(TypeMap *typeMap) : typeMap(typeMap) {

--- a/frontends/p4/simplifyParsers.cpp
+++ b/frontends/p4/simplifyParsers.cpp
@@ -154,28 +154,29 @@ class CollapseChains : public Transform {
 
         // Collapse the states in each chain into a new state with the name and
         // annotations of the chain's head state.
-        auto states = new IR::IndexedVector<IR::ParserState>();
+        IR::IndexedVector<IR::ParserState> states;
         for (auto s : parser->states) {
             if (pred.find(s) != pred.end()) continue;
             if (chainStart.find(s) != chainStart.end()) {
                 // collapse chain
-                auto components = new IR::IndexedVector<IR::StatOrDecl>();
+                IR::IndexedVector<IR::StatOrDecl> components;
                 auto crt = s;
                 LOG1("Chaining states into " << dbp(crt));
                 const IR::Expression *select = nullptr;
                 while (true) {
-                    components->append(crt->components);
+                    components.append(crt->components);
                     select = crt->selectExpression;
                     crt = ::P4::get(chain, crt);
                     if (crt == nullptr) break;
                     LOG1("Adding " << dbp(crt) << " to chain");
                 }
-                s = new IR::ParserState(s->srcInfo, s->name, s->annotations, *components, select);
+                s = new IR::ParserState(s->srcInfo, s->name, s->annotations, std::move(components),
+                                        select);
             }
-            states->push_back(s);
+            states.push_back(s);
         }
 
-        parser->states = *states;
+        parser->states = std::move(states);
         prune();
         return parser;
     }

--- a/frontends/p4/specialize.cpp
+++ b/frontends/p4/specialize.cpp
@@ -28,7 +28,7 @@ limitations under the License.
 
 namespace P4 {
 
-const IR::Type_Declaration *SpecializationInfo::synthesize(const Visitor::Context *ctxt) const {
+const IR::Type_Declaration *SpecializationInfo::synthesize(const Visitor::Context *ctxt) {
     TypeVariableSubstitution tvs;
     ParameterSubstitution subst;
 
@@ -46,16 +46,16 @@ const IR::Type_Declaration *SpecializationInfo::synthesize(const Visitor::Contex
     if (auto parser = clone->to<IR::P4Parser>()) {
         auto newtype = new IR::Type_Parser(name, parser->type->annotations,
                                            new IR::TypeParameters(), parser->getApplyParameters());
-        declarations->append(parser->parserLocals);
+        declarations.append(parser->parserLocals);
         result =
-            new IR::P4Parser(name, newtype, new IR::ParameterList(), *declarations, parser->states);
+            new IR::P4Parser(name, newtype, new IR::ParameterList(), declarations, parser->states);
     } else if (auto control = clone->to<IR::P4Control>()) {
         auto newtype =
             new IR::Type_Control(name, control->type->annotations, new IR::TypeParameters(),
                                  control->getApplyParameters());
-        declarations->append(control->controlLocals);
+        declarations.append(control->controlLocals);
         result =
-            new IR::P4Control(name, newtype, new IR::ParameterList(), *declarations, control->body);
+            new IR::P4Control(name, newtype, new IR::ParameterList(), declarations, control->body);
 
     } else {
         BUG("%1%: unexpected type", specialized);
@@ -72,7 +72,7 @@ static const IR::Argument *convertArgument(const IR::Argument *arg, Specializati
         IR::ID id(param->srcInfo, nName, param->name);
         auto decl =
             new IR::Declaration_Instance(param->srcInfo, id, cce->constructedType, cce->arguments);
-        spec->declarations->push_back(decl);
+        spec->declarations.push_back(decl);
         auto path = new IR::PathExpression(param->srcInfo, new IR::Path(param->srcInfo, id));
         return new IR::Argument(arg->srcInfo, arg->name, path);
     } else {

--- a/frontends/p4/specialize.h
+++ b/frontends/p4/specialize.h
@@ -38,7 +38,7 @@ struct SpecializationInfo {
     /// Values to substitute for constructor arguments.
     IR::Vector<IR::Argument> *constructorArguments;
     /// Declarations to insert in the list of locals.
-    IR::IndexedVector<IR::Declaration> *declarations;
+    IR::IndexedVector<IR::Declaration> declarations;
     /// Invocation which causes this specialization.
     const IR::Node *invocation;
     /// Where in the program should the specialization be inserted.
@@ -49,14 +49,13 @@ struct SpecializationInfo {
         : specialized(cont),
           typeArguments(nullptr),
           constructorArguments(new IR::Vector<IR::Argument>()),
-          declarations(new IR::IndexedVector<IR::Declaration>()),
           invocation(invocation),
           insertBefore(insertion) {
         CHECK_NULL(cont);
         CHECK_NULL(invocation);
         CHECK_NULL(insertion);
     }
-    const IR::Type_Declaration *synthesize(const Visitor::Context *ctxt) const;
+    const IR::Type_Declaration *synthesize(const Visitor::Context *ctxt);
 };
 
 /// Maintains a map from invocation to a SpecializationInfo object.

--- a/frontends/p4/typeChecking/bindVariables.cpp
+++ b/frontends/p4/typeChecking/bindVariables.cpp
@@ -142,14 +142,4 @@ const IR::Node *DoBindTypeVariables::preorder(IR::Annotation *annotation) {
     return annotation;
 }
 
-const IR::Node *DoBindTypeVariables::insertTypes(const IR::Node *node) {
-    CHECK_NULL(node);
-    CHECK_NULL(newTypes);
-    if (newTypes->empty()) return node;
-    newTypes->push_back(node);
-    auto result = newTypes;
-    newTypes = new IR::IndexedVector<IR::Node>();
-    return result;
-}
-
 }  // namespace P4

--- a/frontends/p4/typeChecking/bindVariables.h
+++ b/frontends/p4/typeChecking/bindVariables.h
@@ -9,7 +9,6 @@ namespace P4 {
 
 // Insert explicit type specializations where they are missing
 class DoBindTypeVariables : public Transform {
-    IR::IndexedVector<IR::Node> *newTypes;
     TypeMap *typeMap;
     const IR::Type *getVarValue(const IR::Type_Var *var, const IR::Node *errorPosition) const;
     const IR::Node *insertTypes(const IR::Node *node);
@@ -18,7 +17,6 @@ class DoBindTypeVariables : public Transform {
     explicit DoBindTypeVariables(TypeMap *typeMap) : typeMap(typeMap) {
         CHECK_NULL(typeMap);
         setName("DoBindTypeVariables");
-        newTypes = new IR::IndexedVector<IR::Node>();
     }
 
     /// Don't descend to unstructured annotations, they are not type checked, so we can't process
@@ -29,8 +27,6 @@ class DoBindTypeVariables : public Transform {
     const IR::Node *postorder(IR::Declaration_Instance *decl) override;
     const IR::Node *postorder(IR::MethodCallExpression *expression) override;
     const IR::Node *postorder(IR::ConstructorCallExpression *expression) override;
-    const IR::Node *postorder(IR::P4Parser *parser) override { return insertTypes(parser); }
-    const IR::Node *postorder(IR::P4Control *control) override { return insertTypes(control); }
 };
 
 class BindTypeVariables : public PassManager {

--- a/frontends/p4/typeChecking/typeCheckDecl.cpp
+++ b/frontends/p4/typeChecking/typeCheckDecl.cpp
@@ -59,7 +59,7 @@ const IR::ParameterList *TypeInferenceBase::canonicalizeParameters(
     if (params == nullptr) return params;
 
     bool changes = false;
-    auto vec = new IR::IndexedVector<IR::Parameter>();
+    IR::IndexedVector<IR::Parameter> vec;
     for (auto p : *params->getEnumerator()) {
         auto paramType = getTypeType(p->type);
         if (paramType == nullptr) return nullptr;
@@ -70,10 +70,10 @@ const IR::ParameterList *TypeInferenceBase::canonicalizeParameters(
             changes = true;
         }
         setType(p, paramType);
-        vec->push_back(p);
+        vec.push_back(p);
     }
 
-    if (changes) params = new IR::ParameterList(params->srcInfo, *vec);
+    if (changes) params = new IR::ParameterList(params->srcInfo, std::move(vec));
 
     return params;
 }

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -319,12 +319,12 @@ bool TypeUnification::unify(const BinaryConstraint *constraint) {
             return constraint->reportError(constraints->getCurrentSubstitution(),
                                            "Tuples with different sizes %1% vs %2%",
                                            td->components.size(), ts->components.size());
-        auto missingFields = new IR::Vector<IR::Type>();
+        IR::Vector<IR::Type> missingFields;
         size_t sourceSize = ts->components.size();
         for (size_t i = 0; i < td->components.size(); i++) {
             auto di = td->components.at(i);
             if (hasDots && (i >= sourceSize - 1)) {
-                missingFields->push_back(di);
+                missingFields.push_back(di);
             } else {
                 // Last field is the ... field
                 auto si = ts->components.at(i);
@@ -332,7 +332,7 @@ bool TypeUnification::unify(const BinaryConstraint *constraint) {
             }
         }
         if (hasDots) {
-            auto dotsType = new IR::Type_List(*missingFields);
+            auto dotsType = new IR::Type_List(std::move(missingFields));
             auto dotsField = ts->components.at(sourceSize - 1);
             auto partial = new IR::Type_Fragment(dotsType);
             constraints->add(new EqualityConstraint(dotsField, partial, constraint));

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -350,7 +350,7 @@ bool TypeUnification::unify(const BinaryConstraint *constraint) {
                     "than number of fields %3% in '%4%'",
                     tpl->components.size(), tpl, strct->fields.size(), strct);
             size_t index = 0;
-            auto missingFields = new IR::IndexedVector<IR::StructField>();
+            IR::IndexedVector<IR::StructField> missingFields;
             for (const IR::StructField *f : strct->fields) {
                 if (!hasDots || listSize > index + 1) {
                     // Last field is the ... field
@@ -358,12 +358,12 @@ bool TypeUnification::unify(const BinaryConstraint *constraint) {
                     const IR::Type *destt = f->type;
                     constraints->add(constraint->create(destt, tplField));
                 } else {
-                    missingFields->push_back(f);
+                    missingFields.push_back(f);
                 }
                 index++;
             }
             if (hasDots) {
-                auto dotsType = new IR::Type_UnknownStruct(strct->name, *missingFields);
+                auto dotsType = new IR::Type_UnknownStruct(strct->name, std::move(missingFields));
                 auto dotsField = tpl->components.at(listSize - 1);
                 auto partial = new IR::Type_Fragment(dotsType);
                 constraints->add(new EqualityConstraint(dotsField, partial, constraint));
@@ -390,12 +390,12 @@ bool TypeUnification::unify(const BinaryConstraint *constraint) {
                                                "than number of fields in structure %2%: %3% to %4%",
                                                st->fields.size(), strct->fields.size(), st, strct);
 
-            auto missingFields = new IR::IndexedVector<IR::StructField>();
+            IR::IndexedVector<IR::StructField> missingFields;
             for (const IR::StructField *f : strct->fields) {
                 auto stField = st->getField(f->name);
                 if (stField == nullptr) {
                     if (stHasDots) {
-                        missingFields->push_back(f);
+                        missingFields.push_back(f);
                         continue;
                     } else {
                         return constraint->reportError(constraints->getCurrentSubstitution(),
@@ -409,7 +409,7 @@ bool TypeUnification::unify(const BinaryConstraint *constraint) {
                 constraints->add(c);
             }
             if (stHasDots) {
-                auto dotsType = new IR::Type_UnknownStruct(st->name, *missingFields);
+                auto dotsType = new IR::Type_UnknownStruct(st->name, std::move(missingFields));
                 auto dotsField = st->getField("..."_cs);
                 CHECK_NULL(dotsField);
                 auto partial = new IR::Type_Fragment(dotsType);

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1108,7 +1108,7 @@ baseType
 typeOrVoid
     : typeRef     { $$ = $1; }
     | VOID        { $$ = IR::Type_Void::get(@1); }
-    | IDENTIFIER  { $$ = new IR::Type_Name(@1, new IR::Path(*(new IR::ID(@1, $1)))); }
+    | IDENTIFIER  { $$ = new IR::Type_Name(@1, new IR::Path(IR::ID(@1, $1))); }
         // This is necessary because template arguments may introduce the return type
     ;
 

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -528,7 +528,7 @@ class ControlFlowVisitor : public virtual Visitor {
      * edge are never join points.
      */
     virtual bool filter_join_point(const IR::Node *) { return false; }
-    ControlFlowVisitor() : globals(new std::map<cstring, ControlFlowVisitor &>) {}
+    ControlFlowVisitor() : globals(std::make_shared<std::map<cstring, ControlFlowVisitor &>>()) {}
 
  public:
     ControlFlowVisitor *controlFlowVisitor() override { return this; }
@@ -542,11 +542,10 @@ class ControlFlowVisitor : public virtual Visitor {
     void setUnreachable() { unreachable = true; }
     bool isUnreachable() { return unreachable; }
     void flow_merge_global_to(cstring key) override {
-        auto other = globals->find(key);
-        if (other == globals->end())
-            globals->emplace(key, flow_clone());
-        else
+        if (auto other = globals->find(key); other != globals->end())
             other->second.flow_merge(*this);
+        else
+            globals->emplace(key, flow_clone());
     }
     void flow_merge_global_from(cstring key) override {
         if (auto other = globals->find(key); other != globals->end()) flow_merge(other->second);

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -461,7 +461,7 @@ class Transform : public virtual Visitor {
 #define DEBUG_FLOW_JOIN 0
 
 class ControlFlowVisitor : public virtual Visitor {
-    std::map<cstring, ControlFlowVisitor &> &globals;
+    std::shared_ptr<std::map<cstring, ControlFlowVisitor &>> globals;
 
  protected:
     ControlFlowVisitor *clone() const override = 0;
@@ -528,7 +528,7 @@ class ControlFlowVisitor : public virtual Visitor {
      * edge are never join points.
      */
     virtual bool filter_join_point(const IR::Node *) { return false; }
-    ControlFlowVisitor() : globals(*new std::map<cstring, ControlFlowVisitor &>) {}
+    ControlFlowVisitor() : globals(new std::map<cstring, ControlFlowVisitor &>) {}
 
  public:
     ControlFlowVisitor *controlFlowVisitor() override { return this; }
@@ -542,28 +542,30 @@ class ControlFlowVisitor : public virtual Visitor {
     void setUnreachable() { unreachable = true; }
     bool isUnreachable() { return unreachable; }
     void flow_merge_global_to(cstring key) override {
-        if (globals.count(key))
-            globals.at(key).flow_merge(*this);
+        auto other = globals->find(key);
+        if (other == globals->end())
+            globals->emplace(key, flow_clone());
         else
-            globals.emplace(key, flow_clone());
+            other->second.flow_merge(*this);
     }
     void flow_merge_global_from(cstring key) override {
-        if (globals.count(key)) flow_merge(globals.at(key));
+        auto other = globals->find(key);
+        if (other != globals->end()) flow_merge(other->second);
     }
-    void erase_global(cstring key) override { globals.erase(key); }
-    bool check_global(cstring key) override { return globals.count(key) != 0; }
-    void clear_globals() override { globals.clear(); }
+    void erase_global(cstring key) override { globals->erase(key); }
+    bool check_global(cstring key) override { return globals->count(key) != 0; }
+    void clear_globals() override { globals->clear(); }
     std::pair<cstring, ControlFlowVisitor *> save_global(cstring key) {
         ControlFlowVisitor *cfv = nullptr;
-        if (auto i = globals.find(key); i != globals.end()) {
+        if (auto i = globals->find(key); i != globals->end()) {
             cfv = &i->second;
-            globals.erase(i);
+            globals->erase(i);
         }
         return std::make_pair(key, cfv);
     }
     void restore_global(std::pair<cstring, ControlFlowVisitor *> saved) {
-        globals.erase(saved.first);
-        if (saved.second) globals.emplace(saved.first, *saved.second);
+        globals->erase(saved.first);
+        if (saved.second) globals->emplace(saved.first, *saved.second);
     }
 
     /// RAII class to ensure global key is only used in one place

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -549,8 +549,7 @@ class ControlFlowVisitor : public virtual Visitor {
             other->second.flow_merge(*this);
     }
     void flow_merge_global_from(cstring key) override {
-        auto other = globals->find(key);
-        if (other != globals->end()) flow_merge(other->second);
+        if (auto other = globals->find(key); other != globals->end()) flow_merge(other->second);
     }
     void erase_global(cstring key) override { globals->erase(key); }
     bool check_global(cstring key) override { return globals->count(key) != 0; }

--- a/midend/eliminateInvalidHeaders.cpp
+++ b/midend/eliminateInvalidHeaders.cpp
@@ -20,12 +20,12 @@ namespace P4 {
 
 const IR::Node *DoEliminateInvalidHeaders::postorder(IR::P4Control *control) {
     control->controlLocals.prepend(variables);
-    auto vec = new IR::IndexedVector<IR::StatOrDecl>();
-    vec->srcInfo = control->body->srcInfo;
-    vec->append(statements);
-    vec->append(control->body->components);
+    IR::IndexedVector<IR::StatOrDecl> vec;
+    vec.srcInfo = control->body->srcInfo;
+    vec.append(statements);
+    vec.append(control->body->components);
     control->body =
-        new IR::BlockStatement(control->body->srcInfo, control->body->annotations, *vec);
+        new IR::BlockStatement(control->body->srcInfo, control->body->annotations, std::move(vec));
     statements.clear();
     variables.clear();
     return control;
@@ -40,11 +40,12 @@ const IR::Node *DoEliminateInvalidHeaders::postorder(IR::ParserState *state) {
 }
 
 const IR::Node *DoEliminateInvalidHeaders::postorder(IR::P4Action *action) {
-    auto vec = new IR::IndexedVector<IR::StatOrDecl>();
-    vec->append(variables);
-    vec->append(statements);
-    vec->append(action->body->components);
-    action->body = new IR::BlockStatement(action->body->srcInfo, action->body->annotations, *vec);
+    IR::IndexedVector<IR::StatOrDecl> vec;
+    vec.append(variables);
+    vec.append(statements);
+    vec.append(action->body->components);
+    action->body =
+        new IR::BlockStatement(action->body->srcInfo, action->body->annotations, std::move(vec));
     variables.clear();
     statements.clear();
     return action;

--- a/midend/expandEmit.cpp
+++ b/midend/expandEmit.cpp
@@ -76,7 +76,7 @@ const IR::Node *DoExpandEmit::postorder(IR::MethodCallStatement *statement) {
             std::vector<const IR::Argument *> expansion;
             std::vector<const IR::Type *> expansionTypes;
             if (expandArg(type, arg0, &expansion, &expansionTypes)) {
-                auto vec = new IR::IndexedVector<IR::StatOrDecl>();
+                IR::IndexedVector<IR::StatOrDecl> vec;
                 auto it = expansionTypes.begin();
                 for (auto e : expansion) {
                     auto method = statement->methodCall->method->clone();
@@ -88,10 +88,10 @@ const IR::Node *DoExpandEmit::postorder(IR::MethodCallStatement *statement) {
                     auto mce = new IR::MethodCallExpression(statement->methodCall->srcInfo, method,
                                                             typeArgs, args);
                     auto stat = new IR::MethodCallStatement(mce);
-                    vec->push_back(stat);
+                    vec.push_back(stat);
                     ++it;
                 }
-                return new IR::BlockStatement(*vec);
+                return new IR::BlockStatement(std::move(vec));
             }
         }
     }

--- a/midend/flattenInterfaceStructs.h
+++ b/midend/flattenInterfaceStructs.h
@@ -69,12 +69,12 @@ template <typename T>
 struct StructTypeReplacement : public IHasDbPrint {
     StructTypeReplacement(const P4::TypeMap *typeMap, const IR::Type_StructLike *type,
                           AnnotationSelectionPolicy *policy) {
-        auto vec = new IR::IndexedVector<IR::StructField>();
+        IR::IndexedVector<IR::StructField> vec;
         flatten(typeMap, cstring::empty, type, type->annotations, vec, policy);
         if (type->is<IR::Type_Struct>()) {
-            replacementType = new IR::Type_Struct(type->srcInfo, type->name, *vec);
+            replacementType = new IR::Type_Struct(type->srcInfo, type->name, std::move(vec));
         } else if (type->is<IR::Type_Header>()) {
-            replacementType = new IR::Type_Header(type->srcInfo, type->name, *vec);
+            replacementType = new IR::Type_Header(type->srcInfo, type->name, std::move(vec));
         } else {
             BUG("Unexpected type %1%", type);
         }
@@ -104,7 +104,7 @@ struct StructTypeReplacement : public IHasDbPrint {
     // Helper for constructor
     void flatten(const P4::TypeMap *typeMap, cstring prefix, const IR::Type *type,
                  const IR::Vector<IR::Annotation> &annotations,
-                 IR::IndexedVector<IR::StructField> *fields, AnnotationSelectionPolicy *policy) {
+                 IR::IndexedVector<IR::StructField> &fields, AnnotationSelectionPolicy *policy) {
         // Drop name annotations
         auto ann = IR::Annotations::withoutNameAnnotation(annotations);
         if (auto st = type->to<T>()) {
@@ -125,7 +125,7 @@ struct StructTypeReplacement : public IHasDbPrint {
         }
         cstring fieldName = prefix.replace('.', '_') + std::to_string(fieldNameRemap.size());
         fieldNameRemap.emplace(prefix, fieldName);
-        fields->push_back(new IR::StructField(IR::ID(fieldName), ann, type->getP4Type()));
+        fields.push_back(new IR::StructField(IR::ID(fieldName), ann, type->getP4Type()));
         LOG3("Flatten: " << type << " | " << prefix);
     }
 
@@ -134,7 +134,7 @@ struct StructTypeReplacement : public IHasDbPrint {
     /// given prefix.  For example, for prefix .t and root R this returns
     /// { .s = { .a = R._t_s_a0, .b = R._t_s_b1 }, .y = R._t_y2 }
     const IR::StructExpression *explode(const IR::Expression *root, cstring prefix) {
-        auto vec = new IR::IndexedVector<IR::NamedExpression>();
+        IR::IndexedVector<IR::NamedExpression> vec;
         auto fieldType = ::P4::get(structFieldMap, prefix);
         BUG_CHECK(fieldType, "No field for %1%", prefix);
         for (auto f : fieldType->fields) {
@@ -146,10 +146,10 @@ struct StructTypeReplacement : public IHasDbPrint {
             } else {
                 expr = explode(root, fieldName);
             }
-            vec->push_back(new IR::NamedExpression(f->name, expr));
+            vec.push_back(new IR::NamedExpression(f->name, expr));
         }
         auto type = fieldType->getP4Type()->template to<IR::Type_Name>();
-        return new IR::StructExpression(root->srcInfo, type, type, *vec);
+        return new IR::StructExpression(root->srcInfo, type, type, std::move(vec));
     }
 };
 

--- a/midend/flattenUnions.cpp
+++ b/midend/flattenUnions.cpp
@@ -30,20 +30,20 @@ const IR::Node *HandleValidityHeaderUnion::setInvalidforRest(const IR::Statement
                                                              const IR::Type_HeaderUnion *hu,
                                                              cstring exclude,
                                                              bool setValidforCurrMem) {
-    auto code_block = new IR::IndexedVector<IR::StatOrDecl>;
+    IR::IndexedVector<IR::StatOrDecl> code_block;
     if (setValidforCurrMem) {
-        code_block->push_back(processValidityForStr(s, m, exclude, IR::Type_Header::setValid));
+        code_block.push_back(processValidityForStr(s, m, exclude, IR::Type_Header::setValid));
     }
 
-    code_block->push_back(s);
+    code_block.push_back(s);
 
     for (auto sfu : hu->fields) {
         if (exclude != sfu->name.name) {  // setInvalid for rest of the fields
-            code_block->push_back(
+            code_block.push_back(
                 processValidityForStr(s, m, sfu->name, IR::Type_Header::setInvalid));
         }
     }
-    return new IR::BlockStatement(*code_block);
+    return new IR::BlockStatement(std::move(code_block));
 }
 
 const IR::Node *HandleValidityHeaderUnion::expandIsValid(

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -286,7 +286,7 @@ void DoLocalCopyPropagation::dropValuesUsing(cstring name) {
 void DoLocalCopyPropagation::visit_local_decl(const IR::Declaration_Variable *var) {
     LOG4("Visiting " << var);
     auto [it, inserted] = available.emplace(var->name, VarInfo());
-    if (!inserted) BUG("duplicate var declaration for %s", var->name);
+    BUG_CHECK(inserted, "duplicate var declaration for %s", var->name);
     auto &local = it->second;
     local.local = true;
     if (var->initializer) {
@@ -634,7 +634,7 @@ void DoLocalCopyPropagation::LoopPrepass::postorder(const IR::MethodCallExpressi
                     // to provide per-extern flow info to this (and other) frontend passes.
                     LOG3("loop prepass extern method call " << name);
                     for (auto *n : em->mayCall()) {
-                        if (auto *method = ::P4::getref(*self.methods, obj + '.' + n->getName())) {
+                        if (auto *method = P4::getref(*self.methods, obj + '.' + n->getName())) {
                             LOG4("  might call " << obj << '.' << n->getName());
                             apply_function(method);
                         }

--- a/midend/local_copyprop.cpp
+++ b/midend/local_copyprop.cpp
@@ -122,14 +122,16 @@ class DoLocalCopyPropagation::ElimDead : public Transform {
         return blk;
     }
     IR::P4Table *preorder(IR::P4Table *tbl) override {
-        if (self.tables.count(tbl->name) && self.tables.at(tbl->name).apply_count == 0) {
+        auto table = self.tables->find(tbl->name);
+        if (table != self.tables->end() && table->second.apply_count == 0) {
             LOG3("  removing dead local table " << tbl->name);
             return nullptr;
         }
         return tbl;
     }
     IR::P4Action *preorder(IR::P4Action *act) override {
-        if (self.actions.count(act->name) && self.actions.at(act->name).apply_count == 0) {
+        auto action = self.actions->find(act->name);
+        if (action != self.actions->end() && action->second.apply_count == 0) {
             LOG3("  removing dead local action " << act->name);
             return nullptr;
         }
@@ -151,12 +153,12 @@ class DoLocalCopyPropagation::RewriteTableKeys : public Transform {
     TableInfo *table = nullptr;
     IR::P4Table *preorder(IR::P4Table *tbl) {
         BUG_CHECK(table == nullptr, "corrupt internal state");
-        table = &self.tables[tbl->name];
+        table = &(*self.tables)[tbl->name];
         LOG3("RewriteTableKeys for table " << tbl->name);
         return tbl;
     }
     IR::P4Table *postorder(IR::P4Table *tbl) {
-        BUG_CHECK(table == &self.tables[tbl->name], "corrupt internal state");
+        BUG_CHECK(table == &(*self.tables)[tbl->name], "corrupt internal state");
         table = nullptr;
         return tbl;
     }
@@ -166,9 +168,10 @@ class DoLocalCopyPropagation::RewriteTableKeys : public Transform {
         if (auto name = expr_name(exp)) {
             const Visitor::Context *ctxt = nullptr;
             if (findContext<IR::KeyElement>(ctxt) && ctxt->child_index == 0) {
-                if (table->key_remap.count(name)) {
-                    LOG4("  rewriting key " << name << " : " << table->key_remap.at(name));
-                    return table->key_remap.at(name);
+                auto key = table->key_remap.find(name);
+                if (key != table->key_remap.end()) {
+                    LOG4("  rewriting key " << name << " : " << key->second);
+                    return key->second;
                 }
             }
         }
@@ -282,8 +285,9 @@ void DoLocalCopyPropagation::dropValuesUsing(cstring name) {
 
 void DoLocalCopyPropagation::visit_local_decl(const IR::Declaration_Variable *var) {
     LOG4("Visiting " << var);
-    if (available.count(var->name)) BUG("duplicate var declaration for %s", var->name);
-    auto &local = available[var->name];
+    auto [it, inserted] = available.emplace(var->name, VarInfo());
+    if (!inserted) BUG("duplicate var declaration for %s", var->name);
+    auto &local = it->second;
     local.local = true;
     if (var->initializer) {
         if (!hasSideEffects(var->initializer, getChildContext())) {
@@ -509,16 +513,18 @@ IR::MethodCallExpression *DoLocalCopyPropagation::postorder(IR::MethodCallExpres
     auto *mi = MethodInstance::resolve(mc, this, typeMap, true);
     if (auto mem = mc->method->to<IR::Member>()) {
         if (auto obj = expr_name(mem->expr)) {
-            if (tables.count(obj)) {
+            auto tbl = tables->find(obj);
+            if (tbl != tables->end()) {
                 LOG3("table apply method call " << mc->method);
-                apply_table(&tables[obj]);
+                apply_table(&tbl->second);
                 return mc;
             } else if (auto em = mi->to<ExternMethod>()) {
                 auto ext = em->actualExternType;
                 auto name = obj + '.' + mem->member;
-                if (methods.count(name)) {
+                auto mtd = methods->find(name);
+                if (mtd != methods->end()) {
                     LOG3("concrete method call " << name);
-                    apply_function(&methods[name]);
+                    apply_function(&mtd->second);
                     return mc;
                 } else if (ext && (ext->name == "packet_in" || ext->name == "packet_out")) {
                     LOG3(ext->name << '.' << mem->member << " call");
@@ -532,7 +538,7 @@ IR::MethodCallExpression *DoLocalCopyPropagation::postorder(IR::MethodCallExpres
                     // to provide per-extern flow info to this (and other) frontend passes.
                     LOG3("extern method call " << name);
                     for (auto *n : em->mayCall()) {
-                        if (auto *method = ::P4::getref(methods, obj + '.' + n->getName())) {
+                        if (auto *method = ::P4::getref(*methods, obj + '.' + n->getName())) {
                             LOG4("  might call " << obj << '.' << n->getName());
                             apply_function(method);
                         }
@@ -571,9 +577,10 @@ IR::MethodCallExpression *DoLocalCopyPropagation::postorder(IR::MethodCallExpres
             }
         }
     } else if (auto fn = mc->method->to<IR::PathExpression>()) {
-        if (actions.count(fn->path->name)) {
+        auto act = actions->find(fn->path->name);
+        if (act != actions->end()) {
             LOG3("action method call " << mc->method);
-            apply_function(&actions[fn->path->name]);
+            apply_function(&act->second);
             return mc;
         } else if (mi->is<P4::ExternFunction>()) {
             LOG3("extern function call " << mc->method);
@@ -602,16 +609,18 @@ void DoLocalCopyPropagation::LoopPrepass::postorder(const IR::MethodCallExpressi
     auto *mi = MethodInstance::resolve(mc, &self, self.typeMap, true);
     if (auto mem = mc->method->to<IR::Member>()) {
         if (auto obj = expr_name(mem->expr)) {
-            if (self.tables.count(obj)) {
+            auto tbl = self.tables->find(obj);
+            if (tbl != self.tables->end()) {
                 LOG3("loop prepass table apply method call " << mc->method);
-                apply_table(&self.tables[obj]);
+                apply_table(&tbl->second);
                 return;
             } else if (auto em = mi->to<ExternMethod>()) {
                 auto ext = em->actualExternType;
                 auto name = obj + '.' + mem->member;
-                if (self.methods.count(name)) {
+                auto mtd = self.methods->find(name);
+                if (mtd != self.methods->end()) {
                     LOG3("loop prepass concrete method call " << name);
-                    apply_function(&self.methods[name]);
+                    apply_function(&mtd->second);
                     return;
                 } else if (ext && (ext->name == "packet_in" || ext->name == "packet_out")) {
                     LOG3("loop prepass " << ext->name << '.' << mem->member << " call");
@@ -625,7 +634,7 @@ void DoLocalCopyPropagation::LoopPrepass::postorder(const IR::MethodCallExpressi
                     // to provide per-extern flow info to this (and other) frontend passes.
                     LOG3("loop prepass extern method call " << name);
                     for (auto *n : em->mayCall()) {
-                        if (auto *method = ::P4::getref(self.methods, obj + '.' + n->getName())) {
+                        if (auto *method = ::P4::getref(*self.methods, obj + '.' + n->getName())) {
                             LOG4("  might call " << obj << '.' << n->getName());
                             apply_function(method);
                         }
@@ -647,9 +656,10 @@ void DoLocalCopyPropagation::LoopPrepass::postorder(const IR::MethodCallExpressi
             }
         }
     } else if (auto fn = mc->method->to<IR::PathExpression>()) {
-        if (self.actions.count(fn->path->name)) {
+        auto act = self.actions->find(fn->path->name);
+        if (act != self.actions->end()) {
             LOG3("loop prepass action method call " << mc->method);
-            apply_function(&self.actions[fn->path->name]);
+            apply_function(&act->second);
             return;
         } else if (mi->is<P4::ExternFunction>()) {
             LOG3("self.extern function call " << mc->method);
@@ -672,7 +682,7 @@ IR::P4Action *DoLocalCopyPropagation::preorder(IR::P4Action *act) {
     visitOnce();
     BUG_CHECK(!working && !inferForFunc && available.empty(), "corrupt internal data struct");
     working = true;
-    inferForFunc = &actions[act->name];
+    inferForFunc = &(*actions)[act->name];
     LOG2("DoLocalCopyPropagation working on action " << act->name);
     LOG4(act);
     return act;
@@ -681,7 +691,7 @@ IR::P4Action *DoLocalCopyPropagation::preorder(IR::P4Action *act) {
 IR::P4Action *DoLocalCopyPropagation::postorder(IR::P4Action *act) {
     LOG5("DoLocalCopyPropagation before ElimDead " << act->name);
     LOG5(act);
-    BUG_CHECK(inferForFunc == &actions[act->name], "corrupt internal data struct");
+    BUG_CHECK(inferForFunc == &(*actions)[act->name], "corrupt internal data struct");
     act->body = act->body->apply(ElimDead(*this), getChildContext())->to<IR::BlockStatement>();
     working = false;
     available.clear();
@@ -702,7 +712,7 @@ IR::Function *DoLocalCopyPropagation::preorder(IR::Function *fn) {
     else
         name = fn->name;
     working = true;
-    inferForFunc = &methods[name];
+    inferForFunc = &(*methods)[name];
     LOG2("DoLocalCopyPropagation working on function " << name);
     LOG4(fn);
     return fn;
@@ -717,7 +727,7 @@ IR::Function *DoLocalCopyPropagation::postorder(IR::Function *fn) {
         name = fn->name;
     LOG5("DoLocalCopyPropagation before ElimDead " << name);
     LOG5(fn);
-    BUG_CHECK(inferForFunc == &methods[name], "corrupt internal data struct");
+    BUG_CHECK(inferForFunc == &(*methods)[name], "corrupt internal data struct");
     fn->body = fn->body->apply(ElimDead(*this), getChildContext())->to<IR::BlockStatement>();
     working = false;
     available.clear();
@@ -746,13 +756,13 @@ IR::P4Control *DoLocalCopyPropagation::preorder(IR::P4Control *ctrl) {
     if (!elimUnusedTables) {
         for (auto local : ctrl->controlLocals) {
             if (auto *act = local->to<IR::P4Action>()) {
-                auto &act_info = actions.at(act->name);
+                auto &act_info = actions->at(act->name);
                 if (act_info.apply_count == 0) {
                     // unused action -- preserve any unused locals it references
                     apply_function(&act_info);
                 }
             } else if (auto *tbl = local->to<IR::P4Table>()) {
-                auto &tbl_info = tables.at(tbl->name);
+                auto &tbl_info = tables->at(tbl->name);
                 if (tbl_info.apply_count == 0) {
                     // unused table -- preserve any unused locals it references
                     apply_table(&tbl_info);
@@ -853,17 +863,17 @@ void DoLocalCopyPropagation::apply_table(DoLocalCopyPropagation::TableInfo *tbl)
             ++it;
         }
     }
-    for (auto action : tbl->actions) apply_function(&actions[action]);
+    for (auto action : tbl->actions) apply_function(&(*actions)[action]);
 }
 
 void DoLocalCopyPropagation::LoopPrepass::apply_table(DoLocalCopyPropagation::TableInfo *tbl) {
-    for (auto action : tbl->actions) apply_function(&self.actions[action]);
+    for (auto action : tbl->actions) apply_function(&(*self.actions)[action]);
 }
 
 IR::P4Table *DoLocalCopyPropagation::preorder(IR::P4Table *tbl) {
     visitOnce();
     BUG_CHECK(!inferForTable, "corrupt internal data struct");
-    inferForTable = &tables[tbl->name];
+    inferForTable = &(*tables)[tbl->name];
     inferForTable->keyreads.clear();
     for (auto ale : tbl->getActionList()->actionList)
         inferForTable->actions.insert(ale->getPath()->name);
@@ -871,7 +881,7 @@ IR::P4Table *DoLocalCopyPropagation::preorder(IR::P4Table *tbl) {
 }
 
 IR::P4Table *DoLocalCopyPropagation::postorder(IR::P4Table *tbl) {
-    BUG_CHECK(inferForTable == &tables[tbl->name], "corrupt internal data struct");
+    BUG_CHECK(inferForTable == &(*tables)[tbl->name], "corrupt internal data struct");
     LOG4("table " << tbl->name << " reads=" << inferForTable->keyreads
                   << " actions=" << inferForTable->actions);
     inferForTable = nullptr;
@@ -883,7 +893,7 @@ const IR::P4Parser *DoLocalCopyPropagation::postorder(IR::P4Parser *parser) {
     working = true;
     LOG2("DoLocalCopyPropagation working on parser " << parser->name);
     visit(parser->parserLocals, "parserLocals");  // visit these again with working==true
-    for (auto *state : parser->states) apply_function(&states[state->name]);
+    for (auto *state : parser->states) apply_function(&(*states)[state->name]);
     auto *rv = parser->apply(ElimDead(*this), getChildContext());
     working = false;
     available.clear();
@@ -896,12 +906,12 @@ IR::ParserState *DoLocalCopyPropagation::preorder(IR::ParserState *state) {
     working = true;
     LOG2("DoLocalCopyPropagation working on parser state " << state->name);
     LOG4(state);
-    inferForFunc = &states[state->name];
+    inferForFunc = &(*states)[state->name];
     return state;
 }
 
 IR::ParserState *DoLocalCopyPropagation::postorder(IR::ParserState *state) {
-    BUG_CHECK(working && inferForFunc == &states[state->name], "corrupt internal data struct");
+    BUG_CHECK(working && inferForFunc == &(*states)[state->name], "corrupt internal data struct");
     LOG5("DoLocalCopyPropagation before ElimDead " << state->name);
     LOG5(state);
     state->components = *state->components.apply(ElimDead(*this), getChildContext());
@@ -915,16 +925,15 @@ IR::ParserState *DoLocalCopyPropagation::postorder(IR::ParserState *state) {
 
 // Reset the state of internal data structures after traversing IR,
 // needed for this pass to function correctly when used in a PassRepeated
-Visitor::profile_t DoLocalCopyPropagation::init_apply(const IR::Node *node) {
-    auto rv = Transform::init_apply(node);
+void DoLocalCopyPropagation::end_apply(const IR::Node *node) {
     uid = uid_ctr = 0;  // reset uids
 
     // clear maps
     available.clear();
-    tables.clear();
-    actions.clear();
-    methods.clear();
-    states.clear();
+    tables->clear();
+    actions->clear();
+    methods->clear();
+    states->clear();
     // reset pointers
     inferForFunc = nullptr;
     inferForTable = nullptr;
@@ -933,7 +942,7 @@ Visitor::profile_t DoLocalCopyPropagation::init_apply(const IR::Node *node) {
     elimUnusedTables = false;
     working = false;
 
-    return rv;
+    Transform::end_apply(node);
 }
 
 }  // namespace P4

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -154,10 +154,10 @@ class DoLocalCopyPropagation : public ControlFlowVisitor,
                            std::function<bool(const Context *, const IR::Expression *)> policy,
                            bool eut)
         : typeMap(typeMap),
-          tables(new std::map<cstring, TableInfo>),
-          actions(new std::map<cstring, FuncInfo>),
-          methods(new std::map<cstring, FuncInfo>),
-          states(new std::map<cstring, FuncInfo>),
+          tables(std::make_shared<std::map<cstring, TableInfo>>()),
+          actions(std::make_shared<std::map<cstring, FuncInfo>>()),
+          methods(std::make_shared<std::map<cstring, FuncInfo>>()),
+          states(std::make_shared<std::map<cstring, FuncInfo>>()),
           policy(policy),
           elimUnusedTables(eut) {}
 };

--- a/midend/local_copyprop.h
+++ b/midend/local_copyprop.h
@@ -77,10 +77,10 @@ class DoLocalCopyPropagation : public ControlFlowVisitor,
         bool is_first_write_insert = false;
     };
     std::map<cstring, VarInfo> available;
-    std::map<cstring, TableInfo> &tables;
-    std::map<cstring, FuncInfo> &actions;
-    std::map<cstring, FuncInfo> &methods;
-    std::map<cstring, FuncInfo> &states;
+    std::shared_ptr<std::map<cstring, TableInfo>> tables;
+    std::shared_ptr<std::map<cstring, FuncInfo>> actions;
+    std::shared_ptr<std::map<cstring, FuncInfo>> methods;
+    std::shared_ptr<std::map<cstring, FuncInfo>> states;
     TableInfo *inferForTable = nullptr;
     FuncInfo *inferForFunc = nullptr;
     bool need_key_rewrite = false;
@@ -143,7 +143,7 @@ class DoLocalCopyPropagation : public ControlFlowVisitor,
     const IR::P4Parser *postorder(IR::P4Parser *) override;
     IR::ParserState *preorder(IR::ParserState *) override;
     IR::ParserState *postorder(IR::ParserState *) override;
-    Visitor::profile_t init_apply(const IR::Node *node) override;
+    void end_apply(const IR::Node *node) override;
     class ElimDead;
     class RewriteTableKeys;
 
@@ -154,10 +154,10 @@ class DoLocalCopyPropagation : public ControlFlowVisitor,
                            std::function<bool(const Context *, const IR::Expression *)> policy,
                            bool eut)
         : typeMap(typeMap),
-          tables(*new std::map<cstring, TableInfo>),
-          actions(*new std::map<cstring, FuncInfo>),
-          methods(*new std::map<cstring, FuncInfo>),
-          states(*new std::map<cstring, FuncInfo>),
+          tables(new std::map<cstring, TableInfo>),
+          actions(new std::map<cstring, FuncInfo>),
+          methods(new std::map<cstring, FuncInfo>),
+          states(new std::map<cstring, FuncInfo>),
           policy(policy),
           elimUnusedTables(eut) {}
 };

--- a/midend/simplifyKey.cpp
+++ b/midend/simplifyKey.cpp
@@ -88,11 +88,10 @@ const IR::Node *DoSimplifyKey::doStatement(const IR::Statement *statement,
     auto insertions = get(toInsert, hta.table);
     if (insertions == nullptr) return statement;
 
-    auto result = new IR::IndexedVector<IR::StatOrDecl>();
-    for (auto assign : insertions->statements) result->push_back(assign);
-    result->push_back(statement);
-    auto block = new IR::BlockStatement(*result);
-    return block;
+    IR::IndexedVector<IR::StatOrDecl> result;
+    for (auto assign : insertions->statements) result.push_back(assign);
+    result.push_back(statement);
+    return new IR::BlockStatement(std::move(result));
 }
 
 }  // namespace P4


### PR DESCRIPTION
The codebase contains some trivial leaks, e.g. when a vector is allocated on heap for no particular reason (it is further used by value) and then just dropped.

Try to fix this in certain places of frontend and midend.