### PR TITLE
[Tofino] Replace bf-asm BUG macros with top-level BUG macros. Remove GNU extensions flags. 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,4 +27,6 @@ IncludeCategories:
   - Regex: ".*"
     Priority: 5000
 IncludeIsMainRegex: '(_test)?$'
+WhitespaceSensitiveMacros:
+  - __VA_OPT__
 ...

--- a/backends/tofino/bf-asm/CMakeLists.txt
+++ b/backends/tofino/bf-asm/CMakeLists.txt
@@ -245,7 +245,8 @@ set_source_files_properties(${BFAS_SOURCES} PROPERTIES COMPILE_FLAGS ${BFASM_CXX
 string(REPLACE "-Wno-overloaded-virtual" "" vector_c_flags ${BFASM_CXX_FLAGS})
 set_source_files_properties(vector.c PROPERTIES COMPILE_FLAGS ${vector_c_flags})
 add_executable (bfas ${BFAS_SOURCES})
-# Enable extensions for bfas. FIXME: Do we need this?
+# Enable extensions for bfas.
+# FIXME: This is needed to implement EXPAND_COMMA in target.h. Replace with __VA_OPT__ in C++20?
 target_compile_options(bfas PRIVATE -std=gnu++17)
 # Disable errors for warnings. FIXME: Get rid of this.
 target_compile_options(bfas PUBLIC "-Wno-error")

--- a/backends/tofino/bf-asm/CMakeLists.txt
+++ b/backends/tofino/bf-asm/CMakeLists.txt
@@ -245,9 +245,6 @@ set_source_files_properties(${BFAS_SOURCES} PROPERTIES COMPILE_FLAGS ${BFASM_CXX
 string(REPLACE "-Wno-overloaded-virtual" "" vector_c_flags ${BFASM_CXX_FLAGS})
 set_source_files_properties(vector.c PROPERTIES COMPILE_FLAGS ${vector_c_flags})
 add_executable (bfas ${BFAS_SOURCES})
-# Enable extensions for bfas.
-# FIXME: This is needed to implement EXPAND_COMMA in target.h. Replace with __VA_OPT__ in C++20?
-target_compile_options(bfas PRIVATE -std=gnu++17)
 # Disable errors for warnings. FIXME: Get rid of this.
 target_compile_options(bfas PUBLIC "-Wno-error")
 target_link_libraries (bfas ${BFASM_LIBS} ${BFASM_LIB_DEPS})

--- a/backends/tofino/bf-asm/action_bus.h
+++ b/backends/tofino/bf-asm/action_bus.h
@@ -164,7 +164,7 @@ class ActionBus {
         unsigned lo(Table *tbl) const;  // low bit on the action data bus
         bool is_table_output() const {
             for (auto &d : data) {
-                BUG_CHECK(d.first.type != ActionBusSource::NameRef);
+                BUG_CHECK(d.first.type != ActionBusSource::NameRef, "Unexpected name ref");
                 if (d.first.type == ActionBusSource::TableOutput) return true;
             }
             return false;

--- a/backends/tofino/bf-asm/alias_array.h
+++ b/backends/tofino/bf-asm/alias_array.h
@@ -18,9 +18,9 @@
 #ifndef BACKENDS_TOFINO_BF_ASM_ALIAS_ARRAY_H_
 #define BACKENDS_TOFINO_BF_ASM_ALIAS_ARRAY_H_
 
-#include <stdlib.h>
+#include <cstdlib>
 
-#include "bfas.h"  // for BUG_CHECK
+#include "lib/exceptions.h"
 
 template <size_t S, typename T>
 class alias_array;

--- a/backends/tofino/bf-asm/asm-types.cpp
+++ b/backends/tofino/bf-asm/asm-types.cpp
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include "lib/exceptions.h"
 #include "misc.h"
 
 #pragma GCC diagnostic push
@@ -146,7 +147,7 @@ bitvec get_bitvec(const value_t &v, unsigned max_bits, const char *error_message
 }
 
 uint64_t get_int64(const value_t &v, unsigned max_bits, const char *error_message) {
-    BUG_CHECK(max_bits <= 64);
+    BUG_CHECK(max_bits <= 64, "max_bits must be <= 64");
     bool too_large = false;
     uint64_t value = 0;
     if (CHECKTYPE2(v, tINT, tBIGINT)) {
@@ -158,7 +159,8 @@ uint64_t get_int64(const value_t &v, unsigned max_bits, const char *error_messag
                 value = ((uint64_t)v.bigi.data[1] << 32) + v.bigi.data[0];
                 too_large = v.bigi.size > 2;
             } else {
-                BUG_CHECK(sizeof(uintptr_t) == sizeof(uint64_t));
+                BUG_CHECK(sizeof(uintptr_t) == sizeof(uint64_t),
+                          "sizeof(uintptr_t) is not uint64_t");
                 value = v.bigi.data[0];
                 too_large = v.bigi.size > 1;
             }

--- a/backends/tofino/bf-asm/atcam_match.cpp
+++ b/backends/tofino/bf-asm/atcam_match.cpp
@@ -155,7 +155,7 @@ void AlgTcamMatchTable::setup_column_priority() {
 void AlgTcamMatchTable::verify_entry_priority() {
     int result_bus_word = -1;
     for (int i = 0; i < static_cast<int>(group_info.size()); i++) {
-        BUG_CHECK(group_info[i].result_bus_word >= 0);
+        BUG_CHECK(group_info[i].result_bus_word >= 0, "result bus word must be >= 0");
         if (result_bus_word == -1) {
             result_bus_word = group_info[i].result_bus_word;
         } else if (result_bus_word != group_info[i].result_bus_word) {
@@ -258,7 +258,7 @@ void AlgTcamMatchTable::find_tcam_match() {
     for (auto match_field : match) {
         auto phv_p = dynamic_cast<Phv::Ref *>(match_field);
         if (phv_p == nullptr) {
-            BUG();
+            BUG("expected Phv::Ref");
             continue;
         }
         auto phv_ref = *phv_p;
@@ -381,7 +381,7 @@ std::unique_ptr<json::vector> AlgTcamMatchTable::gen_memory_resource_allocation_
             if (mem_units.empty())
                 vpn_ctr = layout_get_vpn(ram);
             else
-                BUG_CHECK(vpn_ctr == layout_get_vpn(ram));
+                BUG_CHECK(vpn_ctr == layout_get_vpn(ram), "vpn mismatch");
             mem_units.push_back(json_memunit(ram));
             if (mem_units.size() == fmt_width) {
                 json::map tmp;
@@ -398,7 +398,7 @@ std::unique_ptr<json::vector> AlgTcamMatchTable::gen_memory_resource_allocation_
                 mem_units_and_vpns.push_back(std::move(tmp));
             }
         }
-        BUG_CHECK(mem_units.empty());
+        BUG_CHECK(mem_units.empty(), "Memory units not empty");
         mras.push_back(std::move(mra));
     }
     return json::mkuniq<json::vector>(std::move(mras));

--- a/backends/tofino/bf-asm/attached_table.cpp
+++ b/backends/tofino/bf-asm/attached_table.cpp
@@ -192,7 +192,7 @@ unsigned AttachedTable::determine_meter_shiftcount(Table::Call &call, int group,
     if (call.args[0].name() && strcmp(call.args[0].name(), "$DIRECT") == 0) {
         return direct_shiftcount() + tcam_shift;
     } else if (auto f = call.args[0].field()) {
-        BUG_CHECK(int(f->by_group[group]->bit(0) / 128U) == word);
+        BUG_CHECK(int(f->by_group[group]->bit(0) / 128U) == word, "word %d", word);
         return f->by_group[group]->bit(0) % 128U + indirect_shiftcount();
     } else if (auto f = call.args[1].field()) {
         return f->by_group[group]->bit(0) % 128U + METER_ADDRESS_ZERO_PAD;

--- a/backends/tofino/bf-asm/bfas.cpp
+++ b/backends/tofino/bf-asm/bfas.cpp
@@ -29,6 +29,7 @@
 #include "backends/tofino/bf-p4c/git_sha_version.h"  // for BF_P4C_GIT_SHA
 #include "backends/tofino/bf-p4c/version.h"
 #include "constants.h"
+#include "lib/exceptions.h"
 #include "lib/indent.h"
 #include "misc.h"
 #include "parser-tofino-jbay.h"
@@ -150,7 +151,7 @@ void output_all() {
     char build_date[1024];
     struct tm lt;
     localtime_r(&now, &lt);
-    BUG_CHECK(&lt);
+    BUG_CHECK(&lt, "localtime_r failed");
     strftime(build_date, 1024, "%c", &lt);
     ctxtJson["build_date"] = build_date;
     ctxtJson["schema_version"] = SCHEMA_VERSION;

--- a/backends/tofino/bf-asm/bfas.h
+++ b/backends/tofino/bf-asm/bfas.h
@@ -96,6 +96,7 @@ int asm_parse_string(const char *in);
 void no_sections_error_exit();
 bool no_section_error(const char *name);
 
+/// TODO: Replace with lib utilities?
 extern int error_count, warn_count;
 extern void error(int lineno, const char *fmt, va_list);
 void error(int lineno, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
@@ -118,44 +119,8 @@ inline void warning(int lineno, const char *fmt, ...) {
 #endif /* BAREFOOT_INTERNAL */
 }
 
-// FIXME: Replace with library bug macros.
-inline const char *strip_prefix(const char *str, const char *pfx) {
-    if (const char *p = strstr(str, pfx)) return p + strlen(pfx);
-    return str;
-}
-void bug(const char *, int, const char * = 0, ...) __attribute__((format(printf, 3, 4)))
-__attribute__((noreturn));
-inline void bug(const char *fname, int lineno, const char *fmt, ...) {
-#ifdef NDEBUG
-    fprintf(stderr, "Assembler BUG");
-#else
-    fprintf(stderr, "%s:%d: Assembler BUG: ", fname, lineno);
-    if (fmt) {
-        va_list args;
-        va_start(args, fmt);
-        vfprintf(stderr, fmt, args);
-        va_end(args);
-    }
-#endif /* !NDEBUG */
-    fprintf(stderr, "\n");
-    fflush(stderr);
-    std::terminate();
-}
-
 extern std::unique_ptr<std::ostream> open_output(const char *, ...)
     __attribute__((format(printf, 1, 2)));
-
-// FIXME: Replace with library bug macros.
-#define SRCFILE strip_prefix(__FILE__, "bf-asm/")
-#define BUG(...)                               \
-    do {                                       \
-        bug(SRCFILE, __LINE__, ##__VA_ARGS__); \
-    } while (0)
-#define BUG_CHECK(e, ...)                          \
-    do {                                           \
-        if (!(e)) BUG("Check failed" __VA_ARGS__); \
-                                                   \
-    } while (0)
 
 class VersionIter {
     unsigned left, bit;

--- a/backends/tofino/bf-asm/bfas.h
+++ b/backends/tofino/bf-asm/bfas.h
@@ -118,6 +118,7 @@ inline void warning(int lineno, const char *fmt, ...) {
 #endif /* BAREFOOT_INTERNAL */
 }
 
+// FIXME: Replace with library bug macros.
 inline const char *strip_prefix(const char *str, const char *pfx) {
     if (const char *p = strstr(str, pfx)) return p + strlen(pfx);
     return str;
@@ -144,14 +145,16 @@ inline void bug(const char *fname, int lineno, const char *fmt, ...) {
 extern std::unique_ptr<std::ostream> open_output(const char *, ...)
     __attribute__((format(printf, 1, 2)));
 
+// FIXME: Replace with library bug macros.
 #define SRCFILE strip_prefix(__FILE__, "bf-asm/")
 #define BUG(...)                               \
     do {                                       \
         bug(SRCFILE, __LINE__, ##__VA_ARGS__); \
     } while (0)
-#define BUG_CHECK(e, ...)           \
-    do {                            \
-        if (!(e)) BUG(__VA_ARGS__); \
+#define BUG_CHECK(e, ...)                          \
+    do {                                           \
+        if (!(e)) BUG("Check failed" __VA_ARGS__); \
+                                                   \
     } while (0)
 
 class VersionIter {

--- a/backends/tofino/bf-asm/counter.cpp
+++ b/backends/tofino/bf-asm/counter.cpp
@@ -168,7 +168,8 @@ unsigned CounterTable::determine_shiftcount(Table::Call &call, int group, unsign
     if (call.args[0].name() && strcmp(call.args[0].name(), "$DIRECT") == 0) {
         return direct_shiftcount() + tcam_shift;
     } else if (call.args[0].field()) {
-        BUG_CHECK(unsigned(call.args[0].field()->by_group[group]->bit(0) / 128) == word);
+        BUG_CHECK(unsigned(call.args[0].field()->by_group[group]->bit(0) / 128) == word,
+                  "wrong word");
         return call.args[0].field()->by_group[group]->bit(0) % 128 + indirect_shiftcount();
     } else if (call.args[1].field()) {
         return call.args[1].field()->by_group[group]->bit(0) % 128 + STAT_ADDRESS_ZERO_PAD;
@@ -229,7 +230,7 @@ void CounterTable::write_regs_vt(REGS &regs) {
     for (Layout &logical_row : layout) {
         unsigned row = logical_row.row / 2U;
         unsigned side = logical_row.row & 1; /* 0 == left  1 == right */
-        BUG_CHECK(side == 1);                /* no map rams or alus on left side anymore */
+        BUG_CHECK(side == 1, "no map rams or alus on left side anymore");
         /* FIXME factor vpn/mapram stuff with selection.cpp */
         auto vpn = logical_row.vpns.begin();
         auto mapram = logical_row.maprams.begin();
@@ -244,7 +245,7 @@ void CounterTable::write_regs_vt(REGS &regs) {
 
             if (swbox->get_home_row() != row) swbox->setup_row(swbox->get_home_row());
         }
-        BUG_CHECK(home != nullptr);
+        BUG_CHECK(home != nullptr, "no home row");
         LOG2("# DataSwitchbox.setup(" << row << ") home=" << home->row / 2U);
         swbox->setup_row(row);
         for (auto &memunit : logical_row.memunits) {
@@ -301,7 +302,7 @@ void CounterTable::write_regs_vt(REGS &regs) {
                 adr_ctl.adr_dist_oflo_adr_xbar_source_index = 0;
                 adr_ctl.adr_dist_oflo_adr_xbar_source_sel = AdrDist::OVERFLOW;
                 push_on_overflow = true;
-                BUG_CHECK(options.target == TOFINO);
+                BUG_CHECK(options.target == TOFINO, "target not tofino");
             } else {
                 adr_ctl.adr_dist_oflo_adr_xbar_source_index = swbox->get_home_row_logical() % 8;
                 adr_ctl.adr_dist_oflo_adr_xbar_source_sel = AdrDist::STATISTICS;
@@ -312,7 +313,7 @@ void CounterTable::write_regs_vt(REGS &regs) {
     bool run_at_eop = this->run_at_eop();
     if (home_rows.size() > 1) write_alu_vpn_range(regs);
 
-    BUG_CHECK(stats_groups.size() == home_rows.size());
+    BUG_CHECK(stats_groups.size() == home_rows.size(), "stats_groups.size() != home_rows.size()");
     bool first_stats_group = true;
     for (int &idx : stats_groups) {
         auto &movereg_stats_ctl = adrdist.movereg_stats_ctl[idx];

--- a/backends/tofino/bf-asm/crash.cpp
+++ b/backends/tofino/bf-asm/crash.cpp
@@ -36,6 +36,7 @@
 
 #include "bfas.h"
 #include "exename.h"
+#include "lib/exceptions.h"
 #include "lib/hex.h"
 #include "lib/log.h"
 

--- a/backends/tofino/bf-asm/deparser.h
+++ b/backends/tofino/bf-asm/deparser.h
@@ -173,7 +173,7 @@ class Deparser : public Section {
          protected:
             Type(target_t t, gress_t gr, const char *n, int cnt)
                 : target(t), gress(gr), name(n), count(cnt) {
-                BUG_CHECK(!all[target][gress].count(name));
+                BUG_CHECK(!all[target][gress].count(name), "Duplicate name %s", name.c_str());
                 all[target][gress][name] = this;
             }
             ~Type() { all[target][gress].erase(name); }
@@ -182,7 +182,7 @@ class Deparser : public Section {
 #define VIRTUAL_TARGET_METHODS(TARGET)                                            \
     virtual void setregs(Target::TARGET::deparser_regs &regs, Deparser &deparser, \
                          Deparser::Digest &data) {                                \
-        BUG_CHECK(!"target mismatch");                                            \
+        BUG("target mismatch");                                                   \
     }
             FOR_ALL_REGISTER_SETS(VIRTUAL_TARGET_METHODS)
 #undef VIRTUAL_TARGET_METHODS

--- a/backends/tofino/bf-asm/error_mode.cpp
+++ b/backends/tofino/bf-asm/error_mode.cpp
@@ -18,6 +18,7 @@
 #include "error_mode.h"
 
 #include "backends/tofino/bf-asm/stage.h"
+#include "lib/exceptions.h"
 
 DefaultErrorMode DefaultErrorMode::singleton;
 
@@ -140,7 +141,7 @@ void ErrorMode::write_regs(REGS &regs, const Stage *stage, gress_t gress) {
         merge.REG[gress].REG##_dis_pred = 1;                \
         break;                                              \
     default:                                                \
-        BUG();
+        BUG("unexpected error mode");
 
     switch (mode[PREV_ERROR]) { HANDLE_ERROR_CASES(prev_error_ctl, NO) }
     merge.prev_error_ctl[gress].prev_error_ctl_delay = tcam_err_delay;

--- a/backends/tofino/bf-asm/exact_match.cpp
+++ b/backends/tofino/bf-asm/exact_match.cpp
@@ -146,7 +146,8 @@ void ExactMatchTable::determine_ghost_bits() {
                 hash_tables = bitvec(hash_group->tables);
             } else {
                 for (auto &ht : ixb->get_hash_tables()) {
-                    BUG_CHECK(ht.first.type == InputXbar::HashTable::EXACT);
+                    BUG_CHECK(ht.first.type == InputXbar::HashTable::EXACT,
+                              "Unexpected hash table type");
                     hash_tables[ht.first.index] = 1;
                 }
             }
@@ -280,7 +281,7 @@ void ExactMatchTable::generate_stash_overhead_rows() {
                 Ram stash_ram(stash_row, stash_col);
                 if (way_map.count(stash_ram) > 0) {
                     auto way_word = way_map[stash_ram].word;
-                    BUG_CHECK(format);
+                    BUG_CHECK(format, "no format");
                     if (way_word == format->overhead_word) {
                         stash_overhead_rows.push_back(stash_row);
                         break;
@@ -466,7 +467,7 @@ void ExactMatchTable::gen_tbl_cfg(json::vector &out) const {
             way_tbl["way_number"] = way_number++;
             way_tbl["stage_table_type"] = "hash_way";
             auto fmt_width = get_format_width();
-            BUG_CHECK(fmt_width);
+            BUG_CHECK(fmt_width, "format width is zero");
             unsigned ram_depth = way.rams.at(0).isLamb() ? LAMB_DEPTH : SRAM_DEPTH;
             way_tbl["size"] = way.rams.size() / fmt_width * format->groups() * ram_depth;
             add_pack_format(way_tbl, format.get(), false);

--- a/backends/tofino/bf-asm/exename.cpp
+++ b/backends/tofino/bf-asm/exename.cpp
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 
 #include "bfas.h"
+#include "lib/exceptions.h"
 
 template <size_t N>
 static void convertToAbsPath(const char *const relPath, char (&output)[N]) {

--- a/backends/tofino/bf-asm/gateway.cpp
+++ b/backends/tofino/bf-asm/gateway.cpp
@@ -23,6 +23,7 @@
 #include "backends/tofino/bf-asm/tables.h"
 #include "lib/algorithm.h"
 #include "lib/hex.h"
+#include "lib/null.h"
 
 // template specialization declarations
 #include "backends/tofino/bf-asm/jbay/gateway.h"
@@ -553,7 +554,7 @@ void GatewayTable::payload_write_regs(REGS &regs, int row, int type, int bus) {
         xbar_ctl.exact_inhibit_enable = 1;
     }
     if (have_payload >= 0 || match_address >= 0) {
-        BUG_CHECK(payload_unit == bus);
+        BUG_CHECK(payload_unit == bus, "payload_unit %d != bus %d", payload_unit, bus);
         if (type)
             merge.gateway_payload_tind_pbus[row] |= 1 << bus;
         else
@@ -579,7 +580,7 @@ void GatewayTable::payload_write_regs(REGS &regs, int row, int type, int bus) {
 
     int groups = format ? format->groups() : 1;
     if (groups > 1 || payload_map.size() > 1) {
-        BUG_CHECK(type == 0);  // only supported on exact result busses
+        BUG_CHECK(type == 0, "type not supported");  // only supported on exact result busses
         enable_gateway_payload_exact_shift_ovr(regs, row * 2 + bus);
     }
 
@@ -724,7 +725,7 @@ void GatewayTable::write_regs_vt(REGS &regs) {
         gw_reg.gateway_table_ctl.gateway_table_input_data0_select = 1;
         gw_reg.gateway_table_ctl.gateway_table_input_hash0_select = 1;
     } else {
-        BUG_CHECK(search_bus == 1);
+        BUG_CHECK(search_bus == 1, "search_bus must be 1");
         gw_reg.gateway_table_ctl.gateway_table_input_data1_select = 1;
         gw_reg.gateway_table_ctl.gateway_table_input_hash1_select = 1;
     }
@@ -744,7 +745,7 @@ void GatewayTable::write_regs_vt(REGS &regs) {
     int idx = 3;
     gw_reg.gateway_table_ctl.gateway_table_mode = range_match;
     for (auto &line : table) {
-        BUG_CHECK(idx >= 0);
+        BUG_CHECK(idx >= 0, "idx < 0");
         /* FIXME -- hardcoding version/valid to always */
         gw_reg.gateway_table_vv_entry[idx].gateway_table_entry_versionvalid0 = 0x3;
         gw_reg.gateway_table_vv_entry[idx].gateway_table_entry_versionvalid1 = 0x3;
@@ -803,7 +804,7 @@ void GatewayTable::write_regs_vt(REGS &regs) {
                 }
             }
         } else {
-            BUG_CHECK(tmatch);
+            CHECK_NULL(tmatch);
             auto &xbar_ctl = merge.gateway_to_pbus_xbar_ctl[tmatch->indirect_bus];
             xbar_ctl.tind_logical_select = logical_id;
             xbar_ctl.tind_inhibit_enable = 1;

--- a/backends/tofino/bf-asm/gtest/asm-types.cpp
+++ b/backends/tofino/bf-asm/gtest/asm-types.cpp
@@ -27,7 +27,7 @@ auto terminate = ::testing::KilledBySignal(SIGABRT);
 
 TEST(asm_types, get_int64_0) {
     uint32_t i = 0;
-    value_t v{tINT, 0, 0};
+    value_t v{tINT, 0, {0}};
     v.i = i;
     CaptureStderr();
     EXPECT_EQ(get_int64(v), i);
@@ -45,7 +45,7 @@ TEST(asm_types, get_int64_0) {
 
 TEST(asm_types, get_int64_32bit) {
     uint32_t i = 0xAAAAAAAA;
-    value_t v{tINT, 0, 0};
+    value_t v{tINT, 0, {0}};
     v.i = i;
     CaptureStderr();
     EXPECT_EQ(get_int64(v), i);
@@ -62,7 +62,7 @@ TEST(asm_types, get_int64_32bit) {
 
 TEST(asm_types, get_int64_64bit) {
     uint64_t i = 0xAAAAAAAAAAAAAAAA;
-    value_t v{tINT, 0, 0};
+    value_t v{tINT, 0, {0}};
     v.i = i;
     CaptureStderr();
     EXPECT_EQ(get_int64(v), i);
@@ -78,7 +78,7 @@ TEST(asm_types, get_int64_64bit) {
 }
 
 TEST(asm_types, get_bigi_empty) {
-    value_t v{tBIGINT, 0, 0};
+    value_t v{tBIGINT, 0, {0}};
     v.bigi = EMPTY_VECTOR_INIT;
     EXPECT_EQ(get_int64(v), 0);
     EXPECT_EQ(get_bitvec(v), bitvec());
@@ -86,7 +86,7 @@ TEST(asm_types, get_bigi_empty) {
 
 TEST(asm_types, get_int64_bigi_0) {
     uint32_t i = 0;
-    value_t v{tBIGINT, 0, 0};
+    value_t v{tBIGINT, 0, {0}};
     VECTOR_init1(v.bigi, i);
     CaptureStderr();
     EXPECT_EQ(get_int64(v), i);
@@ -104,7 +104,7 @@ TEST(asm_types, get_int64_bigi_0) {
 
 TEST(asm_types, get_int64_bigi_32bit) {
     uint32_t i = 0xAAAAAAAA;
-    value_t v{tBIGINT, 0, 0};
+    value_t v{tBIGINT, 0, {0}};
     VECTOR_init1(v.bigi, i);
     CaptureStderr();
     EXPECT_EQ(get_int64(v), i);
@@ -121,7 +121,7 @@ TEST(asm_types, get_int64_bigi_32bit) {
 
 TEST(asm_types, get_int64_bigi_64bit) {
     uint64_t i = 0xAAAAAAAAAAAAAAAA;
-    value_t v{tBIGINT, 0, 0};
+    value_t v{tBIGINT, 0, {0}};
     if (sizeof(uintptr_t) == sizeof(uint32_t))
         VECTOR_init2(v.bigi, 0xAAAAAAAA, 0xAAAAAAAA);
     else
@@ -140,7 +140,7 @@ TEST(asm_types, get_int64_bigi_64bit) {
 }
 
 TEST(asm_types, get_bitvec_0) {
-    value_t v{tINT, 0, 0};
+    value_t v{tINT, 0, {0}};
     v.i = 0;
     auto i = bitvec(0);
     CaptureStderr();
@@ -157,7 +157,7 @@ TEST(asm_types, get_bitvec_0) {
 }
 
 TEST(asm_types, get_bitvec_32bit) {
-    value_t v{tINT, 0, 0};
+    value_t v{tINT, 0, {0}};
     v.i = 0xAAAAAAAA;
     auto i = bitvec(0xAAAAAAAA);
     CaptureStderr();
@@ -174,7 +174,7 @@ TEST(asm_types, get_bitvec_32bit) {
 }
 
 TEST(asm_types, get_bitvec_64bit) {
-    value_t v{tINT, 0, 0};
+    value_t v{tINT, 0, {0}};
     v.i = 0xAAAAAAAAAAAAAAAA;
     auto i = bitvec(0xAAAAAAAAAAAAAAAA);
     CaptureStderr();
@@ -191,7 +191,7 @@ TEST(asm_types, get_bitvec_64bit) {
 }
 
 TEST(asm_types, get_bitvec_bigi_0) {
-    value_t v{tBIGINT, 0, 0};
+    value_t v{tBIGINT, 0, {0}};
     VECTOR_init1(v.bigi, 0);
     auto i = bitvec(0);
     CaptureStderr();
@@ -208,7 +208,7 @@ TEST(asm_types, get_bitvec_bigi_0) {
 }
 
 TEST(asm_types, get_bitvec_bigi_32bit) {
-    value_t v{tBIGINT, 0, 0};
+    value_t v{tBIGINT, 0, {0}};
     VECTOR_init1(v.bigi, 0xAAAAAAAA);
     auto i = bitvec(0xAAAAAAAA);
     CaptureStderr();
@@ -225,7 +225,7 @@ TEST(asm_types, get_bitvec_bigi_32bit) {
 }
 
 TEST(asm_types, get_bitvec_bigi_64bit) {
-    value_t v{tBIGINT, 0, 0};
+    value_t v{tBIGINT, 0, {0}};
     if (sizeof(uintptr_t) == sizeof(uint32_t))
         VECTOR_init2(v.bigi, 0xAAAAAAAA, 0xAAAAAAAA);
     else
@@ -245,7 +245,7 @@ TEST(asm_types, get_bitvec_bigi_64bit) {
 }
 
 TEST(asm_types, get_bitvec_bigi_128bit) {
-    value_t v{tBIGINT, 0, 0};
+    value_t v{tBIGINT, 0, {0}};
     if (sizeof(uintptr_t) == sizeof(uint32_t))
         VECTOR_init4(v.bigi, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA, 0xAAAAAAAA);
     else

--- a/backends/tofino/bf-asm/hash_dist.cpp
+++ b/backends/tofino/bf-asm/hash_dist.cpp
@@ -19,6 +19,7 @@
 
 #include "backends/tofino/bf-asm/config.h"
 #include "backends/tofino/bf-asm/stage.h"
+#include "lib/exceptions.h"
 #include "lib/range.h"
 
 static void set_output_bit(unsigned &xbar_use, value_t &v) {
@@ -135,9 +136,7 @@ void HashDistribution::pass1(Table *tbl, delay_type_t delay_type, bool non_linea
                 err = true;
                 break;
             default:
-                error(lineno,
-                      "a mod 3 check should only hit these particular cases, of 0, 1, and 2");
-                BUG();
+                BUG("a mod 3 check should only hit these particular cases, of 0, 1, and 2");
         }
         if (!err) {
             for (auto *use : tbl->stage->hash_dist_use[other])
@@ -204,7 +203,7 @@ void HashDistribution::write_regs(REGS &regs, Table *tbl) {
                                                                         2);
                 break;
             default:
-                BUG();
+                BUG("a mod 3 check should only hit these particular cases, 0 and 1");
         }
     }
     for (int oxbar : Range(0, 4))

--- a/backends/tofino/bf-asm/jbay/counter.h
+++ b/backends/tofino/bf-asm/jbay/counter.h
@@ -20,8 +20,8 @@
 
 template <typename REGS>
 void CounterTable::setup_teop_regs_2(REGS &regs, int stats_group_index) {
-    BUG_CHECK(teop >= 0 && teop < 4);
-    BUG_CHECK(gress == EGRESS);
+    BUG_CHECK(teop >= 0 && teop < 4, "Invalid teop: %d", teop);
+    BUG_CHECK(gress == EGRESS, "Invalid gress: %d", gress);
 
     auto &adrdist = regs.rams.match.adrdist;
 
@@ -87,7 +87,7 @@ void CounterTable::write_alu_vpn_range_2(REGS &regs) {
                 }
             }
             if (block_end) {
-                BUG_CHECK(min != 1000000 && max != -1);
+                BUG_CHECK(min != 1000000 && max != -1, " Invalid VPN range");
 
                 bitvec block_range(min, max - min + 1);
                 if (vpn_range.intersects(block_range))
@@ -101,7 +101,7 @@ void CounterTable::write_alu_vpn_range_2(REGS &regs) {
                 break;
             }
         }
-        BUG_CHECK(block_start && block_end);
+        BUG_CHECK(block_start && block_end, "Invalid VPN range");
     }
 
     if (vpn_range != bitvec(minvpn, sparevpn - minvpn))

--- a/backends/tofino/bf-asm/jbay/deparser.cpp
+++ b/backends/tofino/bf-asm/jbay/deparser.cpp
@@ -567,7 +567,7 @@ static void check_jbay_ownership(bitvec phv_use[2]) {
                 mask = 1;
                 break;
             default:
-                BUG();
+                BUG("unexpected size %d", Phv::reg(i)->size);
         }
         group = i & ~mask;
         if (phv_use[EGRESS].getrange(group, mask + 1)) {
@@ -594,7 +594,7 @@ static void setup_jbay_ownership(bitvec phv_use, ubits_base &phv8, ubits_base &p
                 phv32_grps.insert(1U << (reg->deparser_id() / 2U));
                 break;
             default:
-                BUG();
+                BUG("unexpected size %d", reg->size);
         }
     }
 
@@ -725,7 +725,7 @@ void write_jbay_full_checksum_config(
                 write_jbay_checksum_entry(phv_entries[unit_entry.first].entry[remap[1]], mask >> 2,
                                           swap >> 1, povbit, unit_entry.first, val->reg.name);
             else
-                BUG_CHECK((mask >> 2 == 0) && (swap >> 1 == 0));
+                BUG_CHECK((mask >> 2 == 0) && (swap >> 1 == 0), "Invalid checksum");
         }
     }
     int tag_idx = 0;
@@ -1036,7 +1036,7 @@ void Deparser::write_config(Target::JBay::deparser_regs &regs) {
                 int num_words = (size + 31) / 32;
                 int quanta_index = 11;
                 for (int index = num_words - 1; index >= 0; index--) {
-                    BUG_CHECK(quanta_index >= 0);
+                    BUG_CHECK(quanta_index >= 0, "quanta_index < 0");
                     unsigned word = lrnmask.getrange(index * 32, 32);
                     regs.dprsrreg.inp.icr.lrnmask[id].mask[quanta_index--] = word;
                 }

--- a/backends/tofino/bf-asm/jbay/gateway.cpp
+++ b/backends/tofino/bf-asm/jbay/gateway.cpp
@@ -24,7 +24,7 @@ void Target::Tofino::GatewayTable::write_next_table_regs(Target::JBay::mau_regs 
     if (need_next_map_lut) merge.next_table_map_en_gateway |= 1U << logical_id;
     int idx = 3;
     for (auto &line : table) {
-        BUG_CHECK(idx >= 0);
+        BUG_CHECK(idx >= 0, "idx < 0");
         if (!line.run_table) {
             if (need_next_map_lut)
                 merge.gateway_next_table_lut[logical_id][idx] = line.next_map_lut;

--- a/backends/tofino/bf-asm/jbay/gateway.cpp
+++ b/backends/tofino/bf-asm/jbay/gateway.cpp
@@ -96,4 +96,3 @@ void GatewayTable::standalone_write_regs(Target::JBay::mau_regs &regs) {
                                   ~merge.logical_table_thread[0].logical_table_thread_ingress &
                                   ~merge.pred_ghost_thread;
 }
-template void GatewayTable::standalone_write_regs(Target::JBay::mau_regs &regs);

--- a/backends/tofino/bf-asm/jbay/input_xbar.cpp
+++ b/backends/tofino/bf-asm/jbay/input_xbar.cpp
@@ -65,6 +65,3 @@ void InputXbar::write_galois_matrix(Target::JBay::mau_regs &regs, HashTable id,
         }
     }
 }
-
-template void InputXbar::write_galois_matrix(Target::JBay::mau_regs &regs, HashTable id,
-                                             const std::map<int, HashCol> &mat);

--- a/backends/tofino/bf-asm/jbay/instruction.cpp
+++ b/backends/tofino/bf-asm/jbay/instruction.cpp
@@ -31,7 +31,7 @@ void VLIWInstruction::write_regs_2(REGS &regs, Table *tbl, Table::Actions::Actio
     int iaddr = act->addr / ACTION_IMEM_COLORS;
     int color = act->addr % ACTION_IMEM_COLORS;
     unsigned bits = encode();
-    BUG_CHECK(slot >= 0);
+    BUG_CHECK(slot >= 0, "slots must be >= 0");
     unsigned off = slot % Phv::mau_groupsize();
     unsigned side = 0, group = 0;
     switch (slot / Phv::mau_groupsize()) {
@@ -92,14 +92,14 @@ void VLIWInstruction::write_regs_2(REGS &regs, Table *tbl, Table::Actions::Actio
             group = 2;
             break;
         default:
-            BUG();
+            BUG("bad slot size %d", slot / Phv::mau_groupsize());
     }
 
     switch (Phv::reg(slot)->type) {
         case Phv::Register::NORMAL:
             switch (Phv::reg(slot)->size) {
                 case 8:
-                    BUG_CHECK(group == 0 || group == 1);
+                    BUG_CHECK(group == 0 || group == 1, "bad group");
                     imem.imem_subword8[side][group][off][iaddr].imem_subword8_instr = bits;
                     imem.imem_subword8[side][group][off][iaddr].imem_subword8_color = color;
                     imem.imem_subword8[side][group][off][iaddr].imem_subword8_parity =
@@ -112,20 +112,20 @@ void VLIWInstruction::write_regs_2(REGS &regs, Table *tbl, Table::Actions::Actio
                         parity(bits) ^ color;
                     break;
                 case 32:
-                    BUG_CHECK(group == 0 || group == 1);
+                    BUG_CHECK(group == 0 || group == 1, "bad group");
                     imem.imem_subword32[side][group][off][iaddr].imem_subword32_instr = bits;
                     imem.imem_subword32[side][group][off][iaddr].imem_subword32_color = color;
                     imem.imem_subword32[side][group][off][iaddr].imem_subword32_parity =
                         parity(bits) ^ color;
                     break;
                 default:
-                    BUG();
+                    BUG("bad size %d", Phv::reg(slot)->size);
             }
             break;
         case Phv::Register::MOCHA:
             switch (Phv::reg(slot)->size) {
                 case 8:
-                    BUG_CHECK(group == 0 || group == 1);
+                    BUG_CHECK(group == 0 || group == 1, "bad group");
                     imem.imem_mocha_subword8[side][group][off - 12][iaddr]
                         .imem_mocha_subword_instr = bits;
                     imem.imem_mocha_subword8[side][group][off - 12][iaddr]
@@ -142,7 +142,7 @@ void VLIWInstruction::write_regs_2(REGS &regs, Table *tbl, Table::Actions::Actio
                         .imem_mocha_subword_parity = parity(bits) ^ color;
                     break;
                 case 32:
-                    BUG_CHECK(group == 0 || group == 1);
+                    BUG_CHECK(group == 0 || group == 1, "bad group");
                     imem.imem_mocha_subword32[side][group][off - 12][iaddr]
                         .imem_mocha_subword_instr = bits;
                     imem.imem_mocha_subword32[side][group][off - 12][iaddr]
@@ -151,13 +151,13 @@ void VLIWInstruction::write_regs_2(REGS &regs, Table *tbl, Table::Actions::Actio
                         .imem_mocha_subword_parity = parity(bits) ^ color;
                     break;
                 default:
-                    BUG();
+                    BUG("bad size %d", Phv::reg(slot)->size);
             }
             break;
         case Phv::Register::DARK:
             switch (Phv::reg(slot)->size) {
                 case 8:
-                    BUG_CHECK(group == 0 || group == 1);
+                    BUG_CHECK(group == 0 || group == 1, "bad group");
                     imem.imem_dark_subword8[side][group][off - 16][iaddr].imem_dark_subword_instr =
                         bits;
                     imem.imem_dark_subword8[side][group][off - 16][iaddr].imem_dark_subword_color =
@@ -174,7 +174,7 @@ void VLIWInstruction::write_regs_2(REGS &regs, Table *tbl, Table::Actions::Actio
                         .imem_dark_subword_parity = parity(bits) ^ color;
                     break;
                 case 32:
-                    BUG_CHECK(group == 0 || group == 1);
+                    BUG_CHECK(group == 0 || group == 1, "bad group");
                     imem.imem_dark_subword32[side][group][off - 16][iaddr].imem_dark_subword_instr =
                         bits;
                     imem.imem_dark_subword32[side][group][off - 16][iaddr].imem_dark_subword_color =
@@ -183,11 +183,11 @@ void VLIWInstruction::write_regs_2(REGS &regs, Table *tbl, Table::Actions::Actio
                         .imem_dark_subword_parity = parity(bits) ^ color;
                     break;
                 default:
-                    BUG();
+                    BUG("bad size %d", Phv::reg(slot)->size);
             }
             break;
         default:
-            BUG();
+            BUG("bad type %d", Phv::reg(slot)->type);
     }
 
     auto &power_ctl = regs.dp.actionmux_din_power_ctl;

--- a/backends/tofino/bf-asm/jbay/meter.h
+++ b/backends/tofino/bf-asm/jbay/meter.h
@@ -20,8 +20,8 @@
 
 template <typename REGS>
 void MeterTable::setup_teop_regs_2(REGS &regs, int meter_group_index) {
-    BUG_CHECK(teop >= 0 && teop < 4);
-    BUG_CHECK(gress == EGRESS);
+    BUG_CHECK(teop >= 0 && teop < 4, "teop out of range");
+    BUG_CHECK(gress == EGRESS, "gress must be EGRESS");
 
     auto &adrdist = regs.rams.match.adrdist;
     if (!teop_initialized) {
@@ -103,7 +103,7 @@ void MeterTable::write_alu_vpn_range_2(REGS &regs) {
                 }
             }
             if (block_end) {
-                BUG_CHECK(min != 1000000 && max != -1);
+                BUG_CHECK(min != 1000000 && max != -1, "Invalid VPN range");
 
                 bitvec block_range(min, max - min + 1);
                 if (vpn_range.intersects(block_range))
@@ -120,7 +120,7 @@ void MeterTable::write_alu_vpn_range_2(REGS &regs) {
                 break;
             }
         }
-        BUG_CHECK(block_start && block_end);
+        BUG_CHECK(block_start && block_end, "Invalid VPN range");
     }
 
     if (vpn_range != bitvec(minvpn, sparevpn - minvpn))

--- a/backends/tofino/bf-asm/jbay/parser.cpp
+++ b/backends/tofino/bf-asm/jbay/parser.cpp
@@ -177,7 +177,7 @@ int Parser::State::Match::write_load_config(Target::JBay::parser_regs &regs, Par
 
 static void write_output_slot(int lineno, Target::JBay::parser_regs::_memory::_po_action_row *row,
                               unsigned &used, int src, int dest, int bytemask, bool offset) {
-    BUG_CHECK(bytemask > 0 && bytemask < 4);
+    BUG_CHECK(bytemask > 0 && bytemask < 4, "Invalid bytemask %d", bytemask);
     for (int i = 0; i < 20; ++i) {
         if (used & (1 << i)) continue;
         row->phv_dst[i] = dest;
@@ -237,8 +237,8 @@ static void write_output_const_slot(int lineno,
                                     unsigned &used, unsigned src, int dest, int bytemask,
                                     int flags) {
     // use bits 24..27 of 'used' to track the two constant slots
-    BUG_CHECK(bytemask > 0 && bytemask < 4);
-    BUG_CHECK((src & ~((0xffff00ff >> (8 * (bytemask - 1))) & 0xffff)) == 0);
+    BUG_CHECK(bytemask > 0 && bytemask < 4, "Invalid bytemask %d", bytemask);
+    BUG_CHECK((src & ~((0xffff00ff >> (8 * (bytemask - 1))) & 0xffff)) == 0, "Invalid src %d", src);
     // FIXME -- should be able to treat this as 4x8-bit rather than 2x16-bit slots, as long
     // as the ROTATE flag is consistent for each half.
     int cslot = -1;
@@ -276,7 +276,7 @@ void Parser::State::Match::Set::write_output_config(Target::JBay::parser_regs &r
             if (((what >> (8 * i)) & 0xff) == 0) mask &= ~(1 << i);
     }
     if (where->reg.size == 8) {
-        BUG_CHECK((mask & ~1) == 0);
+        BUG_CHECK((mask & ~1) == 0, "Invalid mask %d", mask);
         if (where->reg.index & 1) {
             mask <<= 1;
             what <<= 8;

--- a/backends/tofino/bf-asm/jbay/phv.cpp
+++ b/backends/tofino/bf-asm/jbay/phv.cpp
@@ -60,7 +60,7 @@ void Target::JBay::Phv::init_regs(::Phv &phv) {
             }
         }
     }
-    BUG_CHECK(uid == phv.regs.size());
-    BUG_CHECK(deparser_id == 224);
-    BUG_CHECK(byte == 512);
+    BUG_CHECK(uid == phv.regs.size(), "uid %u != %zu", uid, phv.regs.size());
+    BUG_CHECK(deparser_id == 224, "deparser_id %u != 224", deparser_id);
+    BUG_CHECK(byte == 512, "byte %u != 512", byte);
 }

--- a/backends/tofino/bf-asm/jbay/salu_inst.cpp
+++ b/backends/tofino/bf-asm/jbay/salu_inst.cpp
@@ -47,7 +47,9 @@ struct DivMod : public AluOP {
 // setz op, so can OR with alu1hi to get that result
 DivMod::Decode opDIVMOD("divmod", JBAY, 0x00);
 
-void DivMod::write_regs(Target::Tofino::mau_regs &, Table *, Table::Actions::Action *) { BUG(); }
+void DivMod::write_regs(Target::Tofino::mau_regs &, Table *, Table::Actions::Action *) {
+    BUG("unsupported");
+}
 void DivMod::write_regs(Target::JBay::mau_regs &regs, Table *tbl, Table::Actions::Action *act) {
     AluOP::write_regs(regs, tbl, act);
     int logical_home_row = tbl->layout[0].row;
@@ -114,7 +116,7 @@ Instruction *MinMax::Decode::decode(Table *tbl, const Table::Actions::Action *ac
 }
 Instruction *MinMax::pass1(Table *tbl_, Table::Actions::Action *act) {
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "expected stateful table");
     int mask_size = (opc->opcode & 2) ? 8 : 16;
     constval = boost::none;
     mask->pass1(tbl);
@@ -157,7 +159,7 @@ void MinMax::pass2(Table *tbl, Table::Actions::Action *act) {
 }
 void MinMax::write_regs(Target::JBay::mau_regs &regs, Table *tbl_, Table::Actions::Action *act) {
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "expected stateful table");
     int logical_home_row = tbl->layout[0].row;
     auto &meter_group = regs.rams.map_alu.meter_group[logical_home_row / 4U];
     auto &salu_instr_common = meter_group.stateful.salu_instr_common[act->code];
@@ -190,13 +192,15 @@ void MinMax::write_regs(Target::JBay::mau_regs &regs, Table *tbl_, Table::Action
         salu.salu_pred = 0xffff;
     }
 }
-void MinMax::write_regs(Target::Tofino::mau_regs &, Table *, Table::Actions::Action *) { BUG(); }
+void MinMax::write_regs(Target::Tofino::mau_regs &, Table *, Table::Actions::Action *) {
+    BUG("unsupported");
+}
 
 template <>
 void AluOP::write_regs(Target::JBay::mau_regs &regs, Table *tbl_, Table::Actions::Action *act) {
     LOG2(this);
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "expected stateful table");
     int logical_home_row = tbl->layout[0].row;
     auto &meter_group = regs.rams.map_alu.meter_group[logical_home_row / 4U];
     auto &salu = meter_group.stateful.salu_instr_state_alu[act->code][slot - ALU2LO];
@@ -236,7 +240,7 @@ void AluOP::write_regs(Target::JBay::mau_regs &regs, Table *tbl_, Table::Actions
             salu.salu_const_src = r->index;
             salu.salu_regfile_const = 1;
         } else {
-            BUG();
+            BUG("invalid srca");
         }
     }
     if (srcb) {
@@ -259,7 +263,7 @@ void AluOP::write_regs(Target::JBay::mau_regs &regs, Table *tbl_, Table::Actions
             } else if (auto b = m->of.to<operand::Memory>()) {
                 salu_instr_common.salu_alu2_lo_math_src = b->field->bit(0) > 0 ? 3 : 2;
             } else {
-                BUG();
+                BUG("invalid mathfn operand");
             }
         } else if (auto k = srcb.to<operand::Const>()) {
             salu.salu_bsrc_input = 4;
@@ -275,7 +279,7 @@ void AluOP::write_regs(Target::JBay::mau_regs &regs, Table *tbl_, Table::Actions
             salu.salu_const_src = r->index;
             salu.salu_regfile_const = 1;
         } else {
-            BUG();
+            BUG("invalid srcb");
         }
     }
 }
@@ -312,7 +316,7 @@ template <>
 void CmpOP::write_regs(Target::JBay::mau_regs &regs, Table *tbl_, Table::Actions::Action *act) {
     LOG2(this);
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "expected stateful table");
     int logical_home_row = tbl->layout[0].row;
     auto &meter_group = regs.rams.map_alu.meter_group[logical_home_row / 4U];
     auto &salu = meter_group.stateful.salu_instr_cmp_alu[act->code][slot];
@@ -406,7 +410,7 @@ template <>
 void TMatchOP::write_regs(Target::JBay::mau_regs &regs, Table *tbl_, Table::Actions::Action *act) {
     LOG2(this);
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "expected stateful table");
     int logical_home_row = tbl->layout[0].row;
     auto &meter_group = regs.rams.map_alu.meter_group[logical_home_row / 4U];
     auto &salu = meter_group.stateful.salu_instr_cmp_alu[act->code][slot];
@@ -473,7 +477,7 @@ template <>
 void OutOP::write_regs(Target::JBay::mau_regs &regs, Table *tbl_, Table::Actions::Action *act) {
     LOG2(this);
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "expected stateful table");
     int logical_home_row = tbl->layout[0].row;
     auto &meter_group = regs.rams.map_alu.meter_group[logical_home_row / 4U];
     auto &salu = meter_group.stateful.salu_instr_output_alu[act->code][slot - ALUOUT0];

--- a/backends/tofino/bf-asm/jbay/stage.cpp
+++ b/backends/tofino/bf-asm/jbay/stage.cpp
@@ -110,7 +110,8 @@ void Stage::gen_mau_stage_extension(REGS &regs, json::map &extend) {
     mask0.eop_output_delay_fifo = 0x1;
     mask1.eop_output_delay_fifo = 0x1f;
     BUG_CHECK(regs.rams.match.adrdist.deferred_eop_bus_delay[0].eop_output_delay_fifo &
-              regs.rams.match.adrdist.deferred_eop_bus_delay[1].eop_output_delay_fifo & 1);
+                  regs.rams.match.adrdist.deferred_eop_bus_delay[1].eop_output_delay_fifo & 1,
+              "bad mask");
     registers.push_back(make_reg_vec(regs, regs.rams.match.adrdist.deferred_eop_bus_delay,
                                      "regs.rams.match.adrdist.deferred_eop_bus_delay", mask0, mask0,
                                      mask1));
@@ -125,8 +126,8 @@ void Stage::gen_mau_stage_extension(REGS &regs, json::map &extend) {
     registers.push_back(make_reg_vec(regs, regs.rams.match.merge.exact_match_delay_thread,
                                      "regs.rams.match.merge.exact_match_delay_thread", 0, 0x3,
                                      0x3));
-    BUG_CHECK((regs.rams.match.merge.mpr_thread_delay[0] & 1) == 0);
-    BUG_CHECK((regs.rams.match.merge.mpr_thread_delay[1] & 1) == 0);
+    BUG_CHECK((regs.rams.match.merge.mpr_thread_delay[0] & 1) == 0, "bad mask");
+    BUG_CHECK((regs.rams.match.merge.mpr_thread_delay[1] & 1) == 0, "bad mask");
     registers.push_back(make_reg_vec(regs, regs.rams.match.merge.mpr_thread_delay,
                                      "regs.rams.match.merge.mpr_thread_delay", 1, 1, 0x1f));
 }
@@ -165,7 +166,7 @@ void Stage::write_regs(Target::JBay::mau_regs &regs, bool) {
                 this[-1].pipelength(gress) - this[-1].pred_cycle(gress) + pred_cycle(gress) - 3;
             merge.predication_ctl[gress].start_table_fifo_enable = 1;
         } else {
-            BUG_CHECK(stage_dep[gress] == ACTION_DEP);
+            BUG_CHECK(stage_dep[gress] == ACTION_DEP, "bad stage dep");
             merge.predication_ctl[gress].start_table_fifo_delay0 = 0;
             merge.predication_ctl[gress].start_table_fifo_enable = 0;
         }

--- a/backends/tofino/bf-asm/jbay/stateful.cpp
+++ b/backends/tofino/bf-asm/jbay/stateful.cpp
@@ -17,6 +17,8 @@
 
 #include "backends/tofino/bf-asm/jbay/stateful.h"
 
+#include "lib/null.h"
+
 static const char *function_names[] = {"none", "log", "fifo", "stack", "clear"};
 
 static int decode_push_pop(const value_t &v) {
@@ -166,7 +168,7 @@ int StatefulTable::parse_counter_mode(Target::JBay target, const value_t &v) {
 
 void StatefulTable::set_counter_mode(Target::JBay target, int mode) {
     int fnmode = mode & FUNCTION_MASK;
-    BUG_CHECK(fnmode > 0 && (fnmode >> FUNCTION_SHIFT) <= FUNCTION_FAST_CLEAR);
+    BUG_CHECK(fnmode > 0 && (fnmode >> FUNCTION_SHIFT) <= FUNCTION_FAST_CLEAR, "invalid mode");
     if (stateful_counter_mode && (stateful_counter_mode & FUNCTION_MASK) != fnmode)
         error(lineno, "Incompatible uses (%s and %s) of stateful alu counters",
               function_names[stateful_counter_mode >> FUNCTION_SHIFT],
@@ -300,13 +302,13 @@ void StatefulTable::write_tofino2_common_regs(REGS &regs) {
         }
         if (underflow_action.set()) {
             auto act = actions->action(underflow_action.name);
-            BUG_CHECK(act);
+            CHECK_NULL(act);
             // 4-bit stateful addr MSB encoding for instruction, as given by table 6-67 (6.4.4.11)
             ctl3.slog_underflow_instruction = act->code * 2 + 1;
         }
         if (overflow_action.set()) {
             auto act = actions->action(overflow_action.name);
-            BUG_CHECK(act);
+            CHECK_NULL(act);
             ctl3.slog_overflow_instruction = act->code * 2 + 1;
         }
     } else {

--- a/backends/tofino/bf-asm/map.h
+++ b/backends/tofino/bf-asm/map.h
@@ -141,12 +141,13 @@ IterKeys<PairIter> Keys(std::pair<PairIter, PairIter> range) {
 /* iterate over the values in a map */
 template <class PairIter>
 struct IterValues {
-    class iterator
-        : public std::iterator<typename std::iterator_traits<PairIter>::iterator_category,
-                               typename std::iterator_traits<PairIter>::value_type,
-                               typename std::iterator_traits<PairIter>::difference_type,
-                               typename std::iterator_traits<PairIter>::pointer,
-                               typename std::iterator_traits<PairIter>::reference> {
+    class iterator {
+     public:
+        using iterator_category = typename std::iterator_traits<PairIter>::iterator_category;
+        using value_type = typename std::iterator_traits<PairIter>::value_type;
+        using difference_type = typename std::iterator_traits<PairIter>::difference_type;
+        using pointer = typename std::iterator_traits<PairIter>::pointer;
+        using reference = typename std::iterator_traits<PairIter>::reference;
         PairIter it;
 
      public:

--- a/backends/tofino/bf-asm/match_source.h
+++ b/backends/tofino/bf-asm/match_source.h
@@ -78,7 +78,9 @@ class HashMatchSource : public MatchSource {
         return str.str();
     }
 
-    void dbprint(std::ostream &out) const { out << name() << "(" << lo << ".." << hi << ")"; }
+    void dbprint(std::ostream &out) const override {
+        out << name() << "(" << lo << ".." << hi << ")";
+    }
 };
 
 #endif /* BACKENDS_TOFINO_BF_ASM_MATCH_SOURCE_H_ */

--- a/backends/tofino/bf-asm/match_table.cpp
+++ b/backends/tofino/bf-asm/match_table.cpp
@@ -24,6 +24,7 @@
 #include "input_xbar.h"
 #include "instruction.h"
 #include "lib/algorithm.h"
+#include "lib/null.h"
 #include "misc.h"
 
 Table::Format *MatchTable::get_format() const {
@@ -336,7 +337,7 @@ void MatchTable::write_common_regs(typename TARGET::mau_regs &regs, int type, Ta
     } else {
         /* ternary match with no indirection table */
         auto tern_table = this->to<TernaryMatchTable>();
-        BUG_CHECK(tern_table != nullptr);
+        CHECK_NULL(tern_table);
         if (tern_table->indirect_bus >= 0) result_buses.insert(tern_table->indirect_bus);
         result = this;
     }
@@ -555,7 +556,7 @@ void MatchTable::write_common_regs(typename TARGET::mau_regs &regs, int type, Ta
 
 int MatchTable::get_address_mau_actiondata_adr_default(unsigned log2size, bool per_flow_enable) {
     int huffman_ones = log2size > 2 ? log2size - 3 : 0;
-    BUG_CHECK(huffman_ones < 7);
+    BUG_CHECK(huffman_ones < 7, "Huffman ones out of range");
     int rv = (1 << huffman_ones) - 1;
     rv = ((rv << 10) & 0xf8000) | (rv & 0x1f);
     if (!per_flow_enable) rv |= 1 << 22;

--- a/backends/tofino/bf-asm/misc.cpp
+++ b/backends/tofino/bf-asm/misc.cpp
@@ -23,6 +23,7 @@
 
 #include "backends/tofino/bf-asm/target.h"
 #include "bfas.h"
+#include "lib/exceptions.h"
 
 int remove_name_tail_range(std::string &name, int *size) {
     auto tail = name.rfind('.');
@@ -90,7 +91,7 @@ void gen_instfield_name(const std::string &fullname, std::string &instname,
 }
 
 uint64_t bitMask(unsigned size) {
-    BUG_CHECK(size <= 64 && "bitMask(size), maximum size is 64");
+    BUG_CHECK(size <= 64, "bitMask(size), maximum size is 64");
     if (size == 64) return ~UINT64_C(0);
     return (UINT64_C(1) << size) - 1;
 }
@@ -119,7 +120,7 @@ int parity_2b(uint32_t v) {
 }
 
 bool check_bigint_unsigned(value_t value, uint32_t byte_width) {
-    BUG_CHECK(value.type == tBIGINT);
+    BUG_CHECK(value.type == tBIGINT, "check_bigint_unsigned: not a bigint");
 
     /* -- zero is in the range */
     if (value.bigi.size == 0) return true;
@@ -152,7 +153,7 @@ bool check_bigint_unsigned(value_t value, uint32_t byte_width) {
 }
 
 bool input_int_match(const value_t value, match_t &match, int width) {
-    BUG_CHECK(width <= sizeof(match_t::word0) * 8);
+    BUG_CHECK(width <= sizeof(match_t::word0) * 8, "input_int_match: invalid width");
 
     using MatchType = decltype(match_t::word0);
     MatchType mask;

--- a/backends/tofino/bf-asm/p4_table.cpp
+++ b/backends/tofino/bf-asm/p4_table.cpp
@@ -18,6 +18,7 @@
 #include "p4_table.h"
 
 #include "backends/tofino/bf-asm/tables.h"
+#include "lib/exceptions.h"
 
 static std::map<const P4Table *, alpm_t> alpms;
 
@@ -38,7 +39,7 @@ static unsigned apply_handle_offset(unsigned handle, unsigned offset) {
 static unsigned clear_handle_offset(unsigned handle) { return handle & 0xff00ffff; }
 
 P4Table *P4Table::get(P4Table::type t, VECTOR(pair_t) & data) {
-    BUG_CHECK(t < NUM_TABLE_TYPES);
+    BUG_CHECK(t < NUM_TABLE_TYPES, "bad table type %d", t);
     P4Table *rv;
     auto *h = ::get(data, "handle");
     auto *n = ::get(data, "name");
@@ -159,7 +160,7 @@ json::map *P4Table::base_tbl_cfg(json::vector &out, int size, const Table *table
     tbl["direction"] = direction_name(table->gress);
     if (handle) tbl["handle"] = handle;
     auto table_type = (handle >> 24) & 0x3f;
-    BUG_CHECK(table_type < NUM_TABLE_TYPES);
+    BUG_CHECK(table_type < NUM_TABLE_TYPES, "bad table type %d", table_type);
     tbl["name"] = p4_name();
     tbl["table_type"] = type_name[table_type];
     if (!explicit_size && tbl["size"])
@@ -199,7 +200,7 @@ void P4Table::base_alpm_tbl_cfg(json::map &out, int size, const Table *table,
             json::map &tbl = out;
             tbl["direction"] = direction_name(table->gress);
             auto table_type = (handle >> 24) & 0x3f;
-            BUG_CHECK(table_type < NUM_TABLE_TYPES);
+            BUG_CHECK(table_type < NUM_TABLE_TYPES, "bad table type %d", table_type);
             if (!(*alpm_table_handle & 0xffffff))
                 *alpm_table_handle = apply_handle_offset(
                     (P4Table::MatchEntry << 24) + (++max_handle[table_type]), unique_table_offset);
@@ -248,7 +249,7 @@ std::string P4Table::direction_name(gress_t gress) {
             return "ghost";
             break;
         default:
-            BUG();
+            BUG("Unknown gress type");
     }
     return "";
 }

--- a/backends/tofino/bf-asm/parser-tofino-jbay.cpp
+++ b/backends/tofino/bf-asm/parser-tofino-jbay.cpp
@@ -394,7 +394,7 @@ void Parser::process() {
                 LOG1("Creating new " << gress << " " << name << " state");
                 auto n = states.emplace(name, new State(lineno, name.c_str(), gress, match_t{0, 0},
                                                         VECTOR(pair_t){0, 0, 0}));
-                BUG_CHECK(n.second);
+                BUG_CHECK(n.second, "State %s already defined", name.c_str());
                 State *state = n.first->second;
                 state->def = new State::Match(lineno, gress, *start_state[i]);
                 for (int j = 3; j >= i; j--)
@@ -1177,7 +1177,8 @@ void Parser::State::MatchKey::setup(value_t &spec) {
     // is not necessary as we can have independent byte extractors
     if (Target::MATCH_BYTE_16BIT_PAIRS() && (data[0].byte & data[1].byte) != USE_SAVED) {
         if (data[0].bit >= 0 && data[1].bit >= 0 && data[0].byte + 1 != data[1].byte) {
-            BUG_CHECK((data[0].byte | data[1].byte) != USE_SAVED);
+            BUG_CHECK((data[0].byte | data[1].byte) != USE_SAVED,
+                      "invalid match byte pair: 0x%02x 0x%02x", data[0].byte, data[1].byte);
             int unused = -1;  // unused slot
             for (int i = 0; i < 4; i++) {
                 if (data[i].bit < 0) {
@@ -1197,7 +1198,7 @@ void Parser::State::MatchKey::setup(value_t &spec) {
                 }
             }
             if (unused >= 0) {
-                BUG_CHECK(unused > 1);
+                BUG_CHECK(unused > 1, "Less than 2 unused slots in match bytes");
                 std::swap(data[1], data[unused]);
             } else {
                 error(spec.lineno, "Must have a 16-bit pair in match bytes");
@@ -1621,7 +1622,7 @@ Parser::State::State(int l, const char *n, gress_t gr, match_t sno, const VECTOR
         }
     }
     if (default_data.size) {
-        BUG_CHECK(!def);
+        BUG_CHECK(!def, "def is already set");
         match_t m = {0, 0};
         def = new Match(default_data[0].key.lineno, gress, this, m, default_data);
     }

--- a/backends/tofino/bf-asm/parser-tofino-jbay.h
+++ b/backends/tofino/bf-asm/parser-tofino-jbay.h
@@ -92,11 +92,11 @@ class Parser : public BaseParser, public Contextable {
             explicit Ref(value_t &v) { *this = v; }
             operator bool() const { return ptr.size() > 0; }
             State *operator->() const {
-                BUG_CHECK(ptr.size() == 1);
+                BUG_CHECK(ptr.size() == 1, "pointer size must be 1, got %d", ptr.size());
                 return ptr[0];
             }
             State *operator*() const {
-                BUG_CHECK(ptr.size() == 1);
+                BUG_CHECK(ptr.size() == 1, "pointer size must be 1, got %d", ptr.size());
                 return ptr[0];
             }
             bool operator==(const Ref &a) const { return name == a.name && pattern == a.pattern; }
@@ -601,7 +601,7 @@ void Parser::State::Match::write_common_row_config(REGS &regs, Parser *pa, State
 
     if (buf_req < 0) {
         buf_req = max_off + 1;
-        BUG_CHECK(buf_req <= 32);
+        BUG_CHECK(buf_req <= 32, "Buffer requirement too large: %d", buf_req);
     }
     ea_row.buf_req = buf_req;
 }

--- a/backends/tofino/bf-asm/phv.cpp
+++ b/backends/tofino/bf-asm/phv.cpp
@@ -28,7 +28,7 @@ const Phv::Register Phv::Slice::invalid("<bad>", Phv::Register::NORMAL, 0, ~0, 0
 
 void Phv::init_phv(target_t target_type) {
     if (target) {
-        BUG_CHECK(target->type() == target_type);  // sanity check
+        BUG_CHECK(target->type() == target_type, "target type mismatch");  // sanity check
         return;
     }
     switch (target_type) {
@@ -38,7 +38,7 @@ void Phv::init_phv(target_t target_type) {
         break;
         FOR_ALL_TARGETS(INIT_FOR_TARGET)
         default:
-            BUG();
+            BUG("Unknown target type %d", target_type);
     }
 #undef INIT_FOR_TARGET
     target->init_regs(*this);
@@ -325,7 +325,7 @@ int Phv::get_position_offset(gress_t gress, std::string name) {
     for (auto f : phv_pov_field_sizes[gress]) {
         if (f.first == name) return position_offset;
         // POV should be single bit
-        BUG_CHECK(f.second == 1);
+        BUG_CHECK(f.second == 1, "POV should be single bit");
         position_offset += 1;
     }
     return 0;
@@ -414,7 +414,7 @@ void Phv::output(json::map &ctxt_json) {
                         phv_record[live_string] = live_stage;
                     };
                     auto container_json = field_context_json[slot.first->name];
-                    BUG_CHECK(container_json);
+                    BUG_CHECK(container_json, " No context_json");
                     bool field_added = false;
                     if (!container_json->as_vector()) {
                         // FIXME -- should be flexible about parsing context_json -- continue

--- a/backends/tofino/bf-asm/phv.h
+++ b/backends/tofino/bf-asm/phv.h
@@ -250,7 +250,7 @@ class Phv : public Section {
         }
         bool merge(const Ref &r);
         std::string toString() const override;
-        void dbprint(std::ostream &out) const;
+        void dbprint(std::ostream &out) const override;
 
         int get_lineno() const override { return lineno; }
         int fieldlobit() const override { return lobit(); }

--- a/backends/tofino/bf-asm/phv.h
+++ b/backends/tofino/bf-asm/phv.h
@@ -203,7 +203,7 @@ class Phv : public Section {
               lo(r.lo < 0 ? l : r.lo + l),
               hi(r.lo < 0 ? h : r.lo + h),
               lineno(r.lineno) {
-            BUG_CHECK(r.hi < 0 || hi <= r.hi);
+            BUG_CHECK(r.hi < 0 || hi <= r.hi, "Out of bounds slice: %s", r.toString().c_str());
         }
         Ref(const Register &r, gress_t gr, int lo = -1, int hi = -1);
         explicit operator bool() const { return lineno >= 0; }
@@ -260,7 +260,7 @@ class Phv : public Section {
     };
     // Return register using mau_id as @arg index
     static const Register *reg(int idx) {
-        BUG_CHECK(idx >= 0 && size_t(idx) < phv.regs.size());
+        BUG_CHECK(idx >= 0 && size_t(idx) < phv.regs.size(), "Register index out of range");
         return phv.regs[idx];
     }
 

--- a/backends/tofino/bf-asm/power_ctl.h
+++ b/backends/tofino/bf-asm/power_ctl.h
@@ -18,6 +18,7 @@
 #ifndef BACKENDS_TOFINO_BF_ASM_POWER_CTL_H_
 #define BACKENDS_TOFINO_BF_ASM_POWER_CTL_H_
 
+#include "lib/exceptions.h"
 #include "misc.h"
 
 /* power_ctl is weirdly encoded!
@@ -57,7 +58,7 @@ void set_power_ctl_reg(checked_array<2, checked_array<16, ubits<I>>> &power_ctl,
             reg = (reg % (I * 4));
             break;
         default:
-            BUG();
+            BUG("Invalid power control reg: %d", reg);
     }
     power_ctl[side][reg / I] |= 1U << reg % I;
 }

--- a/backends/tofino/bf-asm/proxy_hash.cpp
+++ b/backends/tofino/bf-asm/proxy_hash.cpp
@@ -47,7 +47,7 @@ bool ProxyHashMatchTable::verify_match_key() {
         }
     }
     auto match_format = format->field("match");
-    if (match_format && match.empty()) BUG_CHECK("Proxy hash table has no match");
+    if (match_format && match.empty()) BUG("Proxy hash table has no match");
     return error_count == 0;
 }
 
@@ -169,7 +169,7 @@ void ProxyHashMatchTable::gen_tbl_cfg(json::vector &out) const {
             way_tbl["way_number"] = way_number++;
             way_tbl["stage_table_type"] = "hash_way";
             auto fmt_width = get_format_width();
-            BUG_CHECK(fmt_width);
+            BUG_CHECK(fmt_width, "width of format is 0");
             way_tbl["size"] = way.rams.size() / fmt_width * format->groups() * 1024;
             add_pack_format(way_tbl, format.get(), false);
             way_tbl["memory_resource_allocation"] = gen_memory_resource_allocation_tbl_cfg(way);

--- a/backends/tofino/bf-asm/salu_inst.cpp
+++ b/backends/tofino/bf-asm/salu_inst.cpp
@@ -134,7 +134,7 @@ struct operand : public IHasDbPrint {
             else if (v == "phv_hi")
                 pi = 1;
             else
-                BUG();
+                BUG("Unknown phv operand %s", v.s);
             if (v.type == tCMD && PCHECKTYPE(v.vec.size == 2, v[1], tRANGE)) {
                 if ((v[1].range.lo & 7) || ((v[1].range.hi + 1) & 7))
                     error(lineno, "only byte slices allowed on %s", v[0].s);
@@ -276,7 +276,7 @@ operand::operand(Table *tbl, const Table::Actions::Action *act, const value_t &v
         }
     }
     if (v->type == tCMD) {
-        BUG_CHECK(v->vec.size > 0 && v->vec[0].type == tSTR);
+        BUG_CHECK(v->vec.size > 0 && v->vec[0].type == tSTR, "bad operand");
         if (auto f = tbl->format->field(v->vec[0].s)) {
             if (v->vec.size > 1 && CHECKTYPE(v->vec[1], tRANGE) && v->vec[1].range.lo != 0)
                 error(v->vec[1].lineno, "Can't slice memory field %s in stateful action",
@@ -539,7 +539,7 @@ bool AluOP::equiv(Instruction *a_) {
 
 Instruction *AluOP::pass1(Table *tbl_, Table::Actions::Action *act) {
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "expected stateful table");
     if (slot < 0 && act->slot_use[slot = (dest ? ALU1HI : ALU1LO)]) slot = dest ? ALU2HI : ALU2LO;
     auto k1 = srca.to<operand::Const>();
     auto k2 = srcb.to<operand::Const>();
@@ -775,7 +775,7 @@ bool CmpOP::equiv(Instruction *a_) {
 
 Instruction *CmpOP::pass1(Table *tbl_, Table::Actions::Action *act) {
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "Expected stateful table");
     if (srca) srca->pass1(tbl);
     if (srcb) srcb->pass1(tbl);
     if (srcc) srcc->pass1(tbl);
@@ -885,7 +885,7 @@ bool TMatchOP::equiv(Instruction *a_) {
 
 Instruction *TMatchOP::pass1(Table *tbl_, Table::Actions::Action *act) {
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "Expected stateful table");
     if (srca) srca->pass1(tbl);
     if (srcb) srcb->pass1(tbl);
     if (tbl->tmatch_use[slot].op) {
@@ -1013,7 +1013,7 @@ Instruction *OutOP::Decode::decode(Table *tbl, const Table::Actions::Action *act
 
 Instruction *OutOP::pass1(Table *tbl_, Table::Actions::Action *act) {
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "Expected stateful table");
     if (src) src->pass1(tbl);
     if (output_mux == STATEFUL_PREDICATION_OUTPUT) {
         if (act->pred_comb_sel >= 0 && act->pred_comb_sel != predication_encode)
@@ -1023,7 +1023,7 @@ Instruction *OutOP::pass1(Table *tbl_, Table::Actions::Action *act) {
     if (lmatch) {
         if (tbl->output_lmatch) {
             auto *other = dynamic_cast<OutOP *>(tbl->output_lmatch);
-            BUG_CHECK(other);
+            BUG_CHECK(other, "Expected outOP");
             if (lmatch_pred != other->lmatch_pred) {
                 error(lineno, "Conflict lmatch output use in stateful %s", tbl->name());
                 error(other->lineno, "conflicting use here");

--- a/backends/tofino/bf-asm/salu_inst.cpp
+++ b/backends/tofino/bf-asm/salu_inst.cpp
@@ -237,7 +237,9 @@ struct operand::MathFn : public Base {
         }
     }
     const char *kind() const override { return "math fn"; }
-    bool phvRead(std::function<void(const ::Phv::Slice &sl)> fn) { return of->phvRead(fn); }
+    bool phvRead(std::function<void(const ::Phv::Slice &sl)> fn) override {
+        return of->phvRead(fn);
+    }
     void pass1(StatefulTable *tbl) override { of->pass1(tbl); }
 };
 
@@ -817,9 +819,7 @@ struct TMatchOP : public SaluInstruction {
     FOR_ALL_REGISTER_SETS(DECLARE_FORWARD_VIRTUAL_INSTRUCTION_WRITE_REGS)
 };
 
-static TMatchOP::Decode opTMatch("tmatch", {
-                                               JBAY,
-                                           });
+static TMatchOP::Decode opTMatch("tmatch", JBAY);
 
 Instruction *TMatchOP::Decode::decode(Table *tbl, const Table::Actions::Action *act,
                                       const VECTOR(value_t) & op) const {

--- a/backends/tofino/bf-asm/selection.cpp
+++ b/backends/tofino/bf-asm/selection.cpp
@@ -245,8 +245,10 @@ bool SelectionTable::validate_length_call(const Table::Call &call) {
 unsigned SelectionTable::determine_length_shiftcount(const Table::Call &call, int group,
                                                      int word) const {
     if (auto f = call.args[0].field()) {
-        BUG_CHECK(f->by_group[group]->bit(0) / 128 == word && group == 0);
-        BUG_CHECK(f->by_group[group]->bit(0) % 128 <= 8);
+        BUG_CHECK(f->by_group[group]->bit(0) / 128 == word && group == 0,
+                  "invalid values for shiftcount: %d %d", f->by_group[0], word);
+        BUG_CHECK(f->by_group[group]->bit(0) % 128 <= 8, "invalid value for shiftcount: %d",
+                  f->by_group[group]->bit(0));
         return f->by_group[group]->bit(0) % 128U;
     }
     return 0;
@@ -323,7 +325,7 @@ void SelectionTable::write_regs_vt(REGS &regs) {
                 adr_ctl.adr_dist_oflo_adr_xbar_source_index = 0;
                 adr_ctl.adr_dist_oflo_adr_xbar_source_sel = AdrDist::OVERFLOW;
                 push_on_overflow = true;
-                BUG_CHECK(options.target == TOFINO);
+                BUG_CHECK(options.target == TOFINO, "push_on_overflow only implemented for Tofino");
             } else {
                 adr_ctl.adr_dist_oflo_adr_xbar_source_index = home->row % 8;
                 adr_ctl.adr_dist_oflo_adr_xbar_source_sel = AdrDist::METER;

--- a/backends/tofino/bf-asm/stage.cpp
+++ b/backends/tofino/bf-asm/stage.cpp
@@ -60,8 +60,8 @@ AsmStage::AsmStage() : Section("stage") {
         Stage::action_bus_slot_map[byte++] = slot;
         Stage::action_bus_slot_size[slot++] = 32;
     }
-    BUG_CHECK(byte == ACTION_DATA_BUS_BYTES);
-    BUG_CHECK(slot == ACTION_DATA_BUS_SLOTS);
+    BUG_CHECK(byte == ACTION_DATA_BUS_BYTES, "action data bus size mismatch");
+    BUG_CHECK(slot == ACTION_DATA_BUS_SLOTS, "action data bus slots mismatch");
 }
 
 void AsmStage::start(int lineno, VECTOR(value_t) args) {
@@ -88,7 +88,7 @@ void AsmStage::input(VECTOR(value_t) args, value_t data) {
             ? GHOST
             : (error(args[1].lineno, "Invalid thread %s", value_desc(args[1])), INGRESS);
     auto &stage = stages(gress);
-    BUG_CHECK(stageno >= 0 && (unsigned)stageno < stage.size());
+    BUG_CHECK(stageno >= 0 && (unsigned)stageno < stage.size(), "invalid stage number");
     if (stages_seen[gress][stageno])
         error(args[0].lineno, "Duplicate stage %d %s", stageno, to_string(gress).c_str());
     stages_seen[gress][stageno] = 1;
@@ -446,7 +446,7 @@ int Stage::first_table(gress_t gress) {
             if (tbl->logical_id < min_logical_id) min_logical_id = tbl->logical_id;
         }
         if (min_logical_id != INT_MAX) {
-            BUG_CHECK((min_logical_id & ~0xf) == 0);
+            BUG_CHECK((min_logical_id & ~0xf) == 0, "min_logical_id %d", min_logical_id);
             return (st.stageno << 4) + min_logical_id;
         }
     }
@@ -738,7 +738,7 @@ void Stage::gen_mau_stage_characteristics(REGS &regs, json::vector &stg_characte
 
 template <class REGS>
 void Stage::gen_configuration_cache(REGS &regs, json::vector &cfg_cache) {
-    BUG();  // Must be specialized for target -- no generic implementation
+    BUG("Must be specialized for target -- no generic implementation");
 }
 
 template <class REGS>

--- a/backends/tofino/bf-asm/stateful.cpp
+++ b/backends/tofino/bf-asm/stateful.cpp
@@ -457,7 +457,7 @@ void StatefulTable::write_regs_vt(REGS &regs) {
         for (Layout &logical_row : layout) {
             unsigned row = logical_row.row / 2U;
             unsigned side = logical_row.row & 1; /* 0 == left  1 == right */
-            BUG_CHECK(side == 1);                /* no map rams or alus on left side anymore */
+            BUG_CHECK(side == 1, "no map rams or alus on left side anymore");
             auto vpn = logical_row.vpns.begin();
             auto mapram = logical_row.maprams.begin();
             auto &map_alu_row = map_alu.row[row];
@@ -519,7 +519,8 @@ void StatefulTable::write_regs_vt(REGS &regs) {
                     adr_ctl.adr_dist_oflo_adr_xbar_source_index = 0;
                     adr_ctl.adr_dist_oflo_adr_xbar_source_sel = AdrDist::OVERFLOW;
                     push_on_overflow = true;
-                    BUG_CHECK(options.target == TOFINO);
+                    BUG_CHECK(options.target == TOFINO,
+                              "push on overflow only supported on Tofino");
                 } else {
                     adr_ctl.adr_dist_oflo_adr_xbar_source_index = home->row % 8;
                     adr_ctl.adr_dist_oflo_adr_xbar_source_sel = AdrDist::METER;

--- a/backends/tofino/bf-asm/synth2port.cpp
+++ b/backends/tofino/bf-asm/synth2port.cpp
@@ -110,9 +110,9 @@ json::map *Synth2Port::add_stage_tbl_cfg(json::map &tbl, const char *type, int s
     tbl["how_referenced"] = hr;
     int entries = 1;
     if (format) {
-        BUG_CHECK(format->log2size <= 7);
+        BUG_CHECK(format->log2size <= 7, "log2size %d > 7", format->log2size);
         if (format->groups() > 1) {
-            BUG_CHECK(format->log2size == 7);
+            BUG_CHECK(format->log2size == 7, "log2size %d != 7", format->log2size);
             entries = format->groups();
         } else {
             entries = 128U >> format->log2size;
@@ -164,7 +164,7 @@ int Synth2Port::get_home_row_for_row(int row) const {
         else if (row / 8 == home_row / 8)
             return home_row;
     }
-    BUG();
+    BUG("Could not find home row for row %d", row);
     return -1;
 }
 

--- a/backends/tofino/bf-asm/tables.cpp
+++ b/backends/tofino/bf-asm/tables.cpp
@@ -76,10 +76,15 @@ Table::Table(int line, std::string &&n, gress_t gr, Stage *s, int lid)
     if (stage) stage->all_refs.insert(&stage);
 }
 Table::~Table() {
-    BUG_CHECK(by_uid && uid >= 0 && uid < by_uid->size(), "invalid uid %d in table", uid);
+    if (by_uid == nullptr || uid < 0 || uid >= by_uid->size()) {
+        error(lineno, "invalid uid %d in table", uid);
+    } else {
+        (*by_uid)[uid] = nullptr;
+    }
     all->erase(name_);
-    (*by_uid)[uid] = nullptr;
-    if (stage) stage->all_refs.erase(&stage);
+    if (stage != nullptr) {
+        stage->all_refs.erase(&stage);
+    }
     if (all->empty()) {
         delete all;
         delete by_uid;

--- a/backends/tofino/bf-asm/tables.h
+++ b/backends/tofino/bf-asm/tables.h
@@ -144,7 +144,7 @@ class Table {
     void setup_maprams(value_t &);
     void setup_vpns(std::vector<Layout> &, VECTOR(value_t) *, bool allow_holes = false);
     virtual void vpn_params(int &width, int &depth, int &period, const char *&period_name) const {
-        BUG();
+        BUG("unsupported");
     }
     virtual int get_start_vpn() { return 0; }
     void alloc_rams(bool logical, BFN::Alloc2Dbase<Table *> &use,
@@ -197,7 +197,7 @@ class Table {
             return *this;
         }
         Ref &operator=(const value_t &a) & {
-            BUG_CHECK(a.type == tSTR);
+            BUG_CHECK(a.type == tSTR, "expected string");
             name = a.s;
             lineno = a.lineno;
             return *this;
@@ -254,11 +254,11 @@ class Table {
         void resolve_long_branch(const Table *tbl, const std::map<int, NextTables> &lbrch);
         bool set() const { return lineno >= 0; }
         int next_table_id() const {
-            BUG_CHECK(resolved);
+            BUG_CHECK(resolved, "next table not resolved");
             return next_table_ ? next_table_->table_id() : Target::END_OF_PIPE();
         }
         std::string next_table_name() const {
-            BUG_CHECK(resolved);
+            BUG_CHECK(resolved, "next table not resolved");
             if (next_table_) {
                 if (auto nxt_p4_name = next_table_->p4_name()) return nxt_p4_name;
             }
@@ -299,7 +299,7 @@ class Table {
                     last = chunk.hi + 1;
                 }
                 if (i == 0) return last;
-                BUG();
+                BUG("unsupported");
                 return 0;  // quiet -Wreturn-type warning
             }
             /* bit(i), adjusted for the immediate shift of the match group of the field
@@ -312,7 +312,7 @@ class Table {
             unsigned hi(unsigned bit) {
                 for (auto &chunk : bits)
                     if (bit >= chunk.lo && bit <= chunk.hi) return chunk.hi;
-                BUG();
+                BUG("unsupported");
                 return 0;  // quiet -Wreturn-type warning
             }
             enum flags_t { NONE = 0, USED_IMMED = 1, ZERO = 3 };
@@ -356,7 +356,7 @@ class Table {
         unsigned groups() const { return fmt.size(); }
         const ordered_map<std::string, Field> &group(int g) const { return fmt.at(g); }
         Field *field(const std::string &n, int group = 0) {
-            BUG_CHECK(group >= 0 && (size_t)group < fmt.size());
+            BUG_CHECK(group >= 0 && (size_t)group < fmt.size(), "invalid group %d", group);
             auto it = fmt[group].find(n);
             if (it != fmt[group].end()) return &it->second;
             return 0;
@@ -468,7 +468,7 @@ class Table {
             Arg(const char *n) : type(Name) { str = strdup(n); }  // NOLINT(runtime/explicit)
             Arg(decltype(Counter) ctr, int mode) : type(Counter) {
                 val = mode;
-                BUG_CHECK(ctr == Counter);
+                BUG_CHECK(ctr == Counter, "invalid counter type");
             }
             ~Arg() {
                 if (type == Name) free(str);
@@ -486,7 +486,7 @@ class Table {
                     case Name:
                         return !strcmp(str, a.str);
                     default:
-                        BUG();
+                        BUG("unknown argument type");
                 }
                 return false;
             }
@@ -756,7 +756,7 @@ class Table {
     virtual const GatewayTable *get_gateway() const { return 0; }
     virtual SelectionTable *get_selector() const { return 0; }
     virtual MeterTable *get_meter() const { return 0; }
-    virtual void set_stateful(StatefulTable *s) { BUG(); }
+    virtual void set_stateful(StatefulTable *s) { BUG("unsupported"); }
     virtual StatefulTable *get_stateful() const { return 0; }
     virtual void set_address_used() {
         // FIXME -- could use better error message(s) -- lineno is not accurate/useful
@@ -774,51 +774,51 @@ class Table {
     virtual const Call &get_action() const { return action; }
     virtual std::vector<Call> get_calls() const;
     virtual bool is_attached(const Table *) const {
-        BUG();
+        BUG("unsupported");
         return false;
     }
     virtual Format::Field *find_address_field(const AttachedTable *) const {
-        BUG();
+        BUG("unsupported");
         return 0;
     }
     virtual Format::Field *get_per_flow_enable_param(MatchTable *) const {
-        BUG();
+        BUG("unsupported");
         return 0;
     }
     virtual Format::Field *get_meter_address_param(MatchTable *) const {
-        BUG();
+        BUG("unsupported");
         return 0;
     }
     virtual Format::Field *get_meter_type_param(MatchTable *) const {
-        BUG();
+        BUG("unsupported");
         return 0;
     }
     virtual int direct_shiftcount() const {
-        BUG();
+        BUG("unsupported");
         return -1;
     }
     virtual int indirect_shiftcount() const {
-        BUG();
+        BUG("unsupported");
         return -1;
     }
     virtual int address_shift() const {
-        BUG();
+        BUG("unsupported");
         return -1;
     }
     virtual int home_row() const {
-        BUG();
+        BUG("unsupported");
         return -1;
     }
     /* mem unitno mapping -- unit numbers used in context json */
     virtual int json_memunit(const MemUnit &u) const;
     virtual int ram_word_width() const { return MEM_WORD_WIDTH; }
     virtual int unitram_type() {
-        BUG();
+        BUG("unsupported");
         return -1;
     }
     virtual bool uses_colormaprams() const { return false; }
     virtual int color_shiftcount(Table::Call &call, int group, int tcam_shift) const {
-        BUG();
+        BUG("unsupported");
         return -1;
     }
     virtual bool adr_mux_select_stats() { return false; }
@@ -839,8 +839,8 @@ class Table {
     const T *to() const {
         return dynamic_cast<const T *>(this);
     }
-    virtual void determine_word_and_result_bus() { BUG(); }
-    virtual int stm_vbus_column() const { BUG(); }
+    virtual void determine_word_and_result_bus() { BUG("unsupported"); }
+    virtual int stm_vbus_column() const { BUG("unsupported"); }
 
     std::string name_;
     int uid;
@@ -902,7 +902,7 @@ class Table {
             if (u == row.memunits.end()) continue;
             return row.vpns.at(u - row.memunits.begin());
         }
-        BUG();
+        BUG("unsupported");
         return 0;
     }
     void layout_vpn_bounds(int &min, int &max, bool spare = false) const {
@@ -966,7 +966,7 @@ class Table {
                                           const Table::Actions::Action *act) const;
     virtual bool validate_call(Table::Call &call, MatchTable *self, size_t required_args,
                                int hash_dist_type, Table::Call &first_call) {
-        BUG();
+        BUG("unsupported");
         return false;
     }
     bool validate_instruction(Table::Call &call) const;
@@ -1408,7 +1408,8 @@ DECLARE_TABLE_TYPE(
     };
     bitvec s0q1_nibbles, s1q0_nibbles; std::vector<Phv::Ref *> s0q1_prefs, s1q0_prefs;
     std::map<int, match_element> s0q1, s1q0; table_type_t table_type()
-        const override { return ATCAM; } void verify_format(Target::Tofino) override;
+        const override { return ATCAM; };
+    void verify_format(Target::Tofino) override;
     void verify_entry_priority(); void setup_column_priority(); void find_tcam_match();
     void gen_unit_cfg(json::vector &units, int size) const;
     std::unique_ptr<json::vector> gen_memory_resource_allocation_tbl_cfg() const;
@@ -1492,8 +1493,8 @@ DECLARE_TABLE_TYPE(TernaryMatchTable, MatchTable, "ternary_match",
     int indirect_bus = -1;   /* indirect bus to use if there's no indirect table */
     void alloc_vpns() override;
     range_match_t get_dirtcam_mode(int group, int byte) const {
-        BUG_CHECK(group >= 0);
-        BUG_CHECK(byte >= 0);
+        BUG_CHECK(group >= 0, "group must be >= 0");
+        BUG_CHECK(byte >= 0, "byte must be >= 0");
         range_match_t dirtcam_mode = NONE;
         for (auto &m : match) {
             if (m.word_group == group) {
@@ -1877,7 +1878,7 @@ DECLARE_TABLE_TYPE(GatewayTable, Table, "gateway",
     template<class REGS> void payload_write_regs(REGS &, int row, int type, int bus);
     template<class REGS> void standalone_write_regs(REGS &regs);
     FOR_ALL_REGISTER_SETS(TARGET_OVERLOAD,
-        virtual void write_next_table_regs, (mau_regs &), { BUG(); })
+        virtual void write_next_table_regs, (mau_regs &), { BUG("unsupported"); })
     bool gateway_needs_ixbar_group() {
         for (auto& m : match)
             if (m.offset < 32)
@@ -1949,8 +1950,8 @@ DECLARE_TABLE_TYPE(
                           (mau_regs & regs, MatchTable *match, int type, int bus,
                            const std::vector<Call::Arg> &args),
                           override) int address_shift()
-        const override { return 7; } std::vector<int>
-            determine_spare_bank_memory_units() const override;
+        const override { return 7; }
+    std::vector<int> determine_spare_bank_memory_units() const override;
     unsigned meter_group() const { return layout.at(0).row / 4U; } int home_row() const override {
         return layout.at(0).row | 3;
     } int unitram_type() override { return UnitRam::SELECTOR; } StatefulTable *get_stateful()
@@ -2027,21 +2028,22 @@ DECLARE_ABSTRACT_TABLE_TYPE(
     } bool global_binding = false;
     bool output_used = false; int home_lineno = -1; std::set<int, std::greater<int>> home_rows;
     json::map * add_stage_tbl_cfg(json::map & tbl, const char *type, int size) const override;
-    public
-    : int get_home_row_for_row(int row) const;
-    void add_alu_indexes(json::map &stage_tbl, std::string alu_indexes) const;
-    OVERLOAD_FUNC_FOREACH(TARGET_CLASS, std::vector<int>, determine_spare_bank_memory_units,
-                          () const, (), override)
-        OVERLOAD_FUNC_FOREACH(TARGET_CLASS, void, alloc_vpns, (), ()) template <class REGS>
-        void write_regs_vt(REGS &regs);
-    FOR_ALL_REGISTER_SETS(TARGET_OVERLOAD, void write_regs, (mau_regs & regs), override)
-    FOR_ALL_REGISTER_SETS(TARGET_OVERLOAD, void write_merge_regs,
-                          (mau_regs & regs, MatchTable *match, int type, int bus,
-                           const std::vector<Call::Arg> &args),
-                          override = 0)
-    void common_init_setup(const VECTOR(pair_t) &, bool, P4Table::type) override;
-    bool common_setup(pair_t &, const VECTOR(pair_t) &, P4Table::type) override;
-    void pass1() override; void pass2() override; void pass3() override;)
+     public:
+        int get_home_row_for_row(int row) const;
+        void add_alu_indexes(json::map &stage_tbl, std::string alu_indexes) const;
+        OVERLOAD_FUNC_FOREACH(TARGET_CLASS, std::vector<int>, determine_spare_bank_memory_units,
+                              () const, (), override)
+        OVERLOAD_FUNC_FOREACH(TARGET_CLASS, void, alloc_vpns, (), ())
+        template <class REGS> void write_regs_vt(REGS &regs);
+        FOR_ALL_REGISTER_SETS(TARGET_OVERLOAD, void write_regs, (mau_regs & regs), override)
+        FOR_ALL_REGISTER_SETS(TARGET_OVERLOAD, void write_merge_regs,
+                              (mau_regs & regs, MatchTable *match, int type, int bus,
+                               const std::vector<Call::Arg> &args),
+                              override = 0)
+        void common_init_setup(const VECTOR(pair_t) &, bool, P4Table::type) override;
+        bool common_setup(pair_t &, const VECTOR(pair_t) &, P4Table::type) override;
+        void pass1() override; void pass2() override; void pass3() override;
+)
 
 DECLARE_TABLE_TYPE(
     CounterTable, Synth2Port, "counter",

--- a/backends/tofino/bf-asm/tables.h
+++ b/backends/tofino/bf-asm/tables.h
@@ -2033,7 +2033,7 @@ DECLARE_ABSTRACT_TABLE_TYPE(
         void add_alu_indexes(json::map &stage_tbl, std::string alu_indexes) const;
         OVERLOAD_FUNC_FOREACH(TARGET_CLASS, std::vector<int>, determine_spare_bank_memory_units,
                               () const, (), override)
-        OVERLOAD_FUNC_FOREACH(TARGET_CLASS, void, alloc_vpns, (), ())
+        OVERLOAD_FUNC_FOREACH(TARGET_CLASS, void, alloc_vpns, (), (), override)
         template <class REGS> void write_regs_vt(REGS &regs);
         FOR_ALL_REGISTER_SETS(TARGET_OVERLOAD, void write_regs, (mau_regs & regs), override)
         FOR_ALL_REGISTER_SETS(TARGET_OVERLOAD, void write_merge_regs,

--- a/backends/tofino/bf-asm/target.cpp
+++ b/backends/tofino/bf-asm/target.cpp
@@ -280,7 +280,7 @@ int Target::numMauStagesOverride = 0;
 
 int Target::encodeConst(int src) {
     SWITCH_FOREACH_TARGET(options.target, return TARGET::encodeConst(src););
-    BUG();
+    BUG("unsupported target");
     return 0;
 }
 

--- a/backends/tofino/bf-asm/target.h
+++ b/backends/tofino/bf-asm/target.h
@@ -72,13 +72,9 @@ struct MemUnit;
 #define TARGETS_USING_REGS(CL, ...) TARGETS_USING_REGS_##CL(__VA_ARGS__)
 #define REGSETS_IN_CLASS(CL, ...) REGSETS_IN_CLASS_##CL(__VA_ARGS__)
 
-#define EXPAND(...) __VA_ARGS__
-#define EXPAND_COMMA(...) , ##__VA_ARGS__
-#define EXPAND_COMMA_CLOSE(...) ,##__VA_ARGS__ )
 #define INSTANTIATE_TARGET_TEMPLATE(TARGET, FUNC, ...) template FUNC(Target::TARGET::__VA_ARGS__);
 #define DECLARE_TARGET_CLASS(TARGET, ...) class TARGET __VA_ARGS__;
 #define FRIEND_TARGET_CLASS(TARGET, ...) friend class Target::TARGET __VA_ARGS__;
-#define TARGET_OVERLOAD(TARGET, FN, ARGS, ...) FN(Target::TARGET::EXPAND ARGS) __VA_ARGS__;
 
 #define PER_TARGET_CONSTANTS(M)                         \
     M(const char *, name)                               \
@@ -700,6 +696,11 @@ void emit_parser_registers(const Target::JBay::top_level_regs *regs, std::ostrea
  * will all have a Target::type argument prepended.  The final ARGS argument is the argument
  * list that that will be forwarded (basically ARGDECL without the types)
  */
+#define EXPAND(...) __VA_ARGS__
+#define EXPAND_COMMA(...) __VA_OPT__(, )##__VA_ARGS__                      // NOLINT
+#define EXPAND_COMMA_CLOSE(...) __VA_OPT__(, ) ##__VA_ARGS__ __VA_OPT__()) // NOLINT
+#define TARGET_OVERLOAD(TARGET, FN, ARGS, ...) FN(Target::TARGET::EXPAND ARGS) __VA_ARGS__;
+
 #define DECL_OVERLOAD_FUNC(TARGET, RTYPE, NAME, ARGDECL, ARGS) \
     RTYPE NAME(Target::TARGET EXPAND_COMMA_CLOSE ARGDECL;
 #define OVERLOAD_FUNC_FOREACH(GROUP, RTYPE, NAME, ARGDECL, ARGS, ...)                    \

--- a/backends/tofino/bf-asm/target.h
+++ b/backends/tofino/bf-asm/target.h
@@ -697,8 +697,10 @@ void emit_parser_registers(const Target::JBay::top_level_regs *regs, std::ostrea
  * list that that will be forwarded (basically ARGDECL without the types)
  */
 #define EXPAND(...) __VA_ARGS__
-#define EXPAND_COMMA(...) __VA_OPT__(, )##__VA_ARGS__                      // NOLINT
-#define EXPAND_COMMA_CLOSE(...) __VA_OPT__(, ) ##__VA_ARGS__ __VA_OPT__()) // NOLINT
+// clang-format off
+#define EXPAND_COMMA(...) __VA_OPT__(,) __VA_ARGS__
+// clang-format on
+#define EXPAND_COMMA_CLOSE(...) __VA_OPT__(,) __VA_ARGS__ )
 #define TARGET_OVERLOAD(TARGET, FN, ARGS, ...) FN(Target::TARGET::EXPAND ARGS) __VA_ARGS__;
 
 #define DECL_OVERLOAD_FUNC(TARGET, RTYPE, NAME, ARGDECL, ARGS) \

--- a/backends/tofino/bf-asm/target.h
+++ b/backends/tofino/bf-asm/target.h
@@ -21,6 +21,7 @@
 #include "asm-types.h"
 #include "backends/tofino/bf-asm/config.h"
 #include "bfas.h"
+#include "lib/exceptions.h"
 #include "map.h"
 
 struct MemUnit;

--- a/backends/tofino/bf-asm/target.h
+++ b/backends/tofino/bf-asm/target.h
@@ -32,41 +32,42 @@ struct MemUnit;
  *  FOR_ALL_TARGET_CLASSES -- metamacro that expands for each distinct target class
  *              a subset of the register sets
  */
-#define FOR_ALL_TARGETS(M, ...) \
-    M(Tofino, ##__VA_ARGS__)    \
-    M(JBay, ##__VA_ARGS__)      \
-    M(Tofino2H, ##__VA_ARGS__)  \
-    M(Tofino2M, ##__VA_ARGS__)  \
-    M(Tofino2U, ##__VA_ARGS__)  \
-    M(Tofino2A0, ##__VA_ARGS__)
-#define FOR_ALL_REGISTER_SETS(M, ...) \
-    M(Tofino, ##__VA_ARGS__)          \
-    M(JBay, ##__VA_ARGS__)
-#define FOR_ALL_TARGET_CLASSES(M, ...) M(Tofino, ##__VA_ARGS__)
+// TODO: clang-format adds space in __VA_OPT__
+#define FOR_ALL_TARGETS(M, ...)           \
+    M(Tofino __VA_OPT__(,) __VA_ARGS__)   \
+    M(JBay __VA_OPT__(,) __VA_ARGS__)     \
+    M(Tofino2H __VA_OPT__(,) __VA_ARGS__) \
+    M(Tofino2M __VA_OPT__(,) __VA_ARGS__) \
+    M(Tofino2U __VA_OPT__(,) __VA_ARGS__) \
+    M(Tofino2A0 __VA_OPT__(,) __VA_ARGS__)
+#define FOR_ALL_REGISTER_SETS(M, ...)   \
+    M(Tofino __VA_OPT__(,) __VA_ARGS__) \
+    M(JBay __VA_OPT__(,) __VA_ARGS__)
+#define FOR_ALL_TARGET_CLASSES(M, ...) M(Tofino __VA_OPT__(,) __VA_ARGS__)
 
 // alias FOR_ALL -> FOR_EACH so the the group name does need to be plural
 #define FOR_EACH_TARGET FOR_ALL_TARGETS
 #define FOR_EACH_REGISTER_SET FOR_ALL_REGISTER_SETS
 #define FOR_EACH_TARGET_CLASS FOR_ALL_TARGET_CLASSES
 
-#define TARGETS_IN_CLASS_Tofino(M, ...) \
-    M(Tofino, ##__VA_ARGS__)            \
-    M(JBay, ##__VA_ARGS__)              \
-    M(Tofino2H, ##__VA_ARGS__)          \
-    M(Tofino2M, ##__VA_ARGS__)          \
-    M(Tofino2U, ##__VA_ARGS__)          \
-    M(Tofino2A0, ##__VA_ARGS__)
+#define TARGETS_IN_CLASS_Tofino(M, ...)   \
+    M(Tofino __VA_OPT__(,) __VA_ARGS__)   \
+    M(JBay __VA_OPT__(,) __VA_ARGS__)     \
+    M(Tofino2H __VA_OPT__(,) __VA_ARGS__) \
+    M(Tofino2M __VA_OPT__(,) __VA_ARGS__) \
+    M(Tofino2U __VA_OPT__(,) __VA_ARGS__) \
+    M(Tofino2A0 __VA_OPT__(,) __VA_ARGS__)
 #define REGSETS_IN_CLASS_Tofino(M, ...) \
-    M(Tofino, ##__VA_ARGS__)            \
-    M(JBay, ##__VA_ARGS__)
+    M(Tofino __VA_OPT__(,) __VA_ARGS__) \
+    M(JBay __VA_OPT__(,) __VA_ARGS__)
 
-#define TARGETS_USING_REGS_JBay(M, ...) \
-    M(JBay, ##__VA_ARGS__)              \
-    M(Tofino2H, ##__VA_ARGS__)          \
-    M(Tofino2M, ##__VA_ARGS__)          \
-    M(Tofino2U, ##__VA_ARGS__)          \
-    M(Tofino2A0, ##__VA_ARGS__)
-#define TARGETS_USING_REGS_Tofino(M, ...) M(Tofino, ##__VA_ARGS__)
+#define TARGETS_USING_REGS_JBay(M, ...)   \
+    M(JBay __VA_OPT__(,) __VA_ARGS__)     \
+    M(Tofino2H __VA_OPT__(,) __VA_ARGS__) \
+    M(Tofino2M __VA_OPT__(,) __VA_ARGS__) \
+    M(Tofino2U __VA_OPT__(,) __VA_ARGS__) \
+    M(Tofino2A0 __VA_OPT__(,) __VA_ARGS__)
+#define TARGETS_USING_REGS_Tofino(M, ...) M(Tofino __VA_OPT__(,) __VA_ARGS__)
 
 #define TARGETS_IN_CLASS(CL, ...) TARGETS_IN_CLASS_##CL(__VA_ARGS__)
 #define TARGETS_USING_REGS(CL, ...) TARGETS_USING_REGS_##CL(__VA_ARGS__)
@@ -697,9 +698,7 @@ void emit_parser_registers(const Target::JBay::top_level_regs *regs, std::ostrea
  * list that that will be forwarded (basically ARGDECL without the types)
  */
 #define EXPAND(...) __VA_ARGS__
-// clang-format off
 #define EXPAND_COMMA(...) __VA_OPT__(,) __VA_ARGS__
-// clang-format on
 #define EXPAND_COMMA_CLOSE(...) __VA_OPT__(,) __VA_ARGS__ )
 #define TARGET_OVERLOAD(TARGET, FN, ARGS, ...) FN(Target::TARGET::EXPAND ARGS) __VA_ARGS__;
 

--- a/backends/tofino/bf-asm/ternary_match.cpp
+++ b/backends/tofino/bf-asm/ternary_match.cpp
@@ -511,7 +511,7 @@ void TernaryMatchTable::write_regs_vt(REGS &regs) {
 std::unique_ptr<json::map> TernaryMatchTable::gen_memory_resource_allocation_tbl_cfg(
     const char *type, const std::vector<Layout> &layout, bool skip_spare_bank) const {
     if (layout.size() == 0) return nullptr;
-    BUG_CHECK(!skip_spare_bank);  // never spares in tcam
+    BUG_CHECK(!skip_spare_bank, "can't spare in tcam");  // never spares in tcam
     json::map mra{{"memory_type", json::string(type)}};
     json::vector &mem_units_and_vpns = mra["memory_units_and_vpns"];
     json::vector mem_units;
@@ -652,7 +652,7 @@ void TernaryMatchTable::gen_entry_cfg(json::vector &out, std::string name, unsig
 
                     // Determine which section of the byte based on which nibble is provided
                     if (dirtcam_mode == DIRTCAM_4B_LO) {
-                        BUG_CHECK(nibbles_of_range.getbit(0));
+                        BUG_CHECK(nibbles_of_range.getbit(0), "no nibbles_of_range.getbit");
                         // Add the difference from the first bit of this byte and the lowest bit
                         range_start_bit += bit + lsb_lo_bit_in_byte - lsb_lo;
                         range_width =
@@ -660,7 +660,7 @@ void TernaryMatchTable::gen_entry_cfg(json::vector &out, std::string name, unsig
                         range_width = std::min(static_cast<int>(range_width), lsb_hi - bit + 1);
                         nibble_offset = lsb_lo_bit_in_byte % 4;
                     } else {
-                        BUG_CHECK(nibbles_of_range.getbit(1));
+                        BUG_CHECK(nibbles_of_range.getbit(1), "no nibbles_of_range.getbit(1)");
                         // Because the bit starts at the upper nibble, the start bit is either the
                         // beginning of the nibble or more
                         range_start_bit += bit + std::max(4, lsb_lo_bit_in_byte) - lsb_lo;
@@ -735,11 +735,11 @@ void TernaryMatchTable::gen_match_fields(json::vector &match_field_list,
                         // a field in the (mid) byte group, which is shared with the adjacent word
                         // group each word gets only 4 bits of the byte group and is placed at msb
                         // Check mid-byte field does not cross byte boundary (40-47)
-                        BUG_CHECK(field_phv.hi < 48);
+                        BUG_CHECK(field_phv.hi < 48, "field_phv.hi >= 48");
                         // Check mid-byte field is associated with even group
                         // | == 5 == | == 1 == | == 5 == | == 5 == | == 1 == | == 5 == |
                         // | Grp 0   | Midbyte0| Grp 1   | Grp 2   | Midbyte1| Grp 3   |
-                        BUG_CHECK((field_group.index & 1) == 0);
+                        BUG_CHECK((field_group.index & 1) == 0, "field_group.index & 1 == 0");
                         // Find groups to place this byte nibble. Check group which has this
                         // group as the byte_group
                         for (auto &m : match) {

--- a/backends/tofino/bf-asm/tofino/counter.h
+++ b/backends/tofino/bf-asm/tofino/counter.h
@@ -28,12 +28,12 @@ class Target::Tofino::CounterTable : public ::CounterTable {
 
 template <>
 void CounterTable::setup_teop_regs(Target::Tofino::mau_regs &, int) {
-    BUG();  // no teop on tofino
+    BUG("teop not supported on tofino");
 }
 
 template <>
 void CounterTable::write_alu_vpn_range(Target::Tofino::mau_regs &) {
-    BUG();  // not available on tofino
+    BUG("alu vpn not available on tofino");
 }
 
 #endif /* BACKENDS_TOFINO_BF_ASM_TOFINO_COUNTER_H_ */

--- a/backends/tofino/bf-asm/tofino/gateway.cpp
+++ b/backends/tofino/bf-asm/tofino/gateway.cpp
@@ -207,7 +207,7 @@ void Target::Tofino::GatewayTable::pass2() {
             if (tbl && !tbl->layout.empty()) {
                 for (auto &row : tbl->layout) {
                     auto match_rbus = row.bus.at(ternary ? Layout::TIND_BUS : Layout::RESULT_BUS);
-                    BUG_CHECK(match_rbus >= 0);  // alloc_busses on the match table must run first
+                    BUG_CHECK(match_rbus >= 0, "alloc_busses on the match table must be run first");
                     if (stage->gw_payload_use[row.row][match_rbus]) {
                         continue;
                     } else {
@@ -228,7 +228,7 @@ void Target::Tofino::GatewayTable::pass2() {
         }
     }
     if (payload_unit >= 0 && !layout[1].bus.count(Layout::RESULT_BUS)) {
-        BUG_CHECK(layout.size() > 1);
+        BUG_CHECK(layout.size() > 1, "layout size <= 1");
         int row = layout[1].row;
         Table *tbl = match_table;
         int ternary = tbl ? 0 : -1;
@@ -301,8 +301,7 @@ void Target::Tofino::GatewayTable::pass3() {
 
 template <>
 void enable_gateway_payload_exact_shift_ovr(Target::Tofino::mau_regs &regs, int bus) {
-    // Not supported on tofino
-    BUG();
+    BUG("enable_gateway_payload_exact_shift_ovr not supported");
 }
 template void enable_gateway_payload_exact_shift_ovr(Target::Tofino::mau_regs &regs, int bus);
 
@@ -311,7 +310,7 @@ void Target::Tofino::GatewayTable::write_next_table_regs(Target::Tofino::mau_reg
     int idx = 3;
     if (need_next_map_lut) error(lineno, "Tofino does not support using next_map_lut in gateways");
     for (auto &line : table) {
-        BUG_CHECK(idx >= 0);
+        BUG_CHECK(idx >= 0, "Index is negative");
         if (!line.run_table)
             merge.gateway_next_table_lut[logical_id][idx] = line.next.next_table_id();
         --idx;

--- a/backends/tofino/bf-asm/tofino/gateway.cpp
+++ b/backends/tofino/bf-asm/tofino/gateway.cpp
@@ -300,10 +300,9 @@ void Target::Tofino::GatewayTable::pass3() {
 }
 
 template <>
-void enable_gateway_payload_exact_shift_ovr(Target::Tofino::mau_regs &regs, int bus) {
+void enable_gateway_payload_exact_shift_ovr(Target::Tofino::mau_regs & /*regs*/, int /*bus*/) {
     BUG("enable_gateway_payload_exact_shift_ovr not supported");
 }
-template void enable_gateway_payload_exact_shift_ovr(Target::Tofino::mau_regs &regs, int bus);
 
 void Target::Tofino::GatewayTable::write_next_table_regs(Target::Tofino::mau_regs &regs) {
     auto &merge = regs.rams.match.merge;

--- a/backends/tofino/bf-asm/tofino/input_xbar.cpp
+++ b/backends/tofino/bf-asm/tofino/input_xbar.cpp
@@ -75,6 +75,3 @@ void InputXbar::write_galois_matrix(Target::Tofino::mau_regs &regs, HashTable id
         }
     }
 }
-
-template void InputXbar::write_galois_matrix(Target::Tofino::mau_regs &regs, HashTable id,
-                                             const std::map<int, HashCol> &mat);

--- a/backends/tofino/bf-asm/tofino/instruction.cpp
+++ b/backends/tofino/bf-asm/tofino/instruction.cpp
@@ -31,7 +31,7 @@ void VLIWInstruction::write_regs(Target::Tofino::mau_regs &regs, Table *tbl,
     int iaddr = act->addr / ACTION_IMEM_COLORS;
     int color = act->addr % ACTION_IMEM_COLORS;
     unsigned bits = encode();
-    BUG_CHECK(slot >= 0);
+    BUG_CHECK(slot >= 0, "slot < 0");
     switch (Phv::reg(slot)->size) {
         case 8:
             imem.imem_subword8[slot - 64][iaddr].imem_subword8_instr = bits;
@@ -49,7 +49,7 @@ void VLIWInstruction::write_regs(Target::Tofino::mau_regs &regs, Table *tbl,
             imem.imem_subword32[slot][iaddr].imem_subword32_parity = parity(bits) ^ color;
             break;
         default:
-            BUG();
+            BUG("Invalid slot: %d", slot);
     }
     auto &power_ctl = regs.dp.actionmux_din_power_ctl;
     phvRead([&](const Phv::Slice &sl) { set_power_ctl_reg(power_ctl, sl.reg.mau_id()); });

--- a/backends/tofino/bf-asm/tofino/meter.h
+++ b/backends/tofino/bf-asm/tofino/meter.h
@@ -28,12 +28,12 @@ class Target::Tofino::MeterTable : public ::MeterTable {
 
 template <>
 void MeterTable::setup_teop_regs(Target::Tofino::mau_regs &, int) {
-    BUG();  // no teop on tofino
+    BUG("teop not supported on tofino");
 }
 
 template <>
 void MeterTable::write_alu_vpn_range(Target::Tofino::mau_regs &) {
-    BUG();  // not available on tofino
+    BUG("alu vpn not available on tofino");
 }
 
 #endif /* BACKENDS_TOFINO_BF_ASM_TOFINO_METER_H_ */

--- a/backends/tofino/bf-asm/tofino/parser.cpp
+++ b/backends/tofino/bf-asm/tofino/parser.cpp
@@ -136,7 +136,7 @@ static phv_use_slots *get_phv_use_slots(int size) {
     else if (size == 8)
         usable_slots = phv_8b_slots;
     else
-        BUG();
+        BUG("unsupported size: %d", size);
 
     return usable_slots;
 }
@@ -151,7 +151,7 @@ static phv_use_slots *get_phv_csum_use_slots(int size) {
     else if (size == 8)
         usable_slots = phv_8b_csum_slots;
     else
-        BUG();
+        BUG("unsupported size: %d", size);
 
     return usable_slots;
 }
@@ -524,7 +524,7 @@ static int encode_constant_for_slot(int slot, unsigned val) {
         case phv_8b_3:
             return val & 0xff;
         default:
-            BUG();
+            BUG("Invalid slot: %d", slot);
             return -1;
     }
 }
@@ -644,13 +644,13 @@ void Parser::mark_unused_output_map(Target::Tofino::parser_regs &regs, void *_ma
 template <>
 void Parser::State::Match::HdrLenIncStop::write_config(
     Tofino::memories_all_parser_::_po_action_row &) const {
-    BUG();  // no hdr_len_inc_stop on tofino; should not get here
+    BUG("no hdr_len_inc_stop on tofino; should not get here");
 }
 
 template <>
 void Parser::State::Match::Clot::write_config(Tofino::memories_all_parser_::_po_action_row &, int,
                                               bool) const {
-    BUG();  // no CLOTs on tofino; should not get here
+    BUG("no CLOTs on tofino; should not get here");
 }
 
 template <>

--- a/backends/tofino/bf-asm/tofino/parser.cpp
+++ b/backends/tofino/bf-asm/tofino/parser.cpp
@@ -1004,9 +1004,9 @@ static void check_16b_extractor_configuration(const unsigned pad_idx, const unsi
     }
 
     // Check the slot configuration - sourcing from global field and no constant for {0,1}
-    BUG_CHECK(
-        *map[pad_idx].src >= PARSER_SRC_MAX_IDX - 3 && *map[pad_idx].src != EXTRACT_SLOT_UNUSED,
-        "Field is not sourcing from the global version field!");
+    BUG_CHECK(*map[pad_idx].src >= PARSER_SRC_MAX_IDX - 3 &&
+                  static_cast<uint64_t>(*map[pad_idx].src) != EXTRACT_SLOT_UNUSED,
+              "Field is not sourcing from the global version field!");
     if (pad_idx == phv_16b_0 || pad_idx == phv_16b_1) {
         BUG_CHECK(*map[pad_idx].src_type == 0,
                   "Invalid configuration of the source type for 16b 2n padding!");

--- a/backends/tofino/bf-asm/tofino/phv.cpp
+++ b/backends/tofino/bf-asm/tofino/phv.cpp
@@ -45,7 +45,7 @@ void Target::Tofino::Phv::init_regs(::Phv &phv) {
             }
         }
     }
-    BUG_CHECK(uid == phv.regs.size());
+    BUG_CHECK(uid == phv.regs.size(), "uid %u != %zu", uid, phv.regs.size());
 }
 
 static bitvec tagalong_group(int n) {

--- a/backends/tofino/bf-asm/tofino/salu_inst.cpp
+++ b/backends/tofino/bf-asm/tofino/salu_inst.cpp
@@ -23,7 +23,7 @@ template <>
 void AluOP::write_regs(Target::Tofino::mau_regs &regs, Table *tbl_, Table::Actions::Action *act) {
     LOG2(this);
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "expected stateful table");
     int logical_home_row = tbl->layout[0].row;
     auto &meter_group = regs.rams.map_alu.meter_group[logical_home_row / 4U];
     auto &salu = meter_group.stateful.salu_instr_state_alu[act->code][slot - ALU2LO];
@@ -51,7 +51,7 @@ void AluOP::write_regs(Target::Tofino::mau_regs &regs, Table *tbl_, Table::Actio
             salu.salu_const_src = r->index;
             salu.salu_regfile_const = 1;
         } else {
-            BUG();
+            BUG("unknown operand");
         }
     }
     if (srcb) {
@@ -65,7 +65,7 @@ void AluOP::write_regs(Target::Tofino::mau_regs &regs, Table *tbl_, Table::Actio
             } else if (auto b = m->of.to<operand::Memory>()) {
                 salu_instr_common.salu_alu2_lo_math_src = b->field->bit(0) > 0 ? 3 : 2;
             } else {
-                BUG();
+                BUG("unknown operand");
             }
         } else if (auto k = srcb.to<operand::Const>()) {
             salu.salu_bsrc_phv = 0;
@@ -81,7 +81,7 @@ void AluOP::write_regs(Target::Tofino::mau_regs &regs, Table *tbl_, Table::Actio
             salu.salu_const_src = r->index;
             salu.salu_regfile_const = 1;
         } else {
-            BUG();
+            BUG("unknown operand");
         }
     }
 }
@@ -109,7 +109,7 @@ template <>
 void CmpOP::write_regs(Target::Tofino::mau_regs &regs, Table *tbl_, Table::Actions::Action *act) {
     LOG2(this);
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "expected stateful table");
     int logical_home_row = tbl->layout[0].row;
     auto &meter_group = regs.rams.map_alu.meter_group[logical_home_row / 4U];
     auto &salu = meter_group.stateful.salu_instr_cmp_alu[act->code][slot];
@@ -149,7 +149,7 @@ void CmpOP::write_regs(Target::Tofino::mau_regs &regs, Table *tbl, Table::Action
 }
 
 void TMatchOP::write_regs(Target::Tofino::mau_regs &regs, Table *tbl, Table::Actions::Action *act) {
-    BUG();  // should never be called
+    BUG("Unreachable state.");
 }
 
 void OutOP::decode_output_mux(Target::Tofino, Table *tbl, value_t &op) {
@@ -178,7 +178,7 @@ template <>
 void OutOP::write_regs(Target::Tofino::mau_regs &regs, Table *tbl_, Table::Actions::Action *act) {
     LOG2(this);
     auto tbl = dynamic_cast<StatefulTable *>(tbl_);
-    BUG_CHECK(tbl);
+    BUG_CHECK(tbl, "expected stateful table");
     int logical_home_row = tbl->layout[0].row;
     auto &meter_group = regs.rams.map_alu.meter_group[logical_home_row / 4U];
     auto &salu = meter_group.stateful.salu_instr_output_alu[act->code];

--- a/backends/tofino/bf-asm/tofino/sram_match.cpp
+++ b/backends/tofino/bf-asm/tofino/sram_match.cpp
@@ -18,6 +18,7 @@
 #include "backends/tofino/bf-asm/stage.h"
 #include "backends/tofino/bf-asm/tables.h"
 #include "lib/log.h"
+#include "lib/null.h"
 
 static int find_in_ixbar(Table *table, std::vector<Phv::Ref> &match) {
     // It would seem like it would be possible to simplify this code by refactoring it
@@ -87,8 +88,8 @@ void SRamMatchTable::setup_word_ixbar_group(Target::Tofino) {
         std::vector<Phv::Ref> phv_ref_match;
         for (auto *source : match) {
             auto phv_ref = dynamic_cast<Phv::Ref *>(source);
-            BUG_CHECK(phv_ref);
-            BUG_CHECK(*phv_ref);
+            CHECK_NULL(phv_ref);
+            BUG_CHECK(*phv_ref, "Null phv_ref");
             phv_ref_match.push_back(*phv_ref);
         }
         word_ixbar_group[i++] = phv_ref_match.empty() ? -1 : find_in_ixbar(this, phv_ref_match);

--- a/backends/tofino/bf-asm/tofino/stage.cpp
+++ b/backends/tofino/bf-asm/tofino/stage.cpp
@@ -45,7 +45,7 @@ void Stage::write_regs(Target::Tofino::mau_regs &regs, bool) {
                     merge.predication_ctl[gress].start_table_fifo_enable = 0;
                     break;
                 default:
-                    BUG();
+                    BUG("bad stage dependency");
             }
         }
         if (stageno != 0) {
@@ -134,7 +134,9 @@ void Stage::gen_configuration_cache(Target::Tofino::mau_regs &regs, json::vector
 
 template <>
 void Stage::gen_mau_stage_extension(Target::Tofino::mau_regs &regs, json::map &extend) {
-    BUG();  // stage extension not supported on tofino
+    BUG("stage extension not supported on Tofino");
 }
 
-void AlwaysRunTable::write_regs(Target::Tofino::mau_regs &) { BUG(); }
+void AlwaysRunTable::write_regs(Target::Tofino::mau_regs &) {
+    BUG("register writes not supported on Tofino");
+}

--- a/backends/tofino/bf-asm/tofino/ternary_match.h
+++ b/backends/tofino/bf-asm/tofino/ternary_match.h
@@ -26,7 +26,7 @@ class Target::Tofino::TernaryMatchTable : public ::TernaryMatchTable {
         : ::TernaryMatchTable(line, n, gr, s, lid) {}
 
     void pass1() override;
-    void check_tcam_match_bus(const std::vector<Table::Layout> &);
+    void check_tcam_match_bus(const std::vector<Table::Layout> & /*unused*/) override;
 };
 
 class Target::Tofino::TernaryIndirectTable : public ::TernaryIndirectTable {

--- a/backends/tofino/bf-asm/top_level.cpp
+++ b/backends/tofino/bf-asm/top_level.cpp
@@ -25,7 +25,7 @@
 TopLevel *TopLevel::all = nullptr;
 
 TopLevel::TopLevel() {
-    BUG_CHECK(!all);
+    BUG_CHECK(!all, "only one TopLevel allowed");
     all = this;
 }
 

--- a/backends/tofino/bf-asm/top_level.h
+++ b/backends/tofino/bf-asm/top_level.h
@@ -37,7 +37,7 @@ class TopLevel {
     static TopLevelRegs<typename T::register_type> *regs();
 #define SET_MAU_STAGE(TARGET)                                                         \
     virtual void set_mau_stage(int, const char *, Target::TARGET::mau_regs *, bool) { \
-        BUG_CHECK(!"register mismatch");                                              \
+        BUG("register mismatch");                                                     \
     }
     FOR_ALL_REGISTER_SETS(SET_MAU_STAGE)
 };

--- a/lib/exceptions.h
+++ b/lib/exceptions.h
@@ -134,6 +134,7 @@ class CompilationError : public P4CExceptionBase {
         : P4CExceptionBase(format, std::forward<Args>(args)...) {}
 };
 
+/// FIXME: Use __VA_OPT__ for calls without an input string?
 #define BUG(...)                                                      \
     do {                                                              \
         throw P4::Util::CompilerBug(__LINE__, __FILE__, __VA_ARGS__); \


### PR DESCRIPTION
- Remove GNU extensions for bfasm. Seems to produce compilation problems on some recent systems.
- Instead, use the C++20 feature `__VA_OPT__` which only emits is argument when there are more variadic args. This seems to compile on all systems, but I need to add some more checks.
- Replace the BUG macros of bfasm with the top-level BUG macros. Also make sure every BUG call actually has a diagnostic. Tried to produce sensible messages for all the calls, but might have slipped in a few places. 

TODO: Recheck error messages and consider emitting a output that is different from `Compiler Bug`?