### PR TITLE
Add Auto-Labeling for Issues using GitHub Actions

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,8 +1,9 @@
+
 name: Auto Label Issues
 
 on:
   issues:
-    types: [opened, edited]  # Runs when an issue is created or modified
+    types: [opened, edited]  
   workflow_dispatch:  # Allows manual triggering
 
 jobs:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,9 +1,8 @@
-
 name: Auto Label Issues
 
 on:
   issues:
-    types: [opened, edited]  
+    types: [opened, edited]  # Runs when an issue is created or modified
   workflow_dispatch:  # Allows manual triggering
 
 jobs:
@@ -18,32 +17,34 @@ jobs:
             const issue = context.payload.issue;
             const labelsToAdd = [];
 
-            // Define keyword-label mapping
+            // Define label mappings based on brackets in title
             const labelMappings = {
-              "bug": "bug",
-              "error": "bug",
-              "fix": "bug",
-              "feature": "enhancement",
-              "docs": "documentation",
-              "question": "question",
-              "dpdk": "dpdk",
-              "p4c": "p4c",
-              "bmv2": "bmv2",
-              "compiler": "compiler",
-              "test": "testing",
-              "breaking change": "breaking-change",
-              "performance": "compiler-performance",
-              "control plane": "control-plane",
-              "core": "core",
-              "duplicate": "duplicate",
-              "ebpf": "ebpf",
-              "psa": "ebpf-psa"
+              "[bug]": "bug",
+              "[error]": "bug",
+              "[fix]": "bug",
+              "[feature]": "enhancement",
+              "[docs]": "documentation",
+              "[dpdk]": "dpdk",
+              "[p4c]": "p4c",
+              "[bmv2]": "bmv2",
+              "[compiler]": "compiler",
+              "[test]": "testing",
+              "[P4Testgen]": "p4tools",
+              "[P4Smith]": "p4tools",
+              "[P4tools]": "p4tools",
+              "[Tofino]":"tofino",
+              "[p4tc]": "p4tc",
+              "[p4fmt]": "p4fmt",
+              "[core]":"core",
+              ""
             };
 
