### PR TITLE
Correctly attach the dontmerge annotation in the desugar_varbit_extract pass.

### DIFF
--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tofino1_only/tna_varbit_extract.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tofino1_only/tna_varbit_extract.p4
@@ -1,0 +1,85 @@
+#include <tna.p4>
+
+header foo_t {
+    varbit<32> foo;
+}
+struct headers {
+    foo_t foo;
+}
+struct ingress_metadata_t {}
+struct egress_headers_t {}
+struct egress_metadata_t {}
+
+
+parser ig_prs(
+    packet_in pkt,
+    out headers hdr,
+    out ingress_metadata_t ig_md,
+    out ingress_intrinsic_metadata_t ig_intr_md)
+{
+    state start {
+        transition foo;
+    }
+
+    state foo {
+        pkt.extract(hdr.foo, (bit<32>)8);
+        transition accept;
+    }
+}
+
+control ig_ctl(
+    inout headers hdr, inout ingress_metadata_t ig_md,
+    in ingress_intrinsic_metadata_t ig_intr_md,
+    in ingress_intrinsic_metadata_from_parser_t ig_prsr_md,
+    inout ingress_intrinsic_metadata_for_deparser_t ig_dprsr_md,
+    inout ingress_intrinsic_metadata_for_tm_t ig_tm_md)
+{
+    apply {
+    }
+}
+
+control ig_dprs(
+    packet_out pkt,
+    inout headers hdr,
+    in ingress_metadata_t ig_md,
+    in ingress_intrinsic_metadata_for_deparser_t ig_dprsr_md)
+{
+    apply {
+    }
+}
+
+parser eg_prs(
+    packet_in pkt,
+    out egress_headers_t eg_hdr, out egress_metadata_t eg_md,
+    out egress_intrinsic_metadata_t eg_intr_md)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control eg_ctl(
+    inout egress_headers_t eg_hdr, inout egress_metadata_t eg_md,
+    in egress_intrinsic_metadata_t eg_intr_md,
+    in egress_intrinsic_metadata_from_parser_t eg_prsr_md,
+    inout egress_intrinsic_metadata_for_deparser_t eg_dprsr_md,
+    inout egress_intrinsic_metadata_for_output_port_t eg_oport_md)
+{
+    apply {
+    }
+}
+
+control eg_dprs(
+    packet_out pkt,
+    inout egress_headers_t eg_hdr, in egress_metadata_t eg_md,
+    in egress_intrinsic_metadata_for_deparser_t eg_dprsr_md)
+{
+    apply {
+    }
+}
+    
+Pipeline(
+    ig_prs(), ig_ctl(), ig_dprs(),
+    eg_prs(), eg_ctl(), eg_dprs()) pipe;
+
+Switch(pipe) main;

--- a/backends/tofino/bf-p4c/midend/desugar_varbit_extract.h
+++ b/backends/tofino/bf-p4c/midend/desugar_varbit_extract.h
@@ -123,12 +123,7 @@ class AnnotateVarbitExtractStates : public Transform {
             if (!method) continue;
 
             if (method->member == "extract" && call->arguments->size() == 2) {
-                // TODO: We do not know the thread of this state.
-                // Add both directions.
-                state->addOrReplaceAnnotation(
-                    new IR::Annotation{"dontmerge"_cs, new IR::StringLiteral("ingress")});
-                state->addOrReplaceAnnotation(
-                    new IR::Annotation{"dontmerge"_cs, new IR::StringLiteral("egress")});
+                state->addOrReplaceAnnotation(new IR::Annotation("dontmerge"_cs, {}));
                 break;
             }
         }

--- a/backends/tofino/bf-p4c/midend/desugar_varbit_extract.h
+++ b/backends/tofino/bf-p4c/midend/desugar_varbit_extract.h
@@ -123,7 +123,12 @@ class AnnotateVarbitExtractStates : public Transform {
             if (!method) continue;
 
             if (method->member == "extract" && call->arguments->size() == 2) {
-                state->addOrReplaceAnnotation("dontmerge"_cs, {});
+                // TODO: We do not know the thread of this state.
+                // Add both directions.
+                state->addOrReplaceAnnotation(
+                    new IR::Annotation{"dontmerge"_cs, new IR::StringLiteral("ingress")});
+                state->addOrReplaceAnnotation(
+                    new IR::Annotation{"dontmerge"_cs, new IR::StringLiteral("egress")});
                 break;
             }
         }


### PR DESCRIPTION
Looks like the annotation was not constructed correctly. Also unsure whether this annotation ever worked in the first place. This attempt tries to fix it. Since we do not know the direction at this point I added an annotation for both directions.

Fixes #5138.

I added the test program to the Tofino tests. Might be worthwhile to add all the tests to a dedicated Tofino directory instead and run the compiler with reference files.