### PR TITLE
[Tofino] Ensure get_schema_version can run without jsl.

### DIFF
--- a/backends/tofino/CMakeLists.txt
+++ b/backends/tofino/CMakeLists.txt
@@ -53,6 +53,8 @@ endif()
 set(BOOST_MIN_VERSION "1.58.0")
 find_package(Boost ${BOOST_MIN_VERSION} REQUIRED)
 
+set(INTERFACES_DIR ${BFN_P4C_SOURCE_DIR}/compiler_interfaces)
+
 # Get the version from bf-p4c/version.h
 file (STRINGS "${BFN_P4C_SOURCE_DIR}/bf-p4c/version.h"
   __version
@@ -90,31 +92,28 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/git_sha_version.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/bf-p4c/git_sha_version.h" @ONLY)
 
 
-macro(get_schema_version schema_file schema_var)
-  execute_process(
-    COMMAND python3 -c "from ${schema_file} import get_schema_version;print(get_schema_version(), end='', flush=True)"
-    OUTPUT_VARIABLE __schema_version
-    RESULT_VARIABLE __schema_errcode
-    ERROR_VARIABLE __schema_errstr
-    WORKING_DIRECTORY ${BFN_P4C_SOURCE_DIR}/compiler_interfaces/schemas)
-  if (${__schema_errcode})
-    MESSAGE(FATAL_ERROR "Error retrieving ${schema_file} version ${__schema_errstr}")
-  endif()
-  set(${schema_var} ${__schema_version})
-endmacro(get_schema_version)
-# Now force cmake to rerun if any of the files that we depend on versions for
-# change: context and manifest for now
-# We generate a pair of dummy dependency files will be ignored
-set(SCHEMA_FILES
-  compiler_interfaces/schemas/context_schema.py
-  compiler_interfaces/schemas/manifest_schema.py
-  compiler_interfaces/schemas/phv_schema.py
-  compiler_interfaces/schemas/power_schema.py
-  compiler_interfaces/schemas/resources_schema.py
-  )
-foreach (f ${SCHEMA_FILES})
-  configure_file(${BFN_P4C_SOURCE_DIR}/${f} ${CMAKE_BINARY_DIR}/${f}.dep)
-endforeach()
+function(get_schema_version SCHEMA_FILE OUTPUT_VAR)
+    set(SCHEMA_PATH "${INTERFACES_DIR}/schemas/${SCHEMA_FILE}.py")
+    if(NOT EXISTS "${SCHEMA_PATH}")
+        message(SEND_ERROR "Schema file not found: ${SCHEMA_PATH}")
+    endif()
+
+    file(READ "${SCHEMA_PATH}" file_content)
+
+    string(REGEX MATCH "major_version[ \t]*=[ \t]*([0-9]+)" _ "${file_content}")
+    set(major_version "${CMAKE_MATCH_1}")
+    string(REGEX MATCH "minor_version[ \t]*=[ \t]*([0-9]+)" _ "${file_content}")
+    set(minor_version "${CMAKE_MATCH_1}")
+    string(REGEX MATCH "patch_version[ \t]*=[ \t]*([0-9]+)" _ "${file_content}")
+    set(patch_version "${CMAKE_MATCH_1}")
+    if(NOT DEFINED major_version OR major_version STREQUAL ""
+       OR NOT DEFINED minor_version OR minor_version STREQUAL ""
+       OR NOT DEFINED patch_version OR patch_version STREQUAL "")
+        message(SEND_ERROR "Failed to parse version from ${VERSION_FILE}")
+    endif()
+
+    set(${OUTPUT_VAR} "${major_version}.${minor_version}.${patch_version}" PARENT_SCOPE)
+endfunction()
 
 if (ENABLE_WERROR)
   # fixme: we do want implicit-fallthrough to be an error, but we have to

--- a/backends/tofino/bf-asm/CMakeLists.txt
+++ b/backends/tofino/bf-asm/CMakeLists.txt
@@ -51,18 +51,6 @@ if (ENABLE_BAREFOOT_INTERNAL)
 endif()
 
 message(STATUS "P4C ${P4C_SOURCE_DIR}")
-macro(get_schema_version schema_file schema_var)
-  execute_process(
-    COMMAND python3 -c "from ${schema_file} import get_schema_version;print(get_schema_version(), end='', flush=True)"
-    OUTPUT_VARIABLE __schema_version
-    RESULT_VARIABLE __schema_errcode
-    ERROR_VARIABLE __schema_errstr
-    WORKING_DIRECTORY ${BFN_P4C_SOURCE_DIR}/compiler_interfaces/schemas)
-  if (${__schema_errcode})
-    MESSAGE(FATAL_ERROR "Error retrieving ${schema_file} version ${__schema_errstr}")
-  endif()
-  set(${schema_var} ${__schema_version})
-endmacro(get_schema_version)
 # Now force cmake to rerun if any of the files that we depend on versions for
 # change: context and manifest for now
 # We generate a pair of dummy dependency files will be ignored

--- a/backends/tofino/bf-p4c/CMakeLists.txt
+++ b/backends/tofino/bf-p4c/CMakeLists.txt
@@ -42,12 +42,12 @@ endif()
 # Note that we need to do this early, before we process any of the rules
 # using schemas (context, manifest, phv, etc.) and packaging the compiler
 # interfaces tools.
-set (INTERFACES_DIR ${BFN_P4C_SOURCE_DIR}/compiler_interfaces)
 set(COMPILER_SCHEMA_TARGETS "${INTERFACES_DIR}/schemas/targets.py")
 set(DEFAULT_SCHEMA_TARGETS "['tofino', 'tofino2', 'tofino2m', 'tofino2u', 'tofino2a0']")
 set(DEFAULT_SCHEMA_P4ARCH "['tna', 't2na', 'psa', 'PISA', 'v1model']")
 file(WRITE ${COMPILER_SCHEMA_TARGETS} "TARGETS = ${DEFAULT_SCHEMA_TARGETS}\n")
 file(APPEND ${COMPILER_SCHEMA_TARGETS} "P4ARCHITECTURES = ${DEFAULT_SCHEMA_P4ARCH}\n")
+
 
 get_schema_version(manifest_schema MANIFEST_SCHEMA_VERSION)
 MESSAGE(STATUS "Found manifest schema version ${MANIFEST_SCHEMA_VERSION}")
@@ -729,12 +729,16 @@ if (EXISTS ${COMPILER_SCHEMA_TARGETS})
   list(APPEND SCHEMA_FILES ${COMPILER_SCHEMA_TARGETS})
 endif()
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist/p4c-build-logs
-  POST_BUILD
-  COMMAND PYTHONPATH=${INTERFACES_DIR}:$ENV{PYTHONPATH} pyinstaller --workpath=${CMAKE_CURRENT_BINARY_DIR}/build --distpath=${CMAKE_CURRENT_BINARY_DIR}/dist ${INTERFACES_DIR}/p4c-build-logs.spec
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist/p4c-build-logs
+  COMMAND PYTHONPATH=${INTERFACES_DIR}:$ENV{PYTHONPATH} pyinstaller
+          --workpath=${CMAKE_CURRENT_BINARY_DIR}/build
+          --distpath=${CMAKE_CURRENT_BINARY_DIR}/dist
+          ${INTERFACES_DIR}/p4c-build-logs.spec
   DEPENDS ${LOGGING_FILES} ${SCHEMA_FILES} ${INTERFACES_DIR}/p4c-build-logs.spec
   WORKING_DIRECTORY ${INTERFACES_DIR}
-  COMMENT "Package logging tools")
+  COMMENT "Packaging logging tools"
+)
 
 add_custom_target(p4c-build-logs
   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/dist/p4c-build-logs)

