### PR TITLE
Generalized array support

### DIFF
--- a/backends/p4tools/common/core/abstract_execution_state.cpp
+++ b/backends/p4tools/common/core/abstract_execution_state.cpp
@@ -158,9 +158,6 @@ std::vector<IR::StateVariable> AbstractExecutionState::getFlatFields(
         for (size_t arrayIndex = 0; arrayIndex < typeStack->getSize(); arrayIndex++) {
             const auto *newArr =
                 HSIndexToMember::produceStackIndex(stackElementsType, parent, arrayIndex);
-            BUG_CHECK(stackElementsType->is<IR::Type_StructLike>(),
-                      "Trying to get the flat fields for a non Type_StructLike element : %1%",
-                      stackElementsType);
             auto subFields = getFlatFields(newArr, validVector);
             flatFields.insert(flatFields.end(), subFields.begin(), subFields.end());
         }

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
@@ -64,6 +64,14 @@ p4tools_add_xfail_reason(
   loop-3-clause-tricky2.p4
 )
 
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-metadata"
+  "Cast failed"
+  # testgen has issues with arrays
+  array1.p4
+  array2.p4
+)
+
 ####################################################################################################
 # 3. WONTFIX
 ####################################################################################################

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -107,6 +107,14 @@ p4tools_add_xfail_reason(
   loop-3-clause-tricky2.p4
 )
 
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-ptf"
+  "Cast failed"
+  # testgen has issues with arrays
+  array1.p4
+  array2.p4
+)
+
 ####################################################################################################
 # 3. WONTFIX
 # These are failures that can not be solved by changing P4Testgen

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufIrXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufIrXfail.cmake
@@ -81,6 +81,14 @@ p4tools_add_xfail_reason(
   loop-3-clause-tricky2.p4
 )
 
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-protobuf-ir"
+  "Cast failed"
+  # testgen has issues with arrays
+  array1.p4
+  array2.p4
+)
+
 ####################################################################################################
 # 3. WONTFIX
 ####################################################################################################

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
@@ -107,6 +107,14 @@ p4tools_add_xfail_reason(
   loop-3-clause-tricky2.p4
 )
 
+p4tools_add_xfail_reason(
+  "testgen-p4c-bmv2-stf"
+  "Cast failed"
+  # testgen has issues with arrays
+  array1.p4
+  array2.p4
+)
+
 ####################################################################################################
 # 3. WONTFIX
 # These are failures that can not be solved by changing P4Testgen

