### PR TITLE
Only push docker image when the branch is main. Not on the merge queue.

### DIFF
--- a/.github/workflows/ci-container-image.yml
+++ b/.github/workflows/ci-container-image.yml
@@ -51,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
           tags: p4lang/p4c:${{ steps.get-tag.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
We are pushing the CI container image also in merge queues because the check condition is too liberal. Make it more specific. 