### PR TITLE
Do not emit a warning when a `switch` expression is constant

### DIFF
--- a/frontends/p4/typeChecking/typeCheckStmt.cpp
+++ b/frontends/p4/typeChecking/typeCheckStmt.cpp
@@ -58,8 +58,6 @@ const IR::Node *TypeInferenceBase::postorder(const IR::SwitchStatement *stat) {
         // switch (expression)
         Comparison comp;
         comp.left = stat->expression;
-        if (isCompileTimeConstant(stat->expression))
-            warn(ErrorType::WARN_MISMATCH, "%1%: constant expression in switch", stat->expression);
 
         auto *sclone = stat->clone();
         bool changed = false;

--- a/testdata/p4_16_errors_outputs/no_warn_const_switch_expr-first.p4
+++ b/testdata/p4_16_errors_outputs/no_warn_const_switch_expr-first.p4
@@ -1,0 +1,28 @@
+void bar(in bit<2> x, out bit<8> y) {
+    switch (x) {
+        2w0b1: {
+            y = 8w2;
+        }
+        2w0b10: {
+            y = 8w3;
+        }
+    }
+}
+control C(out bit<8> y) {
+    action foo() {
+        bar(2w1, y);
+    }
+    table t {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto(out bit<8> y);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_errors_outputs/no_warn_const_switch_expr-frontend.p4
+++ b/testdata/p4_16_errors_outputs/no_warn_const_switch_expr-frontend.p4
@@ -1,0 +1,29 @@
+control C(out bit<8> y) {
+    @name("C.x_0") bit<2> x;
+    @name("C.y_0") bit<8> y_1;
+    @name("C.foo") action foo() {
+        x = 2w1;
+        switch (x) {
+            2w0b1: {
+                y_1 = 8w2;
+            }
+            2w0b10: {
+                y_1 = 8w3;
+            }
+        }
+        y = y_1;
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            foo();
+        }
+        default_action = foo();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto(out bit<8> y);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_errors_outputs/no_warn_const_switch_expr.p4
+++ b/testdata/p4_16_errors_outputs/no_warn_const_switch_expr.p4
@@ -1,0 +1,28 @@
+void bar(in bit<2> x, out bit<8> y) {
+    switch (x) {
+        0b1: {
+            y = 2;
+        }
+        0b10: {
+            y = 3;
+        }
+    }
+}
+control C(out bit<8> y) {
+    action foo() {
+        bar(1, y);
+    }
+    table t {
+        actions = {
+            foo;
+        }
+        default_action = foo;
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto(out bit<8> y);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_errors_outputs/no_warn_const_switch_expr.p4-stderr
+++ b/testdata/p4_16_errors_outputs/no_warn_const_switch_expr.p4-stderr
@@ -1,0 +1,10 @@
+no_warn_const_switch_expr.p4(1): [--Wwarn=uninitialized_out_param] warning: out parameter 'y' may be uninitialized when 'bar' terminates
+void bar(in bit<2> x, out bit<8> y) {
+                                 ^
+no_warn_const_switch_expr.p4(1)
+void bar(in bit<2> x, out bit<8> y) {
+     ^^^
+[--Wwarn=uninitialized_use] warning: y_0 may be uninitialized
+no_warn_const_switch_expr.p4(2): error: SwitchStatement: switch statements not supported in actions on this target
+    switch (x) {
+    ^^^^^^

--- a/testdata/p4_16_samples_outputs/issue2617.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2617.p4-stderr
@@ -1,15 +1,3 @@
-issue2617.p4(64): [--Wwarn=mismatch] warning: 32w1: constant expression in switch
-        switch (32w1) {
-                ^^^^
-issue2617.p4(70): [--Wwarn=mismatch] warning: E.C: constant expression in switch
-        switch (E.C) {
-                ^^^
-issue2617.p4(75): [--Wwarn=mismatch] warning: E.C: constant expression in switch
-        switch (E.C) {
-                ^^^
-issue2617.p4(80): [--Wwarn=mismatch] warning: X.B: constant expression in switch
-        switch (X.B) {
-                ^^^
 issue2617.p4(17): [--Wwarn=parser-transition] warning: SelectCase: unreachable case
             2: two;
             ^^^^^^

--- a/testdata/p4_16_samples_outputs/issue4661_pure_extern_function_const_args.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue4661_pure_extern_function_const_args.p4-stderr
@@ -1,3 +1,0 @@
-issue4661_pure_extern_function_const_args.p4(13): [--Wwarn=mismatch] warning: baz(): constant expression in switch
-        switch(baz()) {
-               ^^^^^

--- a/testdata/p4_16_samples_outputs/pragma-string.p4-stderr
+++ b/testdata/p4_16_samples_outputs/pragma-string.p4-stderr
@@ -1,1 +1,17 @@
+pragma-string.p4(20): [--Wwarn=unused] warning: 'original' is unused
+const bit b = 1;
+          ^
+pragma-string.p4(23): [--Wwarn=unused] warning: 'string \" with \" quotes' is unused
+const bit c = 1;
+          ^
+pragma-string.p4(27): [--Wwarn=unused] warning: 'string with
+newline' is unused
+const bit d = 1;
+          ^
+pragma-string.p4(31): [--Wwarn=unused] warning: 'string with quoted newline' is unused
+const bit e = 1;
+          ^
+pragma-string.p4(34): [--Wwarn=unused] warning: '8-bit string ⟶' is unused
+const bit f = 1;
+          ^
 [--Wwarn=missing] warning: Program does not contain a `main' module

--- a/testdata/p4_16_samples_outputs/psa-example-switch-with-constant-expr.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-example-switch-with-constant-expr.p4-error
@@ -1,3 +1,0 @@
-psa-example-switch-with-constant-expr.p4(65): [--Wwarn=mismatch] warning: 16w2: constant expression in switch
-        switch (16w2) {
-                ^^^^

--- a/testdata/p4_16_samples_outputs/psa-example-switch-with-constant-expr.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-example-switch-with-constant-expr.p4-stderr
@@ -1,3 +1,0 @@
-psa-example-switch-with-constant-expr.p4(65): [--Wwarn=mismatch] warning: 16w2: constant expression in switch
-        switch (16w2) {
-                ^^^^

--- a/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4-error
@@ -1,7 +1,4 @@
 psa-switch-expression-without-default.p4(126): [--Wwarn=missing] warning: SwitchCase: fallthrough with no statement
             92:
             ^^
-psa-switch-expression-without-default.p4(122): [--Wwarn=mismatch] warning: 16w16: constant expression in switch
-        switch (tmp) {
-                ^^^
 [--Wwarn=mismatch] warning: Mismatched header/metadata struct for key elements in table tbl. Copying all match fields to metadata

--- a/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-switch-expression-without-default.p4-stderr
@@ -1,6 +1,3 @@
 psa-switch-expression-without-default.p4(126): [--Wwarn=missing] warning: SwitchCase: fallthrough with no statement
             92:
             ^^
-psa-switch-expression-without-default.p4(122): [--Wwarn=mismatch] warning: 16w16: constant expression in switch
-        switch (tmp) {
-                ^^^

--- a/testdata/p4_16_samples_outputs/string_anno.p4-stderr
+++ b/testdata/p4_16_samples_outputs/string_anno.p4-stderr
@@ -1,1 +1,17 @@
+string_anno.p4(19): [--Wwarn=unused] warning: 'original' is unused
+@name("original") const bit b = 1;
+                            ^
+string_anno.p4(20): [--Wwarn=unused] warning: 'string \" with \" quotes' is unused
+@name("string \" with \" quotes") const bit c = 1;
+                                            ^
+string_anno.p4(22): [--Wwarn=unused] warning: 'string with
+newline' is unused
+newline") const bit d = 1;
+                    ^
+string_anno.p4(23): [--Wwarn=unused] warning: 'string with quoted newline' is unused
+@name("string with quoted newline") const bit e = 1;
+                                              ^
+string_anno.p4(25): [--Wwarn=unused] warning: '8-bit string ⟶' is unused
+@name("8-bit string ⟶") const bit f = 1;
+                                    ^
 [--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
This warning is not very useful IMO, as there are many ways that a `switch` expression that is originally non-constant could become constant after a number of transformations are applied. For example, it could become constant after inlining and copy-propagation. The effects of having a const `switch` expression are benign - the entire `switch` statement will likely just be optimized away.