### PR TITLE
[#4365] [#4907] Add test cases related to issue #4365

### DIFF
--- a/testdata/p4_16_errors/issue4365_no_demote_error_to_info.p4
+++ b/testdata/p4_16_errors/issue4365_no_demote_error_to_info.p4
@@ -1,0 +1,7 @@
+// Ensure that errors cannot be demoted to info messages.
+@command_line("--Winfo=type-error")
+parser p() {
+    state accept {
+        transition reject;
+    }
+}

--- a/testdata/p4_16_errors/issue4365_no_demote_error_to_warning.p4
+++ b/testdata/p4_16_errors/issue4365_no_demote_error_to_warning.p4
@@ -1,0 +1,7 @@
+// Ensure that errors cannot be demoted to warnings.
+@command_line("--Wwarn=type-error")
+parser p() {
+    state accept {
+        transition reject;
+    }
+}

--- a/testdata/p4_16_errors/issue4365_no_disable_error.p4
+++ b/testdata/p4_16_errors/issue4365_no_disable_error.p4
@@ -1,0 +1,7 @@
+// Ensure that errors cannot be disabled.
+@command_line("--Wdisable=type-error")
+parser p() {
+    state accept {
+        transition reject;
+    }
+}

--- a/testdata/p4_16_errors_outputs/issue4365_no_demote_error_to_info.p4
+++ b/testdata/p4_16_errors_outputs/issue4365_no_demote_error_to_info.p4
@@ -1,0 +1,3 @@
+@command_line("--Winfo=type-error") parser p() {
+}
+

--- a/testdata/p4_16_errors_outputs/issue4365_no_demote_error_to_info.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue4365_no_demote_error_to_info.p4-stderr
@@ -1,0 +1,81 @@
+[--Werror=invalid] error: Error type-error cannot be demoted.
+(from pragmas): Compile a P4 program
+--help                                  Print this help message
+--version                               Print compiler version
+-I path                                 Specify include path (passed to preprocessor)
+-D arg=value                            Define macro (passed to preprocessor)
+-U arg                                  Undefine macro (passed to preprocessor)
+-E                                      Preprocess only, do not compile (prints program on stdout)
+-M                                      Output `make` dependency rule only (passed to preprocessor)
+-MD                                     Output `make` dependency rule to file as side effect (passed to preprocessor)
+-MF file                                With -M, specify output file for dependencies (passed to preprocessor)
+-MG                                     with -M, suppress errors for missing headers (passed to preprocessor)
+-MP                                     with -M, add phony target for each dependency (passed to preprocessor)
+-MT target                              With -M, override target of the output rule (passed to preprocessor)
+-MQ target                              Like -Mt, override target but quote special characters (passed to preprocessor)
+--std {p4-14|p4-16}                     Specify language version to compile.
+--nocpp                                 Skip preprocess, assume input file is already preprocessed.
+--disable-annotations[=annotations]     Specify a (comma separated) list of annotations that should be ignored by
+                                        the compiler. A warning will be printed that the annotation is ignored
+--Wdisable[=diagnostic]                 Disable a compiler diagnostic, or disable all warnings if no diagnostic is specified.
+--Winfo[=diagnostic]                    Report an info message for a compiler diagnostic.
+--Wwarn[=diagnostic]                    Report a warning for a compiler diagnostic, or treat all info messages as warnings if no diagnostic is specified.
+--Werror[=diagnostic]                   Report an error for a compiler diagnostic, or treat all warnings as errors if no diagnostic is specified.
+--maxErrorCount errorCount              Set the maximum number of errors to display before failing.
+-T loglevel                             [Compiler debugging] Adjust logging level per file (see below)
+-v                                      [Compiler debugging] Increase verbosity level (can be repeated)
+--top4 pass1[,pass2]                    [Compiler debugging] Dump the P4 representation after
+                                        passes whose name contains one of `passX' regex substrings. Matching is case-insensitive.
+                                        When '-v' is used this will include the compiler IR.
+--dump folder                           [Compiler debugging] Folder where P4 programs are dumped
+--parser-inline-opt                     Enable optimization of inlining of callee parsers (subparsers).
+                                        The optimization is disabled by default.
+                                        When the optimization is disabled, for each invocation of the subparser
+                                        all states of the subparser are inlined, which means that the subparser
+                                        might be inlined multiple times even if it is the same instance
+                                        which is invoked multiple times.
+                                        When the optimization is enabled, compiler tries to identify the cases,
+                                        when it can inline the subparser's states only once for multiple
+                                        invocations of the same subparser instance.
+--doNotEmitIncludes                     [Compiler debugging] If true do not generate #include statements
+--excludeFrontendPasses pass1[,pass2]   Exclude passes from frontend passes whose name is equal
+                                        to one of `passX' strings.
+--listFrontendPasses                    List exact names of all frontend passes
+--excludeMidendPasses pass1[,pass2]     Exclude passes from midend passes whose name is equal
+                                        to one of `passX' strings.
+--toJSON file                           Dump the compiler IR after the midend as JSON in the specified file.
+--ndebug                                Compile program in non-debug mode.
+--testJson                              [Compiler debugging] Dump and undump the IR
+--pp file                               Pretty-print the program in the specified file.
+--p4runtime-file file                   Write a P4Runtime control plane API description to the specified file.
+                                        [Deprecated; use '--p4runtime-files' instead].
+--p4runtime-entries-file file           Write static table entries as a P4Runtime WriteRequest messageto the specified file.
+                                        [Deprecated; use '--p4runtime-entries-files' instead].
+--p4runtime-files filelist              Write the P4Runtime control plane API description to the specified
+                                        files (comma-separated list). The format is inferred from the file
+                                        suffix: .txt, .json, .bin
+--p4runtime-entries-files files         Write static table entries as a P4Runtime WriteRequest message
+                                        to the specified files (comma-separated list); the file format is
+                                        inferred from the suffix. Legal suffixes are .json, .txt and .bin
+--p4runtime-format {binary,json,text}   Choose output format for the P4Runtime API description (default is binary).
+                                        [Deprecated; use '--p4runtime-files' instead].
+--target target                         Compile for the specified target device.
+--arch arch                             Compile for the specified architecture.
+--loopsUnroll                           Unrolling all parser's loops
+-O                                      Optimization level
+--listMidendPasses                      [p4test] Lists exact name of all midend passes.
+--parse-only                            only parse the P4 input, without any further processing
+--validate                              Validate the P4 input, running just the front-end
+--fromJSON file                         read previously dumped json instead of P4 source code
+--turn-off-logn                         Turn off LOGN() statements in the compiler.
+                                        Use '@__debug' annotation to enable LOGN on the annotated P4 object within the source code.
+--preferSwitch                          use passes that use general switch instead of action_run
+Additional usage instructions:
+loglevel format is: "sourceFile:level,...,sourceFile:level"
+where 'sourceFile' is a compiler source file and 'level' is the verbosity level for LOG messages in that file
+issue4365_no_demote_error_to_info.p4(4): [--Werror=invalid] error: Invalid parser state: accept should not be implemented, it is built-in
+    state accept {
+          ^^^^^^
+issue4365_no_demote_error_to_info.p4(3): [--Werror=invalid] error: Parser p has no 'start' state
+parser p() {
+       ^

--- a/testdata/p4_16_errors_outputs/issue4365_no_demote_error_to_warning.p4
+++ b/testdata/p4_16_errors_outputs/issue4365_no_demote_error_to_warning.p4
@@ -1,0 +1,3 @@
+@command_line("--Wwarn=type-error") parser p() {
+}
+

--- a/testdata/p4_16_errors_outputs/issue4365_no_demote_error_to_warning.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue4365_no_demote_error_to_warning.p4-stderr
@@ -1,0 +1,81 @@
+[--Werror=invalid] error: Error type-error cannot be demoted.
+(from pragmas): Compile a P4 program
+--help                                  Print this help message
+--version                               Print compiler version
+-I path                                 Specify include path (passed to preprocessor)
+-D arg=value                            Define macro (passed to preprocessor)
+-U arg                                  Undefine macro (passed to preprocessor)
+-E                                      Preprocess only, do not compile (prints program on stdout)
+-M                                      Output `make` dependency rule only (passed to preprocessor)
+-MD                                     Output `make` dependency rule to file as side effect (passed to preprocessor)
+-MF file                                With -M, specify output file for dependencies (passed to preprocessor)
+-MG                                     with -M, suppress errors for missing headers (passed to preprocessor)
+-MP                                     with -M, add phony target for each dependency (passed to preprocessor)
+-MT target                              With -M, override target of the output rule (passed to preprocessor)
+-MQ target                              Like -Mt, override target but quote special characters (passed to preprocessor)
+--std {p4-14|p4-16}                     Specify language version to compile.
+--nocpp                                 Skip preprocess, assume input file is already preprocessed.
+--disable-annotations[=annotations]     Specify a (comma separated) list of annotations that should be ignored by
+                                        the compiler. A warning will be printed that the annotation is ignored
+--Wdisable[=diagnostic]                 Disable a compiler diagnostic, or disable all warnings if no diagnostic is specified.
+--Winfo[=diagnostic]                    Report an info message for a compiler diagnostic.
+--Wwarn[=diagnostic]                    Report a warning for a compiler diagnostic, or treat all info messages as warnings if no diagnostic is specified.
+--Werror[=diagnostic]                   Report an error for a compiler diagnostic, or treat all warnings as errors if no diagnostic is specified.
+--maxErrorCount errorCount              Set the maximum number of errors to display before failing.
+-T loglevel                             [Compiler debugging] Adjust logging level per file (see below)
+-v                                      [Compiler debugging] Increase verbosity level (can be repeated)
+--top4 pass1[,pass2]                    [Compiler debugging] Dump the P4 representation after
+                                        passes whose name contains one of `passX' regex substrings. Matching is case-insensitive.
+                                        When '-v' is used this will include the compiler IR.
+--dump folder                           [Compiler debugging] Folder where P4 programs are dumped
+--parser-inline-opt                     Enable optimization of inlining of callee parsers (subparsers).
+                                        The optimization is disabled by default.
+                                        When the optimization is disabled, for each invocation of the subparser
+                                        all states of the subparser are inlined, which means that the subparser
+                                        might be inlined multiple times even if it is the same instance
+                                        which is invoked multiple times.
+                                        When the optimization is enabled, compiler tries to identify the cases,
+                                        when it can inline the subparser's states only once for multiple
+                                        invocations of the same subparser instance.
+--doNotEmitIncludes                     [Compiler debugging] If true do not generate #include statements
+--excludeFrontendPasses pass1[,pass2]   Exclude passes from frontend passes whose name is equal
+                                        to one of `passX' strings.
+--listFrontendPasses                    List exact names of all frontend passes
+--excludeMidendPasses pass1[,pass2]     Exclude passes from midend passes whose name is equal
+                                        to one of `passX' strings.
+--toJSON file                           Dump the compiler IR after the midend as JSON in the specified file.
+--ndebug                                Compile program in non-debug mode.
+--testJson                              [Compiler debugging] Dump and undump the IR
+--pp file                               Pretty-print the program in the specified file.
+--p4runtime-file file                   Write a P4Runtime control plane API description to the specified file.
+                                        [Deprecated; use '--p4runtime-files' instead].
+--p4runtime-entries-file file           Write static table entries as a P4Runtime WriteRequest messageto the specified file.
+                                        [Deprecated; use '--p4runtime-entries-files' instead].
+--p4runtime-files filelist              Write the P4Runtime control plane API description to the specified
+                                        files (comma-separated list). The format is inferred from the file
+                                        suffix: .txt, .json, .bin
+--p4runtime-entries-files files         Write static table entries as a P4Runtime WriteRequest message
+                                        to the specified files (comma-separated list); the file format is
+                                        inferred from the suffix. Legal suffixes are .json, .txt and .bin
+--p4runtime-format {binary,json,text}   Choose output format for the P4Runtime API description (default is binary).
+                                        [Deprecated; use '--p4runtime-files' instead].
+--target target                         Compile for the specified target device.
+--arch arch                             Compile for the specified architecture.
+--loopsUnroll                           Unrolling all parser's loops
+-O                                      Optimization level
+--listMidendPasses                      [p4test] Lists exact name of all midend passes.
+--parse-only                            only parse the P4 input, without any further processing
+--validate                              Validate the P4 input, running just the front-end
+--fromJSON file                         read previously dumped json instead of P4 source code
+--turn-off-logn                         Turn off LOGN() statements in the compiler.
+                                        Use '@__debug' annotation to enable LOGN on the annotated P4 object within the source code.
+--preferSwitch                          use passes that use general switch instead of action_run
+Additional usage instructions:
+loglevel format is: "sourceFile:level,...,sourceFile:level"
+where 'sourceFile' is a compiler source file and 'level' is the verbosity level for LOG messages in that file
+issue4365_no_demote_error_to_warning.p4(4): [--Werror=invalid] error: Invalid parser state: accept should not be implemented, it is built-in
+    state accept {
+          ^^^^^^
+issue4365_no_demote_error_to_warning.p4(3): [--Werror=invalid] error: Parser p has no 'start' state
+parser p() {
+       ^

--- a/testdata/p4_16_errors_outputs/issue4365_no_disable_error.p4
+++ b/testdata/p4_16_errors_outputs/issue4365_no_disable_error.p4
@@ -1,0 +1,3 @@
+@command_line("--Wdisable=type-error") parser p() {
+}
+

--- a/testdata/p4_16_errors_outputs/issue4365_no_disable_error.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue4365_no_disable_error.p4-stderr
@@ -1,0 +1,81 @@
+[--Werror=invalid] error: Error type-error cannot be demoted.
+(from pragmas): Compile a P4 program
+--help                                  Print this help message
+--version                               Print compiler version
+-I path                                 Specify include path (passed to preprocessor)
+-D arg=value                            Define macro (passed to preprocessor)
+-U arg                                  Undefine macro (passed to preprocessor)
+-E                                      Preprocess only, do not compile (prints program on stdout)
+-M                                      Output `make` dependency rule only (passed to preprocessor)
+-MD                                     Output `make` dependency rule to file as side effect (passed to preprocessor)
+-MF file                                With -M, specify output file for dependencies (passed to preprocessor)
+-MG                                     with -M, suppress errors for missing headers (passed to preprocessor)
+-MP                                     with -M, add phony target for each dependency (passed to preprocessor)
+-MT target                              With -M, override target of the output rule (passed to preprocessor)
+-MQ target                              Like -Mt, override target but quote special characters (passed to preprocessor)
+--std {p4-14|p4-16}                     Specify language version to compile.
+--nocpp                                 Skip preprocess, assume input file is already preprocessed.
+--disable-annotations[=annotations]     Specify a (comma separated) list of annotations that should be ignored by
+                                        the compiler. A warning will be printed that the annotation is ignored
+--Wdisable[=diagnostic]                 Disable a compiler diagnostic, or disable all warnings if no diagnostic is specified.
+--Winfo[=diagnostic]                    Report an info message for a compiler diagnostic.
+--Wwarn[=diagnostic]                    Report a warning for a compiler diagnostic, or treat all info messages as warnings if no diagnostic is specified.
+--Werror[=diagnostic]                   Report an error for a compiler diagnostic, or treat all warnings as errors if no diagnostic is specified.
+--maxErrorCount errorCount              Set the maximum number of errors to display before failing.
+-T loglevel                             [Compiler debugging] Adjust logging level per file (see below)
+-v                                      [Compiler debugging] Increase verbosity level (can be repeated)
+--top4 pass1[,pass2]                    [Compiler debugging] Dump the P4 representation after
+                                        passes whose name contains one of `passX' regex substrings. Matching is case-insensitive.
+                                        When '-v' is used this will include the compiler IR.
+--dump folder                           [Compiler debugging] Folder where P4 programs are dumped
+--parser-inline-opt                     Enable optimization of inlining of callee parsers (subparsers).
+                                        The optimization is disabled by default.
+                                        When the optimization is disabled, for each invocation of the subparser
+                                        all states of the subparser are inlined, which means that the subparser
+                                        might be inlined multiple times even if it is the same instance
+                                        which is invoked multiple times.
+                                        When the optimization is enabled, compiler tries to identify the cases,
+                                        when it can inline the subparser's states only once for multiple
+                                        invocations of the same subparser instance.
+--doNotEmitIncludes                     [Compiler debugging] If true do not generate #include statements
+--excludeFrontendPasses pass1[,pass2]   Exclude passes from frontend passes whose name is equal
+                                        to one of `passX' strings.
+--listFrontendPasses                    List exact names of all frontend passes
+--excludeMidendPasses pass1[,pass2]     Exclude passes from midend passes whose name is equal
+                                        to one of `passX' strings.
+--toJSON file                           Dump the compiler IR after the midend as JSON in the specified file.
+--ndebug                                Compile program in non-debug mode.
+--testJson                              [Compiler debugging] Dump and undump the IR
+--pp file                               Pretty-print the program in the specified file.
+--p4runtime-file file                   Write a P4Runtime control plane API description to the specified file.
+                                        [Deprecated; use '--p4runtime-files' instead].
+--p4runtime-entries-file file           Write static table entries as a P4Runtime WriteRequest messageto the specified file.
+                                        [Deprecated; use '--p4runtime-entries-files' instead].
+--p4runtime-files filelist              Write the P4Runtime control plane API description to the specified
+                                        files (comma-separated list). The format is inferred from the file
+                                        suffix: .txt, .json, .bin
+--p4runtime-entries-files files         Write static table entries as a P4Runtime WriteRequest message
+                                        to the specified files (comma-separated list); the file format is
+                                        inferred from the suffix. Legal suffixes are .json, .txt and .bin
+--p4runtime-format {binary,json,text}   Choose output format for the P4Runtime API description (default is binary).
+                                        [Deprecated; use '--p4runtime-files' instead].
+--target target                         Compile for the specified target device.
+--arch arch                             Compile for the specified architecture.
+--loopsUnroll                           Unrolling all parser's loops
+-O                                      Optimization level
+--listMidendPasses                      [p4test] Lists exact name of all midend passes.
+--parse-only                            only parse the P4 input, without any further processing
+--validate                              Validate the P4 input, running just the front-end
+--fromJSON file                         read previously dumped json instead of P4 source code
+--turn-off-logn                         Turn off LOGN() statements in the compiler.
+                                        Use '@__debug' annotation to enable LOGN on the annotated P4 object within the source code.
+--preferSwitch                          use passes that use general switch instead of action_run
+Additional usage instructions:
+loglevel format is: "sourceFile:level,...,sourceFile:level"
+where 'sourceFile' is a compiler source file and 'level' is the verbosity level for LOG messages in that file
+issue4365_no_disable_error.p4(4): [--Werror=invalid] error: Invalid parser state: accept should not be implemented, it is built-in
+    state accept {
+          ^^^^^^
+issue4365_no_disable_error.p4(3): [--Werror=invalid] error: Parser p has no 'start' state
+parser p() {
+       ^

--- a/testdata/p4_16_samples/issue4365_wdisable_precedence_over_werror.p4
+++ b/testdata/p4_16_samples/issue4365_wdisable_precedence_over_werror.p4
@@ -1,0 +1,29 @@
+// Expect no errors, as --Wdisable should take precedence over --Werror for warnings.
+@command_line("--Werror", "--Wdisable=uninitialized_use", "--Wdisable=invalid_header")
+header h_t {
+    bit<28> f1;
+    bit<4> f2;
+}
+
+extern void __e(in bit<28> arg);
+
+control C() {
+    action foo() {
+        h_t h;
+        __e(h.f1);
+    }
+
+    table t {
+        actions = { foo; }
+        default_action = foo;
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+
+top(C()) main;

--- a/testdata/p4_16_samples/issue4365_wdisable_precedence_over_werror_control.p4
+++ b/testdata/p4_16_samples/issue4365_wdisable_precedence_over_werror_control.p4
@@ -1,0 +1,29 @@
+// Control testcase to ensure that this program actually emits warnings
+// that can be disabled with --Wdisable=uninitialized_use and --Wdisable=invalid_header.
+header h_t {
+    bit<28> f1;
+    bit<4> f2;
+}
+
+extern void __e(in bit<28> arg);
+
+control C() {
+    action foo() {
+        h_t h;
+        __e(h.f1);
+    }
+
+    table t {
+        actions = { foo; }
+        default_action = foo;
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror-first.p4
+++ b/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror-first.p4
@@ -1,0 +1,25 @@
+@command_line("--Werror", "--Wdisable=uninitialized_use", "--Wdisable=invalid_header") header h_t {
+    bit<28> f1;
+    bit<4>  f2;
+}
+
+extern void __e(in bit<28> arg);
+control C() {
+    action foo() {
+        h_t h;
+        __e(h.f1);
+    }
+    table t {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror-frontend.p4
@@ -1,0 +1,26 @@
+@command_line("--Werror", "--Wdisable=uninitialized_use", "--Wdisable=invalid_header") header h_t {
+    bit<28> f1;
+    bit<4>  f2;
+}
+
+extern void __e(in bit<28> arg);
+control C() {
+    @name("C.h") h_t h_0;
+    @name("C.foo") action foo() {
+        h_0.setInvalid();
+        __e(h_0.f1);
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror-midend.p4
@@ -1,0 +1,26 @@
+@command_line("--Werror", "--Wdisable=uninitialized_use", "--Wdisable=invalid_header") header h_t {
+    bit<28> f1;
+    bit<4>  f2;
+}
+
+extern void __e(in bit<28> arg);
+control C() {
+    @name("C.h") h_t h_0;
+    @name("C.foo") action foo() {
+        h_0.setInvalid();
+        __e(h_0.f1);
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror.p4
+++ b/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror.p4
@@ -1,0 +1,25 @@
+@command_line("--Werror", "--Wdisable=uninitialized_use", "--Wdisable=invalid_header") header h_t {
+    bit<28> f1;
+    bit<4>  f2;
+}
+
+extern void __e(in bit<28> arg);
+control C() {
+    action foo() {
+        h_t h;
+        __e(h.f1);
+    }
+    table t {
+        actions = {
+            foo;
+        }
+        default_action = foo;
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror_control-first.p4
+++ b/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror_control-first.p4
@@ -1,0 +1,25 @@
+header h_t {
+    bit<28> f1;
+    bit<4>  f2;
+}
+
+extern void __e(in bit<28> arg);
+control C() {
+    action foo() {
+        h_t h;
+        __e(h.f1);
+    }
+    table t {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror_control-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror_control-frontend.p4
@@ -1,0 +1,26 @@
+header h_t {
+    bit<28> f1;
+    bit<4>  f2;
+}
+
+extern void __e(in bit<28> arg);
+control C() {
+    @name("C.h") h_t h_0;
+    @name("C.foo") action foo() {
+        h_0.setInvalid();
+        __e(h_0.f1);
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror_control-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror_control-midend.p4
@@ -1,0 +1,26 @@
+header h_t {
+    bit<28> f1;
+    bit<4>  f2;
+}
+
+extern void __e(in bit<28> arg);
+control C() {
+    @name("C.h") h_t h_0;
+    @name("C.foo") action foo() {
+        h_0.setInvalid();
+        __e(h_0.f1);
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror_control.p4
+++ b/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror_control.p4
@@ -1,0 +1,25 @@
+header h_t {
+    bit<28> f1;
+    bit<4>  f2;
+}
+
+extern void __e(in bit<28> arg);
+control C() {
+    action foo() {
+        h_t h;
+        __e(h.f1);
+    }
+    table t {
+        actions = {
+            foo;
+        }
+        default_action = foo;
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror_control.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue4365_wdisable_precedence_over_werror_control.p4-stderr
@@ -1,0 +1,6 @@
+issue4365_wdisable_precedence_over_werror_control.p4(13): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h
+        __e(h.f1);
+            ^
+issue4365_wdisable_precedence_over_werror_control.p4(13): [--Wwarn=uninitialized_use] warning: h.f1 may be uninitialized
+        __e(h.f1);
+            ^^^^


### PR DESCRIPTION
https://github.com/p4lang/p4c/pull/5123 made it very easy to add tests for functionality that is dependent on command-line options, so this PR does that and adds the following test cases:

- Ensure that errors cannot be disabled or demoted to warning or info messages (https://github.com/p4lang/p4c/pull/4366)
- Ensure that `--Wdisable` takes precedence over `--Werror` for warnings (https://github.com/p4lang/p4c/pull/4894)

This also closes #4907.