### PR TITLE
Silence some warnings

### DIFF
--- a/frontends/common/constantFolding.h
+++ b/frontends/common/constantFolding.h
@@ -34,6 +34,7 @@ using namespace literals;
 /// functions.
 class ConstantFoldingPolicy {
  public:
+    virtual ~ConstantFoldingPolicy() = default;
     /// The default hook does not modify anything.
     virtual const IR::Node *hook(Visitor &, IR::PathExpression *) { return nullptr; }
 };

--- a/frontends/common/resolveReferences/referenceMap.h
+++ b/frontends/common/resolveReferences/referenceMap.h
@@ -56,6 +56,7 @@ class MinimalNameGenerator : public NameGenerator, public Inspector {
 // interchangeably when looking up declarations.  This should go away once the refMap does
 class DeclarationLookup {
  public:
+    virtual ~DeclarationLookup() = default;
     virtual const IR::IDeclaration *getDeclaration(const IR::Path *,
                                                    bool notNull = false) const = 0;
     virtual const IR::IDeclaration *getDeclaration(const IR::This *,

--- a/frontends/common/resolveReferences/resolveReferences.h
+++ b/frontends/common/resolveReferences/resolveReferences.h
@@ -90,8 +90,9 @@ class ResolutionContext : virtual public Visitor, public DeclarationLookup {
     /// Resolve a refrence to a type @p type.
     const IR::Type *resolveType(const IR::Type *type) const;
 
-    const IR::IDeclaration *getDeclaration(const IR::Path *path, bool notNull = false) const;
-    const IR::IDeclaration *getDeclaration(const IR::This *, bool notNull = false) const;
+    const IR::IDeclaration *getDeclaration(const IR::Path *path,
+                                           bool notNull = false) const override;
+    const IR::IDeclaration *getDeclaration(const IR::This *, bool notNull = false) const override;
 
     /// Returns the set of decls that exist in the given namespace.
     auto getDeclarations(const IR::INamespace *ns) const {

--- a/frontends/p4-14/fromv1.0/converters.h
+++ b/frontends/p4-14/fromv1.0/converters.h
@@ -110,6 +110,8 @@ class ExternConverter {
         return false;
     }
     ExternConverter() {}
+    virtual ~ExternConverter() = default;
+
     /// register a converter for a p4_14 extern_type
     /// @type: extern_type that the converter works on
     static void addConverter(cstring type, ExternConverter *);
@@ -771,7 +773,7 @@ class CheckIfMultiEntryPoint : public Inspector {
     explicit CheckIfMultiEntryPoint(ProgramStructure *structure) : structure(structure) {
         setName("CheckIfMultiEntryPoint");
     }
-    bool preorder(const IR::ParserState *state) {
+    bool preorder(const IR::ParserState *state) override {
         for (const auto *anno : state->getAnnotations()) {
             if (anno->name == "packet_entry") {
                 structure->parserEntryPoints.emplace(state->name, state);

--- a/frontends/p4-14/fromv1.0/programStructure.h
+++ b/frontends/p4-14/fromv1.0/programStructure.h
@@ -31,6 +31,7 @@ namespace P4::P4V1 {
 
 class ConversionContext {
  public:
+    virtual ~ConversionContext() = default;
     const IR::Expression *header = nullptr;
     const IR::Expression *userMetadata = nullptr;
     const IR::Expression *standardMetadata = nullptr;
@@ -121,6 +122,7 @@ class ProgramStructure {
 
  public:
     ProgramStructure();
+    virtual ~ProgramStructure() = default;
 
     P4V1::V1Model &v1model;
     P4::P4CoreLibrary &p4lib;

--- a/frontends/p4/parameterSubstitution.h
+++ b/frontends/p4/parameterSubstitution.h
@@ -74,7 +74,7 @@ class ParameterSubstitution : public IHasDbPrint {
         return paramList->getEnumerator();
     }
 
-    void dbprint(std::ostream &out) const {
+    void dbprint(std::ostream &out) const override {
         bool brief = (DBPrint::dbgetflags(out) & DBPrint::Brief);
         if (paramList != nullptr) {
             if (!brief) out << "paramList:" << Log::endl;

--- a/frontends/p4/typeChecking/typeSubstitution.h
+++ b/frontends/p4/typeChecking/typeSubstitution.h
@@ -57,7 +57,7 @@ class TypeSubstitution : public IHasDbPrint {
         return true;
     }
 
-    void dbprint(std::ostream &out) const {
+    void dbprint(std::ostream &out) const override {
         if (isIdentity()) out << "Empty substitution";
         bool first = true;
         for (auto it : binding) {

--- a/frontends/p4/typeMap.h
+++ b/frontends/p4/typeMap.h
@@ -73,7 +73,7 @@ class TypeMap final : public ProgramMap {
     const IR::Type *getType(const IR::Node *element, bool notNull = false) const;
     // unwraps a TypeType into its contents
     const IR::Type *getTypeType(const IR::Node *element, bool notNull) const;
-    void dbprint(std::ostream &out) const;
+    void dbprint(std::ostream &out) const override;
     void clear();
     bool isLeftValue(const IR::Expression *expression) const {
         return leftValues.count(expression) > 0;

--- a/frontends/p4/unusedDeclarations.h
+++ b/frontends/p4/unusedDeclarations.h
@@ -47,6 +47,7 @@ class UsedDeclSet : public IHasDbPrint {
 
 class RemoveUnusedPolicy {
  public:
+    virtual ~RemoveUnusedPolicy() = default;
     /// The policy for removing unused declarations is baked into the pass -- targets can specify
     /// their own subclass of the pass with a changed policy and return that here
     virtual RemoveUnusedDeclarations *getRemoveUnusedDeclarationsPass(const UsedDeclSet &used,

--- a/frontends/parsers/p4/abstractP4Lexer.hpp
+++ b/frontends/parsers/p4/abstractP4Lexer.hpp
@@ -10,6 +10,7 @@ class AbstractP4Lexer {
     typedef P4::P4Parser::symbol_type Token;
 
  public:
+    virtual ~AbstractP4Lexer() = default;
     /**
      * Invoked by the parser to advance to the next token in the input stream.
      *

--- a/frontends/parsers/p4/p4AnnotationLexer.hpp
+++ b/frontends/parsers/p4/p4AnnotationLexer.hpp
@@ -20,8 +20,7 @@ class P4AnnotationLexer : public AbstractP4Lexer {
         // Singletons
         EXPRESSION = P4Parser::token_type::TOK_START_EXPRESSION,
         INTEGER = P4Parser::token_type::TOK_START_INTEGER,
-        INTEGER_OR_STRING_LITERAL =
-            P4Parser::token_type::TOK_START_INTEGER_OR_STRING_LITERAL,
+        INTEGER_OR_STRING_LITERAL = P4Parser::token_type::TOK_START_INTEGER_OR_STRING_LITERAL,
         STRING_LITERAL = P4Parser::token_type::TOK_START_STRING_LITERAL,
 
         // Pairs
@@ -32,30 +31,27 @@ class P4AnnotationLexer : public AbstractP4Lexer {
         // Triples
         EXPRESSION_TRIPLE = P4Parser::token_type::TOK_START_EXPRESSION_TRIPLE,
         INTEGER_TRIPLE = P4Parser::token_type::TOK_START_INTEGER_TRIPLE,
-        STRING_LITERAL_TRIPLE =
-            P4Parser::token_type::TOK_START_STRING_LITERAL_TRIPLE,
+        STRING_LITERAL_TRIPLE = P4Parser::token_type::TOK_START_STRING_LITERAL_TRIPLE,
 
         // P4Runtime annotations
-        P4RT_TRANSLATION_ANNOTATION =
-            P4Parser::token_type::TOK_START_P4RT_TRANSLATION_ANNOTATION,
+        P4RT_TRANSLATION_ANNOTATION = P4Parser::token_type::TOK_START_P4RT_TRANSLATION_ANNOTATION,
     };
 
  private:
     Type type;
-    const IR::Vector<IR::AnnotationToken>& body;
+    const IR::Vector<IR::AnnotationToken> &body;
     bool needStart;
     IR::Vector<IR::AnnotationToken>::const_iterator it;
-    const Util::SourceInfo& srcInfo;
+    const Util::SourceInfo &srcInfo;
 
  public:
-    P4AnnotationLexer(Type type, const Util::SourceInfo& srcInfo,
-                      const IR::Vector<IR::AnnotationToken>& body)
-        : type(type), body(body), needStart(true), it(this->body.begin()),
-          srcInfo(srcInfo) { }
+    P4AnnotationLexer(Type type, const Util::SourceInfo &srcInfo,
+                      const IR::Vector<IR::AnnotationToken> &body)
+        : type(type), body(body), needStart(true), it(this->body.begin()), srcInfo(srcInfo) {}
 
-    Token yylex(P4::P4ParserDriver& driver);
+    Token yylex(P4::P4ParserDriver &driver) override;
 };
 
 }  // namespace P4
 
-#endif  /* FRONTENDS_PARSERS_P4_P4ANNOTATIONLEXER_HPP_ */
+#endif /* FRONTENDS_PARSERS_P4_P4ANNOTATIONLEXER_HPP_ */

--- a/ir/configuration.h
+++ b/ir/configuration.h
@@ -23,6 +23,8 @@ namespace P4 {
 /// options. Implementations should be singleton classes.
 class P4CConfiguration {
  public:
+    virtual ~P4CConfiguration() = default;
+
     /// Maximum width supported for a bit field or integer.
     virtual int maximumWidthSupported() const = 0;
 
@@ -32,8 +34,8 @@ class P4CConfiguration {
 
 class DefaultP4CConfiguration : public P4CConfiguration {
  public:
-    int maximumWidthSupported() const { return 2048; }
-    int maximumArraySize() const { return 256; }
+    int maximumWidthSupported() const override { return 2048; }
+    int maximumArraySize() const override { return 256; }
 
     /// @return the singleton instance.
     static const DefaultP4CConfiguration &get() {

--- a/lib/enumerator.h
+++ b/lib/enumerator.h
@@ -217,7 +217,7 @@ class IteratorEnumerator : public Enumerator<typename std::iterator_traits<Iter>
         return std::string(this->name) + ":" + this->stateName();
     }
 
-    bool moveNext() {
+    bool moveNext() override {
         switch (this->state) {
             case EnumeratorState::NotStarted:
                 this->current = this->begin;
@@ -242,7 +242,7 @@ class IteratorEnumerator : public Enumerator<typename std::iterator_traits<Iter>
         throw std::runtime_error("Unexpected enumerator state");
     }
 
-    typename std::iterator_traits<Iter>::value_type getCurrent() const {
+    typename std::iterator_traits<Iter>::value_type getCurrent() const override {
         switch (this->state) {
             case EnumeratorState::NotStarted:
                 throw std::logic_error("You cannot call 'getCurrent' before 'moveNext'");
@@ -254,6 +254,9 @@ class IteratorEnumerator : public Enumerator<typename std::iterator_traits<Iter>
         throw std::runtime_error("Unexpected enumerator state");
     }
 };
+
+template <typename Iter>
+IteratorEnumerator(Iter begin, Iter end, const char *name) -> IteratorEnumerator<Iter>;
 
 /////////////////////////////////////////////////////////////////////
 
@@ -297,8 +300,8 @@ class EmptyEnumerator : public Enumerator<T> {
  public:
     [[nodiscard]] std::string toString() const { return "EmptyEnumerator"; }
     /// Always returns false
-    bool moveNext() { return false; }
-    T getCurrent() const {
+    bool moveNext() override { return false; }
+    T getCurrent() const override {
         throw std::logic_error("You cannot call 'getCurrent' on an EmptyEnumerator");
     }
 };

--- a/lib/error_reporter.h
+++ b/lib/error_reporter.h
@@ -92,6 +92,7 @@ class ErrorReporter {
           defaultWarningDiagnosticAction(DiagnosticAction::Warn) {
         outputstream = &std::cerr;
     }
+    virtual ~ErrorReporter() = default;
 
     // error message for a bug
     template <typename... Args>

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -82,7 +82,7 @@ class P4CExceptionBase : public std::exception {
         message = ::P4::bug_helper(fmt, "", "", std::forward<Args>(args)...);
     }
 
-    const char *what() const noexcept { return message.c_str(); }
+    const char *what() const noexcept override { return message.c_str(); }
 };
 
 /// This class indicates a bug in the compiler

--- a/lib/options.h
+++ b/lib/options.h
@@ -84,6 +84,7 @@ class Options {
 
     explicit Options(std::string_view message)
         : binaryName(nullptr), message(message), compileCommand("") {}
+    virtual ~Options() = default;
 
     /// Checks if parsed options make sense with respect to each-other.
     /// @returns true if the validation was successful and false otherwise.


### PR DESCRIPTION
 - missed overrides
 - lack of virtual distructors in the classes with virtual functions
 - mised CTAD guides Also, it seems that .hpp files somehow used old p4c coding style and were not updated. Fix is while there.