### PR TITLE
Move all config handling into a single place – a config.h file, do not clutter the command line with these additional project-wide defines.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,11 +28,17 @@ genrule(
     outs = ["config.h"],
     # TODO: We should actually check these properly instead of just #undefing them.
     # Maybe select() can help here?
+    # CONFIG_PKGDATADIR is where p4c should look for p4include at runtime.
+    # This will work only if the binary is executed by Bazel. For a general
+    # solution, we would need to make p4c aware of Bazel, specifically:
+    # https://github.com/bazelbuild/bazel/blob/master/tools/cpp/runfiles/runfiles_src.h
     cmd = "sed -e 's|cmakedefine|define|g' \
              -e 's|define HAVE_LIBGC 1|undef HAVE_LIBGC|g' \
              -e 's|define HAVE_LIBBACKTRACE 1|undef HAVE_LIBBACKTRACE|g' \
              -e 's|define HAVE_MM_MALLOC_H 1|undef HAVE_MM_MALLOC_H|g' \
-             < $(SRCS) > $(OUTS)",
+             -e 's|@MAX_LOGGING_LEVEL@|10|g' \
+             -e 's|@CONFIG_PKGDATADIR@|external/%s|g' \
+             < $(SRCS) > $(OUTS)" % repository_name(),
     visibility = ["//visibility:private"],
 )
 
@@ -214,13 +220,6 @@ cc_library(
         "backends/dpdk/spec.cpp",
         "backends/dpdk/dbprint-dpdk.cpp",
         "backends/dpdk/printUtils.cpp",
-    ],
-    copts = [
-        # Where p4c should look for p4include at runtime.
-        ("-DCONFIG_PKGDATADIR=\\\"external/%s\\\"" % repository_name()),
-        # This will work only if the binary is executed by Bazel. For a general
-        # solution, we would need to make p4c aware of Bazel, specifically:
-        # https://github.com/bazelbuild/bazel/blob/master/tools/cpp/runfiles/runfiles_src.h
     ],
     textual_hdrs = glob([
         "ir/**/*.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,6 @@ set (P4C_DRIVER_NAME "p4c" CACHE STRING "Customize the name of the driver script
 
 set(MAX_LOGGING_LEVEL 10 CACHE STRING "Control the maximum logging level for -T logs")
 set_property(CACHE MAX_LOGGING_LEVEL PROPERTY STRINGS 0 1 2 3 4 5 6 7 8 9 10)
-add_definitions(-DMAX_LOGGING_LEVEL=${MAX_LOGGING_LEVEL})
 
 if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE "Release")
@@ -198,6 +197,10 @@ find_package (BISON 3.0 REQUIRED)
 if (ENABLE_GTESTS)
   include(GoogleTest)
   p4c_obtain_googletest()
+  # Some P4C source files include gtest files. This will be propagated to the
+  # definition in config.h We need this definition to guard against compilation
+  # errors.
+  set(P4C_GTEST_ENABLED ON)
 endif ()
 include(Abseil)
 p4c_obtain_abseil()
@@ -373,8 +376,8 @@ include_directories (
   ${P4C_BINARY_DIR}
   ${P4C_SOURCE_DIR}/extensions
   )
-add_definitions (-DCONFIG_PREFIX="${CMAKE_INSTALL_PREFIX}")
-add_definitions (-DCONFIG_PKGDATADIR="${CMAKE_INSTALL_PREFIX}/${P4C_ARTIFACTS_OUTPUT_DIRECTORY}")
+set(CONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
+set(CONFIG_PKGDATADIR ${CMAKE_INSTALL_PREFIX}/${P4C_ARTIFACTS_OUTPUT_DIRECTORY})
 
 set (CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} ${P4C_CXX_FLAGS}")
 set (CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} ${P4C_CXX_FLAGS}")

--- a/cmake/GoogleTest.cmake
+++ b/cmake/GoogleTest.cmake
@@ -1,7 +1,4 @@
 macro(p4c_obtain_googletest)
-  # Some P4C source files include gtest files.
-  # We need this definition to guard against compilation errors.
-  add_definitions(-DP4C_GTEST_ENABLED)
   # Print download state while setting up GTest.
   set(FETCHCONTENT_QUIET_PREV ${FETCHCONTENT_QUIET})
   set(FETCHCONTENT_QUIET OFF)

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -33,3 +33,12 @@
 
 /* Define to 1 if you have the mm_malloc.h header */
 #cmakedefine HAVE_MM_MALLOC_H 1
+
+#cmakedefine CONFIG_PKGDATADIR "@CONFIG_PKGDATADIR@"
+
+#cmakedefine CONFIG_PREFIX "@CONFIG_PREFIX@"
+
+/* The maximum logging level for -T logs */
+#cmakedefine MAX_LOGGING_LEVEL @MAX_LOGGING_LEVEL@
+
+#cmakedefine P4C_GTEST_ENABLED 1

--- a/lib/json.h
+++ b/lib/json.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <type_traits>
 #include <vector>
 
+#include "config.h"
 #ifdef P4C_GTEST_ENABLED
 #include "gtest/gtest_prod.h"
 #endif

--- a/lib/source_file.h
+++ b/lib/source_file.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/strings/str_format.h"
+#include "config.h"
 #include "cstring.h"
 #include "stringify.h"
 


### PR DESCRIPTION
There are multiple reasons for this:
 - Control fine-grained inclusion. If option changed, not the whole project need to be rebuilt
 - `CONFIG_PKGDATADIR` / `CONFIG_PREFIX` are paths and might contain special symbols that might be not so good on command line
 - Overall uniformity