### PR TITLE
Small fixes for p4tc

### DIFF
--- a/backends/tc/ebpfCodeGen.cpp
+++ b/backends/tc/ebpfCodeGen.cpp
@@ -1260,7 +1260,8 @@ void IngressDeparserPNA::emit(EBPF::CodeBuilder *builder) {
     builder->emitIndent();
     builder->appendLine("// 0x0800 = IPv4, 0x86dd = IPv6");
     builder->emitIndent();
-    builder->append("if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) ");
+    builder->append(
+        "if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) ");
     builder->blockStart();
     builder->emitIndent();
     builder->appendFormat("saved_proto = skb->protocol");
@@ -1269,7 +1270,7 @@ void IngressDeparserPNA::emit(EBPF::CodeBuilder *builder) {
     builder->appendFormat("have_saved_proto = true");
     builder->endOfStatement(true);
     builder->emitIndent();
-    builder->appendFormat("bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800)");
+    builder->appendFormat("bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800))");
     builder->endOfStatement(true);
     builder->emitIndent();
     builder->appendFormat("bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set))");

--- a/backends/tc/ebpfCodeGen.cpp
+++ b/backends/tc/ebpfCodeGen.cpp
@@ -485,6 +485,9 @@ void TCIngressPipelinePNA::emitGlobalMetadataInitializer(EBPF::CodeBuilder *buil
     builder->emitIndent();
     builder->append("compiler_meta__->recirculate = false;");
     builder->newline();
+    builder->emitIndent();
+    builder->append("compiler_meta__->egress_port = 0;");
+    builder->newline();
 
     // workaround to make TC protocol-independent, DO NOT REMOVE
     builder->emitIndent();

--- a/backends/tc/runtime/pna.h
+++ b/backends/tc/runtime/pna.h
@@ -114,12 +114,12 @@ struct __attribute__((__packed__)) p4tc_table_entry_act_bpf {
 
 struct p4tc_table_entry_create_bpf_params__local {
         struct p4tc_table_entry_act_bpf act_bpf;
+        u32 profile_id;
         u32 pipeid;
         u32 tblid;
-        u32 profile_id;
-        u32 handle;                                                                     
-        u32 classid;                                                                               
-        u32 chain;                     
+        u32 handle;
+        u32 chain;
+        u32 classid;
         u16 proto;
         u16 prio;
 };

--- a/testdata/p4tc_samples_outputs/add_entry_1_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/add_entry_1_example_control_blocks.c
@@ -318,6 +318,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/add_entry_1_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/add_entry_1_example_control_blocks.c
@@ -162,10 +162,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/add_entry_3_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/add_entry_3_example_control_blocks.c
@@ -318,6 +318,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/add_entry_3_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/add_entry_3_example_control_blocks.c
@@ -162,10 +162,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/add_entry_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/add_entry_example_control_blocks.c
@@ -391,6 +391,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/add_entry_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/add_entry_example_control_blocks.c
@@ -236,10 +236,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/calculator_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/calculator_control_blocks.c
@@ -333,6 +333,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/calculator_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/calculator_control_blocks.c
@@ -200,10 +200,10 @@ if (/* hdr->p4calc.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/checksum_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/checksum_control_blocks.c
@@ -134,10 +134,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/checksum_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/checksum_control_blocks.c
@@ -289,6 +289,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/const_entries_range_mask_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/const_entries_range_mask_control_blocks.c
@@ -154,6 +154,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/const_entries_range_mask_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/const_entries_range_mask_control_blocks.c
@@ -119,10 +119,10 @@ static __always_inline int process(struct __sk_buff *skb, struct Header_t *h, st
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/default_action_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_01_control_blocks.c
@@ -347,6 +347,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/default_action_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_01_control_blocks.c
@@ -190,10 +190,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
@@ -210,10 +210,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_example_control_blocks.c
@@ -367,6 +367,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/default_action_with_param_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_01_control_blocks.c
@@ -367,6 +367,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/default_action_with_param_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_01_control_blocks.c
@@ -210,10 +210,10 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/default_action_with_param_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_control_blocks.c
@@ -210,10 +210,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/default_action_with_param_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_action_with_param_control_blocks.c
@@ -367,6 +367,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
@@ -213,6 +213,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/default_hit_const_example_control_blocks.c
@@ -135,10 +135,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/digest_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/digest_01_control_blocks.c
@@ -310,6 +310,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/digest_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/digest_01_control_blocks.c
@@ -155,10 +155,10 @@ if (meta->send_digest) {
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/digest_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/digest_control_blocks.c
@@ -311,6 +311,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/digest_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/digest_control_blocks.c
@@ -156,10 +156,10 @@ if (meta->send_digest) {
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/digest_parser_meta_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/digest_parser_meta_control_blocks.c
@@ -151,10 +151,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/digest_parser_meta_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/digest_parser_meta_control_blocks.c
@@ -306,6 +306,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/direct_counter_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/direct_counter_example_control_blocks.c
@@ -300,6 +300,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/direct_counter_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/direct_counter_example_control_blocks.c
@@ -143,10 +143,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/direct_meter_color_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/direct_meter_color_control_blocks.c
@@ -302,6 +302,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/direct_meter_color_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/direct_meter_color_control_blocks.c
@@ -145,10 +145,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/direct_meter_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/direct_meter_control_blocks.c
@@ -139,10 +139,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/direct_meter_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/direct_meter_control_blocks.c
@@ -296,6 +296,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
@@ -290,6 +290,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/drop_packet_example_control_blocks.c
@@ -133,10 +133,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
@@ -362,6 +362,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_01_control_blocks.c
@@ -207,10 +207,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
@@ -364,6 +364,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/global_action_example_02_control_blocks.c
@@ -209,10 +209,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/hash1_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/hash1_control_blocks.c
@@ -68,10 +68,10 @@ ingress_h_reg;
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/hash1_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/hash1_control_blocks.c
@@ -187,6 +187,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/hash_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/hash_control_blocks.c
@@ -68,10 +68,10 @@ ingress_h_reg ^ 0xFFFFFFFF;
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/hash_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/hash_control_blocks.c
@@ -191,6 +191,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/indirect_counter_01_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/indirect_counter_01_example_control_blocks.c
@@ -149,10 +149,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/indirect_counter_01_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/indirect_counter_01_example_control_blocks.c
@@ -306,6 +306,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/internetchecksum_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/internetchecksum_01_control_blocks.c
@@ -241,10 +241,10 @@ struct p4tc_ext_csum_params chk_csum = {};
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/internetchecksum_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/internetchecksum_01_control_blocks.c
@@ -475,6 +475,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/ipip_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/ipip_control_blocks.c
@@ -175,10 +175,10 @@ if (/* hdr->outer.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/ipip_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/ipip_control_blocks.c
@@ -413,6 +413,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/is_host_port_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/is_host_port_control_blocks.c
@@ -146,10 +146,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/is_host_port_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/is_host_port_control_blocks.c
@@ -303,6 +303,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/is_net_port_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/is_net_port_control_blocks.c
@@ -146,10 +146,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/is_net_port_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/is_net_port_control_blocks.c
@@ -303,6 +303,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
@@ -358,10 +358,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/matchtype_control_blocks.c
@@ -515,6 +515,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/meter_color_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/meter_color_control_blocks.c
@@ -146,10 +146,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/meter_color_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/meter_color_control_blocks.c
@@ -303,6 +303,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/meter_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/meter_control_blocks.c
@@ -301,6 +301,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/meter_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/meter_control_blocks.c
@@ -144,10 +144,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
@@ -521,6 +521,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/mix_matchtype_example_control_blocks.c
@@ -364,10 +364,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
@@ -772,6 +772,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_01_control_blocks.c
@@ -615,10 +615,10 @@ if (hdr->ipv4.protocol != 4 || (hdr->tcp.srcPort <= 3)) {
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
@@ -772,6 +772,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/multiple_tables_example_02_control_blocks.c
@@ -615,10 +615,10 @@ if (hdr->ipv4.protocol == 6 || ((hdr->ipv4.version > 1) && (hdr->ipv4.ihl <= 2))
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
@@ -208,10 +208,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/name_annotation_example_control_blocks.c
@@ -365,6 +365,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/no_table_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/no_table_example_control_blocks.c
@@ -66,10 +66,10 @@ if ((u32)skb->ifindex == 4) {
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/no_table_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/no_table_example_control_blocks.c
@@ -257,6 +257,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
@@ -208,10 +208,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_01_control_blocks.c
@@ -365,6 +365,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
@@ -341,6 +341,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/noaction_example_02_control_blocks.c
@@ -184,10 +184,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
@@ -131,10 +131,10 @@ if (((u32)skb->ifindex == 2 && /* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/nummask_annotation_example_control_blocks.c
@@ -209,6 +209,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
@@ -320,6 +320,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/send_to_port_example_control_blocks.c
@@ -163,10 +163,10 @@ ext_val = *ext_val_ptr;
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
@@ -375,6 +375,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/set_entry_timer_example_control_blocks.c
@@ -218,10 +218,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
@@ -291,6 +291,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_exact_example_control_blocks.c
@@ -134,10 +134,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/simple_extern_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_extern_example_control_blocks.c
@@ -185,10 +185,10 @@ ext_val = *ext_val_ptr;
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/simple_extern_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_extern_example_control_blocks.c
@@ -342,6 +342,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
@@ -134,10 +134,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_lpm_example_control_blocks.c
@@ -289,6 +289,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
@@ -140,10 +140,10 @@ static __always_inline int process(struct __sk_buff *skb, struct my_ingress_head
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/simple_ternary_example_control_blocks.c
@@ -295,6 +295,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
@@ -208,10 +208,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/size_param_example_control_blocks.c
@@ -365,6 +365,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/skb_meta_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/skb_meta_control_blocks.c
@@ -151,10 +151,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/skb_meta_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/skb_meta_control_blocks.c
@@ -314,6 +314,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_01_control_blocks.c
@@ -228,10 +228,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_01_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_01_control_blocks.c
@@ -385,6 +385,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_02_control_blocks.c
@@ -210,10 +210,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_02_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_02_control_blocks.c
@@ -367,6 +367,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_03_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_03_control_blocks.c
@@ -367,6 +367,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_03_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_03_control_blocks.c
@@ -210,10 +210,10 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_04_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_04_control_blocks.c
@@ -222,10 +222,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_04_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_04_control_blocks.c
@@ -379,6 +379,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_05_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_05_control_blocks.c
@@ -219,10 +219,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_05_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_05_control_blocks.c
@@ -376,6 +376,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_06_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_06_control_blocks.c
@@ -228,10 +228,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_06_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_06_control_blocks.c
@@ -385,6 +385,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_07_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_07_control_blocks.c
@@ -237,10 +237,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_07_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_07_control_blocks.c
@@ -394,6 +394,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_08_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_08_control_blocks.c
@@ -237,10 +237,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_08_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_08_control_blocks.c
@@ -394,6 +394,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_09_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_09_control_blocks.c
@@ -228,10 +228,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/tc_may_override_example_09_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_may_override_example_09_control_blocks.c
@@ -385,6 +385,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/tc_type_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_type_annotation_example_control_blocks.c
@@ -186,10 +186,10 @@ if (/* hdr->ipv4.isValid() */
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/tc_type_annotation_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/tc_type_annotation_example_control_blocks.c
@@ -341,6 +341,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;

--- a/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
@@ -120,10 +120,10 @@ static __always_inline int process(struct __sk_buff *skb, struct headers_t *hdr,
         bool have_saved_proto = false;
         // bpf_skb_adjust_room works only when protocol is IPv4 or IPv6
         // 0x0800 = IPv4, 0x86dd = IPv6
-        if ((skb->protocol != 0x0800) && (skb->protocol != 0x86dd)) {
+        if ((skb->protocol != bpf_htons(0x0800)) && (skb->protocol != bpf_htons(0x86dd))) {
             saved_proto = skb->protocol;
             have_saved_proto = true;
-            bpf_p4tc_skb_set_protocol(skb, &sa->set, 0x0800);
+            bpf_p4tc_skb_set_protocol(skb, &sa->set, bpf_htons(0x0800));
             bpf_p4tc_skb_meta_set(skb, &sa->set, sizeof(sa->set));
         }
         ;

--- a/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
+++ b/testdata/p4tc_samples_outputs/test_ipv6_example_control_blocks.c
@@ -305,6 +305,7 @@ int tc_ingress_func(struct __sk_buff *skb) {
     struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
     compiler_meta__->drop = false;
     compiler_meta__->recirculate = false;
+    compiler_meta__->egress_port = 0;
     if (!compiler_meta__->recirculated) {
         compiler_meta__->mark = 153;
         struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;


### PR DESCRIPTION
- Convert IPv4 and IPv6 protocol values to network order before comparison
- Update pna.h
- Zero initialise compiler_meta__->egress_port