### PR TITLE
Teach functions inliner to inline into if condition

### DIFF
--- a/frontends/p4/functionsInlining.h
+++ b/frontends/p4/functionsInlining.h
@@ -86,6 +86,7 @@ class FunctionsInliner : public AbstractInliner<FunctionsInlineList, FunctionsIn
     const IR::Node *preorder(IR::MethodCallStatement *statement) override;
     const IR::Node *preorder(IR::MethodCallExpression *expr) override;
     const IR::Node *preorder(IR::AssignmentStatement *statement) override;
+    const IR::Node *preorder(IR::IfStatement *statement) override;
 };
 
 typedef InlineDriver<FunctionsInlineList, FunctionsInlineWorkList> InlineFunctionsDriver;

--- a/testdata/p4_16_samples/inline-function2.p4
+++ b/testdata/p4_16_samples/inline-function2.p4
@@ -1,0 +1,33 @@
+bit foo(in bit a) {
+  return a + 1; 
+}
+
+control p(inout bit bt) {
+    action a(inout bit y0, bit y1) {
+      bit y2 = y1 > 0 ? 1w1 : 0;
+      if (y2 == 1) {
+         y0 = 0;
+      } else if (y1 != 1) {
+         y0 = y0 | 1w1;
+      }
+    }
+
+    action b() {
+        a(bt, foo(bt));
+        a(bt, 1);
+    }
+
+    table t {
+        actions = { b; }
+        default_action = b;
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+control simple<T>(inout T arg);
+package m<T>(simple<T> pipe);
+
+m(p()) main;

--- a/testdata/p4_16_samples_outputs/inline-function2-first.p4
+++ b/testdata/p4_16_samples_outputs/inline-function2-first.p4
@@ -1,0 +1,30 @@
+bit<1> foo(in bit<1> a) {
+    return a + 1w1;
+}
+control p(inout bit<1> bt) {
+    action a(inout bit<1> y0, bit<1> y1) {
+        bit<1> y2 = (y1 > 1w0 ? 1w1 : 1w0);
+        if (y2 == 1w1) {
+            y0 = 1w0;
+        } else if (y1 != 1w1) {
+            y0 = y0 | 1w1;
+        }
+    }
+    action b() {
+        a(bt, foo(bt));
+        a(bt, 1w1);
+    }
+    table t {
+        actions = {
+            b();
+        }
+        default_action = b();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control simple<T>(inout T arg);
+package m<T>(simple<T> pipe);
+m<bit<1>>(p()) main;

--- a/testdata/p4_16_samples_outputs/inline-function2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/inline-function2-frontend.p4
@@ -1,0 +1,53 @@
+control p(inout bit<1> bt) {
+    @name("p.y2") bit<1> y2_0;
+    @name("p.tmp") bit<1> tmp;
+    @name("p.y0") bit<1> y0;
+    @name("p.y0") bit<1> y0_1;
+    @name("p.a_0") bit<1> a;
+    @name("p.retval") bit<1> retval;
+    @name("p.a_1") bit<1> a_2;
+    @name("p.retval") bit<1> retval_1;
+    @name("p.b") action b() {
+        y0 = bt;
+        a = bt;
+        retval = a + 1w1;
+        if (retval > 1w0) {
+            tmp = 1w1;
+        } else {
+            tmp = 1w0;
+        }
+        y2_0 = tmp;
+        if (y2_0 == 1w1) {
+            y0 = 1w0;
+        } else {
+            a_2 = bt;
+            retval_1 = a_2 + 1w1;
+            if (retval_1 != 1w1) {
+                y0 = y0 | 1w1;
+            }
+        }
+        bt = y0;
+        y0_1 = bt;
+        tmp = 1w1;
+        y2_0 = tmp;
+        if (y2_0 == 1w1) {
+            y0_1 = 1w0;
+        } else {
+            ;
+        }
+        bt = y0_1;
+    }
+    @name("p.t") table t_0 {
+        actions = {
+            b();
+        }
+        default_action = b();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control simple<T>(inout T arg);
+package m<T>(simple<T> pipe);
+m<bit<1>>(p()) main;

--- a/testdata/p4_16_samples_outputs/inline-function2-midend.p4
+++ b/testdata/p4_16_samples_outputs/inline-function2-midend.p4
@@ -1,0 +1,33 @@
+control p(inout bit<1> bt) {
+    @name("p.tmp") bit<1> tmp;
+    @name("p.y0") bit<1> y0;
+    @name("p.b") action b() {
+        y0 = bt;
+        if (bt + 1w1 > 1w0) {
+            tmp = 1w1;
+        } else {
+            tmp = 1w0;
+        }
+        if (tmp == 1w1) {
+            y0 = 1w0;
+        } else if (bt + 1w1 != 1w1) {
+            y0 = bt | 1w1;
+        }
+        bt = y0;
+        tmp = 1w1;
+        bt = 1w0;
+    }
+    @name("p.t") table t_0 {
+        actions = {
+            b();
+        }
+        default_action = b();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control simple<T>(inout T arg);
+package m<T>(simple<T> pipe);
+m<bit<1>>(p()) main;

--- a/testdata/p4_16_samples_outputs/inline-function2.p4
+++ b/testdata/p4_16_samples_outputs/inline-function2.p4
@@ -1,0 +1,30 @@
+bit<1> foo(in bit<1> a) {
+    return a + 1;
+}
+control p(inout bit<1> bt) {
+    action a(inout bit<1> y0, bit<1> y1) {
+        bit<1> y2 = (y1 > 0 ? 1w1 : 0);
+        if (y2 == 1) {
+            y0 = 0;
+        } else if (y1 != 1) {
+            y0 = y0 | 1w1;
+        }
+    }
+    action b() {
+        a(bt, foo(bt));
+        a(bt, 1);
+    }
+    table t {
+        actions = {
+            b;
+        }
+        default_action = b;
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control simple<T>(inout T arg);
+package m<T>(simple<T> pipe);
+m(p()) main;


### PR DESCRIPTION
The problem is hidden in many cases by side effects ordering, however, it could be further exposed for action arguments after actions inlining.

Without this PR we're ending in ICE trying to perform an inline as inliner can only do this for plain `MethodCallStatement` and `AssignmentStatement`.