### PR TITLE
Fix missing <tuple> include in alloc.h causing compilation failure

### DIFF
--- a/backends/tofino/bf-p4c/common/alloc.h
+++ b/backends/tofino/bf-p4c/common/alloc.h
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 
 #include <stdexcept>
+#include <tuple>
 #include <utility>
 
 namespace BFN {


### PR DESCRIPTION
Fixes a compilation error on GCC 12+ where std::tuple<int, int, int> is used without including the <tuple> header.
```
In file included from /builddir/build/BUILD/p4c-1.2.5.5/backends/tofino/bf-p4c/mau/memories.h:24,
                 from /builddir/build/BUILD/p4c-1.2.5.5/backends/tofino/bf-p4c/mau/jbay_next_table.h:23,
                 from /builddir/build/BUILD/p4c-1.2.5.5/backends/tofino/bf-p4c/mau/jbay_next_table.cpp:19:
/builddir/build/BUILD/p4c-1.2.5.5/backends/tofino/bf-p4c/common/alloc.h:213:45: error: 'i' has incomplete type
  213 |     T &operator[](std::tuple<int, int, int> i) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^
In file included from /usr/include/c++/12/bits/stl_algobase.h:64,
                 from /usr/include/c++/12/vector:60,
                 from /builddir/build/BUILD/p4c-1.2.5.5/backends/tofino/bf-p4c/lib/dyn_vector.h:22,
                 from /builddir/build/BUILD/p4c-1.2.5.5/backends/tofino/bf-p4c/mau/jbay_next_table.h:22:
/usr/include/c++/12/bits/stl_pair.h:90:11: note: declaration of 'class std::tuple<int, int, int>'
   90 |     class tuple;
      |           ^~~~~
/builddir/build/BUILD/p4c-1.2.5.5/backends/tofino/bf-p4c/common/alloc.h:219:51: error: 'i' has incomplete type
  219 |     const T &operator[](std::tuple<int, int, int> i) const {
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~^
/usr/include/c++/12/bits/stl_pair.h:90:11: note: declaration of 'class std::tuple<int, int, int>'
   90 |     class tuple;
      |           ^~~~~
```
The issue is caused by a missing `#include <tuple>` in `alloc.h`.  
This patch adds the required header to fix the error.