### PR TITLE
Remove old vector workarounds, slightly modernize

### DIFF
--- a/ir/indexed_vector.h
+++ b/ir/indexed_vector.h
@@ -74,7 +74,7 @@ class IndexedVector : public Vector<T> {
     }
     IndexedVector &operator=(const IndexedVector &) = default;
     IndexedVector &operator=(IndexedVector &&) = default;
-    explicit IndexedVector(const T *a) { push_back(std::move(a)); }
+    explicit IndexedVector(const T *a) { push_back(a); }
     explicit IndexedVector(const safe_vector<const T *> &a) {
         insert(Vector<T>::end(), a.begin(), a.end());
     }
@@ -92,7 +92,8 @@ class IndexedVector : public Vector<T> {
     // TODO: Although this is not a const_iterator, it should NOT
     // be used to modify the vector directly.  I don't know
     // how to enforce this property, though.
-    typedef typename Vector<T>::iterator iterator;
+    using iterator = typename Vector<T>::iterator;
+    using const_iterator = typename Vector<T>::const_iterator;
 
     const IDeclaration *getDeclaration(cstring name) const {
         auto it = declarations.find(name);

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -67,7 +67,7 @@ class Vector : public VectorBase {
     explicit Vector(JSONLoader &json);
     Vector &operator=(const Vector &) = default;
     Vector &operator=(Vector &&) = default;
-    explicit Vector(const T *a) { vec.emplace_back(std::move(a)); }
+    explicit Vector(const T *a) { vec.emplace_back(a); }
     explicit Vector(const safe_vector<const T *> &a) { vec.insert(vec.end(), a.begin(), a.end()); }
     Vector(std::initializer_list<const T *> a) : vec(a) {}
     template <class InputIt>
@@ -75,8 +75,10 @@ class Vector : public VectorBase {
     Vector(Util::Enumerator<const T *> *e)  // NOLINT(runtime/explicit)
         : vec(e->begin(), e->end()) {}
     static Vector<T> *fromJSON(JSONLoader &json);
-    typedef typename safe_vector<const T *>::iterator iterator;
-    typedef typename safe_vector<const T *>::const_iterator const_iterator;
+
+    using iterator = typename safe_vector<const T *>::iterator;
+    using const_iterator = typename safe_vector<const T *>::const_iterator;
+
     iterator begin() { return vec.begin(); }
     const_iterator begin() const { return vec.begin(); }
     VectorBase::iterator VectorBase_begin() const override {
@@ -103,11 +105,7 @@ class Vector : public VectorBase {
     iterator erase(iterator s, iterator e) { return vec.erase(s, e); }
     template <typename ForwardIter>
     iterator insert(iterator i, ForwardIter b, ForwardIter e) {
-        /* FIXME -- GCC prior to 4.9 is broken and the insert routine returns void
-         * FIXME -- rather than an iterator.  So we recalculate it from an index */
-        int index = i - vec.begin();
-        vec.insert(i, b, e);
-        return vec.begin() + index;
+        return vec.insert(i, b, e);
     }
 
     template <typename Container>
@@ -136,18 +134,10 @@ class Vector : public VectorBase {
     }
 
     iterator insert(iterator i, const T *v) {
-        /* FIXME -- GCC prior to 4.9 is broken and the insert routine returns void
-         * FIXME -- rather than an iterator.  So we recalculate it from an index */
-        int index = i - vec.begin();
-        vec.insert(i, v);
-        return vec.begin() + index;
+        return vec.insert(i, v);
     }
     iterator insert(iterator i, size_t n, const T *v) {
-        /* FIXME -- GCC prior to 4.9 is broken and the insert routine returns void
-         * FIXME -- rather than an iterator.  So we recalculate it from an index */
-        int index = i - vec.begin();
-        vec.insert(i, n, v);
-        return vec.begin() + index;
+        return vec.insert(i, n, v);
     }
 
     const T *const &operator[](size_t idx) const { return vec[idx]; }

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -133,12 +133,8 @@ class Vector : public VectorBase {
         push_back(item->to<T>());
     }
 
-    iterator insert(iterator i, const T *v) {
-        return vec.insert(i, v);
-    }
-    iterator insert(iterator i, size_t n, const T *v) {
-        return vec.insert(i, n, v);
-    }
+    iterator insert(iterator i, const T *v) { return vec.insert(i, v); }
+    iterator insert(iterator i, size_t n, const T *v) { return vec.insert(i, n, v); }
 
     const T *const &operator[](size_t idx) const { return vec[idx]; }
     const T *&operator[](size_t idx) { return vec[idx]; }

--- a/ir/vector.h
+++ b/ir/vector.h
@@ -214,16 +214,6 @@ class Vector : public VectorBase {
     DECLARE_TYPEINFO_WITH_DISCRIMINATOR(Vector<T>, NodeDiscriminator::VectorT, T, VectorBase);
 };
 
-}  // namespace P4::IR
-
-// XXX(seth): We use this namespace to hide our get() overloads from ADL. GCC
-// 4.8 has a bug which causes these overloads to be considered when get() is
-// called on a type in the global namespace, even if the number of arguments
-// doesn't match up, which can trigger template instantiations that cause
-// errors.
-namespace P4 {
-namespace GetImpl {
-
 template <class T, class U>
 const T *get(const IR::Vector<T> &vec, U name) {
     for (auto el : vec)
@@ -238,9 +228,6 @@ const T *get(const IR::Vector<T> *vec, U name) {
     return nullptr;
 }
 
-}  // namespace GetImpl
-using namespace GetImpl;  // NOLINT(build/namespaces)
-
-}  // namespace P4
+}  // namespace P4::IR
 
 #endif /* IR_VECTOR_H_ */


### PR DESCRIPTION
Long overdue cleanup I noticed when working on #5133. Apparently these are workarounds for GCC 4.*, we are safe to remove them as we require GCC 9+. A small potential for breaking change due to the `GetImpl` namespace being removed and the `get` for `IR::Vector` moving to `P4::IR` to facilitate ADL. If anyone calls the `get` with explicit namespace (or has explicit `using` on it) they should just remove the namespaces and rely on argument-dependent lookup.

When there, I also slightly modernized parts of the code & fixed some weirdness.