### PR TITLE
[#5211] Run `UniqueNames` before `SimplifyParsers` pass

### DIFF
--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -211,9 +211,12 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         new SwitchAddDefault,
         new FrontEndDump(),  // used for testing the program at this point
         new RemoveAllUnusedDeclarations(*policy, true),
+        // Give each local declaration a unique internal name.
+        // Must run before SimplifyParsers, which may merge adjacent states that
+        // contain same-named state-local variables.
+        new UniqueNames(),
         new SimplifyParsers(),
         new ResetHeaders(&typeMap),
-        new UniqueNames(),       // Give each local declaration a unique internal name
         new MoveDeclarations(),  // Move all local declarations to the beginning
         new MoveInitializers(),
         new SideEffectOrdering(&typeMap, policy->skipSideEffectOrdering()),

--- a/frontends/p4/simplifyParsers.h
+++ b/frontends/p4/simplifyParsers.h
@@ -29,6 +29,9 @@ namespace P4 {
  *  - there are no other outgoing edges from ```s1```,
  *  - there are no other incoming edges to ```s2```,
  *  - and ```s2``` does not have annotations.
+ *
+ * Note that UniqueNames must run before this pass, so that we won't end up
+ * with same-named state-local variables in the same state.
  */
 class SimplifyParsers : public Transform {
  public:

--- a/testdata/p4_16_samples/issue5211_simplify_parsers_dup_state_local_var_decl.p4
+++ b/testdata/p4_16_samples/issue5211_simplify_parsers_dup_state_local_var_decl.p4
@@ -1,0 +1,26 @@
+#include <core.p4>
+
+struct S {
+    bit<16> f1;
+    bit<8> f2;
+}
+
+parser p(packet_in p, out S s) {
+    state start { transition s0; }
+    state s0 {
+        bit<16> local = p.lookahead<bit<16>>();
+        s.f1 = local;
+        transition s1;
+    }
+    state s1 {
+        bit<8> local = p.lookahead<bit<8>>();
+        s.f2 = local;
+        transition s2;
+    }
+    state s2 { transition accept; }
+}
+
+parser simple(packet_in packet, out S s);
+package top(simple e);
+top(p()) main;
+

--- a/testdata/p4_16_samples_outputs/issue2176-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2176-bmv2.p4-stderr
@@ -12,10 +12,10 @@ issue2176-bmv2.p4(43): [--Wwarn=ordering] warning: h.h.b: 'out' argument has fie
                            ^^^^^
 issue2176-bmv2.p4(43)
         do_action_2(h.h.b, h.h.b, h.h.b);
-                    ^^^^^
+                                  ^^^^^
 issue2176-bmv2.p4(43): [--Wwarn=ordering] warning: h.h.b: 'out' argument has fields in common with h.h.b
         do_action_2(h.h.b, h.h.b, h.h.b);
                                   ^^^^^
 issue2176-bmv2.p4(43)
         do_action_2(h.h.b, h.h.b, h.h.b);
-                    ^^^^^
+                           ^^^^^

--- a/testdata/p4_16_samples_outputs/issue5211_simplify_parsers_dup_state_local_var_decl-first.p4
+++ b/testdata/p4_16_samples_outputs/issue5211_simplify_parsers_dup_state_local_var_decl-first.p4
@@ -1,0 +1,29 @@
+#include <core.p4>
+
+struct S {
+    bit<16> f1;
+    bit<8>  f2;
+}
+
+parser p(packet_in p, out S s) {
+    state start {
+        transition s0;
+    }
+    state s0 {
+        bit<16> local = p.lookahead<bit<16>>();
+        s.f1 = local;
+        transition s1;
+    }
+    state s1 {
+        bit<8> local = p.lookahead<bit<8>>();
+        s.f2 = local;
+        transition s2;
+    }
+    state s2 {
+        transition accept;
+    }
+}
+
+parser simple(packet_in packet, out S s);
+package top(simple e);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/issue5211_simplify_parsers_dup_state_local_var_decl-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue5211_simplify_parsers_dup_state_local_var_decl-frontend.p4
@@ -1,0 +1,22 @@
+#include <core.p4>
+
+struct S {
+    bit<16> f1;
+    bit<8>  f2;
+}
+
+parser p(packet_in p, out S s) {
+    @name("p.local") bit<16> local_0;
+    @name("p.local") bit<8> local_1;
+    state start {
+        local_0 = p.lookahead<bit<16>>();
+        s.f1 = local_0;
+        local_1 = p.lookahead<bit<8>>();
+        s.f2 = local_1;
+        transition accept;
+    }
+}
+
+parser simple(packet_in packet, out S s);
+package top(simple e);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/issue5211_simplify_parsers_dup_state_local_var_decl-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue5211_simplify_parsers_dup_state_local_var_decl-midend.p4
@@ -1,0 +1,22 @@
+#include <core.p4>
+
+struct S {
+    bit<16> f1;
+    bit<8>  f2;
+}
+
+parser p(packet_in p, out S s) {
+    @name("p.local") bit<16> local_0;
+    @name("p.local") bit<8> local_1;
+    state start {
+        local_0 = p.lookahead<bit<16>>();
+        s.f1 = local_0;
+        local_1 = p.lookahead<bit<8>>();
+        s.f2 = local_1;
+        transition accept;
+    }
+}
+
+parser simple(packet_in packet, out S s);
+package top(simple e);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/issue5211_simplify_parsers_dup_state_local_var_decl.p4
+++ b/testdata/p4_16_samples_outputs/issue5211_simplify_parsers_dup_state_local_var_decl.p4
@@ -1,0 +1,29 @@
+#include <core.p4>
+
+struct S {
+    bit<16> f1;
+    bit<8>  f2;
+}
+
+parser p(packet_in p, out S s) {
+    state start {
+        transition s0;
+    }
+    state s0 {
+        bit<16> local = p.lookahead<bit<16>>();
+        s.f1 = local;
+        transition s1;
+    }
+    state s1 {
+        bit<8> local = p.lookahead<bit<8>>();
+        s.f2 = local;
+        transition s2;
+    }
+    state s2 {
+        transition accept;
+    }
+}
+
+parser simple(packet_in packet, out S s);
+package top(simple e);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/issue5211_simplify_parsers_dup_state_local_var_decl.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue5211_simplify_parsers_dup_state_local_var_decl.p4-stderr
@@ -1,0 +1,6 @@
+issue5211_simplify_parsers_dup_state_local_var_decl.p4(8): [--Wwarn=shadow] warning: 'p' shadows 'parser p'
+parser p(packet_in p, out S s) {
+                   ^
+issue5211_simplify_parsers_dup_state_local_var_decl.p4(8)
+parser p(packet_in p, out S s) {
+       ^


### PR DESCRIPTION
Fixes #5211 by renaming all state-local variables with equal names before merging states in `SimplifyParsers`