### PR TITLE
Allow constant folding of serializable enums of different types

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -463,8 +463,7 @@ const IR::Node *DoConstantFolding::compare(const IR::Operation_Binary *e) {
     if (typesKnown) {
         auto le = EnumInstance::resolve(eleft, typeMap);
         auto re = EnumInstance::resolve(eright, typeMap);
-        if (le != nullptr && re != nullptr) {
-            BUG_CHECK(le->type == re->type, "%1%: different enum types in comparison", e);
+        if (le != nullptr && re != nullptr && le->type == re->type) {
             bool bresult = (le->name == re->name) == eqTest;
             return new IR::BoolLiteral(e->srcInfo, IR::Type_Boolean::get(), bresult);
         }

--- a/testdata/p4_16_samples/enumCmp.p4
+++ b/testdata/p4_16_samples/enumCmp.p4
@@ -1,0 +1,33 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+
+enum bit<8> E1 { A = 1, B = 2, C = 10 }
+enum bit<8> E2 { X = 2, Y = 1, Z = 3 }
+
+header data_t {
+    E1          e1;
+    E2          e2;
+    bit<8>      a;
+    bit<8>      b;
+    bit<8>      c;
+}
+
+struct headers {
+    data_t      data;
+}
+
+
+control c(inout headers hdr) {
+    apply {
+        if (hdr.data.e1 == hdr.data.e2) { hdr.data.a[0+:1] = 1; }
+        if (hdr.data.e1 == E1.A) { hdr.data.a[1+:1] = 1; }
+        if (hdr.data.e1 == E2.X) { hdr.data.a[2+:1] = 1; }
+        if (hdr.data.e1 == hdr.data.c) { hdr.data.a[3+:1] = 1; }
+        if (hdr.data.c == E1.B) { hdr.data.a[4+:1] = 1; }
+        if (hdr.data.c == E2.Y) { hdr.data.a[5+:1] = 1; }
+        if (E1.A == E2.X) { hdr.data.b[0+:1] = 1; }
+        if (E1.A == E2.Y) { hdr.data.b[1+:1] = 1; }
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/enumCmp-first.p4
+++ b/testdata/p4_16_samples_outputs/enumCmp-first.p4
@@ -1,0 +1,56 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+enum bit<8> E1 {
+    A = 8w1,
+    B = 8w2,
+    C = 8w10
+}
+
+enum bit<8> E2 {
+    X = 8w2,
+    Y = 8w1,
+    Z = 8w3
+}
+
+header data_t {
+    E1     e1;
+    E2     e2;
+    bit<8> a;
+    bit<8> b;
+    bit<8> c;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        if (hdr.data.e1 == hdr.data.e2) {
+            hdr.data.a[0:0] = 1w1;
+        }
+        if (hdr.data.e1 == E1.A) {
+            hdr.data.a[1:1] = 1w1;
+        }
+        if (hdr.data.e1 == E2.X) {
+            hdr.data.a[2:2] = 1w1;
+        }
+        if (hdr.data.e1 == hdr.data.c) {
+            hdr.data.a[3:3] = 1w1;
+        }
+        if (hdr.data.c == E1.B) {
+            hdr.data.a[4:4] = 1w1;
+        }
+        if (hdr.data.c == E2.Y) {
+            hdr.data.a[5:5] = 1w1;
+        }
+        if (E1.A == E2.X) {
+            hdr.data.b[0:0] = 1w1;
+        }
+        if (E1.A == E2.Y) {
+            hdr.data.b[1:1] = 1w1;
+        }
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_samples_outputs/enumCmp-frontend.p4
+++ b/testdata/p4_16_samples_outputs/enumCmp-frontend.p4
@@ -1,0 +1,56 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+enum bit<8> E1 {
+    A = 8w1,
+    B = 8w2,
+    C = 8w10
+}
+
+enum bit<8> E2 {
+    X = 8w2,
+    Y = 8w1,
+    Z = 8w3
+}
+
+header data_t {
+    E1     e1;
+    E2     e2;
+    bit<8> a;
+    bit<8> b;
+    bit<8> c;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        if (hdr.data.e1 == hdr.data.e2) {
+            hdr.data.a[0:0] = 1w1;
+        }
+        if (hdr.data.e1 == E1.A) {
+            hdr.data.a[1:1] = 1w1;
+        }
+        if (hdr.data.e1 == E2.X) {
+            hdr.data.a[2:2] = 1w1;
+        }
+        if (hdr.data.e1 == hdr.data.c) {
+            hdr.data.a[3:3] = 1w1;
+        }
+        if (hdr.data.c == E1.B) {
+            hdr.data.a[4:4] = 1w1;
+        }
+        if (hdr.data.c == E2.Y) {
+            hdr.data.a[5:5] = 1w1;
+        }
+        if (E1.A == E2.X) {
+            hdr.data.b[0:0] = 1w1;
+        }
+        if (E1.A == E2.Y) {
+            hdr.data.b[1:1] = 1w1;
+        }
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_samples_outputs/enumCmp-midend.p4
+++ b/testdata/p4_16_samples_outputs/enumCmp-midend.p4
@@ -1,0 +1,102 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+header data_t {
+    bit<8> e1;
+    bit<8> e2;
+    bit<8> a;
+    bit<8> b;
+    bit<8> c;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    @hidden action enumCmp22() {
+        hdr.data.a[0:0] = 1w1;
+    }
+    @hidden action enumCmp23() {
+        hdr.data.a[1:1] = 1w1;
+    }
+    @hidden action enumCmp24() {
+        hdr.data.a[2:2] = 1w1;
+    }
+    @hidden action enumCmp25() {
+        hdr.data.a[3:3] = 1w1;
+    }
+    @hidden action enumCmp26() {
+        hdr.data.a[4:4] = 1w1;
+    }
+    @hidden action enumCmp27() {
+        hdr.data.a[5:5] = 1w1;
+    }
+    @hidden action enumCmp29() {
+        hdr.data.b[1:1] = 1w1;
+    }
+    @hidden table tbl_enumCmp22 {
+        actions = {
+            enumCmp22();
+        }
+        const default_action = enumCmp22();
+    }
+    @hidden table tbl_enumCmp23 {
+        actions = {
+            enumCmp23();
+        }
+        const default_action = enumCmp23();
+    }
+    @hidden table tbl_enumCmp24 {
+        actions = {
+            enumCmp24();
+        }
+        const default_action = enumCmp24();
+    }
+    @hidden table tbl_enumCmp25 {
+        actions = {
+            enumCmp25();
+        }
+        const default_action = enumCmp25();
+    }
+    @hidden table tbl_enumCmp26 {
+        actions = {
+            enumCmp26();
+        }
+        const default_action = enumCmp26();
+    }
+    @hidden table tbl_enumCmp27 {
+        actions = {
+            enumCmp27();
+        }
+        const default_action = enumCmp27();
+    }
+    @hidden table tbl_enumCmp29 {
+        actions = {
+            enumCmp29();
+        }
+        const default_action = enumCmp29();
+    }
+    apply {
+        if (hdr.data.e1 == hdr.data.e2) {
+            tbl_enumCmp22.apply();
+        }
+        if (hdr.data.e1 == 8w1) {
+            tbl_enumCmp23.apply();
+        }
+        if (hdr.data.e1 == 8w2) {
+            tbl_enumCmp24.apply();
+        }
+        if (hdr.data.e1 == hdr.data.c) {
+            tbl_enumCmp25.apply();
+        }
+        if (hdr.data.c == 8w2) {
+            tbl_enumCmp26.apply();
+        }
+        if (hdr.data.c == 8w1) {
+            tbl_enumCmp27.apply();
+        }
+        tbl_enumCmp29.apply();
+    }
+}
+
+top<headers>(c()) main;

--- a/testdata/p4_16_samples_outputs/enumCmp.p4
+++ b/testdata/p4_16_samples_outputs/enumCmp.p4
@@ -1,0 +1,56 @@
+control proto<P>(inout P pkt);
+package top<P>(proto<P> p);
+enum bit<8> E1 {
+    A = 1,
+    B = 2,
+    C = 10
+}
+
+enum bit<8> E2 {
+    X = 2,
+    Y = 1,
+    Z = 3
+}
+
+header data_t {
+    E1     e1;
+    E2     e2;
+    bit<8> a;
+    bit<8> b;
+    bit<8> c;
+}
+
+struct headers {
+    data_t data;
+}
+
+control c(inout headers hdr) {
+    apply {
+        if (hdr.data.e1 == hdr.data.e2) {
+            hdr.data.a[0+:1] = 1;
+        }
+        if (hdr.data.e1 == E1.A) {
+            hdr.data.a[1+:1] = 1;
+        }
+        if (hdr.data.e1 == E2.X) {
+            hdr.data.a[2+:1] = 1;
+        }
+        if (hdr.data.e1 == hdr.data.c) {
+            hdr.data.a[3+:1] = 1;
+        }
+        if (hdr.data.c == E1.B) {
+            hdr.data.a[4+:1] = 1;
+        }
+        if (hdr.data.c == E2.Y) {
+            hdr.data.a[5+:1] = 1;
+        }
+        if (E1.A == E2.X) {
+            hdr.data.b[0+:1] = 1;
+        }
+        if (E1.A == E2.Y) {
+            hdr.data.b[1+:1] = 1;
+        }
+    }
+}
+
+top(c()) main;


### PR DESCRIPTION
Typechecking (and the P4 spec) allow comparing values of serializable enum types, however, ConstantFolding was hitting a BUG_CHECK when that happened with two constants of different serializable enums.