### PR TITLE
[Generator] Add an explicit modifier to the IR generator.

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -66,6 +66,7 @@ jobs:
                 "[frontend]":"core",
                 "[midend]":"core",
                 "[parser]":"core",
+                "[generator]":"core",
               };
             } else {
               // PR label mappings (only the ones you want for PRs)
@@ -74,6 +75,7 @@ jobs:
                 "[infra]": "infrastructure",
                 "[midend]":"core",
                 "[parser]":"core",
+                "[generator]":"core",
                 "[dpdk]": "dpdk",  
                 "[p4-spec]": "p4-spec",
                 "[tofino]":"tofino",

--- a/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tofino1_only/tna_varbit_extract.p4
+++ b/backends/p4tools/modules/testgen/targets/tofino/test/p4-programs/tofino1_only/tna_varbit_extract.p4
@@ -1,0 +1,85 @@
+#include <tna.p4>
+
+header foo_t {
+    varbit<32> foo;
+}
+struct headers {
+    foo_t foo;
+}
+struct ingress_metadata_t {}
+struct egress_headers_t {}
+struct egress_metadata_t {}
+
+
+parser ig_prs(
+    packet_in pkt,
+    out headers hdr,
+    out ingress_metadata_t ig_md,
+    out ingress_intrinsic_metadata_t ig_intr_md)
+{
+    state start {
+        transition foo;
+    }
+
+    state foo {
+        pkt.extract(hdr.foo, (bit<32>)8);
+        transition accept;
+    }
+}
+
+control ig_ctl(
+    inout headers hdr, inout ingress_metadata_t ig_md,
+    in ingress_intrinsic_metadata_t ig_intr_md,
+    in ingress_intrinsic_metadata_from_parser_t ig_prsr_md,
+    inout ingress_intrinsic_metadata_for_deparser_t ig_dprsr_md,
+    inout ingress_intrinsic_metadata_for_tm_t ig_tm_md)
+{
+    apply {
+    }
+}
+
+control ig_dprs(
+    packet_out pkt,
+    inout headers hdr,
+    in ingress_metadata_t ig_md,
+    in ingress_intrinsic_metadata_for_deparser_t ig_dprsr_md)
+{
+    apply {
+    }
+}
+
+parser eg_prs(
+    packet_in pkt,
+    out egress_headers_t eg_hdr, out egress_metadata_t eg_md,
+    out egress_intrinsic_metadata_t eg_intr_md)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control eg_ctl(
+    inout egress_headers_t eg_hdr, inout egress_metadata_t eg_md,
+    in egress_intrinsic_metadata_t eg_intr_md,
+    in egress_intrinsic_metadata_from_parser_t eg_prsr_md,
+    inout egress_intrinsic_metadata_for_deparser_t eg_dprsr_md,
+    inout egress_intrinsic_metadata_for_output_port_t eg_oport_md)
+{
+    apply {
+    }
+}
+
+control eg_dprs(
+    packet_out pkt,
+    inout egress_headers_t eg_hdr, in egress_metadata_t eg_md,
+    in egress_intrinsic_metadata_for_deparser_t eg_dprsr_md)
+{
+    apply {
+    }
+}
+    
+Pipeline(
+    ig_prs(), ig_ctl(), ig_dprs(),
+    eg_prs(), eg_ctl(), eg_dprs()) pipe;
+
+Switch(pipe) main;

--- a/backends/tofino/bf-p4c/midend/desugar_varbit_extract.h
+++ b/backends/tofino/bf-p4c/midend/desugar_varbit_extract.h
@@ -123,7 +123,7 @@ class AnnotateVarbitExtractStates : public Transform {
             if (!method) continue;
 
             if (method->member == "extract" && call->arguments->size() == 2) {
-                state->addOrReplaceAnnotation("dontmerge"_cs, {});
+                state->addOrReplaceAnnotation(new IR::Annotation("dontmerge"_cs, {}));
                 break;
             }
         }

--- a/ir/base.def
+++ b/ir/base.def
@@ -242,7 +242,7 @@ class Annotation {
     inline Annotation(Util::SourceInfo si, ID n,
                       std::initializer_list<const Expression *> a, bool structured = false)
         : Node(si), name(n), body(a), structured(structured) {}
-    inline Annotation(Util::SourceInfo si, ID n,
+    inline explicit Annotation(Util::SourceInfo si, ID n,
                       const Expression *a, bool structured = false)
         : Node(si), name(n), body(), structured(structured) {
         body.emplace<ExpressionAnnotation>(a);
@@ -252,7 +252,7 @@ class Annotation {
     inline Annotation(Util::SourceInfo si, ID n, const IndexedVector<NamedExpression> &kv,
                       bool structured = false)
         : Node(si), name(n), body(kv), structured(structured) {}
-    inline Annotation(ID n, const Expression *a, bool structured = false)
+    inline explicit Annotation(ID n, const Expression *a, bool structured = false)
         : name(n), body(), structured(structured) {
         body.emplace<ExpressionAnnotation>(a);
     }
@@ -445,6 +445,12 @@ interface IAnnotated {
     inline void addOrReplaceAnnotation(Annotation ann) {
         Annotations::addOrReplace(getAnnotations(), ann);
     }
+#emit
+    // FIXME: We shouldn't need this delete.
+    // Ideally, we only accept references to expressions.
+    void addOrReplaceAnnotation(cstring name, std::nullptr_t expr, bool structured = false) = delete;
+    void addAnnotation(cstring name, std::nullptr_t expr, bool structured = false) = delete;
+#end
 }
 
 interface IInstance {

--- a/tools/ir-generator/ir-generator-lex.l
+++ b/tools/ir-generator/ir-generator-lex.l
@@ -72,6 +72,7 @@ static std::string      comment_block;
 "delete"        { return DELETE; }
 "enum"          { return ENUM; }
 "inline"        { return INLINE; }
+"explicit"      { return EXPLICIT; }
 "interface"     { return INTERFACE; }
 "namespace"     { return NAMESPACE; }
 "new"           { return NEW; }

--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -79,8 +79,9 @@ static IrNamespace *current_namespace = LookupScope().resolve(0);
     }                           emit;
 }
 
-%token          ABSTRACT APPLY CLASS CONST DBLCOL DEFAULT DELETE ENUM INLINE INTERFACE NAMESPACE
-                NEW NULLOK OPERATOR OPTIONAL PRIVATE PROTECTED PUBLIC STATIC VARIANT VIRTUAL
+%token          ABSTRACT APPLY CLASS CONST DBLCOL DEFAULT DELETE ENUM INLINE EXPLICIT
+                INTERFACE NAMESPACE NEW NULLOK OPERATOR OPTIONAL PRIVATE PROTECTED
+                PUBLIC STATIC VARIANT VIRTUAL
 %token<str>     BLOCK COMMENTBLOCK IDENTIFIER INCLUDE INTEGER NO STRING ZERO
 %token<emit>    EMITBLOCK
 
@@ -255,9 +256,11 @@ method
           { if ($2 != $<irClass>0->name)
                 yyerror("constructor name %s doesn't match class name %s", $2.c_str(),
                         $<irClass>0->name.c_str());
-            if ($1 & ~IrField::Inline)
+            if ($1 & ~(IrField::Inline | IrField::Explicit))
                 yyerror("%s invalid on constructor", IrElement::modifier($1));
-            ($<irMethod>$ = new IrMethod(@2, $2))->inImpl = !($1 & IrField::Inline);
+            $<irMethod>$ = new IrMethod(@2, $2);
+            $<irMethod>$->inImpl = !($1 & IrField::Inline);
+            $<irMethod>$->isExplicit = ($1 & IrField::Explicit);
             $<irMethod>$->clss = $<irClass>0; }
       optArgList { BEGIN(PARSE_CTOR_INIT); } ')' body
           { ($$ = $<irMethod>4)->body = $8;
@@ -341,6 +344,7 @@ irField
 modifier
     : NULLOK    { $$ = IrElement::NullOK; }
     | INLINE    { $$ = IrElement::Inline; }
+    | EXPLICIT  { $$ = IrElement::Explicit; }
     | OPTIONAL  { $$ = IrElement::Optional; }
     | STATIC    { $$ = IrElement::Static; }
     | VIRTUAL   { $$ = IrElement::Virtual; }

--- a/tools/ir-generator/irclass.cpp
+++ b/tools/ir-generator/irclass.cpp
@@ -359,6 +359,7 @@ void IrMethod::generate_hdr(std::ostream &out) const {
     if (isStatic) out << "static ";
     if (isVirtual) out << "virtual ";
     if (isFriend) out << "friend ";
+    if (isExplicit) out << "explicit ";
     generate_proto(out, false, isUser);
     if (isOverride) out << " override";
     if (inImpl || !body)

--- a/tools/ir-generator/irclass.h
+++ b/tools/ir-generator/irclass.h
@@ -96,6 +96,7 @@ class IrElement : public Util::IHasSourceInfo {
         Virtual = 1 << 3,
         Static = 1 << 4,
         Const = 1 << 5,
+        Explicit = 1 << 6,
     };
     static inline const char *modifier(int m) {
         if (m & IrElement::NullOK) return "NullOK";
@@ -104,6 +105,7 @@ class IrElement : public Util::IHasSourceInfo {
         if (m & IrElement::Static) return "static";
         if (m & IrElement::Inline) return "inline";
         if (m & IrElement::Const) return "const";
+        if (m & IrElement::Explicit) return "explicit";
         return "";
     }
 };
@@ -129,7 +131,7 @@ class IrMethod : public IrElement {
     std::vector<const IrField *> args;
     cstring body;
     bool inImpl = false, isConst = false, isOverride = false, isStatic = false, isVirtual = false,
-         isUser = false, isFriend = false;
+         isUser = false, isFriend = false, isExplicit = false;
     IrMethod(Util::SourceInfo info, cstring name, cstring body)
         : IrElement(info), name(name), body(body) {}
     IrMethod(Util::SourceInfo info, cstring name) : IrElement(info), name(name) {}


### PR DESCRIPTION
Use this modifier to make sure we can not pass `{}` to constructors.