### PR TITLE
[P4Testgen] Add global table hit variable to testgen table stepper

### DIFF
--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
@@ -40,9 +40,8 @@ class TableStepper {
         const IR::Type *type, const IR::P4Table *table, cstring name,
         std::optional<int> idx1_opt = std::nullopt, std::optional<int> idx2_opt = std::nullopt);
 
-    /// @returns the boolean-typed state variable that tracks whether an action was executed
-    /// as the result of a table hit or miss.
-    static const IR::StateVariable &getGlobalTableHitVar();
+    /// @returns the string-typed state variable that tracks the current active table.
+    static const IR::StateVariable &getActiveTableVar();
 
     /// @returns the boolean-typed state variable that tracks whether a table has resulted in a hit.
     /// The value of this variable is false if the table misses or is not reached.

--- a/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
+++ b/backends/p4tools/modules/testgen/core/small_step/table_stepper.h
@@ -40,6 +40,10 @@ class TableStepper {
         const IR::Type *type, const IR::P4Table *table, cstring name,
         std::optional<int> idx1_opt = std::nullopt, std::optional<int> idx2_opt = std::nullopt);
 
+    /// @returns the boolean-typed state variable that tracks whether an action was executed
+    /// as the result of a table hit or miss.
+    static const IR::StateVariable &getGlobalTableHitVar();
+
     /// @returns the boolean-typed state variable that tracks whether a table has resulted in a hit.
     /// The value of this variable is false if the table misses or is not reached.
     static const IR::StateVariable &getTableHitVar(const IR::P4Table *table);


### PR DESCRIPTION
Attempting to implement an extern function within testgen that returns `true` if the action this function was called from was executed as the result of a hit, `false` otherwise. In other words, `false` if taking the default action, otherwise `true`.

This would require to have access to the table context, or some way to access the already existing `TableStepper::getTableHitVar()` within the relevant target's `expr_stepper` file. This would mean we would have to propagate the `P4Table` from `TableStepper::evalTargetTable()` to our `TargetExprStepper::evalExternMethodCall()`

Instead, I added this `TableStepper::getGlobalTableHitVar()` to be able to tell within testgen whether the current action being executed was a result of a table hit or miss.

@fruffy would you possibly know a better way to determine whether we are in a default/non-default action when hitting this extern function call?