### PR TITLE
[P4TC] Align key components to the nearest 8-bit size

### DIFF
--- a/backends/ebpf/codeGen.h
+++ b/backends/ebpf/codeGen.h
@@ -128,8 +128,10 @@ class CodeGenInspector : public Inspector {
     void widthCheck(const IR::Node *node) const;
     void emitAndConvertByteOrder(const IR::Expression *expr, cstring byte_order);
     void emitTCBinaryOperation(const IR::Operation_Binary *b, bool isScalar);
-    void emitTCAssignmentEndianessConversion(const IR::Expression *lexpr,
-                                             const IR::Expression *rexpr);
+    void emitTCAssignmentEndianessConversion(const IR::Type *ltype, const IR::Expression *lexpr,
+                                             const IR::Expression *rexpr, cstring lpath);
+    void getBitAlignment(const IR::Expression *expression);
+    bool storeBitAlignment(const IR::Type *ltype, const IR::Expression *lexpr, cstring lpath);
 };
 
 class EBPFInitializerUtils {

--- a/backends/ebpf/ebpfBackend.cpp
+++ b/backends/ebpf/ebpfBackend.cpp
@@ -32,7 +32,7 @@ void emitFilterModel(const EbpfOptions &options, Target *target, const IR::Tople
     CodeBuilder c(target);
     CodeBuilder h(target);
 
-    EBPFTypeFactory::createFactory(typeMap);
+    EBPFTypeFactory::createFactory(typeMap, false);
     auto ebpfprog = new EBPFProgram(options, toplevel->getProgram(), refMap, typeMap, toplevel);
     if (!ebpfprog->build()) return;
 

--- a/backends/ebpf/ebpfParser.cpp
+++ b/backends/ebpf/ebpfParser.cpp
@@ -185,17 +185,17 @@ bool StateTranslationVisitor::preorder(const IR::SelectExpression *expression) {
     BUG_CHECK(expression->select->components.size() == 1, "%1%: tuple not eliminated in select",
               expression->select);
     selectValue = state->parser->program->refMap->newName("select");
-    auto type = state->parser->program->typeMap->getType(expression->select, true);
-    if (auto list = type->to<IR::Type_List>()) {
+    selectType = state->parser->program->typeMap->getType(expression->select, true);
+    if (auto list = selectType->to<IR::Type_List>()) {
         BUG_CHECK(list->components.size() == 1, "%1% list type with more than 1 element", list);
-        type = list->components.at(0);
+        selectType = list->components.at(0);
     }
-    auto etype = EBPFTypeFactory::instance->create(type);
+    auto etype = EBPFTypeFactory::instance->create(selectType);
     builder->emitIndent();
     etype->declare(builder, selectValue, false);
     builder->endOfStatement(true);
 
-    emitAssignStatement(type, nullptr, selectValue, expression->select->components.at(0));
+    emitAssignStatement(selectType, nullptr, selectValue, expression->select->components.at(0));
     builder->newline();
 
     // Init value_sets

--- a/backends/ebpf/ebpfParser.h
+++ b/backends/ebpf/ebpfParser.h
@@ -32,6 +32,7 @@ class StateTranslationVisitor : public CodeGenInspector {
  protected:
     /// Stores the result of evaluating the select argument.
     cstring selectValue;
+    const IR::Type *selectType;
 
     P4::P4CoreLibrary &p4lib;
     const EBPFParserState *state;

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -62,8 +62,10 @@ class EBPFTypeFactory {
 
  public:
     static EBPFTypeFactory *instance;
-    static void createFactory(const P4::TypeMap *typeMap) {
+    static bool isTC;
+    static void createFactory(const P4::TypeMap *typeMap, bool TC) {
         EBPFTypeFactory::instance = new EBPFTypeFactory(typeMap);
+        EBPFTypeFactory::isTC = TC;
     }
     virtual EBPFType *create(const IR::Type *type);
 };
@@ -221,6 +223,20 @@ class EBPFMethodDeclaration : public EBPFObject {
     void emit(CodeBuilder *builder);
 
     DECLARE_TYPEINFO(EBPFMethodDeclaration, EBPFObject);
+};
+
+class EBPFScalarTypePNA : public EBPFScalarType {
+    bool isPrimitiveByteAligned = false;
+
+ public:
+    explicit EBPFScalarTypePNA(const IR::Type_Bits *bits) : EBPFScalarType(bits) {
+        isPrimitiveByteAligned = (width <= 8 || width <= 16 || (width > 24 && width <= 32) ||
+                                  (width > 56 && width <= 64));
+    }
+    unsigned alignment() const;
+    void declare(CodeBuilder *builder, cstring id, bool asPointer);
+    void declareInit(CodeBuilder *builder, cstring id, bool asPointer);
+    void emitInitializer(CodeBuilder *builder);
 };
 
 }  // namespace P4::EBPF

--- a/backends/ebpf/psa/backend.cpp
+++ b/backends/ebpf/psa/backend.cpp
@@ -61,7 +61,7 @@ void PSASwitchBackend::convert(const IR::ToplevelBlock *tlb) {
     main->apply(*parsePsaArch);
     program = toplevel->getProgram();
 
-    EBPFTypeFactory::createFactory(typeMap);
+    EBPFTypeFactory::createFactory(typeMap, false);
     auto *convertToEbpfPSA = new ConvertToEbpfPSA(options, refMap, typeMap);
     PassManager toEBPF = {
         new P4::DiscoverStructure(&structure),

--- a/backends/ebpf/target.h
+++ b/backends/ebpf/target.h
@@ -238,6 +238,11 @@ class P4TCTarget : public KernelSamplesTarget {
         }
         return "HOST"_cs;
     }
+
+    bool isPrimitiveByteAligned(int width) const {
+        return (width <= 8 || width <= 16 || (width > 24 && width <= 32) ||
+                (width > 56 && width <= 64));
+    }
 };
 
 /// Target XDP.

--- a/backends/tc/CMakeLists.txt
+++ b/backends/tc/CMakeLists.txt
@@ -63,6 +63,7 @@ set(P4TC_BACKEND_HEADERS
    pnaProgramStructure.h
    tcAnnotations.h
    tcExterns.h
+   handleBitAlignment.h
    version.h
    ../ebpf/codeGen.h
    ../ebpf/ebpfBackend.h

--- a/backends/tc/backend.cpp
+++ b/backends/tc/backend.cpp
@@ -101,7 +101,7 @@ bool Backend::ebpfCodeGen(P4::ReferenceMap *refMapEBPF, P4::TypeMap *typeMapEBPF
     main->apply(*parsePnaArch);
     program = top->getProgram();
 
-    EBPF::EBPFTypeFactory::createFactory(typeMapEBPF);
+    EBPF::EBPFTypeFactory::createFactory(typeMapEBPF, true);
     auto convertToEbpf = new ConvertToEbpfPNA(ebpfOption, refMapEBPF, typeMapEBPF, tcIR);
     PassManager toEBPF = {
         new P4::DiscoverStructure(&structure),

--- a/backends/tc/ebpfCodeGen.h
+++ b/backends/tc/ebpfCodeGen.h
@@ -105,6 +105,7 @@ class PNAArchTC : public PNAEbpfGenerator {
     void emitParser(EBPF::CodeBuilder *builder) const override;
     void emitHeader(EBPF::CodeBuilder *builder) const override;
     void emitInstances(EBPF::CodeBuilder *builder) const override;
+    void emitGlobalFunctions(EBPF::CodeBuilder *builder) const;
 };
 
 class TCIngressPipelinePNA : public EBPF::TCIngressPipeline {
@@ -133,6 +134,7 @@ class PnaStateTranslationVisitor : public EBPF::PsaStateTranslationVisitor {
     void compileExtractField(const IR::Expression *expr, const IR::StructField *field,
                              unsigned hdrOffsetBits, EBPF::EBPFType *type) override;
     void compileLookahead(const IR::Expression *destination) override;
+    bool preorder(const IR::SelectCase *selectCase) override;
 };
 
 class EBPFPnaParser : public EBPF::EBPFPsaParser {

--- a/testdata/p4tc_samples_outputs/add_entry_1_example_parser.c
+++ b/testdata/p4tc_samples_outputs/add_entry_1_example_parser.c
@@ -85,7 +85,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             __builtin_memcpy(&hdr->ethernet.srcAddr, pkt + BYTES(ebpf_packetOffsetInBits), 6);

--- a/testdata/p4tc_samples_outputs/add_entry_1_example_parser.h
+++ b/testdata/p4tc_samples_outputs/add_entry_1_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -39,8 +39,8 @@ struct headers_t {
     struct ipv4_t ipv4; /* ipv4_t */
 };
 struct tuple_0 {
-    u64 f0; /* bit<48> */
-    u64 f1; /* bit<48> */
+    u8 f0[6]; /* bit<48> */
+    u8 f1[6]; /* bit<48> */
 };
 
 struct hdr_md {
@@ -64,4 +64,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/add_entry_3_example_parser.c
+++ b/testdata/p4tc_samples_outputs/add_entry_3_example_parser.c
@@ -85,7 +85,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             __builtin_memcpy(&hdr->ethernet.srcAddr, pkt + BYTES(ebpf_packetOffsetInBits), 6);

--- a/testdata/p4tc_samples_outputs/add_entry_3_example_parser.h
+++ b/testdata/p4tc_samples_outputs/add_entry_3_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -39,8 +39,8 @@ struct headers_t {
     struct ipv4_t ipv4; /* ipv4_t */
 };
 struct tuple_0 {
-    u64 f0; /* bit<48> */
-    u64 f1; /* bit<48> */
+    u8 f0[6]; /* bit<48> */
+    u8 f1[6]; /* bit<48> */
 };
 
 struct hdr_md {
@@ -64,4 +64,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/add_entry_example_parser.h
+++ b/testdata/p4tc_samples_outputs/add_entry_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -64,4 +64,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/calculator_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/calculator_control_blocks.c
@@ -69,7 +69,7 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
     meta = &(hdrMd->cpumap_usermeta);
 {
         u8 hit;
-        u64 tmp_5 = 0;
+        u8 tmp_5[6] = {0};
         {
 if (/* hdr->p4calc.isValid() */
             hdr->p4calc.ebpf_valid) {
@@ -102,9 +102,9 @@ if (/* hdr->p4calc.isValid() */
                             case MAINCONTROLIMPL_CALCULATE_ACT_MAINCONTROLIMPL_OPERATION_ADD: 
                                 {
                                     hdr->p4calc.res = (hdr->p4calc.operand_a + hdr->p4calc.operand_b);
-                                                                        tmp_5 = hdr->ethernet.dstAddr;
-                                                                        hdr->ethernet.dstAddr = hdr->ethernet.srcAddr;
-                                                                        hdr->ethernet.srcAddr = tmp_5;
+                                                                        storePrimitive64((u8 *)&tmp_5, 48, (getPrimitive64((u8 *)hdr->ethernet.dstAddr, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)hdr->ethernet.srcAddr, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)tmp_5, 48)));
                                     /* send_to_port(skb->ifindex) */
                                     compiler_meta__->drop = false;
                                     send_to_port(skb->ifindex);
@@ -113,9 +113,9 @@ if (/* hdr->p4calc.isValid() */
                             case MAINCONTROLIMPL_CALCULATE_ACT_MAINCONTROLIMPL_OPERATION_SUB: 
                                 {
                                     hdr->p4calc.res = (hdr->p4calc.operand_a - hdr->p4calc.operand_b);
-                                                                        tmp_5 = hdr->ethernet.dstAddr;
-                                                                        hdr->ethernet.dstAddr = hdr->ethernet.srcAddr;
-                                                                        hdr->ethernet.srcAddr = tmp_5;
+                                                                        storePrimitive64((u8 *)&tmp_5, 48, (getPrimitive64((u8 *)hdr->ethernet.dstAddr, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)hdr->ethernet.srcAddr, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)tmp_5, 48)));
                                     /* send_to_port(skb->ifindex) */
                                     compiler_meta__->drop = false;
                                     send_to_port(skb->ifindex);
@@ -124,9 +124,9 @@ if (/* hdr->p4calc.isValid() */
                             case MAINCONTROLIMPL_CALCULATE_ACT_MAINCONTROLIMPL_OPERATION_AND: 
                                 {
                                     hdr->p4calc.res = (hdr->p4calc.operand_a & hdr->p4calc.operand_b);
-                                                                        tmp_5 = hdr->ethernet.dstAddr;
-                                                                        hdr->ethernet.dstAddr = hdr->ethernet.srcAddr;
-                                                                        hdr->ethernet.srcAddr = tmp_5;
+                                                                        storePrimitive64((u8 *)&tmp_5, 48, (getPrimitive64((u8 *)hdr->ethernet.dstAddr, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)hdr->ethernet.srcAddr, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)tmp_5, 48)));
                                     /* send_to_port(skb->ifindex) */
                                     compiler_meta__->drop = false;
                                     send_to_port(skb->ifindex);
@@ -135,9 +135,9 @@ if (/* hdr->p4calc.isValid() */
                             case MAINCONTROLIMPL_CALCULATE_ACT_MAINCONTROLIMPL_OPERATION_OR: 
                                 {
                                     hdr->p4calc.res = (hdr->p4calc.operand_a | hdr->p4calc.operand_b);
-                                                                        tmp_5 = hdr->ethernet.dstAddr;
-                                                                        hdr->ethernet.dstAddr = hdr->ethernet.srcAddr;
-                                                                        hdr->ethernet.srcAddr = tmp_5;
+                                                                        storePrimitive64((u8 *)&tmp_5, 48, (getPrimitive64((u8 *)hdr->ethernet.dstAddr, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)hdr->ethernet.srcAddr, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)tmp_5, 48)));
                                     /* send_to_port(skb->ifindex) */
                                     compiler_meta__->drop = false;
                                     send_to_port(skb->ifindex);
@@ -146,9 +146,9 @@ if (/* hdr->p4calc.isValid() */
                             case MAINCONTROLIMPL_CALCULATE_ACT_MAINCONTROLIMPL_OPERATION_XOR: 
                                 {
                                     hdr->p4calc.res = (hdr->p4calc.operand_a ^ hdr->p4calc.operand_b);
-                                                                        tmp_5 = hdr->ethernet.dstAddr;
-                                                                        hdr->ethernet.dstAddr = hdr->ethernet.srcAddr;
-                                                                        hdr->ethernet.srcAddr = tmp_5;
+                                                                        storePrimitive64((u8 *)&tmp_5, 48, (getPrimitive64((u8 *)hdr->ethernet.dstAddr, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)hdr->ethernet.srcAddr, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)tmp_5, 48)));
                                     /* send_to_port(skb->ifindex) */
                                     compiler_meta__->drop = false;
                                     send_to_port(skb->ifindex);
@@ -230,7 +230,7 @@ if (/* hdr->p4calc.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -245,7 +245,7 @@ if (/* hdr->p4calc.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/calculator_parser.c
+++ b/testdata/p4tc_samples_outputs/calculator_parser.c
@@ -140,10 +140,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 hdr_start = hdr_start_save;
                 ebpf_packetOffsetInBits = ebpf_packetOffsetInBits_save;
             }
-            u32 select_0;
-            select_0 = (((((u32)(((u16)tmp_0.p << 8) | ((u16)tmp_2.four & 0xff)) << 8) & ((1ULL << 24) - 1)) | (((u32)tmp_4.ver & 0xff) & ((1ULL << 24) - 1))) & ((1ULL << 24) - 1));
-            if (select_0 == 0x503401)goto parse_p4calc;
-            if ((select_0 & 0x0) == (0x0 & 0x0))goto accept;
+            u8 select_0[3];
+            storePrimitive32((u8 *)&select_0, 24, ((((((u32)(((u16)tmp_0.p << 8) | ((u16)tmp_2.four & 0xff)) << 8) & ((1ULL << 24) - 1)) | (((u32)tmp_4.ver & 0xff) & ((1ULL << 24) - 1))) & ((1ULL << 24) - 1))));
+            if (getPrimitive32((u8 *)select_0, 24) == 0x503401)goto parse_p4calc;
+            if ((getPrimitive32((u8 *)select_0, 24) & 0x0) == (0x0 & 0x0))goto accept;
             else goto reject;
         }
         parse_p4calc: {
@@ -188,10 +188,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/calculator_parser.h
+++ b/testdata/p4tc_samples_outputs/calculator_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -55,4 +55,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/checksum_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/checksum_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -89,8 +89,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                     switch (value->action) {
                         case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                             {
-                                hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                 /* send_to_port(value->u.ingress_send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/checksum_parser.h
+++ b/testdata/p4tc_samples_outputs/checksum_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -78,4 +78,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/const_entries_range_mask_parser.h
+++ b/testdata/p4tc_samples_outputs/const_entries_range_mask_parser.h
@@ -47,3 +47,48 @@ REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
 
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
+

--- a/testdata/p4tc_samples_outputs/default_action_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_01_control_blocks.c
@@ -220,7 +220,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -235,7 +235,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/default_action_example_01_parser.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_01_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/default_action_example_01_parser.h
+++ b/testdata/p4tc_samples_outputs/default_action_example_01_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
@@ -240,7 +240,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -255,7 +255,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/default_action_example_parser.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/default_action_example_parser.h
+++ b/testdata/p4tc_samples_outputs/default_action_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/default_action_with_param_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_01_control_blocks.c
@@ -240,7 +240,7 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -255,7 +255,7 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/default_action_with_param_01_parser.c
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_01_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/default_action_with_param_01_parser.h
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_01_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/default_action_with_param_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_control_blocks.c
@@ -240,7 +240,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -255,7 +255,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/default_action_with_param_parser.c
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/default_action_with_param_parser.h
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
@@ -165,7 +165,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->eth.dstAddr = htonll(hdr->eth.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->eth.dstAddr, 48, (htonll(getPrimitive64(hdr->eth.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->eth.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->eth.dstAddr))[1];
@@ -180,7 +180,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->eth.srcAddr = htonll(hdr->eth.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->eth.srcAddr, 48, (htonll(getPrimitive64(hdr->eth.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->eth.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->eth.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/default_hit_const_example_parser.c
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example_parser.c
@@ -133,10 +133,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->eth.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->eth.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->eth.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->eth.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->eth.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/default_hit_const_example_parser.h
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -74,4 +74,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/digest_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/digest_01_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port;
-            u64 srcMac;
-            u64 dstMac;
+            u8 srcMac[6];
+            u8 dstMac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -92,8 +92,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                         switch (value->action) {
                             case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                                 {
-                                    hdr->ethernet.srcAddr = value->u.ingress_send_nh.srcMac;
-                                                                        hdr->ethernet.dstAddr = value->u.ingress_send_nh.dstMac;
+                                    storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.srcMac, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dstMac, 48)));
                                                                         meta->ingress_port = skb->ifindex;
                                                                         meta->send_digest = true;
                                     /* send_to_port(value->u.ingress_send_nh.port) */

--- a/testdata/p4tc_samples_outputs/digest_01_parser.h
+++ b/testdata/p4tc_samples_outputs/digest_01_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -41,7 +41,7 @@ struct my_ingress_metadata_t {
     u8 send_digest; /* bool */
 };
 struct mac_learn_digest_t {
-    u64 srcAddr; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u32 ingress_port; /* PortId_t */
 };
 
@@ -66,4 +66,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/digest_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/digest_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port;
-            u64 srcMac;
-            u64 dstMac;
+            u8 srcMac[6];
+            u8 dstMac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -92,8 +92,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                         switch (value->action) {
                             case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                                 {
-                                    hdr->ethernet.srcAddr = value->u.ingress_send_nh.srcMac;
-                                                                        hdr->ethernet.dstAddr = value->u.ingress_send_nh.dstMac;
+                                    storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.srcMac, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dstMac, 48)));
                                                                         meta->ingress_port = skb->ifindex;
                                                                         meta->send_digest = true;
                                     /* send_to_port(value->u.ingress_send_nh.port) */
@@ -125,7 +125,7 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         __builtin_memset((void *) &mac_learn_digest_0, 0, sizeof(struct mac_learn_digest_t ));
 {
 if (meta->send_digest) {
-                mac_learn_digest_0.srcAddr = hdr->ethernet.srcAddr;
+                storePrimitive64((u8 *)&mac_learn_digest_0.srcAddr, 48, (getPrimitive64((u8 *)hdr->ethernet.srcAddr, 48)));
                                 mac_learn_digest_0.ingress_port = meta->ingress_port;
                 /* digest_inst_0.pack(mac_learn_digest_0) */
 

--- a/testdata/p4tc_samples_outputs/digest_parser.h
+++ b/testdata/p4tc_samples_outputs/digest_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -41,7 +41,7 @@ struct my_ingress_metadata_t {
     u8 send_digest; /* bool */
 };
 struct mac_learn_digest_t {
-    u64 srcAddr; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u32 ingress_port; /* PortId_t */
 };
 
@@ -66,4 +66,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/digest_parser_meta_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/digest_parser_meta_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port;
-            u64 srcMac;
-            u64 dstMac;
+            u8 srcMac[6];
+            u8 dstMac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -91,8 +91,8 @@ if (/* hdr->ipv4.isValid() */
                         switch (value->action) {
                             case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                                 {
-                                    hdr->ethernet.srcAddr = value->u.ingress_send_nh.srcMac;
-                                                                        hdr->ethernet.dstAddr = value->u.ingress_send_nh.dstMac;
+                                    storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.srcMac, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dstMac, 48)));
                                     /* send_to_port(value->u.ingress_send_nh.port) */
                                     compiler_meta__->drop = false;
                                     send_to_port(value->u.ingress_send_nh.port);

--- a/testdata/p4tc_samples_outputs/digest_parser_meta_parser.h
+++ b/testdata/p4tc_samples_outputs/digest_parser_meta_parser.h
@@ -15,8 +15,8 @@ struct my_ingress_metadata_t {
     u32 ingress_port; /* PortId_t */
 };
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -65,4 +65,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/direct_counter_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/direct_counter_example_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -92,8 +92,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                     switch (value->action) {
                         case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                             {
-                                hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                 /* send_to_port(value->u.ingress_send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/direct_counter_example_parser.h
+++ b/testdata/p4tc_samples_outputs/direct_counter_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/direct_meter_color_parser.h
+++ b/testdata/p4tc_samples_outputs/direct_meter_color_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/direct_meter_parser.h
+++ b/testdata/p4tc_samples_outputs/direct_meter_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
@@ -163,7 +163,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -178,7 +178,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/drop_packet_example_parser.c
+++ b/testdata/p4tc_samples_outputs/drop_packet_example_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/drop_packet_example_parser.h
+++ b/testdata/p4tc_samples_outputs/drop_packet_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
@@ -28,7 +28,7 @@ struct __attribute__((__packed__)) ingress_nh_table2_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
+            u8 dmac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -52,8 +52,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } _send_nh;
         struct {
         } ingress_drop;
@@ -116,8 +116,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
 /* send_to_port(value->u._send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u._send_nh.port_id);
-                                                                hdr->ethernet.srcAddr = value->u._send_nh.smac;
-                                                                hdr->ethernet.dstAddr = value->u._send_nh.dmac;
+                                                                storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u._send_nh.smac, 48)));
+                                                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u._send_nh.dmac, 48)));
                             }
                             break;
                         case INGRESS_NH_TABLE_ACT_INGRESS_DROP: 
@@ -163,7 +163,7 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                     switch (value->action) {
                         case INGRESS_NH_TABLE2_ACT_INGRESS_SEND_NH: 
                             {
-                                hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                 /* send_to_port(value->u.ingress_send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/global_action_example_01_parser.h
+++ b/testdata/p4tc_samples_outputs/global_action_example_01_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table2_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -53,8 +53,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } _drop;
@@ -114,8 +114,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                     switch (value->action) {
                         case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                             {
-                                hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                 /* send_to_port(value->u.ingress_send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u.ingress_send_nh.port_id);
@@ -164,8 +164,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                     switch (value->action) {
                         case INGRESS_NH_TABLE2_ACT_INGRESS_SEND_NH: 
                             {
-                                hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                 /* send_to_port(value->u.ingress_send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/global_action_example_02_parser.h
+++ b/testdata/p4tc_samples_outputs/global_action_example_02_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/hash1_parser.h
+++ b/testdata/p4tc_samples_outputs/hash1_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -77,4 +77,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/hash_parser.h
+++ b/testdata/p4tc_samples_outputs/hash_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -77,4 +77,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/indirect_counter_01_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/indirect_counter_01_example_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -95,8 +95,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                     switch (value->action) {
                         case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                             {
-                                hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                 /* send_to_port(value->u.ingress_send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/indirect_counter_01_example_parser.h
+++ b/testdata/p4tc_samples_outputs/indirect_counter_01_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/internetchecksum_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/internetchecksum_01_control_blocks.c
@@ -33,7 +33,7 @@ struct __attribute__((__packed__)) ingress_fwd_table_value {
             u32 port;
         } ingress_set_ipip_csum;
         struct __attribute__((__packed__)) {
-            u64 dmac;
+            u8 dmac[6];
             u32 port;
         } ingress_set_nh;
         struct {
@@ -106,7 +106,7 @@ if (/* hdr->outer.isValid() */
                                 break;
                             case INGRESS_FWD_TABLE_ACT_INGRESS_SET_NH: 
                                 {
-                                    hdr->ethernet.dstAddr = value->u.ingress_set_nh.dmac;
+                                    storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_set_nh.dmac, 48)));
                                     /* send_to_port(value->u.ingress_set_nh.port) */
                                     compiler_meta__->drop = false;
                                     send_to_port(value->u.ingress_set_nh.port);

--- a/testdata/p4tc_samples_outputs/internetchecksum_01_parser.h
+++ b/testdata/p4tc_samples_outputs/internetchecksum_01_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -84,4 +84,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/ipip_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/ipip_control_blocks.c
@@ -33,7 +33,7 @@ struct __attribute__((__packed__)) Main_fwd_table_value {
             u32 port;
         } Main_set_ipip;
         struct __attribute__((__packed__)) {
-            u64 dmac;
+            u8 dmac[6];
             u32 port;
         } Main_set_nh;
         struct {
@@ -106,7 +106,7 @@ if (/* hdr->outer.isValid() */
                                 break;
                             case MAIN_FWD_TABLE_ACT_MAIN_SET_NH: 
                                 {
-                                    hdr->ethernet.dstAddr = value->u.Main_set_nh.dmac;
+                                    storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.Main_set_nh.dmac, 48)));
                                     /* send_to_port(value->u.Main_set_nh.port) */
                                     compiler_meta__->drop = false;
                                     send_to_port(value->u.Main_set_nh.port);

--- a/testdata/p4tc_samples_outputs/is_host_port_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/is_host_port_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -100,8 +100,8 @@ if (/* hdr->ipv4.isValid() */
                         switch (value->action) {
                             case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                                 {
-                                    hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                        hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                    storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                     /* send_to_port(value->u.ingress_send_nh.port_id) */
                                     compiler_meta__->drop = false;
                                     send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/is_host_port_parser.h
+++ b/testdata/p4tc_samples_outputs/is_host_port_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/is_net_port_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/is_net_port_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -100,8 +100,8 @@ if (/* hdr->ipv4.isValid() */
                         switch (value->action) {
                             case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                                 {
-                                    hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                        hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                    storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                     /* send_to_port(value->u.ingress_send_nh.port_id) */
                                     compiler_meta__->drop = false;
                                     send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/is_net_port_parser.h
+++ b/testdata/p4tc_samples_outputs/is_net_port_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
@@ -388,7 +388,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -403,7 +403,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/matchtype_parser.c
+++ b/testdata/p4tc_samples_outputs/matchtype_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/matchtype_parser.h
+++ b/testdata/p4tc_samples_outputs/matchtype_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/meter_color_parser.h
+++ b/testdata/p4tc_samples_outputs/meter_color_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/meter_parser.h
+++ b/testdata/p4tc_samples_outputs/meter_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
@@ -394,7 +394,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -409,7 +409,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example_parser.c
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example_parser.h
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
@@ -645,7 +645,7 @@ if (hdr->ipv4.protocol != 4 || (hdr->tcp.srcPort <= 3)) {
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -660,7 +660,7 @@ if (hdr->ipv4.protocol != 4 || (hdr->tcp.srcPort <= 3)) {
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01_parser.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01_parser.c
@@ -133,10 +133,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01_parser.h
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -74,4 +74,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
@@ -645,7 +645,7 @@ if (hdr->ipv4.protocol == 6 || ((hdr->ipv4.version > 1) && (hdr->ipv4.ihl <= 2))
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -660,7 +660,7 @@ if (hdr->ipv4.protocol == 6 || ((hdr->ipv4.version > 1) && (hdr->ipv4.ihl <= 2))
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02_parser.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02_parser.c
@@ -133,10 +133,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02_parser.h
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -74,4 +74,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
@@ -238,7 +238,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -253,7 +253,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/name_annotation_example_parser.c
+++ b/testdata/p4tc_samples_outputs/name_annotation_example_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/name_annotation_example_parser.h
+++ b/testdata/p4tc_samples_outputs/name_annotation_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/no_table_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/no_table_example_control_blocks.c
@@ -96,7 +96,7 @@ if ((u32)skb->ifindex == 4) {
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -111,7 +111,7 @@ if ((u32)skb->ifindex == 4) {
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/no_table_example_parser.c
+++ b/testdata/p4tc_samples_outputs/no_table_example_parser.c
@@ -108,10 +108,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/no_table_example_parser.h
+++ b/testdata/p4tc_samples_outputs/no_table_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -68,4 +68,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
@@ -238,7 +238,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -253,7 +253,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/noaction_example_01_parser.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_01_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/noaction_example_01_parser.h
+++ b/testdata/p4tc_samples_outputs/noaction_example_01_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
@@ -214,7 +214,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -229,7 +229,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/noaction_example_02_parser.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_02_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/noaction_example_02_parser.h
+++ b/testdata/p4tc_samples_outputs/noaction_example_02_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
@@ -161,7 +161,7 @@ if (((u32)skb->ifindex == 2 && /* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->eth.dstAddr = htonll(hdr->eth.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->eth.dstAddr, 48, (htonll(getPrimitive64(hdr->eth.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->eth.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->eth.dstAddr))[1];
@@ -176,7 +176,7 @@ if (((u32)skb->ifindex == 2 && /* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->eth.srcAddr = htonll(hdr->eth.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->eth.srcAddr, 48, (htonll(getPrimitive64(hdr->eth.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->eth.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->eth.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example_parser.c
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example_parser.c
@@ -133,10 +133,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->eth.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->eth.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->eth.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->eth.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->eth.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example_parser.h
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -74,4 +74,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
@@ -193,7 +193,7 @@ ext_val = *ext_val_ptr;
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -208,7 +208,7 @@ ext_val = *ext_val_ptr;
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/send_to_port_example_parser.c
+++ b/testdata/p4tc_samples_outputs/send_to_port_example_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/send_to_port_example_parser.h
+++ b/testdata/p4tc_samples_outputs/send_to_port_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
@@ -248,7 +248,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -263,7 +263,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example_parser.c
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example_parser.h
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -89,8 +89,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                     switch (value->action) {
                         case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                             {
-                                hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                 /* send_to_port(value->u.ingress_send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/simple_exact_example_parser.h
+++ b/testdata/p4tc_samples_outputs/simple_exact_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/simple_extern_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_extern_example_control_blocks.c
@@ -32,8 +32,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } ingress_ext_reg;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -140,8 +140,8 @@ ext_val = *ext_val_ptr;
                             break;
                         case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                             {
-                                hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                 /* send_to_port(value->u.ingress_send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/simple_extern_example_parser.h
+++ b/testdata/p4tc_samples_outputs/simple_extern_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -66,4 +66,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -89,8 +89,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                     switch (value->action) {
                         case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                             {
-                                hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                 /* send_to_port(value->u.ingress_send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/simple_lpm_example_parser.h
+++ b/testdata/p4tc_samples_outputs/simple_lpm_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
@@ -33,8 +33,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port_id;
-            u64 dmac;
-            u64 smac;
+            u8 dmac[6];
+            u8 smac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -95,8 +95,8 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
                     switch (value->action) {
                         case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
                             {
-                                hdr->ethernet.srcAddr = value->u.ingress_send_nh.smac;
-                                                                hdr->ethernet.dstAddr = value->u.ingress_send_nh.dmac;
+                                storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.smac, 48)));
+                                                                storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (getPrimitive64((u8 *)value->u.ingress_send_nh.dmac, 48)));
                                 /* send_to_port(value->u.ingress_send_nh.port_id) */
                                 compiler_meta__->drop = false;
                                 send_to_port(value->u.ingress_send_nh.port_id);

--- a/testdata/p4tc_samples_outputs/simple_ternary_example_parser.h
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
@@ -238,7 +238,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -253,7 +253,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/size_param_example_parser.c
+++ b/testdata/p4tc_samples_outputs/size_param_example_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/size_param_example_parser.h
+++ b/testdata/p4tc_samples_outputs/size_param_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/skb_meta_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/skb_meta_control_blocks.c
@@ -28,8 +28,8 @@ struct __attribute__((__packed__)) ingress_nh_table_value {
         } _NoAction;
         struct __attribute__((__packed__)) {
             u32 port;
-            u64 srcMac;
-            u64 dstMac;
+            u8 srcMac[6];
+            u8 dstMac[6];
         } ingress_send_nh;
         struct {
         } ingress_drop;
@@ -105,8 +105,8 @@ if (/* hdr->ipv4.isValid() */
                                     /* skb_set_meta() */
                                     bpf_p4tc_skb_meta_set(skb,&sa->set,sizeof(sa->set));
                                     tmp_5 = bpf_p4tc_skb_get_tstamp(skb, &sa->get);
-                                                                        hdr->ethernet.srcAddr = (((u64)tmp_5 ^ bpf_cpu_to_be64(value->u.ingress_send_nh.srcMac)) & ((1ULL << 48) - 1));
-                                                                        hdr->ethernet.dstAddr = ntohll(value->u.ingress_send_nh.dstMac << 16);
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (((getPrimitive64((u8 *)value->u.ingress_send_nh.srcMac, 48) ^ bpf_cpu_to_be64(getPrimitive64((u8 *)value->u.ingress_send_nh.srcMac, 48))) & ((1ULL << 48) - 1))));
+                                                                        storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (ntohll(getPrimitive64((u8 *)value->u.ingress_send_nh.dstMac, 48) << 16)));
                                     /* send_to_port(value->u.ingress_send_nh.port) */
                                     compiler_meta__->drop = false;
                                     send_to_port(value->u.ingress_send_nh.port);
@@ -181,7 +181,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -196,7 +196,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/skb_meta_parser.c
+++ b/testdata/p4tc_samples_outputs/skb_meta_parser.c
@@ -89,10 +89,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct my_ingress_h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/skb_meta_parser.h
+++ b/testdata/p4tc_samples_outputs/skb_meta_parser.h
@@ -16,8 +16,8 @@ struct my_ingress_metadata_t {
 struct empty_metadata_t {
 };
 struct ethernet_t {
-    u64 dstAddr; /* bit<48> */
-    u64 srcAddr; /* bit<48> */
+    u8 dstAddr[6]; /* bit<48> */
+    u8 srcAddr[6]; /* bit<48> */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_01_control_blocks.c
@@ -258,7 +258,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -273,7 +273,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_01_parser.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_01_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_01_parser.h
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_01_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_02_control_blocks.c
@@ -240,7 +240,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -255,7 +255,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_02_parser.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_02_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_02_parser.h
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_02_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_03_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_03_control_blocks.c
@@ -240,7 +240,7 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -255,7 +255,7 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_03_parser.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_03_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_03_parser.h
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_03_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_04_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_04_control_blocks.c
@@ -252,7 +252,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -267,7 +267,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_04_parser.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_04_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_04_parser.h
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_04_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -61,4 +61,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_05_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_05_control_blocks.c
@@ -249,7 +249,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -264,7 +264,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_05_parser.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_05_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_05_parser.h
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_05_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -61,4 +61,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_06_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_06_control_blocks.c
@@ -258,7 +258,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -273,7 +273,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_06_parser.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_06_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_06_parser.h
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_06_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_07_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_07_control_blocks.c
@@ -267,7 +267,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -282,7 +282,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_07_parser.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_07_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_07_parser.h
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_07_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_08_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_08_control_blocks.c
@@ -267,7 +267,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -282,7 +282,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_08_parser.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_08_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_08_parser.h
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_08_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -62,4 +62,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_09_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_09_control_blocks.c
@@ -258,7 +258,7 @@ if (/* hdr->ipv4.isValid() */
                 return TC_ACT_SHOT;
             }
             
-            hdr->ethernet.dstAddr = htonll(hdr->ethernet.dstAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (htonll(getPrimitive64(hdr->ethernet.dstAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
@@ -273,7 +273,7 @@ if (/* hdr->ipv4.isValid() */
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = htonll(hdr->ethernet.srcAddr << 16);
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (htonll(getPrimitive64(hdr->ethernet.srcAddr, 48) << 16)));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
             write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
             ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_09_parser.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_09_parser.c
@@ -85,10 +85,10 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
                 goto reject;
             }
 
-            hdr->ethernet.dstAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.dstAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
-            hdr->ethernet.srcAddr = (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
+            storePrimitive64((u8 *)&hdr->ethernet.srcAddr, 48, (u64)((load_dword(pkt, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48)));
             ebpf_packetOffsetInBits += 48;
 
             hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_09_parser.h
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_09_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -61,4 +61,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/tc_type_annotation_example_parser.h
+++ b/testdata/p4tc_samples_outputs/tc_type_annotation_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -60,4 +60,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 

--- a/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
@@ -66,7 +66,7 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
                 struct MainControlImpl_tbl_default_key key;
                 __builtin_memset(&key, 0, sizeof(key));
                 key.keysz = 128;
-                __builtin_memcpy(&(key.field0[0]), &(hdr->ipv6.srcAddr[0]), 16);
+                __builtin_memcpy(&(key.field0), &(hdr->ipv6.srcAddr), 16);
                 struct p4tc_table_entry_act_bpf *act_bpf;
                 /* value */
                 struct MainControlImpl_tbl_default_value *value = NULL;
@@ -200,7 +200,7 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
             write_partial(pkt + BYTES(ebpf_packetOffsetInBits) + 0 + 1, 4, 4, (ebpf_byte));
             ebpf_packetOffsetInBits += 8;
 
-            hdr->ipv6.flowLabel = htonl(hdr->ipv6.flowLabel << 12);
+            storePrimitive32((u8 *)&hdr->ipv6.flowLabel, 20, (htonl(getPrimitive32(hdr->ipv6.flowLabel, 20) << 12)));
             ebpf_byte = ((char*)(&hdr->ipv6.flowLabel))[0];
             write_partial(pkt + BYTES(ebpf_packetOffsetInBits) + 0, 4, 0, (ebpf_byte >> 4));
             write_partial(pkt + BYTES(ebpf_packetOffsetInBits) + 0 + 1, 4, 4, (ebpf_byte));

--- a/testdata/p4tc_samples_outputs/test_ipv6_example_parser.c
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example_parser.c
@@ -41,7 +41,7 @@ static __always_inline int run_parser(struct __sk_buff *skb, struct headers_t *h
             hdr->ipv6.trafficClass = (u8)((load_half(pkt, BYTES(ebpf_packetOffsetInBits)) >> 4) & EBPF_MASK(u8, 8));
             ebpf_packetOffsetInBits += 8;
 
-            hdr->ipv6.flowLabel = (u32)((load_word(pkt, BYTES(ebpf_packetOffsetInBits)) >> 8) & EBPF_MASK(u32, 20));
+            storePrimitive32((u8 *)&hdr->ipv6.flowLabel, 20, (u32)((load_word(pkt, BYTES(ebpf_packetOffsetInBits)) >> 8) & EBPF_MASK(u32, 20)));
             ebpf_packetOffsetInBits += 20;
 
             hdr->ipv6.payloadLength = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));

--- a/testdata/p4tc_samples_outputs/test_ipv6_example_parser.h
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example_parser.h
@@ -12,8 +12,8 @@
 
 
 struct ethernet_t {
-    u64 dstAddr; /* EthernetAddress */
-    u64 srcAddr; /* EthernetAddress */
+    u8 dstAddr[6]; /* EthernetAddress */
+    u8 srcAddr[6]; /* EthernetAddress */
     u16 etherType; /* bit<16> */
     u8 ebpf_valid;
 };
@@ -35,7 +35,7 @@ struct ipv4_t {
 struct ipv6_t {
     u8 version; /* bit<4> */
     u8 trafficClass; /* bit<8> */
-    u32 flowLabel; /* bit<20> */
+    u8 flowLabel[3]; /* bit<20> */
     u16 payloadLength; /* bit<16> */
     u8 nextHeader; /* bit<8> */
     u8 hopLimit; /* bit<8> */
@@ -71,4 +71,49 @@ REGISTER_START()
 REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
 BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
 REGISTER_END()
+
+static inline u32 getPrimitive32(u8 *a, int size) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   return  ((((u32)a[2]) <<16) | (((u32)a[1]) << 8) | a[0]);
+}
+static inline u64 getPrimitive64(u8 *a, int size) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   if(size <= 40) {
+       return  ((((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+   } else {
+       if(size <= 48) {
+           return  ((((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       } else {
+           return  ((((u64)a[6]) << 48) | (((u64)a[5]) << 40) | (((u64)a[4]) << 32) | (((u64)a[3]) << 24) | (((u64)a[2]) << 16) | (((u64)a[1]) << 8) | a[0]);
+       }
+   }
+}
+static inline void storePrimitive32(u8 *a, int size, u32 value) {
+   if(size <= 16 || size > 24) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+}
+static inline void storePrimitive64(u8 *a, int size, u64 value) {
+   if(size <= 32 || size > 56) {
+       bpf_printk("Invalid size.");
+   };
+   a[0] = (u8)(value);
+   a[1] = (u8)(value >> 8);
+   a[2] = (u8)(value >> 16);
+   a[3] = (u8)(value >> 24);
+   a[4] = (u8)(value >> 32);
+   if (size > 40) {
+       a[5] = (u8)(value >> 40);
+   }
+   if (size > 48) {
+       a[6] = (u8)(value >> 48);
+   }
+}
 


### PR DESCRIPTION
As of now, whenever there is a key component that is a bit-type which doesn't correspond to primitive C type (u8, u16, u32, ...),
the compiler generates it as using the closest primitive C type that is larger then X in bit<X>
For example -
```
bit<24> dest_op;
```
dest_op here is converted into u32 like below -
```
u32 dest_op;
```
This won't work, because the P4TC side is expecting the bit<24> (`dest_op`) to be contained in `3 bytes` and not 4. All key components are expected to be 8-bit aligned. The new declaration for 'dest_op' would be -
```
u8 dest_op[3];
```

For all operations, compiler will call function 'getPrimitiveXX()' which will convert u8[] into primitive type (u32 or u64).
For reverse assignment operations compiler calls 'storePrimitiveXX()' which converts primitive types to u8 [ ] array.

@vbnogueira @jhsmt
