### PR TITLE
Pass to get rid of action_run() calls

### DIFF
--- a/backends/p4test/CMakeLists.txt
+++ b/backends/p4test/CMakeLists.txt
@@ -22,6 +22,7 @@ set (P4TEST_SRCS
   midend.cpp
   )
 set (P4TEST_HDRS
+  p4test.h
   midend.h
   )
 

--- a/backends/p4test/midend.cpp
+++ b/backends/p4test/midend.cpp
@@ -33,6 +33,7 @@ limitations under the License.
 #include "midend/complexComparison.h"
 #include "midend/copyStructures.h"
 #include "midend/def_use.h"
+#include "midend/eliminateActionRun.h"
 #include "midend/eliminateInvalidHeaders.h"
 #include "midend/eliminateNewtype.h"
 #include "midend/eliminateSerEnums.h"
@@ -76,7 +77,7 @@ class SkipControls : public P4::ActionSynthesisPolicy {
     }
 };
 
-MidEnd::MidEnd(CompilerOptions &options, std::ostream *outStream) {
+MidEnd::MidEnd(P4TestOptions &options, std::ostream *outStream) {
     bool isv1 = options.langVersion == CompilerOptions::FrontendVersion::P4_14;
     refMap.setIsV1(isv1);
     auto evaluator = new P4::EvaluatorPass(&refMap, &typeMap);
@@ -125,7 +126,8 @@ MidEnd::MidEnd(CompilerOptions &options, std::ostream *outStream) {
          new P4::SimplifyControlFlow(&typeMap, true),
          new P4::CompileTimeOperations(),
          new P4::TableHit(&typeMap),
-         new P4::EliminateSwitch(&typeMap),
+         !options.preferSwitch ? new P4::EliminateSwitch(&typeMap) : nullptr,
+         options.preferSwitch ? new P4::ElimActionRun() : nullptr,
          new P4::ResolveReferences(&refMap),
          new P4::TypeChecking(&refMap, &typeMap, true),  // update types before ComputeDefUse
          new PassRepeated({

--- a/backends/p4test/midend.h
+++ b/backends/p4test/midend.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "frontends/common/options.h"
 #include "frontends/p4/evaluator/evaluator.h"
 #include "ir/ir.h"
+#include "p4test.h"
 
 namespace P4::P4Test {
 
@@ -32,7 +33,7 @@ class MidEnd : public PassManager {
     IR::ToplevelBlock *toplevel = nullptr;
 
     void addDebugHook(DebugHook hook) { hooks.push_back(hook); }
-    explicit MidEnd(CompilerOptions &options, std::ostream *outStream = nullptr);
+    explicit MidEnd(P4TestOptions &options, std::ostream *outStream = nullptr);
     IR::ToplevelBlock *process(const IR::P4Program *&program) {
         addDebugHooks(hooks, true);
         program = program->apply(*this);

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "p4test.h"
+
 #include <fstream>  // IWYU pragma: keep
 #include <iostream>
 
@@ -35,57 +37,56 @@ limitations under the License.
 #include "lib/nullstream.h"
 #include "midend.h"
 
-using namespace P4;
-
-class P4TestOptions : public CompilerOptions {
- public:
-    bool parseOnly = false;
-    bool validateOnly = false;
-    bool loadIRFromJson = false;
-    P4TestOptions() {
-        registerOption(
-            "--listMidendPasses", nullptr,
-            [this](const char *) {
-                listMidendPasses = true;
-                loadIRFromJson = false;
-                P4Test::MidEnd MidEnd(*this, outStream);
-                exit(0);
-                return false;
-            },
-            "[p4test] Lists exact name of all midend passes.\n");
-        registerOption(
-            "--parse-only", nullptr,
-            [this](const char *) {
-                parseOnly = true;
-                return true;
-            },
-            "only parse the P4 input, without any further processing");
-        registerOption(
-            "--validate", nullptr,
-            [this](const char *) {
-                validateOnly = true;
-                return true;
-            },
-            "Validate the P4 input, running just the front-end");
-        registerOption(
-            "--fromJSON", "file",
-            [this](const char *arg) {
-                loadIRFromJson = true;
-                file = arg;
-                return true;
-            },
-            "read previously dumped json instead of P4 source code");
-        registerOption(
-            "--turn-off-logn", nullptr,
-            [](const char *) {
-                ::P4::Log::Detail::enableLoggingGlobally = false;
-                return true;
-            },
-            "Turn off LOGN() statements in the compiler.\n"
-            "Use '@__debug' annotation to enable LOGN on "
-            "the annotated P4 object within the source code.\n");
-    }
-};
+P4TestOptions::P4TestOptions() {
+    registerOption(
+        "--listMidendPasses", nullptr,
+        [this](const char *) {
+            listMidendPasses = true;
+            loadIRFromJson = false;
+            P4Test::MidEnd MidEnd(*this, outStream);
+            exit(0);
+            return false;
+        },
+        "[p4test] Lists exact name of all midend passes.\n");
+    registerOption(
+        "--parse-only", nullptr,
+        [this](const char *) {
+            parseOnly = true;
+            return true;
+        },
+        "only parse the P4 input, without any further processing");
+    registerOption(
+        "--validate", nullptr,
+        [this](const char *) {
+            validateOnly = true;
+            return true;
+        },
+        "Validate the P4 input, running just the front-end");
+    registerOption(
+        "--fromJSON", "file",
+        [this](const char *arg) {
+            loadIRFromJson = true;
+            file = arg;
+            return true;
+        },
+        "read previously dumped json instead of P4 source code");
+    registerOption(
+        "--turn-off-logn", nullptr,
+        [](const char *) {
+            ::P4::Log::Detail::enableLoggingGlobally = false;
+            return true;
+        },
+        "Turn off LOGN() statements in the compiler.\n"
+        "Use '@__debug' annotation to enable LOGN on "
+        "the annotated P4 object within the source code.\n");
+    registerOption(
+        "--preferSwitch", nullptr,
+        [this](const char *) {
+            preferSwitch = true;
+            return true;
+        },
+        "use passes that use general switch instead of action_run");
+}
 
 class P4TestPragmas : public P4::P4COptionPragmaParser {
     std::optional<IOptionPragmaParser::CommandLineOptions> tryToParse(

--- a/backends/p4test/p4test.h
+++ b/backends/p4test/p4test.h
@@ -1,0 +1,33 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef BACKENDS_P4TEST_P4TEST_H_
+#define BACKENDS_P4TEST_P4TEST_H_
+
+#include "frontends/common/options.h"
+
+using namespace P4;
+
+class P4TestOptions : public CompilerOptions {
+ public:
+    bool parseOnly = false;
+    bool validateOnly = false;
+    bool loadIRFromJson = false;
+    bool preferSwitch = false;
+    P4TestOptions();
+};
+
+#endif /* BACKENDS_P4TEST_P4TEST_H_ */

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -21,6 +21,7 @@ set (MIDEND_SRCS
   copyStructures.cpp
   coverage.cpp
   def_use.cpp
+  eliminateActionRun.cpp
   eliminateInvalidHeaders.cpp
   eliminateNewtype.cpp
   eliminateSerEnums.cpp
@@ -74,6 +75,7 @@ set (MIDEND_HDRS
   copyStructures.h
   coverage.h
   def_use.h
+  eliminateActionRun.h
   eliminateInvalidHeaders.h
   eliminateNewtype.h
   eliminateSerEnums.h

--- a/midend/eliminateActionRun.cpp
+++ b/midend/eliminateActionRun.cpp
@@ -1,0 +1,126 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "eliminateActionRun.h"
+
+#include "frontends/p4/methodInstance.h"
+
+namespace P4 {
+
+void ElimActionRun::ActionTableUse::postorder(const IR::Member *mem) {
+    if (mem->member != IR::Type_Table::action_run) return;
+    auto *mce = mem->expr->to<IR::MethodCallExpression>();
+    if (!mce) return;
+    auto *mi = MethodInstance::resolve(mce, this);
+    auto *tbl = mi->object->to<IR::P4Table>();
+    if (!tbl) return;
+    LOG3("found: " << mem);
+    auto [it, inserted] = self.actionRunTables.emplace(tbl->name, tbl);
+    if (!inserted) {
+        LOG3("  (additional apply() of table)");
+        return;
+    }
+    auto *info = &it->second;
+    IR::IndexedVector<IR::Declaration_ID> tags;
+    for (auto *ale : tbl->getActionList()->actionList) {
+        cstring name = ale->getName();
+        BUG_CHECK(!self.actionsToModify.count(name),
+                  "action %s used in multiple tables (%s and %s) -- LocalizeActions must be run "
+                  "before ElimActionRun",
+                  name, self.actionsToModify.at(name)->tbl->name, tbl->name);
+        self.actionsToModify[name] = info;
+        cstring tag = self.nameGen.newName(tbl->name + "_" + name);
+        info->actions.emplace(name, tag);
+        tags.push_back(new IR::Declaration_ID(tag));
+        LOG4("  action " << name << " [" << ale->expression << "] -> " << tag);
+    }
+    info->action_tags =
+        new IR::Type_Enum(self.nameGen.newName(tbl->name + "_action_run_t"), std::move(tags));
+    info->action_run = new IR::Declaration_Variable(self.nameGen.newName(tbl->name + "_action_run"),
+                                                    new IR::Type_Name(info->action_tags->name));
+}
+
+const IR::Expression *ElimActionRun::RewriteActionRun::postorder(IR::Member *mem) {
+    if (mem->member != IR::Type_Table::action_run) return mem;
+    auto *mce = mem->expr->to<IR::MethodCallExpression>();
+    if (!mce) return mem;
+    auto *mi = MethodInstance::resolve(mce, this);
+    auto *tbl = mi->object->to<IR::P4Table>();
+    if (!tbl) return mem;
+    auto &info = self.actionRunTables.at(tbl->name);
+    auto *parent = findContext<IR::Statement>();
+    BUG_CHECK(parent && parent->is<IR::SwitchStatement>(), "action_run not in switch");
+    auto &pps = self.prepend_statement[parent];
+    if (!pps) pps = new IR::Vector<IR::StatOrDecl>;
+    pps->push_back(new IR::MethodCallStatement(mce));
+    self.add_to_control.push_back(info.action_run);
+    return new IR::PathExpression(new IR::Type_Name(info.action_tags->name), info.action_run->name);
+}
+
+const IR::P4Action *ElimActionRun::RewriteActionRun::preorder(IR::P4Action *act) {
+    auto *info = get(self.actionsToModify, act->name);
+    if (!info) return act;
+    auto *body = act->body->clone();
+    auto *tag_type = new IR::Type_Name(info->action_tags->name);
+
+    body->components.insert(
+        body->components.begin(),
+        new IR::AssignmentStatement(
+            new IR::PathExpression(tag_type->clone(), info->action_run->name),
+            new IR::Member(new IR::TypeNameExpression(tag_type), info->actions.at(act->name))));
+    act->body = body;
+    return act;
+}
+
+const IR::SwitchCase *ElimActionRun::RewriteActionRun::postorder(IR::SwitchCase *swCase) {
+    auto *swtch = getParent<IR::SwitchStatement>();
+    BUG_CHECK(swtch, "case not in switch");
+    if (!self.prepend_statement.count(swtch)) return swCase;
+    if (swCase->label->is<IR::DefaultExpression>()) return swCase;
+    auto *pe = swCase->label->to<IR::PathExpression>();
+    BUG_CHECK(pe, "case label is not an action name");
+    auto *info = self.actionsToModify.at(pe->path->name);
+    auto *tag_type = new IR::Type_Name(info->action_tags->name);
+    swCase->label =
+        new IR::Member(new IR::TypeNameExpression(tag_type), info->actions.at(pe->path->name));
+    return swCase;
+}
+
+const IR::Node *ElimActionRun::RewriteActionRun::postorder(IR::Statement *stmt) {
+    auto *pps = get(self.prepend_statement, stmt);
+    if (!pps) return stmt;
+    pps->push_back(stmt);
+    self.prepend_statement.erase(stmt);
+    return pps;
+}
+
+const IR::P4Control *ElimActionRun::RewriteActionRun::postorder(IR::P4Control *ctrl) {
+    BUG_CHECK(self.prepend_statement.empty(), "orphan action_run in control %s", ctrl->name);
+    ctrl->controlLocals.prepend(self.add_to_control);
+    if (!self.add_to_control.empty()) LOG4(ctrl);
+    self.add_to_control.clear();
+    return ctrl;
+}
+
+const IR::P4Program *ElimActionRun::RewriteActionRun::postorder(IR::P4Program *prog) {
+    auto front = prog->objects.begin();
+    for (auto &[_, info] : self.actionRunTables)
+        front = std::next(prog->objects.insert(front, info.action_tags));
+    return prog;
+}
+
+}  // namespace P4

--- a/midend/eliminateActionRun.h
+++ b/midend/eliminateActionRun.h
@@ -1,0 +1,112 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIDEND_ELIMINATEACTIONRUN_H_
+#define MIDEND_ELIMINATEACTIONRUN_H_
+
+#include "frontends/common/resolveReferences/resolveReferences.h"
+#include "ir/ir.h"
+
+namespace P4 {
+
+/** Pass to convert table.apply().action_run into a temp metadata.
+ *
+ * This will take code that looks like
+ *
+ *              switch (table.apply().action_run) {
+ *                  .. cases for actions in the table ..
+ *
+ * and convert it into:
+ *
+ *              enum new_meta_t { .. tags for actions in the table ..
+ *                              } new_meta;
+ *              table.apply();
+ *              switch (new_meta) {
+ *                  .. cases for tags corresponding to actions ..
+ *
+ * where all the actions are modified to additionally set `new_meta` and
+ * the declaration of `new_meta` is up enough to be in scope for all the actions.
+ *
+ * This is more or less the reverse of what the EliminateSwitch pass does, so it
+ * never makes sense to include this pass along with EliminateSwitch.
+ */
+class ElimActionRun : public PassManager {
+    MinimalNameGenerator nameGen;
+
+    struct atinfo_t {
+        const IR::P4Table *tbl;
+        const IR::Type_Enum *action_tags;
+        const IR::Declaration_Variable *action_run;
+        std::map<cstring, cstring> actions;
+        explicit atinfo_t(const IR::P4Table *t) : tbl(t) {}
+    };
+
+    std::map<cstring, atinfo_t> actionRunTables;
+    std::map<cstring, atinfo_t *> actionsToModify;
+    std::map<const IR::Statement *, IR::Vector<IR::StatOrDecl> *> prepend_statement;
+    IR::Vector<IR::Declaration> add_to_control;
+
+    class ActionTableUse : public Inspector, public ResolutionContext {
+        ElimActionRun &self;
+
+     public:
+        explicit ActionTableUse(ElimActionRun &s) : self(s) {}
+
+        bool preorder(const IR::P4Parser *) override { return false; }
+        bool preorder(const IR::P4Action *) override { return false; }
+        bool preorder(const IR::Function *) override { return false; }
+
+        void postorder(const IR::Member *) override;
+    } actionTableUse;
+
+    class RewriteActionRun : public Transform, public ResolutionContext {
+        ElimActionRun &self;
+
+     public:
+        explicit RewriteActionRun(ElimActionRun &s) : self(s) {}
+
+        const IR::P4Parser *preorder(IR::P4Parser *p) override {
+            prune();
+            return p;
+        }
+        const IR::Function *preorder(IR::Function *f) override {
+            prune();
+            return f;
+        }
+
+        const IR::Expression *postorder(IR::Member *) override;
+        const IR::P4Action *preorder(IR::P4Action *) override;
+        const IR::SwitchCase *postorder(IR::SwitchCase *) override;
+        const IR::Node *postorder(IR::Statement *) override;
+        const IR::P4Control *postorder(IR::P4Control *) override;
+        const IR::P4Program *postorder(IR::P4Program *) override;
+    };
+
+ public:
+    ElimActionRun() : actionTableUse(*this) {
+        addPasses({&actionTableUse, new PassIf([this]() { return !actionRunTables.empty(); },
+                                               {
+                                                   &nameGen,
+                                                   new RewriteActionRun(*this),
+                                                   [this]() { actionRunTables.clear(); },
+                                               })});
+    }
+};
+
+}  // namespace P4
+
+#endif /* MIDEND_ELIMINATEACTIONRUN_H_ */

--- a/testdata/p4_16_samples/elimActRun1.p4
+++ b/testdata/p4_16_samples/elimActRun1.p4
@@ -1,0 +1,51 @@
+#include <core.p4>
+
+@command_line("--preferSwitch")
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    action dummy_action() {    }
+    table simple_table_1 {
+        key = {
+            48w1 : exact @name("key") ;
+        }
+        actions = {
+            dummy_action();
+        }
+    }
+    table simple_table_2 {
+        key = {
+            48w1 : exact @name("key") ;
+        }
+        actions = {
+            dummy_action();
+        }
+    }
+    apply {
+        switch (simple_table_1.apply().action_run) {
+            dummy_action: {
+                switch (simple_table_2.apply().action_run) {
+                    dummy_action: {
+                        h.eth_hdr.src_addr = 4;
+                        return;
+                    }
+                }
+            }
+        }
+        exit;
+
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> c);
+top(ingress()) main;

--- a/testdata/p4_16_samples_outputs/elimActRun1-first.p4
+++ b/testdata/p4_16_samples_outputs/elimActRun1-first.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+
+@command_line("--preferSwitch") header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    action dummy_action() {
+    }
+    table simple_table_1 {
+        key = {
+            48w1: exact @name("key");
+        }
+        actions = {
+            dummy_action();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    table simple_table_2 {
+        key = {
+            48w1: exact @name("key");
+        }
+        actions = {
+            dummy_action();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        switch (simple_table_1.apply().action_run) {
+            dummy_action: {
+                switch (simple_table_2.apply().action_run) {
+                    dummy_action: {
+                        h.eth_hdr.src_addr = 48w4;
+                        return;
+                    }
+                    default: {
+                    }
+                }
+            }
+            default: {
+            }
+        }
+        exit;
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_samples_outputs/elimActRun1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/elimActRun1-frontend.p4
@@ -1,0 +1,69 @@
+#include <core.p4>
+
+@command_line("--preferSwitch") header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    @name("ingress.hasReturned") bool hasReturned;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_2() {
+    }
+    @name("ingress.dummy_action") action dummy_action() {
+    }
+    @name("ingress.dummy_action") action dummy_action_1() {
+    }
+    @name("ingress.simple_table_1") table simple_table {
+        key = {
+            48w1: exact @name("key");
+        }
+        actions = {
+            dummy_action();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    @name("ingress.simple_table_2") table simple_table_0 {
+        key = {
+            48w1: exact @name("key");
+        }
+        actions = {
+            dummy_action_1();
+            @defaultonly NoAction_2();
+        }
+        default_action = NoAction_2();
+    }
+    apply {
+        hasReturned = false;
+        switch (simple_table.apply().action_run) {
+            dummy_action: {
+                switch (simple_table_0.apply().action_run) {
+                    dummy_action_1: {
+                        h.eth_hdr.src_addr = 48w4;
+                        hasReturned = true;
+                    }
+                    default: {
+                    }
+                }
+            }
+            default: {
+            }
+        }
+        if (hasReturned) {
+            ;
+        } else {
+            exit;
+        }
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_samples_outputs/elimActRun1-midend.p4
+++ b/testdata/p4_16_samples_outputs/elimActRun1-midend.p4
@@ -1,0 +1,113 @@
+enum simple_table_action_run_t {
+    simple_table_dummy_action,
+    simple_table_NoAction
+}
+
+enum simple_table_0_action_run_t {
+    simple_table_0_dummy_action,
+    simple_table_0_NoAction
+}
+
+#include <core.p4>
+
+@command_line("--preferSwitch") header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    simple_table_action_run_t simple_table_action_run;
+    simple_table_0_action_run_t simple_table_0_action_run;
+    @name("ingress.hasReturned") bool hasReturned;
+    bit<48> key_0;
+    bit<48> key_1;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+        simple_table_action_run = simple_table_action_run_t.simple_table_NoAction;
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_2() {
+        simple_table_0_action_run = simple_table_0_action_run_t.simple_table_0_NoAction;
+    }
+    @name("ingress.dummy_action") action dummy_action() {
+        simple_table_action_run = simple_table_action_run_t.simple_table_dummy_action;
+    }
+    @name("ingress.dummy_action") action dummy_action_1() {
+        simple_table_0_action_run = simple_table_0_action_run_t.simple_table_0_dummy_action;
+    }
+    @name("ingress.simple_table_1") table simple_table {
+        key = {
+            key_0: exact @name("key");
+        }
+        actions = {
+            dummy_action();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    @name("ingress.simple_table_2") table simple_table_0 {
+        key = {
+            key_1: exact @name("key");
+        }
+        actions = {
+            dummy_action_1();
+            @defaultonly NoAction_2();
+        }
+        default_action = NoAction_2();
+    }
+    @hidden action elimActRun1l19() {
+        hasReturned = false;
+        key_0 = 48w1;
+    }
+    @hidden action elimActRun1l27() {
+        key_1 = 48w1;
+    }
+    @hidden action elimActRun1l38() {
+        h.eth_hdr.src_addr = 48w4;
+        hasReturned = true;
+    }
+    @hidden table tbl_elimActRun1l19 {
+        actions = {
+            elimActRun1l19();
+        }
+        const default_action = elimActRun1l19();
+    }
+    @hidden table tbl_elimActRun1l27 {
+        actions = {
+            elimActRun1l27();
+        }
+        const default_action = elimActRun1l27();
+    }
+    @hidden table tbl_elimActRun1l38 {
+        actions = {
+            elimActRun1l38();
+        }
+        const default_action = elimActRun1l38();
+    }
+    apply {
+        tbl_elimActRun1l19.apply();
+        simple_table.apply();
+        switch (simple_table_action_run) {
+            simple_table_action_run_t.simple_table_dummy_action: {
+                tbl_elimActRun1l27.apply();
+                simple_table_0.apply();
+                switch (simple_table_0_action_run) {
+                    simple_table_0_action_run_t.simple_table_0_dummy_action: {
+                        tbl_elimActRun1l38.apply();
+                    }
+                    default: {
+                    }
+                }
+            }
+            default: {
+            }
+        }
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_samples_outputs/elimActRun1.p4
+++ b/testdata/p4_16_samples_outputs/elimActRun1.p4
@@ -1,0 +1,49 @@
+#include <core.p4>
+
+@command_line("--preferSwitch") header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+}
+
+control ingress(inout Headers h) {
+    action dummy_action() {
+    }
+    table simple_table_1 {
+        key = {
+            48w1: exact @name("key");
+        }
+        actions = {
+            dummy_action();
+        }
+    }
+    table simple_table_2 {
+        key = {
+            48w1: exact @name("key");
+        }
+        actions = {
+            dummy_action();
+        }
+    }
+    apply {
+        switch (simple_table_1.apply().action_run) {
+            dummy_action: {
+                switch (simple_table_2.apply().action_run) {
+                    dummy_action: {
+                        h.eth_hdr.src_addr = 4;
+                        return;
+                    }
+                }
+            }
+        }
+        exit;
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> c);
+top(ingress()) main;

--- a/testdata/p4_16_samples_outputs/elimActRun1.p4-stderr
+++ b/testdata/p4_16_samples_outputs/elimActRun1.p4-stderr
@@ -1,0 +1,12 @@
+elimActRun1.p4(19): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            48w1 : exact @name("key") ;
+            ^^^^
+elimActRun1.p4(27): [--Wwarn=ignore-prop] warning: KeyElement: constant key element
+            48w1 : exact @name("key") ;
+            ^^^^
+elimActRun1.p4(19): [--Wwarn=mismatch] warning: 48w1: Constant key field
+            48w1 : exact @name("key") ;
+            ^^^^
+elimActRun1.p4(27): [--Wwarn=mismatch] warning: 48w1: Constant key field
+            48w1 : exact @name("key") ;
+            ^^^^

--- a/testdata/p4_16_samples_outputs/elimActRun1.p4.entries.txtpb
+++ b/testdata/p4_16_samples_outputs/elimActRun1.p4.entries.txtpb
@@ -1,0 +1,3 @@
+# proto-file: p4/v1/p4runtime.proto
+# proto-message: p4.v1.WriteRequest
+

--- a/testdata/p4_16_samples_outputs/elimActRun1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/elimActRun1.p4.p4info.txtpb
@@ -1,0 +1,73 @@
+# proto-file: p4/config/v1/p4info.proto
+# proto-message: p4.config.v1.P4Info
+
+pkg_info {
+  arch: "v1model"
+}
+tables {
+  preamble {
+    id: 36787877
+    name: "ingress.simple_table_1"
+    alias: "simple_table_1"
+  }
+  match_fields {
+    id: 1
+    name: "key"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 27880877
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
+  }
+  size: 1024
+}
+tables {
+  preamble {
+    id: 48738834
+    name: "ingress.simple_table_2"
+    alias: "simple_table_2"
+  }
+  match_fields {
+    id: 1
+    name: "key"
+    bitwidth: 48
+    match_type: EXACT
+  }
+  action_refs {
+    id: 27880877
+  }
+  action_refs {
+    id: 21257015
+    annotations: "@defaultonly"
+    scope: DEFAULT_ONLY
+  }
+  initial_default_action {
+    action_id: 21257015
+  }
+  size: 1024
+}
+actions {
+  preamble {
+    id: 21257015
+    name: "NoAction"
+    alias: "NoAction"
+    annotations: "@noWarn(\"unused\")"
+  }
+}
+actions {
+  preamble {
+    id: 27880877
+    name: "ingress.dummy_action"
+    alias: "dummy_action"
+  }
+}
+type_info {
+}


### PR DESCRIPTION
This is a general midend pass for any target that does not support `action_run` directly.  It rewrites the actions in a table that uses action_run to set a newly introduced metadata tmp enum that records which action was run, and changes the switch statement to use that.

It is kind-of logically the reverse of EliminateSwitch, which converts switch statements that *don't* use `action_run()` into ones that do, so it would never make sense to use both passes for a backend.

Need to update p4test so we can select which pass(es) to run in a test by some annotation in the test program to better allow testing this.
