### PR TITLE
Fixes and improvements for loop unrolling

### DIFF
--- a/ir/pattern.h
+++ b/ir/pattern.h
@@ -117,6 +117,23 @@ class Pattern {
         Pattern operator!=(int a) { return Pattern(*this) != Pattern(a); }
     };
 
+    template<class T = IR::AssignmentStatement>
+    class Assign : public Base {
+        static_assert(std::is_base_of_v<IR::BaseAssignmentStatement, T>);
+        Base *left, *right;
+
+     public:
+        bool match(const IR::Node *n) override {
+            if (auto as = n->to<T>()) {
+                if (left->match(as->left) && right->match(as->right)) return true;
+            }
+            return false;
+        }
+        Assign(Base *l, Base *r) : left(l), right(r) {}  // NOLINT(runtime/explicit)
+        Assign(Base *l, int val) : left(l), right(new Const(val)) {}  // NOLINT(runtime/explicit)
+        Assign(Base *l, big_int val) : left(l), right(new Const(val)) {}  // NOLINT(runtime/explicit)
+    };
+
     template <class T>
     Pattern(const T *&m) : pattern(new MatchExt<T>(m)) {}  // NOLINT(runtime/explicit)
     template <class T>

--- a/ir/pattern.h
+++ b/ir/pattern.h
@@ -117,7 +117,7 @@ class Pattern {
         Pattern operator!=(int a) { return Pattern(*this) != Pattern(a); }
     };
 
-    template<class T = IR::AssignmentStatement>
+    template <class T = IR::AssignmentStatement>
     class Assign : public Base {
         static_assert(std::is_base_of_v<IR::BaseAssignmentStatement, T>);
         Base *left, *right;
@@ -129,9 +129,10 @@ class Pattern {
             }
             return false;
         }
-        Assign(Base *l, Base *r) : left(l), right(r) {}  // NOLINT(runtime/explicit)
-        Assign(Base *l, int val) : left(l), right(new Const(val)) {}  // NOLINT(runtime/explicit)
-        Assign(Base *l, big_int val) : left(l), right(new Const(val)) {}  // NOLINT(runtime/explicit)
+        Assign(Base *l, Base *r) : left(l), right(r) {}
+        Assign(const Pattern &l, const Pattern &r) : left(l.pattern), right(r.pattern) {}
+        Assign(Base *l, int val) : left(l), right(new Const(val)) {}
+        Assign(Base *l, big_int val) : left(l), right(new Const(val)) {}
     };
 
     template <class T>

--- a/midend/def_use.cpp
+++ b/midend/def_use.cpp
@@ -534,6 +534,7 @@ const IR::Expression *ComputeDefUse::do_read(def_info_t &di, const IR::Expressio
         defuse.uses[l->node].insert(loc);
         defuse.defs[loc->node].insert(l);
     }
+    LOG8("  " << defuse.defs[loc->node]);
     return e;
 }
 
@@ -717,7 +718,7 @@ std::ostream &operator<<(std::ostream &out, const ComputeDefUse::loc_t &loc) {
 }
 
 std::ostream &operator<<(std::ostream &out, const hvec_set<const ComputeDefUse::loc_t *> &s) {
-    out << ": {";
+    out << "{";
     const char *sep = " ";
     for (auto *l : s) {
         out << sep << *l;
@@ -739,7 +740,7 @@ std::ostream &operator<<(
         out << '(' << p.first->srcInfo.toSourcePositionData(&line, &col);
         out << ':' << line << ':' << (col + 1) << ')';
     }
-    out << p.second;
+    out << ": " << p.second;
     return out;
 }
 

--- a/midend/def_use.h
+++ b/midend/def_use.h
@@ -50,7 +50,7 @@ class ComputeDefUse : public Inspector,
     ComputeDefUse *clone() const override {
         auto *rv = new ComputeDefUse(*this);
         rv->uid = ++uid_ctr;
-        LOG8("ComputeDefUse::clone " << rv->uid);
+        LOG8("ComputeDefUse::clone " << rv->uid << " <- " << uid);
         return rv;
     }
     void flow_merge(Visitor &) override;
@@ -201,6 +201,8 @@ class ComputeDefUse : public Inspector,
         return out << cdu.defuse;
     }
 };
+
+std::ostream &operator<<(std::ostream &, const hvec_set<const ComputeDefUse::loc_t *> &);
 
 }  // namespace P4
 

