### PR TITLE
Fix compile-time concatenation with negative right operand

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -800,7 +800,7 @@ const IR::Node *DoConstantFolding::postorder(IR::Concat *e) {
 
     // The concatenation result would be wrong if the negative value was used for the second
     // argument (because the big_int binary representation does not match what the P4 spec expects).
-    // Thereore, we convert the second argument to a unsigned literal with the same binary
+    // Therefore, we convert the second argument to a unsigned literal with the same binary
     // representation as the P4 mandates for the signed value and concatenate these.
     if (rt->isSigned) {
         rt = IR::Type_Bits::get(rt->size);

--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -805,13 +805,13 @@ const IR::Node *DoConstantFolding::postorder(IR::Concat *e) {
     big_int rvalue = right->value;
     if (rt->isSigned) {
         // Reuse conversion from Constant's ctor. Temporary Type & Constant -> allocate on stack.
-        IR::Type_Bits utype(rt->size, false);
+        IR::Type_Bits utype(rt->width_bits(), false);
         rvalue = IR::Constant(&utype, rvalue, 10, true /* no warning */).value;
     }
 
-    auto resultType = IR::Type_Bits::get(lt->size + rt->size, lt->isSigned);
+    auto resultType = IR::Type_Bits::get(lt->width_bits() + rt->width_bits(), lt->isSigned);
     if (overflowWidth(e, resultType->width_bits())) return e;
-    big_int value = (left->value << rt->size) | rvalue;
+    big_int value = (left->value << rt->width_bits()) | rvalue;
     return new IR::Constant(e->srcInfo, resultType, value, left->base);
 }
 

--- a/testdata/p4_16_samples/issue5231-const-int-concat.p4
+++ b/testdata/p4_16_samples/issue5231-const-int-concat.p4
@@ -1,0 +1,23 @@
+#include <core.p4>
+
+void positive() {
+    const int<7> a = 7s0b_010_0111;
+    const int<9> b = 9s0b_0_1110_0011;
+    const int<16> c = a ++ b;
+    const int<16> d = 7s0b_0100111 ++ 9s0b_011100011;
+    const int<16> e = 16s0b_010_0111_0_1110_0011;
+
+    static_assert(c == d);
+    static_assert(c == e);
+}
+
+void negative() {
+    const int<7> a = 7s0b_110_0111;
+    const int<9> b = 9s0b_1_1110_0011;
+    const int<16> c = a ++ b;
+    const int<16> d = 7s0b_1100111 ++ 9s0b_111100011;
+    const int<16> e = 16s0b_110_0111_1_1110_0011;
+
+    static_assert(c == d);
+    static_assert(c == e);
+}

--- a/testdata/p4_16_samples_outputs/issue5231-const-int-concat-first.p4
+++ b/testdata/p4_16_samples_outputs/issue5231-const-int-concat-first.p4
@@ -1,0 +1,16 @@
+#include <core.p4>
+
+void positive() {
+    const int<7> a = 7s0b100111;
+    const int<9> b = 9s0b11100011;
+    const int<16> c = 16s0b100111011100011;
+    const int<16> d = 16s0b100111011100011;
+    const int<16> e = 16s0b100111011100011;
+}
+void negative() {
+    const int<7> a = -7s0b11001;
+    const int<9> b = -9s0b11101;
+    const int<16> c = -16s0b11000000011101;
+    const int<16> d = -16s0b11000000011101;
+    const int<16> e = -16s0b11000000011101;
+}

--- a/testdata/p4_16_samples_outputs/issue5231-const-int-concat-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue5231-const-int-concat-frontend.p4
@@ -1,0 +1,2 @@
+#include <core.p4>
+

--- a/testdata/p4_16_samples_outputs/issue5231-const-int-concat-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue5231-const-int-concat-midend.p4
@@ -1,0 +1,2 @@
+#include <core.p4>
+

--- a/testdata/p4_16_samples_outputs/issue5231-const-int-concat.p4
+++ b/testdata/p4_16_samples_outputs/issue5231-const-int-concat.p4
@@ -1,0 +1,20 @@
+#include <core.p4>
+
+void positive() {
+    const int<7> a = 7s0b100111;
+    const int<9> b = 9s0b11100011;
+    const int<16> c = a ++ b;
+    const int<16> d = 7s0b100111 ++ 9s0b11100011;
+    const int<16> e = 16s0b100111011100011;
+    static_assert(c == d);
+    static_assert(c == e);
+}
+void negative() {
+    const int<7> a = -7s0b11001;
+    const int<9> b = -9s0b11101;
+    const int<16> c = a ++ b;
+    const int<16> d = -7s0b11001 ++ -9s0b11101;
+    const int<16> e = -16s0b11000000011101;
+    static_assert(c == d);
+    static_assert(c == e);
+}

--- a/testdata/p4_16_samples_outputs/issue5231-const-int-concat.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue5231-const-int-concat.p4-stderr
@@ -1,0 +1,16 @@
+issue5231-const-int-concat.p4(15): [--Wwarn=overflow] warning: 7s0b1100111: signed value does not fit in 7 bits
+    const int<7> a = 7s0b_110_0111
+                     ^^^^^^^^^^^^^
+issue5231-const-int-concat.p4(16): [--Wwarn=overflow] warning: 9s0b111100011: signed value does not fit in 9 bits
+    const int<9> b = 9s0b_1_1110_0011
+                     ^^^^^^^^^^^^^^^^
+issue5231-const-int-concat.p4(18): [--Wwarn=overflow] warning: 7s0b1100111: signed value does not fit in 7 bits
+    const int<16> d = 7s0b_1100111
+                      ^^^^^^^^^^^^
+issue5231-const-int-concat.p4(18): [--Wwarn=overflow] warning: 9s0b111100011: signed value does not fit in 9 bits
+    const int<16> d = 7s0b_1100111 ++ 9s0b_111100011
+                                      ^^^^^^^^^^^^^^
+issue5231-const-int-concat.p4(19): [--Wwarn=overflow] warning: 16s0b1100111111100011: signed value does not fit in 16 bits
+    const int<16> e = 16s0b_110_0111_1_1110_0011
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+[--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
Fixes #5231. The problem is most likely in the binary representation of the `big_int` for negative numbers. The solution is to always convert the right operand to a unsigned value with the same representation as does the signed value have.