--- a/backends/tofino/compiler_interfaces/p4c-build-logs.spec
+++ b/backends/tofino/compiler_interfaces/p4c-build-logs.spec
@@ -6,7 +6,7 @@ import os.path, sys
 block_cipher = None
 
 a = Analysis(['p4c-build-logs'],
-             # pathex=['tools'],
+             pathex=['tools'],
              binaries=None, # cython_mods,
              datas=[ ('schemas/*.py', 'schemas')],
              # hiddenimports=[],

--- a/backends/tofino/compiler_interfaces/pyproject.toml
+++ b/backends/tofino/compiler_interfaces/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "compiler-interfaces"
+version = "0.1.0"
+description = "Compiler interfaces for Tofino"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "jsl>=0.2.4",
+    "jsonschema==2.6.0",
+    "pyinstaller>=6.12.0",
+]

--- a/backends/tofino/compiler_interfaces/schemas/bfrt_schema.py
+++ b/backends/tofino/compiler_interfaces/schemas/bfrt_schema.py
@@ -35,12 +35,12 @@ Version Notes:
 """
 
 major_version = 1
-medium_version = 5
-minor_version = 1
+minor_version = 5
+patch_version = 1
 
 
 def get_schema_version():
-    return "%s.%s.%s" % (str(major_version), str(medium_version), str(minor_version))
+    return "%s.%s.%s" % (str(major_version), str(minor_version), str(patch_version))
 
 
 ########################################################

--- a/backends/tofino/compiler_interfaces/schemas/context_schema.py
+++ b/backends/tofino/compiler_interfaces/schemas/context_schema.py
@@ -150,12 +150,12 @@ Version Notes:
 """
 
 major_version = 1
-medium_version = 12
-minor_version = 4
+minor_version = 12
+patch_version = 4
 
 
 def get_schema_version():
-    return "%s.%s.%s" % (str(major_version), str(medium_version), str(minor_version))
+    return "%s.%s.%s" % (str(major_version), str(minor_version), str(patch_version))
 
 
 ########################################################

