### PR TITLE
[BMv2] PNA: hash default + enum fix

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -176,6 +176,26 @@ set (BMV2_PSA_TEST_SUITES
   ${psa_tests}
 )
 
+set (PNA_INCLUDE_PATTERNS "include.*pna.p4")
+set (PNA_EXCLUDE_PATTERNS "include.*v1model.p4" "include.*dpdk")
+set (P4TESTS_FOR_PNA
+  "${P4C_SOURCE_DIR}/testdata/p4_16_samples/*-bmv2.p4"
+  "${P4C_SOURCE_DIR}/testdata/p4_16_samples/pna-*.p4"
+  )
+p4c_find_tests("${P4TESTS_FOR_PNA}" pna_test_candidates INCLUDE "${PNA_INCLUDE_PATTERNS}" EXCLUDE "${PNA_EXCLUDE_PATTERNS}")
+# Exclude dpdk tests from PNA test candidates
+# FIXME: some of these work with BMv2 -- potentially enable later
+set (pna_tests "")
+foreach (t ${pna_test_candidates})
+  if (NOT t MATCHES ".*-dpdk-.*.p4")
+    list (APPEND pna_tests ${t})
+  endif()
+endforeach()
+
+set (BMV2_PNA_TEST_SUITES
+  ${pna_tests}
+)
+
 # Execute PTF tests for these files.
 set (BMV2_PTF_TEST_SUITES
   "${P4C_SOURCE_DIR}/testdata/p4_16_samples/ternary2-bmv2.p4"
@@ -183,7 +203,8 @@ set (BMV2_PTF_TEST_SUITES
 
 # -p to use psa switch model
 # -a to pass flags to compiler
-set (testExtraFlags "${testExtraFlags} -p -a='--target bmv2 --arch psa'")
+set (testExtraFlagsPSA "${testExtraFlags} -p -a='--target bmv2 --arch psa'")
+set (testExtraFlagsPNA "${testExtraFlags} --use_pna -a='--target bmv2 --arch pna'")
 
 set (XFAIL_TESTS
   # This test defines two lpm keys for a table.
@@ -225,6 +246,15 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/hashing-non-tuple-bmv2.p4
   # Similarly, this test hashes on a bit input.
   testdata/p4_16_samples/issue584-1-bmv2.p4
+  # These pna tests are not ready to run on bmv2 yet
+  testdata/p4_16_samples/pna-example-SelectByDirection.p4  # error: SelectByDirection(...): not supported
+  testdata/p4_16_samples/pna-example-SelectByDirection1.p4  # error: SelectByDirection(...): not supported
+  testdata/p4_16_samples/pna-example-SelectByDirection2.p4  # error: SelectByDirection(...): not supported
+  testdata/p4_16_samples/pna-example-header-union.p4  # Error -11
+  testdata/p4_16_samples/pna-example-header-union1.p4  # Error -11
+  testdata/p4_16_samples/pna-example-pass-2.p4  # Conditional execution in actions not supported
+  testdata/p4_16_samples/pna-example-tcp-connection-tracking.p4  # Conditional execution in actions not supported
+  testdata/p4_16_samples/pna-extract-local-header.p4  # error: IfStatement: not supported within a deparser on this target
 )
 
 set (BMV2_PARSER_INLINE_TESTS "${P4C_SOURCE_DIR}/testdata/p4_16_samples/parser-inline/*.p4")
@@ -253,9 +283,15 @@ else()
 endif()
 
 if (HAVE_PSA_SWITCH)
-  p4c_add_tests("bmv2" ${BMV2_DRIVER} "${BMV2_PSA_TEST_SUITES}" "${XFAIL_TESTS}" ${testExtraFlags})
+  p4c_add_tests("bmv2" ${BMV2_DRIVER} "${BMV2_PSA_TEST_SUITES}" "${XFAIL_TESTS}" ${testExtraFlagsPSA})
 else()
   MESSAGE(WARNING "BMv2 PSA switch is not available, not adding PSA BMv2 tests")
+endif()
+
+if (HAVE_PNA_NIC)
+  p4c_add_tests("bmv2" ${BMV2_DRIVER} "${BMV2_PNA_TEST_SUITES}" "${XFAIL_TESTS}" ${testExtraFlagsPNA})
+else()
+  MESSAGE(WARNING "BMv2 PNA switch is not available, not adding PNA BMv2 tests")
 endif()
 
 set (GTEST_BMV2_SOURCES

--- a/backends/bmv2/pna_nic/midend.cpp
+++ b/backends/bmv2/pna_nic/midend.cpp
@@ -76,6 +76,7 @@ class PnaEnumOn32Bits : public P4::ChooseEnumRepresentation {
     bool convert(const IR::Type_Enum *type) const override {
         if (type->name == "PNA_PacketPath_t") return true;
         if (type->name == "PNA_MeterColor_t") return true;
+        if (type->name == "PNA_Direction_t") return true;
         if (type->srcInfo.isValid()) {
             auto sourceFile = type->srcInfo.getSourceFile();
             if (sourceFile.endsWith(filename))

--- a/backends/bmv2/portable_common/portable.cpp
+++ b/backends/bmv2/portable_common/portable.cpp
@@ -222,6 +222,10 @@ cstring PortableCodeGenerator::convertHashAlgorithm(cstring algo) {
     if (algo == "IDENTITY") {
         return "identity"_cs;
     }
+    // Target default chosen to be crc16
+    if (algo == "TARGET_DEFAULT") {
+        return "crc16"_cs;
+    }
 
     return nullptr;
 }

--- a/backends/bmv2/run-bmv2-test.py
+++ b/backends/bmv2/run-bmv2-test.py
@@ -84,6 +84,7 @@ PARSER.add_argument(
     help="replace reference outputs with newly generated ones",
 )
 PARSER.add_argument("-p", "--use_psa", dest="use_psa", action="store_true", help="Use psa switch")
+PARSER.add_argument("--use_pna", dest="use_pna", action="store_true", help="Use pna nic")
 PARSER.add_argument(
     "-bd",
     "--buildir",
@@ -250,6 +251,8 @@ def process_file(options: Options) -> int:
 
     if options.use_psa:
         binary = options.compiler_build_dir.joinpath("p4c-bm2-psa")
+    elif options.use_pna:
+        binary = options.compiler_build_dir.joinpath("p4c-bm2-pna")
     else:
         binary = options.compiler_build_dir.joinpath("p4c-bm2-ss")
 
@@ -359,6 +362,7 @@ def create_options(test_args: Any) -> Optional[Options]:
     for init_cmd in test_args.init_cmds:
         options.init_commands.append(init_cmd)
     options.use_psa = test_args.use_psa
+    options.use_pna = test_args.use_pna
     if test_args.pp:
         options.compiler_options.append(test_args.pp)
     if test_args.gdb:


### PR DESCRIPTION
BMv2 PNA fixes:
* Convert `PNA_Direction_t` to a 32b value. (`PNA_Direction_t` is defined in p4include/pna.p4 but not p4include/bmv2/pna.p4)
* Convert TARGET_DEFAULT to CRC16 for the hash algorithm.

Enable some PNA tests in ctest

Note: There are currently multiple versions of pna.p4 that differ from one another (p4include/pna.p4, p4include/bmv2/pna.p4, p4include/tc/pna.p4 and p4include/dpdk/pna.p4). This PR attempts to provide some base-level compatibility with the p4include/pna.p4 file.