--- a/frontends/p4/typeChecking/typeCheckExpr.cpp
+++ b/frontends/p4/typeChecking/typeCheckExpr.cpp
@@ -1706,7 +1706,12 @@ const IR::Node *TypeInferenceBase::postorder(const IR::Member *expression) {
 
     if (auto *stack = type->to<IR::Type_Stack>()) {
         auto parser = findContext<IR::P4Parser>();
-        if (member == IR::Type_Stack::next || member == IR::Type_Stack::last) {
+        auto eltype = stack->elementType;
+        if (!eltype->is<IR::Type_Header>() && !eltype->is<IR::Type_HeaderUnion>() /* &&
+            !eltype->is<IR::Type_SpecializedCanonical>() */) {
+            typeError("%1%: '%2%' can only be used on header stacks", expression, member);
+            return expression;
+        } else if (member == IR::Type_Stack::next || member == IR::Type_Stack::last) {
             if (parser == nullptr) {
                 typeError("%1%: 'last', and 'next' for stacks can only be used in a parser",
                           expression);

--- a/frontends/p4/typeChecking/typeCheckExpr.cpp
+++ b/frontends/p4/typeChecking/typeCheckExpr.cpp
@@ -1707,8 +1707,8 @@ const IR::Node *TypeInferenceBase::postorder(const IR::Member *expression) {
     if (auto *stack = type->to<IR::Type_Stack>()) {
         auto parser = findContext<IR::P4Parser>();
         auto eltype = stack->elementType;
-        if (!eltype->is<IR::Type_Header>() && !eltype->is<IR::Type_HeaderUnion>() /* &&
-            !eltype->is<IR::Type_SpecializedCanonical>() */) {
+        if (auto sc = eltype->to<IR::Type_SpecializedCanonical>()) eltype = sc->baseType;
+        if (!eltype->is<IR::Type_Header>() && !eltype->is<IR::Type_HeaderUnion>()) {
             typeError("%1%: '%2%' can only be used on header stacks", expression, member);
             return expression;
         } else if (member == IR::Type_Stack::next || member == IR::Type_Stack::last) {

--- a/frontends/p4/typeChecking/typeCheckTypes.cpp
+++ b/frontends/p4/typeChecking/typeCheckTypes.cpp
@@ -427,9 +427,12 @@ const IR::Node *TypeInferenceBase::postorder(const IR::Type_Header *type) {
     auto canon = setTypeType(type);
     auto validator = [this](const IR::Type *t) {
         while (1) {
-            if (t->is<IR::Type_Newtype>()) t = getTypeType(t->to<IR::Type_Newtype>()->type);
-            else if (auto *st = t->to<IR::Type_Stack>()) t = st->elementType;
-            else break;
+            if (t->is<IR::Type_Newtype>())
+                t = getTypeType(t->to<IR::Type_Newtype>()->type);
+            else if (auto *st = t->to<IR::Type_Stack>())
+                t = st->elementType;
+            else
+                break;
         }
         return t->is<IR::Type_Bits>() || t->is<IR::Type_Varbits>() ||
                (t->is<IR::Type_Struct>() && onlyBitsOrBitStructs(t)) || t->is<IR::Type_SerEnum>() ||

--- a/frontends/p4/typeChecking/typeCheckTypes.cpp
+++ b/frontends/p4/typeChecking/typeCheckTypes.cpp
@@ -379,17 +379,7 @@ const IR::Node *TypeInferenceBase::postorder(const IR::Type_Typedef *tdecl) {
 }
 
 const IR::Node *TypeInferenceBase::postorder(const IR::Type_Stack *type) {
-    auto canon = setTypeType(type);
-    if (canon == nullptr) return type;
-
-    auto etype = canon->to<IR::Type_Stack>()->elementType;
-    if (etype == nullptr) return type;
-
-#if 0
-    if (!etype->is<IR::Type_Header>() && !etype->is<IR::Type_HeaderUnion>() &&
-        !etype->is<IR::Type_SpecializedCanonical>())
-        typeError("Header stack %1% used with non-header type %2%", type, etype->toString());
-#endif
+    setTypeType(type);
     return type;
 }
 

--- a/frontends/p4/typeChecking/typeCheckTypes.cpp
+++ b/frontends/p4/typeChecking/typeCheckTypes.cpp
@@ -47,6 +47,7 @@ bool hasVarbitsOrUnions(const TypeMap *typeMap, const IR::Type *type) {
 
 bool TypeInferenceBase::onlyBitsOrBitStructs(const IR::Type *type) const {
     // called for a canonical type
+    while (auto *st = type->to<IR::Type_Stack>()) type = st->elementType;
     if (type->is<IR::Type_Bits>() || type->is<IR::Type_Boolean>() || type->is<IR::Type_SerEnum>()) {
         return true;
     } else if (auto ht = type->to<IR::Type_Struct>()) {
@@ -426,17 +427,8 @@ const IR::Node *TypeInferenceBase::postorder(const IR::StructField *field) {
 const IR::Node *TypeInferenceBase::postorder(const IR::Type_Header *type) {
     auto canon = setTypeType(type);
     auto validator = [this](const IR::Type *t) {
-        while (1) {
-            if (t->is<IR::Type_Newtype>())
-                t = getTypeType(t->to<IR::Type_Newtype>()->type);
-            else if (auto *st = t->to<IR::Type_Stack>())
-                t = st->elementType;
-            else
-                break;
-        }
-        return t->is<IR::Type_Bits>() || t->is<IR::Type_Varbits>() ||
-               (t->is<IR::Type_Struct>() && onlyBitsOrBitStructs(t)) || t->is<IR::Type_SerEnum>() ||
-               t->is<IR::Type_Boolean>() || t->is<IR::Type_Var>() ||
+        while (t->is<IR::Type_Newtype>()) t = getTypeType(t->to<IR::Type_Newtype>()->type);
+        return onlyBitsOrBitStructs(t) || t->is<IR::Type_Varbits>() || t->is<IR::Type_Var>() ||
                t->is<IR::Type_SpecializedCanonical>();
     };
     validateFields(canon, validator);

--- a/frontends/p4/typeChecking/typeCheckTypes.cpp
+++ b/frontends/p4/typeChecking/typeCheckTypes.cpp
@@ -384,9 +384,11 @@ const IR::Node *TypeInferenceBase::postorder(const IR::Type_Stack *type) {
     auto etype = canon->to<IR::Type_Stack>()->elementType;
     if (etype == nullptr) return type;
 
+#if 0
     if (!etype->is<IR::Type_Header>() && !etype->is<IR::Type_HeaderUnion>() &&
         !etype->is<IR::Type_SpecializedCanonical>())
         typeError("Header stack %1% used with non-header type %2%", type, etype->toString());
+#endif
     return type;
 }
 
@@ -424,7 +426,11 @@ const IR::Node *TypeInferenceBase::postorder(const IR::StructField *field) {
 const IR::Node *TypeInferenceBase::postorder(const IR::Type_Header *type) {
     auto canon = setTypeType(type);
     auto validator = [this](const IR::Type *t) {
-        while (t->is<IR::Type_Newtype>()) t = getTypeType(t->to<IR::Type_Newtype>()->type);
+        while (1) {
+            if (t->is<IR::Type_Newtype>()) t = getTypeType(t->to<IR::Type_Newtype>()->type);
+            else if (auto *st = t->to<IR::Type_Stack>()) t = st->elementType;
+            else break;
+        }
         return t->is<IR::Type_Bits>() || t->is<IR::Type_Varbits>() ||
                (t->is<IR::Type_Struct>() && onlyBitsOrBitStructs(t)) || t->is<IR::Type_SerEnum>() ||
                t->is<IR::Type_Boolean>() || t->is<IR::Type_Var>() ||

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -91,6 +91,15 @@ inline std::ostream& operator<<(std::ostream& out, const OptionalConst& oc) {
 // forbidden in C++. We avoid the problem using a typedef.
 typedef const IR::Type ConstType;
 
+struct NameTypePair {
+    const IR::ID *name;
+    const IR::Type *type;
+};
+
+inline std::ostream &operator<<(std::ostream &out, const NameTypePair &nt) {
+    return out << nt.name << ":" << nt.type;
+}
+
 }  // namespace P4
 
 #ifndef YYDEBUG
@@ -263,6 +272,7 @@ using namespace P4;
 
 
 %type<IR::ID*>              name dot_name nonTypeName nonTableKwName annotationName
+%type<NameTypePair>         declarator
 %type<IR::Direction>        direction
 %type<IR::Path*>            prefixedNonTypeName prefixedType
 %type<IR::IndexedVector<IR::Type_Var>*>  typeParameterList
@@ -274,6 +284,7 @@ using namespace P4;
                             nonBraceExpression forCollectionExpr
 %type<ConstType*>           baseType typeOrVoid specializedType headerStackType
                             typeRef tupleType typeArg realTypeArg namedType p4listType
+                            derivedTypeDeclarationAsType
 %type<IR::Type_Name*>       typeName
 %type<IR::Argument*>        argument
 %type<IR::Vector<IR::Argument>*>  argumentList nonEmptyArgList
@@ -757,8 +768,10 @@ nonEmptyParameterList
     ;
 
 parameter
-    : optAnnotations direction typeRef name { $$ = new IR::Parameter(@4, *$4, *$1, $2, $3, nullptr); }
-    | optAnnotations direction typeRef name "=" expression { $$ = new IR::Parameter(@4, *$4, *$1, $2, $3, $6); }
+    : optAnnotations direction typeRef declarator {
+            $$ = new IR::Parameter(@4, *$4.name, *$1, $2, $4.type, nullptr); }
+    | optAnnotations direction typeRef declarator "=" expression {
+            $$ = new IR::Parameter(@4, *$4.name, *$1, $2, $4.type, $6); }
     ;
 
 direction
@@ -1180,6 +1193,12 @@ derivedTypeDeclaration
     | enumDeclaration                  { $$ = $1; }
     ;
 
+// workaround for bison's broken type variant handling that needs an explicit conversion
+// to the base class
+derivedTypeDeclarationAsType
+    : derivedTypeDeclaration           { $$ = static_cast<const IR::Type *>($1); }
+    ;
+
 headerTypeDeclaration
     : optAnnotations HEADER name { driver.structure->pushContainerType(*$3, true); } optTypeParameters {
         driver.structure->markAsTemplate(*$3);
@@ -1210,7 +1229,7 @@ structFieldList
     ;
 
 structField
-    : optAnnotations typeRef name ";"  { $$ = new IR::StructField(@3, *$3, *$1, $2); }
+    : optAnnotations typeRef declarator ";"  { $$ = new IR::StructField(@3, *$3.name, *$1, $3.type); }
     ;
 
 enumDeclaration
@@ -1252,12 +1271,15 @@ identifierList
     ;
 
 typedefDeclaration
-    : optAnnotations TYPEDEF typeRef name   { driver.structure->declareType(*$4);
-          $$ = new IR::Type_Typedef(@4, *$4, *$1, $3); }
-    | optAnnotations TYPEDEF derivedTypeDeclaration name   { driver.structure->declareType(*$4);
-                        $$ = new IR::Type_Typedef(@4, *$4, *$1, $3); }
-    | optAnnotations TYPE typeRef name   { driver.structure->declareType(*$4);
-          $$ = new IR::Type_Newtype(@4, *$4, *$1, $3); }
+    : optAnnotations TYPEDEF typeRef declarator {
+            driver.structure->declareType(*$4.name);
+            $$ = new IR::Type_Typedef(@4, *$4.name, *$1, $4.type); }
+    | optAnnotations TYPEDEF derivedTypeDeclarationAsType declarator {
+            driver.structure->declareType(*$4.name);
+            $$ = new IR::Type_Typedef(@4, *$4.name, *$1, $4.type); }
+    | optAnnotations TYPE typeRef declarator {
+            driver.structure->declareType(*$4.name);
+            $$ = new IR::Type_Newtype(@4, *$4.name, *$1, $4.type); }
     ;
 
 /*************************** STATEMENTS *************************/
@@ -1562,18 +1584,24 @@ variableDeclaration
     ;
 
 variableDeclarationWithoutSemicolon
-    : annotations typeRef name optInitializer
-                                     { $$ = new IR::Declaration_Variable(@1+@4, *$3, *$1, $2, $4);
-                                       driver.structure->declareObject(*$3, $2->toString()); }
-    | typeRef name optInitializer
-                                     { $$ = new IR::Declaration_Variable(@1+@3, *$2, $1, $3);
-                                       driver.structure->declareObject(*$2, $1->toString()); }
+    : annotations typeRef declarator optInitializer
+                         { $$ = new IR::Declaration_Variable(@1+@4, *$3.name, *$1, $3.type, $4);
+                           driver.structure->declareObject(*$3.name, $3.type->toString()); }
+    | typeRef declarator optInitializer
+                         { $$ = new IR::Declaration_Variable(@1+@3, *$2.name, $2.type, $3);
+                           driver.structure->declareObject(*$2.name, $2.type->toString()); }
     ;
 
 constantDeclaration
-    : optAnnotations CONST typeRef name "=" initializer ";"
-                                     { $$ = new IR::Declaration_Constant(@4, *$4, *$1, $3, $6);
-                                       driver.structure->declareObject(*$4, $3->toString()); }
+    : optAnnotations CONST typeRef declarator "=" initializer ";"
+                         { $$ = new IR::Declaration_Constant(@4, *$4.name, *$1, $4.type, $6);
+                           driver.structure->declareObject(*$4.name, $4.type->toString()); }
+    ;
+
+declarator
+    : name                { $$.name = $1; $$.type = $<ConstType *>0; }
+    | declarator "[" expression "]"
+                          { $$ = $1; $$.type = new IR::Type_Stack(@2+@4, $1.type, $3); }
     ;
 
 optInitializer

--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1087,8 +1087,7 @@ tupleType
     ;
 
 headerStackType
-    : typeName "[" expression "]"         { $$ = new IR::Type_Stack(@1+@4, $1, $3); }
-    | specializedType "[" expression "]"  { $$ = new IR::Type_Stack(@1+@4, $1, $3); }
+    : typeRef "[" expression "]"         { $$ = new IR::Type_Stack(@1+@4, $1, $3); }
     ;
 
 specializedType

--- a/midend/hsIndexSimplify.cpp
+++ b/midend/hsIndexSimplify.cpp
@@ -80,7 +80,7 @@ IR::Node *HSIndexContretizer::eliminateArrayIndexes(HSIndexFinder &aiFinder,
     size_t sz = typeStack->getSize();
     if ((expansion += (sz - 1)) > maxExpansion) {
         if (expansion - sz < maxExpansion)
-            error(ErrorType::ERR_OVERLIMIT, "%1%too much expansion from non-const array indexes",
+            error(ErrorType::ERR_OVERLIMIT, "%1%Too much expansion from non-const array indexes",
                   statement->srcInfo);
         return statement;
     }

--- a/midend/hsIndexSimplify.cpp
+++ b/midend/hsIndexSimplify.cpp
@@ -53,6 +53,8 @@ const IR::Node *HSIndexTransform::postorder(IR::ArrayIndex *curArrayIndex) {
     return curArrayIndex;
 }
 
+int HSIndexContretizer::idCtr;
+
 IR::Node *HSIndexContretizer::eliminateArrayIndexes(HSIndexFinder &aiFinder,
                                                     IR::Statement *statement,
                                                     const IR::Expression *expr) {
@@ -76,6 +78,14 @@ IR::Node *HSIndexContretizer::eliminateArrayIndexes(HSIndexFinder &aiFinder,
     IR::IfStatement *newIf = nullptr;
     const auto *typeStack = aiFinder.arrayIndex->left->type->checkedTo<IR::Type_Stack>();
     size_t sz = typeStack->getSize();
+    if ((expansion += (sz - 1)) > maxExpansion) {
+        if (expansion - sz < maxExpansion)
+            error(ErrorType::ERR_OVERLIMIT, "%1%too much expansion from non-const array indexes",
+                  statement->srcInfo);
+        return statement;
+    }
+    LOG5("HSIndexContretizer(" << id << ") expand " << aiFinder.arrayIndex << " by " << sz
+                               << ",  expansion = " << expansion);
     for (size_t i = 0; i < sz; i++) {
         HSIndexTransform aiRewriter(aiFinder, i);
         const auto *newStatement = statement->apply(aiRewriter)->to<IR::Statement>();
@@ -174,7 +184,8 @@ IR::Node *HSIndexContretizer::preorder(IR::P4Control *control) {
     auto *newControl = controlKeySimplified->clone();
     IR::IndexedVector<IR::Declaration> newControlLocals;
     GeneratedVariablesMap blockGeneratedVariables;
-    HSIndexContretizer hsSimplifier(typeMap, nameGen, &newControlLocals, &blockGeneratedVariables);
+    HSIndexContretizer hsSimplifier(typeMap, maxExpansion, nameGen, &newControlLocals,
+                                    &blockGeneratedVariables);
     newControl->body = newControl->body->apply(hsSimplifier)->to<IR::BlockStatement>();
     for (const auto *declaration : controlKeySimplified->controlLocals) {
         if (declaration->is<IR::P4Action>()) {
@@ -184,6 +195,7 @@ IR::Node *HSIndexContretizer::preorder(IR::P4Control *control) {
         }
     }
     newControl->controlLocals = newControlLocals;
+    prune();
     return newControl;
 }
 
@@ -198,7 +210,8 @@ IR::Node *HSIndexContretizer::preorder(IR::BlockStatement *blockStatement) {
     if (aiFinder.arrayIndex == nullptr) {
         return blockStatement;
     }
-    HSIndexContretizer hsSimplifier(typeMap, nameGen, locals, generatedVariables);
+    HSIndexContretizer hsSimplifier(typeMap, maxExpansion, nameGen, locals, generatedVariables);
+    hsSimplifier.expansion = expansion;
     auto *newBlock = blockStatement->clone();
     IR::IndexedVector<IR::StatOrDecl> newComponents;
     for (auto &component : blockStatement->components) {
@@ -212,6 +225,7 @@ IR::Node *HSIndexContretizer::preorder(IR::BlockStatement *blockStatement) {
         }
     }
     newBlock->components = newComponents;
+    expansion = hsSimplifier.expansion;
     return newBlock;
 }
 

--- a/midend/hsIndexSimplify.h
+++ b/midend/hsIndexSimplify.h
@@ -71,17 +71,23 @@ class HSIndexContretizer : public Transform {
     std::shared_ptr<MinimalNameGenerator> nameGen;
     IR::IndexedVector<IR::Declaration> *locals;
     GeneratedVariablesMap *generatedVariables;
+    size_t expansion = 0, maxExpansion;
+    int id;
+    static int idCtr;
 
  public:
-    explicit HSIndexContretizer(TypeMap *typeMap,
+    explicit HSIndexContretizer(TypeMap *typeMap, size_t maxExpansion,
                                 std::shared_ptr<MinimalNameGenerator> nameGen = nullptr,
                                 IR::IndexedVector<IR::Declaration> *locals = nullptr,
                                 GeneratedVariablesMap *generatedVariables = nullptr)
         : typeMap(typeMap),
           nameGen(nameGen),
           locals(locals),
-          generatedVariables(generatedVariables) {
+          generatedVariables(generatedVariables),
+          maxExpansion(maxExpansion) {
+        id = ++idCtr;
         if (generatedVariables == nullptr) generatedVariables = new GeneratedVariablesMap();
+        LOG5("HSIndexContretizer(" << id << ") maxExpansion = " << maxExpansion);
     }
     Visitor::profile_t init_apply(const IR::Node *node) override {
         auto rv = Transform::init_apply(node);
@@ -109,10 +115,10 @@ class HSIndexContretizer : public Transform {
 
 class HSIndexSimplifier : public PassManager {
  public:
-    explicit HSIndexSimplifier(TypeMap *typeMap) {
+    explicit HSIndexSimplifier(TypeMap *typeMap, size_t maxExpansion = 1000) {
         // remove block statements
         passes.push_back(new TypeChecking(nullptr, typeMap, true));
-        passes.push_back(new HSIndexContretizer(typeMap));
+        passes.push_back(new HSIndexContretizer(typeMap, maxExpansion));
         setName("HSIndexSimplifier");
     }
 };

--- a/testdata/p4_16_errors/array4.p4
+++ b/testdata/p4_16_errors/array4.p4
@@ -1,0 +1,31 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+
+struct S {
+    bit<16> f1;
+    bit<8>[16] nested_arr;
+    bit<16> f2;
+}
+
+header data_t {
+    S[16]  arr;
+    bit<4>     w;
+    bit<4>     x;
+    bit<4>     y;
+    bit<4>     z;
+}
+
+struct headers {
+    data_t      data;
+}
+
+
+control c(inout headers hdr) {
+    apply {
+        bit<8>[16] t1 = hdr.data.arr[hdr.data.z].nested_arr;
+        bit<8> t2 = t1[hdr.data.w];
+        hdr.data.arr[hdr.data.x].nested_arr[hdr.data.y] = t2;
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors/stack_e.p4
+++ b/testdata/p4_16_errors/stack_e.p4
@@ -20,11 +20,12 @@ control p()
 {
     apply {
         h[5] stack;
-        s[5] stack1; // non-header illegal in header stack
+        s[5] stack1; // 'normal' array can't use stack operations
 
         // out of range indexes
         h b = stack[1231092310293];
         h c = stack[-2];
         h d = stack[6];
+        s e = stack1.next;
     }
 }

--- a/testdata/p4_16_errors_outputs/array4-first.p4
+++ b/testdata/p4_16_errors_outputs/array4-first.p4
@@ -1,0 +1,29 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+struct S {
+    bit<16>    f1;
+    bit<8>[16] nested_arr;
+    bit<16>    f2;
+}
+
+header data_t {
+    S[16]  arr;
+    bit<4> w;
+    bit<4> x;
+    bit<4> y;
+    bit<4> z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        bit<8>[16] t1 = hdr.data.arr[hdr.data.z].nested_arr;
+        bit<8> t2 = t1[hdr.data.w];
+        hdr.data.arr[hdr.data.x].nested_arr[hdr.data.y] = t2;
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_errors_outputs/array4-frontend.p4
+++ b/testdata/p4_16_errors_outputs/array4-frontend.p4
@@ -1,0 +1,31 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+struct S {
+    bit<16>    f1;
+    bit<8>[16] nested_arr;
+    bit<16>    f2;
+}
+
+header data_t {
+    S[16]  arr;
+    bit<4> w;
+    bit<4> x;
+    bit<4> y;
+    bit<4> z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    @name("c.t1") bit<8>[16] t1_0;
+    @name("c.t2") bit<8> t2_0;
+    apply {
+        t1_0 = hdr.data.arr[hdr.data.z].nested_arr;
+        t2_0 = t1_0[hdr.data.w];
+        hdr.data.arr[hdr.data.x].nested_arr[hdr.data.y] = t2_0;
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_errors_outputs/array4.p4
+++ b/testdata/p4_16_errors_outputs/array4.p4
@@ -1,0 +1,29 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+struct S {
+    bit<16>    f1;
+    bit<8>[16] nested_arr;
+    bit<16>    f2;
+}
+
+header data_t {
+    S[16]  arr;
+    bit<4> w;
+    bit<4> x;
+    bit<4> y;
+    bit<4> z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        bit<8>[16] t1 = hdr.data.arr[hdr.data.z].nested_arr;
+        bit<8> t2 = t1[hdr.data.w];
+        hdr.data.arr[hdr.data.x].nested_arr[hdr.data.y] = t2;
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/array4.p4-stderr
+++ b/testdata/p4_16_errors_outputs/array4.p4-stderr
@@ -1,0 +1,3 @@
+array4.p4(27): [--Werror=overlimit] error: Too much expansion from non-const array indexes
+        hdr.data.arr[hdr.data.x].nested_arr[hdr.data.y] = t2;
+                                                        ^

--- a/testdata/p4_16_errors_outputs/stack_e.p4
+++ b/testdata/p4_16_errors_outputs/stack_e.p4
@@ -11,6 +11,7 @@ control p() {
         h b = stack[1231092310293];
         h c = stack[-2];
         h d = stack[6];
+        s e = stack1.next;
     }
 }
 

--- a/testdata/p4_16_errors_outputs/stack_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stack_e.p4-stderr
@@ -1,6 +1,6 @@
-stack_e.p4(23): [--Werror=type-error] error: Header stack struct s[5] used with non-header type struct s
-        s[5] stack1; // non-header illegal in header stack
-        ^^^^
 stack_e.p4(26): [--Werror=overlimit] error: 1231092310293: Value too large for int
         h b = stack[1231092310293];
                     ^^^^^^^^^^^^^
+stack_e.p4(29): [--Werror=type-error] error: stack1.next: 'next' can only be used on header stacks
+        s e = stack1.next;
+              ^^^^^^^^^^^

--- a/testdata/p4_16_samples/array1.p4
+++ b/testdata/p4_16_samples/array1.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header data_t {
+    bit<32>     f1;
+    bit<32>     f2;
+    bit<16>     h1;
+    bit<16>     h2;
+    bit<8>[16]  arr;
+}
+
+struct metadata {}
+
+struct headers {
+    data_t      data;
+}
+
+parser p(packet_in b,
+         out headers hdr,
+         inout metadata meta,
+         inout standard_metadata_t stdmeta) {
+    state start {
+        b.extract(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t stdmeta) {
+    apply {
+        hdr.data.arr[0] = hdr.data.f1[0+:8];
+        hdr.data.arr[1] = hdr.data.f1[8+:8];
+        hdr.data.arr[2] = hdr.data.f1[16+:8];
+        hdr.data.arr[3] = hdr.data.f1[24+:8];
+        hdr.data.arr[4] = hdr.data.f2[0+:8];
+        hdr.data.arr[5] = hdr.data.f2[8+:8];
+        hdr.data.arr[6] = hdr.data.f2[16+:8];
+        hdr.data.arr[7] = hdr.data.f2[24+:8];
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata meta,
+               inout standard_metadata_t stdmeta) {
+    apply {}
+}
+
+control vc(inout headers hdr,
+           inout metadata meta) {
+    apply {}
+}
+
+control uc(inout headers hdr,
+           inout metadata meta) {
+    apply {}
+}
+
+control deparser(packet_out packet,
+                 in headers hdr) {
+    apply {
+        packet.emit(hdr);
+    }
+}
+
+V1Switch<headers, metadata>(p(),
+                            vc(),
+                            ingress(),
+                            egress(),
+                            uc(),
+                            deparser()) main;

--- a/testdata/p4_16_samples/array2.p4
+++ b/testdata/p4_16_samples/array2.p4
@@ -1,0 +1,71 @@
+#include <core.p4>
+#include <v1model.p4>
+
+header data_t {
+    bit<32>     f1;
+    bit<32>     f2;
+    bit<16>     h1;
+    bit<16>     h2;
+    bit<8>      arr[16];
+}
+
+struct metadata {}
+
+struct headers {
+    data_t      data;
+}
+
+parser p(packet_in b,
+         out headers hdr,
+         inout metadata meta,
+         inout standard_metadata_t stdmeta) {
+    state start {
+        b.extract(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t stdmeta) {
+    apply {
+        hdr.data.arr[0] = hdr.data.f1[0+:8];
+        hdr.data.arr[1] = hdr.data.f1[8+:8];
+        hdr.data.arr[2] = hdr.data.f1[16+:8];
+        hdr.data.arr[3] = hdr.data.f1[24+:8];
+        hdr.data.arr[4] = hdr.data.f2[0+:8];
+        hdr.data.arr[5] = hdr.data.f2[8+:8];
+        hdr.data.arr[6] = hdr.data.f2[16+:8];
+        hdr.data.arr[7] = hdr.data.f2[24+:8];
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata meta,
+               inout standard_metadata_t stdmeta) {
+    apply {}
+}
+
+control vc(inout headers hdr,
+           inout metadata meta) {
+    apply {}
+}
+
+control uc(inout headers hdr,
+           inout metadata meta) {
+    apply {}
+}
+
+control deparser(packet_out packet,
+                 in headers hdr) {
+    apply {
+        packet.emit(hdr);
+    }
+}
+
+V1Switch<headers, metadata>(p(),
+                            vc(),
+                            ingress(),
+                            egress(),
+                            uc(),
+                            deparser()) main;

--- a/testdata/p4_16_samples/array3.p4
+++ b/testdata/p4_16_samples/array3.p4
@@ -1,0 +1,30 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+
+struct S {
+    bit<16> f1;
+    bit<8>[16] nested_arr;
+    bit<16> f2;
+}
+
+header data_t {
+    S[16]  arr;
+    bit<4>     w;
+    bit<4>     x;
+    bit<4>     y;
+    bit<4>     z;
+}
+
+struct headers {
+    data_t      data;
+}
+
+
+control c(inout headers hdr) {
+    apply {
+        hdr.data.arr[0].nested_arr[1] =
+            hdr.data.arr[2].nested_arr[3];
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples/array5.p4
+++ b/testdata/p4_16_samples/array5.p4
@@ -1,0 +1,23 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+
+header data_t {
+    bit<8>[2][2]  arr;
+    bit<1>     w;
+    bit<1>     x;
+    bit<1>     y;
+    bit<1>     z;
+}
+
+struct headers {
+    data_t      data;
+}
+
+
+control c(inout headers hdr) {
+    apply {
+        hdr.data.arr[hdr.data.w][hdr.data.x] = hdr.data.arr[hdr.data.y][hdr.data.z];
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/array1-first.p4
+++ b/testdata/p4_16_samples_outputs/array1-first.p4
@@ -1,0 +1,61 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header data_t {
+    bit<32>    f1;
+    bit<32>    f2;
+    bit<16>    h1;
+    bit<16>    h2;
+    bit<8>[16] arr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    data_t data;
+}
+
+parser p(packet_in b, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        b.extract<data_t>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+        hdr.data.arr[0] = hdr.data.f1[7:0];
+        hdr.data.arr[1] = hdr.data.f1[15:8];
+        hdr.data.arr[2] = hdr.data.f1[23:16];
+        hdr.data.arr[3] = hdr.data.f1[31:24];
+        hdr.data.arr[4] = hdr.data.f2[7:0];
+        hdr.data.arr[5] = hdr.data.f2[15:8];
+        hdr.data.arr[6] = hdr.data.f2[23:16];
+        hdr.data.arr[7] = hdr.data.f2[31:24];
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control deparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<headers>(hdr);
+    }
+}
+
+V1Switch<headers, metadata>(p(), vc(), ingress(), egress(), uc(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/array1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/array1-frontend.p4
@@ -1,0 +1,61 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header data_t {
+    bit<32>    f1;
+    bit<32>    f2;
+    bit<16>    h1;
+    bit<16>    h2;
+    bit<8>[16] arr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    data_t data;
+}
+
+parser p(packet_in b, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        b.extract<data_t>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+        hdr.data.arr[0] = hdr.data.f1[7:0];
+        hdr.data.arr[1] = hdr.data.f1[15:8];
+        hdr.data.arr[2] = hdr.data.f1[23:16];
+        hdr.data.arr[3] = hdr.data.f1[31:24];
+        hdr.data.arr[4] = hdr.data.f2[7:0];
+        hdr.data.arr[5] = hdr.data.f2[15:8];
+        hdr.data.arr[6] = hdr.data.f2[23:16];
+        hdr.data.arr[7] = hdr.data.f2[31:24];
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control deparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<headers>(hdr);
+    }
+}
+
+V1Switch<headers, metadata>(p(), vc(), ingress(), egress(), uc(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/array1-midend.p4
+++ b/testdata/p4_16_samples_outputs/array1-midend.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header data_t {
+    bit<32>    f1;
+    bit<32>    f2;
+    bit<16>    h1;
+    bit<16>    h2;
+    bit<8>[16] arr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    data_t data;
+}
+
+parser p(packet_in b, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        b.extract<data_t>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    @hidden action array1l32() {
+        hdr.data.arr[0] = hdr.data.f1[7:0];
+        hdr.data.arr[1] = hdr.data.f1[15:8];
+        hdr.data.arr[2] = hdr.data.f1[23:16];
+        hdr.data.arr[3] = hdr.data.f1[31:24];
+        hdr.data.arr[4] = hdr.data.f2[7:0];
+        hdr.data.arr[5] = hdr.data.f2[15:8];
+        hdr.data.arr[6] = hdr.data.f2[23:16];
+        hdr.data.arr[7] = hdr.data.f2[31:24];
+    }
+    @hidden table tbl_array1l32 {
+        actions = {
+            array1l32();
+        }
+        const default_action = array1l32();
+    }
+    apply {
+        tbl_array1l32.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control deparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<data_t>(hdr.data);
+    }
+}
+
+V1Switch<headers, metadata>(p(), vc(), ingress(), egress(), uc(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/array1.p4
+++ b/testdata/p4_16_samples_outputs/array1.p4
@@ -1,0 +1,61 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header data_t {
+    bit<32>    f1;
+    bit<32>    f2;
+    bit<16>    h1;
+    bit<16>    h2;
+    bit<8>[16] arr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    data_t data;
+}
+
+parser p(packet_in b, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        b.extract(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+        hdr.data.arr[0] = hdr.data.f1[0+:8];
+        hdr.data.arr[1] = hdr.data.f1[8+:8];
+        hdr.data.arr[2] = hdr.data.f1[16+:8];
+        hdr.data.arr[3] = hdr.data.f1[24+:8];
+        hdr.data.arr[4] = hdr.data.f2[0+:8];
+        hdr.data.arr[5] = hdr.data.f2[8+:8];
+        hdr.data.arr[6] = hdr.data.f2[16+:8];
+        hdr.data.arr[7] = hdr.data.f2[24+:8];
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control deparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr);
+    }
+}
+
+V1Switch<headers, metadata>(p(), vc(), ingress(), egress(), uc(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/array1.p4.entries.txtpb
+++ b/testdata/p4_16_samples_outputs/array1.p4.entries.txtpb
@@ -1,0 +1,3 @@
+# proto-file: p4/v1/p4runtime.proto
+# proto-message: p4.v1.WriteRequest
+

--- a/testdata/p4_16_samples_outputs/array1.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/array1.p4.p4info.txtpb
@@ -1,0 +1,6 @@
+# proto-file: p4/config/v1/p4info.proto
+# proto-message: p4.config.v1.P4Info
+
+pkg_info {
+  arch: "v1model"
+}

--- a/testdata/p4_16_samples_outputs/array2-first.p4
+++ b/testdata/p4_16_samples_outputs/array2-first.p4
@@ -1,0 +1,61 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header data_t {
+    bit<32>    f1;
+    bit<32>    f2;
+    bit<16>    h1;
+    bit<16>    h2;
+    bit<8>[16] arr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    data_t data;
+}
+
+parser p(packet_in b, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        b.extract<data_t>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+        hdr.data.arr[0] = hdr.data.f1[7:0];
+        hdr.data.arr[1] = hdr.data.f1[15:8];
+        hdr.data.arr[2] = hdr.data.f1[23:16];
+        hdr.data.arr[3] = hdr.data.f1[31:24];
+        hdr.data.arr[4] = hdr.data.f2[7:0];
+        hdr.data.arr[5] = hdr.data.f2[15:8];
+        hdr.data.arr[6] = hdr.data.f2[23:16];
+        hdr.data.arr[7] = hdr.data.f2[31:24];
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control deparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<headers>(hdr);
+    }
+}
+
+V1Switch<headers, metadata>(p(), vc(), ingress(), egress(), uc(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/array2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/array2-frontend.p4
@@ -1,0 +1,61 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header data_t {
+    bit<32>    f1;
+    bit<32>    f2;
+    bit<16>    h1;
+    bit<16>    h2;
+    bit<8>[16] arr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    data_t data;
+}
+
+parser p(packet_in b, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        b.extract<data_t>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+        hdr.data.arr[0] = hdr.data.f1[7:0];
+        hdr.data.arr[1] = hdr.data.f1[15:8];
+        hdr.data.arr[2] = hdr.data.f1[23:16];
+        hdr.data.arr[3] = hdr.data.f1[31:24];
+        hdr.data.arr[4] = hdr.data.f2[7:0];
+        hdr.data.arr[5] = hdr.data.f2[15:8];
+        hdr.data.arr[6] = hdr.data.f2[23:16];
+        hdr.data.arr[7] = hdr.data.f2[31:24];
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control deparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<headers>(hdr);
+    }
+}
+
+V1Switch<headers, metadata>(p(), vc(), ingress(), egress(), uc(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/array2-midend.p4
+++ b/testdata/p4_16_samples_outputs/array2-midend.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header data_t {
+    bit<32>    f1;
+    bit<32>    f2;
+    bit<16>    h1;
+    bit<16>    h2;
+    bit<8>[16] arr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    data_t data;
+}
+
+parser p(packet_in b, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        b.extract<data_t>(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    @hidden action array2l32() {
+        hdr.data.arr[0] = hdr.data.f1[7:0];
+        hdr.data.arr[1] = hdr.data.f1[15:8];
+        hdr.data.arr[2] = hdr.data.f1[23:16];
+        hdr.data.arr[3] = hdr.data.f1[31:24];
+        hdr.data.arr[4] = hdr.data.f2[7:0];
+        hdr.data.arr[5] = hdr.data.f2[15:8];
+        hdr.data.arr[6] = hdr.data.f2[23:16];
+        hdr.data.arr[7] = hdr.data.f2[31:24];
+    }
+    @hidden table tbl_array2l32 {
+        actions = {
+            array2l32();
+        }
+        const default_action = array2l32();
+    }
+    apply {
+        tbl_array2l32.apply();
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control deparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit<data_t>(hdr.data);
+    }
+}
+
+V1Switch<headers, metadata>(p(), vc(), ingress(), egress(), uc(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/array2.p4
+++ b/testdata/p4_16_samples_outputs/array2.p4
@@ -1,0 +1,61 @@
+#include <core.p4>
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header data_t {
+    bit<32>    f1;
+    bit<32>    f2;
+    bit<16>    h1;
+    bit<16>    h2;
+    bit<8>[16] arr;
+}
+
+struct metadata {
+}
+
+struct headers {
+    data_t data;
+}
+
+parser p(packet_in b, out headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    state start {
+        b.extract(hdr.data);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+        hdr.data.arr[0] = hdr.data.f1[0+:8];
+        hdr.data.arr[1] = hdr.data.f1[8+:8];
+        hdr.data.arr[2] = hdr.data.f1[16+:8];
+        hdr.data.arr[3] = hdr.data.f1[24+:8];
+        hdr.data.arr[4] = hdr.data.f2[0+:8];
+        hdr.data.arr[5] = hdr.data.f2[8+:8];
+        hdr.data.arr[6] = hdr.data.f2[16+:8];
+        hdr.data.arr[7] = hdr.data.f2[24+:8];
+    }
+}
+
+control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t stdmeta) {
+    apply {
+    }
+}
+
+control vc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control uc(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+control deparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr);
+    }
+}
+
+V1Switch<headers, metadata>(p(), vc(), ingress(), egress(), uc(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/array2.p4.entries.txtpb
+++ b/testdata/p4_16_samples_outputs/array2.p4.entries.txtpb
@@ -1,0 +1,3 @@
+# proto-file: p4/v1/p4runtime.proto
+# proto-message: p4.v1.WriteRequest
+

--- a/testdata/p4_16_samples_outputs/array2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/array2.p4.p4info.txtpb
@@ -1,0 +1,6 @@
+# proto-file: p4/config/v1/p4info.proto
+# proto-message: p4.config.v1.P4Info
+
+pkg_info {
+  arch: "v1model"
+}

--- a/testdata/p4_16_samples_outputs/array3-first.p4
+++ b/testdata/p4_16_samples_outputs/array3-first.p4
@@ -1,0 +1,27 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+struct S {
+    bit<16>    f1;
+    bit<8>[16] nested_arr;
+    bit<16>    f2;
+}
+
+header data_t {
+    S[16]  arr;
+    bit<4> w;
+    bit<4> x;
+    bit<4> y;
+    bit<4> z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        hdr.data.arr[0].nested_arr[1] = hdr.data.arr[2].nested_arr[3];
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_samples_outputs/array3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/array3-frontend.p4
@@ -1,0 +1,27 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+struct S {
+    bit<16>    f1;
+    bit<8>[16] nested_arr;
+    bit<16>    f2;
+}
+
+header data_t {
+    S[16]  arr;
+    bit<4> w;
+    bit<4> x;
+    bit<4> y;
+    bit<4> z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        hdr.data.arr[0].nested_arr[1] = hdr.data.arr[2].nested_arr[3];
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_samples_outputs/array3-midend.p4
+++ b/testdata/p4_16_samples_outputs/array3-midend.p4
@@ -1,0 +1,36 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+struct S {
+    bit<16>    f1;
+    bit<8>[16] nested_arr;
+    bit<16>    f2;
+}
+
+header data_t {
+    S[16]  arr;
+    bit<4> w;
+    bit<4> x;
+    bit<4> y;
+    bit<4> z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    @hidden action array3l25() {
+        hdr.data.arr[0].nested_arr[1] = hdr.data.arr[2].nested_arr[3];
+    }
+    @hidden table tbl_array3l25 {
+        actions = {
+            array3l25();
+        }
+        const default_action = array3l25();
+    }
+    apply {
+        tbl_array3l25.apply();
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_samples_outputs/array3.p4
+++ b/testdata/p4_16_samples_outputs/array3.p4
@@ -1,0 +1,27 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+struct S {
+    bit<16>    f1;
+    bit<8>[16] nested_arr;
+    bit<16>    f2;
+}
+
+header data_t {
+    S[16]  arr;
+    bit<4> w;
+    bit<4> x;
+    bit<4> y;
+    bit<4> z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        hdr.data.arr[0].nested_arr[1] = hdr.data.arr[2].nested_arr[3];
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/array5-first.p4
+++ b/testdata/p4_16_samples_outputs/array5-first.p4
@@ -1,0 +1,21 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+header data_t {
+    bit<8>[2][2] arr;
+    bit<1>       w;
+    bit<1>       x;
+    bit<1>       y;
+    bit<1>       z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        hdr.data.arr[hdr.data.w][hdr.data.x] = hdr.data.arr[hdr.data.y][hdr.data.z];
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_samples_outputs/array5-frontend.p4
+++ b/testdata/p4_16_samples_outputs/array5-frontend.p4
@@ -1,0 +1,21 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+header data_t {
+    bit<8>[2][2] arr;
+    bit<1>       w;
+    bit<1>       x;
+    bit<1>       y;
+    bit<1>       z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        hdr.data.arr[hdr.data.w][hdr.data.x] = hdr.data.arr[hdr.data.y][hdr.data.z];
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_samples_outputs/array5-midend.p4
+++ b/testdata/p4_16_samples_outputs/array5-midend.p4
@@ -1,0 +1,512 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+header data_t {
+    bit<8>[2][2] arr;
+    bit<1>       w;
+    bit<1>       x;
+    bit<1>       y;
+    bit<1>       z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    bit<1> hsiVar;
+    bit<1> hsiVar_0;
+    bit<1> hsiVar_1;
+    bit<8> hsVar;
+    bit<1> hsiVar_2;
+    @hidden action array5l19() {
+        hdr.data.arr[1w0][1w0] = hdr.data.arr[1w0][1w0];
+    }
+    @hidden action array5l19_0() {
+        hdr.data.arr[1w0][1w0] = hdr.data.arr[1w0][1w1];
+    }
+    @hidden action array5l19_1() {
+        hdr.data.arr[1w0][1w0] = hsVar;
+    }
+    @hidden action array5l19_2() {
+        hsiVar_2 = hdr.data.z;
+    }
+    @hidden action array5l19_3() {
+        hdr.data.arr[1w0][1w0] = hdr.data.arr[1w1][1w0];
+    }
+    @hidden action array5l19_4() {
+        hdr.data.arr[1w0][1w0] = hdr.data.arr[1w1][1w1];
+    }
+    @hidden action array5l19_5() {
+        hdr.data.arr[1w0][1w0] = hsVar;
+    }
+    @hidden action array5l19_6() {
+        hsiVar_2 = hdr.data.z;
+    }
+    @hidden action array5l19_7() {
+        hdr.data.arr[1w0][1w0] = hsVar;
+    }
+    @hidden action array5l19_8() {
+        hsiVar_1 = hdr.data.y;
+    }
+    @hidden action array5l19_9() {
+        hdr.data.arr[1w0][1w1] = hdr.data.arr[1w0][1w0];
+    }
+    @hidden action array5l19_10() {
+        hdr.data.arr[1w0][1w1] = hdr.data.arr[1w0][1w1];
+    }
+    @hidden action array5l19_11() {
+        hdr.data.arr[1w0][1w1] = hsVar;
+    }
+    @hidden action array5l19_12() {
+        hsiVar_2 = hdr.data.z;
+    }
+    @hidden action array5l19_13() {
+        hdr.data.arr[1w0][1w1] = hdr.data.arr[1w1][1w0];
+    }
+    @hidden action array5l19_14() {
+        hdr.data.arr[1w0][1w1] = hdr.data.arr[1w1][1w1];
+    }
+    @hidden action array5l19_15() {
+        hdr.data.arr[1w0][1w1] = hsVar;
+    }
+    @hidden action array5l19_16() {
+        hsiVar_2 = hdr.data.z;
+    }
+    @hidden action array5l19_17() {
+        hdr.data.arr[1w0][1w1] = hsVar;
+    }
+    @hidden action array5l19_18() {
+        hsiVar_1 = hdr.data.y;
+    }
+    @hidden action array5l19_19() {
+        hsiVar_0 = hdr.data.x;
+    }
+    @hidden action array5l19_20() {
+        hdr.data.arr[1w1][1w0] = hdr.data.arr[1w0][1w0];
+    }
+    @hidden action array5l19_21() {
+        hdr.data.arr[1w1][1w0] = hdr.data.arr[1w0][1w1];
+    }
+    @hidden action array5l19_22() {
+        hdr.data.arr[1w1][1w0] = hsVar;
+    }
+    @hidden action array5l19_23() {
+        hsiVar_2 = hdr.data.z;
+    }
+    @hidden action array5l19_24() {
+        hdr.data.arr[1w1][1w0] = hdr.data.arr[1w1][1w0];
+    }
+    @hidden action array5l19_25() {
+        hdr.data.arr[1w1][1w0] = hdr.data.arr[1w1][1w1];
+    }
+    @hidden action array5l19_26() {
+        hdr.data.arr[1w1][1w0] = hsVar;
+    }
+    @hidden action array5l19_27() {
+        hsiVar_2 = hdr.data.z;
+    }
+    @hidden action array5l19_28() {
+        hdr.data.arr[1w1][1w0] = hsVar;
+    }
+    @hidden action array5l19_29() {
+        hsiVar_1 = hdr.data.y;
+    }
+    @hidden action array5l19_30() {
+        hdr.data.arr[1w1][1w1] = hdr.data.arr[1w0][1w0];
+    }
+    @hidden action array5l19_31() {
+        hdr.data.arr[1w1][1w1] = hdr.data.arr[1w0][1w1];
+    }
+    @hidden action array5l19_32() {
+        hdr.data.arr[1w1][1w1] = hsVar;
+    }
+    @hidden action array5l19_33() {
+        hsiVar_2 = hdr.data.z;
+    }
+    @hidden action array5l19_34() {
+        hdr.data.arr[1w1][1w1] = hdr.data.arr[1w1][1w0];
+    }
+    @hidden action array5l19_35() {
+        hdr.data.arr[1w1][1w1] = hdr.data.arr[1w1][1w1];
+    }
+    @hidden action array5l19_36() {
+        hdr.data.arr[1w1][1w1] = hsVar;
+    }
+    @hidden action array5l19_37() {
+        hsiVar_2 = hdr.data.z;
+    }
+    @hidden action array5l19_38() {
+        hdr.data.arr[1w1][1w1] = hsVar;
+    }
+    @hidden action array5l19_39() {
+        hsiVar_1 = hdr.data.y;
+    }
+    @hidden action array5l19_40() {
+        hsiVar_0 = hdr.data.x;
+    }
+    @hidden action array5l19_41() {
+        hsiVar = hdr.data.w;
+    }
+    @hidden table tbl_array5l19 {
+        actions = {
+            array5l19_41();
+        }
+        const default_action = array5l19_41();
+    }
+    @hidden table tbl_array5l19_0 {
+        actions = {
+            array5l19_19();
+        }
+        const default_action = array5l19_19();
+    }
+    @hidden table tbl_array5l19_1 {
+        actions = {
+            array5l19_8();
+        }
+        const default_action = array5l19_8();
+    }
+    @hidden table tbl_array5l19_2 {
+        actions = {
+            array5l19_2();
+        }
+        const default_action = array5l19_2();
+    }
+    @hidden table tbl_array5l19_3 {
+        actions = {
+            array5l19();
+        }
+        const default_action = array5l19();
+    }
+    @hidden table tbl_array5l19_4 {
+        actions = {
+            array5l19_0();
+        }
+        const default_action = array5l19_0();
+    }
+    @hidden table tbl_array5l19_5 {
+        actions = {
+            array5l19_1();
+        }
+        const default_action = array5l19_1();
+    }
+    @hidden table tbl_array5l19_6 {
+        actions = {
+            array5l19_6();
+        }
+        const default_action = array5l19_6();
+    }
+    @hidden table tbl_array5l19_7 {
+        actions = {
+            array5l19_3();
+        }
+        const default_action = array5l19_3();
+    }
+    @hidden table tbl_array5l19_8 {
+        actions = {
+            array5l19_4();
+        }
+        const default_action = array5l19_4();
+    }
+    @hidden table tbl_array5l19_9 {
+        actions = {
+            array5l19_5();
+        }
+        const default_action = array5l19_5();
+    }
+    @hidden table tbl_array5l19_10 {
+        actions = {
+            array5l19_7();
+        }
+        const default_action = array5l19_7();
+    }
+    @hidden table tbl_array5l19_11 {
+        actions = {
+            array5l19_18();
+        }
+        const default_action = array5l19_18();
+    }
+    @hidden table tbl_array5l19_12 {
+        actions = {
+            array5l19_12();
+        }
+        const default_action = array5l19_12();
+    }
+    @hidden table tbl_array5l19_13 {
+        actions = {
+            array5l19_9();
+        }
+        const default_action = array5l19_9();
+    }
+    @hidden table tbl_array5l19_14 {
+        actions = {
+            array5l19_10();
+        }
+        const default_action = array5l19_10();
+    }
+    @hidden table tbl_array5l19_15 {
+        actions = {
+            array5l19_11();
+        }
+        const default_action = array5l19_11();
+    }
+    @hidden table tbl_array5l19_16 {
+        actions = {
+            array5l19_16();
+        }
+        const default_action = array5l19_16();
+    }
+    @hidden table tbl_array5l19_17 {
+        actions = {
+            array5l19_13();
+        }
+        const default_action = array5l19_13();
+    }
+    @hidden table tbl_array5l19_18 {
+        actions = {
+            array5l19_14();
+        }
+        const default_action = array5l19_14();
+    }
+    @hidden table tbl_array5l19_19 {
+        actions = {
+            array5l19_15();
+        }
+        const default_action = array5l19_15();
+    }
+    @hidden table tbl_array5l19_20 {
+        actions = {
+            array5l19_17();
+        }
+        const default_action = array5l19_17();
+    }
+    @hidden table tbl_array5l19_21 {
+        actions = {
+            array5l19_40();
+        }
+        const default_action = array5l19_40();
+    }
+    @hidden table tbl_array5l19_22 {
+        actions = {
+            array5l19_29();
+        }
+        const default_action = array5l19_29();
+    }
+    @hidden table tbl_array5l19_23 {
+        actions = {
+            array5l19_23();
+        }
+        const default_action = array5l19_23();
+    }
+    @hidden table tbl_array5l19_24 {
+        actions = {
+            array5l19_20();
+        }
+        const default_action = array5l19_20();
+    }
+    @hidden table tbl_array5l19_25 {
+        actions = {
+            array5l19_21();
+        }
+        const default_action = array5l19_21();
+    }
+    @hidden table tbl_array5l19_26 {
+        actions = {
+            array5l19_22();
+        }
+        const default_action = array5l19_22();
+    }
+    @hidden table tbl_array5l19_27 {
+        actions = {
+            array5l19_27();
+        }
+        const default_action = array5l19_27();
+    }
+    @hidden table tbl_array5l19_28 {
+        actions = {
+            array5l19_24();
+        }
+        const default_action = array5l19_24();
+    }
+    @hidden table tbl_array5l19_29 {
+        actions = {
+            array5l19_25();
+        }
+        const default_action = array5l19_25();
+    }
+    @hidden table tbl_array5l19_30 {
+        actions = {
+            array5l19_26();
+        }
+        const default_action = array5l19_26();
+    }
+    @hidden table tbl_array5l19_31 {
+        actions = {
+            array5l19_28();
+        }
+        const default_action = array5l19_28();
+    }
+    @hidden table tbl_array5l19_32 {
+        actions = {
+            array5l19_39();
+        }
+        const default_action = array5l19_39();
+    }
+    @hidden table tbl_array5l19_33 {
+        actions = {
+            array5l19_33();
+        }
+        const default_action = array5l19_33();
+    }
+    @hidden table tbl_array5l19_34 {
+        actions = {
+            array5l19_30();
+        }
+        const default_action = array5l19_30();
+    }
+    @hidden table tbl_array5l19_35 {
+        actions = {
+            array5l19_31();
+        }
+        const default_action = array5l19_31();
+    }
+    @hidden table tbl_array5l19_36 {
+        actions = {
+            array5l19_32();
+        }
+        const default_action = array5l19_32();
+    }
+    @hidden table tbl_array5l19_37 {
+        actions = {
+            array5l19_37();
+        }
+        const default_action = array5l19_37();
+    }
+    @hidden table tbl_array5l19_38 {
+        actions = {
+            array5l19_34();
+        }
+        const default_action = array5l19_34();
+    }
+    @hidden table tbl_array5l19_39 {
+        actions = {
+            array5l19_35();
+        }
+        const default_action = array5l19_35();
+    }
+    @hidden table tbl_array5l19_40 {
+        actions = {
+            array5l19_36();
+        }
+        const default_action = array5l19_36();
+    }
+    @hidden table tbl_array5l19_41 {
+        actions = {
+            array5l19_38();
+        }
+        const default_action = array5l19_38();
+    }
+    apply {
+        tbl_array5l19.apply();
+        if (hsiVar == 1w0) {
+            tbl_array5l19_0.apply();
+            if (hsiVar_0 == 1w0) {
+                tbl_array5l19_1.apply();
+                if (hsiVar_1 == 1w0) {
+                    tbl_array5l19_2.apply();
+                    if (hsiVar_2 == 1w0) {
+                        tbl_array5l19_3.apply();
+                    } else if (hsiVar_2 == 1w1) {
+                        tbl_array5l19_4.apply();
+                    } else if (hsiVar_2 >= 1w1) {
+                        tbl_array5l19_5.apply();
+                    }
+                } else if (hsiVar_1 == 1w1) {
+                    tbl_array5l19_6.apply();
+                    if (hsiVar_2 == 1w0) {
+                        tbl_array5l19_7.apply();
+                    } else if (hsiVar_2 == 1w1) {
+                        tbl_array5l19_8.apply();
+                    } else if (hsiVar_2 >= 1w1) {
+                        tbl_array5l19_9.apply();
+                    }
+                } else if (hsiVar_1 >= 1w1) {
+                    tbl_array5l19_10.apply();
+                }
+            } else if (hsiVar_0 == 1w1) {
+                tbl_array5l19_11.apply();
+                if (hsiVar_1 == 1w0) {
+                    tbl_array5l19_12.apply();
+                    if (hsiVar_2 == 1w0) {
+                        tbl_array5l19_13.apply();
+                    } else if (hsiVar_2 == 1w1) {
+                        tbl_array5l19_14.apply();
+                    } else if (hsiVar_2 >= 1w1) {
+                        tbl_array5l19_15.apply();
+                    }
+                } else if (hsiVar_1 == 1w1) {
+                    tbl_array5l19_16.apply();
+                    if (hsiVar_2 == 1w0) {
+                        tbl_array5l19_17.apply();
+                    } else if (hsiVar_2 == 1w1) {
+                        tbl_array5l19_18.apply();
+                    } else if (hsiVar_2 >= 1w1) {
+                        tbl_array5l19_19.apply();
+                    }
+                } else if (hsiVar_1 >= 1w1) {
+                    tbl_array5l19_20.apply();
+                }
+            }
+        } else if (hsiVar == 1w1) {
+            tbl_array5l19_21.apply();
+            if (hsiVar_0 == 1w0) {
+                tbl_array5l19_22.apply();
+                if (hsiVar_1 == 1w0) {
+                    tbl_array5l19_23.apply();
+                    if (hsiVar_2 == 1w0) {
+                        tbl_array5l19_24.apply();
+                    } else if (hsiVar_2 == 1w1) {
+                        tbl_array5l19_25.apply();
+                    } else if (hsiVar_2 >= 1w1) {
+                        tbl_array5l19_26.apply();
+                    }
+                } else if (hsiVar_1 == 1w1) {
+                    tbl_array5l19_27.apply();
+                    if (hsiVar_2 == 1w0) {
+                        tbl_array5l19_28.apply();
+                    } else if (hsiVar_2 == 1w1) {
+                        tbl_array5l19_29.apply();
+                    } else if (hsiVar_2 >= 1w1) {
+                        tbl_array5l19_30.apply();
+                    }
+                } else if (hsiVar_1 >= 1w1) {
+                    tbl_array5l19_31.apply();
+                }
+            } else if (hsiVar_0 == 1w1) {
+                tbl_array5l19_32.apply();
+                if (hsiVar_1 == 1w0) {
+                    tbl_array5l19_33.apply();
+                    if (hsiVar_2 == 1w0) {
+                        tbl_array5l19_34.apply();
+                    } else if (hsiVar_2 == 1w1) {
+                        tbl_array5l19_35.apply();
+                    } else if (hsiVar_2 >= 1w1) {
+                        tbl_array5l19_36.apply();
+                    }
+                } else if (hsiVar_1 == 1w1) {
+                    tbl_array5l19_37.apply();
+                    if (hsiVar_2 == 1w0) {
+                        tbl_array5l19_38.apply();
+                    } else if (hsiVar_2 == 1w1) {
+                        tbl_array5l19_39.apply();
+                    } else if (hsiVar_2 >= 1w1) {
+                        tbl_array5l19_40.apply();
+                    }
+                } else if (hsiVar_1 >= 1w1) {
+                    tbl_array5l19_41.apply();
+                }
+            }
+        }
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_samples_outputs/array5.p4
+++ b/testdata/p4_16_samples_outputs/array5.p4
@@ -1,0 +1,21 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+header data_t {
+    bit<8>[2][2] arr;
+    bit<1>       w;
+    bit<1>       x;
+    bit<1>       y;
+    bit<1>       z;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        hdr.data.arr[hdr.data.w][hdr.data.x] = hdr.data.arr[hdr.data.y][hdr.data.z];
+    }
+}
+
+top(c()) main;


### PR DESCRIPTION
First change relaxes frontend checks to allow arrays in general as per https://github.com/p4lang/p4-spec/issues/1320.  Non-header arrays only support indexing, not any other header stack operations

Second change adds support for C-style array declarators, with the array size *after* the name instead of before it.