### PR TITLE
JSONGenerator/Loader cleanups

### DIFF
--- a/backends/bmv2/pna_nic/main.cpp
+++ b/backends/bmv2/pna_nic/main.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *const argv[]) {
         }
         std::istream inJson(&fb);
         JSONLoader jsonFileLoader(inJson);
-        if (jsonFileLoader.json == nullptr) {
+        if (!jsonFileLoader) {
             ::P4::error(ErrorType::ERR_IO, "%s: Not valid input file", options.file);
             return 1;
         }

--- a/backends/bmv2/pna_nic/main.cpp
+++ b/backends/bmv2/pna_nic/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char *const argv[]) {
         if (::P4::errorCount() > 1 || toplevel == nullptr || toplevel->getMain() == nullptr)
             return 1;
         if (options.dumpJsonFile.empty())
-            JSONGenerator(*openFile(options.dumpJsonFile, true), true) << program << std::endl;
+            JSONGenerator(*openFile(options.dumpJsonFile, true), true).emit(program);
     } catch (const std::exception &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;

--- a/backends/bmv2/psa_switch/main.cpp
+++ b/backends/bmv2/psa_switch/main.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *const argv[]) {
         }
         std::istream inJson(&fb);
         JSONLoader jsonFileLoader(inJson);
-        if (jsonFileLoader.json == nullptr) {
+        if (!jsonFileLoader) {
             ::P4::error(ErrorType::ERR_IO, "%s: Not valid input file", options.file);
             return 1;
         }

--- a/backends/bmv2/psa_switch/main.cpp
+++ b/backends/bmv2/psa_switch/main.cpp
@@ -102,7 +102,7 @@ int main(int argc, char *const argv[]) {
         if (::P4::errorCount() > 1 || toplevel == nullptr || toplevel->getMain() == nullptr)
             return 1;
         if (!options.dumpJsonFile.empty())
-            JSONGenerator(*openFile(options.dumpJsonFile, true), true) << program << std::endl;
+            JSONGenerator(*openFile(options.dumpJsonFile, true), true).emit(program);
     } catch (const std::exception &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;

--- a/backends/bmv2/simple_switch/main.cpp
+++ b/backends/bmv2/simple_switch/main.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *const argv[]) {
         }
         std::istream inJson(&fb);
         JSONLoader jsonFileLoader(inJson);
-        if (jsonFileLoader.json == nullptr) {
+        if (!jsonFileLoader) {
             ::P4::error(ErrorType::ERR_IO, "%s: Not valid json input file", options.file);
             return 1;
         }

--- a/backends/bmv2/simple_switch/main.cpp
+++ b/backends/bmv2/simple_switch/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *const argv[]) {
         if (::P4::errorCount() > 1 || toplevel == nullptr || toplevel->getMain() == nullptr)
             return 1;
         if (!options.dumpJsonFile.empty() && !options.loadIRFromJson)
-            JSONGenerator(*openFile(options.dumpJsonFile, true), true) << program << std::endl;
+            JSONGenerator(*openFile(options.dumpJsonFile, true), true).emit(program);
     } catch (const std::exception &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;

--- a/backends/dpdk/main.cpp
+++ b/backends/dpdk/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char *const argv[]) {
         if (::P4::errorCount() > 1 || toplevel == nullptr || toplevel->getMain() == nullptr)
             return 1;
         if (!options.dumpJsonFile.empty())
-            JSONGenerator(*openFile(options.dumpJsonFile, true), true) << program << std::endl;
+            JSONGenerator(*openFile(options.dumpJsonFile, true), true).emit(program);
     } catch (const std::exception &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;

--- a/backends/dpdk/main.cpp
+++ b/backends/dpdk/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *const argv[]) {
         }
         std::istream inJson(&fb);
         JSONLoader jsonFileLoader(inJson);
-        if (jsonFileLoader.json == nullptr) {
+        if (!jsonFileLoader) {
             ::P4::error(ErrorType::ERR_INVALID, "Not valid input file");
             return 1;
         }

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -56,7 +56,7 @@ void compile(EbpfOptions &options) {
 
         std::istream inJson(&fb);
         JSONLoader jsonFileLoader(inJson);
-        if (jsonFileLoader.json == nullptr) {
+        if (!jsonFileLoader) {
             ::P4::error(ErrorType::ERR_IO, "%s: Not valid input file", options.file);
             return;
         }

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -84,7 +84,7 @@ void compile(EbpfOptions &options) {
     midend.addDebugHook(hook);
     auto toplevel = midend.run(options, program);
     if (!options.dumpJsonFile.empty())
-        JSONGenerator(*openFile(options.dumpJsonFile, true)) << program << std::endl;
+        JSONGenerator(*openFile(options.dumpJsonFile, true)).emit(program);
     if (::P4::errorCount() > 0) return;
 
     EBPF::run_ebpf_backend(options, toplevel, &midend.refMap, &midend.typeMap);

--- a/backends/graphs/p4c-graphs.cpp
+++ b/backends/graphs/p4c-graphs.cpp
@@ -181,7 +181,7 @@ int main(int argc, char *const argv[]) {
     try {
         top = midEnd.process(program);
         if (!options.dumpJsonFile.empty())
-            JSONGenerator(*openFile(options.dumpJsonFile, true)) << program << std::endl;
+            JSONGenerator(*openFile(options.dumpJsonFile, true)).emit(program);
     } catch (const std::exception &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;

--- a/backends/graphs/p4c-graphs.cpp
+++ b/backends/graphs/p4c-graphs.cpp
@@ -151,7 +151,7 @@ int main(int argc, char *const argv[]) {
 
         std::istream inJson(&fb);
         JSONLoader jsonFileLoader(inJson);
-        if (jsonFileLoader.json == nullptr) {
+        if (!jsonFileLoader) {
             ::P4::error(ErrorType::ERR_IO, "Not valid input file");
             return 1;
         }

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -185,17 +185,17 @@ int main(int argc, char *const argv[]) {
         }
         if (program) {
             if (!options.dumpJsonFile.empty())
-                JSONGenerator(*openFile(options.dumpJsonFile, true), true) << program << std::endl;
+                JSONGenerator(*openFile(options.dumpJsonFile, true), true).emit(program);
             if (options.debugJson) {
                 std::stringstream ss1, ss2;
                 JSONGenerator gen1(ss1), gen2(ss2);
-                gen1 << program;
+                gen1.emit(program);
 
                 const IR::Node *node = nullptr;
                 JSONLoader loader(ss1);
                 loader >> node;
 
-                gen2 << node;
+                gen2.emit(node);
                 if (ss1.str() != ss2.str()) {
                     error(ErrorType::ERR_UNEXPECTED, "json mismatch");
                     std::ofstream t1("t1.json"), t2("t2.json");

--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -340,13 +340,13 @@ Z3Solver::Z3Solver(bool isIncremental, std::optional<std::istream *> inOpt)
     JSONLoader loader(*inOpt.value());
 
     JSONLoader solverCheckpoints(loader, "checkpoints");
-    BUG_CHECK(solverCheckpoints.json->is<JsonVector>(),
+    BUG_CHECK(solverCheckpoints.is<JsonVector>(),
               "Z3 solver loading: can't find list of checkpoint");
     solverCheckpoints >> checkpoints;
 
     // loading all assertions
     JSONLoader solverAssertions(loader, "assertions");
-    BUG_CHECK(solverAssertions.json->is<JsonVector>(),
+    BUG_CHECK(solverAssertions.is<JsonVector>(),
               "Z3 solver loading: can't find list of assertions");
     safe_vector<const Constraint *> assertions;
     solverAssertions >> assertions;

--- a/backends/p4tools/common/core/z3_solver.cpp
+++ b/backends/p4tools/common/core/z3_solver.cpp
@@ -299,15 +299,11 @@ const IR::Literal *Z3Solver::toLiteral(const z3::expr &e, const IR::Type *type) 
 }
 
 void Z3Solver::toJSON(JSONGenerator &json) const {
-    json << json.indent << "{\n";
-    json.indent++;
-    json << json.indent << "\"checkpoints\" : " << checkpoints;
-    json << ",\n";
-    json << json.indent << "\"declarations\" : " << declaredVarsById;
-    json << ",\n";
-    json << json.indent << "\"assertions\" : " << p4Assertions;
-    json.indent--;
-    json << json.indent << "}\n";
+    auto state = json.begin_object();
+    json.emit("checkpoints", checkpoints);
+    json.emit("declarations", declaredVarsById);
+    json.emit("assertions", p4Assertions);
+    json.end_object(state);
 }
 
 void Z3Solver::addZ3Pushes(size_t &chkIndex, size_t asrtIndex) {

--- a/backends/tc/tc.cpp
+++ b/backends/tc/tc.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *const argv[]) {
             return 1;
         }
         if (!options.dumpJsonFile.empty())
-            JSONGenerator(*openFile(options.dumpJsonFile, true)) << toplevel << std::endl;
+            JSONGenerator(*openFile(options.dumpJsonFile, true)).emit(toplevel);
     } catch (const Util::P4CExceptionBase &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;

--- a/backends/tofino/bf-p4c/ir/arch.def
+++ b/backends/tofino/bf-p4c/ir/arch.def
@@ -101,9 +101,9 @@ class P4Thread {
     const IR::P4Control *mau = nullptr;
     const IR::P4Control *deparser = nullptr;
     toJSON {
-        json << json.indent << "\"parsers\" : " << parsers << "," << std::endl
-             << json.indent << "\"mau\" : " << mau << "," << std::endl
-             << json.indent << "\"deparser\" : " << deparser; }
+        json.emit("parsers", parsers);
+        json.emit("mau", mau);
+        json.emit("deparser", deparser); }
     fromJSON {
         IR::BFN::P4Thread * thread = new IR::BFN::P4Thread();
         json.load("parsers", thread->parsers);

--- a/backends/tofino/bf-p4c/ir/tofino.def
+++ b/backends/tofino/bf-p4c/ir/tofino.def
@@ -96,10 +96,10 @@ class BFN::Pipe {
                 hw_constrained_fields == a.hw_constrained_fields;
         }
         toJSON {
-            json << json.indent << "\"parser\" : " << parsers << "," << std::endl
-                 << json.indent << "\"mau\" : " << mau << "," << std::endl
-                 << json.indent << "\"deparser\" : " << deparser << std::endl
-                 << json.indent << "\"hw_constrained_fields\" : " <<  hw_constrained_fields; }
+            json.emit("parser", parsers);
+            json.emit("mau", mau);
+            json.emit("deparser", deparser);
+            json.emit("hw_constrained_fields",  hw_constrained_fields); }
         fromJSON {
             IR::BFN::Pipe::thread_t * thread = new IR::BFN::Pipe::thread_t();
             json.load("parsers", thread->parsers);

--- a/backends/tofino/bf-p4c/ir/unique_id.cpp
+++ b/backends/tofino/bf-p4c/ir/unique_id.cpp
@@ -30,8 +30,8 @@ static const char *attached_id_to_str[] = {"",      "tind",     "idletime", "sta
 static const char *speciality_to_str[] = {"", "atcam", "dleft"};
 
 void UniqueAttachedId::toJSON(P4::JSONGenerator &json) const {
-    json << json.indent << "\"name\": " << name << ",\n"
-         << json.indent << "\"type\": " << type << ",\n";
+    json.emit("name", name);
+    json.emit("type", type);
 }
 
 UniqueAttachedId UniqueAttachedId::fromJSON(P4::JSONLoader &json) {

--- a/backends/tofino/bf-p4c/ir/unique_id.cpp
+++ b/backends/tofino/bf-p4c/ir/unique_id.cpp
@@ -36,9 +36,10 @@ void UniqueAttachedId::toJSON(P4::JSONGenerator &json) const {
 
 UniqueAttachedId UniqueAttachedId::fromJSON(P4::JSONLoader &json) {
     UniqueAttachedId uai;
-    if (!json.json) return uai;
-    json.load("name", uai.name);
-    json.load("type", uai.type);
+    if (json) {
+        json.load("name", uai.name);
+        json.load("type", uai.type);
+    }
     return uai;
 }
 

--- a/backends/tofino/bf-p4c/mau/hash_function.cpp
+++ b/backends/tofino/bf-p4c/mau/hash_function.cpp
@@ -580,7 +580,7 @@ void IR::MAU::HashFunction::build_algorithm_t(bfn_hash_algorithm_ *alg) const {
 }
 
 IR::MAU::HashFunction *IR::MAU::HashFunction::fromJSON(JSONLoader &json) {
-    if (!json.json) return nullptr;
+    if (!json) return nullptr;
     auto *rv = new HashFunction;
     int type = 0;
     json.load("type", type);

--- a/backends/tofino/bf-p4c/mau/hash_function.cpp
+++ b/backends/tofino/bf-p4c/mau/hash_function.cpp
@@ -542,14 +542,14 @@ bool IR::MAU::HashFunction::convertPolynomialExtern(const IR::GlobalRef *ref) {
 }
 
 void IR::MAU::HashFunction::toJSON(JSONGenerator &json) const {
-    json << json.indent << "\"type\": " << static_cast<int>(type) << ",\n"
-         << json.indent << "\"size\": " << size << ",\n"
-         << json.indent << "\"msb\": " << msb << ",\n"
-         << json.indent << "\"reverse\": " << reverse << ",\n"
-         << json.indent << "\"poly\": " << poly << ",\n"
-         << json.indent << "\"init\": " << init << ",\n"
-         << json.indent << "\"xor\": " << final_xor << ",\n"
-         << json.indent << "\"extend\": " << extend;
+    json.emit("type", static_cast<int>(type));
+    json.emit("size", size);
+    json.emit("msb", msb);
+    json.emit("reverse", reverse);
+    json.emit("poly", poly);
+    json.emit("init", init);
+    json.emit("xor", final_xor);
+    json.emit("extend", extend);
 }
 
 void IR::MAU::HashFunction::build_algorithm_t(bfn_hash_algorithm_ *alg) const {

--- a/backends/tofino/bf-p4c/mau/resource.h
+++ b/backends/tofino/bf-p4c/mau/resource.h
@@ -74,7 +74,7 @@ struct TableResourceAlloc {
         meter_format.clear();
         meter_xbar.reset();
     }
-    void toJSON(P4::JSONGenerator &json) const { json << "null"; }
+    void toJSON(P4::JSONGenerator &json) const { json.emit(nullptr); }
     static TableResourceAlloc *fromJSON(P4::JSONLoader &) { return nullptr; }
 
     void merge_instr(const TableResourceAlloc *);

--- a/backends/tofino/bf-p4c/p4c-barefoot.cpp
+++ b/backends/tofino/bf-p4c/p4c-barefoot.cpp
@@ -479,7 +479,7 @@ int main(int ac, char **av) {
             // Print out the IR for p4i after frontend (--toJson "-" signifies stdout)
             auto &irFile = irFilePath != "-" ? *openFile(irFilePath, false) : std::cout;
             LOG3("IR dump after frontend to " << irFilePath);
-            JSONGenerator(irFile, true) << program << std::endl;
+            JSONGenerator(irFile, true).emit(program);
         }
 
 #if BAREFOOT_INTERNAL

--- a/backends/tofino/bf-p4c/parde/clot/clot.cpp
+++ b/backends/tofino/bf-p4c/parde/clot/clot.cpp
@@ -193,28 +193,25 @@ void Clot::set_slices(cstring parser_state, const std::vector<const PHV::FieldSl
     }
 }
 
-void Clot::toJSON(JSONGenerator &json) const { json << *this; }
+void Clot::toJSON(JSONGenerator &json) const {
+    json.emit("tag", tag);
+    json.emit("gress", gress);
+    json.emit("pov_bit", pov_bit);
+    json.emit("stack_depth", stack_depth);
+    json.emit("stack_inc", stack_inc);
+}
 
-/* static */ Clot *Clot::fromJSON(JSONLoader &json) {
-    if (auto *v = json.json->to<JsonString>()) return new Clot(cstring(v->c_str()));
-    BUG("Couldn't decode JSON value to clot");
-    return new Clot();
+Clot::Clot(JSONLoader &json) {
+    json.load("tag", tag);
+    json.load("gress", gress);
+    json.load("pov_bit", pov_bit);
+    json.load("stack_depth", stack_depth);
+    json.load("stack_inc", stack_inc);
 }
 
 std::ostream &operator<<(std::ostream &out, const Clot &clot) { return out << "CLOT " << clot.tag; }
 
 std::ostream &operator<<(std::ostream &out, const Clot *clot) {
-    if (clot)
-        return out << *clot;
-    else
-        return out << "(nullptr)";
-}
-
-P4::JSONGenerator &operator<<(P4::JSONGenerator &out, const Clot &clot) {
-    return out << clot.toString();
-}
-
-P4::JSONGenerator &operator<<(P4::JSONGenerator &out, const Clot *clot) {
     if (clot)
         return out << *clot;
     else

--- a/backends/tofino/bf-p4c/parde/clot/clot.h
+++ b/backends/tofino/bf-p4c/parde/clot/clot.h
@@ -85,7 +85,8 @@ class Clot final : public LiftCompare<Clot> {
 
     /// JSON serialization/deserialization.
     void toJSON(JSONGenerator &json) const;
-    static Clot *fromJSON(JSONLoader &json);
+    explicit Clot(JSONLoader &json);
+    static Clot *fromJSON(JSONLoader &json) { return new Clot(json); }
 
     /// Identifies the hardware CLOT associated with this object.
     unsigned tag;
@@ -185,7 +186,5 @@ class Clot final : public LiftCompare<Clot> {
 
 std::ostream &operator<<(std::ostream &out, const Clot &clot);
 std::ostream &operator<<(std::ostream &out, const Clot *clot);
-P4::JSONGenerator &operator<<(P4::JSONGenerator &out, const Clot &clot);
-P4::JSONGenerator &operator<<(P4::JSONGenerator &out, const Clot *clot);
 
 #endif /* BACKENDS_TOFINO_BF_P4C_PARDE_CLOT_CLOT_H_ */

--- a/backends/tofino/bf-p4c/parde/marshal.cpp
+++ b/backends/tofino/bf-p4c/parde/marshal.cpp
@@ -19,6 +19,8 @@
 #include "marshal.h"
 
 #include "ir/ir.h"
+#include "ir/json_generator.h"
+#include "ir/json_loader.h"
 
 std::string MarshaledFrom::toString() const {
     std::stringstream tmp;
@@ -26,10 +28,17 @@ std::string MarshaledFrom::toString() const {
     return tmp.str();
 }
 
-void MarshaledFrom::toJSON(JSONGenerator &json) const { json << *this; }
+void MarshaledFrom::toJSON(JSONGenerator &json) const {
+    json.emit("gress", gress);
+    json.emit("field_name", field_name);
+    json.emit("pre_padding", pre_padding);
+}
 
 /* static */
-MarshaledFrom MarshaledFrom::fromJSON(JSONLoader &) {
-    BUG("Uninmplemented");
-    return MarshaledFrom();
+MarshaledFrom MarshaledFrom::fromJSON(JSONLoader &json) {
+    MarshaledFrom rv;
+    json.load("gress", rv.gress);
+    json.load("field_name", rv.field_name);
+    json.load("pre_padding", rv.pre_padding);
+    return rv;
 }

--- a/backends/tofino/bf-p4c/parde/marshal.h
+++ b/backends/tofino/bf-p4c/parde/marshal.h
@@ -65,11 +65,6 @@ inline std::ostream &operator<<(std::ostream &s, const MarshaledFrom &m) {
     return s;
 }
 
-inline JSONGenerator &operator<<(JSONGenerator &out, const MarshaledFrom &c) {
-    c.toJSON(out);
-    return out;
-}
-
 }  // namespace P4
 
 #endif /* PARDE_MARSHAL_H_ */

--- a/backends/tofino/bf-p4c/parde/match_register.cpp
+++ b/backends/tofino/bf-p4c/parde/match_register.cpp
@@ -43,15 +43,11 @@ MatchRegister::MatchRegister(cstring n) : name(n), id(s_id++) {
         BUG("Invalid parser match register %s", name);
 }
 
-void MatchRegister::toJSON(JSONGenerator &json) const { json << *this; }
+void MatchRegister::toJSON(JSONGenerator &json) const { json.emit(toString()); }
 
 /* static */
 MatchRegister MatchRegister::fromJSON(JSONLoader &json) {
     if (auto *v = json.json->to<JsonString>()) return MatchRegister(cstring(v->c_str()));
     BUG("Couldn't decode JSON value to parser match register");
     return MatchRegister();
-}
-
-P4::JSONGenerator &operator<<(P4::JSONGenerator &out, const MatchRegister &c) {
-    return out << c.toString();
 }

--- a/backends/tofino/bf-p4c/parde/match_register.cpp
+++ b/backends/tofino/bf-p4c/parde/match_register.cpp
@@ -47,7 +47,7 @@ void MatchRegister::toJSON(JSONGenerator &json) const { json.emit(toString()); }
 
 /* static */
 MatchRegister MatchRegister::fromJSON(JSONLoader &json) {
-    if (auto *v = json.json->to<JsonString>()) return MatchRegister(cstring(v->c_str()));
+    if (json.is<JsonString>()) return MatchRegister(json.as<JsonString>());
     BUG("Couldn't decode JSON value to parser match register");
     return MatchRegister();
 }

--- a/backends/tofino/bf-p4c/phv/phv.cpp
+++ b/backends/tofino/bf-p4c/phv/phv.cpp
@@ -162,7 +162,7 @@ cstring Container::toString() const {
 void Container::toJSON(P4::JSONGenerator &json) const { json.emit(toString()); }
 
 /* static */ Container Container::fromJSON(P4::JSONLoader &json) {
-    if (auto *v = json.json->to<JsonString>()) return Container(v->c_str());
+    if (json.is<JsonString>()) return Container(json.as<JsonString>().c_str());
     BUG("Couldn't decode JSON value to container");
     return Container();
 }

--- a/backends/tofino/bf-p4c/phv/phv.cpp
+++ b/backends/tofino/bf-p4c/phv/phv.cpp
@@ -159,7 +159,7 @@ cstring Container::toString() const {
     return tmp.str();
 }
 
-void Container::toJSON(P4::JSONGenerator &json) const { json << *this; }
+void Container::toJSON(P4::JSONGenerator &json) const { json.emit(toString()); }
 
 /* static */ Container Container::fromJSON(P4::JSONLoader &json) {
     if (auto *v = json.json->to<JsonString>()) return Container(v->c_str());
@@ -257,10 +257,6 @@ std::ostream &operator<<(std::ostream &out, PHV::Type t) { return out << t.kind(
 
 std::ostream &operator<<(std::ostream &out, const PHV::Container c) {
     return out << c.type() << c.index();
-}
-
-P4::JSONGenerator &operator<<(P4::JSONGenerator &out, const PHV::Container c) {
-    return out << c.toString();
 }
 
 std::ostream &operator<<(std::ostream &out, ordered_set<const PHV::Container *> &c_set) {

--- a/ir/ir-inline.h
+++ b/ir/ir-inline.h
@@ -138,18 +138,11 @@ void IR::Vector<T>::parallel_visit_children(Visitor &v, const char *) const {
 IRNODE_DEFINE_APPLY_OVERLOAD(Vector, template <class T>, <T>)
 template <class T>
 void IR::Vector<T>::toJSON(JSONGenerator &json) const {
-    const char *sep = "";
     Node::toJSON(json);
-    json << "," << std::endl << json.indent++ << "\"vec\" : [";
-    for (auto &k : vec) {
-        json << sep << std::endl << json.indent << k;
-        sep = ",";
-    }
-    --json.indent;
-    if (*sep) {
-        json << std::endl << json.indent;
-    }
-    json << "]";
+    json.emit_tag("vec");
+    auto state = json.begin_vector();
+    for (auto &k : vec) json.emit(k);
+    json.end_vector(state);
 }
 
 std::ostream &operator<<(std::ostream &out, const IR::Vector<IR::Expression> &v);
@@ -188,18 +181,11 @@ void IR::IndexedVector<T>::visit_children(Visitor &v, const char *name) const {
 }
 template <class T>
 void IR::IndexedVector<T>::toJSON(JSONGenerator &json) const {
-    const char *sep = "";
     Vector<T>::toJSON(json);
-    json << "," << std::endl << json.indent++ << "\"declarations\" : {";
-    for (const auto &k : declarations) {
-        json << sep << std::endl << json.indent << k.first << " : " << k.second;
-        sep = ",";
-    }
-    --json.indent;
-    if (*sep != 0) {
-        json << std::endl << json.indent;
-    }
-    json << "}";
+    json.emit_tag("declarations");
+    auto state = json.begin_object();
+    for (auto &k : declarations) json.emit(k.first, k.second);
+    json.end_object(state);
 }
 IRNODE_DEFINE_APPLY_OVERLOAD(IndexedVector, template <class T>, <T>)
 
@@ -278,18 +264,11 @@ template <class T, template <class K, class V, class COMP, class ALLOC> class MA
           class COMP /*= std::less<cstring>*/,
           class ALLOC /*= std::allocator<std::pair<cstring, const T*>>*/>
 void IR::NameMap<T, MAP, COMP, ALLOC>::toJSON(JSONGenerator &json) const {
-    const char *sep = "";
     Node::toJSON(json);
-    json << "," << std::endl << json.indent++ << "\"symbols\" : {";
-    for (auto &k : symbols) {
-        json << sep << std::endl << json.indent << k.first << " : " << k.second;
-        sep = ",";
-    }
-    --json.indent;
-    if (*sep) {
-        json << std::endl << json.indent;
-    }
-    json << "}";
+    json.emit_tag("symbols");
+    auto state = json.begin_object();
+    for (auto &k : symbols) json.emit(k.first, k.second);
+    json.end_object(state);
 }
 
 template <class KEY, class VALUE,

--- a/ir/json_generator.h
+++ b/ir/json_generator.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <variant>
 
@@ -140,7 +141,7 @@ class JSONGenerator {
         if (output_state == TOP) out << std::endl;
     }
 
-    void emit_tag(const char *tag) {
+    void emit_tag(std::string_view tag) {
         switch (output_state) {
             case OBJ_START:
                 out << '{' << std::endl << ++indent;
@@ -160,21 +161,10 @@ class JSONGenerator {
     }
 
     template <typename T>
-    void emit(const char *tag, const T &val) {
+    void emit(std::string_view tag, const T &val) {
         emit_tag(tag);
         output_state = OBJ_MID;
         generate(val);
-    }
-
-    void emit_tag(cstring tag) { emit_tag(tag.c_str()); }
-    void emit_tag(std::string tag) { emit_tag(tag.c_str()); }
-    template <typename T>
-    void emit(cstring tag, const T &val) {
-        emit(tag.c_str(), val);
-    }
-    template <typename T>
-    void emit(std::string tag, const T &val) {
-        emit(tag.c_str(), val);
     }
 
  private:

--- a/ir/json_generator.h
+++ b/ir/json_generator.h
@@ -155,7 +155,7 @@ class JSONGenerator {
             case OBJ_END:
                 BUG("invalid json output state for emit_tag");
         }
-        out << '\"' << tag << "\" : ";
+        out << '\"' << cstring(tag).escapeJson() << "\" : ";
         output_state = OBJ_AFTERTAG;
     }
 

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -299,24 +299,10 @@ class JSONLoader {
         if (is<JsonString>()) v = as<JsonString>();
     }
     void unpack_json(cstring &v) {
-        std::string tmp = as<JsonString>();
-        std::string::size_type p = 0;
-        while ((p = tmp.find('\\', p)) != std::string::npos) {
-            tmp.erase(p, 1);
-            switch (tmp[p]) {
-                case 'n':
-                    tmp[p] = '\n';
-                    break;
-                case 'r':
-                    tmp[p] = '\r';
-                    break;
-                case 't':
-                    tmp[p] = '\t';
-                    break;
-            }
-            p++;
-        }
-        if (!json->is<JsonNull>()) v = tmp;
+        if (is<JsonString>())
+            v = cstring(as<JsonString>());
+        else if (is<JsonNull>())
+            v = cstring();
     }
     void unpack_json(IR::ID &v) {
         if (!json->is<JsonNull>()) v.name = as<JsonString>();

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <map>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -69,7 +70,7 @@ class JSONLoader {
         : node_refs(refs), json(json) {}
 
  public:
-    JSONLoader(const JSONLoader &unpacker, const std::string &field)
+    JSONLoader(const JSONLoader &unpacker, std::string_view field)
         : node_refs(unpacker.node_refs), json(nullptr) {
         if (!unpacker) return;
         if (auto *obj = unpacker.json->to<JsonObject>()) {
@@ -385,7 +386,7 @@ class JSONLoader {
 
  public:
     template <typename T>
-    bool load(const std::string field, T *&v) {
+    bool load(std::string_view field, T *&v) {
         if (auto loader = JSONLoader(*this, field)) {
             loader.unpack_json(v);
             return true;
@@ -396,7 +397,7 @@ class JSONLoader {
     }
 
     template <typename T>
-    bool load(const std::string field, T &v) {
+    bool load(std::string_view field, T &v) {
         if (auto loader = JSONLoader(*this, field)) {
             loader.unpack_json(v);
             return true;

--- a/ir/json_loader.h
+++ b/ir/json_loader.h
@@ -53,43 +53,57 @@ class JSONLoader {
         static const bool value = sizeof(test<T>(0)) == sizeof(char);
     };
 
- public:
     std::unordered_map<int, IR::Node *> &node_refs;
-    JsonData *json = nullptr;
+    std::unique_ptr<JsonData> json_root;
+    const JsonData *json = nullptr;
 
+ public:
     explicit JSONLoader(std::istream &in)
         : node_refs(*(new std::unordered_map<int, IR::Node *>())) {
-        in >> json;
+        in >> json_root;
+        json = json_root.get();
     }
 
-    explicit JSONLoader(JsonData *json)
-        : node_refs(*(new std::unordered_map<int, IR::Node *>())), json(json) {}
-
+ private:
     JSONLoader(JsonData *json, std::unordered_map<int, IR::Node *> &refs)
         : node_refs(refs), json(json) {}
 
+ public:
     JSONLoader(const JSONLoader &unpacker, const std::string &field)
         : node_refs(unpacker.node_refs), json(nullptr) {
-        if (auto *obj = unpacker.json->to<JsonObject>()) json = get(obj, field);
+        if (!unpacker) return;
+        if (auto *obj = unpacker.json->to<JsonObject>()) {
+            if (auto it = obj->find(field); it != obj->end()) {
+                json = it->second.get();
+            }
+        }
+    }
+
+    explicit operator bool() const { return json != nullptr; }
+    template <typename T>
+    [[nodiscard]] bool is() const {
+        return json && json->is<T>();
+    }
+    template <typename T>
+    [[nodiscard]] const T &as() const {
+        return json->as<T>();
     }
 
  private:
     const IR::Node *get_node() {
         if (!json || !json->is<JsonObject>()) return nullptr;  // invalid json exception?
-        int id = json->as<JsonObject>().get_id();
+        int id;
+        load("Node_ID", id);
         if (id >= 0) {
             if (node_refs.find(id) == node_refs.end()) {
-                if (auto fn = get(IR::unpacker_table, json->as<JsonObject>().get_type())) {
+                cstring type;
+                load("Node_Type", type);
+                if (auto fn = get(IR::unpacker_table, type)) {
                     node_refs[id] = fn(*this);
                     // Creating JsonObject from source_info read from jsonFile
                     // and setting SourceInfo for each node
                     // when "--fromJSON" flag is used
-                    JsonObject *obj = new JsonObject(json->as<JsonObject>().get_sourceJson());
-                    if (obj->hasSrcInfo() == true) {
-                        node_refs[id]->srcInfo =
-                            Util::SourceInfo(obj->get_filename(), obj->get_line(),
-                                             obj->get_column(), obj->get_sourceFragment());
-                    }
+                    node_refs[id]->sourceInfoFromJSON(*this);
                 } else {
                     return nullptr;
                 }  // invalid json exception?
@@ -102,8 +116,9 @@ class JSONLoader {
     template <typename T>
     void unpack_json(safe_vector<T> &v) {
         T temp;
-        for (auto e : json->as<JsonVector>()) {
-            load(e, temp);
+        v.clear();
+        for (auto &e : as<JsonVector>()) {
+            load(e.get(), temp);
             v.push_back(temp);
         }
     }
@@ -111,8 +126,9 @@ class JSONLoader {
     template <typename T>
     void unpack_json(std::set<T> &v) {
         T temp;
-        for (auto e : json->as<JsonVector>()) {
-            load(e, temp);
+        v.clear();
+        for (auto &e : as<JsonVector>()) {
+            load(e.get(), temp);
             v.insert(temp);
         }
     }
@@ -120,8 +136,9 @@ class JSONLoader {
     template <typename T>
     void unpack_json(ordered_set<T> &v) {
         T temp;
-        for (auto e : json->as<JsonVector>()) {
-            load(e, temp);
+        v.clear();
+        for (auto &e : as<JsonVector>()) {
+            load(e.get(), temp);
             v.insert(temp);
         }
     }
@@ -156,30 +173,46 @@ class JSONLoader {
     template <typename K, typename V>
     void unpack_json(std::map<K, V> &v) {
         std::pair<K, V> temp;
-        for (auto e : json->as<JsonObject>()) {
-            JsonString *k = new JsonString(e.first);
-            load(k, temp.first);
-            load(e.second, temp.second);
-            v.insert(temp);
+        v.clear();
+        if (is<JsonVector>()) {
+            for (auto &e : as<JsonVector>()) {
+                load(e.get(), temp);
+                v.insert(temp);
+            }
+        } else {
+            for (auto &e : as<JsonObject>()) {
+                JsonString *k = new JsonString(e.first);
+                load(k, temp.first);
+                load(e.second.get(), temp.second);
+                v.insert(temp);
+            }
         }
     }
     template <typename K, typename V>
     void unpack_json(ordered_map<K, V> &v) {
         std::pair<K, V> temp;
-        for (auto e : json->as<JsonObject>()) {
-            JsonString *k = new JsonString(e.first);
-            load(k, temp.first);
-            load(e.second, temp.second);
-            v.insert(temp);
+        v.clear();
+        if (is<JsonVector>()) {
+            for (auto &e : as<JsonVector>()) {
+                load(e.get(), temp);
+                v.insert(temp);
+            }
+        } else {
+            for (auto &e : as<JsonObject>()) {
+                JsonString *k = new JsonString(e.first);
+                load(k, temp.first);
+                load(e.second.get(), temp.second);
+                v.insert(temp);
+            }
         }
     }
     template <typename V>
     void unpack_json(string_map<V> &v) {
         std::pair<cstring, V> temp;
-        for (auto e : json->as<JsonObject>()) {
-            JsonString *k = new JsonString(e.first);
-            load(k, temp.first);
-            load(e.second, temp.second);
+        v.clear();
+        for (auto &e : as<JsonObject>()) {
+            temp.first = e.first;
+            load(e.second.get(), temp.second);
             v.insert(temp);
         }
     }
@@ -187,78 +220,86 @@ class JSONLoader {
     template <typename K, typename V>
     void unpack_json(std::multimap<K, V> &v) {
         std::pair<K, V> temp;
-        for (auto e : json->as<JsonObject>()) {
-            JsonString *k = new JsonString(e.first);
-            load(k, temp.first);
-            load(e.second, temp.second);
-            v.insert(temp);
+        v.clear();
+        if (is<JsonVector>()) {
+            for (auto &e : as<JsonVector>()) {
+                load(e.get(), temp);
+                v.insert(temp);
+            }
+        } else {
+            for (auto &e : as<JsonObject>()) {
+                JsonString *k = new JsonString(e.first);
+                load(k, temp.first);
+                load(e.second.get(), temp.second);
+                v.insert(temp);
+            }
         }
     }
 
     template <typename T>
     void unpack_json(std::vector<T> &v) {
         T temp;
-        for (auto e : json->as<JsonVector>()) {
-            load(e, temp);
+        v.clear();
+        for (auto &e : as<JsonVector>()) {
+            load(e.get(), temp);
             v.push_back(temp);
         }
     }
 
     template <typename T, typename U>
     void unpack_json(std::pair<T, U> &v) {
-        const JsonObject *obj = json->checkedTo<JsonObject>();
-        load(::P4::get(obj, "first"), v.first);
-        load(::P4::get(obj, "second"), v.second);
+        load("first", v.first);
+        load("second", v.second);
     }
 
     template <typename T>
     void unpack_json(std::optional<T> &v) {
-        const JsonObject *obj = json->checkedTo<JsonObject>();
         bool isValid = false;
-        load(::P4::get(obj, "valid"), isValid);
+        load("valid", isValid);
         if (!isValid) {
             v = std::nullopt;
             return;
         }
         T value;
-        load(::P4::get(obj, "value"), value), v = std::move(value);
+        load("value", value);
+        v = std::move(value);
     }
 
     template <int N, class Variant>
-    std::enable_if_t<N == std::variant_size_v<Variant>> unpack_variant(const JsonObject *,
-                                                                       int /*target*/,
+    std::enable_if_t<N == std::variant_size_v<Variant>> unpack_variant(int /*target*/,
                                                                        Variant & /*variant*/) {
         BUG("Error traversing variant during load");
     }
 
     template <int N, class Variant>
-    std::enable_if_t<(N < std::variant_size_v<Variant>)> unpack_variant(const JsonObject *obj,
-                                                                        int target,
+    std::enable_if_t<(N < std::variant_size_v<Variant>)> unpack_variant(int target,
                                                                         Variant &variant) {
         if (N == target) {
             variant.template emplace<N>();
-            load(P4::get(obj, "value"), std::get<N>(variant));
+            load("value", std::get<N>(variant));
         } else
-            unpack_variant<N + 1>(obj, target, variant);
+            unpack_variant<N + 1>(target, variant);
     }
 
     template <class... Types>
     void unpack_json(std::variant<Types...> &v) {
-        const JsonObject *obj = json->checkedTo<JsonObject>();
         int index = -1;
-        load(P4::get(obj, "variant_index"), index);
-        unpack_variant<0>(obj, index, v);
+        load("variant_index", index);
+        unpack_variant<0>(index, v);
     }
 
-    void unpack_json(bool &v) { v = json->as<JsonBoolean>(); }
+    void unpack_json(bool &v) { v = as<JsonBoolean>(); }
 
     template <typename T>
     std::enable_if_t<std::is_integral_v<T>> unpack_json(T &v) {
-        v = json->as<JsonNumber>();
+        v = as<JsonNumber>();
     }
-    void unpack_json(big_int &v) { v = json->as<JsonNumber>().val; }
+    void unpack_json(big_int &v) { v = as<JsonNumber>().val; }
+    void unpack_json(std::string &v) {
+        if (is<JsonString>()) v = as<JsonString>();
+    }
     void unpack_json(cstring &v) {
-        std::string tmp = json->as<JsonString>();
+        std::string tmp = as<JsonString>();
         std::string::size_type p = 0;
         while ((p = tmp.find('\\', p)) != std::string::npos) {
             tmp.erase(p, 1);
@@ -278,7 +319,7 @@ class JSONLoader {
         if (!json->is<JsonNull>()) v = tmp;
     }
     void unpack_json(IR::ID &v) {
-        if (!json->is<JsonNull>()) v.name = json->as<JsonString>();
+        if (!json->is<JsonNull>()) v.name = as<JsonString>();
     }
 
     void unpack_json(LTBitMatrix &m) {
@@ -346,33 +387,36 @@ class JSONLoader {
     void unpack_json(T (&v)[N]) {
         if (auto *j = json->to<JsonVector>()) {
             for (size_t i = 0; i < N && i < j->size(); ++i) {
-                json = (*j)[i];
-                unpack_json(v[i]);
+                load((*j)[i].get(), v[i]);
             }
         }
     }
 
- public:
     template <typename T>
     void load(JsonData *json, T &v) {
         JSONLoader(json, node_refs).unpack_json(v);
     }
 
+ public:
     template <typename T>
-    void load(const std::string field, T *&v) {
-        JSONLoader loader(*this, field);
-        if (loader.json == nullptr) {
-            v = nullptr;
-        } else {
+    bool load(const std::string field, T *&v) {
+        if (auto loader = JSONLoader(*this, field)) {
             loader.unpack_json(v);
+            return true;
+        } else {
+            v = nullptr;
+            return false;
         }
     }
 
     template <typename T>
-    void load(const std::string field, T &v) {
-        JSONLoader loader(*this, field);
-        if (loader.json == nullptr) return;
-        loader.unpack_json(v);
+    bool load(const std::string field, T &v) {
+        if (auto loader = JSONLoader(*this, field)) {
+            loader.unpack_json(v);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     template <typename T>

--- a/ir/json_parser.cpp
+++ b/ir/json_parser.cpp
@@ -76,7 +76,7 @@ std::istream &operator>>(std::istream &in, std::unique_ptr<JsonData> &json) {
         in >> ch;
         switch (ch) {
             case '{': {
-                ordered_map<std::string, std::unique_ptr<JsonData>> obj;
+                string_map<std::unique_ptr<JsonData>> obj;
                 do {
                     in >> std::ws >> ch;
                     if (ch == '}') break;

--- a/ir/json_parser.cpp
+++ b/ir/json_parser.cpp
@@ -55,7 +55,7 @@ std::ostream &operator<<(std::ostream &out, const JsonData *json) {
         }
         out << "]";
     } else if (auto *s = json->to<JsonString>()) {
-        out << "\"" << s->c_str() << "\"";
+        out << "\"" << cstring(*s).escapeJson() << "\"";
 
     } else if (auto *num = json->to<JsonNumber>()) {
         out << num->val;
@@ -66,6 +66,22 @@ std::ostream &operator<<(std::ostream &out, const JsonData *json) {
         out << "null";
     }
     return out;
+}
+
+static int charcode(char *to, const char *p, int max) {
+    int ch = 0, i;
+    for (i = 0; i < max; ++i) {
+        if (p[i] >= '0' && p[i] <= '9')
+            ch = (ch << 4) + p[i] - '0';
+        else if (p[i] >= 'A' && p[i] <= 'F')
+            ch = (ch << 4) + p[i] - 'A' + 10;
+        else if (p[i] >= 'a' && p[i] <= 'f')
+            ch = (ch << 4) + p[i] - 'a' + 10;
+        else
+            break;
+    }
+    *to = ch;
+    return i;
 }
 
 std::istream &operator>>(std::istream &in, std::unique_ptr<JsonData> &json) {
@@ -118,6 +134,37 @@ std::istream &operator>>(std::istream &in, std::unique_ptr<JsonData> &json) {
                     std::string more;
                     getline(in, more, '"');
                     s += more;
+                }
+                for (auto p = s.find('\\'); p != std::string::npos; p = s.find('\\', p)) {
+                    s.erase(p, 1);
+                    switch (s[p]) {
+                        case '\\':
+                            ++p;
+                            break;
+                        case 'b':
+                            s[p] = '\b';
+                            break;
+                        case 'f':
+                            s[p] = '\f';
+                            break;
+                        case 'n':
+                            s[p] = '\n';
+                            break;
+                        case 'r':
+                            s[p] = '\r';
+                            break;
+                        case 't':
+                            s[p] = '\t';
+                            break;
+                        case 'u':
+                            s.erase(p+1, charcode(&s[p], &s[p+1], 4));
+                            break;
+                        case 'x':
+                            s.erase(p+1, charcode(&s[p], &s[p+1], 2));
+                            break;
+                        default:
+                            break;
+                    }
                 }
                 json = std::make_unique<JsonString>(s);
                 return in;

--- a/ir/json_parser.h
+++ b/ir/json_parser.h
@@ -71,14 +71,19 @@ class JsonVector : public JsonData, public std::vector<std::unique_ptr<JsonData>
 };
 
 class JsonObject : public JsonData, public ordered_map<std::string, std::unique_ptr<JsonData>> {
-    // bool _hasSrcInfo = true;
-
  public:
     JsonObject() {}
     JsonObject(const JsonObject &obj) = delete;
     JsonObject &operator=(JsonObject &&) = default;
     JsonObject(ordered_map<std::string, std::unique_ptr<JsonData>> &&v)  // NOLINT(runtime/explicit)
         : ordered_map<std::string, std::unique_ptr<JsonData>>(std::move(v)) {}
+
+    // FIXME -- need to create a copy of the string_view to lookup.  With C++20, this
+    // should not be needed, except ordered_map still requires it as its internal
+    // map is weird and doesn't support a templated find (and it is not clear how to).
+    using ordered_map<std::string, std::unique_ptr<JsonData>>::find;
+    iterator find(std::string_view k) { return find(std::string(k)); }
+    const_iterator find(std::string_view k) const { return find(std::string(k)); }
 
     DECLARE_TYPEINFO(JsonObject, JsonData);
 };

--- a/ir/node.cpp
+++ b/ir/node.cpp
@@ -155,6 +155,15 @@ void IR::Node::sourceInfoToJSON(JSONGenerator &json) const {
     json.end_object(state);
 }
 
+void IR::Node::sourceInfoFromJSON(JSONLoader &json) {
+    if (auto si = JSONLoader(json, "Source_Info")) {
+        si.load("filename", srcInfo.filename);
+        si.load("line", srcInfo.line);
+        si.load("column", srcInfo.column);
+        si.load("source_fragment", srcInfo.srcBrief);
+    }
+}
+
 IRNODE_DEFINE_APPLY_OVERLOAD(Node, , )
 
 }  // namespace P4

--- a/ir/node.cpp
+++ b/ir/node.cpp
@@ -50,8 +50,8 @@ void IR::Node::traceCreation() const {
 int IR::Node::currentId = 0;
 
 void IR::Node::toJSON(JSONGenerator &json) const {
-    json << json.indent << "\"Node_ID\" : " << id << "," << std::endl
-         << json.indent << "\"Node_Type\" : " << node_type_name();
+    json.emit("Node_ID", id);
+    json.emit("Node_Type", node_type_name());
 }
 
 IR::Node::Node(JSONLoader &json) : id(-1) {
@@ -146,16 +146,13 @@ void IR::Node::sourceInfoToJSON(JSONGenerator &json) const {
         // Same reasoning as above.
         return;
     }
-
-    json << "," << std::endl << json.indent++ << "\"Source_Info\" : {" << std::endl;
-
-    json << json.indent << "\"filename\" : " << fName << "," << std::endl;
-    json << json.indent << "\"line\" : " << lineNumber << "," << std::endl;
-    json << json.indent << "\"column\" : " << columnNumber << "," << std::endl;
-    json << json.indent << "\"source_fragment\" : " << si.toBriefSourceFragment().escapeJson()
-         << std::endl;
-
-    json << --json.indent << "}";
+    json.emit_tag("Source_Info");
+    auto state = json.begin_object();
+    json.emit("filename", fName);
+    json.emit("line", lineNumber);
+    json.emit("column", columnNumber);
+    json.emit("source_fragment", si.toBriefSourceFragment());
+    json.end_object(state);
 }
 
 IRNODE_DEFINE_APPLY_OVERLOAD(Node, , )

--- a/ir/node.h
+++ b/ir/node.h
@@ -148,6 +148,7 @@ class Node : public virtual INode {
     cstring toString() const override { return node_type_name(); }
     void toJSON(JSONGenerator &json) const override;
     void sourceInfoToJSON(JSONGenerator &json) const;
+    void sourceInfoFromJSON(JSONLoader &json);
     Util::JsonObject *sourceInfoJsonObj() const;
     /* operator== does a 'shallow' comparison, comparing two Node subclass objects for equality,
      * and comparing pointers in the Node directly for equality */

--- a/test/gtest/dumpjson.cpp
+++ b/test/gtest/dumpjson.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "ir/visitor.h"
 
 using namespace P4;
+using namespace P4::literals;
 
 TEST(IR, DumpJSON) {
     auto c = new IR::Constant(2);
@@ -38,4 +39,62 @@ TEST(IR, DumpJSON) {
     const IR::Node *e2 = nullptr;
     loader >> e2;
     JSONGenerator(std::cout).emit(e2);
+}
+
+TEST(JSON, string_map) {
+    std::vector<string_map<std::string>> data, copy;
+    data.resize(2);
+    data[0]["x"] = "\ttab";
+    data[0]["a"] = "\"";
+    data[1]["?"] = "question";
+    data[1]["-"] = "dash";
+    data[1]["\x1c"] = "esc";
+
+    std::stringstream ss;
+    JSONGenerator(ss).emit(data);
+
+    // std::cout << ss.str();
+
+    JSONLoader(ss) >> copy;
+
+    EXPECT_EQ(data.size(), copy.size());
+    EXPECT_EQ(data[0], copy[0]);
+    EXPECT_EQ(data[1], copy[1]);
+}
+
+TEST(JSON, std_map) {
+    std::map<big_int, bitvec> data, copy;
+    data[big_int(1) << 100].setrange(100, 100);
+    data[1] = bitvec(1);
+
+    std::stringstream ss;
+    JSONGenerator(ss).emit(data);
+
+    // std::cout << ss.str();
+
+    JSONLoader(ss) >> copy;
+
+    EXPECT_EQ(data, copy);
+}
+
+TEST(JSON, variant) {
+    std::vector<std::variant<int, std::string>> data, copy;
+    data.emplace_back(2);
+    data.emplace_back(10);
+    data.emplace_back("foobar");
+    data.emplace_back(10);
+    data.emplace_back(1);
+    data.emplace_back("x");
+
+    std::stringstream ss;
+    JSONGenerator(ss).emit(data);
+
+    // std::cout << ss.str();
+
+    JSONLoader(ss) >> copy;
+
+    EXPECT_EQ(data.size(), copy.size());
+    for (size_t i = 0; i < data.size() && i < copy.size(); ++i) {
+        EXPECT_EQ(data[i], copy[i]);
+    }
 }

--- a/test/gtest/dumpjson.cpp
+++ b/test/gtest/dumpjson.cpp
@@ -29,7 +29,7 @@ TEST(IR, DumpJSON) {
     IR::Expression *e1 = new IR::Add(Util::SourceInfo(), c, c);
 
     std::stringstream ss, ss2;
-    JSONGenerator(ss) << e1 << std::endl;
+    JSONGenerator(ss).emit(e1);
     std::cout << ss.str();
 
     JSONLoader loader(ss);
@@ -37,5 +37,5 @@ TEST(IR, DumpJSON) {
 
     const IR::Node *e2 = nullptr;
     loader >> e2;
-    JSONGenerator(std::cout) << e2 << std::endl;
+    JSONGenerator(std::cout).emit(e2);
 }

--- a/test/gtest/dumpjson.cpp
+++ b/test/gtest/dumpjson.cpp
@@ -33,7 +33,7 @@ TEST(IR, DumpJSON) {
     std::cout << ss.str();
 
     JSONLoader loader(ss);
-    std::cout << loader.json;
+    std::cout << loader.as<JsonData>();
 
     const IR::Node *e2 = nullptr;
     loader >> e2;

--- a/test/gtest/load_ir_from_json.cpp
+++ b/test/gtest/load_ir_from_json.cpp
@@ -52,7 +52,7 @@ TEST_F(FromJSONTest, load_ir_from_json) {
         "grep -v program outputFROM.json > outputFROM.json.tmp; "
         "mv outputFROM.json.tmp outputFROM.json");
     ASSERT_FALSE(exitCode);
-    exitCode = system("diff outputTO.json outputFROM.json");
+    exitCode = system("json_diff outputTO.json outputFROM.json");
     ASSERT_FALSE(exitCode);
     exitCode = system("rm -f outputFROM.json outputTo.json");
     ASSERT_FALSE(exitCode);

--- a/test/gtest/load_ir_from_json.cpp
+++ b/test/gtest/load_ir_from_json.cpp
@@ -52,7 +52,7 @@ TEST_F(FromJSONTest, load_ir_from_json) {
         "grep -v program outputFROM.json > outputFROM.json.tmp; "
         "mv outputFROM.json.tmp outputFROM.json");
     ASSERT_FALSE(exitCode);
-    exitCode = system("json_diff outputTO.json outputFROM.json");
+    exitCode = system("diff outputTO.json outputFROM.json");
     ASSERT_FALSE(exitCode);
     exitCode = system("rm -f outputFROM.json outputTo.json");
     ASSERT_FALSE(exitCode);

--- a/test/gtest/rtti_test.cpp
+++ b/test/gtest/rtti_test.cpp
@@ -91,7 +91,7 @@ TEST(RTTI, JsonRestore) {
     IR::Expression *e1 = new IR::Add(Util::SourceInfo(), c, c);
 
     std::stringstream ss;
-    JSONGenerator(ss) << e1 << '\n';
+    JSONGenerator(ss).emit(e1);
 
     JSONLoader loader(ss);
 

--- a/tools/ir-generator/methods.cpp
+++ b/tools/ir-generator/methods.cpp
@@ -351,10 +351,9 @@ const ordered_map<cstring, IrMethod::info_t> IrMethod::Generate = {
           for (auto f : *cl->getFields()) {
               if (f->type && *f->type == NamedType::SourceInfo())
                   continue;  // FIXME -- deal with SourcInfo
-              if (!f->isInline && f->nullOK)
-                  buf << cl->indent << "if (" << f->name << " != nullptr) ";
-              buf << cl->indent << "json << \",\" << std::endl << json.indent << \"\\\"" << f->name
-                  << "\\\" : \" << " << "this->" << f->name << ";" << std::endl;
+              buf << cl->indent;
+              if (!f->isInline && f->nullOK) buf << "if (" << f->name << " != nullptr) ";
+              buf << "json.emit(\"" << f->name << "\", " << f->name << ");" << std::endl;
           }
           buf << "}";
           return {buf};


### PR DESCRIPTION
In trying to use the JSONGenerator/Loader code for additional things, I found a number of ways in which they are tricky to use and easy to use incorrectly (as well as some ways they are used incorrectly), mostly due to having exposed internals.  So I made all those internals `private` and provided a cleaner interface to be used

- JSONGenerator now uses `emit` methods to output values (rather than allowing `<< arbitrary text` which was erro prone), and ensures that objects only contain key-value pairs and vector only contain values (no keys) and things match up properly.
- JSONLoader now provides `is` tester methods for checking that values are the expected type, and manages its internal memory with `unique_ptr` so as to not require the garbage collector.