### PR TITLE
Fix copy & paste typo in flattenStructExpression

### DIFF
--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2MetadataXfail.cmake
@@ -64,14 +64,6 @@ p4tools_add_xfail_reason(
   loop-3-clause-tricky2.p4
 )
 
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2-metadata"
-  "Cast failed"
-  # testgen has issues with arrays
-  array1.p4
-  array2.p4
-)
-
 ####################################################################################################
 # 3. WONTFIX
 ####################################################################################################

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -109,7 +109,7 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-ptf"
-  "Cast failed"
+  "nested stack"
   # testgen has issues with arrays
   array1.p4
   array2.p4

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufIrXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2ProtobufIrXfail.cmake
@@ -81,14 +81,6 @@ p4tools_add_xfail_reason(
   loop-3-clause-tricky2.p4
 )
 
-p4tools_add_xfail_reason(
-  "testgen-p4c-bmv2-protobuf-ir"
-  "Cast failed"
-  # testgen has issues with arrays
-  array1.p4
-  array2.p4
-)
-
 ####################################################################################################
 # 3. WONTFIX
 ####################################################################################################

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2STFXfail.cmake
@@ -109,7 +109,7 @@ p4tools_add_xfail_reason(
 
 p4tools_add_xfail_reason(
   "testgen-p4c-bmv2-stf"
-  "Cast failed"
+  "nested stack"
   # testgen has issues with arrays
   array1.p4
   array2.p4

--- a/ir/irutils.cpp
+++ b/ir/irutils.cpp
@@ -143,7 +143,7 @@ std::vector<const Expression *> flattenStructExpression(const StructExpression *
         if (const auto *subStructExpr = listElem->expression->to<StructExpression>()) {
             auto subList = flattenStructExpression(subStructExpr);
             exprList.insert(exprList.end(), subList.begin(), subList.end());
-        } else if (const auto *subListExpr = listElem->to<BaseListExpression>()) {
+        } else if (const auto *subListExpr = listElem->expression->to<BaseListExpression>()) {
             auto subList = flattenListExpression(subListExpr);
             exprList.insert(exprList.end(), subList.begin(), subList.end());
         } else {


### PR DESCRIPTION
StructExpression entries are NamedExpressions, so we might peel to underlying expression to recurse further.