--- a/midend/unrollLoops.cpp
+++ b/midend/unrollLoops.cpp
@@ -183,6 +183,10 @@ long UnrollLoops::evalLoop(const IR::Expression *exp, long val,
 long UnrollLoops::evalLoop(const IR::BaseAssignmentStatement *assign, long val,
                            const ComputeDefUse::locset_t &idefs, bool &fail) {
     if (assign->is<IR::AssignmentStatement>()) return evalLoop(assign->right, val, idefs, fail);
+    if (val != evalLoop(assign->left, val, idefs, fail) || fail) {
+        fail = true;
+        return 1;
+    }
     if (assign->is<IR::MulAssign>()) return val * evalLoop(assign->right, val, idefs, fail);
     if (assign->is<IR::DivAssign>()) return val / evalLoop(assign->right, val, idefs, fail);
     if (assign->is<IR::ModAssign>()) return val % evalLoop(assign->right, val, idefs, fail);

--- a/midend/unrollLoops.cpp
+++ b/midend/unrollLoops.cpp
@@ -205,18 +205,16 @@ bool UnrollLoops::findLoopBounds(IR::ForStatement *fstmt, loop_bounds_t &bounds)
         auto d = resolveUnique(v->path->name, P4::ResolutionType::Any);
         bounds.index = d ? d->to<IR::Declaration_Variable>() : nullptr;
         if (!bounds.index) return false;
-        const IR::BaseAssignmentStatement *init = nullptr, *incr = nullptr;
-        const IR::Constant *initval = nullptr;
+        const IR::BaseAssignmentStatement *incr = nullptr;
+        Pattern::Match<IR::Constant> initval;
         auto &index_defs = defUse->getDefs(v);
         if (index_defs.size() != 2) {
             // must be exactly 2 defs -- one to a constant before the loop and one
             // to a non-constant in the loop
             return false;
-        } else if ((init = index_defs.front()->parent->node->to<IR::AssignmentStatement>()) &&
-                   (initval = init->right->to<IR::Constant>())) {
+        } else if (Pattern::Assign(v, initval).match(index_defs.front()->parent->node)) {
             incr = index_defs.back()->parent->node->to<IR::BaseAssignmentStatement>();
-        } else if ((init = index_defs.back()->parent->node->to<IR::AssignmentStatement>()) &&
-                   (initval = init->right->to<IR::Constant>())) {
+        } else if (Pattern::Assign(v, initval).match(index_defs.back()->parent->node)) {
             incr = index_defs.front()->parent->node->to<IR::BaseAssignmentStatement>();
         } else {
             return false;

--- a/testdata/p4_16_samples/forloop8.p4
+++ b/testdata/p4_16_samples/forloop8.p4
@@ -1,0 +1,54 @@
+@test_keep_opassign
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> frag_offset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdr_checksum;
+    bit<32> src_addr;
+    bit<32> dst_addr;
+}
+
+struct headers_t {
+    ipv4_t ipv4;
+}
+
+struct empty_metadata_t {
+}
+
+// Pipeline section
+control c(
+    inout headers_t headers,
+    inout empty_metadata_t user_meta
+) {
+    apply {
+        bit<32> sum = 1;
+        @unroll
+        for (
+            bit<8> i = 20; // init statement
+            i != 0; // condition
+            i -= 2 // update statement
+        ) {
+            if (i == 64) {
+                continue;
+            } else {
+                sum += 1;
+                i -= 1;
+            }
+        }
+
+        if (sum == 10) {
+            headers.ipv4.src_addr = sum;
+        }
+    }
+}
+
+control c_<H, M>(inout H h, inout M m);
+package top<H, M>(c_<H, M> c);
+top(c()) main;

--- a/testdata/p4_16_samples/forloop9.p4
+++ b/testdata/p4_16_samples/forloop9.p4
@@ -1,0 +1,28 @@
+#include <core.p4>
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+
+header t1 {
+    bit<32>     f1;
+    bit<16>     h1;
+    bit<8>      b1;
+    bit<8>      cnt;
+}
+
+struct headers_t {
+    t1          head;
+}
+
+control c(inout headers_t hdrs) {
+    apply {
+        bit<32> i = 0;
+        @no_unroll
+        for (bit<32> j = 0; j < 10; j += 1) { i += 1; }
+        @unroll
+        for (; i < 20;) {
+            hdrs.head.h1 += 1;
+        }
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/forloop8-first.p4
+++ b/testdata/p4_16_samples_outputs/forloop8-first.p4
@@ -1,0 +1,42 @@
+@test_keep_opassign header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> frag_offset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdr_checksum;
+    bit<32> src_addr;
+    bit<32> dst_addr;
+}
+
+struct headers_t {
+    ipv4_t ipv4;
+}
+
+struct empty_metadata_t {
+}
+
+control c(inout headers_t headers, inout empty_metadata_t user_meta) {
+    apply {
+        bit<32> sum = 32w1;
+        @unroll for (bit<8> i = 8w20; i != 8w0; i -= 8w2) {
+            if (i == 8w64) {
+                continue;
+            } else {
+                sum += 32w1;
+                i -= 8w1;
+            }
+        }
+        if (sum == 32w10) {
+            headers.ipv4.src_addr = sum;
+        }
+    }
+}
+
+control c_<H, M>(inout H h, inout M m);
+package top<H, M>(c_<H, M> c);
+top<headers_t, empty_metadata_t>(c()) main;

--- a/testdata/p4_16_samples_outputs/forloop8-frontend.p4
+++ b/testdata/p4_16_samples_outputs/forloop8-frontend.p4
@@ -1,0 +1,44 @@
+@test_keep_opassign header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> frag_offset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdr_checksum;
+    bit<32> src_addr;
+    bit<32> dst_addr;
+}
+
+struct headers_t {
+    ipv4_t ipv4;
+}
+
+struct empty_metadata_t {
+}
+
+control c(inout headers_t headers, inout empty_metadata_t user_meta) {
+    @name("c.sum") bit<32> sum_0;
+    @name("c.i") bit<8> i_0;
+    apply {
+        sum_0 = 32w1;
+        @unroll for (i_0 = 8w20; i_0 != 8w0; i_0 -= 8w2) {
+            if (i_0 == 8w64) {
+                continue;
+            } else {
+                sum_0 += 32w1;
+                i_0 -= 8w1;
+            }
+        }
+        if (sum_0 == 32w10) {
+            headers.ipv4.src_addr = sum_0;
+        }
+    }
+}
+
+control c_<H, M>(inout H h, inout M m);
+package top<H, M>(c_<H, M> c);
+top<headers_t, empty_metadata_t>(c()) main;

--- a/testdata/p4_16_samples_outputs/forloop8-midend.p4
+++ b/testdata/p4_16_samples_outputs/forloop8-midend.p4
@@ -1,0 +1,71 @@
+@test_keep_opassign header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> frag_offset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdr_checksum;
+    bit<32> src_addr;
+    bit<32> dst_addr;
+}
+
+struct headers_t {
+    ipv4_t ipv4;
+}
+
+struct empty_metadata_t {
+}
+
+control c(inout headers_t headers, inout empty_metadata_t user_meta) {
+    @name("c.sum") bit<32> sum_0;
+    @name("c.i") bit<8> i_0;
+    @hidden action forloop8l41() {
+        sum_0 += 32w1;
+        i_0 -= 8w1;
+    }
+    @hidden action forloop8l31() {
+        sum_0 = 32w1;
+    }
+    @hidden action forloop8l47() {
+        headers.ipv4.src_addr = sum_0;
+    }
+    @hidden table tbl_forloop8l31 {
+        actions = {
+            forloop8l31();
+        }
+        const default_action = forloop8l31();
+    }
+    @hidden table tbl_forloop8l41 {
+        actions = {
+            forloop8l41();
+        }
+        const default_action = forloop8l41();
+    }
+    @hidden table tbl_forloop8l47 {
+        actions = {
+            forloop8l47();
+        }
+        const default_action = forloop8l47();
+    }
+    apply {
+        tbl_forloop8l31.apply();
+        @unroll for (i_0 = 8w20; i_0 != 8w0; i_0 -= 8w2) {
+            if (i_0 == 8w64) {
+                continue;
+            } else {
+                tbl_forloop8l41.apply();
+            }
+        }
+        if (sum_0 == 32w10) {
+            tbl_forloop8l47.apply();
+        }
+    }
+}
+
+control c_<H, M>(inout H h, inout M m);
+package top<H, M>(c_<H, M> c);
+top<headers_t, empty_metadata_t>(c()) main;

--- a/testdata/p4_16_samples_outputs/forloop8.p4
+++ b/testdata/p4_16_samples_outputs/forloop8.p4
@@ -1,0 +1,42 @@
+@test_keep_opassign header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> frag_offset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdr_checksum;
+    bit<32> src_addr;
+    bit<32> dst_addr;
+}
+
+struct headers_t {
+    ipv4_t ipv4;
+}
+
+struct empty_metadata_t {
+}
+
+control c(inout headers_t headers, inout empty_metadata_t user_meta) {
+    apply {
+        bit<32> sum = 1;
+        @unroll for (bit<8> i = 20; i != 0; i -= 2) {
+            if (i == 64) {
+                continue;
+            } else {
+                sum += 1;
+                i -= 1;
+            }
+        }
+        if (sum == 10) {
+            headers.ipv4.src_addr = sum;
+        }
+    }
+}
+
+control c_<H, M>(inout H h, inout M m);
+package top<H, M>(c_<H, M> c);
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/forloop8.p4-stderr
+++ b/testdata/p4_16_samples_outputs/forloop8.p4-stderr
@@ -1,0 +1,3 @@
+forloop8.p4(33): [--Wwarn=unsupported] warning: Can't unroll loop: ForStatement
+        for (
+        ^

--- a/testdata/p4_16_samples_outputs/forloop9-first.p4
+++ b/testdata/p4_16_samples_outputs/forloop9-first.p4
@@ -1,0 +1,28 @@
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+header t1 {
+    bit<32> f1;
+    bit<16> h1;
+    bit<8>  b1;
+    bit<8>  cnt;
+}
+
+struct headers_t {
+    t1 head;
+}
+
+control c(inout headers_t hdrs) {
+    apply {
+        bit<32> i = 32w0;
+        @no_unroll for (bit<32> j = 32w0; j < 32w10; j += 32w1) {
+            i += 32w1;
+        }
+        @unroll for (; i < 32w20; ) {
+            hdrs.head.h1 += 16w1;
+        }
+    }
+}
+
+top<headers_t>(c()) main;

--- a/testdata/p4_16_samples_outputs/forloop9-frontend.p4
+++ b/testdata/p4_16_samples_outputs/forloop9-frontend.p4
@@ -1,0 +1,30 @@
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+header t1 {
+    bit<32> f1;
+    bit<16> h1;
+    bit<8>  b1;
+    bit<8>  cnt;
+}
+
+struct headers_t {
+    t1 head;
+}
+
+control c(inout headers_t hdrs) {
+    @name("c.i") bit<32> i_0;
+    @name("c.j") bit<32> j_0;
+    apply {
+        i_0 = 32w0;
+        @no_unroll for (j_0 = 32w0; j_0 < 32w10; j_0 = j_0 + 32w1) {
+            i_0 = i_0 + 32w1;
+        }
+        @unroll for (; i_0 < 32w20; ) {
+            hdrs.head.h1 = hdrs.head.h1 + 16w1;
+        }
+    }
+}
+
+top<headers_t>(c()) main;

--- a/testdata/p4_16_samples_outputs/forloop9-midend.p4
+++ b/testdata/p4_16_samples_outputs/forloop9-midend.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+header t1 {
+    bit<32> f1;
+    bit<16> h1;
+    bit<8>  b1;
+    bit<8>  cnt;
+}
+
+struct headers_t {
+    t1 head;
+}
+
+control c(inout headers_t hdrs) {
+    @name("c.i") bit<32> i_0;
+    @name("c.j") bit<32> j_0;
+    @hidden action forloop9l20() {
+        i_0 = i_0 + 32w1;
+    }
+    @hidden action forloop9l18() {
+        i_0 = 32w0;
+    }
+    @hidden action forloop9l23() {
+        hdrs.head.h1 = hdrs.head.h1 + 16w1;
+    }
+    @hidden table tbl_forloop9l18 {
+        actions = {
+            forloop9l18();
+        }
+        const default_action = forloop9l18();
+    }
+    @hidden table tbl_forloop9l20 {
+        actions = {
+            forloop9l20();
+        }
+        const default_action = forloop9l20();
+    }
+    @hidden table tbl_forloop9l23 {
+        actions = {
+            forloop9l23();
+        }
+        const default_action = forloop9l23();
+    }
+    apply {
+        tbl_forloop9l18.apply();
+        @no_unroll for (j_0 = 32w0; j_0 < 32w10; j_0 = j_0 + 32w1) {
+            tbl_forloop9l20.apply();
+        }
+        @unroll for (; i_0 < 32w20; ) {
+            tbl_forloop9l23.apply();
+        }
+    }
+}
+
+top<headers_t>(c()) main;

--- a/testdata/p4_16_samples_outputs/forloop9.p4
+++ b/testdata/p4_16_samples_outputs/forloop9.p4
@@ -1,0 +1,28 @@
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+header t1 {
+    bit<32> f1;
+    bit<16> h1;
+    bit<8>  b1;
+    bit<8>  cnt;
+}
+
+struct headers_t {
+    t1 head;
+}
+
+control c(inout headers_t hdrs) {
+    apply {
+        bit<32> i = 0;
+        @no_unroll for (bit<32> j = 0; j < 10; j += 1) {
+            i += 1;
+        }
+        @unroll for (; i < 20; ) {
+            hdrs.head.h1 += 1;
+        }
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/forloop9.p4-stderr
+++ b/testdata/p4_16_samples_outputs/forloop9.p4-stderr
@@ -1,0 +1,3 @@
+forloop9.p4(22): [--Wwarn=unsupported] warning: Can't unroll loop: ForStatement
+        for (; i < 20;) {
+        ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Discovered a problem with loop unrolling where the update was an opAssign that had not been expanded.  Also some Pattern improvements for matching AssignmentStatements.