### PR TITLE
lib: Add P4::warningCount() and P4::infoCount()

### DIFF
--- a/lib/error.h
+++ b/lib/error.h
@@ -30,17 +30,22 @@ limitations under the License.
 
 namespace P4 {
 
-/// @return the number of errors encountered so far in the current compilation
-/// context.
+/// @return the number of errors encountered so far in the current compilation context.
 inline unsigned errorCount() { return BaseCompileContext::get().errorReporter().getErrorCount(); }
 
-/// @return the number of diagnostics (either errors or warnings) encountered so
-/// far in the current compilation context.
+/// @return the number of warnings encountered so far in the current compilation context.
+inline unsigned warningCount() { return BaseCompileContext::get().errorReporter().getWarningCount(); }
+
+/// @return the number of infos encountered so far in the current compilation context.
+inline unsigned infoCount() { return BaseCompileContext::get().errorReporter().getInfoCount(); }
+
+/// @return the number of diagnostics (either errors, warnings or infos) encountered so far in the
+/// current compilation context.
 inline unsigned diagnosticCount() {
     return BaseCompileContext::get().errorReporter().getDiagnosticCount();
 }
 
-// Errors (and warnings) are specified using boost::format format strings, i.e.,
+// Errors (and warnings and info) are specified using boost::format format strings, i.e.,
 // %1%, %2%, etc (starting at 1, not at 0).
 // Some compatibility for printf-style arguments is also supported.
 

--- a/lib/error.h
+++ b/lib/error.h
@@ -34,7 +34,9 @@ namespace P4 {
 inline unsigned errorCount() { return BaseCompileContext::get().errorReporter().getErrorCount(); }
 
 /// @return the number of warnings encountered so far in the current compilation context.
-inline unsigned warningCount() { return BaseCompileContext::get().errorReporter().getWarningCount(); }
+inline unsigned warningCount() {
+    return BaseCompileContext::get().errorReporter().getWarningCount();
+}
 
 /// @return the number of infos encountered so far in the current compilation context.
 inline unsigned infoCount() { return BaseCompileContext::get().errorReporter().getInfoCount(); }

--- a/lib/error.h
+++ b/lib/error.h
@@ -45,7 +45,7 @@ inline unsigned diagnosticCount() {
     return BaseCompileContext::get().errorReporter().getDiagnosticCount();
 }
 
-// Errors (and warnings and info) are specified using boost::format format strings, i.e.,
+// Errors, warnings, and info are specified using boost::format format strings, i.e.,
 // %1%, %2%, etc (starting at 1, not at 0).
 // Some compatibility for printf-style arguments is also supported.
 

--- a/lib/error.h
+++ b/lib/error.h
@@ -45,7 +45,7 @@ inline unsigned diagnosticCount() {
     return BaseCompileContext::get().errorReporter().getDiagnosticCount();
 }
 
-// Errors, warnings, and info are specified using boost::format format strings, i.e.,
+// Errors, warnings, and infos are specified using boost::format format strings, i.e.,
 // %1%, %2%, etc (starting at 1, not at 0).
 // Some compatibility for printf-style arguments is also supported.
 

--- a/test/gtest/diagnostics.cpp
+++ b/test/gtest/diagnostics.cpp
@@ -69,7 +69,10 @@ TEST_F(Diagnostics, P4_16_Disable) {
         @diagnostic("uninitialized_out_param", "disable")
     )"));
     EXPECT_TRUE(test);
-    EXPECT_EQ(0u, ::P4::diagnosticCount());
+    EXPECT_EQ(0u, P4::diagnosticCount());
+    EXPECT_EQ(0u, P4::errorCount());
+    EXPECT_EQ(0u, P4::warningCount());
+    EXPECT_EQ(0u, P4::infoCount());
 }
 
 TEST_F(Diagnostics, P4_16_Warn) {
@@ -77,8 +80,9 @@ TEST_F(Diagnostics, P4_16_Warn) {
         @diagnostic("uninitialized_out_param", "warn")
     )"));
     EXPECT_TRUE(test);
-    EXPECT_EQ(1u, ::P4::diagnosticCount());
-    EXPECT_EQ(0u, ::P4::errorCount());
+    EXPECT_EQ(1u, P4::diagnosticCount());
+    EXPECT_EQ(1u, P4::warningCount());
+    EXPECT_EQ(0u, P4::errorCount());
 }
 
 TEST_F(Diagnostics, P4_16_Error) {
@@ -86,8 +90,9 @@ TEST_F(Diagnostics, P4_16_Error) {
         @diagnostic("uninitialized_out_param", "error")
     )"));
     EXPECT_FALSE(test);
-    EXPECT_EQ(1u, ::P4::diagnosticCount());
-    EXPECT_EQ(1u, ::P4::errorCount());
+    EXPECT_EQ(1u, P4::diagnosticCount());
+    EXPECT_EQ(0u, P4::warningCount());
+    EXPECT_EQ(1u, P4::errorCount());
 }
 
 TEST_F(Diagnostics, DISABLED_P4_14_Disable) {
@@ -95,7 +100,7 @@ TEST_F(Diagnostics, DISABLED_P4_14_Disable) {
         @pragma diagnostic uninitialized_use disable
     )"));
     EXPECT_TRUE(test);
-    EXPECT_EQ(0u, ::P4::diagnosticCount());
+    EXPECT_EQ(0u, P4::diagnosticCount());
 }
 
 TEST_F(Diagnostics, DISABLED_P4_14_Warn) {
@@ -103,8 +108,9 @@ TEST_F(Diagnostics, DISABLED_P4_14_Warn) {
         @pragma diagnostic uninitialized_use warn
     )"));
     EXPECT_TRUE(test);
-    EXPECT_EQ(1u, ::P4::diagnosticCount());
-    EXPECT_EQ(0u, ::P4::errorCount());
+    EXPECT_EQ(1u, P4::diagnosticCount());
+    EXPECT_EQ(1u, P4::warningCount());
+    EXPECT_EQ(0u, P4::errorCount());
 }
 
 TEST_F(Diagnostics, DISABLED_P4_14_Error) {
@@ -112,8 +118,9 @@ TEST_F(Diagnostics, DISABLED_P4_14_Error) {
         @pragma diagnostic uninitialized_use error
     )"));
     EXPECT_FALSE(test);
-    EXPECT_EQ(1u, ::P4::diagnosticCount());
-    EXPECT_EQ(1u, ::P4::errorCount());
+    EXPECT_EQ(1u, P4::diagnosticCount());
+    EXPECT_EQ(0u, P4::warningCount());
+    EXPECT_EQ(1u, P4::errorCount());
 }
 
 TEST_F(Diagnostics, NestedCompileContexts) {
@@ -131,8 +138,9 @@ TEST_F(Diagnostics, NestedCompileContexts) {
                 @diagnostic("uninitialized_out_param", "error")
             )"));
             EXPECT_FALSE(test);
-            EXPECT_EQ(1u, ::P4::diagnosticCount());
-            EXPECT_EQ(1u, ::P4::errorCount());
+            EXPECT_EQ(1u, P4::diagnosticCount());
+            EXPECT_EQ(0u, P4::warningCount());
+            EXPECT_EQ(1u, P4::errorCount());
         }
 
         // Run a test with `uninitialized_out_param` disabled. The error from
@@ -141,7 +149,7 @@ TEST_F(Diagnostics, NestedCompileContexts) {
             @diagnostic("uninitialized_out_param", "disable")
         )"));
         EXPECT_TRUE(test);
-        EXPECT_EQ(0u, ::P4::diagnosticCount());
+        EXPECT_EQ(0u, P4::diagnosticCount());
     }
 
     // Run a test with no diagnostic pragma for `uninitialized_out_param`. It
