### PR TITLE
Make struct used by digest in p4tc packed 

### DIFF
--- a/backends/ebpf/ebpfType.cpp
+++ b/backends/ebpf/ebpfType.cpp
@@ -196,6 +196,7 @@ EBPFStructType::EBPFStructType(const IR::Type_StructLike *strct) : EBPFType(strc
         }
         fields.push_back(new EBPFField(type, f));
     }
+    packed = false;
 }
 
 void EBPFStructType::declare(CodeBuilder *builder, cstring id, bool asPointer) {
@@ -232,6 +233,8 @@ void EBPFStructType::emitInitializer(CodeBuilder *builder) {
 void EBPFStructType::emit(CodeBuilder *builder) {
     builder->emitIndent();
     builder->append(kind);
+    builder->spc();
+    if (packed) builder->append("__attribute__((__packed__))");
     builder->spc();
     builder->append(name);
     builder->spc();

--- a/backends/ebpf/ebpfType.h
+++ b/backends/ebpf/ebpfType.h
@@ -169,6 +169,7 @@ class EBPFStructType : public EBPFType, public IHasWidth {
     std::vector<EBPFField *> fields;
     unsigned width;
     unsigned implWidth;
+    bool packed;
 
     explicit EBPFStructType(const IR::Type_StructLike *strct);
     void declare(CodeBuilder *builder, cstring id, bool asPointer) override;

--- a/backends/tc/ebpfCodeGen.cpp
+++ b/backends/tc/ebpfCodeGen.cpp
@@ -1659,7 +1659,7 @@ const PNAEbpfGenerator *ConvertToEbpfPNA::build(const IR::ToplevelBlock *tlb) {
     auto pipeline_converter = new ConvertToEbpfPipelineTC(
         "tc-ingress"_cs, EBPF::TC_INGRESS, options, pipelineParser->checkedTo<IR::ParserBlock>(),
         pipelineControl->checkedTo<IR::ControlBlock>(),
-        pipelineDeparser->checkedTo<IR::ControlBlock>(), refmap, typemap, tcIR);
+        pipelineDeparser->checkedTo<IR::ControlBlock>(), refmap, typemap, tcIR, ebpfTypes);
     pipeline->apply(*pipeline_converter);
     tlb->getProgram()->apply(*pipeline_converter);
     auto tcIngress = pipeline_converter->getEbpfPipeline();
@@ -1690,8 +1690,9 @@ bool ConvertToEbpfPipelineTC::preorder(const IR::PackageBlock *block) {
     pipeline->control = control_converter->getEBPFControl();
     CHECK_NULL(pipeline->control);
 
-    auto deparser_converter = new ConvertToEBPFDeparserPNA(
-        pipeline, pipeline->parser->headers, pipeline->control->outputStandardMetadata, tcIR);
+    auto deparser_converter =
+        new ConvertToEBPFDeparserPNA(pipeline, pipeline->parser->headers,
+                                     pipeline->control->outputStandardMetadata, tcIR, ebpfTypes);
     deparserBlock->apply(*deparser_converter);
     pipeline->deparser = deparser_converter->getEBPFDeparser();
     CHECK_NULL(pipeline->deparser);
@@ -1900,6 +1901,15 @@ bool ConvertToEBPFDeparserPNA::preorder(const IR::Declaration_Instance *di) {
             deparser->addExternDeclaration = true;
             cstring instance = EBPF::EBPFObject::externalName(di);
             auto digest = new EBPFDigestPNA(program, di, typeName, tcIR);
+            for (auto type : ebpfTypes) {
+                if (type->is<EBPF::EBPFStructType>()) {
+                    auto structType = type->to<EBPF::EBPFStructType>();
+
+                    auto structValueType =
+                        dynamic_cast<P4::EBPF::EBPFStructType *>(digest->valueType);
+                    if (structValueType->name == structType->name) structType->packed = true;
+                }
+            }
             deparser->digests.emplace(instance, digest);
         }
     }

--- a/backends/tc/ebpfCodeGen.cpp
+++ b/backends/tc/ebpfCodeGen.cpp
@@ -1901,13 +1901,15 @@ bool ConvertToEBPFDeparserPNA::preorder(const IR::Declaration_Instance *di) {
             deparser->addExternDeclaration = true;
             cstring instance = EBPF::EBPFObject::externalName(di);
             auto digest = new EBPFDigestPNA(program, di, typeName, tcIR);
-            for (auto type : ebpfTypes) {
-                if (type->is<EBPF::EBPFStructType>()) {
-                    auto structType = type->to<EBPF::EBPFStructType>();
 
-                    auto structValueType =
-                        dynamic_cast<P4::EBPF::EBPFStructType *>(digest->valueType);
-                    if (structValueType->name == structType->name) structType->packed = true;
+            if (digest->valueType->is<EBPF::EBPFStructType>()) {
+                for (auto type : ebpfTypes) {
+                    if (type->is<EBPF::EBPFStructType>()) {
+                        auto structType = type->to<EBPF::EBPFStructType>();
+                        auto digestType = digest->valueType->to<EBPF::EBPFStructType>();
+
+                        if (digestType->name == structType->name) structType->packed = true;
+                    }
                 }
             }
             deparser->digests.emplace(instance, digest);

--- a/backends/tc/ebpfCodeGen.h
+++ b/backends/tc/ebpfCodeGen.h
@@ -257,13 +257,15 @@ class ConvertToEbpfPipelineTC : public Inspector {
     P4::ReferenceMap *refmap;
     EBPF::EBPFPipeline *pipeline;
     const ConvertToBackendIR *tcIR;
+    std::vector<EBPF::EBPFType *> ebpfTypes;
 
  public:
     ConvertToEbpfPipelineTC(cstring name, EBPF::pipeline_type type, const EbpfOptions &options,
                             const IR::ParserBlock *parserBlock,
                             const IR::ControlBlock *controlBlock,
                             const IR::ControlBlock *deparserBlock, P4::ReferenceMap *refmap,
-                            P4::TypeMap *typemap, const ConvertToBackendIR *tcIR)
+                            P4::TypeMap *typemap, const ConvertToBackendIR *tcIR,
+                            std::vector<EBPF::EBPFType *> ebpfTypes)
         : name(name),
           type(type),
           options(options),
@@ -273,7 +275,8 @@ class ConvertToEbpfPipelineTC : public Inspector {
           typemap(typemap),
           refmap(refmap),
           pipeline(nullptr),
-          tcIR(tcIR) {}
+          tcIR(tcIR),
+          ebpfTypes(ebpfTypes) {}
 
     bool preorder(const IR::PackageBlock *block) override;
     EBPF::EBPFPipeline *getEbpfPipeline() { return pipeline; }
@@ -370,15 +373,18 @@ class ConvertToEBPFDeparserPNA : public Inspector {
     const IR::Parameter *parserHeaders;
     const IR::Parameter *istd;
     const ConvertToBackendIR *tcIR;
+    std::vector<EBPF::EBPFType *> ebpfTypes;
     TC::IngressDeparserPNA *deparser;
 
  public:
     ConvertToEBPFDeparserPNA(EBPF::EBPFProgram *program, const IR::Parameter *parserHeaders,
-                             const IR::Parameter *istd, const ConvertToBackendIR *tcIR)
+                             const IR::Parameter *istd, const ConvertToBackendIR *tcIR,
+                             std::vector<EBPF::EBPFType *> ebpfTypes)
         : program(program),
           parserHeaders(parserHeaders),
           istd(istd),
           tcIR(tcIR),
+          ebpfTypes(ebpfTypes),
           deparser(nullptr) {}
 
     bool preorder(const IR::ControlBlock *) override;

--- a/testdata/p4tc_samples_outputs/digest_parser.h
+++ b/testdata/p4tc_samples_outputs/digest_parser.h
@@ -40,7 +40,7 @@ struct my_ingress_metadata_t {
     u32 ingress_port; /* PortId_t */
     u8 send_digest; /* bool */
 };
-struct mac_learn_digest_t {
+struct __attribute__((__packed__)) mac_learn_digest_t {
     u8 srcAddr[6]; /* bit<48> */
     u32 ingress_port; /* PortId_t */
 };

--- a/testdata/p4tc_samples_outputs/digest_parser_meta_parser.h
+++ b/testdata/p4tc_samples_outputs/digest_parser_meta_parser.h
@@ -39,7 +39,7 @@ struct my_ingress_headers_t {
     struct ethernet_t ethernet; /* ethernet_t */
     struct ipv4_t ipv4; /* ipv4_t */
 };
-struct ipv4_learn_digest_t {
+struct __attribute__((__packed__)) ipv4_learn_digest_t {
     u32 srcAddr; /* bit<32> */
     u32 ingress_port; /* PortId_t */
 };


### PR DESCRIPTION
The p4tc control path expects the digest message to be packed
For example, in testdata/p4tc_samples/digest.p4 we have the following
struct being sent throught digest pack:

```
struct mac_learn_digest_t {
    @tc_type("macaddr") bit<48> srcAddr;
    @tc_type("dev") PortId_t ingress_port;
};
```

As an eBPF C struct, this will be:

```
struct mac_learn_digest_t {
    u8 srcAddr[6]; /* bit<48> */
    u32 ingress_port; /* PortId_t */
};
```

Notice that this will create padding between srcAddr
and ingress_port. To avoid this we are making structs associated with
digest messages packed. So the previous struct will become:

```
struct __attribute__((__packed__)) mac_learn_digest_t {
    u8 srcAddr[6]; /* bit<48> */
    u32 ingress_port; /* PortId_t */
};
```