### PR TITLE
Ignore typeless structs in unstructured annotations

### DIFF
--- a/frontends/p4/specializeGenericTypes.cpp
+++ b/frontends/p4/specializeGenericTypes.cpp
@@ -167,6 +167,9 @@ const IR::Node *ReplaceTypeUses::postorder(IR::Type_Specialized *type) {
 }
 
 const IR::Node *ReplaceTypeUses::postorder(IR::StructExpression *expression) {
+    const IR::Annotation *anNode = findContext<IR::Annotation>();
+    if (anNode != nullptr && !anNode->structured) return expression;
+
     auto st = getOriginal<IR::StructExpression>()->structType;
     if (!st) {
         ::P4::error(ErrorType::ERR_TYPE_ERROR,


### PR DESCRIPTION
This pass expects struct expressions in unstructured annotations to have explicit types. Using { } in unstructured annotation is actually allowed by the language spec, it does not make sense for the frontend to prevent this (in fact any sequence of tokens can be used as long as parentheses are balanced).