### PR TITLE
Bazel build: use Clang and bump rules_foreign and protobuf versions.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,4 +3,10 @@ common --enable_workspace
 # Enable once #5066 is resolved.
 common --noenable_bzlmod
 
-build --action_env=BAZEL_CXXOPTS="-std=c++17"
+# Use C++17.
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
+
+# Force the use of Clang for all builds.
+build --action_env=CC=clang
+build --action_env=CXX=clang++

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -6,6 +6,26 @@ load("//:bazel/p4c_deps.bzl", "p4c_deps")
 
 p4c_deps()
 
+# -- Load Rules Foreign CC -----------------------------------------------------
+
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+
+# This sets up some common toolchains for building targets. For more details, please see
+# https://bazel-contrib.github.io/rules_foreign_cc/0.14.0/flatten.html#rules_foreign_cc_dependencies
+rules_foreign_cc_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
+
 # -- Dependencies of dependencies. ---------------------------------------------
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
@@ -38,12 +58,6 @@ load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
 
-# -- Load Rules Foreign CC -----------------------------------------------------
-
-load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
-
-rules_foreign_cc_dependencies()
-
 # -- Load Buildifier (for formatting) ------------------------------------------
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -62,10 +76,6 @@ http_archive(
 load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
 
 buildifier_prebuilt_deps()
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
 
 load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
 

--- a/bazel/BUILD.z3.bazel
+++ b/bazel/BUILD.z3.bazel
@@ -7,6 +7,11 @@ filegroup(
 
 configure_make(
     name = "api",
+    args = [
+        "--directory build",
+        "-j8",
+    ],
+    configure_in_place = True,
     # Bazel redacts certain cc macros such as __DATA__ and __TIMESTAMP__
     # since they will cause the compiled code to have timestamps or other
     # similar information in it, causing the compilation to be
@@ -25,19 +30,14 @@ configure_make(
     # 0, which is a valid c++ expression.
     # This is a minor improvement on top of:
     # https://github.com/bazelbuild/rules_foreign_cc/issues/239
-    configure_env_vars = {
+    env = {
         "CFLAGS": "-Dredacted=0",
         "CXXFLAGS": "-Dredacted=0",
         "PYTHON": "python3",
     },
-    configure_in_place = True,
     lib_source = ":all",
-    make_commands = [
-        "cd build",
-        "make -j8",  # Use -j8, hardcoded but otherwise it will be too slow.
-        "make install",
-    ],
     out_binaries = ["z3"],
     out_shared_libs = ["libz3.so"],
+    targets = ["install"],
     visibility = ["//visibility:public"],
 )

--- a/bazel/example/.bazelrc
+++ b/bazel/example/.bazelrc
@@ -3,4 +3,10 @@ common --enable_workspace
 # Enable once #5066 is resolved.
 common --noenable_bzlmod
 
-build --action_env=BAZEL_CXXOPTS="-std=c++17"
+# Use C++17.
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
+
+# Force the use of Clang for all builds.
+build --action_env=CC=clang
+build --action_env=CXX=clang++

--- a/bazel/example/WORKSPACE.bazel
+++ b/bazel/example/WORKSPACE.bazel
@@ -1,5 +1,7 @@
 workspace(name = "example_p4_project")
 
+# -- Direct dependencies. ------------------------------------------------------
+
 # May replace this with `git_repository` or `http_archive` in your own project.
 local_repository(
     name = "com_github_p4lang_p4c",
@@ -15,6 +17,26 @@ local_repository(
 load("@com_github_p4lang_p4c//:bazel/p4c_deps.bzl", "p4c_deps")
 
 p4c_deps()
+
+# -- Load Rules Foreign CC -----------------------------------------------------
+
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+
+# This sets up some common toolchains for building targets. For more details, please see
+# https://bazel-contrib.github.io/rules_foreign_cc/0.14.0/flatten.html#rules_foreign_cc_dependencies
+rules_foreign_cc_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()
 
 # -- Dependencies of dependencies. ---------------------------------------------
 

--- a/bazel/p4c_deps.bzl
+++ b/bazel/p4c_deps.bzl
@@ -79,16 +79,17 @@ filegroup(
     if not native.existing_rule("com_google_protobuf"):
         http_archive(
             name = "com_google_protobuf",
-            url = "https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protobuf-25.3.tar.gz",
-            strip_prefix = "protobuf-25.3",
-            sha256 = "d19643d265b978383352b3143f04c0641eea75a75235c111cc01a1350173180e",
+            url = "https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protobuf-29.3.tar.gz",
+            strip_prefix = "protobuf-29.3",
+            integrity = "sha256-AIoRzFb5uWZ5tMKF/QX0bTF9aFvjq1JLKjEL4PutmH4=",
+            # sha256 = "d19643d265b978383352b3143f04c0641eea75a75235c111cc01a1350173180e",
         )
     if not native.existing_rule("rules_foreign_cc"):
         http_archive(
             name = "rules_foreign_cc",
-            sha256 = "d54742ffbdc6924f222d2179f0e10e911c5c659c4ae74158e9fe827aad862ac6",
-            strip_prefix = "rules_foreign_cc-0.2.0",
-            url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.2.0.tar.gz",
+            sha256 = "e0f0ebb1a2223c99a904a565e62aa285bf1d1a8aeda22d10ea2127591624866c",
+            strip_prefix = "rules_foreign_cc-0.14.0",
+            url = "https://github.com/bazel-contrib/rules_foreign_cc/releases/download/0.14.0/rules_foreign_cc-0.14.0.tar.gz",
         )
     if not native.existing_rule("com_github_z3prover_z3"):
         http_archive(


### PR DESCRIPTION
This is is preparation for migrating to Bzlmod ( #5066), which requires up-to-date versions of all dependencies.