### PR TITLE
Add new node pattern matching boilerplate & make use of it

### DIFF
--- a/frontends/p4/reassociation.cpp
+++ b/frontends/p4/reassociation.cpp
@@ -49,8 +49,8 @@ void Reassociation::reassociate(IR::Operation_Binary *root) {
     const IR::Operation_Binary *lhs;
     const IR::Constant *c1, *c2;
     const IR::Expression *e;
-    if (match(root, m_BinOp(m_CombineAnd(m_BinOp(lhs), m_BinOp(m_Expr(e), m_Constant(c1))),
-                            m_Constant(c2))) &&
+    if (match(root,
+              m_BinOp(m_AllOf(m_BinOp(lhs), m_BinOp(m_Expr(e), m_Constant(c1))), m_Constant(c2))) &&
         lhs->getStringOp() == root->getStringOp()) {
         auto *newRight = root->clone();
         newRight->left = c1;

--- a/frontends/p4/reassociation.h
+++ b/frontends/p4/reassociation.h
@@ -24,8 +24,10 @@ namespace P4 {
 
 using namespace literals;
 
-/** Implements a pass that reorders associative operations when beneficial.
- * For example, (a + c0) + c1 is rewritten as a + (c0 + c1) when cs are constants.
+/** Implements a pass that reorders associative operations when beneficial.  For
+ * example, (a + c0) + c1 is rewritten as a + (c0 + c1) when cs are constants.
+ * The pass performs only local reassociation transformation, it does not (yet)
+ * implement "push to leaves" optimization.
  */
 class Reassociation final : public Modifier {
  public:

--- a/frontends/p4/reassociation.h
+++ b/frontends/p4/reassociation.h
@@ -27,26 +27,25 @@ using namespace literals;
 /** Implements a pass that reorders associative operations when beneficial.
  * For example, (a + c0) + c1 is rewritten as a + (c0 + c1) when cs are constants.
  */
-class Reassociation final : public Transform {
+class Reassociation final : public Modifier {
  public:
     Reassociation() {
         visitDagOnce = true;
         setName("Reassociation");
     }
-    using Transform::postorder;
+    using Modifier::postorder;
 
-    const IR::Node *reassociate(IR::Operation_Binary *root);
+    void reassociate(IR::Operation_Binary *root);
 
-    const IR::Node *postorder(IR::Add *expr) override { return reassociate(expr); }
-    const IR::Node *postorder(IR::Mul *expr) override { return reassociate(expr); }
-    const IR::Node *postorder(IR::BOr *expr) override { return reassociate(expr); }
-    const IR::Node *postorder(IR::BAnd *expr) override { return reassociate(expr); }
-    const IR::Node *postorder(IR::BXor *expr) override { return reassociate(expr); }
-    const IR::BlockStatement *preorder(IR::BlockStatement *bs) override {
+    void postorder(IR::Add *expr) override { reassociate(expr); }
+    void postorder(IR::Mul *expr) override { reassociate(expr); }
+    void postorder(IR::BOr *expr) override { reassociate(expr); }
+    void postorder(IR::BAnd *expr) override { reassociate(expr); }
+    void postorder(IR::BXor *expr) override { reassociate(expr); }
+    bool preorder(IR::BlockStatement *bs) override {
         // FIXME: Do we need to check for expression, so we'd be able to fine tune, e.g.
         // @disable_optimization("reassociation")
-        if (bs->hasAnnotation(IR::Annotation::disableOptimizationAnnotation)) prune();
-        return bs;
+        return !bs->hasAnnotation(IR::Annotation::disableOptimizationAnnotation);
     }
 };
 

--- a/frontends/p4/strengthReduction.cpp
+++ b/frontends/p4/strengthReduction.cpp
@@ -16,6 +16,8 @@ limitations under the License.
 
 #include "strengthReduction.h"
 
+#include "ir/pattern.h"
+
 namespace P4 {
 
 /// @section Helper methods
@@ -78,9 +80,8 @@ const IR::Node *DoStrengthReduction::postorder(IR::UPlus *expr) { return expr->e
 const IR::Node *DoStrengthReduction::postorder(IR::BAnd *expr) {
     if (isAllOnes(expr->left)) return expr->right;
     if (isAllOnes(expr->right)) return expr->left;
-    auto l = expr->left->to<IR::Cmpl>();
-    auto r = expr->right->to<IR::Cmpl>();
-    if (l && r)
+    const IR::Cmpl *l, *r;
+    if (match(expr, m_BinOp(m_Cmpl(l), m_Cmpl(r))))
         return new IR::Cmpl(expr->srcInfo, expr->type,
                             new IR::BOr(expr->srcInfo, expr->type, l->expr, r->expr));
 
@@ -94,11 +95,11 @@ const IR::Node *DoStrengthReduction::postorder(IR::BAnd *expr) {
 const IR::Node *DoStrengthReduction::postorder(IR::BOr *expr) {
     if (isZero(expr->left)) return expr->right;
     if (isZero(expr->right)) return expr->left;
-    auto l = expr->left->to<IR::Cmpl>();
-    auto r = expr->right->to<IR::Cmpl>();
-    if (l && r)
+    const IR::Cmpl *l, *r;
+    if (match(expr, m_BinOp(m_Cmpl(l), m_Cmpl(r))))
         return new IR::Cmpl(expr->srcInfo, expr->type,
                             new IR::BAnd(expr->srcInfo, expr->type, l->expr, r->expr));
+
     if (hasSideEffects(expr)) return expr;
     if (expr->left->equiv(*expr->right)) return expr->left;
     return expr;
@@ -182,10 +183,11 @@ const IR::Node *DoStrengthReduction::postorder(IR::Sub *expr) {
     if (isZero(expr->right)) return expr->left;
     if (isZero(expr->left)) return new IR::Neg(expr->srcInfo, expr->type, expr->right);
     // Replace `a - constant` with `a + (-constant)`
-    if (enableSubConstToAddTransform && expr->right->is<IR::Constant>()) {
-        auto cst = expr->right->to<IR::Constant>();
-        auto neg = new IR::Constant(cst->srcInfo, cst->type, -cst->value, cst->base, true);
-        auto result = new IR::Add(expr->srcInfo, expr->type, expr->left, neg);
+    const IR::Constant *cst;
+    if (enableSubConstToAddTransform && match(expr->right, m_Constant(cst))) {
+        auto result =
+            new IR::Add(expr->srcInfo, expr->type, expr->left,
+                        new IR::Constant(cst->srcInfo, cst->type, -cst->value, cst->base, true));
         return result;
     }
     if (hasSideEffects(expr)) return expr;
@@ -203,15 +205,14 @@ const IR::Node *DoStrengthReduction::postorder(IR::Add *expr) {
 
 const IR::Node *DoStrengthReduction::postorder(IR::Shl *expr) {
     if (isZero(expr->right)) return expr->left;
-    if (const auto *sh2 = expr->left->to<IR::Shl>()) {
-        if (sh2->right->type->is<IR::Type_InfInt>() && expr->right->type->is<IR::Type_InfInt>()) {
-            // (a << b) << c is a << (b + c)
-            auto *result =
-                new IR::Shl(expr->srcInfo, sh2->left->type, sh2->left,
-                            new IR::Add(expr->srcInfo, sh2->right->type, sh2->right, expr->right));
-            LOG3("Replace " << expr << " with " << result);
-            return result;
-        }
+    const IR::Expression *a, *b, *c;
+    // (a << b) << c is a << (b + c)
+    if (match(expr, m_BinOp(m_Shl(m_Expr(a), m_AllOf(m_Expr(b), m_Type<IR::Type_InfInt>())),
+                            m_AllOf(m_Expr(c), m_Type<IR::Type_InfInt>())))) {
+        auto *result =
+            new IR::Shl(expr->srcInfo, a->type, a, new IR::Add(expr->srcInfo, b->type, b, c));
+        LOG3("Replace " << expr << " with " << result);
+        return result;
     }
 
     if (!hasSideEffects(expr->right) && isZero(expr->left)) return expr->left;
@@ -220,15 +221,15 @@ const IR::Node *DoStrengthReduction::postorder(IR::Shl *expr) {
 
 const IR::Node *DoStrengthReduction::postorder(IR::Shr *expr) {
     if (isZero(expr->right)) return expr->left;
-    if (auto sh2 = expr->left->to<IR::Shr>()) {
-        if (sh2->right->type->is<IR::Type_InfInt>() && expr->right->type->is<IR::Type_InfInt>()) {
-            // (a >> b) >> c is a >> (b + c)
-            auto *result =
-                new IR::Shr(expr->srcInfo, sh2->left->type, sh2->left,
-                            new IR::Add(expr->srcInfo, sh2->right->type, sh2->right, expr->right));
-            LOG3("Replace " << expr << " with " << result);
-            return result;
-        }
+    const IR::Expression *a, *b, *c;
+    // (a << b) << c is a << (b + c)
+    if (match(expr, m_BinOp(m_Shr(m_Expr(a), m_AllOf(m_Expr(b), m_Type<IR::Type_InfInt>())),
+                            m_AllOf(m_Expr(c), m_Type<IR::Type_InfInt>())))) {
+        // (a >> b) >> c is a >> (b + c)
+        auto *result =
+            new IR::Shr(expr->srcInfo, a->type, a, new IR::Add(expr->srcInfo, b->type, b, c));
+        LOG3("Replace " << expr << " with " << result);
+        return result;
     }
     if (!hasSideEffects(expr->right) && isZero(expr->left)) return expr->left;
     return expr;
@@ -291,11 +292,8 @@ const IR::Node *DoStrengthReduction::postorder(IR::Mod *expr) {
 
 const IR::Node *DoStrengthReduction::postorder(IR::Range *range) {
     // Range a..a is the same as a
-    if (auto c0 = range->left->to<IR::Constant>()) {
-        if (auto c1 = range->right->to<IR::Constant>()) {
-            if (c0->value == c1->value) return c0;
-        }
-    }
+    const IR::Constant *c0, *c1;
+    if (match(range, m_BinOp(m_Constant(c0), m_Constant(c1))) && c0->value == c1->value) return c0;
     return range;
 }
 

--- a/ir/pattern.h
+++ b/ir/pattern.h
@@ -206,6 +206,231 @@ inline Pattern operator^(int v, const Pattern &a) { return Pattern(v) ^ a; }
 inline Pattern operator&&(int v, const Pattern &a) { return Pattern(v) && a; }
 inline Pattern operator||(int v, const Pattern &a) { return Pattern(v) || a; }
 
+template <typename Node, typename Pattern>
+bool match(const Node *n, const Pattern &P) {
+    return const_cast<Pattern &>(P).match(n);
+}
+
+namespace detail {
+
+template <typename Node>
+struct node_match {
+    template <typename ITy>
+    bool match(const ITy *n) {
+        return n->template is<Node>();
+    }
+};
+
+/// Inverting matcher
+template <typename M>
+struct match_unless {
+    M matcher;
+
+    match_unless(const M &matcher) : matcher(matcher) {}  // NOLINT(runtime/explicit)
+
+    template <typename ITy>
+    bool match(ITy *n) {
+        return !matcher.match(n);
+    }
+};
+
+/// Matching combinators
+template <typename LM, typename RM>
+struct match_combine_or {
+    LM lm;
+    RM rm;
+
+    match_combine_or(const LM &left, const RM &right) : lm(left), rm(right) {}
+
+    template <typename ITy>
+    bool match(ITy *n) {
+        if (lm.match(n)) return true;
+        if (rm.match(n)) return true;
+        return false;
+    }
+};
+
+template <typename LM, typename RM>
+struct match_combine_and {
+    LM lm;
+    RM rm;
+
+    match_combine_and(const LM &left, const RM &right) : lm(left), rm(right) {}
+
+    template <typename ITy>
+    bool match(const ITy *n) {
+        if (lm.match(n))
+            if (rm.match(n)) return true;
+        return false;
+    }
+};
+
+struct bigint_match {
+    const big_int *&res;
+
+    bigint_match(const big_int *&res) : res(res) {}  // NOLINT(runtime/explicit)
+
+    template <typename Node>
+    bool match(const Node *n) {
+        if (const auto *c = n->template to<IR::Constant>()) {
+            res = &c->value;
+            return true;
+        }
+        return false;
+    }
+};
+
+template <int64_t val>
+struct constantint_match {
+    template <typename ITy>
+    bool match(const ITy *n) {
+        if (const auto *c = n->template to<IR::Constant>()) {
+            const big_int &ci = c->value;
+
+            if (val >= 0) return ci == static_cast<uint64_t>(val);
+
+            // If val is negative, and ci is shorter than it, truncate to the
+            // right number of bits.  If it is larger, then we have to sign
+            // extend.  Just compare their negated values.
+            return -ci == -val;
+        }
+        return false;
+    }
+};
+
+template <typename Node>
+struct bind_node {
+    const Node *&nr;
+
+    bind_node(const Node *&n) : nr(n) {}  // NOLINT(runtime/explicit)
+
+    template <typename ITy>
+    bool match(const ITy *n) {
+        if (auto *cn = n->template to<Node>()) {
+            nr = cn;
+            return true;
+        }
+        return false;
+    }
+};
+
+struct specificnode_ty {
+    const IR::Node *node;
+
+    specificnode_ty(const IR::Node *n) : node(n) {}  // NOLINT(runtime/explicit)
+
+    template <typename ITy>
+    bool match(ITy *n) {
+        return node == n;
+    }
+};
+
+template <typename LHS, typename RHS, bool Commutable = false>
+struct AnyBinaryOp_match {
+    LHS l;
+    RHS r;
+
+    AnyBinaryOp_match(const LHS &l, const RHS &r) : l(l), r(r) {}
+
+    template <typename OpTy>
+    bool match(OpTy *n) {
+        if (auto *bo = n->template to<IR::Operation_Binary>())
+            return (l.match(bo->left) && r.match(bo->right)) ||
+                   (Commutable && l.match(bo->right) && r.match(bo->left));
+
+        return false;
+    }
+};
+
+template <typename OP>
+struct AnyUnaryOp_match {
+    OP x;
+
+    AnyUnaryOp_match(const OP &x) : x(x) {}  // NOLINT(runtime/explicit)
+
+    template <typename OpTy>
+    bool match(OpTy *n) {
+        if (auto *uo = n->template to<IR::Operation_Unary>()) return x.match(uo->expr);
+        return false;
+    }
+};
+
+}  // namespace detail
+
+/// Match an arbitrary node and ignore it.
+inline auto m_Node() { return detail::node_match<IR::Node>(); }
+
+/// Match an arbitrary unary operation and ignore it.
+inline auto m_UnOp() { return detail::node_match<IR::Operation_Unary>(); }
+
+/// Match an arbitrary binary operation and ignore it.
+inline auto m_BinOp() { return detail::node_match<IR::Operation_Binary>(); }
+
+/// Match an arbitrary relation operation and ignore it.
+inline auto m_RelOp() { return detail::node_match<IR::Operation_Relation>(); }
+
+/// Match an arbitrary Constant and ignore it.
+inline auto m_Constant() { return detail::node_match<IR::Constant>(); }
+
+/// Match an arbitrary Expression and ignore it.
+inline auto m_Expr() { return detail::node_match<IR::Expression>(); }
+
+/// Match if the inner matcher does *NOT* match.
+template <typename Matcher>
+inline auto m_Unless(const Matcher &m) {
+    return detail::match_unless<Matcher>(m);
+}
+
+/// Combine two pattern matchers matching L || R
+template <typename LM, typename RM>
+inline auto m_CombineOr(const LM &l, const RM &r) {
+    return detail::match_combine_or<LM, RM>(l, r);
+}
+
+/// Combine two pattern matchers matching L && R
+template <typename LM, typename RM>
+inline auto m_CombineAnd(const LM &l, const RM &r) {
+    return detail::match_combine_and<LM, RM>(l, r);
+}
+
+/// Match a Constant, binding the specified pointer to the contained big_int.
+inline auto m_BigInt(const big_int *&res) { return detail::bigint_match(res); }
+
+/// Match a Constant with int of a specific value.
+template <int64_t val>
+inline auto m_ConstantInt() {
+    return detail::constantint_match<val>();
+}
+
+/// Match a node, capturing it if we match.
+inline detail::bind_node<const IR::Node> m_Node(const IR::Node *&n) { return n; }
+/// Match a Constant, capturing the value if we match.
+inline detail::bind_node<IR::Constant> m_Constant(const IR::Constant *&c) { return c; }
+/// Match an Expression, capturing the value if we match.
+inline detail::bind_node<IR::Expression> m_Expr(const IR::Expression *&e) { return e; }
+/// Match if we have a specific specified node.
+inline detail::specificnode_ty m_Specific(const IR::Node *n) { return n; }
+
+/// Match a unary operator, capturing it if we match.
+inline detail::bind_node<IR::Operation_Unary> m_UnOp(const IR::Operation_Unary *&uo) { return uo; }
+/// Match a binary operator, capturing it if we match.
+inline detail::bind_node<IR::Operation_Binary> m_BinOp(const IR::Operation_Binary *&bo) {
+    return bo;
+}
+/// Match a relation operator, capturing it if we match.
+inline detail::bind_node<IR::Operation_Relation> m_RelOp(const IR::Operation_Relation *&ro) {
+    return ro;
+}
+
+template <typename LHS, typename RHS>
+inline auto m_BinOp(const LHS &l, const RHS &r) {
+    return detail::AnyBinaryOp_match<LHS, RHS>(l, r);
+}
+
+template <typename OP>
+inline auto m_UnOp(const OP &x) {
+    return detail::AnyUnaryOp_match<OP>(x);
+}
 }  // namespace P4
 
 #endif /* IR_PATTERN_H_ */

--- a/midend/simplifyBitwise.cpp
+++ b/midend/simplifyBitwise.cpp
@@ -21,10 +21,13 @@ void SimplifyBitwise::assignSlices(const IR::Expression *expr, big_int mask) {
 }
 
 const IR::Node *SimplifyBitwise::preorder(IR::BaseAssignmentStatement *as) {
-    Pattern::Match<IR::Expression> a, b;
-    Pattern::Match<IR::Constant> maskA, maskB;
+    const IR::Expression *a, *b;
+    const IR::Constant *maskA, *maskB;
 
-    if (!((a & maskA) | (b & maskB)).match(as->right)) return as;
+    if (!match(as->right,
+               m_BOr(m_BAnd(m_Expr(a), m_Constant(maskA)), m_BAnd(m_Expr(b), m_Constant(maskB)))))
+        return as;
+
     if ((maskA->value & maskB->value) != 0) return as;
 
     changing_as = as;

--- a/midend/unrollLoops.cpp
+++ b/midend/unrollLoops.cpp
@@ -195,9 +195,9 @@ long UnrollLoops::evalLoop(const IR::BaseAssignmentStatement *assign, long val,
 }
 
 bool UnrollLoops::findLoopBounds(IR::ForStatement *fstmt, loop_bounds_t &bounds) {
-    Pattern::Match<IR::PathExpression> v;
-    Pattern::Match<IR::Constant> k;
-    if (v.Relation(k).match(fstmt->condition)) {
+    const IR::PathExpression *v;
+    const IR::Constant *k;
+    if (match(fstmt->condition, m_RelOp(m_PathExpr(v), m_Constant(k)))) {
         auto d = resolveUnique(v->path->name, P4::ResolutionType::Any);
         bounds.index = d ? d->to<IR::Declaration_Variable>() : nullptr;
         if (!bounds.index) return false;

--- a/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-first.p4
@@ -140,7 +140,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".format_options_timestamp") action format_options_timestamp() {
         hdr.ipv4_option_NOP.pop_front(3);
         hdr.ipv4_option_EOL.pop_front(3);
-        hdr.ipv4_base.ihl = (bit<4>)(8w5 + (hdr.ipv4_option_timestamp.len >> 3));
+        hdr.ipv4_base.ihl = (bit<4>)((hdr.ipv4_option_timestamp.len >> 3) + 8w5);
     }
     @name(".format_options_both") action format_options_both() {
         hdr.ipv4_option_NOP.pop_front(3);
@@ -148,7 +148,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ipv4_option_NOP.push_front(1);
         hdr.ipv4_option_NOP[0].setValid();
         hdr.ipv4_option_NOP[0].value = 8w0x1;
-        hdr.ipv4_base.ihl = (bit<4>)(8w8 + (hdr.ipv4_option_timestamp.len >> 2));
+        hdr.ipv4_base.ihl = (bit<4>)((hdr.ipv4_option_timestamp.len >> 2) + 8w8);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-frontend.p4
@@ -149,7 +149,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".format_options_timestamp") action format_options_timestamp() {
         hdr.ipv4_option_NOP.pop_front(3);
         hdr.ipv4_option_EOL.pop_front(3);
-        hdr.ipv4_base.ihl = (bit<4>)(8w5 + (hdr.ipv4_option_timestamp.len >> 3));
+        hdr.ipv4_base.ihl = (bit<4>)((hdr.ipv4_option_timestamp.len >> 3) + 8w5);
     }
     @name(".format_options_both") action format_options_both() {
         hdr.ipv4_option_NOP.pop_front(3);
@@ -157,7 +157,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ipv4_option_NOP.push_front(1);
         hdr.ipv4_option_NOP[0].setValid();
         hdr.ipv4_option_NOP[0].value = 8w0x1;
-        hdr.ipv4_base.ihl = (bit<4>)(8w8 + (hdr.ipv4_option_timestamp.len >> 2));
+        hdr.ipv4_base.ihl = (bit<4>)((hdr.ipv4_option_timestamp.len >> 2) + 8w8);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
+++ b/testdata/p4_14_samples_outputs/TLV_parsing-midend.p4
@@ -153,7 +153,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
     @name(".format_options_timestamp") action format_options_timestamp() {
         hdr.ipv4_option_NOP.pop_front(3);
         hdr.ipv4_option_EOL.pop_front(3);
-        hdr.ipv4_base.ihl = (bit<4>)(8w5 + (hdr.ipv4_option_timestamp.len >> 3));
+        hdr.ipv4_base.ihl = (bit<4>)((hdr.ipv4_option_timestamp.len >> 3) + 8w5);
     }
     @name(".format_options_both") action format_options_both() {
         hdr.ipv4_option_NOP.pop_front(3);
@@ -161,7 +161,7 @@ control egress(inout headers hdr, inout metadata meta, inout standard_metadata_t
         hdr.ipv4_option_NOP.push_front(1);
         hdr.ipv4_option_NOP[0].setValid();
         hdr.ipv4_option_NOP[0].value = 8w0x1;
-        hdr.ipv4_base.ihl = (bit<4>)(8w8 + (hdr.ipv4_option_timestamp.len >> 2));
+        hdr.ipv4_base.ihl = (bit<4>)((hdr.ipv4_option_timestamp.len >> 2) + 8w8);
     }
     @name("._nop") action _nop() {
     }

--- a/testdata/p4_14_samples_outputs/axon-first.p4
+++ b/testdata/p4_14_samples_outputs/axon-first.p4
@@ -44,7 +44,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         packet.extract<axon_head_t>(hdr.axon_head);
         meta.my_metadata.fwdHopCount = hdr.axon_head.fwdHopCount;
         meta.my_metadata.revHopCount = hdr.axon_head.revHopCount;
-        meta.my_metadata.headerLen = (bit<16>)(8w2 + hdr.axon_head.fwdHopCount) + (bit<16>)hdr.axon_head.revHopCount;
+        meta.my_metadata.headerLen = (bit<16>)(hdr.axon_head.fwdHopCount + 8w2) + (bit<16>)hdr.axon_head.revHopCount;
         transition select(hdr.axon_head.fwdHopCount) {
             8w0: accept;
             default: parse_next_fwdHop;

--- a/testdata/p4_14_samples_outputs/axon-frontend.p4
+++ b/testdata/p4_14_samples_outputs/axon-frontend.p4
@@ -46,7 +46,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         packet.extract<axon_head_t>(hdr.axon_head);
         meta.my_metadata.fwdHopCount = hdr.axon_head.fwdHopCount;
         meta.my_metadata.revHopCount = hdr.axon_head.revHopCount;
-        meta.my_metadata.headerLen = (bit<16>)(8w2 + hdr.axon_head.fwdHopCount) + (bit<16>)hdr.axon_head.revHopCount;
+        meta.my_metadata.headerLen = (bit<16>)(hdr.axon_head.fwdHopCount + 8w2) + (bit<16>)hdr.axon_head.revHopCount;
         transition select(hdr.axon_head.fwdHopCount) {
             8w0: accept;
             default: parse_next_fwdHop;

--- a/testdata/p4_14_samples_outputs/axon-midend.p4
+++ b/testdata/p4_14_samples_outputs/axon-midend.p4
@@ -46,7 +46,7 @@ parser ParserImpl(packet_in packet, out headers hdr, inout metadata meta, inout 
         packet.extract<axon_head_t>(hdr.axon_head);
         meta._my_metadata_fwdHopCount0 = hdr.axon_head.fwdHopCount;
         meta._my_metadata_revHopCount1 = hdr.axon_head.revHopCount;
-        meta._my_metadata_headerLen2 = (bit<16>)(8w2 + hdr.axon_head.fwdHopCount) + (bit<16>)hdr.axon_head.revHopCount;
+        meta._my_metadata_headerLen2 = (bit<16>)(hdr.axon_head.fwdHopCount + 8w2) + (bit<16>)hdr.axon_head.revHopCount;
         transition select(hdr.axon_head.fwdHopCount) {
             8w0: accept;
             default: parse_next_fwdHop;

--- a/testdata/p4_14_samples_outputs/gateway6-first.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-first.p4
@@ -55,7 +55,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction();
     }
     apply {
-        if (8w1 == 8w15 & hdr.data.b2) {
+        if (8w1 == hdr.data.b2 & 8w15) {
             test1.apply();
         } else {
             test2.apply();

--- a/testdata/p4_14_samples_outputs/gateway6-frontend.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-frontend.p4
@@ -64,7 +64,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_2();
     }
     apply {
-        if (8w1 == 8w15 & hdr.data.b2) {
+        if (8w1 == hdr.data.b2 & 8w15) {
             test1_0.apply();
         } else {
             test2_0.apply();

--- a/testdata/p4_14_samples_outputs/gateway6-midend.p4
+++ b/testdata/p4_14_samples_outputs/gateway6-midend.p4
@@ -64,7 +64,7 @@ control ingress(inout headers hdr, inout metadata meta, inout standard_metadata_
         default_action = NoAction_2();
     }
     apply {
-        if (8w1 == 8w15 & hdr.data.b2) {
+        if (8w1 == hdr.data.b2 & 8w15) {
             test1_0.apply();
         } else {
             test2_0.apply();

--- a/testdata/p4_16_samples/reassoc-1.p4
+++ b/testdata/p4_16_samples/reassoc-1.p4
@@ -1,0 +1,19 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+    bit<32> data2;
+}
+
+parser p0(packet_in p, out Header h) {
+    state start {
+        p.extract(h);
+        h.data = 8 + h.data2 - 8 - 8 - 2 - 16;
+        transition accept;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+package top(proto _p);
+
+top(p0()) main;

--- a/testdata/p4_16_samples/strength7.p4
+++ b/testdata/p4_16_samples/strength7.p4
@@ -1,0 +1,60 @@
+#include <core.p4>
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+
+extern T foo<T>(in T x);
+
+header t1 {
+    bit<8>     x;
+}
+
+struct headers_t {
+    t1          t1;
+}
+
+control c(inout headers_t hdrs) {
+    action shrl1(bit<8> x, bit<8> y) {
+        bit<8> z = (x >> y) << y;
+        hdrs.t1.x = z;
+    }
+
+    action shrl2(bit<8> x) {
+        bit<8> z = (x >> 2) << 2;
+        hdrs.t1.x = z;
+    }
+
+    action shrl3(bit<8> x) {
+        bit<8> z = (x >> 9) << 9;
+        hdrs.t1.x = z;
+    }
+
+    action shlr1(bit<8> x, bit<8> y) {
+        bit<8> z = (x << y) >> y;
+        hdrs.t1.x = z;
+    }
+
+    action shlr2(bit<8> x) {
+        bit<8> z = (x << 2) >> 2;
+        hdrs.t1.x = z;
+    }
+
+    action shlr3(bit<8> x) {
+        bit<8> z = (x << 9) >> 9;
+        hdrs.t1.x = z;
+    }
+
+    table test {
+        key = { hdrs.t1.x: exact; }
+        actions = {
+                     shrl1; shlr1;
+                     shrl2; shlr2;
+                     shrl3; shlr3;
+                  }
+    }
+
+    apply {
+        test.apply();
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/dash/dash-pipeline-pna-dpdk-first.p4
+++ b/testdata/p4_16_samples_outputs/dash/dash-pipeline-pna-dpdk-first.p4
@@ -344,7 +344,7 @@ action push_vxlan_tunnel_u0(inout headers_t hdr, in EthernetAddress overlay_dmac
     if (hdr.customer_ipv6.isValid()) {
         customer_ip_len = customer_ip_len + 16w40 + hdr.customer_ipv6.payload_length;
     }
-    hdr.u0_ipv4.total_len = 16w50 + customer_ip_len;
+    hdr.u0_ipv4.total_len = customer_ip_len + 16w50;
     hdr.u0_ipv4.version = 4w4;
     hdr.u0_ipv4.ihl = 4w5;
     hdr.u0_ipv4.diffserv = 8w0;
@@ -359,7 +359,7 @@ action push_vxlan_tunnel_u0(inout headers_t hdr, in EthernetAddress overlay_dmac
     hdr.u0_udp.setValid();
     hdr.u0_udp.src_port = 16w0;
     hdr.u0_udp.dst_port = 16w4789;
-    hdr.u0_udp.length = 16w30 + customer_ip_len;
+    hdr.u0_udp.length = customer_ip_len + 16w30;
     hdr.u0_udp.checksum = 16w0;
     hdr.u0_vxlan.setValid();
     hdr.u0_vxlan.reserved = 24w0;
@@ -381,7 +381,7 @@ action push_vxlan_tunnel_u1(inout headers_t hdr, in EthernetAddress overlay_dmac
     if (hdr.u0_ipv6.isValid()) {
         u0_ip_len = u0_ip_len + 16w40 + hdr.u0_ipv6.payload_length;
     }
-    hdr.u1_ipv4.total_len = 16w50 + u0_ip_len;
+    hdr.u1_ipv4.total_len = u0_ip_len + 16w50;
     hdr.u1_ipv4.version = 4w4;
     hdr.u1_ipv4.ihl = 4w5;
     hdr.u1_ipv4.diffserv = 8w0;
@@ -396,7 +396,7 @@ action push_vxlan_tunnel_u1(inout headers_t hdr, in EthernetAddress overlay_dmac
     hdr.u1_udp.setValid();
     hdr.u1_udp.src_port = 16w0;
     hdr.u1_udp.dst_port = 16w4789;
-    hdr.u1_udp.length = 16w30 + u0_ip_len;
+    hdr.u1_udp.length = u0_ip_len + 16w30;
     hdr.u1_udp.checksum = 16w0;
     hdr.u1_vxlan.setValid();
     hdr.u1_vxlan.reserved = 24w0;
@@ -418,8 +418,8 @@ action push_nvgre_tunnel_u0(inout headers_t hdr, in EthernetAddress overlay_dmac
     if (hdr.customer_ipv6.isValid()) {
         customer_ip_len = customer_ip_len + 16w40 + hdr.customer_ipv6.payload_length;
     }
-    hdr.u0_ipv4.total_len = 16w50 + customer_ip_len;
-    hdr.u0_ipv4.total_len = 16w42 + hdr.u0_ipv4.total_len;
+    hdr.u0_ipv4.total_len = customer_ip_len + 16w50;
+    hdr.u0_ipv4.total_len = hdr.u0_ipv4.total_len + 16w42;
     hdr.u0_ipv4.version = 4w4;
     hdr.u0_ipv4.ihl = 4w5;
     hdr.u0_ipv4.diffserv = 8w0;
@@ -453,8 +453,8 @@ action push_nvgre_tunnel_u1(inout headers_t hdr, in EthernetAddress overlay_dmac
     if (hdr.u0_ipv6.isValid()) {
         u0_ip_len = u0_ip_len + 16w40 + hdr.u0_ipv6.payload_length;
     }
-    hdr.u1_ipv4.total_len = 16w50 + u0_ip_len;
-    hdr.u1_ipv4.total_len = 16w42 + hdr.u1_ipv4.total_len;
+    hdr.u1_ipv4.total_len = u0_ip_len + 16w50;
+    hdr.u1_ipv4.total_len = hdr.u1_ipv4.total_len + 16w42;
     hdr.u1_ipv4.version = 4w4;
     hdr.u1_ipv4.ihl = 4w5;
     hdr.u1_ipv4.diffserv = 8w0;

--- a/testdata/p4_16_samples_outputs/dash/dash-pipeline-pna-dpdk-frontend.p4
+++ b/testdata/p4_16_samples_outputs/dash/dash-pipeline-pna-dpdk-frontend.p4
@@ -798,7 +798,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_24.customer_ipv6.isValid()) {
             customer_ip_len_0 = customer_ip_len_0 + 16w40 + hdr_24.customer_ipv6.payload_length;
         }
-        hdr_24.u0_ipv4.total_len = 16w50 + customer_ip_len_0;
+        hdr_24.u0_ipv4.total_len = customer_ip_len_0 + 16w50;
         hdr_24.u0_ipv4.version = 4w4;
         hdr_24.u0_ipv4.ihl = 4w5;
         hdr_24.u0_ipv4.diffserv = 8w0;
@@ -813,7 +813,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_24.u0_udp.setValid();
         hdr_24.u0_udp.src_port = 16w0;
         hdr_24.u0_udp.dst_port = 16w4789;
-        hdr_24.u0_udp.length = 16w30 + customer_ip_len_0;
+        hdr_24.u0_udp.length = customer_ip_len_0 + 16w30;
         hdr_24.u0_udp.checksum = 16w0;
         hdr_24.u0_vxlan.setValid();
         hdr_24.u0_vxlan.reserved = 24w0;
@@ -843,7 +843,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_25.customer_ipv6.isValid()) {
             customer_ip_len_3 = customer_ip_len_3 + 16w40 + hdr_25.customer_ipv6.payload_length;
         }
-        hdr_25.u0_ipv4.total_len = 16w50 + customer_ip_len_3;
+        hdr_25.u0_ipv4.total_len = customer_ip_len_3 + 16w50;
         hdr_25.u0_ipv4.version = 4w4;
         hdr_25.u0_ipv4.ihl = 4w5;
         hdr_25.u0_ipv4.diffserv = 8w0;
@@ -858,7 +858,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_25.u0_udp.setValid();
         hdr_25.u0_udp.src_port = 16w0;
         hdr_25.u0_udp.dst_port = 16w4789;
-        hdr_25.u0_udp.length = 16w30 + customer_ip_len_3;
+        hdr_25.u0_udp.length = customer_ip_len_3 + 16w30;
         hdr_25.u0_udp.checksum = 16w0;
         hdr_25.u0_vxlan.setValid();
         hdr_25.u0_vxlan.reserved = 24w0;
@@ -888,7 +888,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_26.customer_ipv6.isValid()) {
             customer_ip_len_4 = customer_ip_len_4 + 16w40 + hdr_26.customer_ipv6.payload_length;
         }
-        hdr_26.u0_ipv4.total_len = 16w50 + customer_ip_len_4;
+        hdr_26.u0_ipv4.total_len = customer_ip_len_4 + 16w50;
         hdr_26.u0_ipv4.version = 4w4;
         hdr_26.u0_ipv4.ihl = 4w5;
         hdr_26.u0_ipv4.diffserv = 8w0;
@@ -903,7 +903,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_26.u0_udp.setValid();
         hdr_26.u0_udp.src_port = 16w0;
         hdr_26.u0_udp.dst_port = 16w4789;
-        hdr_26.u0_udp.length = 16w30 + customer_ip_len_4;
+        hdr_26.u0_udp.length = customer_ip_len_4 + 16w30;
         hdr_26.u0_udp.checksum = 16w0;
         hdr_26.u0_vxlan.setValid();
         hdr_26.u0_vxlan.reserved = 24w0;
@@ -933,7 +933,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_27.u0_ipv6.isValid()) {
             u0_ip_len_0 = u0_ip_len_0 + 16w40 + hdr_27.u0_ipv6.payload_length;
         }
-        hdr_27.u1_ipv4.total_len = 16w50 + u0_ip_len_0;
+        hdr_27.u1_ipv4.total_len = u0_ip_len_0 + 16w50;
         hdr_27.u1_ipv4.version = 4w4;
         hdr_27.u1_ipv4.ihl = 4w5;
         hdr_27.u1_ipv4.diffserv = 8w0;
@@ -948,7 +948,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_27.u1_udp.setValid();
         hdr_27.u1_udp.src_port = 16w0;
         hdr_27.u1_udp.dst_port = 16w4789;
-        hdr_27.u1_udp.length = 16w30 + u0_ip_len_0;
+        hdr_27.u1_udp.length = u0_ip_len_0 + 16w30;
         hdr_27.u1_udp.checksum = 16w0;
         hdr_27.u1_vxlan.setValid();
         hdr_27.u1_vxlan.reserved = 24w0;
@@ -978,7 +978,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_28.u0_ipv6.isValid()) {
             u0_ip_len_3 = u0_ip_len_3 + 16w40 + hdr_28.u0_ipv6.payload_length;
         }
-        hdr_28.u1_ipv4.total_len = 16w50 + u0_ip_len_3;
+        hdr_28.u1_ipv4.total_len = u0_ip_len_3 + 16w50;
         hdr_28.u1_ipv4.version = 4w4;
         hdr_28.u1_ipv4.ihl = 4w5;
         hdr_28.u1_ipv4.diffserv = 8w0;
@@ -993,7 +993,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_28.u1_udp.setValid();
         hdr_28.u1_udp.src_port = 16w0;
         hdr_28.u1_udp.dst_port = 16w4789;
-        hdr_28.u1_udp.length = 16w30 + u0_ip_len_3;
+        hdr_28.u1_udp.length = u0_ip_len_3 + 16w30;
         hdr_28.u1_udp.checksum = 16w0;
         hdr_28.u1_vxlan.setValid();
         hdr_28.u1_vxlan.reserved = 24w0;
@@ -1023,7 +1023,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_29.u0_ipv6.isValid()) {
             u0_ip_len_4 = u0_ip_len_4 + 16w40 + hdr_29.u0_ipv6.payload_length;
         }
-        hdr_29.u1_ipv4.total_len = 16w50 + u0_ip_len_4;
+        hdr_29.u1_ipv4.total_len = u0_ip_len_4 + 16w50;
         hdr_29.u1_ipv4.version = 4w4;
         hdr_29.u1_ipv4.ihl = 4w5;
         hdr_29.u1_ipv4.diffserv = 8w0;
@@ -1038,7 +1038,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_29.u1_udp.setValid();
         hdr_29.u1_udp.src_port = 16w0;
         hdr_29.u1_udp.dst_port = 16w4789;
-        hdr_29.u1_udp.length = 16w30 + u0_ip_len_4;
+        hdr_29.u1_udp.length = u0_ip_len_4 + 16w30;
         hdr_29.u1_udp.checksum = 16w0;
         hdr_29.u1_vxlan.setValid();
         hdr_29.u1_vxlan.reserved = 24w0;

--- a/testdata/p4_16_samples_outputs/dash/dash-pipeline-pna-dpdk-midend.p4
+++ b/testdata/p4_16_samples_outputs/dash/dash-pipeline-pna-dpdk-midend.p4
@@ -641,7 +641,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_24_customer_ipv6.isValid()) {
             customer_ip_len_0 = customer_ip_len_0 + 16w40 + hdr_24_customer_ipv6.payload_length;
         }
-        hdr_24_u0_ipv4.total_len = 16w50 + customer_ip_len_0;
+        hdr_24_u0_ipv4.total_len = customer_ip_len_0 + 16w50;
         hdr_24_u0_ipv4.version = 4w4;
         hdr_24_u0_ipv4.ihl = 4w5;
         hdr_24_u0_ipv4.diffserv = 8w0;
@@ -656,7 +656,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_24_u0_udp.setValid();
         hdr_24_u0_udp.src_port = 16w0;
         hdr_24_u0_udp.dst_port = 16w4789;
-        hdr_24_u0_udp.length = 16w30 + customer_ip_len_0;
+        hdr_24_u0_udp.length = customer_ip_len_0 + 16w30;
         hdr_24_u0_udp.checksum = 16w0;
         hdr_24_u0_vxlan.setValid();
         hdr_24_u0_vxlan.reserved = 24w0;
@@ -692,7 +692,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_25_customer_ipv6.isValid()) {
             customer_ip_len_3 = customer_ip_len_3 + 16w40 + hdr_25_customer_ipv6.payload_length;
         }
-        hdr_25_u0_ipv4.total_len = 16w50 + customer_ip_len_3;
+        hdr_25_u0_ipv4.total_len = customer_ip_len_3 + 16w50;
         hdr_25_u0_ipv4.version = 4w4;
         hdr_25_u0_ipv4.ihl = 4w5;
         hdr_25_u0_ipv4.diffserv = 8w0;
@@ -707,7 +707,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_25_u0_udp.setValid();
         hdr_25_u0_udp.src_port = 16w0;
         hdr_25_u0_udp.dst_port = 16w4789;
-        hdr_25_u0_udp.length = 16w30 + customer_ip_len_3;
+        hdr_25_u0_udp.length = customer_ip_len_3 + 16w30;
         hdr_25_u0_udp.checksum = 16w0;
         hdr_25_u0_vxlan.setValid();
         hdr_25_u0_vxlan.reserved = 24w0;
@@ -743,7 +743,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_26_customer_ipv6.isValid()) {
             customer_ip_len_4 = customer_ip_len_4 + 16w40 + hdr_26_customer_ipv6.payload_length;
         }
-        hdr_26_u0_ipv4.total_len = 16w50 + customer_ip_len_4;
+        hdr_26_u0_ipv4.total_len = customer_ip_len_4 + 16w50;
         hdr_26_u0_ipv4.version = 4w4;
         hdr_26_u0_ipv4.ihl = 4w5;
         hdr_26_u0_ipv4.diffserv = 8w0;
@@ -758,7 +758,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_26_u0_udp.setValid();
         hdr_26_u0_udp.src_port = 16w0;
         hdr_26_u0_udp.dst_port = 16w4789;
-        hdr_26_u0_udp.length = 16w30 + customer_ip_len_4;
+        hdr_26_u0_udp.length = customer_ip_len_4 + 16w30;
         hdr_26_u0_udp.checksum = 16w0;
         hdr_26_u0_vxlan.setValid();
         hdr_26_u0_vxlan.reserved = 24w0;
@@ -794,7 +794,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_27_u0_ipv6.isValid()) {
             u0_ip_len_0 = u0_ip_len_0 + 16w40 + hdr_27_u0_ipv6.payload_length;
         }
-        hdr_27_u1_ipv4.total_len = 16w50 + u0_ip_len_0;
+        hdr_27_u1_ipv4.total_len = u0_ip_len_0 + 16w50;
         hdr_27_u1_ipv4.version = 4w4;
         hdr_27_u1_ipv4.ihl = 4w5;
         hdr_27_u1_ipv4.diffserv = 8w0;
@@ -809,7 +809,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_27_u1_udp.setValid();
         hdr_27_u1_udp.src_port = 16w0;
         hdr_27_u1_udp.dst_port = 16w4789;
-        hdr_27_u1_udp.length = 16w30 + u0_ip_len_0;
+        hdr_27_u1_udp.length = u0_ip_len_0 + 16w30;
         hdr_27_u1_udp.checksum = 16w0;
         hdr_27_u1_vxlan.setValid();
         hdr_27_u1_vxlan.reserved = 24w0;
@@ -845,7 +845,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_28_u0_ipv6.isValid()) {
             u0_ip_len_3 = u0_ip_len_3 + 16w40 + hdr_28_u0_ipv6.payload_length;
         }
-        hdr_28_u1_ipv4.total_len = 16w50 + u0_ip_len_3;
+        hdr_28_u1_ipv4.total_len = u0_ip_len_3 + 16w50;
         hdr_28_u1_ipv4.version = 4w4;
         hdr_28_u1_ipv4.ihl = 4w5;
         hdr_28_u1_ipv4.diffserv = 8w0;
@@ -860,7 +860,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_28_u1_udp.setValid();
         hdr_28_u1_udp.src_port = 16w0;
         hdr_28_u1_udp.dst_port = 16w4789;
-        hdr_28_u1_udp.length = 16w30 + u0_ip_len_3;
+        hdr_28_u1_udp.length = u0_ip_len_3 + 16w30;
         hdr_28_u1_udp.checksum = 16w0;
         hdr_28_u1_vxlan.setValid();
         hdr_28_u1_vxlan.reserved = 24w0;
@@ -896,7 +896,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         if (hdr_29_u0_ipv6.isValid()) {
             u0_ip_len_4 = u0_ip_len_4 + 16w40 + hdr_29_u0_ipv6.payload_length;
         }
-        hdr_29_u1_ipv4.total_len = 16w50 + u0_ip_len_4;
+        hdr_29_u1_ipv4.total_len = u0_ip_len_4 + 16w50;
         hdr_29_u1_ipv4.version = 4w4;
         hdr_29_u1_ipv4.ihl = 4w5;
         hdr_29_u1_ipv4.diffserv = 8w0;
@@ -911,7 +911,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, in pna_main_inp
         hdr_29_u1_udp.setValid();
         hdr_29_u1_udp.src_port = 16w0;
         hdr_29_u1_udp.dst_port = 16w4789;
-        hdr_29_u1_udp.length = 16w30 + u0_ip_len_4;
+        hdr_29_u1_udp.length = u0_ip_len_4 + 16w30;
         hdr_29_u1_udp.checksum = 16w0;
         hdr_29_u1_vxlan.setValid();
         hdr_29_u1_vxlan.reserved = 24w0;

--- a/testdata/p4_16_samples_outputs/dash/dash-pipeline-v1model-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/dash/dash-pipeline-v1model-bmv2-first.p4
@@ -338,7 +338,7 @@ action push_vxlan_tunnel_u0(inout headers_t hdr, in EthernetAddress overlay_dmac
     hdr.u0_ethernet.src_addr = underlay_smac;
     hdr.u0_ethernet.ether_type = 16w0x800;
     hdr.u0_ipv4.setValid();
-    hdr.u0_ipv4.total_len = hdr.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr.customer_ipv4.isValid() + hdr.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() + 16w50;
+    hdr.u0_ipv4.total_len = hdr.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr.customer_ipv4.isValid() + hdr.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() * 16w40 + 16w50;
     hdr.u0_ipv4.version = 4w4;
     hdr.u0_ipv4.ihl = 4w5;
     hdr.u0_ipv4.diffserv = 8w0;
@@ -353,7 +353,7 @@ action push_vxlan_tunnel_u0(inout headers_t hdr, in EthernetAddress overlay_dmac
     hdr.u0_udp.setValid();
     hdr.u0_udp.src_port = 16w0;
     hdr.u0_udp.dst_port = 16w4789;
-    hdr.u0_udp.length = hdr.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr.customer_ipv4.isValid() + hdr.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() + 16w30;
+    hdr.u0_udp.length = hdr.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr.customer_ipv4.isValid() + hdr.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() * 16w40 + 16w30;
     hdr.u0_udp.checksum = 16w0;
     hdr.u0_vxlan.setValid();
     hdr.u0_vxlan.reserved = 24w0;
@@ -368,7 +368,7 @@ action push_vxlan_tunnel_u1(inout headers_t hdr, in EthernetAddress overlay_dmac
     hdr.u1_ethernet.src_addr = underlay_smac;
     hdr.u1_ethernet.ether_type = 16w0x800;
     hdr.u1_ipv4.setValid();
-    hdr.u1_ipv4.total_len = hdr.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr.u0_ipv4.isValid() + hdr.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + 16w50;
+    hdr.u1_ipv4.total_len = hdr.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr.u0_ipv4.isValid() + hdr.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() * 16w40 + 16w50;
     hdr.u1_ipv4.version = 4w4;
     hdr.u1_ipv4.ihl = 4w5;
     hdr.u1_ipv4.diffserv = 8w0;
@@ -383,7 +383,7 @@ action push_vxlan_tunnel_u1(inout headers_t hdr, in EthernetAddress overlay_dmac
     hdr.u1_udp.setValid();
     hdr.u1_udp.src_port = 16w0;
     hdr.u1_udp.dst_port = 16w4789;
-    hdr.u1_udp.length = hdr.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr.u0_ipv4.isValid() + hdr.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + 16w30;
+    hdr.u1_udp.length = hdr.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr.u0_ipv4.isValid() + hdr.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() * 16w40 + 16w30;
     hdr.u1_udp.checksum = 16w0;
     hdr.u1_vxlan.setValid();
     hdr.u1_vxlan.reserved = 24w0;
@@ -398,8 +398,8 @@ action push_nvgre_tunnel_u0(inout headers_t hdr, in EthernetAddress overlay_dmac
     hdr.u0_ethernet.src_addr = underlay_smac;
     hdr.u0_ethernet.ether_type = 16w0x800;
     hdr.u0_ipv4.setValid();
-    hdr.u0_ipv4.total_len = hdr.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr.customer_ipv4.isValid() + hdr.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() + 16w42;
-    hdr.u0_ipv4.total_len = 16w42 + hdr.u0_ipv4.total_len;
+    hdr.u0_ipv4.total_len = hdr.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr.customer_ipv4.isValid() + hdr.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr.customer_ipv6.isValid() * 16w40 + 16w42;
+    hdr.u0_ipv4.total_len = hdr.u0_ipv4.total_len + 16w42;
     hdr.u0_ipv4.version = 4w4;
     hdr.u0_ipv4.ihl = 4w5;
     hdr.u0_ipv4.diffserv = 8w0;
@@ -426,8 +426,8 @@ action push_nvgre_tunnel_u1(inout headers_t hdr, in EthernetAddress overlay_dmac
     hdr.u1_ethernet.src_addr = underlay_smac;
     hdr.u1_ethernet.ether_type = 16w0x800;
     hdr.u1_ipv4.setValid();
-    hdr.u1_ipv4.total_len = hdr.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr.u0_ipv4.isValid() + hdr.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + 16w42;
-    hdr.u1_ipv4.total_len = 16w42 + hdr.u1_ipv4.total_len;
+    hdr.u1_ipv4.total_len = hdr.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr.u0_ipv4.isValid() + hdr.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr.u0_ipv6.isValid() * 16w40 + 16w42;
+    hdr.u1_ipv4.total_len = hdr.u1_ipv4.total_len + 16w42;
     hdr.u1_ipv4.version = 4w4;
     hdr.u1_ipv4.ihl = 4w5;
     hdr.u1_ipv4.diffserv = 8w0;

--- a/testdata/p4_16_samples_outputs/dash/dash-pipeline-v1model-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/dash/dash-pipeline-v1model-bmv2-frontend.p4
@@ -797,7 +797,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_24.u0_ethernet.src_addr = underlay_smac_12;
         hdr_24.u0_ethernet.ether_type = 16w0x800;
         hdr_24.u0_ipv4.setValid();
-        hdr_24.u0_ipv4.total_len = hdr_24.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_24.customer_ipv4.isValid() + hdr_24.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_24.customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_24.customer_ipv6.isValid() + 16w50;
+        hdr_24.u0_ipv4.total_len = hdr_24.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_24.customer_ipv4.isValid() + hdr_24.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_24.customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_24.customer_ipv6.isValid() * 16w40 + 16w50;
         hdr_24.u0_ipv4.version = 4w4;
         hdr_24.u0_ipv4.ihl = 4w5;
         hdr_24.u0_ipv4.diffserv = 8w0;
@@ -812,7 +812,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_24.u0_udp.setValid();
         hdr_24.u0_udp.src_port = 16w0;
         hdr_24.u0_udp.dst_port = 16w4789;
-        hdr_24.u0_udp.length = hdr_24.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_24.customer_ipv4.isValid() + hdr_24.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_24.customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_24.customer_ipv6.isValid() + 16w30;
+        hdr_24.u0_udp.length = hdr_24.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_24.customer_ipv4.isValid() + hdr_24.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_24.customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_24.customer_ipv6.isValid() * 16w40 + 16w30;
         hdr_24.u0_udp.checksum = 16w0;
         hdr_24.u0_vxlan.setValid();
         hdr_24.u0_vxlan.reserved = 24w0;
@@ -840,7 +840,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_25.u0_ethernet.src_addr = underlay_smac_13;
         hdr_25.u0_ethernet.ether_type = 16w0x800;
         hdr_25.u0_ipv4.setValid();
-        hdr_25.u0_ipv4.total_len = hdr_25.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_25.customer_ipv4.isValid() + hdr_25.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_25.customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_25.customer_ipv6.isValid() + 16w50;
+        hdr_25.u0_ipv4.total_len = hdr_25.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_25.customer_ipv4.isValid() + hdr_25.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_25.customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_25.customer_ipv6.isValid() * 16w40 + 16w50;
         hdr_25.u0_ipv4.version = 4w4;
         hdr_25.u0_ipv4.ihl = 4w5;
         hdr_25.u0_ipv4.diffserv = 8w0;
@@ -855,7 +855,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_25.u0_udp.setValid();
         hdr_25.u0_udp.src_port = 16w0;
         hdr_25.u0_udp.dst_port = 16w4789;
-        hdr_25.u0_udp.length = hdr_25.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_25.customer_ipv4.isValid() + hdr_25.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_25.customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_25.customer_ipv6.isValid() + 16w30;
+        hdr_25.u0_udp.length = hdr_25.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_25.customer_ipv4.isValid() + hdr_25.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_25.customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_25.customer_ipv6.isValid() * 16w40 + 16w30;
         hdr_25.u0_udp.checksum = 16w0;
         hdr_25.u0_vxlan.setValid();
         hdr_25.u0_vxlan.reserved = 24w0;
@@ -883,7 +883,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_26.u0_ethernet.src_addr = underlay_smac_14;
         hdr_26.u0_ethernet.ether_type = 16w0x800;
         hdr_26.u0_ipv4.setValid();
-        hdr_26.u0_ipv4.total_len = hdr_26.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_26.customer_ipv4.isValid() + hdr_26.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_26.customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_26.customer_ipv6.isValid() + 16w50;
+        hdr_26.u0_ipv4.total_len = hdr_26.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_26.customer_ipv4.isValid() + hdr_26.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_26.customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_26.customer_ipv6.isValid() * 16w40 + 16w50;
         hdr_26.u0_ipv4.version = 4w4;
         hdr_26.u0_ipv4.ihl = 4w5;
         hdr_26.u0_ipv4.diffserv = 8w0;
@@ -898,7 +898,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_26.u0_udp.setValid();
         hdr_26.u0_udp.src_port = 16w0;
         hdr_26.u0_udp.dst_port = 16w4789;
-        hdr_26.u0_udp.length = hdr_26.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_26.customer_ipv4.isValid() + hdr_26.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_26.customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_26.customer_ipv6.isValid() + 16w30;
+        hdr_26.u0_udp.length = hdr_26.customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_26.customer_ipv4.isValid() + hdr_26.customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_26.customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_26.customer_ipv6.isValid() * 16w40 + 16w30;
         hdr_26.u0_udp.checksum = 16w0;
         hdr_26.u0_vxlan.setValid();
         hdr_26.u0_vxlan.reserved = 24w0;
@@ -926,7 +926,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_27.u1_ethernet.src_addr = underlay_smac_15;
         hdr_27.u1_ethernet.ether_type = 16w0x800;
         hdr_27.u1_ipv4.setValid();
-        hdr_27.u1_ipv4.total_len = hdr_27.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_27.u0_ipv4.isValid() + hdr_27.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_27.u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_27.u0_ipv6.isValid() + 16w50;
+        hdr_27.u1_ipv4.total_len = hdr_27.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_27.u0_ipv4.isValid() + hdr_27.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_27.u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_27.u0_ipv6.isValid() * 16w40 + 16w50;
         hdr_27.u1_ipv4.version = 4w4;
         hdr_27.u1_ipv4.ihl = 4w5;
         hdr_27.u1_ipv4.diffserv = 8w0;
@@ -941,7 +941,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_27.u1_udp.setValid();
         hdr_27.u1_udp.src_port = 16w0;
         hdr_27.u1_udp.dst_port = 16w4789;
-        hdr_27.u1_udp.length = hdr_27.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_27.u0_ipv4.isValid() + hdr_27.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_27.u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_27.u0_ipv6.isValid() + 16w30;
+        hdr_27.u1_udp.length = hdr_27.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_27.u0_ipv4.isValid() + hdr_27.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_27.u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_27.u0_ipv6.isValid() * 16w40 + 16w30;
         hdr_27.u1_udp.checksum = 16w0;
         hdr_27.u1_vxlan.setValid();
         hdr_27.u1_vxlan.reserved = 24w0;
@@ -969,7 +969,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_28.u1_ethernet.src_addr = underlay_smac_16;
         hdr_28.u1_ethernet.ether_type = 16w0x800;
         hdr_28.u1_ipv4.setValid();
-        hdr_28.u1_ipv4.total_len = hdr_28.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_28.u0_ipv4.isValid() + hdr_28.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_28.u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_28.u0_ipv6.isValid() + 16w50;
+        hdr_28.u1_ipv4.total_len = hdr_28.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_28.u0_ipv4.isValid() + hdr_28.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_28.u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_28.u0_ipv6.isValid() * 16w40 + 16w50;
         hdr_28.u1_ipv4.version = 4w4;
         hdr_28.u1_ipv4.ihl = 4w5;
         hdr_28.u1_ipv4.diffserv = 8w0;
@@ -984,7 +984,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_28.u1_udp.setValid();
         hdr_28.u1_udp.src_port = 16w0;
         hdr_28.u1_udp.dst_port = 16w4789;
-        hdr_28.u1_udp.length = hdr_28.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_28.u0_ipv4.isValid() + hdr_28.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_28.u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_28.u0_ipv6.isValid() + 16w30;
+        hdr_28.u1_udp.length = hdr_28.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_28.u0_ipv4.isValid() + hdr_28.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_28.u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_28.u0_ipv6.isValid() * 16w40 + 16w30;
         hdr_28.u1_udp.checksum = 16w0;
         hdr_28.u1_vxlan.setValid();
         hdr_28.u1_vxlan.reserved = 24w0;
@@ -1012,7 +1012,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_29.u1_ethernet.src_addr = underlay_smac_17;
         hdr_29.u1_ethernet.ether_type = 16w0x800;
         hdr_29.u1_ipv4.setValid();
-        hdr_29.u1_ipv4.total_len = hdr_29.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_29.u0_ipv4.isValid() + hdr_29.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_29.u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_29.u0_ipv6.isValid() + 16w50;
+        hdr_29.u1_ipv4.total_len = hdr_29.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_29.u0_ipv4.isValid() + hdr_29.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_29.u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_29.u0_ipv6.isValid() * 16w40 + 16w50;
         hdr_29.u1_ipv4.version = 4w4;
         hdr_29.u1_ipv4.ihl = 4w5;
         hdr_29.u1_ipv4.diffserv = 8w0;
@@ -1027,7 +1027,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_29.u1_udp.setValid();
         hdr_29.u1_udp.src_port = 16w0;
         hdr_29.u1_udp.dst_port = 16w4789;
-        hdr_29.u1_udp.length = hdr_29.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_29.u0_ipv4.isValid() + hdr_29.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_29.u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_29.u0_ipv6.isValid() + 16w30;
+        hdr_29.u1_udp.length = hdr_29.u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_29.u0_ipv4.isValid() + hdr_29.u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_29.u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_29.u0_ipv6.isValid() * 16w40 + 16w30;
         hdr_29.u1_udp.checksum = 16w0;
         hdr_29.u1_vxlan.setValid();
         hdr_29.u1_vxlan.reserved = 24w0;

--- a/testdata/p4_16_samples_outputs/dash/dash-pipeline-v1model-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/dash/dash-pipeline-v1model-bmv2-midend.p4
@@ -631,7 +631,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_24_u0_ethernet.src_addr = meta._encap_data_underlay_smac49;
         hdr_24_u0_ethernet.ether_type = 16w0x800;
         hdr_24_u0_ipv4.setValid();
-        hdr_24_u0_ipv4.total_len = hdr_24_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_24_customer_ipv4.isValid() + hdr_24_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_24_customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_24_customer_ipv6.isValid() + 16w50;
+        hdr_24_u0_ipv4.total_len = hdr_24_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_24_customer_ipv4.isValid() + hdr_24_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_24_customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_24_customer_ipv6.isValid() * 16w40 + 16w50;
         hdr_24_u0_ipv4.version = 4w4;
         hdr_24_u0_ipv4.ihl = 4w5;
         hdr_24_u0_ipv4.diffserv = 8w0;
@@ -646,7 +646,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_24_u0_udp.setValid();
         hdr_24_u0_udp.src_port = 16w0;
         hdr_24_u0_udp.dst_port = 16w4789;
-        hdr_24_u0_udp.length = hdr_24_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_24_customer_ipv4.isValid() + hdr_24_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_24_customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_24_customer_ipv6.isValid() + 16w30;
+        hdr_24_u0_udp.length = hdr_24_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_24_customer_ipv4.isValid() + hdr_24_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_24_customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_24_customer_ipv6.isValid() * 16w40 + 16w30;
         hdr_24_u0_udp.checksum = 16w0;
         hdr_24_u0_vxlan.setValid();
         hdr_24_u0_vxlan.reserved = 24w0;
@@ -680,7 +680,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_25_u0_ethernet.src_addr = meta._encap_data_underlay_smac49;
         hdr_25_u0_ethernet.ether_type = 16w0x800;
         hdr_25_u0_ipv4.setValid();
-        hdr_25_u0_ipv4.total_len = hdr_25_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_25_customer_ipv4.isValid() + hdr_25_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_25_customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_25_customer_ipv6.isValid() + 16w50;
+        hdr_25_u0_ipv4.total_len = hdr_25_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_25_customer_ipv4.isValid() + hdr_25_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_25_customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_25_customer_ipv6.isValid() * 16w40 + 16w50;
         hdr_25_u0_ipv4.version = 4w4;
         hdr_25_u0_ipv4.ihl = 4w5;
         hdr_25_u0_ipv4.diffserv = 8w0;
@@ -695,7 +695,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_25_u0_udp.setValid();
         hdr_25_u0_udp.src_port = 16w0;
         hdr_25_u0_udp.dst_port = 16w4789;
-        hdr_25_u0_udp.length = hdr_25_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_25_customer_ipv4.isValid() + hdr_25_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_25_customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_25_customer_ipv6.isValid() + 16w30;
+        hdr_25_u0_udp.length = hdr_25_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_25_customer_ipv4.isValid() + hdr_25_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_25_customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_25_customer_ipv6.isValid() * 16w40 + 16w30;
         hdr_25_u0_udp.checksum = 16w0;
         hdr_25_u0_vxlan.setValid();
         hdr_25_u0_vxlan.reserved = 24w0;
@@ -729,7 +729,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_26_u0_ethernet.src_addr = meta._encap_data_underlay_smac49;
         hdr_26_u0_ethernet.ether_type = 16w0x800;
         hdr_26_u0_ipv4.setValid();
-        hdr_26_u0_ipv4.total_len = hdr_26_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_26_customer_ipv4.isValid() + hdr_26_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_26_customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_26_customer_ipv6.isValid() + 16w50;
+        hdr_26_u0_ipv4.total_len = hdr_26_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_26_customer_ipv4.isValid() + hdr_26_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_26_customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_26_customer_ipv6.isValid() * 16w40 + 16w50;
         hdr_26_u0_ipv4.version = 4w4;
         hdr_26_u0_ipv4.ihl = 4w5;
         hdr_26_u0_ipv4.diffserv = 8w0;
@@ -744,7 +744,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_26_u0_udp.setValid();
         hdr_26_u0_udp.src_port = 16w0;
         hdr_26_u0_udp.dst_port = 16w4789;
-        hdr_26_u0_udp.length = hdr_26_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_26_customer_ipv4.isValid() + hdr_26_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_26_customer_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_26_customer_ipv6.isValid() + 16w30;
+        hdr_26_u0_udp.length = hdr_26_customer_ipv4.total_len * (bit<16>)(bit<1>)hdr_26_customer_ipv4.isValid() + hdr_26_customer_ipv6.payload_length * (bit<16>)(bit<1>)hdr_26_customer_ipv6.isValid() + (bit<16>)(bit<1>)hdr_26_customer_ipv6.isValid() * 16w40 + 16w30;
         hdr_26_u0_udp.checksum = 16w0;
         hdr_26_u0_vxlan.setValid();
         hdr_26_u0_vxlan.reserved = 24w0;
@@ -778,7 +778,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_27_u1_ethernet.src_addr = meta._encap_data_underlay_smac49;
         hdr_27_u1_ethernet.ether_type = 16w0x800;
         hdr_27_u1_ipv4.setValid();
-        hdr_27_u1_ipv4.total_len = hdr_27_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_27_u0_ipv4.isValid() + hdr_27_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_27_u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_27_u0_ipv6.isValid() + 16w50;
+        hdr_27_u1_ipv4.total_len = hdr_27_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_27_u0_ipv4.isValid() + hdr_27_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_27_u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_27_u0_ipv6.isValid() * 16w40 + 16w50;
         hdr_27_u1_ipv4.version = 4w4;
         hdr_27_u1_ipv4.ihl = 4w5;
         hdr_27_u1_ipv4.diffserv = 8w0;
@@ -793,7 +793,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_27_u1_udp.setValid();
         hdr_27_u1_udp.src_port = 16w0;
         hdr_27_u1_udp.dst_port = 16w4789;
-        hdr_27_u1_udp.length = hdr_27_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_27_u0_ipv4.isValid() + hdr_27_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_27_u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_27_u0_ipv6.isValid() + 16w30;
+        hdr_27_u1_udp.length = hdr_27_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_27_u0_ipv4.isValid() + hdr_27_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_27_u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_27_u0_ipv6.isValid() * 16w40 + 16w30;
         hdr_27_u1_udp.checksum = 16w0;
         hdr_27_u1_vxlan.setValid();
         hdr_27_u1_vxlan.reserved = 24w0;
@@ -827,7 +827,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_28_u1_ethernet.src_addr = meta._encap_data_underlay_smac49;
         hdr_28_u1_ethernet.ether_type = 16w0x800;
         hdr_28_u1_ipv4.setValid();
-        hdr_28_u1_ipv4.total_len = hdr_28_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_28_u0_ipv4.isValid() + hdr_28_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_28_u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_28_u0_ipv6.isValid() + 16w50;
+        hdr_28_u1_ipv4.total_len = hdr_28_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_28_u0_ipv4.isValid() + hdr_28_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_28_u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_28_u0_ipv6.isValid() * 16w40 + 16w50;
         hdr_28_u1_ipv4.version = 4w4;
         hdr_28_u1_ipv4.ihl = 4w5;
         hdr_28_u1_ipv4.diffserv = 8w0;
@@ -842,7 +842,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_28_u1_udp.setValid();
         hdr_28_u1_udp.src_port = 16w0;
         hdr_28_u1_udp.dst_port = 16w4789;
-        hdr_28_u1_udp.length = hdr_28_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_28_u0_ipv4.isValid() + hdr_28_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_28_u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_28_u0_ipv6.isValid() + 16w30;
+        hdr_28_u1_udp.length = hdr_28_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_28_u0_ipv4.isValid() + hdr_28_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_28_u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_28_u0_ipv6.isValid() * 16w40 + 16w30;
         hdr_28_u1_udp.checksum = 16w0;
         hdr_28_u1_vxlan.setValid();
         hdr_28_u1_vxlan.reserved = 24w0;
@@ -876,7 +876,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_29_u1_ethernet.src_addr = meta._encap_data_underlay_smac49;
         hdr_29_u1_ethernet.ether_type = 16w0x800;
         hdr_29_u1_ipv4.setValid();
-        hdr_29_u1_ipv4.total_len = hdr_29_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_29_u0_ipv4.isValid() + hdr_29_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_29_u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_29_u0_ipv6.isValid() + 16w50;
+        hdr_29_u1_ipv4.total_len = hdr_29_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_29_u0_ipv4.isValid() + hdr_29_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_29_u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_29_u0_ipv6.isValid() * 16w40 + 16w50;
         hdr_29_u1_ipv4.version = 4w4;
         hdr_29_u1_ipv4.ihl = 4w5;
         hdr_29_u1_ipv4.diffserv = 8w0;
@@ -891,7 +891,7 @@ control dash_ingress(inout headers_t hdr, inout metadata_t meta, inout standard_
         hdr_29_u1_udp.setValid();
         hdr_29_u1_udp.src_port = 16w0;
         hdr_29_u1_udp.dst_port = 16w4789;
-        hdr_29_u1_udp.length = hdr_29_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_29_u0_ipv4.isValid() + hdr_29_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_29_u0_ipv6.isValid() + 16w40 * (bit<16>)(bit<1>)hdr_29_u0_ipv6.isValid() + 16w30;
+        hdr_29_u1_udp.length = hdr_29_u0_ipv4.total_len * (bit<16>)(bit<1>)hdr_29_u0_ipv4.isValid() + hdr_29_u0_ipv6.payload_length * (bit<16>)(bit<1>)hdr_29_u0_ipv6.isValid() + (bit<16>)(bit<1>)hdr_29_u0_ipv6.isValid() * 16w40 + 16w30;
         hdr_29_u1_udp.checksum = 16w0;
         hdr_29_u1_vxlan.setValid();
         hdr_29_u1_vxlan.reserved = 24w0;

--- a/testdata/p4_16_samples_outputs/ex1-first.p4
+++ b/testdata/p4_16_samples_outputs/ex1-first.p4
@@ -4,5 +4,5 @@ struct S {
 }
 
 action a(in S w, out bit<8> z) {
-    z = 8w10 + w.s;
+    z = w.s + 8w10;
 }

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2-first.p4
@@ -111,7 +111,7 @@ parser PROTParser(packet_in packet, out headers hdr, inout metadata meta, inout 
         transition parse_prot_inf_0;
     }
     state parse_prot_inf_0 {
-        meta.currPos = (bit<8>)(9w3 + (meta.addrLen >> 6));
+        meta.currPos = (bit<8>)((meta.addrLen >> 6) + 9w3);
         bool currentISelected = hdr.prot_common.curri == meta.currPos;
         subParser.apply(packet, hdr.prot_inf_0, meta, currentISelected, hdr.prot_common.curri);
         transition parse_prot_h_0_pre;

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2-frontend.p4
@@ -92,7 +92,7 @@ parser PROTParser(packet_in packet, out headers hdr, inout metadata meta, inout 
         paddingLen_0 = 9w64 - (meta.addrLen & 9w63) & 9w63;
         packet.extract<prot_host_addr_padding_t>(hdr.prot_host_addr_padding, (bit<32>)paddingLen_0);
         meta.addrLen = meta.addrLen + paddingLen_0;
-        meta.currPos = (bit<8>)(9w3 + (meta.addrLen >> 6));
+        meta.currPos = (bit<8>)((meta.addrLen >> 6) + 9w3);
         inf_0.setInvalid();
         meta_0 = meta;
         currI_0 = hdr.prot_common.curri;

--- a/testdata/p4_16_samples_outputs/issue1879-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue1879-bmv2-midend.p4
@@ -84,15 +84,15 @@ parser PROTParser(packet_in packet, out headers hdr, inout metadata meta, inout 
         meta._addrLen2 = meta._addrLen2 + 9w32;
         packet.extract<prot_host_addr_padding_t>(hdr.prot_host_addr_padding, (bit<32>)(9w64 - (meta._addrLen2 & 9w63) & 9w63));
         meta._addrLen2 = meta._addrLen2 + (9w64 - (meta._addrLen2 & 9w63) & 9w63);
-        meta._currPos3 = (bit<8>)(9w3 + (meta._addrLen2 >> 6));
+        meta._currPos3 = (bit<8>)((meta._addrLen2 >> 6) + 9w3);
         inf_0.setInvalid();
         meta_0_currenti.upDirection = meta._currenti_upDirection4;
         packet.extract<prot_i_t>(inf_0);
-        meta_0_currenti.upDirection = meta._currenti_upDirection4 + (bit<1>)(hdr.prot_common.curri == (bit<8>)(9w3 + (meta._addrLen2 >> 6))) * inf_0.upDirection;
+        meta_0_currenti.upDirection = meta._currenti_upDirection4 + (bit<1>)(hdr.prot_common.curri == (bit<8>)((meta._addrLen2 >> 6) + 9w3)) * inf_0.upDirection;
         hdr.prot_inf_0 = inf_0;
         meta._hLeft1 = inf_0.segLen;
-        meta._currPos3 = (bit<8>)(9w3 + (meta._addrLen2 >> 6)) + 8w1;
-        meta._currenti_upDirection4 = meta._currenti_upDirection4 + (bit<1>)(hdr.prot_common.curri == (bit<8>)(9w3 + (meta._addrLen2 >> 6))) * inf_0.upDirection;
+        meta._currPos3 = (bit<8>)((meta._addrLen2 >> 6) + 9w3) + 8w1;
+        meta._currenti_upDirection4 = meta._currenti_upDirection4 + (bit<1>)(hdr.prot_common.curri == (bit<8>)((meta._addrLen2 >> 6) + 9w3)) * inf_0.upDirection;
         transition parse_prot_h_0_pre;
     }
     state parse_prot_h_0_pre {

--- a/testdata/p4_16_samples_outputs/issue2221-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2221-bmv2-first.p4
@@ -29,8 +29,8 @@ parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t
 control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<16> dummy_var;
-        dummy_var = 16w0 & function_with_side_effect(h.eth_hdr.eth_type);
-        dummy_var = 16w0 * function_with_side_effect(h.eth_hdr.eth_type);
+        dummy_var = function_with_side_effect(h.eth_hdr.eth_type) & 16w0;
+        dummy_var = function_with_side_effect(h.eth_hdr.eth_type) * 16w0;
         dummy_var = 16w0 >> function_with_side_effect(h.eth_hdr.eth_type);
     }
 }

--- a/testdata/p4_16_samples_outputs/issue2279-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2279-first.p4
@@ -11,7 +11,7 @@ struct Headers {
 control c(inout Headers hdr) {
     bit<16> tmp_val = 16w3;
     action do_action() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val > 16w2 ? 16w3 : 16w1) + 16w3;
     }
     apply {
         do_action();

--- a/testdata/p4_16_samples_outputs/issue2279-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279-frontend.p4
@@ -13,7 +13,7 @@ control c(inout Headers hdr) {
     @name("c.do_action") action do_action() {
     }
     @name("c.do_action") action do_action_1() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val_0 > 16w2 ? 16w3 : 16w1) + 16w3;
     }
     apply {
         tmp_val_0 = 16w3;

--- a/testdata/p4_16_samples_outputs/issue2279_1-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_1-first.p4
@@ -11,7 +11,7 @@ struct Headers {
 control c(inout Headers hdr) {
     bit<16> tmp_val = 16w3;
     action do_action() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val > 16w2 ? 16w3 : 16w1) + 16w3;
         tmp_val[7:0] = 8w4;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/issue2279_1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_1-frontend.p4
@@ -14,7 +14,7 @@ control c(inout Headers hdr) {
         tmp_val_0[7:0] = 8w4;
     }
     @name("c.do_action") action do_action_1() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val_0 > 16w2 ? 16w3 : 16w1) + 16w3;
     }
     apply {
         tmp_val_0 = 16w3;

--- a/testdata/p4_16_samples_outputs/issue2279_1-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_1-midend.p4
@@ -14,7 +14,7 @@ control c(inout Headers hdr) {
         tmp_val_0[7:0] = 8w4;
     }
     @name("c.do_action") action do_action_1() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val_0 > 16w2 ? 16w3 : 16w1) + 16w3;
     }
     @hidden action issue2279_1l12() {
         tmp_val_0 = 16w3;

--- a/testdata/p4_16_samples_outputs/issue2279_2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_2-first.p4
@@ -11,7 +11,7 @@ struct Headers {
 control c(inout Headers hdr) {
     bit<16> tmp_val = 16w3;
     action do_action() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val > 16w2 ? 16w3 : 16w1) + 16w3;
         tmp_val = 16w4;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/issue2279_2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_2-frontend.p4
@@ -13,7 +13,7 @@ control c(inout Headers hdr) {
     @name("c.do_action") action do_action() {
     }
     @name("c.do_action") action do_action_1() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val_0 > 16w2 ? 16w3 : 16w1) + 16w3;
     }
     apply {
         do_action();

--- a/testdata/p4_16_samples_outputs/issue2279_3-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_3-first.p4
@@ -11,7 +11,7 @@ struct Headers {
 control c(inout Headers hdr) {
     bool tmp_val = false;
     action do_action() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val ? 16w3 : 16w1) + 16w3;
         tmp_val = true;
     }
     apply {

--- a/testdata/p4_16_samples_outputs/issue2279_3-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_3-frontend.p4
@@ -14,7 +14,7 @@ control c(inout Headers hdr) {
         tmp_val_0 = true;
     }
     @name("c.do_action") action do_action_1() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val_0 ? 16w3 : 16w1) + 16w3;
     }
     apply {
         do_action();

--- a/testdata/p4_16_samples_outputs/issue2279_4-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_4-first.p4
@@ -11,7 +11,7 @@ struct Headers {
 control c(inout Headers hdr) {
     bit<16> tmp_val = 16w3;
     action do_action() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val > 16w2 ? 16w3 : 16w1) + 16w3;
     }
     apply {
         do_action();

--- a/testdata/p4_16_samples_outputs/issue2279_4-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_4-frontend.p4
@@ -11,10 +11,10 @@ struct Headers {
 control c(inout Headers hdr) {
     @name("c.tmp_val") bit<16> tmp_val_0;
     @name("c.do_action") action do_action() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val_0 > 16w2 ? 16w3 : 16w1) + 16w3;
     }
     @name("c.do_action") action do_action_1() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val_0 > 16w2 ? 16w3 : 16w1) + 16w3;
     }
     apply {
         tmp_val_0 = 16w3;

--- a/testdata/p4_16_samples_outputs/issue2279_4-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2279_4-midend.p4
@@ -14,7 +14,7 @@ control c(inout Headers hdr) {
         hdr.eth_hdr.eth_type = 16w6;
     }
     @name("c.do_action") action do_action_1() {
-        hdr.eth_hdr.eth_type = 16w3 + (tmp_val_0 > 16w2 ? 16w3 : 16w1);
+        hdr.eth_hdr.eth_type = (tmp_val_0 > 16w2 ? 16w3 : 16w1) + 16w3;
     }
     @hidden action issue2279_4l12() {
         tmp_val_0 = 16w3;

--- a/testdata/p4_16_samples_outputs/issue2287-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2287-bmv2-first.p4
@@ -61,8 +61,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
     apply {
         bit<8> dummy_var;
         bool dummy_bool;
-        dummy_var = 8w0 & function_with_side_effect(h.h.a);
-        dummy_var = 8w0 * function_with_side_effect(h.h.b);
+        dummy_var = function_with_side_effect(h.h.a) & 8w0;
+        dummy_var = function_with_side_effect(h.h.b) * 8w0;
         dummy_var = 8w0 / function_with_side_effect(h.h.c);
         dummy_var = 8w0 >> function_with_side_effect(h.h.d);
         dummy_var = 8w0 << function_with_side_effect(h.h.e);
@@ -70,8 +70,8 @@ control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
         dummy_var = function_with_side_effect(h.h.g);
         dummy_var = 8w0 |-| function_with_side_effect(h.h.h);
         dummy_var = 8w255 |+| function_with_side_effect(h.h.i);
-        dummy_var = 8w255 + function_with_side_effect(h.h.j);
-        dummy_var = 8w255 | function_with_side_effect(h.h.k);
+        dummy_var = function_with_side_effect(h.h.j) + 8w255;
+        dummy_var = function_with_side_effect(h.h.k) | 8w255;
         dummy_var = -function_with_side_effect(h.h.l);
         dummy_var = (16w1 ++ function_with_side_effect(h.h.m))[15:8];
         dummy_bool = true;

--- a/testdata/p4_16_samples_outputs/issue3394-first.p4
+++ b/testdata/p4_16_samples_outputs/issue3394-first.p4
@@ -19,7 +19,7 @@ control C1(int a, inout bit<8> b) {
         if (b == (bit<8>)a) {
             b = (bit<8>)a + 8w1;
         } else {
-            b = (bit<8>)(1 + a);
+            b = (bit<8>)(a + 1);
         }
     }
 }

--- a/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment-first.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment-first.p4
@@ -128,7 +128,7 @@ control MainControlImpl(inout parsed_headers_t hdrs, inout user_meta_t umeta, in
         hdrs.ipv4[0].ihl = 4w5;
         hdrs.ipv4[0].dscp = 6w5;
         hdrs.ipv4[0].ecn = 2w0;
-        hdrs.ipv4[0].length = 16w20 + umeta.L2_packet_len_bytes;
+        hdrs.ipv4[0].length = umeta.L2_packet_len_bytes + 16w20;
         hdrs.ipv4[0].identification = 16w0;
         hdrs.ipv4[0].rsvd = 1w0;
         hdrs.ipv4[0].df = 1w0;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment-frontend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment-frontend.p4
@@ -126,7 +126,7 @@ control MainControlImpl(inout parsed_headers_t hdrs, inout user_meta_t umeta, in
         hdrs.ipv4[0].ihl = 4w5;
         hdrs.ipv4[0].dscp = 6w5;
         hdrs.ipv4[0].ecn = 2w0;
-        hdrs.ipv4[0].length = 16w20 + umeta.L2_packet_len_bytes;
+        hdrs.ipv4[0].length = umeta.L2_packet_len_bytes + 16w20;
         hdrs.ipv4[0].identification = 16w0;
         hdrs.ipv4[0].rsvd = 1w0;
         hdrs.ipv4[0].df = 1w0;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment-midend.p4
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment-midend.p4
@@ -126,7 +126,7 @@ control MainControlImpl(inout parsed_headers_t hdrs, inout user_meta_t umeta, in
         hdrs.ipv4[0].ihl = 4w5;
         hdrs.ipv4[0].dscp = 6w5;
         hdrs.ipv4[0].ecn = 2w0;
-        hdrs.ipv4[0].length = 16w20 + umeta.L2_packet_len_bytes;
+        hdrs.ipv4[0].length = umeta.L2_packet_len_bytes + 16w20;
         hdrs.ipv4[0].identification = 16w0;
         hdrs.ipv4[0].rsvd = 1w0;
         hdrs.ipv4[0].df = 1w0;

--- a/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment.p4.spec
+++ b/testdata/p4_16_samples_outputs/pna-dpdk-header-stack-assignment.p4.spec
@@ -137,8 +137,8 @@ action encap_one_tunnel_layer_ipv4 args instanceof encap_one_tunnel_layer_ipv4_a
 	and m.MainControlT_tmp_2 0xFC
 	mov h.ipv4_0.dscp_ecn m.MainControlT_tmp_2
 	or h.ipv4_0.dscp_ecn 0x0
-	mov h.ipv4_0.length 0x14
-	add h.ipv4_0.length m.local_metadata_L2_packet_len_bytes
+	mov h.ipv4_0.length m.local_metadata_L2_packet_len_bytes
+	add h.ipv4_0.length 0x14
 	mov h.ipv4_0.identification 0x0
 	mov m.MainControlT_tmp_3 h.ipv4_0.rsvd_df_mf_frag_off
 	and m.MainControlT_tmp_3 0x7FFF

--- a/testdata/p4_16_samples_outputs/precedence-lt-first.p4
+++ b/testdata/p4_16_samples_outputs/precedence-lt-first.p4
@@ -10,7 +10,7 @@ struct data {
 
 control C(inout data d, inout bit<16> foo, Object o) {
     apply {
-        if (8w4 + d.f < 8w10) {
+        if (d.f + 8w4 < 8w10) {
             d.foo = (bit<8>)(o.foo<bit<16>>());
         }
     }

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-1-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-1-first.p4
@@ -68,12 +68,12 @@ control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata
         b.meta = 32w1 << b.meta2;
         b.meta1 = 32w0x800 >> b.meta2;
         b.meta2 = 16w0xf0 - b.meta2;
-        b.meta4 = 32w0x808 + ~b.meta6;
+        b.meta4 = ~b.meta6 + 32w0x808;
         b.meta3 = -b.meta3;
         b.meta6 = 32w0x808 - b.meta3;
         b.meta3 = b.meta3 + 32w0x1;
         b.meta5 = b.meta7 + 16w0xf0;
-        b.meta7 = 16w0xf0 + b.meta2;
+        b.meta7 = b.meta2 + 16w0xf0;
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-1-frontend.p4
@@ -67,12 +67,12 @@ control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata
         b.meta = 32w1 << b.meta2;
         b.meta1 = 32w0x800 >> b.meta2;
         b.meta2 = 16w0xf0 - b.meta2;
-        b.meta4 = 32w0x808 + ~b.meta6;
+        b.meta4 = ~b.meta6 + 32w0x808;
         b.meta3 = -b.meta3;
         b.meta6 = 32w0x808 - b.meta3;
         b.meta3 = b.meta3 + 32w0x1;
         b.meta5 = b.meta7 + 16w0xf0;
-        b.meta7 = 16w0xf0 + b.meta2;
+        b.meta7 = b.meta2 + 16w0xf0;
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-1-midend.p4
@@ -65,16 +65,16 @@ control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata
         b.meta = 32w1 << b.meta2;
         b.meta1 = 32w0x800 >> b.meta2;
         b.meta2 = 16w0xf0 - b.meta2;
-        b.meta4 = 32w0x808 + ~b.meta6;
+        b.meta4 = ~b.meta6 + 32w0x808;
         b.meta3 = -b.meta3;
         b.meta6 = 32w0x808 - b.meta3;
         b.meta3 = b.meta3 + 32w0x1;
         b.meta5 = b.meta7 + 16w0xf0;
-        b.meta7 = 16w0xf0 + b.meta2;
+        b.meta7 = b.meta2 + 16w0xf0;
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;
-        b.meta = b.meta2 ++ (16w0xf0 + b.meta2);
+        b.meta = b.meta2 ++ (b.meta2 + 16w0xf0);
     }
     @hidden table tbl_psadpdkbinaryoperations1l79 {
         actions = {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-1.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-1.p4.spec
@@ -75,8 +75,8 @@ apply {
 	mov m.local_metadata_meta2 m.Ingress_tmp
 	mov m.tmpxor 0xFFFFFFFF
 	xor m.tmpxor m.local_metadata_meta6
-	mov m.local_metadata_meta4 0x808
-	add m.local_metadata_meta4 m.tmpxor
+	mov m.local_metadata_meta4 m.tmpxor
+	add m.local_metadata_meta4 0x808
 	mov m.Ingress_tmp_0 0x0
 	sub m.Ingress_tmp_0 m.local_metadata_meta3
 	mov m.local_metadata_meta3 m.Ingress_tmp_0
@@ -85,15 +85,15 @@ apply {
 	add m.local_metadata_meta3 0x1
 	mov m.local_metadata_meta5 m.local_metadata_meta7
 	add m.local_metadata_meta5 0xF0
-	mov m.local_metadata_meta7 0xF0
-	add m.local_metadata_meta7 m.local_metadata_meta2
+	mov m.local_metadata_meta7 m.local_metadata_meta2
+	add m.local_metadata_meta7 0xF0
 	mov h.dstAddr m.local_metadata_meta
 	mov h.srcAddr m.local_metadata_meta1
 	mov h.etherType m.local_metadata_meta2
 	mov m.Ingress_tmp_3 m.local_metadata_meta2
 	shl m.Ingress_tmp_3 0x10
-	mov m.Ingress_tmp_4 0xF0
-	add m.Ingress_tmp_4 m.local_metadata_meta2
+	mov m.Ingress_tmp_4 m.local_metadata_meta2
+	add m.Ingress_tmp_4 0xF0
 	mov m.Ingress_tmp_6 m.Ingress_tmp_4
 	and m.Ingress_tmp_6 0xFFFF
 	mov m.local_metadata_meta m.Ingress_tmp_3

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-first.p4
@@ -68,11 +68,11 @@ control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata
         b.meta = 32w1 << b.meta2;
         b.meta1 = 32w0x800 >> b.meta2;
         b.meta2 = 16w0xf0 - b.meta2;
-        b.meta4 = 32w0x808 + b.meta6;
+        b.meta4 = b.meta6 + 32w0x808;
         b.meta6 = 32w0x808 - b.meta3;
         b.meta3 = b.meta3 + 32w0x1;
         b.meta5 = b.meta7 + 16w0xf0;
-        b.meta7 = 16w0xf0 + b.meta2;
+        b.meta7 = b.meta2 + 16w0xf0;
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-frontend.p4
@@ -67,11 +67,11 @@ control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata
         b.meta = 32w1 << b.meta2;
         b.meta1 = 32w0x800 >> b.meta2;
         b.meta2 = 16w0xf0 - b.meta2;
-        b.meta4 = 32w0x808 + b.meta6;
+        b.meta4 = b.meta6 + 32w0x808;
         b.meta6 = 32w0x808 - b.meta3;
         b.meta3 = b.meta3 + 32w0x1;
         b.meta5 = b.meta7 + 16w0xf0;
-        b.meta7 = 16w0xf0 + b.meta2;
+        b.meta7 = b.meta2 + 16w0xf0;
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations-midend.p4
@@ -65,15 +65,15 @@ control MyIC(inout ethernet_t a, inout metadata b, in psa_ingress_input_metadata
         b.meta = 32w1 << b.meta2;
         b.meta1 = 32w0x800 >> b.meta2;
         b.meta2 = 16w0xf0 - b.meta2;
-        b.meta4 = 32w0x808 + b.meta6;
+        b.meta4 = b.meta6 + 32w0x808;
         b.meta6 = 32w0x808 - b.meta3;
         b.meta3 = b.meta3 + 32w0x1;
         b.meta5 = b.meta7 + 16w0xf0;
-        b.meta7 = 16w0xf0 + b.meta2;
+        b.meta7 = b.meta2 + 16w0xf0;
         a.dstAddr = (bit<48>)b.meta;
         a.srcAddr = (bit<48>)b.meta1;
         a.etherType = b.meta2;
-        b.meta = b.meta2 ++ (16w0xf0 + b.meta2);
+        b.meta = b.meta2 ++ (b.meta2 + 16w0xf0);
     }
     @hidden table tbl_psadpdkbinaryoperations79 {
         actions = {

--- a/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-dpdk-binary-operations.p4.spec
@@ -71,22 +71,22 @@ apply {
 	mov m.Ingress_tmp 0xF0
 	sub m.Ingress_tmp m.local_metadata_meta2
 	mov m.local_metadata_meta2 m.Ingress_tmp
-	mov m.local_metadata_meta4 0x808
-	add m.local_metadata_meta4 m.local_metadata_meta6
+	mov m.local_metadata_meta4 m.local_metadata_meta6
+	add m.local_metadata_meta4 0x808
 	mov m.local_metadata_meta6 0x808
 	sub m.local_metadata_meta6 m.local_metadata_meta3
 	add m.local_metadata_meta3 0x1
 	mov m.local_metadata_meta5 m.local_metadata_meta7
 	add m.local_metadata_meta5 0xF0
-	mov m.local_metadata_meta7 0xF0
-	add m.local_metadata_meta7 m.local_metadata_meta2
+	mov m.local_metadata_meta7 m.local_metadata_meta2
+	add m.local_metadata_meta7 0xF0
 	mov h.dstAddr m.local_metadata_meta
 	mov h.srcAddr m.local_metadata_meta1
 	mov h.etherType m.local_metadata_meta2
 	mov m.Ingress_tmp_1 m.local_metadata_meta2
 	shl m.Ingress_tmp_1 0x10
-	mov m.Ingress_tmp_2 0xF0
-	add m.Ingress_tmp_2 m.local_metadata_meta2
+	mov m.Ingress_tmp_2 m.local_metadata_meta2
+	add m.Ingress_tmp_2 0xF0
 	mov m.Ingress_tmp_4 m.Ingress_tmp_2
 	and m.Ingress_tmp_4 0xFFFF
 	mov m.local_metadata_meta m.Ingress_tmp_1

--- a/testdata/p4_16_samples_outputs/reassoc-1-first.p4
+++ b/testdata/p4_16_samples_outputs/reassoc-1-first.p4
@@ -1,0 +1,18 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+    bit<32> data2;
+}
+
+parser p0(packet_in p, out Header h) {
+    state start {
+        p.extract<Header>(h);
+        h.data = h.data2 + 32w4294967270;
+        transition accept;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+package top(proto _p);
+top(p0()) main;

--- a/testdata/p4_16_samples_outputs/reassoc-1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/reassoc-1-frontend.p4
@@ -1,0 +1,18 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+    bit<32> data2;
+}
+
+parser p0(packet_in p, out Header h) {
+    state start {
+        p.extract<Header>(h);
+        h.data = h.data2 + 32w4294967270;
+        transition accept;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+package top(proto _p);
+top(p0()) main;

--- a/testdata/p4_16_samples_outputs/reassoc-1-midend.p4
+++ b/testdata/p4_16_samples_outputs/reassoc-1-midend.p4
@@ -1,0 +1,18 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+    bit<32> data2;
+}
+
+parser p0(packet_in p, out Header h) {
+    state start {
+        p.extract<Header>(h);
+        h.data = h.data2 + 32w4294967270;
+        transition accept;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+package top(proto _p);
+top(p0()) main;

--- a/testdata/p4_16_samples_outputs/reassoc-1.p4
+++ b/testdata/p4_16_samples_outputs/reassoc-1.p4
@@ -1,0 +1,18 @@
+#include <core.p4>
+
+header Header {
+    bit<32> data;
+    bit<32> data2;
+}
+
+parser p0(packet_in p, out Header h) {
+    state start {
+        p.extract(h);
+        h.data = 8 + h.data2 - 8 - 8 - 2 - 16;
+        transition accept;
+    }
+}
+
+parser proto(packet_in p, out Header h);
+package top(proto _p);
+top(p0()) main;

--- a/testdata/p4_16_samples_outputs/shift_precendence-first.p4
+++ b/testdata/p4_16_samples_outputs/shift_precendence-first.p4
@@ -2,7 +2,7 @@ control i(out bit<4> a, out bit<16> x) {
     bit<4> tmp_0;
     apply {
         tmp_0 = 4w0;
-        a = 4w1 & 4w2 + tmp_0 >> 4w2;
+        a = tmp_0 + 4w2 >> 4w2 & 4w1;
         x = 16w0xfff;
     }
 }

--- a/testdata/p4_16_samples_outputs/shift_precendence-frontend.p4
+++ b/testdata/p4_16_samples_outputs/shift_precendence-frontend.p4
@@ -2,7 +2,7 @@ control i(out bit<4> a, out bit<16> x) {
     @name("i.tmp_0") bit<4> tmp;
     apply {
         tmp = 4w0;
-        a = 4w1 & 4w2 + tmp >> 4w2;
+        a = tmp + 4w2 >> 4w2 & 4w1;
         x = 16w0xfff;
     }
 }

--- a/testdata/p4_16_samples_outputs/strength7-first.p4
+++ b/testdata/p4_16_samples_outputs/strength7-first.p4
@@ -1,0 +1,59 @@
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+extern T foo<T>(in T x);
+header t1 {
+    bit<8> x;
+}
+
+struct headers_t {
+    t1 t1;
+}
+
+control c(inout headers_t hdrs) {
+    action shrl1(bit<8> x, bit<8> y) {
+        bit<8> z = x & 8w255 << y;
+        hdrs.t1.x = z;
+    }
+    action shrl2(bit<8> x) {
+        bit<8> z = x & 8w252;
+        hdrs.t1.x = z;
+    }
+    action shrl3(bit<8> x) {
+        bit<8> z = 8w0;
+        hdrs.t1.x = z;
+    }
+    action shlr1(bit<8> x, bit<8> y) {
+        bit<8> z = x & 8w255 >> y;
+        hdrs.t1.x = z;
+    }
+    action shlr2(bit<8> x) {
+        bit<8> z = x & 8w63;
+        hdrs.t1.x = z;
+    }
+    action shlr3(bit<8> x) {
+        bit<8> z = 8w0;
+        hdrs.t1.x = z;
+    }
+    table test {
+        key = {
+            hdrs.t1.x: exact @name("hdrs.t1.x");
+        }
+        actions = {
+            shrl1();
+            shlr1();
+            shrl2();
+            shlr2();
+            shrl3();
+            shlr3();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        test.apply();
+    }
+}
+
+top<headers_t>(c()) main;

--- a/testdata/p4_16_samples_outputs/strength7-frontend.p4
+++ b/testdata/p4_16_samples_outputs/strength7-frontend.p4
@@ -1,0 +1,67 @@
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+extern T foo<T>(in T x);
+header t1 {
+    bit<8> x;
+}
+
+struct headers_t {
+    t1 t1;
+}
+
+control c(inout headers_t hdrs) {
+    @name("c.z") bit<8> z_0;
+    @name("c.z") bit<8> z_1;
+    @name("c.z") bit<8> z_2;
+    @name("c.z") bit<8> z_3;
+    @name("c.z") bit<8> z_4;
+    @name("c.z") bit<8> z_5;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("c.shrl1") action shrl1(@name("x") bit<8> x_6, @name("y") bit<8> y) {
+        z_0 = x_6 & 8w255 << y;
+        hdrs.t1.x = z_0;
+    }
+    @name("c.shrl2") action shrl2(@name("x") bit<8> x_7) {
+        z_1 = x_7 & 8w252;
+        hdrs.t1.x = z_1;
+    }
+    @name("c.shrl3") action shrl3(@name("x") bit<8> x_8) {
+        z_2 = 8w0;
+        hdrs.t1.x = z_2;
+    }
+    @name("c.shlr1") action shlr1(@name("x") bit<8> x_9, @name("y") bit<8> y_2) {
+        z_3 = x_9 & 8w255 >> y_2;
+        hdrs.t1.x = z_3;
+    }
+    @name("c.shlr2") action shlr2(@name("x") bit<8> x_10) {
+        z_4 = x_10 & 8w63;
+        hdrs.t1.x = z_4;
+    }
+    @name("c.shlr3") action shlr3(@name("x") bit<8> x_11) {
+        z_5 = 8w0;
+        hdrs.t1.x = z_5;
+    }
+    @name("c.test") table test_0 {
+        key = {
+            hdrs.t1.x: exact @name("hdrs.t1.x");
+        }
+        actions = {
+            shrl1();
+            shlr1();
+            shrl2();
+            shlr2();
+            shrl3();
+            shlr3();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        test_0.apply();
+    }
+}
+
+top<headers_t>(c()) main;

--- a/testdata/p4_16_samples_outputs/strength7-midend.p4
+++ b/testdata/p4_16_samples_outputs/strength7-midend.p4
@@ -1,0 +1,55 @@
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+extern T foo<T>(in T x);
+header t1 {
+    bit<8> x;
+}
+
+struct headers_t {
+    t1 t1;
+}
+
+control c(inout headers_t hdrs) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("c.shrl1") action shrl1(@name("x") bit<8> x_6, @name("y") bit<8> y) {
+        hdrs.t1.x = x_6 & 8w255 << y;
+    }
+    @name("c.shrl2") action shrl2(@name("x") bit<8> x_7) {
+        hdrs.t1.x = x_7 & 8w252;
+    }
+    @name("c.shrl3") action shrl3(@name("x") bit<8> x_8) {
+        hdrs.t1.x = 8w0;
+    }
+    @name("c.shlr1") action shlr1(@name("x") bit<8> x_9, @name("y") bit<8> y_2) {
+        hdrs.t1.x = x_9 & 8w255 >> y_2;
+    }
+    @name("c.shlr2") action shlr2(@name("x") bit<8> x_10) {
+        hdrs.t1.x = x_10 & 8w63;
+    }
+    @name("c.shlr3") action shlr3(@name("x") bit<8> x_11) {
+        hdrs.t1.x = 8w0;
+    }
+    @name("c.test") table test_0 {
+        key = {
+            hdrs.t1.x: exact @name("hdrs.t1.x");
+        }
+        actions = {
+            shrl1();
+            shlr1();
+            shrl2();
+            shlr2();
+            shrl3();
+            shlr3();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        test_0.apply();
+    }
+}
+
+top<headers_t>(c()) main;

--- a/testdata/p4_16_samples_outputs/strength7.p4
+++ b/testdata/p4_16_samples_outputs/strength7.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+extern T foo<T>(in T x);
+header t1 {
+    bit<8> x;
+}
+
+struct headers_t {
+    t1 t1;
+}
+
+control c(inout headers_t hdrs) {
+    action shrl1(bit<8> x, bit<8> y) {
+        bit<8> z = x >> y << y;
+        hdrs.t1.x = z;
+    }
+    action shrl2(bit<8> x) {
+        bit<8> z = x >> 2 << 2;
+        hdrs.t1.x = z;
+    }
+    action shrl3(bit<8> x) {
+        bit<8> z = x >> 9 << 9;
+        hdrs.t1.x = z;
+    }
+    action shlr1(bit<8> x, bit<8> y) {
+        bit<8> z = x << y >> y;
+        hdrs.t1.x = z;
+    }
+    action shlr2(bit<8> x) {
+        bit<8> z = x << 2 >> 2;
+        hdrs.t1.x = z;
+    }
+    action shlr3(bit<8> x) {
+        bit<8> z = x << 9 >> 9;
+        hdrs.t1.x = z;
+    }
+    table test {
+        key = {
+            hdrs.t1.x: exact;
+        }
+        actions = {
+            shrl1;
+            shlr1;
+            shrl2;
+            shlr2;
+            shrl3;
+            shlr3;
+        }
+    }
+    apply {
+        test.apply();
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/strength7.p4-stderr
+++ b/testdata/p4_16_samples_outputs/strength7.p4-stderr
@@ -1,0 +1,18 @@
+strength7.p4(27): [--Wwarn=overflow] warning: x >> 9: shifting value with 8 bits by 9
+        bit<8> z = (x >> 9) << 9;
+                    ^^^^^^
+strength7.p4(27): [--Wwarn=overflow] warning: x >> 9 << 9: shifting value with 8 bits by 9
+        bit<8> z = (x >> 9) << 9;
+                   ^^^^^^^^^^^^^
+strength7.p4(42): [--Wwarn=overflow] warning: x << 9: shifting value with 8 bits by 9
+        bit<8> z = (x << 9) >> 9;
+                    ^^^^^^
+strength7.p4(42): [--Wwarn=overflow] warning: x << 9 >> 9: shifting value with 8 bits by 9
+        bit<8> z = (x << 9) >> 9;
+                   ^^^^^^^^^^^^^
+strength7.p4(26): [--Wwarn=unused] warning: 'x' is unused
+    action shrl3(bit<8> x) {
+                        ^
+strength7.p4(41): [--Wwarn=unused] warning: 'x' is unused
+    action shlr3(bit<8> x) {
+                        ^


### PR DESCRIPTION
 * Add node pattern matching implementation similar to LLVM's IR pattern matching:
   * More flexible & generic than present pattern matching, could be further extended if necessary
   * Can optionally bind nodes in the pattern to local variables
   * Can match types, can perform deferred matching (e.g. refine the match further on)
 * Switch reassociation and strength reduction to this new implementation
 * Extend reassociation (and document its limitations)
 * Add couple more strength reduction patterns