### PR TITLE
Generate JSON actions and keys fields array even when they are empty 

### DIFF
--- a/backends/tc/introspection.cpp
+++ b/backends/tc/introspection.cpp
@@ -307,25 +307,22 @@ Util::JsonObject *IntrospectionGenerator::genTableInfo(struct TableAttributes *t
     tableJson->emplace("tentries", tbl->tentries);
     tableJson->emplace("permissions", tbl->permissions);
     tableJson->emplace("nummask", tbl->numMask);
-    if (tbl->keysize != 0) {
-        tableJson->emplace("keysize", tbl->keysize);
-    }
+    tableJson->emplace("keysize", tbl->keysize);
+
     auto keysJson = new Util::JsonArray();
     for (auto keyField : tbl->keyFields) {
         auto keyJson = genKeyInfo(keyField);
         keysJson->append(keyJson);
     }
-    if (keysJson->size() != 0) {
-        tableJson->emplace("keyfields", keysJson);
-    }
+    tableJson->emplace("keyfields", keysJson);
+
     auto actionsJson = new Util::JsonArray();
     for (auto action : tbl->actions) {
         auto actionJson = genActionInfo(action);
         actionsJson->append(actionJson);
     }
-    if (actionsJson->size() != 0) {
-        tableJson->emplace("actions", actionsJson);
-    }
+    tableJson->emplace("actions", actionsJson);
+
     return tableJson;
 }
 

--- a/testdata/p4tc_samples_outputs/default_action_example_01.json
+++ b/testdata/p4tc_samples_outputs/default_action_example_01.json
@@ -83,7 +83,8 @@
           "match_type" : "exact",
           "bitwidth" : 8
         }
-      ]
+      ],
+      "actions" : []
     }
   ]
 }

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01.json
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01.json
@@ -236,7 +236,8 @@
           "match_type" : "exact",
           "bitwidth" : 13
         }
-      ]
+      ],
+      "actions" : []
     },
     {
       "name" : "MainControlImpl/set_ct_options",

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02.json
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02.json
@@ -222,7 +222,8 @@
           "match_type" : "exact",
           "bitwidth" : 13
         }
-      ]
+      ],
+      "actions" : []
     },
     {
       "name" : "MainControlImpl/set_ct_options",

--- a/testdata/p4tc_samples_outputs/noaction_example_02.json
+++ b/testdata/p4tc_samples_outputs/noaction_example_02.json
@@ -62,7 +62,8 @@
           "match_type" : "exact",
           "bitwidth" : 3
         }
-      ]
+      ],
+      "actions" : []
     }
   ]
 }

--- a/testdata/p4tc_samples_outputs/tc_type_annotation_example.json
+++ b/testdata/p4tc_samples_outputs/tc_type_annotation_example.json
@@ -69,7 +69,8 @@
           "match_type" : "exact",
           "bitwidth" : 3
         }
-      ]
+      ],
+      "actions" : []
     }
   ]
 }


### PR DESCRIPTION
Generate JSON actions, keys fields array even when they are empty
Also generate keysize = 0 whenever the keysize is zero instead of
omitting it from the JSON file