### PR TITLE
[bmv2]: support Random extern for psa/pna

### DIFF
--- a/backends/bmv2/CMakeLists.txt
+++ b/backends/bmv2/CMakeLists.txt
@@ -230,7 +230,6 @@ set (XFAIL_TESTS
   testdata/p4_16_samples/psa-example-parser-checksum.p4 # error: error.NoError: unsupported exact key expression
   testdata/p4_16_samples/psa-meter4.p4 # Compiler Bug: backends/bmv2/portable_common/portable.cpp:574: Null info
   testdata/p4_16_samples/psa-meter5.p4 # Compiler Bug: backends/bmv2/portable_common/portable.cpp:574: Null info
-  testdata/p4_16_samples/psa-random.p4 # vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
   testdata/p4_16_samples/psa-table-hit-miss.p4 # error: Program can not be implemented on this target since it
                                                # contains a path from table MyIC.tbl back to itself
   # This reads stack.next

--- a/backends/bmv2/common/action.cpp
+++ b/backends/bmv2/common/action.cpp
@@ -56,10 +56,19 @@ void ActionConverter::convertActionBody(const IR::Vector<IR::StatOrDecl> *body,
                 auto mi = P4::MethodInstance::resolve(mce, ctxt->refMap, ctxt->typeMap);
                 auto em = mi->to<P4::ExternMethod>();
                 if (em != nullptr) {
-                    if ((em->originalExternType->name.name == "Register" ||
-                         em->method->name.name == "read") ||
-                        (em->originalExternType->name.name == "Meter" &&
-                         em->method->name.name == "execute")) {
+                    if (em->originalExternType->name.name == "Random" &&
+                        em->method->name.name == "read") {
+                        isR = true;
+                        auto dest = new IR::Argument(l);
+                        auto args = new IR::Vector<IR::Argument>();
+                        args->push_back(dest);  // dest
+                        mce2 = new IR::MethodCallExpression(mce->method, mce->typeArguments);
+                        mce2->arguments = args;
+                        s = new IR::MethodCallStatement(mce);
+                    } else if ((em->originalExternType->name.name == "Register" ||
+                                em->method->name.name == "read") ||
+                               (em->originalExternType->name.name == "Meter" &&
+                                em->method->name.name == "execute")) {
                         isR = true;
                         // l = l->to<IR::PathExpression>();
                         // BUG_CHECK(l != nullptr, "register_read dest cast failed");

--- a/backends/bmv2/portable_common/portable.cpp
+++ b/backends/bmv2/portable_common/portable.cpp
@@ -335,20 +335,21 @@ Util::IJson *ExternConverter_Random::convertExternObject(UNUSED ConversionContex
                                                          UNUSED const IR::MethodCallExpression *mc,
                                                          UNUSED const IR::StatOrDecl *s,
                                                          UNUSED const bool &emitExterns) {
-    if (mc->arguments->size() != 3) {
-        modelError("Expected 3 arguments for %1%", mc);
+    if (mc->arguments->size() != 1) {
+        modelError("Expected 1 argument for %1%", mc);
         return nullptr;
     }
     auto primitive = mkPrimitive("modify_field_rng_uniform"_cs);
     auto params = mkParameters(primitive);
     primitive->emplace_non_null("source_info"_cs, em->method->sourceInfoJsonObj());
     auto dest = ctxt->conv->convert(mc->arguments->at(0)->expression);
-    /* TODO */
-    // auto lo = ctxt->conv->convert(mc->arguments->at(1)->expression);
-    // auto hi = ctxt->conv->convert(mc->arguments->at(2)->expression);
+    // Get low/high values from the declaration instance
+    auto di = em->object->to<IR::Declaration_Instance>();
+    auto lo = ctxt->conv->convert(di->arguments->at(0)->expression);
+    auto hi = ctxt->conv->convert(di->arguments->at(1)->expression);
     params->append(dest);
-    // params->append(lo);
-    // params->append(hi);
+    params->append(lo);
+    params->append(hi);
     return primitive;
 }
 


### PR DESCRIPTION
Fix the following error with PSA/PNA Random:
```
vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
```