### PR TITLE
Fix segmentation failure in ConstantTypeSubstitution

### DIFF
--- a/frontends/p4/typeChecking/constantTypeSubstitution.h
+++ b/frontends/p4/typeChecking/constantTypeSubstitution.h
@@ -42,7 +42,7 @@ class ConstantTypeSubstitution : public Transform, ResolutionContext {
 
     const IR::Node *postorder(IR::Constant *cst) override {
         auto cstType = typeMap->getType(getOriginal(), true);
-        if (!cstType->is<IR::ITypeVar>()) return cst;
+        if (!cstType || !cstType->is<IR::ITypeVar>()) return cst;
         auto repl = cstType;
         while (repl->is<IR::ITypeVar>()) {
             auto next = subst->get(repl->to<IR::ITypeVar>());

--- a/testdata/p4_16_samples/issue5268.p4
+++ b/testdata/p4_16_samples/issue5268.p4
@@ -1,0 +1,34 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+struct S {
+    bit<32> a;
+    bit<32> b;
+}
+
+
+control proto();
+package top(proto _p);
+
+control c() {
+    apply {
+
+        bool b5 = (S) { a = 1, b = 2 } == { a = 1, bb = 2 };
+        bool b5_ = { a = 1, b = 2 } == (S) { a = 363, b = 2147483650 };
+
+    }
+}
+
+top(c()) main;


### PR DESCRIPTION
fixes #5268.

As the `getType(..., true)` should fail with a `BUG`, I don't think we need to add anything more than just a check for the type being null. In the example from issue, there is a preceding type error which supresses the `BUG_CHECK` about unknown type (as the type map is possibly inconsistent due to previous errors).