### PR TITLE
Remove empty v1.def

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -190,7 +190,6 @@ genrule(
             $(location ir/type.def) \
             $(location ir/expression.def) \
             $(location ir/ir.def) \
-            $(location ir/v1.def) \
             $(locations :ir_extra_defs)
     """,
     tools = [":ir_generator"],


### PR DESCRIPTION
This file was empty but still present in the PR. Remove it and fix the associated Bazel build file. 