### PR TITLE
BMv2: ActionSelector fix + enable backends

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -165,8 +165,11 @@ set (BMV2_V1MODEL_TEST_SUITES
   )
 
 set (PSA_INCLUDE_PATTERNS "include.*psa.p4")
-set (PSA_EXCLUDE_PATTERNS "include.*v1model.p4")
-set (P4TESTS_FOR_PSA "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*-bmv2.p4")
+set (PSA_EXCLUDE_PATTERNS "include.*v1model.p4" "include.*dpdk")
+set (P4TESTS_FOR_PSA
+  "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*-bmv2.p4"
+  "${P4C_SOURCE_DIR}/testdata/p4_16_samples/psa-*.p4"
+  )
 p4c_find_tests("${P4TESTS_FOR_PSA}" psa_tests INCLUDE "${PSA_INCLUDE_PATTERNS}" EXCLUDE "${PSA_EXCLUDE_PATTERNS}")
 
 set (BMV2_PSA_TEST_SUITES
@@ -203,6 +206,12 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/issue1205-bmv2.p4
   # These psa tests are not ready to run on bmv2 yet
   testdata/p4_16_samples/psa-example-digest-bmv2.p4
+  testdata/p4_16_samples/psa-example-parser-checksum.p4 # error: error.NoError: unsupported exact key expression
+  testdata/p4_16_samples/psa-meter4.p4 # Compiler Bug: backends/bmv2/portable_common/portable.cpp:574: Null info
+  testdata/p4_16_samples/psa-meter5.p4 # Compiler Bug: backends/bmv2/portable_common/portable.cpp:574: Null info
+  testdata/p4_16_samples/psa-random.p4 # vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
+  testdata/p4_16_samples/psa-table-hit-miss.p4 # error: Program can not be implemented on this target since it
+                                               # contains a path from table MyIC.tbl back to itself
   # This reads stack.next
   testdata/p4_16_samples/issue692-bmv2.p4
   # These test use computations in the verify/update checksum controls - unsupported

--- a/backends/bmv2/portable_common/portable.cpp
+++ b/backends/bmv2/portable_common/portable.cpp
@@ -667,7 +667,16 @@ void ExternConverter_ActionSelector::convertExternInstance(UNUSED ConversionCont
         modelError("%1%: expected a member", hash->getNode());
         return;
     }
-    auto algo = ExternConverter::convertHashAlgorithm(hash->to<IR::Declaration_ID>()->name);
+    // ExternConverter::convertHashAlgorithm() expects v1model names
+    // Convert from PSA/PNA names to v1model names
+    PortableCodeGenerator pcg;
+    auto v1modelHashName = pcg.convertHashAlgorithm(hash->to<IR::Declaration_ID>()->name);
+    if (v1modelHashName.isNullOrEmpty()) {
+        ::P4::error(ErrorType::ERR_UNSUPPORTED,
+                    "%1%: unsupported hash algorithm for action selector", hash);
+        return;
+    }
+    auto algo = ExternConverter::convertHashAlgorithm(v1modelHashName);
     selector->emplace("algo"_cs, algo);
     auto input = ctxt->get_selector_input(c->to<IR::Declaration_Instance>());
     if (input == nullptr) {

--- a/tools/driver/p4c_src/p4c.bmv2.cfg
+++ b/tools/driver/p4c_src/p4c.bmv2.cfg
@@ -20,10 +20,19 @@ class BMV2Backend(BackendDriver):
     def __init__(self, target, arch, argParser):
         BackendDriver.__init__(self, target, arch, argParser)
 
+        prog = 'p4c-bm2-ss'
+        if arch == 'psa':
+            prog = 'p4c-bm2-psa'
+        elif arch == 'pna':
+            prog = 'p4c-bm2-pna'
+        elif arch != 'v1model':
+            print("Error: unknown architecture", arch, file=sys.stderr)
+            exit(1)
+
         # commands
         self.add_command('preprocessor', 'cc')
         self.add_command('compiler',
-                         os.path.join(os.environ['P4C_BIN_DIR'],'p4c-bm2-ss'))
+                         os.path.join(os.environ['P4C_BIN_DIR'], prog))
         # order of invocation
         self.enable_commands(['preprocessor', 'compiler'])
 
@@ -37,6 +46,9 @@ class BMV2Backend(BackendDriver):
         if (opts.help_pragmas):
             print(self, "backend does not provide help message for pragmas/annotations")
             exit(0)
+
+        if self._arch == 'psa' or self._arch == 'pna':
+            print(f"Warning: architecture {self._arch} support is experimental", file=sys.stderr)
 
         # process the options related to source file
         basepath = os.path.join(opts.output_directory, self._source_basename)
@@ -58,8 +70,9 @@ simple_switch_target = BMV2Backend('bmv2', 'v1model', argParser)
 config.target.append(simple_switch_target)
 
 # PSA implementation on BMv2
-psa_target = BackendDriver('bmv2', 'psa')
-psa_target.add_command('none', \
-        '/bin/echo "target ' + str(psa_target) + ' not yet implemented"')
-psa_target.enable_commands(['none'])
+psa_target = BMV2Backend('bmv2', 'psa', argParser)
 config.target.append(psa_target)
+
+# PNA implementation on BMv2
+pna_target = BMV2Backend('bmv2', 'pna', argParser)
+config.target.append(pna_target)

--- a/tools/driver/p4c_src/p4c.bmv2.cfg
+++ b/tools/driver/p4c_src/p4c.bmv2.cfg
@@ -20,12 +20,13 @@ class BMV2Backend(BackendDriver):
     def __init__(self, target, arch, argParser):
         BackendDriver.__init__(self, target, arch, argParser)
 
-        prog = 'p4c-bm2-ss'
-        if arch == 'psa':
+        if arch == 'v1model':
+            prog = 'p4c-bm2-ss'
+        elif arch == 'psa':
             prog = 'p4c-bm2-psa'
         elif arch == 'pna':
             prog = 'p4c-bm2-pna'
-        elif arch != 'v1model':
+        else:
             print("Error: unknown architecture", arch, file=sys.stderr)
             exit(1)
 


### PR DESCRIPTION
Changes:
* ActionSelector: The`ExternConverter::convertHashAlgorithm()` function expects v1model names (lowercase). Convert PSA/PNA names to v1model names before invoking this function.
* Enable psa and pna backens for BMv2, but print warning messages that these are experimental.
* Add additional psa tests for bmv2:
  * Add any psa-* tests in testdata/p4_16_samples that are not dpdk tests. (Although some of these do pass.)
  * Update xfails for the handful of fails.