@@ -149,8 +157,8 @@ TEST_F(Diagnostics, NestedCompileContexts) {
     // by the previous tests should be gone.
     auto test = createP4_16DiagnosticsTestCase(P4_SOURCE(R"()"));
     EXPECT_TRUE(test);
-    EXPECT_EQ(1u, ::P4::diagnosticCount());
-    EXPECT_EQ(0u, ::P4::errorCount());
+    EXPECT_EQ(1u, P4::diagnosticCount());
+    EXPECT_EQ(0u, P4::errorCount());
 }
 
 TEST_F(Diagnostics, CompilerOptions) {
@@ -170,23 +178,25 @@ TEST_F(Diagnostics, CompilerOptions) {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Wdisable"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(0u, ::P4::diagnosticCount());
+        EXPECT_EQ(0u, P4::diagnosticCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Wwarn"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(1u, ::P4::diagnosticCount());
-        EXPECT_EQ(0u, ::P4::errorCount());
+        EXPECT_EQ(1u, P4::diagnosticCount());
+        EXPECT_EQ(1u, P4::warningCount());
+        EXPECT_EQ(0u, P4::errorCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Werror"});
         EXPECT_FALSE(test);
-        EXPECT_EQ(1u, ::P4::diagnosticCount());
-        EXPECT_EQ(1u, ::P4::errorCount());
+        EXPECT_EQ(1u, P4::diagnosticCount());
+        EXPECT_EQ(0u, P4::warningCount());
+        EXPECT_EQ(1u, P4::errorCount());
     }
 
     // Check that `--Wdisable`, `--Wwarn`, and `--Werror`, when used with an
@@ -196,39 +206,43 @@ TEST_F(Diagnostics, CompilerOptions) {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Wdisable=uninitialized_out_param"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(0u, ::P4::diagnosticCount());
+        EXPECT_EQ(0u, P4::diagnosticCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Wdisable=unknown_diagnostic"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(1u, ::P4::diagnosticCount());
-        EXPECT_EQ(0u, ::P4::errorCount());
+        EXPECT_EQ(1u, P4::diagnosticCount());
+        EXPECT_EQ(1u, P4::warningCount());
+        EXPECT_EQ(0u, P4::errorCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Wwarn=uninitialized_out_param"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(1u, ::P4::diagnosticCount());
-        EXPECT_EQ(0u, ::P4::errorCount());
+        EXPECT_EQ(1u, P4::diagnosticCount());
+        EXPECT_EQ(1u, P4::warningCount());
+        EXPECT_EQ(0u, P4::errorCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Werror=uninitialized_out_param"});
         EXPECT_FALSE(test);
-        EXPECT_EQ(1u, ::P4::diagnosticCount());
-        EXPECT_EQ(1u, ::P4::errorCount());
+        EXPECT_EQ(1u, P4::diagnosticCount());
+        EXPECT_EQ(0u, P4::warningCount());
+        EXPECT_EQ(1u, P4::errorCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Werror=unknown_diagnostic"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(1u, ::P4::diagnosticCount());
-        EXPECT_EQ(0u, ::P4::errorCount());
+        EXPECT_EQ(1u, P4::diagnosticCount());
+        EXPECT_EQ(1u, P4::warningCount());
+        EXPECT_EQ(0u, P4::errorCount());
     }
 
     // Check that e.g. `--Wdisable foo` is treated as two arguments, rather than
@@ -243,8 +257,18 @@ TEST_F(Diagnostics, CompilerOptions) {
         // treated as an argument to `--Wdisable`, then
         // `uninitialized_out_param` would still be enabled and a warning would
         // fire.
-        EXPECT_EQ(0u, ::P4::diagnosticCount());
+        EXPECT_EQ(0u, P4::diagnosticCount());
     }
 }
+
+TEST_F(Diagnostics, BasicInfo) {
+    AutoCompileContext autoContext(new GTestContext);
+    info(P4::ErrorType::INFO_INFERRED, "test");
+    EXPECT_EQ(1u, P4::diagnosticCount());
+    EXPECT_EQ(1u, P4::infoCount());
+    EXPECT_EQ(0u, P4::warningCount());
+    EXPECT_EQ(0u, P4::errorCount());
+}
+
 
 }  // namespace P4::Test

--- a/test/gtest/diagnostics.cpp
+++ b/test/gtest/diagnostics.cpp
@@ -158,6 +158,7 @@ TEST_F(Diagnostics, NestedCompileContexts) {
     auto test = createP4_16DiagnosticsTestCase(P4_SOURCE(R"()"));
     EXPECT_TRUE(test);
     EXPECT_EQ(1u, diagnosticCount());
+    EXPECT_EQ(1u, warningCount());
     EXPECT_EQ(0u, errorCount());
 }
 
@@ -269,6 +270,5 @@ TEST_F(Diagnostics, BasicInfo) {
     EXPECT_EQ(0u, warningCount());
     EXPECT_EQ(0u, errorCount());
 }
-
 
 }  // namespace P4::Test

--- a/test/gtest/diagnostics.cpp
+++ b/test/gtest/diagnostics.cpp
@@ -69,10 +69,10 @@ TEST_F(Diagnostics, P4_16_Disable) {
         @diagnostic("uninitialized_out_param", "disable")
     )"));
     EXPECT_TRUE(test);
-    EXPECT_EQ(0u, P4::diagnosticCount());
-    EXPECT_EQ(0u, P4::errorCount());
-    EXPECT_EQ(0u, P4::warningCount());
-    EXPECT_EQ(0u, P4::infoCount());
+    EXPECT_EQ(0u, diagnosticCount());
+    EXPECT_EQ(0u, errorCount());
+    EXPECT_EQ(0u, warningCount());
+    EXPECT_EQ(0u, infoCount());
 }
 
 TEST_F(Diagnostics, P4_16_Warn) {
@@ -80,9 +80,9 @@ TEST_F(Diagnostics, P4_16_Warn) {
         @diagnostic("uninitialized_out_param", "warn")
     )"));
     EXPECT_TRUE(test);
-    EXPECT_EQ(1u, P4::diagnosticCount());
-    EXPECT_EQ(1u, P4::warningCount());
-    EXPECT_EQ(0u, P4::errorCount());
+    EXPECT_EQ(1u, diagnosticCount());
+    EXPECT_EQ(1u, warningCount());
+    EXPECT_EQ(0u, errorCount());
 }
 
 TEST_F(Diagnostics, P4_16_Error) {
@@ -90,9 +90,9 @@ TEST_F(Diagnostics, P4_16_Error) {
         @diagnostic("uninitialized_out_param", "error")
     )"));
     EXPECT_FALSE(test);
-    EXPECT_EQ(1u, P4::diagnosticCount());
-    EXPECT_EQ(0u, P4::warningCount());
-    EXPECT_EQ(1u, P4::errorCount());
+    EXPECT_EQ(1u, diagnosticCount());
+    EXPECT_EQ(0u, warningCount());
+    EXPECT_EQ(1u, errorCount());
 }
 
 TEST_F(Diagnostics, DISABLED_P4_14_Disable) {
@@ -100,7 +100,7 @@ TEST_F(Diagnostics, DISABLED_P4_14_Disable) {
         @pragma diagnostic uninitialized_use disable
     )"));
     EXPECT_TRUE(test);
-    EXPECT_EQ(0u, P4::diagnosticCount());
+    EXPECT_EQ(0u, diagnosticCount());
 }
 
 TEST_F(Diagnostics, DISABLED_P4_14_Warn) {
@@ -108,9 +108,9 @@ TEST_F(Diagnostics, DISABLED_P4_14_Warn) {
         @pragma diagnostic uninitialized_use warn
     )"));
     EXPECT_TRUE(test);
-    EXPECT_EQ(1u, P4::diagnosticCount());
-    EXPECT_EQ(1u, P4::warningCount());
-    EXPECT_EQ(0u, P4::errorCount());
+    EXPECT_EQ(1u, diagnosticCount());
+    EXPECT_EQ(1u, warningCount());
+    EXPECT_EQ(0u, errorCount());
 }
 
 TEST_F(Diagnostics, DISABLED_P4_14_Error) {
@@ -118,9 +118,9 @@ TEST_F(Diagnostics, DISABLED_P4_14_Error) {
         @pragma diagnostic uninitialized_use error
     )"));
     EXPECT_FALSE(test);
-    EXPECT_EQ(1u, P4::diagnosticCount());
-    EXPECT_EQ(0u, P4::warningCount());
-    EXPECT_EQ(1u, P4::errorCount());
+    EXPECT_EQ(1u, diagnosticCount());
+    EXPECT_EQ(0u, warningCount());
+    EXPECT_EQ(1u, errorCount());
 }
 
 TEST_F(Diagnostics, NestedCompileContexts) {
@@ -138,9 +138,9 @@ TEST_F(Diagnostics, NestedCompileContexts) {
                 @diagnostic("uninitialized_out_param", "error")
             )"));
             EXPECT_FALSE(test);
-            EXPECT_EQ(1u, P4::diagnosticCount());
-            EXPECT_EQ(0u, P4::warningCount());
-            EXPECT_EQ(1u, P4::errorCount());
+            EXPECT_EQ(1u, diagnosticCount());
+            EXPECT_EQ(0u, warningCount());
+            EXPECT_EQ(1u, errorCount());
         }
 
         // Run a test with `uninitialized_out_param` disabled. The error from
@@ -149,7 +149,7 @@ TEST_F(Diagnostics, NestedCompileContexts) {
             @diagnostic("uninitialized_out_param", "disable")
         )"));
         EXPECT_TRUE(test);
-        EXPECT_EQ(0u, P4::diagnosticCount());
+        EXPECT_EQ(0u, diagnosticCount());
     }
 
     // Run a test with no diagnostic pragma for `uninitialized_out_param`. It
@@ -157,12 +157,12 @@ TEST_F(Diagnostics, NestedCompileContexts) {
     // by the previous tests should be gone.
     auto test = createP4_16DiagnosticsTestCase(P4_SOURCE(R"()"));
     EXPECT_TRUE(test);
-    EXPECT_EQ(1u, P4::diagnosticCount());
-    EXPECT_EQ(0u, P4::errorCount());
+    EXPECT_EQ(1u, diagnosticCount());
+    EXPECT_EQ(0u, errorCount());
 }
 
 TEST_F(Diagnostics, CompilerOptions) {
-    using CommandLineOptions = P4::IOptionPragmaParser::CommandLineOptions;
+    using CommandLineOptions = IOptionPragmaParser::CommandLineOptions;
 
     auto parseWithCompilerOptions =
         [](const CommandLineOptions &args) -> std::optional<FrontendTestCase> {
@@ -178,25 +178,25 @@ TEST_F(Diagnostics, CompilerOptions) {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Wdisable"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(0u, P4::diagnosticCount());
+        EXPECT_EQ(0u, diagnosticCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Wwarn"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(1u, P4::diagnosticCount());
-        EXPECT_EQ(1u, P4::warningCount());
-        EXPECT_EQ(0u, P4::errorCount());
+        EXPECT_EQ(1u, diagnosticCount());
+        EXPECT_EQ(1u, warningCount());
+        EXPECT_EQ(0u, errorCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Werror"});
         EXPECT_FALSE(test);
-        EXPECT_EQ(1u, P4::diagnosticCount());
-        EXPECT_EQ(0u, P4::warningCount());
-        EXPECT_EQ(1u, P4::errorCount());
+        EXPECT_EQ(1u, diagnosticCount());
+        EXPECT_EQ(0u, warningCount());
+        EXPECT_EQ(1u, errorCount());
     }
 
     // Check that `--Wdisable`, `--Wwarn`, and `--Werror`, when used with an
@@ -206,43 +206,43 @@ TEST_F(Diagnostics, CompilerOptions) {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Wdisable=uninitialized_out_param"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(0u, P4::diagnosticCount());
+        EXPECT_EQ(0u, diagnosticCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Wdisable=unknown_diagnostic"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(1u, P4::diagnosticCount());
-        EXPECT_EQ(1u, P4::warningCount());
-        EXPECT_EQ(0u, P4::errorCount());
+        EXPECT_EQ(1u, diagnosticCount());
+        EXPECT_EQ(1u, warningCount());
+        EXPECT_EQ(0u, errorCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Wwarn=uninitialized_out_param"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(1u, P4::diagnosticCount());
-        EXPECT_EQ(1u, P4::warningCount());
-        EXPECT_EQ(0u, P4::errorCount());
+        EXPECT_EQ(1u, diagnosticCount());
+        EXPECT_EQ(1u, warningCount());
+        EXPECT_EQ(0u, errorCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Werror=uninitialized_out_param"});
         EXPECT_FALSE(test);
-        EXPECT_EQ(1u, P4::diagnosticCount());
-        EXPECT_EQ(0u, P4::warningCount());
-        EXPECT_EQ(1u, P4::errorCount());
+        EXPECT_EQ(1u, diagnosticCount());
+        EXPECT_EQ(0u, warningCount());
+        EXPECT_EQ(1u, errorCount());
     }
 
     {
         AutoCompileContext autoContext(new GTestContext);
         auto test = parseWithCompilerOptions({"(test)", "--Werror=unknown_diagnostic"});
         EXPECT_TRUE(test);
-        EXPECT_EQ(1u, P4::diagnosticCount());
-        EXPECT_EQ(1u, P4::warningCount());
-        EXPECT_EQ(0u, P4::errorCount());
+        EXPECT_EQ(1u, diagnosticCount());
+        EXPECT_EQ(1u, warningCount());
+        EXPECT_EQ(0u, errorCount());
     }
 
     // Check that e.g. `--Wdisable foo` is treated as two arguments, rather than
@@ -257,17 +257,17 @@ TEST_F(Diagnostics, CompilerOptions) {
         // treated as an argument to `--Wdisable`, then
         // `uninitialized_out_param` would still be enabled and a warning would
         // fire.
-        EXPECT_EQ(0u, P4::diagnosticCount());
+        EXPECT_EQ(0u, diagnosticCount());
     }
 }
 
 TEST_F(Diagnostics, BasicInfo) {
     AutoCompileContext autoContext(new GTestContext);
     info(P4::ErrorType::INFO_INFERRED, "test");
-    EXPECT_EQ(1u, P4::diagnosticCount());
-    EXPECT_EQ(1u, P4::infoCount());
-    EXPECT_EQ(0u, P4::warningCount());
-    EXPECT_EQ(0u, P4::errorCount());
+    EXPECT_EQ(1u, diagnosticCount());
+    EXPECT_EQ(1u, infoCount());
+    EXPECT_EQ(0u, warningCount());
+    EXPECT_EQ(0u, errorCount());
 }
 
 


### PR DESCRIPTION
There is `errorCount` and `diagnosticCount` but no `warningCount` and no `infoCount`. This PR adds them.