-            // Check if issue title or body contains keywords
+          
+
+            // Check if issue title contains bracketed keywords
+            const title = issue.title.toLowerCase();
             for (const [keyword, label] of Object.entries(labelMappings)) {
-              if (issue.title.toLowerCase().includes(keyword) || 
-                  issue.body.toLowerCase().includes(keyword)) {
+              if (title.includes(keyword.toLowerCase()) && !excludedLabels.includes(keyword)) {
                 labelsToAdd.push(label);
               }
             }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -20,15 +20,12 @@ jobs:
             // Define label mappings based on brackets in title
             const labelMappings = {
               "[bug]": "bug",
-              "[error]": "bug",
-              "[fix]": "bug",
               "[feature]": "enhancement",
               "[docs]": "documentation",
               "[dpdk]": "dpdk",
-              "[p4c]": "p4c",
+            
               "[bmv2]": "bmv2",
-              "[compiler]": "compiler",
-              "[test]": "testing",
+           
               "[P4Testgen]": "p4tools",
               "[P4Smith]": "p4tools",
               "[P4tools]": "p4tools",
@@ -36,7 +33,14 @@ jobs:
               "[p4tc]": "p4tc",
               "[p4fmt]": "p4fmt",
               "[core]":"core",
-              ""
+              "[p4-spec]": "p4-spec",
+              "[control-plane]": "control-plane",
+              "[P4runtime]":"control-plane",
+              "[frontend]":"core",
+              "[midend]":"core",
+              "[parser]":"core",
+
+              
             };
 
           

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -17,7 +17,7 @@ jobs:
             const issue = context.payload.issue;
             const labelsToAdd = [];
 
-          
+            // Define keyword-label mapping
             const labelMappings = {
               "bug": "bug",
               "error": "bug",
@@ -29,10 +29,17 @@ jobs:
               "p4c": "p4c",
               "bmv2": "bmv2",
               "compiler": "compiler",
-              "test": "testing"
+              "test": "testing",
+              "breaking change": "breaking-change",
+              "performance": "compiler-performance",
+              "control plane": "control-plane",
+              "core": "core",
+              "duplicate": "duplicate",
+              "ebpf": "ebpf",
+              "psa": "ebpf-psa"
             };
 
-        
+            // Check if issue title or body contains keywords
             for (const [keyword, label] of Object.entries(labelMappings)) {
               if (issue.title.toLowerCase().includes(keyword) || 
                   issue.body.toLowerCase().includes(keyword)) {

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -16,16 +16,14 @@ jobs:
           script: |
             const issue = context.payload.issue;
             const labelsToAdd = [];
-
+            
             // Define label mappings based on brackets in title
             const labelMappings = {
               "[bug]": "bug",
               "[feature]": "enhancement",
               "[docs]": "documentation",
-              "[dpdk]": "dpdk",
-            
-              "[bmv2]": "bmv2",
-           
+              "[dpdk]": "dpdk",              
+              "[bmv2]": "bmv2",              
               "[P4Testgen]": "p4tools",
               "[P4Smith]": "p4tools",
               "[P4tools]": "p4tools",
@@ -38,21 +36,17 @@ jobs:
               "[P4runtime]":"control-plane",
               "[frontend]":"core",
               "[midend]":"core",
-              "[parser]":"core",
-
-              
+              "[parser]":"core",              
             };
-
-          
-
+            
             // Check if issue title contains bracketed keywords
             const title = issue.title.toLowerCase();
             for (const [keyword, label] of Object.entries(labelMappings)) {
-              if (title.includes(keyword.toLowerCase()) && !excludedLabels.includes(keyword)) {
+              if (title.includes(keyword.toLowerCase())) {
                 labelsToAdd.push(label);
               }
             }
-
+            
             if (labelsToAdd.length > 0) {
               github.rest.issues.addLabels({
                 issue_number: context.issue.number,

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,46 +1,91 @@
-name: Auto Label Issues
+name: Auto Label Issues and PRs
 
 on:
   issues:
     types: [opened, edited]  # Runs when an issue is created or modified
+  pull_request:
+    types: [opened, edited]  # Runs when a PR is created or modified
   workflow_dispatch:  # Allows manual triggering
 
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - name: Auto-label Issues
+      - name: Auto-label Issues and PRs
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const issue = context.payload.issue;
+            // Determine if we're processing an issue or PR
+            const isIssue = !!context.payload.issue;
+            const isPR = !!context.payload.pull_request;
+            
+            let itemToLabel;
+            let itemNumber;
+            
+            if (isIssue) {
+              itemToLabel = context.payload.issue;
+              itemNumber = context.issue.number;
+            } else if (isPR) {
+              itemToLabel = context.payload.pull_request;
+              itemNumber = context.payload.pull_request.number;
+            } else {
+              console.log("Not an issue or PR event, exiting");
+              return;
+            }
+            
             const labelsToAdd = [];
             
             // Define label mappings based on brackets in title
-            const labelMappings = {
-              "[bug]": "bug",
-              "[feature]": "enhancement",
-              "[docs]": "documentation",
-              "[dpdk]": "dpdk",              
-              "[bmv2]": "bmv2",              
-              "[P4Testgen]": "p4tools",
-              "[P4Smith]": "p4tools",
-              "[P4tools]": "p4tools",
-              "[Tofino]":"tofino",
-              "[p4tc]": "p4tc",
-              "[p4fmt]": "p4fmt",
-              "[core]":"core",
-              "[p4-spec]": "p4-spec",
-              "[control-plane]": "control-plane",
-              "[P4runtime]":"control-plane",
-              "[frontend]":"core",
-              "[midend]":"core",
-              "[parser]":"core",              
-            };
+            let labelMappings;
             
-            // Check if issue title contains bracketed keywords
-            const title = issue.title.toLowerCase();
+            if (isIssue) {
+              // Issue label mappings (original set)
+              labelMappings = {
+                "[bug]": "bug",
+                "[feature]": "enhancement",
+                "[docs]": "documentation",
+                "[dpdk]": "dpdk",              
+                "[bmv2]": "bmv2",              
+                "[P4Testgen]": "p4tools",
+                "[P4Smith]": "p4tools",
+                "[P4tools]": "p4tools",
+                "[Tofino]":"tofino",
+                "[p4tc]": "p4tc",
+                "[p4fmt]": "p4fmt",
+                "[core]":"core",
+                "[p4-spec]": "p4-spec",
+                "[control-plane]": "control-plane",
+                "[P4runtime]":"control-plane",
+                "[frontend]":"core",
+                "[midend]":"core",
+                "[parser]":"core",
+              };
+            } else {
+              // PR label mappings (only the ones you want for PRs)
+              labelMappings = {
+                "[core]":"core",
+                "[midend]":"core",
+                "[parser]":"core",
+                "[dpdk]": "dpdk",  
+                "[p4-spec]": "p4-spec",
+                "[tofino]":"tofino",
+                "[bmv2]":"bmv2",
+                "[docs]":"documentation",
+                "[documentation]":"documentation",
+                "[P4Testgen]": "p4tools",
+                "[P4Smith]": "p4tools",
+                "[P4tools]": "p4tools",
+                "[control-plane]": "control-plane",
+                "[P4runtime]":"control-plane",
+                "[p4tc]": "p4tc",
+                "[p4fmt]": "p4fmt",
+                // Add any other PR-specific labels here
+              };
+            }
+            
+            // Check if title contains bracketed keywords
+            const title = itemToLabel.title.toLowerCase();
             for (const [keyword, label] of Object.entries(labelMappings)) {
               if (title.includes(keyword.toLowerCase())) {
                 labelsToAdd.push(label);
@@ -48,10 +93,20 @@ jobs:
             }
             
             if (labelsToAdd.length > 0) {
-              github.rest.issues.addLabels({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                labels: labelsToAdd
-              });
+              if (isIssue) {
+                github.rest.issues.addLabels({
+                  issue_number: itemNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  labels: labelsToAdd
+                });
+              } else {
+                // PRs use the issues API for labels
+                github.rest.issues.addLabels({
+                  issue_number: itemNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  labels: labelsToAdd
+                });
+              }
             }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,50 @@
+name: Auto Label Issues
+
+on:
+  issues:
+    types: [opened, edited]  # Runs when an issue is created or modified
+  workflow_dispatch:  # Allows manual triggering
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-label Issues
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const labelsToAdd = [];
+
+          
+            const labelMappings = {
+              "bug": "bug",
+              "error": "bug",
+              "fix": "bug",
+              "feature": "enhancement",
+              "docs": "documentation",
+              "question": "question",
+              "dpdk": "dpdk",
+              "p4c": "p4c",
+              "bmv2": "bmv2",
+              "compiler": "compiler",
+              "test": "testing"
+            };
+
+        
+            for (const [keyword, label] of Object.entries(labelMappings)) {
+              if (issue.title.toLowerCase().includes(keyword) || 
+                  issue.body.toLowerCase().includes(keyword)) {
+                labelsToAdd.push(label);
+              }
+            }
+
+            if (labelsToAdd.length > 0) {
+              github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: labelsToAdd
+              });
+            }


### PR DESCRIPTION
# Automatic Issue and PR Labeling System

## Overview
This feature provides an automated labeling system for GitHub issues and pull requests based on standardized tags in their titles. The system automatically detects bracketed keywords in titles and applies corresponding labels, streamlining triaging and categorization of contributions.

## How It Works
When an issue or pull request is created or edited, the GitHub Action workflow analyzes its title for bracketed keywords (e.g., `[bug]`, `[feature]`, `[core]`) and automatically applies the relevant labels to the item. This reduces manual labeling work for maintainers and ensures consistent categorization.


https://github.com/user-attachments/assets/8046b884-f24d-4370-833b-23c52f1edbed

## Supported Tags

### For Both Issues and PRs
The system recognizes the following tags in both issue and PR titles:
- `[core]` → "core"
- `[midend]` → "core"
- `[parser]` → "core"
- `[dpdk]` → "dpdk"
- `[bmv2]` → "bmv2"
- `[P4Testgen]` → "p4tools"
- `[P4Smith]` → "p4tools"
- `[P4tools]` → "p4tools"
- `[Tofino]` → "tofino"
- `[p4tc]` → "p4tc"
- `[p4fmt]` → "p4fmt"
- `[p4-spec]` → "p4-spec"
- `[control-plane]` → "control-plane"
- `[P4runtime]` → "control-plane"
- `[docs]` / `[documentation]` → "documentation"

### Additional Tags for Issues Only
Issues also support:
- `[bug]` → "bug"
- `[feature]` → "enhancement"
- `[frontend]` → "core"

## Usage Guide

### For Contributors
When creating an issue or pull request:
1. Include relevant bracketed tags in your title
2. You can include multiple tags if necessary (e.g., `[bug][core] Fix memory leak in parser`)
3. Tags are case-insensitive, so `[bmv2]`, `[BMV2]`, and `[Bmv2]` all work
4. Only include tags that accurately represent the content of your issue or PR

Example issue title:
```
[bug][bmv2] Parser fails on malformed headers
```

Example PR title:
```
[p4tc][core] Implement packet processing pipeline
```

### For Maintainers
- The system automatically applies labels upon issue/PR creation and title edits
- Manual label adjustments can still be made if needed
- The workflow can be manually triggered via workflow_dispatch if necessary

## Benefits
- Reduces manual labeling work for project maintainers
- Ensures consistent labeling across issues and PRs
- Improves searchability and organization of the project
- Helps contributors properly categorize their submissions
- Streamlines the triage process for new issues and PRs

## Technical Implementation
The feature is implemented as a GitHub Action workflow using the GitHub Script action. The workflow is triggered on issue and PR creation/editing events and uses the GitHub API to apply appropriate labels.

The workflow:
1. Detects whether it's processing an issue or PR
2. Applies the appropriate label mapping based on the content type
3. Scans the title for bracketed keywords
4. Applies all matching labels via the GitHub API