### PR TITLE
Consistently set & propagate child names

### DIFF
--- a/backends/p4tools/p4tools.def
+++ b/backends/p4tools/p4tools.def
@@ -219,7 +219,7 @@ public:
         out << "Concolic_" << label << "(" << arguments << ")";
     }
 
-    visit_children { v.visit(type, "type"); }
+    visit_children { (void)n; v.visit(type, "type"); }
 
     ConcolicVariable(const Type *type, cstring methodName,
                      const Vector<Argument> *arguments, int srcIdentifier, int concolicId,

--- a/backends/tofino/bf-p4c/ir/arch.def
+++ b/backends/tofino/bf-p4c/ir/arch.def
@@ -113,7 +113,7 @@ class P4Thread {
     }
 #apply
     visit_children {
-        parsers.parallel_visit_children(v);
+        parsers.parallel_visit_children(v, n);
         v.visit(mau);
         v.visit(deparser);
     }

--- a/backends/tofino/bf-p4c/ir/mau.def
+++ b/backends/tofino/bf-p4c/ir/mau.def
@@ -489,20 +489,20 @@ class Table : BFN::Unit, IAnnotated  {
 #emit
     // We use a template to obtain polymorphism on the constness of `this`.
     template<class THIS>
-    static void visit_children(THIS*, Visitor& v);
+    static void visit_children(THIS*, Visitor& v, const char *n);
 
     struct payload_info_t; // data to pass between the below helper methods
     /// Helper for visit_children. Visits the match table for when it is not
     /// gateway-inhibited.
     // We use a template to obtain polymorphism on the constness of `this`.
     template<class THIS>
-    static void visit_match_table(THIS* self, Visitor& v, payload_info_t &);
+    static void visit_match_table(THIS* self, Visitor& v, const char *n, payload_info_t &);
 
     /// Helper for visit_children. Visits the gateway payload, for when the
     /// match table is gateway-inhibited.
     // We use a template to obtain polymorphism on the constness of `this`.
     template<class THIS>
-    static void visit_gateway_inhibited(THIS* self, Visitor& v, payload_info_t &);
+    static void visit_gateway_inhibited(THIS* self, Visitor& v, const char *n, payload_info_t &);
 #end
 #apply
 }
@@ -800,7 +800,7 @@ class TypedPrimitive : Primitive {
     TypedPrimitive(Util::SourceInfo srcInfo, const IR::Type* return_type, const IR::Type* m_type, cstring name)
     : Primitive(srcInfo, return_type, name), method_type(m_type) { }
 
-    visit_children { Primitive::visit_children(v); }
+    visit_children { Primitive::visit_children(v, n); }
 }
 
 /// A single MAU instruction.  For the most part instructions look exactly like Primitives,
@@ -945,14 +945,14 @@ class Action : VLIWInstruction, IAnnotated {
     }
 
     visit_children {
-        VLIWInstruction::visit_children(v);
+        VLIWInstruction::visit_children(v, n);
         if (parallel)
-            action.parallel_visit_children(v);
+            action.parallel_visit_children(v, n);
         else
-            action.visit_children(v);
+            action.visit_children(v, n);
         v.visit(annotations, "annotations");
-        default_params.visit_children(v);
-        stateful_calls.visit_children(v);
+        default_params.visit_children(v, n);
+        stateful_calls.visit_children(v, n);
     }
 #apply
 }
