### PR TITLE
[#5152] Write preprocessed P4 to `repro.p4` file when `-P` option is provided

### DIFF
--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -23,8 +23,10 @@ limitations under the License.
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <fstream>
 #include <memory>
 #include <regex>
+#include <sstream>
 #include <unordered_set>
 
 #include "absl/strings/escaping.h"
@@ -119,6 +121,13 @@ ParserOptions::ParserOptions(std::string_view defaultMessage) : Util::Options(de
             return true;
         },
         "Output `make` dependency rule only (passed to preprocessor)");
+    registerOption(
+        "-P", nullptr,
+        [this](const char *) {
+            savePreprocessed = true;
+            return true;
+        },
+        "Saves preprocessed P4 to repro.p4 and do not exit compilation.");
     registerOption(
         "-MD", nullptr,
         [this](const char *) {
@@ -421,6 +430,18 @@ const char *ParserOptions::getIncludePath() const {
     return path.c_str();
 }
 
+// From (folder, file.ext, suffix)  returns
+// folder/file-suffix.ext
+static std::filesystem::path makeFileName(const std::filesystem::path &folder,
+                                          const std::filesystem::path &name,
+                                          std::string_view baseSuffix) {
+    std::filesystem::path newName(name.stem());
+    newName += baseSuffix;
+    newName += name.extension();
+
+    return folder / newName;
+}
+
 std::optional<ParserOptions::PreprocessorResult> ParserOptions::preprocess() const {
     FILE *in = nullptr;
 
@@ -455,19 +476,25 @@ std::optional<ParserOptions::PreprocessorResult> ParserOptions::preprocess() con
         }
         return std::nullopt;
     }
+
+    if (savePreprocessed) {
+        std::filesystem::path fileName = makeFileName(dumpFolder, "repro.p4", "");
+        std::stringstream stream;
+        char *line = nullptr;
+        size_t len = 0;
+        ssize_t read = 0;
+
+        while ((read = getline(&line, &len, in)) != -1) {
+            stream << line;
+        }
+        std::ofstream filestream{fileName};
+        if (filestream) {
+            if (Log::verbose()) std::cerr << "Writing preprocessed P4 to " << fileName << std::endl;
+            filestream << stream.str();
+        }
+        filestream.close();
+    }
     return ParserOptions::PreprocessorResult(in, &closeFile);
-}
-
-// From (folder, file.ext, suffix)  returns
-// folder/file-suffix.ext
-static std::filesystem::path makeFileName(const std::filesystem::path &folder,
-                                          const std::filesystem::path &name,
-                                          std::string_view baseSuffix) {
-    std::filesystem::path newName(name.stem());
-    newName += baseSuffix;
-    newName += name.extension();
-
-    return folder / newName;
 }
 
 bool ParserOptions::isv1() const { return langVersion == ParserOptions::FrontendVersion::P4_14; }

--- a/frontends/common/parser_options.h
+++ b/frontends/common/parser_options.h
@@ -81,6 +81,8 @@ class ParserOptions : public Util::Options {
     std::filesystem::path file;
     /// if true preprocess only
     bool doNotCompile = false;
+    /// if true save preprocessed P4 to repro.p4
+    bool savePreprocessed = false;
     /// Compiler version.
     cstring compilerVersion;
     /// if true skip preprocess


### PR DESCRIPTION
Closes #5152.

Marking as draft until we decide:

- What to name the option - I have named it `-P` (for "Preprocessed") for now, but @asl also suggested `--save-temps`.
- What to name the generated file - I named it `repro.p4` (short for "reproducer"), but maybe there is a better name.