### PR TITLE
Upgrade `clang-format` to v18.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ The P4C CMakeLists.txt will use that name to figure the full path of the files t
 
 clang-format, black, and isort need to be installed before the linter can be used. They can be installed with the following command:
 ```
-uv pip install "clang-format==18.1.0" "black==24.3.0" "isort==5.13.2"
+uv pip install "clang-format==18.1.8" "black==24.3.0" "isort==5.13.2"
 ```
 clang-format can be checked using the `make clang-format` command. Complaints can be fixed by running `make clang-format-fix-errors`. black and isort can be checked using the `make black` or `make isort` command respectively. Complaints can be fixed by running `make black-fix-errors` or `make isort-fix-errors`.
 

--- a/backends/p4fmt/attach.h
+++ b/backends/p4fmt/attach.h
@@ -17,7 +17,7 @@ class Attach : public Inspector {
     enum class TraversalType { Preorder, Postorder };
 
     explicit Attach(std::unordered_map<const Util::Comment *, bool> &processedComments)
-        : processedComments(processedComments){};
+        : processedComments(processedComments) {};
 
     void attachCommentsToNode(const IR::Node *, TraversalType);
 

--- a/backends/tofino/bf-asm/parser-tofino-jbay.h
+++ b/backends/tofino/bf-asm/parser-tofino-jbay.h
@@ -457,7 +457,7 @@ class AsmParser : public BaseAsmParser {
     void init_port_use(bitvec &port_use, const value_t &arg);
 
  public:
-    AsmParser() : BaseAsmParser("parser"){};
+    AsmParser() : BaseAsmParser("parser") {};
     ~AsmParser() {}
 
     // For gtest

--- a/backends/tofino/bf-asm/vector.h
+++ b/backends/tofino/bf-asm/vector.h
@@ -85,8 +85,7 @@
          : ((vec).size = 3, (vec).data[0] = (v1), (vec).data[1] = (v2), (vec).data[2] = (v3), \
             (vec).data[3] = (v4), (vec).data[4] = (v5), 0))
 
-#define EMPTY_VECTOR_INIT \
-    { 0, 0, 0 }
+#define EMPTY_VECTOR_INIT {0, 0, 0}
 
 /* VECTOR_fini(vec)
  *   destroys a vector, freeing memory

--- a/backends/tofino/bf-p4c/common/merge_pov_bits.cpp
+++ b/backends/tofino/bf-p4c/common/merge_pov_bits.cpp
@@ -225,7 +225,7 @@ class IdentifyPovMergeTargets : public ParserInspector {
     explicit IdentifyPovMergeTargets(const PhvInfo &phv, const CollectParserInfo &parser_info,
                                      const HeaderValidityAnalysis &hva,
                                      ordered_map<const PHV::Field *, const PHV::Field *> &merge_pov)
-        : phv(phv), parser_info(parser_info), hva(hva), merge_pov(merge_pov){};
+        : phv(phv), parser_info(parser_info), hva(hva), merge_pov(merge_pov) {};
 };
 
 /**
@@ -355,7 +355,7 @@ class UpdatePovBits : public Transform {
  public:
     explicit UpdatePovBits(const PhvInfo &phv, const HeaderValidityAnalysis &hva,
                            const ordered_map<const PHV::Field *, const PHV::Field *> &merge_pov)
-        : phv(phv), hva(hva), merge_pov(merge_pov){};
+        : phv(phv), hva(hva), merge_pov(merge_pov) {};
 };
 
 /**

--- a/backends/tofino/bf-p4c/midend/eliminate_tuples.h
+++ b/backends/tofino/bf-p4c/midend/eliminate_tuples.h
@@ -45,7 +45,7 @@ class InsertHashStructExpression : public Transform {
  public:
     InsertHashStructExpression(
         std::map<const IR::Expression *, const IR::HashListExpression *> *update_hashes)
-        : update_hashes(update_hashes){};
+        : update_hashes(update_hashes) {};
 
     const IR::Node *preorder(IR::StructExpression *se) override;
 };

--- a/backends/tofino/bf-p4c/midend/initialize_mirror_io_select.h
+++ b/backends/tofino/bf-p4c/midend/initialize_mirror_io_select.h
@@ -33,7 +33,7 @@ class DoInitializeMirrorIOSelect : public Transform {
     cstring egIntrMdForDprsrName;
 
  public:
-    DoInitializeMirrorIOSelect(){};
+    DoInitializeMirrorIOSelect() {};
 
     // disable this pass if the @disable_egress_mirror_io_select_initialization pragma is used
     const IR::Node *preorder(IR::P4Program *p) override {

--- a/backends/tofino/bf-p4c/p4c-barefoot.cpp
+++ b/backends/tofino/bf-p4c/p4c-barefoot.cpp
@@ -555,7 +555,7 @@ int main(int ac, char **av) {
             Logging::Manifest &manifest;
 
          public:
-            explicit manifest_generator_guard(Logging::Manifest &manifest) : manifest(manifest){};
+            explicit manifest_generator_guard(Logging::Manifest &manifest) : manifest(manifest) {};
             ~manifest_generator_guard() {
                 try {
                     manifest.setSuccess(::errorCount() == 0);

--- a/backends/tofino/bf-p4c/phv/solver/action_constraint_solver.h
+++ b/backends/tofino/bf-p4c/phv/solver/action_constraint_solver.h
@@ -126,7 +126,7 @@ enum class ErrorCode {
 struct Error {
     ErrorCode code;
     cstring msg;
-    Error(ErrorCode code, cstring msg) : code(code), msg(msg){};
+    Error(ErrorCode code, cstring msg) : code(code), msg(msg) {};
 };
 
 /// ContainerSpec container specification.
@@ -340,7 +340,7 @@ class ActionMoveSolver : public ActionSolverBase {
 /// are not set in this action need to be not live.
 class ActionMochaSolver : public ActionSolverBase {
  public:
-    ActionMochaSolver(){};
+    ActionMochaSolver() {};
     Result solve() override;
 };
 
@@ -351,7 +351,7 @@ class ActionMochaSolver : public ActionSolverBase {
 /// are not set in this action need not to be not live.
 class ActionDarkSolver : public ActionSolverBase {
  public:
-    ActionDarkSolver(){};
+    ActionDarkSolver() {};
     Result solve() override;
 };
 

--- a/backends/tofino/bf-p4c/phv/v2/allocator_base.h
+++ b/backends/tofino/bf-p4c/phv/v2/allocator_base.h
@@ -295,7 +295,7 @@ class AllocatorBase {
     explicit AllocatorBase(const PhvKit &kit) : kit_i(kit) {
         kit_i.parser_packing_validator->set_trivial_pass(kit.settings.trivial_alloc);
     };
-    virtual ~AllocatorBase(){};
+    virtual ~AllocatorBase() {};
 
     /////////////////////////////////////////////////////////////////
     /// ALLOCATION functions common to trivial and greedy allocation

--- a/backends/tofino/bf-p4c/phv/v2/greedy_allocator.h
+++ b/backends/tofino/bf-p4c/phv/v2/greedy_allocator.h
@@ -97,7 +97,7 @@ class GreedyAllocator : public AllocatorBase {
 
  public:
     GreedyAllocator(const PhvKit &kit, PhvInfo &phv, int pipe_id)
-        : AllocatorBase(kit), phv_i(phv), pipe_id_i(pipe_id){};
+        : AllocatorBase(kit), phv_i(phv), pipe_id_i(pipe_id) {};
 
     /// @returns false if allocation failed.
     /// allocate all @p clusters to phv_i. This function will directly print out errors

--- a/frontends/p4/parseAnnotations.h
+++ b/frontends/p4/parseAnnotations.h
@@ -27,113 +27,95 @@ limitations under the License.
 namespace P4 {
 
 // A no-op handler. Useful for avoiding warnings about ignored annotations.
-#define PARSE_SKIP(aname) \
-    { aname, &P4::ParseAnnotations::parseSkip }
+#define PARSE_SKIP(aname) {aname, &P4::ParseAnnotations::parseSkip}
 
 // Parses an empty annotation.
-#define PARSE_EMPTY(aname) \
-    { aname, &P4::ParseAnnotations::parseEmpty }
+#define PARSE_EMPTY(aname) {aname, &P4::ParseAnnotations::parseEmpty}
 
 // Parses an annotation with a single-element body.
-#define PARSE(aname, tname)                                                                       \
-    {                                                                                             \
-        aname, [](IR::Annotation *annotation) {                                                   \
-            const IR::tname *parsed =                                                             \
-                P4::P4ParserDriver::parse##tname(annotation->srcInfo, annotation->getUnparsed()); \
-            if (parsed != nullptr) {                                                              \
-                annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(parsed);           \
-            }                                                                                     \
-            return parsed != nullptr;                                                             \
-        }                                                                                         \
-    }
+#define PARSE(aname, tname)                                                                    \
+    {aname, [](IR::Annotation *annotation) {                                                   \
+         const IR::tname *parsed =                                                             \
+             P4::P4ParserDriver::parse##tname(annotation->srcInfo, annotation->getUnparsed()); \
+         if (parsed != nullptr) {                                                              \
+             annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(parsed);           \
+         }                                                                                     \
+         return parsed != nullptr;                                                             \
+     }}
 
 // Parses an annotation that is either an integer constant or a string literal.
-#define PARSE_CONSTANT_OR_STRING_LITERAL(aname)                                              \
-    {                                                                                        \
-        aname, [](IR::Annotation *annotation) {                                              \
-            const IR::Expression *parsed = P4::P4ParserDriver::parseConstantOrStringLiteral( \
-                annotation->srcInfo, annotation->getUnparsed());                             \
-            if (parsed != nullptr) {                                                         \
-                annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(parsed);      \
-            }                                                                                \
-            return parsed != nullptr;                                                        \
-        }                                                                                    \
-    }
+#define PARSE_CONSTANT_OR_STRING_LITERAL(aname)                                           \
+    {aname, [](IR::Annotation *annotation) {                                              \
+         const IR::Expression *parsed = P4::P4ParserDriver::parseConstantOrStringLiteral( \
+             annotation->srcInfo, annotation->getUnparsed());                             \
+         if (parsed != nullptr) {                                                         \
+             annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(parsed);      \
+         }                                                                                \
+         return parsed != nullptr;                                                        \
+     }}
 
-#define PARSE_CONSTANT(aname)                                                                      \
-    {                                                                                              \
-        aname, [](IR::Annotation *annotation) {                                                    \
-            const IR::Expression *parsed =                                                         \
-                P4::P4ParserDriver::parseConstant(annotation->srcInfo, annotation->getUnparsed()); \
-            if (parsed != nullptr) {                                                               \
-                annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(parsed);            \
-            }                                                                                      \
-            return parsed != nullptr;                                                              \
-        }                                                                                          \
-    }
+#define PARSE_CONSTANT(aname)                                                                   \
+    {aname, [](IR::Annotation *annotation) {                                                    \
+         const IR::Expression *parsed =                                                         \
+             P4::P4ParserDriver::parseConstant(annotation->srcInfo, annotation->getUnparsed()); \
+         if (parsed != nullptr) {                                                               \
+             annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(parsed);            \
+         }                                                                                      \
+         return parsed != nullptr;                                                              \
+     }}
 
-#define PARSE_STRING_LITERAL(aname)                                                     \
-    {                                                                                   \
-        aname, [](IR::Annotation *annotation) {                                         \
-            const IR::Expression *parsed = P4::P4ParserDriver::parseStringLiteral(      \
-                annotation->srcInfo, annotation->getUnparsed());                        \
-            if (parsed != nullptr) {                                                    \
-                annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(parsed); \
-            }                                                                           \
-            return parsed != nullptr;                                                   \
-        }                                                                               \
-    }
+#define PARSE_STRING_LITERAL(aname)                                                  \
+    {aname, [](IR::Annotation *annotation) {                                         \
+         const IR::Expression *parsed = P4::P4ParserDriver::parseStringLiteral(      \
+             annotation->srcInfo, annotation->getUnparsed());                        \
+         if (parsed != nullptr) {                                                    \
+             annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(parsed); \
+         }                                                                           \
+         return parsed != nullptr;                                                   \
+     }}
 
 // Parses an annotation whose body is a pair.
-#define PARSE_PAIR(aname, tname)                                                               \
-    {                                                                                          \
-        aname, [](IR::Annotation *annotation) {                                                \
-            const IR::Vector<IR::Expression> *parsed = P4::P4ParserDriver::parse##tname##Pair( \
-                annotation->srcInfo, annotation->getUnparsed());                               \
-            if (parsed != nullptr) {                                                           \
-                annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(*parsed);       \
-            }                                                                                  \
-            return parsed != nullptr;                                                          \
-        }                                                                                      \
-    }
+#define PARSE_PAIR(aname, tname)                                                            \
+    {aname, [](IR::Annotation *annotation) {                                                \
+         const IR::Vector<IR::Expression> *parsed = P4::P4ParserDriver::parse##tname##Pair( \
+             annotation->srcInfo, annotation->getUnparsed());                               \
+         if (parsed != nullptr) {                                                           \
+             annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(*parsed);       \
+         }                                                                                  \
+         return parsed != nullptr;                                                          \
+     }}
 
 // Parses an annotation whose body is a triple.
-#define PARSE_TRIPLE(aname, tname)                                                               \
-    {                                                                                            \
-        aname, [](IR::Annotation *annotation) {                                                  \
-            const IR::Vector<IR::Expression> *parsed = P4::P4ParserDriver::parse##tname##Triple( \
-                annotation->srcInfo, annotation->getUnparsed());                                 \
-            if (parsed != nullptr) {                                                             \
-                annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(*parsed);         \
-            }                                                                                    \
-            return parsed != nullptr;                                                            \
-        }                                                                                        \
-    }
+#define PARSE_TRIPLE(aname, tname)                                                            \
+    {aname, [](IR::Annotation *annotation) {                                                  \
+         const IR::Vector<IR::Expression> *parsed = P4::P4ParserDriver::parse##tname##Triple( \
+             annotation->srcInfo, annotation->getUnparsed());                                 \
+         if (parsed != nullptr) {                                                             \
+             annotation->body.emplace<IR::Annotation::ExpressionAnnotation>(*parsed);         \
+         }                                                                                    \
+         return parsed != nullptr;                                                            \
+     }}
 
 // Parses an annotation whose body is a list of expressions.
-#define PARSE_EXPRESSION_LIST(aname) \
-    { aname, &P4::ParseAnnotations::parseExpressionList }
+#define PARSE_EXPRESSION_LIST(aname) {aname, &P4::ParseAnnotations::parseExpressionList}
 
 // Parses an annotation whose body is a list of key-value pairs.
-#define PARSE_KV_LIST(aname) \
-    { aname, &P4::ParseAnnotations::parseKvList }
+#define PARSE_KV_LIST(aname) {aname, &P4::ParseAnnotations::parseKvList}
 
 // Parses an annotation whose body is a list of integer constants.
-#define PARSE_CONSTANT_LIST(aname) \
-    { aname, &P4::ParseAnnotations::parseConstantList }
+#define PARSE_CONSTANT_LIST(aname) {aname, &P4::ParseAnnotations::parseConstantList}
 
 // Parses an annotation whose body is a list, where each element is an integer constant or a string
 // literal.
 #define PARSE_CONSTANT_OR_STRING_LITERAL_LIST(aname) \
-    { aname, &P4::ParseAnnotations::parseConstantOrStringLiteralList }
+    {aname, &P4::ParseAnnotations::parseConstantOrStringLiteralList}
 
 // Parses an annotation whose body is a list of string literals.
-#define PARSE_STRING_LITERAL_LIST(aname) \
-    { aname, &P4::ParseAnnotations::parseStringLiteralList }
+#define PARSE_STRING_LITERAL_LIST(aname) {aname, &P4::ParseAnnotations::parseStringLiteralList}
 
 // Parses a P4Runtime translation which contains both types or expressions.
 #define PARSE_P4RUNTIME_TRANSLATION(aname) \
-    { aname, &P4::ParseAnnotations::parseP4rtTranslationAnnotation }
+    {aname, &P4::ParseAnnotations::parseP4rtTranslationAnnotation}
 
 class ParseAnnotations : public Modifier {
  public:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "thrift==0.21.0",
     "protobuf==3.20.2 ; python_version > '3.6'",
     "protobuf==3.19.2 ; python_version <= '3.6'",
-    "clang-format==18.1.0",
+    "clang-format==18.1.8",
     "black==24.3.0 ; python_version > '3.6'",
     "black==22.8.0 ; python_version <= '3.6'",
     "isort==5.13.2 ; python_version > '3.6'",


### PR DESCRIPTION
`ninja clang-format` currently fails on `main` branch when run locally. Perhaps the CI is not enforcing clang-formatting for these files?