### PR TITLE
Fix missing space when emitting error enum with toP4.

### DIFF
--- a/frontends/p4/toP4/toP4.cpp
+++ b/frontends/p4/toP4/toP4.cpp
@@ -660,7 +660,7 @@ bool ToP4::preorder(const IR::Type_Error *d) {
                                 })
                                 ->toVector();
     if (!isDeclaration || !userErrors.empty()) {
-        builder.append("error");
+        builder.append("error ");
 
         if (!isDeclaration) {
             return false;


### PR DESCRIPTION
Fixes a problem introduced by #5036 that leads to mismatched output when producing reference files. The error enum is missing some whitespace. I am actually confused why this doesn't trigger mismatches. Possibly because our diff ignores whitespace. 