### PR TITLE
[P4Testgen] Print and error instead of throwing a BUG when the architecture package does not match.

### DIFF
--- a/backends/p4tools/common/lib/util.cpp
+++ b/backends/p4tools/common/lib/util.cpp
@@ -145,7 +145,6 @@ std::vector<const IR::Type_Declaration *> argumentsToTypeDeclarations(
 
         if (const auto *ctorCall = expr->to<IR::ConstructorCallExpression>()) {
             const auto *constructedTypeName = ctorCall->constructedType->checkedTo<IR::Type_Name>();
-
             // Find the corresponding type declaration in the top-level namespace.
             declType =
                 findProgramDecl(ns, constructedTypeName->path)->checkedTo<IR::Type_Declaration>();

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
@@ -124,7 +124,7 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-metadata"
-  "with type Type_Specialized is not a Type_Declaration"
+  "P4Testgen back end only supports a 'V1Switch' main"
   # Pipeline as a parameter of a switch, not a valid v1model program
   issue1304.p4
 )

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -189,7 +189,7 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
-  "with type Type_Specialized is not a Type_Declaration"
+  "P4Testgen back end only supports a 'V1Switch' main"
   # Pipeline as a parameter of a switch, not a valid v1model program
   issue1304.p4
 )

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufIrXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufIrXfail.cmake
@@ -141,7 +141,7 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-protobuf-ir"
-  "with type Type_Specialized is not a Type_Declaration"
+  "P4Testgen back end only supports a 'V1Switch' main"
   # Pipeline as a parameter of a switch, not a valid v1model program
   issue1304.p4
 )

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufXfail.cmake
@@ -111,7 +111,7 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-protobuf"
-  "with type Type_Specialized is not a Type_Declaration"
+  "P4Testgen back end only supports a 'V1Switch' main"
   # Pipeline as a parameter of a switch, not a valid v1model program
   issue1304.p4
 )

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
@@ -188,7 +188,7 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-stf"
-  "with type Type_Specialized is not a Type_Declaration"
+  "P4Testgen back end only supports a 'V1Switch' main"
   # Pipeline as a parameter of a switch, not a valid v1model program
   issue1304.p4
 )


### PR DESCRIPTION
Fixes #5276.