### PR TITLE
Remove confidential & proprietary notices from Tofino testgen test programs

### DIFF
--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/parser_reject.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/parser_reject.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #include <tna.p4>
 

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/port_metadata_unpack.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/port_metadata_unpack.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_action_declaration.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_action_declaration.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_action_profile_default.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_action_profile_default.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_advance.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_advance.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_cast.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_cast.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_drop.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_drop.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_emit_extern.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_emit_extern.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_empty.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_empty.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_exit.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_exit.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_1.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_1.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_2.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_2.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_3.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_3.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_4.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_4.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_5.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_5.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_6.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_6.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_7.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_7.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_8.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_extract_emit_8.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_1.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_1.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_10.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_10.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_2.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_2.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_3.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_3.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_4.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_4.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_5.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_5.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_6.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_6.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_7.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_7.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_8.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_8.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_9.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_hash_9.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_if_stmt.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_if_stmt.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_mirror_2.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_mirror_2.p4
@@ -17,27 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #include <tna.p4>
 

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_pvs_fixed.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_pvs_fixed.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 3
 #include <t3na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_random_extern.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_random_extern.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #include <tna.p4>
 

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_register_action_1.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_register_action_1.p4
@@ -17,27 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_register_action_2.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_register_action_2.p4
@@ -17,27 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_simple_assign_1.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_simple_assign_1.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_simple_assign_2.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_simple_assign_2.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_control_exact.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_control_exact.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_control_lpm.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_control_lpm.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_control_ternary.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_control_ternary.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_control_ternary_anno.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_control_ternary_anno.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_entries_range.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_entries_range.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 3
 #include <t3na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_no_key.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_table_no_key.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_tainted_table_key.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_tainted_table_key.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_undefined.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tna_undefined.p4
@@ -17,26 +17,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-/*******************************************************************************
- * BAREFOOT NETWORKS CONFIDENTIAL & PROPRIETARY
- *
- * Copyright (c) 2019-present Barefoot Networks, Inc.
- *
- * All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains the property of
- * Barefoot Networks, Inc. and its suppliers, if any. The intellectual and
- * technical concepts contained herein are proprietary to Barefoot Networks, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents, patents in
- * process, and are protected by trade secret or copyright law.  Dissemination of
- * this information or reproduction of this material is strictly forbidden unless
- * prior written permission is obtained from Barefoot Networks, Inc.
- *
- * No warranty, explicit or implicit is provided, unless granted under a written
- * agreement with Barefoot Networks, Inc.
- *
- ******************************************************************************/
-
 #include <core.p4>
 #if __TARGET_TOFINO__ == 2
 #include <t2na.p4>


### PR DESCRIPTION
All of these files had an Intel copyright notice and Apache-2.0 license _earlier in the file's text_ than the older confidential & proprietary notices that are being removed in this change.  It appears that some automated process was used to add the new copyright notices before publication, but they failed to remove the old one.

With these changes, every one of the changed files still has a copyright notes and an Apache-2.0 license notice, which I am not adding, but leaving there unchanged.