@@ -1004,8 +1004,8 @@ class SaluAction : VLIWInstruction, IAnnotated {
     std::map<int, int> output_param_to_alu = {};
 
     visit_children {
-        VLIWInstruction::visit_children(v);
-        action.visit_children(v);
+        VLIWInstruction::visit_children(v, n);
+        action.visit_children(v, n);
         v.visit(annotations, "annotations");
         v.visit(output_dst, "output_dst");
     }

--- a/backends/tofino/bf-p4c/ir/parde-lowered.def
+++ b/backends/tofino/bf-p4c/ir/parde-lowered.def
@@ -289,7 +289,7 @@ class LoweredParserState : Unit {
     toString { return name; }
     visit_children {
         v.visit(select);
-        transitions.parallel_visit_children(v); }
+        transitions.parallel_visit_children(v, n); }
 
     /// The name of this state. This does not necessarily correspond to any
     /// state name in the P4 program.

--- a/backends/tofino/bf-p4c/ir/parde.def
+++ b/backends/tofino/bf-p4c/ir/parde.def
@@ -486,9 +486,9 @@ class ParserState : Unit {
     gress_t thread() const override { return gress; }
     toString { return name; }
     visit_children {
-        statements.visit_children(v);
-        selects.visit_children(v);
-        transitions.parallel_visit_children(v); }
+        statements.visit_children(v, n);
+        selects.visit_children(v, n);
+        transitions.parallel_visit_children(v, n); }
     const IR::ParserState* p4State() const {
         BUG_CHECK(p4States.size() == 1, "Expecing exactly one state in p4States but saw %1%",
                   p4States.size());

--- a/backends/tofino/bf-p4c/ir/tofino.def
+++ b/backends/tofino/bf-p4c/ir/tofino.def
@@ -160,7 +160,7 @@ class BFN::Pipe {
                 v.visit(ghost_thread.ghost_parser, "ghost_parser");
                 v.visit(ghost_thread.ghost_mau, "ghost_mau");
             } else {
-                thread[th->thread].parsers.parallel_visit_children(v);
+                thread[th->thread].parsers.parallel_visit_children(v, n);
                 ControlFlowVisitor::GuardGlobal guard_except(v, "-EXIT-"_cs);
                 v.visit(thread[th->thread].mau, "mau");
                 v.flow_merge_global_from("-EXIT-"_cs);
@@ -171,7 +171,7 @@ class BFN::Pipe {
             // FIXME -- doesn't do flow_clone/merge properly, but fixing will
             // break ParserGraph (at least) as it doesn't do merge properly
             for (auto &th : thread) {
-                th.parsers.parallel_visit_children(v);
+                th.parsers.parallel_visit_children(v, n);
                 ControlFlowVisitor::GuardGlobal guard_except(v, "-EXIT-"_cs);
                 v.visit(th.mau, "mau");
                 v.flow_merge_global_from("-EXIT-"_cs);
@@ -196,13 +196,13 @@ class BFN::BridgePath : BFN::Pipe {
     visit_children {
         // does not have support for ghost thread yet.
         for (auto &th : threads.at(INGRESS)) {
-            th.parsers.parallel_visit_children(v);
+            th.parsers.parallel_visit_children(v, n);
             ControlFlowVisitor::GuardGlobal guard_except(v, "-EXIT-"_cs);
             v.visit(th.mau, "mau");
             v.flow_merge_global_from("-EXIT-"_cs);
             v.visit(th.deparser, "deparser"); }
         for (auto &th : threads.at(EGRESS)) {
-            th.parsers.parallel_visit_children(v);
+            th.parsers.parallel_visit_children(v, n);
             ControlFlowVisitor::GuardGlobal guard_except(v, "-EXIT-"_cs);
             v.visit(th.mau, "mau");
             v.flow_merge_global_from("-EXIT-"_cs);
@@ -231,7 +231,7 @@ class BFN::Toplevel {
 
 #apply
     visit_children {
-        v.visit(pipes);
+        v.visit(pipes, n);
     }
 }
 
@@ -467,7 +467,7 @@ class BFN::AliasMember : IR::Member {
     }
 
     visit_children {
-        IR::Member::visit_children(v);
+        IR::Member::visit_children(v, n);
     }
 
 #noequiv
@@ -504,7 +504,7 @@ class BFN::AliasSlice : IR::Slice {
     }
 
     visit_children {
-        IR::Slice::visit_children(v);
+        IR::Slice::visit_children(v, n);
     }
 
 #emit

--- a/backends/tofino/bf-p4c/mau/asm_output.cpp
+++ b/backends/tofino/bf-p4c/mau/asm_output.cpp
@@ -1394,7 +1394,7 @@ class MauAsmOutput::EmitAction : public Inspector, public TofinoWriteContext {
             is_empty = false;
             alias.clear();
         }
-        act->action.visit_children(*this);
+        act->action.visit_children(*this, "action");
         // Dumping the information on stateful calls.  For anything that has a meter type,
         // the meter type is dumped first, followed by the address location.  This is
         // required to generate override_full_.*_addr information
@@ -1783,7 +1783,7 @@ class MauAsmOutput::EmitAlwaysRunAction : public MauAsmOutput::EmitAction {
     bool preorder(const IR::MAU::Action *act) override {
         indent++;
         is_empty = true;
-        act->visit_children(*this);
+        act->visit_children(*this, "action");
         return false;
     }
 

--- a/backends/tofino/bf-p4c/parde/clot/header_validity_analysis.cpp
+++ b/backends/tofino/bf-p4c/parde/clot/header_validity_analysis.cpp
@@ -57,7 +57,7 @@ Visitor::profile_t HeaderValidityAnalysis::init_apply(const IR::Node *root) {
 }
 
 bool HeaderValidityAnalysis::preorder(const IR::MAU::Action *act) {
-    act->action.visit_children(*this);
+    act->action.visit_children(*this, "action");
     return false;
 }
 

--- a/backends/tofino/bf-p4c/phv/analysis/build_mutex.cpp
+++ b/backends/tofino/bf-p4c/phv/analysis/build_mutex.cpp
@@ -41,7 +41,7 @@ void BuildMutex::mark(const PHV::Field *f) {
 }
 
 bool BuildMutex::preorder(const IR::MAU::Action *act) {
-    act->action.visit_children(*this);
+    act->action.visit_children(*this, "action");
     return false;
 }
 

--- a/frontends/p4-14/ir-v1.def
+++ b/frontends/p4-14/ir-v1.def
@@ -160,7 +160,7 @@ class If :  Expression {
     visit_children {
         v.visit(pred, "pred");
         SplitFlowVisit<Vector<Expression>>(v, ifTrue, ifFalse).run_visit();
-        Expression::visit_children(v);
+        Expression::visit_children(v, n);
     }
 }
 
@@ -255,6 +255,7 @@ class CalculatedField : IAnnotated {
     const Vector<Annotation> &getAnnotations() const override { return annotations; }
     Vector<Annotation> &getAnnotations() override { return annotations; }
     visit_children {
+        (void)n;
         v.visit(field, "field");
         for (auto &s : specs) v.visit(s.cond, s.name.name.c_str());
         v.visit(annotations, "annotations"); }
@@ -384,6 +385,7 @@ class ActionFunction : IAnnotated {
                 return a;
         return nullptr; }
     visit_children {
+        (void)n;
         v.visit(action, "action");
         // DANGER -- visiting action first so type inferencing will push types to
         // DANGER -- action args based on use.  This is immoral.

--- a/frontends/p4/functionsInlining.cpp
+++ b/frontends/p4/functionsInlining.cpp
@@ -200,7 +200,7 @@ const IR::Node *FunctionsInliner::preorder(IR::IfStatement *statement) {
 
 const IR::Node *FunctionsInliner::preorder(IR::P4Parser *parser) {
     if (preCaller()) {
-        parser->visit_children(*this);
+        parser->visit_children(*this, parser->name.name.c_str());
         return postCaller(parser);
     } else {
         return parser;
@@ -211,14 +211,14 @@ const IR::Node *FunctionsInliner::preorder(IR::P4Control *control) {
     bool hasWork = preCaller();
     // We always visit the children: there may be function calls in
     // actions within the control
-    control->visit_children(*this);
+    control->visit_children(*this, control->name.name.c_str());
     if (hasWork) return postCaller(control);
     return control;
 }
 
 const IR::Node *FunctionsInliner::preorder(IR::Function *function) {
     if (preCaller()) {
-        function->visit_children(*this);
+        function->visit_children(*this, function->name.name.c_str());
         return postCaller(function);
     } else {
         return function;
@@ -227,7 +227,7 @@ const IR::Node *FunctionsInliner::preorder(IR::Function *function) {
 
 const IR::Node *FunctionsInliner::preorder(IR::P4Action *action) {
     if (preCaller()) {
-        action->visit_children(*this);
+        action->visit_children(*this, action->name.name.c_str());
         return postCaller(action);
     } else {
         return action;

--- a/ir/base.def
+++ b/ir/base.def
@@ -169,7 +169,7 @@ abstract Expression {
     /// It is used by the P4_14 front-end and by some back-ends.
     /// It is not visited by the visitors by default (can be visited explicitly in preorder)
     optional Type type = Type::Unknown::get();
-    visit_children { (void)v; }
+    visit_children { (void)v; (void)n; }
 #apply
 }
 

--- a/ir/expression.def
+++ b/ir/expression.def
@@ -279,7 +279,7 @@ class Constant : Literal {
         }
         return Util::toString(value, width, sign, base);
     }
-    visit_children { v.visit(type, "type"); }
+    visit_children { (void)n; v.visit(type, "type"); }
 }
 
 class BoolLiteral : Literal {
@@ -413,6 +413,7 @@ class Mux : Operation_Ternary {
     stringOp = "?:";
     precedence = DBPrint::Prec_Low;
     visit_children {
+        (void)n;
         v.visit(e0, "e0");
         SplitFlowVisit<Expression>(v, e1, e2).run_visit(); }
     inline Mux { if (type->is<Type::Unknown>() && e1 && e2 && e1->type == e2->type) type = e1->type; }
@@ -450,6 +451,7 @@ class SelectExpression : Expression {
     ListExpression            select;
     inline Vector<SelectCase> selectCases;
     visit_children {
+        (void)n;
         v.visit(select, "select");
         SplitFlowVisitVector<SelectCase>(v, selectCases).run_visit(); }
 }

--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -215,8 +215,8 @@ class IndexedVector : public Vector<T> {
         return "IndexedVector<" + T::static_type_name() + ">";
     }
     static cstring static_type_name() { return "IndexedVector<" + T::static_type_name() + ">"; }
-    void visit_children(Visitor &v) override;
-    void visit_children(Visitor &v) const override;
+    void visit_children(Visitor &v, const char *name) override;
+    void visit_children(Visitor &v, const char *name) const override;
 
     void toJSON(JSONGenerator &json) const override;
     static IndexedVector<T> *fromJSON(JSONLoader &json);

--- a/ir/ir-inline.h
+++ b/ir/ir-inline.h
@@ -80,9 +80,9 @@ namespace P4 {
 IRNODE_ALL_TEMPLATES(DEFINE_APPLY_FUNCTIONS, inline)
 
 template <class T>
-void IR::Vector<T>::visit_children(Visitor &v) {
+void IR::Vector<T>::visit_children(Visitor &v, const char *name) {
     for (auto i = vec.begin(); i != vec.end();) {
-        const IR::Node *n = v.apply_visitor(*i);
+        const IR::Node *n = v.apply_visitor(*i, name);
         if (!n && *i) {
             i = erase(i);
             continue;
@@ -124,15 +124,15 @@ void IR::Vector<T>::visit_children(Visitor &v) {
     }
 }
 template <class T>
-void IR::Vector<T>::visit_children(Visitor &v) const {
-    for (auto &a : vec) v.visit(a);
+void IR::Vector<T>::visit_children(Visitor &v, const char *name) const {
+    for (auto &a : vec) v.visit(a, name);
 }
 template <class T>
-void IR::Vector<T>::parallel_visit_children(Visitor &v) {
+void IR::Vector<T>::parallel_visit_children(Visitor &v, const char *) {
     SplitFlowVisitVector<T>(v, *this).run_visit();
 }
 template <class T>
-void IR::Vector<T>::parallel_visit_children(Visitor &v) const {
+void IR::Vector<T>::parallel_visit_children(Visitor &v, const char *) const {
     SplitFlowVisitVector<T>(v, *this).run_visit();
 }
 IRNODE_DEFINE_APPLY_OVERLOAD(Vector, template <class T>, <T>)
@@ -156,9 +156,9 @@ std::ostream &operator<<(std::ostream &out, const IR::Vector<IR::Expression> &v)
 std::ostream &operator<<(std::ostream &out, const IR::Vector<IR::Annotation> &v);
 
 template <class T>
-void IR::IndexedVector<T>::visit_children(Visitor &v) {
+void IR::IndexedVector<T>::visit_children(Visitor &v, const char *name) {
     for (auto i = begin(); i != end();) {
-        auto n = v.apply_visitor(*i);
+        auto n = v.apply_visitor(*i, name);
         if (!n && *i) {
             i = erase(i);
             continue;
@@ -183,8 +183,8 @@ void IR::IndexedVector<T>::visit_children(Visitor &v) {
     }
 }
 template <class T>
-void IR::IndexedVector<T>::visit_children(Visitor &v) const {
-    for (auto &a : *this) v.visit(a);
+void IR::IndexedVector<T>::visit_children(Visitor &v, const char *name) const {
+    for (auto &a : *this) v.visit(a, name);
 }
 template <class T>
 void IR::IndexedVector<T>::toJSON(JSONGenerator &json) const {
@@ -233,7 +233,7 @@ static inline void namemap_insert_helper(typename ordered_map<cstring, T>::itera
 template <class T, template <class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
           class COMP /*= std::less<cstring>*/,
           class ALLOC /*= std::allocator<std::pair<const cstring, const T*>>*/>
-void IR::NameMap<T, MAP, COMP, ALLOC>::visit_children(Visitor &v) {
+void IR::NameMap<T, MAP, COMP, ALLOC>::visit_children(Visitor &v, const char *) {
     map_t new_symbols;
     for (auto i = symbols.begin(); i != symbols.end();) {
         const IR::Node *n = v.apply_visitor(i->second, i->first.c_str());
@@ -269,7 +269,7 @@ void IR::NameMap<T, MAP, COMP, ALLOC>::visit_children(Visitor &v) {
 template <class T, template <class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
           class COMP /*= std::less<cstring>*/,
           class ALLOC /*= std::allocator<std::pair<cstring, const T*>>*/>
-void IR::NameMap<T, MAP, COMP, ALLOC>::visit_children(Visitor &v) const {
+void IR::NameMap<T, MAP, COMP, ALLOC>::visit_children(Visitor &v, const char *) const {
     for (auto &k : symbols) {
         v.visit(k.second, k.first.c_str());
     }
@@ -296,11 +296,11 @@ template <class KEY, class VALUE,
           template <class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
           class COMP /*= std::less<cstring>*/,
           class ALLOC /*= std::allocator<std::pair<cstring, const T*>>*/>
-void IR::NodeMap<KEY, VALUE, MAP, COMP, ALLOC>::visit_children(Visitor &v) {
+void IR::NodeMap<KEY, VALUE, MAP, COMP, ALLOC>::visit_children(Visitor &v, const char *name) {
     map_t new_symbols;
     for (auto i = symbols.begin(); i != symbols.end();) {
         auto nk = i->first;
-        v.visit(nk);
+        v.visit(nk, name);
         if (!nk && i->first) {
             i = symbols.erase(i);
         } else if (nk == i->first) {
@@ -312,7 +312,7 @@ void IR::NodeMap<KEY, VALUE, MAP, COMP, ALLOC>::visit_children(Visitor &v) {
             }
         } else {
             auto nv = i->second;
-            v.visit(nv);
+            v.visit(nv, name);
             if (nv) new_symbols.emplace(nk, nv);
             i = symbols.erase(i);
         }
@@ -323,10 +323,10 @@ template <class KEY, class VALUE,
           template <class K, class V, class COMP, class ALLOC> class MAP /*= std::map */,
           class COMP /*= std::less<cstring>*/,
           class ALLOC /*= std::allocator<std::pair<cstring, const T*>>*/>
-void IR::NodeMap<KEY, VALUE, MAP, COMP, ALLOC>::visit_children(Visitor &v) const {
+void IR::NodeMap<KEY, VALUE, MAP, COMP, ALLOC>::visit_children(Visitor &v, const char *name) const {
     for (auto &k : symbols) {
-        v.visit(k.first);
-        v.visit(k.second);
+        v.visit(k.first, name);
+        v.visit(k.second, name);
     }
 }
 

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -16,7 +16,7 @@
   bool operator==(const T &a) const;
   void validate() const;
   const char *node_type_name() const;
-  void visit_children(Visitor &v);
+  void visit_children(Visitor &v, const char *name);
   void dump_fields(std::ostream& out) const;
 
   C comments are ignored.
@@ -479,6 +479,7 @@ class IfStatement : Statement {
     Statement        ifTrue;
     NullOK Statement ifFalse;
     visit_children {
+        (void)n;
         v.visit(condition, "condition");
         SplitFlowVisit<Statement>(v, ifTrue, ifFalse).run_visit(); }
 }
@@ -540,6 +541,7 @@ class SwitchStatement : Statement {
     Expression expression;
     inline Vector<SwitchCase> cases;
     visit_children {
+        (void)n;
         v.visit(expression, "expression");
         SplitFlowVisit<SwitchCase> split(v);
         for (auto &c : cases) split.addNode(c);
@@ -646,7 +648,7 @@ abstract Block : CompileTimeValue {
         auto it = constantValue.find(node);
         BUG_CHECK(it != constantValue.end(), "%1%: No such node %2%", this, node);
         return it->second; }
-    visit_children { (void)v; }
+    visit_children { (void)v; (void)n; }
     virtual const IDeclaration* getContainer() const { return nullptr; }
 }
 

--- a/ir/loop-visitor.cpp
+++ b/ir/loop-visitor.cpp
@@ -50,8 +50,8 @@ void IR::ForStatement::visit_children(THIS *self, Visitor &v) {
     }
 }
 
-void IR::ForStatement::visit_children(Visitor &v) { visit_children(this, v); }
-void IR::ForStatement::visit_children(Visitor &v) const { visit_children(this, v); }
+void IR::ForStatement::visit_children(Visitor &v, const char *) { visit_children(this, v); }
+void IR::ForStatement::visit_children(Visitor &v, const char *) const { visit_children(this, v); }
 
 template <class THIS>
 void IR::ForInStatement::visit_children(THIS *self, Visitor &v) {
@@ -73,27 +73,27 @@ void IR::ForInStatement::visit_children(THIS *self, Visitor &v) {
         v.visit(self->body, "body", 3);
     }
 }
-void IR::ForInStatement::visit_children(Visitor &v) { visit_children(this, v); }
-void IR::ForInStatement::visit_children(Visitor &v) const { visit_children(this, v); }
+void IR::ForInStatement::visit_children(Visitor &v, const char *) { visit_children(this, v); }
+void IR::ForInStatement::visit_children(Visitor &v, const char *) const { visit_children(this, v); }
 
-void IR::BreakStatement::visit_children(Visitor &v) const {
+void IR::BreakStatement::visit_children(Visitor &v, const char *) const {
     if (auto *cfv = v.controlFlowVisitor()) {
         cfv->flow_merge_global_to("-BREAK-"_cs);
         cfv->setUnreachable();
     }
 }
-void IR::BreakStatement::visit_children(Visitor &v) {
-    return const_cast<const IR::BreakStatement *>(this)->visit_children(v);
+void IR::BreakStatement::visit_children(Visitor &v, const char *name) {
+    return const_cast<const IR::BreakStatement *>(this)->visit_children(v, name);
 }
 
-void IR::ContinueStatement::visit_children(Visitor &v) const {
+void IR::ContinueStatement::visit_children(Visitor &v, const char *) const {
     if (auto *cfv = v.controlFlowVisitor()) {
         cfv->flow_merge_global_to("-CONTINUE-"_cs);
         cfv->setUnreachable();
     }
 }
-void IR::ContinueStatement::visit_children(Visitor &v) {
-    return const_cast<const IR::ContinueStatement *>(this)->visit_children(v);
+void IR::ContinueStatement::visit_children(Visitor &v, const char *name) {
+    return const_cast<const IR::ContinueStatement *>(this)->visit_children(v, name);
 }
 
 }  // namespace P4

--- a/ir/namemap.h
+++ b/ir/namemap.h
@@ -146,8 +146,8 @@ class NameMap : public Node {
     }
     cstring node_type_name() const override { return "NameMap<" + T::static_type_name() + ">"; }
     static cstring static_type_name() { return "NameMap<" + T::static_type_name() + ">"; }
-    void visit_children(Visitor &v) override;
-    void visit_children(Visitor &v) const override;
+    void visit_children(Visitor &v, const char *) override;
+    void visit_children(Visitor &v, const char *) const override;
     void toJSON(JSONGenerator &json) const override;
     static NameMap<T, MAP, COMP, ALLOC> *fromJSON(JSONLoader &json);
 

--- a/ir/node.h
+++ b/ir/node.h
@@ -159,8 +159,8 @@ class Node : public virtual INode {
     virtual bool operator==(const CLASS &) const { return false; }
     IRNODE_ALL_SUBCLASSES(DEFINE_OPEQ_FUNC)
 #undef DEFINE_OPEQ_FUNC
-    virtual void visit_children(Visitor &) {}
-    virtual void visit_children(Visitor &) const {}
+    virtual void visit_children(Visitor &, const char * /*name*/ = nullptr) {}
+    virtual void visit_children(Visitor &, const char * /*name*/ = nullptr) const {}
 
     bool operator!=(const Node &n) const { return !operator==(n); }
 

--- a/ir/nodemap.h
+++ b/ir/nodemap.h
@@ -91,8 +91,8 @@ class NodeMap : public Node {
     static cstring static_type_name() {
         return "NodeMap<" + KEY::static_type_name() + "," + VALUE::static_type_name() + ">";
     }
-    void visit_children(Visitor &v) override;
-    void visit_children(Visitor &v) const override;
+    void visit_children(Visitor &v, const char *) override;
+    void visit_children(Visitor &v, const char *) const override;
 
     DECLARE_TYPEINFO(NodeMap, Node);
 };

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -201,10 +201,10 @@ class Vector : public VectorBase {
     }
     cstring node_type_name() const override { return "Vector<" + T::static_type_name() + ">"; }
     static cstring static_type_name() { return "Vector<" + T::static_type_name() + ">"; }
-    void visit_children(Visitor &v) override;
-    void visit_children(Visitor &v) const override;
-    virtual void parallel_visit_children(Visitor &v);
-    virtual void parallel_visit_children(Visitor &v) const;
+    void visit_children(Visitor &v, const char *name) override;
+    void visit_children(Visitor &v, const char *name) const override;
+    virtual void parallel_visit_children(Visitor &v, const char *name = nullptr);
+    virtual void parallel_visit_children(Visitor &v, const char *name = nullptr) const;
     void toJSON(JSONGenerator &json) const override;
     Util::Enumerator<const T *> *getEnumerator() const { return Util::enumerate(vec); }
     template <typename S>

--- a/ir/visitor.cpp
+++ b/ir/visitor.cpp
@@ -446,7 +446,7 @@ struct PushContext {
         current.parent = stack;
         current.node = current.original = node;
         current.child_index = 0;
-        current.child_name = "";
+        current.child_name = nullptr;
         current.depth = stack ? stack->depth + 1 : 1;
         assert(current.depth < 10000);  // stack overflow?
         stack = &current;
@@ -471,7 +471,7 @@ class ForwardChildren : public Visitor {
 }  // namespace
 
 const IR::Node *Modifier::apply_visitor(const IR::Node *n, const char *name) {
-    if (ctxt && name) ctxt->child_name = name;
+    if (ctxt) ctxt->child_name = name;
     if (n) {
         PushContext local(ctxt, n);
         switch (visited->try_start(n, visitDagOnce)) {
@@ -489,10 +489,10 @@ const IR::Node *Modifier::apply_visitor(const IR::Node *n, const char *name) {
                 local.current.node = copy;
                 if (!dontForwardChildrenBeforePreorder) {
                     ForwardChildren forward_children(*visited);
-                    copy->visit_children(forward_children);
+                    copy->visit_children(forward_children, name);
                 }
                 if (copy->apply_visitor_preorder(*this)) {
-                    copy->visit_children(*this);
+                    copy->visit_children(*this, name);
                     copy->apply_visitor_postorder(*this);
                 }
                 if (visited->finish(n, copy)) (n = copy)->validate();
@@ -508,7 +508,7 @@ const IR::Node *Modifier::apply_visitor(const IR::Node *n, const char *name) {
 }
 
 const IR::Node *Inspector::apply_visitor(const IR::Node *n, const char *name) {
-    if (ctxt && name) ctxt->child_name = name;
+    if (ctxt) ctxt->child_name = name;
     if (n && !join_flows(n)) {
         PushContext local(ctxt, n);
         switch (visited->try_start(n, visitDagOnce)) {
@@ -520,7 +520,7 @@ const IR::Node *Inspector::apply_visitor(const IR::Node *n, const char *name) {
                 break;
             default:  // New or Revisit
                 if (n->apply_visitor_preorder(*this)) {
-                    n->visit_children(*this);
+                    n->visit_children(*this, name);
                     n->apply_visitor_postorder(*this);
                 }
                 visited->finish(n);
@@ -536,7 +536,7 @@ const IR::Node *Inspector::apply_visitor(const IR::Node *n, const char *name) {
 }
 
 const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
-    if (ctxt && name) ctxt->child_name = name;
+    if (ctxt) ctxt->child_name = name;
     if (n) {
         PushContext local(ctxt, n);
         switch (visited->try_start(n, visitDagOnce)) {
@@ -554,7 +554,7 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
                 local.current.node = copy;
                 if (!dontForwardChildrenBeforePreorder) {
                     ForwardChildren forward_children(*visited);
-                    copy->visit_children(forward_children);
+                    copy->visit_children(forward_children, name);
                 }
                 bool save_prune_flag = prune_flag;
                 prune_flag = false;
@@ -581,7 +581,7 @@ const IR::Node *Transform::apply_visitor(const IR::Node *n, const char *name) {
                     }
                 }
                 if (!prune_flag) {
-                    copy->visit_children(*this);
+                    copy->visit_children(*this, name);
                     final_result = copy->apply_visitor_postorder(*this);
                 }
                 prune_flag = save_prune_flag;

--- a/ir/visitor.h
+++ b/ir/visitor.h
@@ -49,11 +49,11 @@ struct Visitor_Context {
     // in the Visitor::apply_visitor functions as we do the recursive
     // descent traversal.  pre/postorder function can access this
     // context via getContext/findContext
-    const Visitor_Context *parent;
-    const IR::Node *node, *original;
-    mutable const char *child_name;
-    mutable int child_index;
-    int depth;
+    const Visitor_Context *parent = nullptr;
+    const IR::Node *node = nullptr, *original = nullptr;
+    mutable const char *child_name = nullptr;
+    mutable int child_index = 0;
+    int depth = 0;
     template <class T>
     inline const T *findContext(const Visitor_Context *&c) const {
         c = this;
@@ -145,26 +145,26 @@ class Visitor {
     IRNODE_ALL_SUBCLASSES(DECLARE_VISIT_FUNCTIONS)
 #undef DECLARE_VISIT_FUNCTIONS
     void visit(IR::Node &n, const char *name = 0) {
-        if (name && ctxt) ctxt->child_name = name;
-        n.visit_children(*this);
+        if (ctxt) ctxt->child_name = name;
+        n.visit_children(*this, name);
     }
     void visit(const IR::Node &n, const char *name = 0) {
-        if (name && ctxt) ctxt->child_name = name;
-        n.visit_children(*this);
+        if (ctxt) ctxt->child_name = name;
+        n.visit_children(*this, name);
     }
     void visit(IR::Node &n, const char *name, int cidx) {
         if (ctxt) {
             ctxt->child_name = name;
             ctxt->child_index = cidx;
         }
-        n.visit_children(*this);
+        n.visit_children(*this, name);
     }
     void visit(const IR::Node &n, const char *name, int cidx) {
         if (ctxt) {
             ctxt->child_name = name;
             ctxt->child_index = cidx;
         }
-        n.visit_children(*this);
+        n.visit_children(*this, name);
     }
     template <class T>
     void parallel_visit(IR::Vector<T> &v, const char *name = 0) {

--- a/tools/ir-generator/type.cpp
+++ b/tools/ir-generator/type.cpp
@@ -127,6 +127,11 @@ NamedType &NamedType::SourceInfo() {
     return nt;
 }
 
+NamedType &NamedType::Char() {
+    static NamedType nt("char"_cs);
+    return nt;
+}
+
 cstring NamedType::toString() const {
     if (resolved) return resolved->fullName();
     if (!lookup && name == "ID") return "IR::ID"_cs;  // hack -- ID is in namespace P4::IR

--- a/tools/ir-generator/type.h
+++ b/tools/ir-generator/type.h
@@ -101,6 +101,7 @@ class NamedType : public Type {
     }
 
     static NamedType &Bool();
+    static NamedType &Char();
     static NamedType &Int();
     static NamedType &Void();
     static NamedType &Cstring();


### PR DESCRIPTION
`child_name` is only updated on the context if it is non-empty. Looks like it was a ad-hoc approach to propagate `child_name` for `Vector` / `IndexedVector` as these do not have context and visitation of them looks like as we just unroll the vector.

However, these caused unwanted side effects in many places (and could be easily seen via e.g. dumper pass). Consider, for example, `P4Parser`:
```c++
void IR::P4Parser::visit_children(Visitor & v) const {
    Type_Declaration::visit_children(v);
    v.visit(type, "type");
    v.visit(constructorParams, "constructorParams");
    parserLocals.visit_children(v);
    states.visit_children(v);
}
```

Here the `child_name` inside `parserLocals.visit_children(v)` and `states.visit_children(v)` would be `constructorParams` and this is not something we'd want (note multiple `constructorParams` fields):
```
  [671] P4Parser name=p declid=1
    type: [30] Type_Parser name=p declid=0
      typeParameters: [5] TypeParameters
      applyParams: [26] ParameterList
        [10] Parameter name=check declid=0 direction=in
          type: [8] Type_Boolean
        [18] Parameter name=foo declid=1 direction=in
          type: [16] Type_Bits size=10 isSigned=0
        [23] Parameter name=matches declid=2 direction=out
          type: [21] Type_Boolean
    constructorParams: [153] ParameterList
    constructorParams: [490] Declaration_Variable name=val1 declid=12
      type: [2] Type_Bits size=32 isSigned=0
      initializer: [487] Cast
        type: [2] Type_Bits size=32 isSigned=0...
        expr: [486] Constant value=2 base=10
          type: [2] Type_Bits size=32 isSigned=0...
        destType: [2] Type_Bits size=32 isSigned=0...
    constructorParams: [696] ParserState name=start declid=4
```

Here we extend `visit_children` to accept a name argument and use to to pass the upper-level field name. Example above becomes:
```
  objects: [671] P4Parser name=p declid=1
    type: [30] Type_Parser name=p declid=0
      typeParameters: [5] TypeParameters
      applyParams: [26] ParameterList
        parameters: [10] Parameter name=check declid=0 direction=in
          type: [8] Type_Boolean
        parameters: [18] Parameter name=foo declid=1 direction=in
          type: [16] Type_Bits size=10 isSigned=0
        parameters: [23] Parameter name=matches declid=2 direction=out
          type: [21] Type_Boolean
    constructorParams: [153] ParameterList
    parserLocals: [490] Declaration_Variable name=val1 declid=12
      type: [2] Type_Bits size=32 isSigned=0
      initializer: [487] Cast
        type: [2] Type_Bits size=32 isSigned=0...
        expr: [486] Constant value=2 base=10
          type: [2] Type_Bits size=32 isSigned=0...
        destType: [2] Type_Bits size=32 isSigned=0...
    states: [696] ParserState name=start declid=4
      selectExpression: [699] SelectExpression
        type: [548] Type_State
        select: [701] ListExpression
          type: [516] Type_List
            components: [446] Type_Bits size=10 isSigned=0
            components: [510] Type_List
              components: [2] Type_Bits size=32 isSigned=0...
              components: [2] Type_Bits size=32 isSigned=0...
```