### PR TITLE
BMv2: DirectCounter and InternetChecksum fixes

### DIFF
--- a/backends/bmv2/pna_nic/pnaNic.cpp
+++ b/backends/bmv2/pna_nic/pnaNic.cpp
@@ -318,7 +318,7 @@ void ExternConverter_InternetChecksum::convertExternInstance(UNUSED ConversionCo
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto trim = inst->controlPlaneName().find(".");
-    auto block = inst->controlPlaneName().trim(trim);
+    auto block = inst->controlPlaneName().before(trim);
     auto pnaStructure = static_cast<PnaProgramStructure *>(ctxt->structure);
     auto mainParser = pnaStructure->parsers.at("main_parser"_cs)->controlPlaneName();
     auto mainDeparser = pnaStructure->deparsers.at("main_deparser"_cs)->controlPlaneName();

--- a/backends/bmv2/portable_common/portable.cpp
+++ b/backends/bmv2/portable_common/portable.cpp
@@ -475,12 +475,12 @@ void ExternConverter_DirectCounter::convertExternInstance(UNUSED ConversionConte
             modelError("%1%: expected a declaration_id", tp ? tp->getNode() : eb->getNode());
             return;
         }
-        if (eb->getConstructorParameters()->size() < 2) {
-            modelError("%1%: expected 2 parameters", eb);
+        if (eb->getConstructorParameters()->size() < 1) {
+            modelError("%1%: expected 1 parameter", eb);
             return;
         }
         auto arg = tp->to<IR::Declaration_ID>();
-        auto param = eb->getConstructorParameters()->getParameter(1);
+        auto param = eb->getConstructorParameters()->getParameter(0);
         auto mem = arg->toString();
         LOG5("In convertParam with param " << param->toString() << " and mem " << mem);
         auto jsn = ctxt->conv->convertParam(param, mem);

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -335,7 +335,7 @@ void ExternConverter_InternetChecksum::convertExternInstance(UNUSED ConversionCo
     auto inst = c->to<IR::Declaration_Instance>();
     cstring name = inst->controlPlaneName();
     auto trim = inst->controlPlaneName().find(".");
-    auto block = inst->controlPlaneName().trim(trim);
+    auto block = inst->controlPlaneName().before(trim);
     auto psaStructure = static_cast<P4::PsaProgramStructure *>(ctxt->structure);
     auto ingressParser = psaStructure->parsers.at("ingress"_cs)->controlPlaneName();
     auto ingressDeparser = psaStructure->deparsers.at("ingress"_cs)->controlPlaneName();


### PR DESCRIPTION
Fix a pair of BMv2 issues for PNA/PSA:

* DirectCounter: `ExternConverter_DirectCounter::convertExternInstance` was trying to access the 2nd parameter, but DirectCounter only takes a single parameter (the counter type). Adjust to access the 1st parameter.
* InternetChecksum: `ExternConverter_InternetChecksum::convertExternInstance` was incorrectly using `cstring::trim()` instead of `cstring::before` when identifying the block name.