### PR TITLE
Fix failing Fedora tests.

### DIFF
--- a/backends/ebpf/runtime/ebpf_common.h
+++ b/backends/ebpf/runtime/ebpf_common.h
@@ -19,7 +19,6 @@ limitations under the License.
  * It should be included with new target header files.
  */
 
-#include <stdio.h>          // printf
 #include <stdbool.h>        // true and false
 #include <linux/types.h>    // u8, u16, u32, u64
 
@@ -31,12 +30,3 @@ typedef signed int s32;
 typedef unsigned int u32;
 typedef signed long long s64;
 typedef unsigned long long u64;
-
-
-/// Helper function.
-/// Print a byte buffer according to the specified length.
-static inline void print_n_bytes(void *receiveBuffer, int num) {
-    for (int i = 0; i < num; i++)
-        printf("%02x", ((unsigned char *)receiveBuffer)[i]);
-    printf("\n");
-}

--- a/backends/ebpf/runtime/ebpf_kernel.h
+++ b/backends/ebpf/runtime/ebpf_kernel.h
@@ -23,8 +23,9 @@ limitations under the License.
 
 #include "ebpf_common.h"
 
-#include <bpf/bpf_endian.h> // definitions for bpf_ntohs etc...
+#include <stddef.h> // size_t
 
+#include <bpf/bpf_endian.h> // definitions for bpf_ntohs etc...
 #undef htonl
 #undef htons
 #define htons(d) bpf_htons(d)

--- a/backends/ebpf/runtime/ebpf_test.h
+++ b/backends/ebpf/runtime/ebpf_test.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include "ebpf_common.h"
 
 #include <endian.h>
+#include <stdio.h>          // printf
 
 /// define some byte order conversions, these mimic bpf_endian.h
 #define htonll(x) htobe64(x)
@@ -104,5 +105,12 @@ struct bpf_table tables[] = {
 extern struct bpf_table tables[];
 extern int ebpf_filter(struct sk_buff *skb);
 
+/// Helper function.
+/// Print a byte buffer according to the specified length.
+static inline void print_n_bytes(void *receiveBuffer, int num) {
+    for (int i = 0; i < num; i++)
+        printf("%02x", ((unsigned char *)receiveBuffer)[i]);
+    printf("\n");
+}
 
 #endif  // BACKENDS_EBPF_RUNTIME_EBPF_USER_H_

--- a/tools/install_fedora_deps.sh
+++ b/tools/install_fedora_deps.sh
@@ -15,6 +15,7 @@ if [ "$IN_DOCKER" == "TRUE" ]; then
 fi
 
 sudo dnf install -y -q \
+    awk \
     automake \
     bison \
     boost-devel \


### PR DESCRIPTION
- Install missing awk tool.
- Shuffle some includes around for the eBPF tests.

The PTF eBPF failure is unrelated. 