### PR TITLE
improve SideEffects and StrengthReduction

### DIFF
--- a/frontends/p4/simplify.cpp
+++ b/frontends/p4/simplify.cpp
@@ -75,7 +75,7 @@ const IR::Node *DoSimplifyControlFlow::postorder(IR::IfStatement *statement) {
         statement->ifTrue = e;
     }
 
-    if (SideEffects::check(statement->condition, this, this, typeMap, getChildContext()))
+    if (SideEffects::check(statement->condition, this, typeMap, getChildContext()))
         return statement;
     if (statement->ifTrue->is<IR::EmptyStatement>() &&
         (statement->ifFalse == nullptr || statement->ifFalse->is<IR::EmptyStatement>()))
@@ -104,7 +104,7 @@ const IR::Node *DoSimplifyControlFlow::postorder(IR::SwitchStatement *statement)
             LOG2("Removing switch statement " << statement << " keeping " << mce);
             return new IR::MethodCallStatement(statement->srcInfo, mce);
         }
-        if (SideEffects::check(statement->expression, this, this, typeMap, getChildContext()))
+        if (SideEffects::check(statement->expression, this, typeMap, getChildContext()))
             // This can happen if this pass is run before SideEffectOrdering.
             return statement;
         LOG2("Removing switch statement " << statement);

--- a/frontends/p4/simplifyDefUse.cpp
+++ b/frontends/p4/simplifyDefUse.cpp
@@ -1476,9 +1476,9 @@ class RemoveUnused : public Transform {
         if (!hasUses.hasUses(getOriginal())) {
             Log::TempIndent indent;
             LOG3("Removing statement " << getOriginal() << " " << statement << indent);
-            SideEffects se(refMap, typeMap);
+            SideEffects se(typeMap);
             se.setCalledBy(this);
-            (void)statement->right->apply(se);
+            (void)statement->right->apply(se, getChildContext());
 
             if (se.nodeWithSideEffect != nullptr) {
                 // We expect that at this point there can't be more than 1

--- a/frontends/p4/strengthReduction.cpp
+++ b/frontends/p4/strengthReduction.cpp
@@ -129,7 +129,7 @@ const IR::Node *DoStrengthReduction::postorder(IR::LAnd *expr) {
     if (isFalse(expr->left)) return expr->left;
     if (isTrue(expr->left)) return expr->right;
     if (isTrue(expr->right)) return expr->left;
-    // Note that remaining case is not simplified, due to possible side effects in expr->left
+    if (isFalse(expr->right) && !hasSideEffects(expr->left)) return expr->right;
     return expr;
 }
 
@@ -137,7 +137,7 @@ const IR::Node *DoStrengthReduction::postorder(IR::LOr *expr) {
     if (isFalse(expr->left)) return expr->right;
     if (isTrue(expr->left)) return expr->left;
     if (isFalse(expr->right)) return expr->left;
-    // Note that remaining case is not simplified, due to semantics of short-circuit evaluation
+    if (isTrue(expr->right) && !hasSideEffects(expr->left)) return expr->right;
     return expr;
 }
 

--- a/testdata/p4_16_samples_outputs/issue1985-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1985-first.p4
@@ -35,7 +35,7 @@ control c3(inout headers hdr, inout metadata meta, inout standard_metadata_t std
     }
     table t {
         actions = {
-            a(hdr.h.isValid() || true);
+            a(true);
             @defaultonly NoAction();
         }
         default_action = NoAction();

--- a/testdata/p4_16_samples_outputs/strength-first.p4
+++ b/testdata/p4_16_samples_outputs/strength-first.p4
@@ -35,9 +35,9 @@ control strength() {
         bool z;
         z = z;
         z = z;
-        z = z && false;
         z = false;
-        z = z || true;
+        z = false;
+        z = true;
         z = true;
         z = z;
         z = z;


### PR DESCRIPTION
* use ResolutionContext in P4::SideEffects so a refMap is not needed
* improve StrengthReduction of && and ||
  - A && false -> false iff A has no side effects
  - A || true -> true iff A has no side effects