--- a/backends/tofino/compiler_interfaces/schemas/jgf_schema.py
+++ b/backends/tofino/compiler_interfaces/schemas/jgf_schema.py
@@ -21,12 +21,12 @@ Version notes:
 """
 
 major_version = 1
-revision_version = 0  # (medium version)
-addition_version = 0  # (minor version)
+minor_version = 0
+patch_version = 0
 
 
 def get_schema_version():
-    return "%s.%s.%s" % (str(major_version), str(revision_version), str(addition_version))
+    return "%s.%s.%s" % (str(major_version), str(minor_version), str(patch_version))
 
 
 ########################################################

--- a/backends/tofino/compiler_interfaces/schemas/mau_schema.py
+++ b/backends/tofino/compiler_interfaces/schemas/mau_schema.py
@@ -21,12 +21,12 @@ Version Notes:
 """
 
 major_version = 1
-medium_version = 0
 minor_version = 0
+patch_version = 0
 
 
 def get_schema_version():
-    return "%s.%s.%s" % (str(major_version), str(medium_version), str(minor_version))
+    return "%s.%s.%s" % (str(major_version), str(minor_version), str(patch_version))
 
 
 ########################################################

--- a/backends/tofino/compiler_interfaces/schemas/metrics_schema.py
+++ b/backends/tofino/compiler_interfaces/schemas/metrics_schema.py
@@ -46,12 +46,12 @@ Version Notes:
 """
 
 major_version = 1
-medium_version = 1
-minor_version = 0
+minor_version = 1
+patch_version = 0
 
 
 def get_schema_version():
-    return "%s.%s.%s" % (str(major_version), str(medium_version), str(minor_version))
+    return "%s.%s.%s" % (str(major_version), str(minor_version), str(patch_version))
 
 
 ########################################################

--- a/backends/tofino/compiler_interfaces/schemas/phv_schema.py
+++ b/backends/tofino/compiler_interfaces/schemas/phv_schema.py
@@ -58,12 +58,12 @@ Version Notes:
 """
 
 major_version = 3
-medium_version = 0
 minor_version = 0
+patch_version = 0
 
 
 def get_schema_version():
-    return "%s.%s.%s" % (str(major_version), str(medium_version), str(minor_version))
+    return "%s.%s.%s" % (str(major_version), str(minor_version), str(patch_version))
 
 
 ########################################################

--- a/backends/tofino/compiler_interfaces/schemas/power_schema.py
+++ b/backends/tofino/compiler_interfaces/schemas/power_schema.py
@@ -23,12 +23,12 @@ Version Notes:
 """
 
 major_version = 1
-medium_version = 0
-minor_version = 1
+minor_version = 0
+patch_version = 1
 
 
 def get_schema_version():
-    return "%s.%s.%s" % (str(major_version), str(medium_version), str(minor_version))
+    return "%s.%s.%s" % (str(major_version), str(minor_version), str(patch_version))
 
 
 ########################################################

--- a/backends/tofino/compiler_interfaces/schemas/requirements.txt
+++ b/backends/tofino/compiler_interfaces/schemas/requirements.txt
@@ -1,2 +1,0 @@
-jsonschema==2.6.0
-jsl

--- a/backends/tofino/compiler_interfaces/schemas/resources_schema.py
+++ b/backends/tofino/compiler_interfaces/schemas/resources_schema.py
@@ -89,12 +89,12 @@ Version Notes:
 """
 
 major_version = 2
-medium_version = 4
-minor_version = 2
+minor_version = 4
+patch_version = 2
 
 
 def get_schema_version():
-    return "%s.%s.%s" % (str(major_version), str(medium_version), str(minor_version))
+    return "%s.%s.%s" % (str(major_version), str(minor_version), str(patch_version))
 
 
 """

--- a/backends/tofino/compiler_interfaces/schemas/source_info_schema.py
+++ b/backends/tofino/compiler_interfaces/schemas/source_info_schema.py
@@ -19,12 +19,12 @@ Initial version
 
 # versioning follows SchemaVer convention
 major_version = 1
-revision_version = 0
-addition_version = 0
+minor_version = 0
+patch_version = 0
 
 
 def get_schema_version():
-    return "%s.%s.%s" % (str(major_version), str(revision_version), str(addition_version))
+    return "%s.%s.%s" % (str(major_version), str(minor_version), str(patch_version))
 
 
 ########################################################

--- a/backends/tofino/compiler_interfaces/schemas/table_graph_schema.py
+++ b/backends/tofino/compiler_interfaces/schemas/table_graph_schema.py
@@ -18,12 +18,12 @@ from schemas.jgf_schema import Graph, GraphEdge, GraphNode, JsonGraphFormatSchem
 """
 
 major_version = 1  # (major)
-revision_version = 0  # (medium)
-addition_version = 1  # (minor)
+minor_version = 0  # (medium)
+patch_version = 1  # (minor)
 
 
 def get_schema_version():
-    return "%s.%s.%s" % (str(major_version), str(revision_version), str(addition_version))
+    return "%s.%s.%s" % (str(major_version), str(minor_version), str(patch_version))
 
 
 ########################################################


### PR DESCRIPTION
Fix an annoyance where `cmake` for Tofino can not be run without having pyinstaller installed. This is bothersome on Ubuntu 24.04, which requires the use of virtual environments. 