### PR TITLE
Add checks to annotation getters.

### DIFF
--- a/ir/base.def
+++ b/ir/base.def
@@ -332,17 +332,36 @@ class Annotation {
             Vector<Expression>,
             IndexedVector<NamedExpression>> body;
 
-    inline auto &getUnparsed() { return std::get<UnparsedAnnotation>(body); }
-    inline const auto &getUnparsed() const { return std::get<UnparsedAnnotation>(body); }
-    inline auto &getExpr() { return std::get<ExpressionAnnotation>(body); }
-    inline const auto &getExpr() const { return std::get<ExpressionAnnotation>(body); }
+    inline auto &getUnparsed() {
+        BUG_CHECK(annotationKind() == Kind::Unparsed, "Annotation has been parsed already.");
+        return std::get<UnparsedAnnotation>(body);
+    }
+    inline const auto &getUnparsed() const {
+        BUG_CHECK(annotationKind() == Kind::Unparsed, "Annotation has been parsed already.");
+        return std::get<UnparsedAnnotation>(body);
+    }
+    inline auto &getExpr() {
+        BUG_CHECK(annotationKind() == Kind::Unstructured || annotationKind() == Kind::StructuredExpressionList, "Annotation does not contain an expression list.");
+        return std::get<ExpressionAnnotation>(body);
+     }
+    inline const auto &getExpr() const {
+        BUG_CHECK(annotationKind() == Kind::Unstructured || annotationKind() == Kind::StructuredExpressionList, "Annotation does not contain an expression list.");
+        return std::get<ExpressionAnnotation>(body);
+    }
     inline Expression getExpr(size_t idx) const {
+        BUG_CHECK(annotationKind() == Kind::Unstructured || annotationKind() == Kind::StructuredExpressionList, "Annotation does not contain an expression list.");
         const auto &expr = getExpr();
         BUG_CHECK(idx < expr.size(), "invalid annotation expression index");
         return expr[idx];
     }
-    inline auto &getKV() { return std::get<KVAnnotation>(body); }
-    inline const auto &getKV() const { return std::get<KVAnnotation>(body); }
+    inline auto &getKV() {
+        BUG_CHECK(annotationKind() == Kind::StructuredKVList, "Annotation does not contain a key-value list.");
+        return std::get<KVAnnotation>(body);
+    }
+    inline const auto &getKV() const {
+        BUG_CHECK(annotationKind() == Kind::StructuredKVList, "Annotation does not contain a key-value list.");
+        return std::get<KVAnnotation>(body);
+    }
 
     /// If this is true this is a structured annotation, and there are some
     /// constraints on its contents.

--- a/ir/base.def
+++ b/ir/base.def
@@ -355,11 +355,11 @@ class Annotation {
         return expr[idx];
     }
     inline auto &getKV() {
-        BUG_CHECK(annotationKind() == Kind::StructuredKVList, "Annotation does not contain a key-value list.");
+        BUG_CHECK(std::holds_alternative<KVAnnotation>(body), "Annotation does not contain a key-value list.");
         return std::get<KVAnnotation>(body);
     }
     inline const auto &getKV() const {
-        BUG_CHECK(annotationKind() == Kind::StructuredKVList, "Annotation does not contain a key-value list.");
+        BUG_CHECK(std::holds_alternative<KVAnnotation>(body), "Annotation does not contain a key-value list.");
         return std::get<KVAnnotation>(body);
     }
 

--- a/ir/base.def
+++ b/ir/base.def
@@ -333,34 +333,56 @@ class Annotation {
             IndexedVector<NamedExpression>> body;
 
     inline auto &getUnparsed() {
-        BUG_CHECK(annotationKind() == Kind::Unparsed, "Annotation has been parsed already.");
-        return std::get<UnparsedAnnotation>(body);
+        try {
+            return std::get<UnparsedAnnotation>(body);
+        } catch (const std::bad_variant_access &) {
+            BUG("Annotation has been parsed already.");
+        }
     }
     inline const auto &getUnparsed() const {
-        BUG_CHECK(annotationKind() == Kind::Unparsed, "Annotation has been parsed already.");
-        return std::get<UnparsedAnnotation>(body);
+        try {
+            return std::get<UnparsedAnnotation>(body);
+        } catch (const std::bad_variant_access &) {
+            BUG("Annotation has been parsed already.");
+        }
     }
     inline auto &getExpr() {
-        BUG_CHECK(annotationKind() == Kind::Unstructured || annotationKind() == Kind::StructuredExpressionList, "Annotation does not contain an expression list.");
-        return std::get<ExpressionAnnotation>(body);
+        try {
+            return std::get<ExpressionAnnotation>(body);
+        } catch (const std::bad_variant_access &) {
+            BUG("Annotation does not contain an expression list.");
+        }
      }
     inline const auto &getExpr() const {
-        BUG_CHECK(annotationKind() == Kind::Unstructured || annotationKind() == Kind::StructuredExpressionList, "Annotation does not contain an expression list.");
-        return std::get<ExpressionAnnotation>(body);
+        try {
+            return std::get<ExpressionAnnotation>(body);
+        } catch (const std::bad_variant_access &) {
+            BUG("Annotation does not contain an expression list.");
+        }
     }
     inline Expression getExpr(size_t idx) const {
-        BUG_CHECK(annotationKind() == Kind::Unstructured || annotationKind() == Kind::StructuredExpressionList, "Annotation does not contain an expression list.");
-        const auto &expr = getExpr();
-        BUG_CHECK(idx < expr.size(), "invalid annotation expression index");
-        return expr[idx];
+        try {
+            const auto &expr = getExpr();
+            return expr[idx];
+        } catch (const std::out_of_range &) {
+            BUG("invalid annotation expression index");
+        } catch (const std::bad_variant_access &) {
+            BUG("Annotation does not contain an expression list.");
+        }
     }
     inline auto &getKV() {
-        BUG_CHECK(std::holds_alternative<KVAnnotation>(body), "Annotation does not contain a key-value list.");
-        return std::get<KVAnnotation>(body);
+        try {
+            return std::get<KVAnnotation>(body);
+        } catch (const std::bad_variant_access &) {
+            BUG("Annotation does not contain a key-value list.");
+        }
     }
     inline const auto &getKV() const {
-        BUG_CHECK(std::holds_alternative<KVAnnotation>(body), "Annotation does not contain a key-value list.");
-        return std::get<KVAnnotation>(body);
+        try {
+            return std::get<KVAnnotation>(body);
+        } catch (const std::bad_variant_access &) {
+            BUG("Annotation does not contain a key-value list.");
+        }
     }
 
     /// If this is true this is a structured annotation, and there are some


### PR DESCRIPTION
Provide more useful feedback when trying to retrieve content from an annotation the wrong way. 