### PR TITLE
Enable support for table property default_action for all v1model table types

### DIFF
--- a/backends/bmv2/common/control.h
+++ b/backends/bmv2/common/control.h
@@ -378,14 +378,6 @@ class ControlConverter : public Inspector {
         auto defact =
             table->properties->getProperty(IR::TableProperties::defaultActionPropertyName);
         if (defact != nullptr) {
-            if (!simple) {
-                ::P4::warning(
-                    ErrorType::WARN_UNSUPPORTED,
-                    "Target does not support default_action for %1% (due to action profiles)",
-                    table);
-                return result;
-            }
-
             if (!defact->value->is<IR::ExpressionValue>()) {
                 ::P4::error(ErrorType::ERR_EXPECTED, "%1%: expected an action", defact);
                 return result;


### PR DESCRIPTION
including those with property implementation equal to action_profile or action_selector.

Historical note: p4c disabled support for default_action on these kinds of tables in 2016, with a comment that behavioral-model did not support it at that time.  Support was added to behavioral-model in 2018, but it appears no one has tried to enable it in the p4c bmv2 backend before now.