### PR TITLE
@persistent annotation for data persistent across packets

### DIFF
--- a/backends/bmv2/pna_nic/midend.cpp
+++ b/backends/bmv2/pna_nic/midend.cpp
@@ -49,6 +49,7 @@ limitations under the License.
 #include "midend/midEndLast.h"
 #include "midend/nestedStructs.h"
 #include "midend/orderArguments.h"
+#include "midend/persistToReg.h"
 #include "midend/predication.h"
 #include "midend/removeAssertAssume.h"
 #include "midend/removeLeftSlices.h"
@@ -112,6 +113,7 @@ PnaNicMidEnd::PnaNicMidEnd(CompilerOptions &options, std::ostream *outStream)
     if (BMV2::PnaNicContext::get().options().loadIRFromJson == false) {
         addPasses({
             options.ndebug ? new P4::RemoveAssertAssume(&typeMap) : nullptr,
+            new P4::PersistToReg("Register"_cs),
             new P4::TypeChecking(&refMap, &typeMap),
             new P4::SimplifyExternMethodCalls(&typeMap),
             new P4::TypeChecking(&refMap, &typeMap),

--- a/backends/bmv2/psa_switch/midend.cpp
+++ b/backends/bmv2/psa_switch/midend.cpp
@@ -49,6 +49,7 @@ limitations under the License.
 #include "midend/midEndLast.h"
 #include "midend/nestedStructs.h"
 #include "midend/orderArguments.h"
+#include "midend/persistToReg.h"
 #include "midend/predication.h"
 #include "midend/removeAssertAssume.h"
 #include "midend/removeLeftSlices.h"
@@ -112,6 +113,7 @@ PsaSwitchMidEnd::PsaSwitchMidEnd(CompilerOptions &options, std::ostream *outStre
     if (BMV2::PsaSwitchContext::get().options().loadIRFromJson == false) {
         addPasses({
             options.ndebug ? new P4::RemoveAssertAssume(&typeMap) : nullptr,
+            new P4::PersistToReg("Register"_cs),
             new P4::TypeChecking(&refMap, &typeMap),
             new P4::SimplifyExternMethodCalls(&typeMap),
             new P4::TypeChecking(&refMap, &typeMap),

--- a/backends/bmv2/simple_switch/midend.cpp
+++ b/backends/bmv2/simple_switch/midend.cpp
@@ -53,6 +53,7 @@ limitations under the License.
 #include "midend/nestedStructs.h"
 #include "midend/orderArguments.h"
 #include "midend/parserUnroll.h"
+#include "midend/persistToReg.h"
 #include "midend/removeAssertAssume.h"
 #include "midend/removeLeftSlices.h"
 #include "midend/removeMiss.h"
@@ -78,6 +79,7 @@ SimpleSwitchMidEnd::SimpleSwitchMidEnd(CompilerOptions &options, std::ostream *o
         addPasses(
             {options.ndebug ? new P4::RemoveAssertAssume(&typeMap) : nullptr,
              new P4::CheckTableSize(),
+             new P4::PersistToReg("register"_cs),
              new P4::TypeChecking(&refMap, &typeMap),
              new P4::SimplifyExternMethodCalls(&typeMap),
              new P4::TypeChecking(&refMap, &typeMap),

--- a/backends/dpdk/midend.cpp
+++ b/backends/dpdk/midend.cpp
@@ -56,6 +56,7 @@ limitations under the License.
 #include "midend/noMatch.h"
 #include "midend/orderArguments.h"
 #include "midend/parserUnroll.h"
+#include "midend/persistToReg.h"
 #include "midend/predication.h"
 #include "midend/removeAssertAssume.h"
 #include "midend/removeExits.h"
@@ -169,6 +170,7 @@ DpdkMidEnd::DpdkMidEnd(CompilerOptions &options, std::ostream *outStream) {
     if (!DPDK::DpdkContext::get().options().loadIRFromJson) {
         addPasses({
             options.ndebug ? new P4::RemoveAssertAssume(&typeMap) : nullptr,
+            new P4::PersistToReg("Register"_cs),
             new P4::RemoveMiss(&typeMap),
             new P4::EliminateNewtype(&typeMap),
             new P4::EliminateSerEnums(&typeMap),

--- a/frontends/p4/parseAnnotations.cpp
+++ b/frontends/p4/parseAnnotations.cpp
@@ -30,6 +30,7 @@ ParseAnnotations::HandlerMap ParseAnnotations::standardHandlers() {
         PARSE_EMPTY(IR::Annotation::pureAnnotation),
         PARSE_EMPTY(IR::Annotation::tableOnlyAnnotation),
         PARSE_EMPTY(IR::Annotation::unlikelyAnnotation),
+        PARSE_EMPTY(IR::Annotation::persistentAnnotation),
         PARSE_EMPTY("disable_optimization"_cs),
         PARSE_EMPTY("unroll"_cs),
         PARSE_EMPTY("nounroll"_cs),

--- a/ir/annotations.cpp
+++ b/ir/annotations.cpp
@@ -41,6 +41,7 @@ const cstring IR::Annotation::disableOptimizationAnnotation = "disable_optimizat
 const cstring IR::Annotation::inlinedFromAnnotation = "inlinedFrom"_cs;
 const cstring IR::Annotation::likelyAnnotation = "likely"_cs;
 const cstring IR::Annotation::unlikelyAnnotation = "unlikely"_cs;
+const cstring IR::Annotation::persistentAnnotation = "persistent"_cs;
 
 namespace Annotations {
 void addIfNew(Vector<Annotation> &annotations, cstring name, const Expression *expr,

--- a/ir/base.def
+++ b/ir/base.def
@@ -293,6 +293,7 @@ class Annotation {
     static const cstring inlinedFromAnnotation; /// annotation to mark block of inlined function
     static const cstring likelyAnnotation;  /// annotation for likely taken blocks/branchs
     static const cstring unlikelyAnnotation;  /// annotation for likely not taken blocks/branchs
+    static const cstring persistentAnnotation;  /// annotation for persistent data
     toString{ return absl::StrCat("@", name); }
     validate{
         BUG_CHECK(!name.name.isNullOrEmpty(), "empty annotation name");

--- a/midend/CMakeLists.txt
+++ b/midend/CMakeLists.txt
@@ -44,6 +44,7 @@ set (MIDEND_SRCS
   noMatch.cpp
   orderArguments.cpp
   parserUnroll.cpp
+  persistToReg.cpp
   predication.cpp
   removeAssertAssume.cpp
   removeComplexExpressions.cpp
@@ -101,6 +102,7 @@ set (MIDEND_HDRS
   noMatch.h
   orderArguments.h
   parserUnroll.h
+  persistToReg.h
   predication.h
   removeAssertAssume.h
   removeComplexExpressions.h

--- a/midend/persistToReg.cpp
+++ b/midend/persistToReg.cpp
@@ -1,0 +1,276 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "persistToReg.h"
+
+#include <map>
+
+#include "frontends/common/resolveReferences/referenceMap.h"  // for MinimalNameGenerator
+#include "ir/ir.h"
+#include "ir/irutils.h"
+
+namespace P4 {
+
+using namespace literals;
+
+class FindPersist : public Inspector {
+ public:
+    struct info_t {
+        const IR::Declaration_Variable *var;
+        const IR::Type *eltype = nullptr;
+        const IR::Type::Bits *idx_type = nullptr;
+        int regsize = 0;
+    };
+
+ private:
+    std::map<cstring, info_t> persist;
+    profile_t init_apply(const IR::Node *root) {
+        persist.clear();
+        return Inspector::init_apply(root);
+    }
+    bool preorder(const IR::Declaration_Variable *decl) {
+        if (!decl->hasAnnotation(IR::Annotation::persistentAnnotation)) return false;
+        LOG2("FindPersist: " << decl);
+        auto &info = persist[decl->name.name];
+        info.var = decl;
+        if (auto *st = decl->type->to<IR::Type_Array>()) {
+            info.eltype = st->elementType;
+            auto *size = st->size->to<IR::Constant>();
+            BUG_CHECK(size, "Array size not constant: %s", decl);
+            info.regsize = size->asInt();
+        } else {
+            info.eltype = decl->type;
+            info.regsize = 1;
+        }
+        return true;
+    }
+    bool preorder(const IR::ArrayIndex *ai) {
+        auto *pe = ai->left->to<IR::PathExpression>();
+        auto *itype = ai->right->type->to<IR::Type::Bits>();
+        if (pe && itype) {
+            if (auto *info = at(pe->path->name)) {
+                if (!info->idx_type && (itype->size > 30 || (1 << itype->size) >= info->regsize))
+                    info->idx_type = itype;
+            }
+        }
+        return true;
+    }
+    void end_apply() {
+        for (auto &[_, info] : persist)
+            if (!info.idx_type)
+                info.idx_type = IR::Type::Bits::get(std::max(ceil_log2(info.regsize), 1));
+    }
+
+ public:
+    FindPersist() {}
+    bool empty() const { return persist.empty(); }
+    info_t *at(cstring name) {
+        if (auto i = persist.find(name); i != persist.end()) return &i->second;
+        return nullptr;
+    }
+    const info_t *at(cstring name) const {
+        if (auto i = persist.find(name); i != persist.end()) return &i->second;
+        return nullptr;
+    }
+    const info_t *at(const IR::Expression *expr) const {
+        if (auto *ai = expr->to<IR::ArrayIndex>()) return at(ai->left);
+        if (auto *pe = expr->to<IR::PathExpression>()) return at(pe->path->name);
+        return nullptr;
+    }
+};
+
+class RewritePersistAsReg : public Transform, public P4WriteContext {
+    cstring regExtern;
+    const FindPersist *persist;
+    MinimalNameGenerator *nameGen;
+    const IR::Type *regSizeType;
+    const IR::Method *readMethod, *writeMethod;
+    std::map<cstring, const IR::Declaration_Instance *> regDecls;
+    IR::IndexedVector<IR::StatOrDecl> prependToCurrentStmt;
+
+    IR::P4Program *preorder(IR::P4Program *top) {
+        const IR::Type_Extern *regType = nullptr;
+        for (auto *decl : *top->getDeclsByName(regExtern)) {
+            BUG_CHECK(!regType, "Multiple %s declarations%s%s", regExtern, regType->srcInfo,
+                      decl->getNode()->srcInfo);
+            regType = decl->to<IR::Type_Extern>();
+        }
+        BUG_CHECK(regType, "No %s extern", regExtern);
+        for (auto *method : regType->methods) {
+            if (method->name == regExtern) {  // constructor
+                regSizeType = method->getParameters()->getParameter(0)->type;
+            } else if (method->name == "read"_cs) {
+                readMethod = method;
+            } else if (method->name == "write"_cs) {
+                writeMethod = method;
+            }
+        }
+        prependToCurrentStmt.clear();
+        return top;
+    }
+
+    IR::Declaration *preorder(IR::Declaration_Variable *decl) {
+        prune();
+        if (!decl->hasAnnotation(IR::Annotation::persistentAnnotation)) return decl;
+        auto *info = persist->at(decl->name.name);
+        BUG_CHECK(info, "persist mismatch ", decl);
+        auto *types = new IR::Vector<IR::Type>({info->eltype, info->idx_type});
+        auto *type = new IR::Type_Specialized(new IR::Type_Name(IR::ID(regExtern)), types);
+        auto *args = new IR::Vector<IR::Argument>(
+            {new IR::Argument(new IR::Constant(regSizeType, info->regsize))});
+        auto *rv =
+            new IR::Declaration_Instance(decl->srcInfo, decl->name, decl->annotations, type, args);
+        bool ok = regDecls.emplace(decl->name.name, rv).second;
+        BUG_CHECK(ok, "duplicate regster %s", rv);
+        return rv;
+    }
+
+    const IR::MethodCallExpression *makeCall(const Util::SourceInfo &srcInfo,
+                                             const FindPersist::info_t *info,
+                                             const IR::Method *method, const IR::Expression *index,
+                                             const IR::Expression *value) {
+        auto *reg = regDecls.at(info->var->name);
+        auto *args = new IR::Vector<IR::Argument>;
+        for (auto *param : method->getParameters()->parameters) {
+            if (param->name == "index"_cs) {
+                if (!index) index = new IR::Constant(info->idx_type, 0);
+                if (param->type->is<IR::Type::Bits>() && index->type != param->type)
+                    index = new IR::Cast(param->type, index);
+                args->emplace_back(param->name, index);
+            } else if (param->name == "value"_cs || param->name == "result"_cs) {
+                BUG_CHECK(value, "Value not set");
+                if (!param->type->is<IR::Type_Name>() && value->type != param->type)
+                    value = new IR::Cast(param->type, value);
+                args->emplace_back(param->name, value);
+            } else {
+                BUG("unknown parameter %s to %s.%s", param->name, regExtern, method->name);
+            }
+        }
+        auto *rtype = method->type->returnType;
+        if (rtype->is<IR::Type_Name>() || rtype->is<IR::Type_Var>()) rtype = info->eltype;
+        return new IR::MethodCallExpression(
+            srcInfo, rtype,
+            new IR::Member(method->type, new IR::PathExpression(reg->type, info->var->name),
+                           method->name),
+            args);
+    }
+
+    cstring tempName(cstring reg) { return nameGen->newName(reg + "_tmp"); }
+
+    // rebuild the LHS of an assignment by taking the expression parts from lhs that are 'above'
+    // old and relayer them on rv and return that
+    const IR::Expression *makeLHS(const IR::Expression *rv, const IR::Expression *old,
+                                  const IR::Expression *lhs) {
+        if (old == lhs) return rv;
+        if (auto *sl = lhs->to<IR::AbstractSlice>()) {
+            auto *n = sl->clone();
+            n->e0 = makeLHS(rv, old, n->e0);
+            return n;
+        }
+        if (auto *m = lhs->to<IR::Member>()) {
+            auto *n = m->clone();
+            n->expr = makeLHS(rv, old, n->expr);
+            return n;
+        }
+        BUG("unexpected lhs %s", lhs);
+    }
+
+    const IR::Node *preorder(IR::BaseAssignmentStatement *assign) {
+        auto *exp = assign->left;
+        while (1) {
+            if (auto *sl = exp->to<IR::AbstractSlice>())
+                exp = sl->e0;
+            else if (auto *m = exp->to<IR::Member>())
+                exp = m->expr;
+            else
+                break;
+        }
+        auto *info = persist->at(exp);
+        if (!info) return assign;
+        bool needCopy = exp != assign->left || assign->is<IR::OpAssignmentStatement>();
+        auto *val = assign->right;
+        const IR::Expression *index = nullptr;
+        if (auto *ai = exp->to<IR::ArrayIndex>()) index = ai->right;
+        IR::IndexedVector<IR::StatOrDecl> rv;
+        if (needCopy) {
+            auto tmpvar = tempName(info->var->name.toString());
+            rv.push_back(new IR::Declaration_Variable(tmpvar, info->eltype));
+            if (readMethod->type->returnType->is<IR::Type_Void>()) {
+                rv.push_back(new IR::MethodCallStatement(
+                    makeCall(exp->srcInfo, info, readMethod, index,
+                             new IR::PathExpression(info->eltype, tmpvar))));
+            } else {
+                rv.push_back(new IR::AssignmentStatement(
+                    exp->srcInfo, new IR::PathExpression(info->eltype, tmpvar),
+                    makeCall(exp->srcInfo, info, readMethod, index, 0)));
+            }
+            assign->left = makeLHS(new IR::PathExpression(info->eltype, tmpvar), exp, assign->left);
+            rv.push_back(assign);
+            val = new IR::PathExpression(info->eltype, tmpvar);
+        }
+        auto *mcs =
+            new IR::MethodCallStatement(makeCall(assign->srcInfo, info, writeMethod, index, val));
+        rv.push_back(mcs);
+        return inlineBlock(*this, std::move(rv));
+    }
+
+    const IR::Expression *doRead(const IR::Expression *exp, const IR::Expression *index) {
+        if (auto *info = persist->at(exp)) {
+            if (readMethod->type->returnType->is<IR::Type_Void>()) {
+                auto tmpvar = tempName(info->var->name.toString());
+                prependToCurrentStmt.push_back(new IR::Declaration_Variable(tmpvar, info->eltype));
+                prependToCurrentStmt.push_back(new IR::MethodCallStatement(
+                    makeCall(exp->srcInfo, info, readMethod, index,
+                             new IR::PathExpression(info->eltype, tmpvar))));
+                return new IR::PathExpression(info->eltype, tmpvar);
+            } else {
+                return makeCall(exp->srcInfo, info, readMethod, index, nullptr);
+            }
+        }
+        return exp;
+    }
+
+    const IR::Expression *preorder(IR::ArrayIndex *ai) { return doRead(ai, ai->right); }
+    const IR::Expression *preorder(IR::PathExpression *pe) { return doRead(pe, nullptr); }
+    const IR::Member *preorder(IR::Member *m) {
+        // need to avoid recursing into the member function calls created by makeCall
+        if (m->type->is<IR::Type_Method>()) prune();
+        return m;
+    }
+
+    const IR::Node *postorder(IR::Statement *stmt) {
+        if (prependToCurrentStmt.empty()) return stmt;
+        prependToCurrentStmt.push_back(stmt);
+        auto *rv = inlineBlock(*this, std::move(prependToCurrentStmt));
+        prependToCurrentStmt.clear();
+        return rv;
+    }
+
+ public:
+    RewritePersistAsReg(cstring re, const FindPersist *p, MinimalNameGenerator *ng)
+        : regExtern(re), persist(p), nameGen(ng) {}
+};
+
+PersistToReg::PersistToReg(cstring regExtern) {
+    auto *findPersist = new FindPersist;
+    auto *nameGen = new MinimalNameGenerator;
+    addPasses(
+        {findPersist, PassIf([=]() { return !findPersist->empty(); },
+                             {nameGen, new RewritePersistAsReg(regExtern, findPersist, nameGen)})});
+}
+
+}  // namespace P4

--- a/midend/persistToReg.h
+++ b/midend/persistToReg.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MIDEND_PERSISTTOREG_H_
+#define MIDEND_PERSISTTOREG_H_
+
+#include "ir/pass_manager.h"
+
+namespace P4 {
+
+class PersistToReg : public PassManager {
+ public:
+    explicit PersistToReg(cstring regExtern);
+};
+
+}  // namespace P4
+
+#endif /* MIDEND_PERSISTTOREG_H_ */

--- a/testdata/p4_16_samples/psa-persistent-bmv2.p4
+++ b/testdata/p4_16_samples/psa-persistent-bmv2.p4
@@ -1,0 +1,146 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+struct EMPTY { };
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
+struct headers_t {
+    ethernet_t       ethernet;
+    output_data_t    output_data;
+}
+
+struct metadata_t {
+}
+
+parser MyIP(
+    packet_in pkt,
+    out headers_t hdr,
+    inout metadata_t user_meta,
+    in psa_ingress_parser_input_metadata_t istd,
+    in EMPTY resubmit_meta,
+    in EMPTY recirculate_meta)
+{
+    state start {
+        pkt.extract(hdr.ethernet);
+        pkt.extract(hdr.output_data);
+        transition accept;
+    }
+}
+
+parser MyEP(
+    packet_in pkt,
+    out headers_t hdr,
+    inout metadata_t user_meta,
+    in psa_egress_parser_input_metadata_t istd,
+    in EMPTY normal_meta,
+    in EMPTY clone_i2e_meta,
+    in EMPTY clone_e2e_meta)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(
+    inout headers_t hdr,
+    inout metadata_t user_meta,
+    in    psa_ingress_input_metadata_t istd,
+    inout psa_ingress_output_metadata_t ostd)
+{
+    @persistent bit<16> reg[6];
+
+    bit<8> idx;
+    bit<8> action_type;
+    bit<16> orig_data;
+    bit<16> next_data;
+
+    apply {
+        if (hdr.ethernet.isValid()) {
+            idx = hdr.ethernet.dstAddr[7:0];
+            action_type = hdr.ethernet.dstAddr[15:8];
+            bool validAction = (action_type >= 1) && (action_type <= 3);
+
+            if (validAction) {
+                orig_data = reg[idx];
+            }
+            if (action_type == 1) {
+                // store a value into the register from packet header
+                next_data = hdr.ethernet.dstAddr[47:32];
+            } else if (action_type == 2) {
+                // read register, without changing its current value
+                next_data = orig_data;
+            } else if (action_type == 3) {
+                // increment the value currently in the register
+                next_data = orig_data + 1;
+            } else {
+                orig_data = 0xdead;
+                next_data = 0xbeef;
+            }
+            if (idx < 6)
+                reg[idx] = next_data;
+
+            hdr.output_data.word0 = (bit<32>) orig_data;
+            hdr.output_data.word1 = (bit<32>) next_data;
+        }
+        send_to_port(ostd, (PortId_t) 1);
+    }
+}
+
+control MyEC(
+    inout headers_t hdr,
+    inout metadata_t user_meta,
+    in    psa_egress_input_metadata_t  istd,
+    inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control MyID(
+    packet_out pkt,
+    out EMPTY clone_i2e_meta,
+    out EMPTY resubmit_meta,
+    out EMPTY normal_meta,
+    inout headers_t hdr,
+    in metadata_t user_meta,
+    in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.output_data);
+    }
+}
+
+control MyED(
+    packet_out pkt,
+    out EMPTY clone_e2e_meta,
+    out EMPTY recirculate_meta,
+    inout headers_t hdr,
+    in metadata_t user_meta,
+    in psa_egress_output_metadata_t istd,
+    in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply { }
+}
+
+IngressPipeline(MyIP(), MyIC(), MyID()) ip;
+EgressPipeline(MyEP(), MyEC(), MyED()) ep;
+
+PSA_Switch(
+    ip,
+    PacketReplicationEngine(),
+    ep,
+    BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples/psa-persistent-bmv2.stf
+++ b/testdata/p4_16_samples/psa-persistent-bmv2.stf
@@ -1,0 +1,109 @@
+# Initialize all 6 elements of register array to have the same value
+# 0xcafe
+
+packet 4 cafe 0000 01 00 010000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 01 00 010000000000 ffff   ******** 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 01 01 020000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 01 01 020000000000 ffff   ******** 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 01 02 030000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 01 02 030000000000 ffff   ******** 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 01 03 040000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 01 03 040000000000 ffff   ******** 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 01 04 050000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 01 04 050000000000 ffff   ******** 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 01 05 060000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 01 05 060000000000 ffff   ******** 0000cafe deadbeef deadbeef $
+
+
+# Read all 6 of them back to confirm that they contain the value
+# written.
+
+packet 4 cafe 0000 02 00 110000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 00 110000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 01 120000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 01 120000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 02 130000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 02 130000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 03 140000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 03 140000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 04 150000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 04 150000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 05 160000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 05 160000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+# Try incrementing the register array at index 6, 8, 16, 32, and 64,
+# all of which are outside the bounds of the legal index range of [0,
+# 5].  Then read all values again and ensure that none of them have
+# changed.
+
+packet 4 cafe 0000 03 06 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 03 06 000000000000 ffff   ******** ******** deadbeef deadbeef
+
+packet 4 cafe 0000 03 08 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 03 08 000000000000 ffff   ******** ******** deadbeef deadbeef
+
+packet 4 cafe 0000 03 10 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 03 10 000000000000 ffff   ******** ******** deadbeef deadbeef
+
+packet 4 cafe 0000 03 20 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 03 20 000000000000 ffff   ******** ******** deadbeef deadbeef
+
+packet 4 cafe 0000 03 40 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 03 40 000000000000 ffff   ******** ******** deadbeef deadbeef
+
+
+packet 4 cafe 0000 02 00 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 00 000000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 01 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 01 000000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 02 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 02 000000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 03 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 03 000000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 04 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 04 000000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 05 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 05 000000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+# Now try incrementing the value at index 5, and store a value of
+# 0xf00d at index 0.  Then read all values back and ensure they have
+# the expected contents.
+
+packet 4 cafe 0000 03 05 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 03 05 000000000000 ffff   0000cafe 0000caff deadbeef deadbeef
+
+packet 4 f00d 0000 01 00 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 f00d 0000 01 00 000000000000 ffff   0000cafe 0000f00d deadbeef deadbeef
+
+packet 4 cafe 0000 02 00 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 00 000000000000 ffff   0000f00d 0000f00d deadbeef deadbeef $
+
+packet 4 cafe 0000 02 01 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 01 000000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 02 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 02 000000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 03 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 03 000000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 04 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 04 000000000000 ffff   0000cafe 0000cafe deadbeef deadbeef $
+
+packet 4 cafe 0000 02 05 000000000000 ffff   deadbeef deadbeef deadbeef deadbeef
+expect 1 cafe 0000 02 05 000000000000 ffff   0000caff 0000caff deadbeef deadbeef $

--- a/testdata/p4_16_samples_outputs/psa-persistent-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/psa-persistent-bmv2-first.p4
@@ -1,0 +1,96 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+struct EMPTY {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
+struct headers_t {
+    ethernet_t    ethernet;
+    output_data_t output_data;
+}
+
+struct metadata_t {
+}
+
+parser MyIP(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in EMPTY resubmit_meta, in EMPTY recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in EMPTY normal_meta, in EMPTY clone_i2e_meta, in EMPTY clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @persistent bit<16>[6] reg;
+    bit<8> idx;
+    bit<8> action_type;
+    bit<16> orig_data;
+    bit<16> next_data;
+    apply {
+        if (hdr.ethernet.isValid()) {
+            idx = hdr.ethernet.dstAddr[7:0];
+            action_type = hdr.ethernet.dstAddr[15:8];
+            bool validAction = action_type >= 8w1 && action_type <= 8w3;
+            if (validAction) {
+                orig_data = reg[idx];
+            }
+            if (action_type == 8w1) {
+                next_data = hdr.ethernet.dstAddr[47:32];
+            } else if (action_type == 8w2) {
+                next_data = orig_data;
+            } else if (action_type == 8w3) {
+                next_data = orig_data + 16w1;
+            } else {
+                orig_data = 16w0xdead;
+                next_data = 16w0xbeef;
+            }
+            if (idx < 8w6) {
+                reg[idx] = next_data;
+            }
+            hdr.output_data.word0 = (bit<32>)orig_data;
+            hdr.output_data.word1 = (bit<32>)next_data;
+        }
+        send_to_port(ostd, (PortId_t)32w1);
+    }
+}
+
+control MyEC(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control MyID(packet_out pkt, out EMPTY clone_i2e_meta, out EMPTY resubmit_meta, out EMPTY normal_meta, inout headers_t hdr, in metadata_t user_meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<output_data_t>(hdr.output_data);
+    }
+}
+
+control MyED(packet_out pkt, out EMPTY clone_e2e_meta, out EMPTY recirculate_meta, inout headers_t hdr, in metadata_t user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+EgressPipeline<headers_t, metadata_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-persistent-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/psa-persistent-bmv2-frontend.p4
@@ -1,0 +1,107 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+struct EMPTY {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
+struct headers_t {
+    ethernet_t    ethernet;
+    output_data_t output_data;
+}
+
+struct metadata_t {
+}
+
+parser MyIP(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in EMPTY resubmit_meta, in EMPTY recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in EMPTY normal_meta, in EMPTY clone_i2e_meta, in EMPTY clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @persistent @name("MyIC.reg") bit<16>[6] reg_0;
+    @name("MyIC.idx") bit<8> idx_0;
+    @name("MyIC.action_type") bit<8> action_type_0;
+    @name("MyIC.orig_data") bit<16> orig_data_0;
+    @name("MyIC.next_data") bit<16> next_data_0;
+    @name("MyIC.validAction") bool validAction_0;
+    @name("MyIC.meta") psa_ingress_output_metadata_t meta_0;
+    @name("MyIC.egress_port") PortId_t egress_port_0;
+    @noWarn("unused") @name(".send_to_port") action send_to_port_0() {
+        meta_0 = ostd;
+        egress_port_0 = (PortId_t)32w1;
+        meta_0.drop = false;
+        meta_0.multicast_group = (MulticastGroup_t)32w0;
+        meta_0.egress_port = egress_port_0;
+        ostd = meta_0;
+    }
+    apply {
+        if (hdr.ethernet.isValid()) {
+            idx_0 = hdr.ethernet.dstAddr[7:0];
+            action_type_0 = hdr.ethernet.dstAddr[15:8];
+            validAction_0 = action_type_0 >= 8w1 && action_type_0 <= 8w3;
+            if (validAction_0) {
+                orig_data_0 = reg_0[idx_0];
+            }
+            if (action_type_0 == 8w1) {
+                next_data_0 = hdr.ethernet.dstAddr[47:32];
+            } else if (action_type_0 == 8w2) {
+                next_data_0 = orig_data_0;
+            } else if (action_type_0 == 8w3) {
+                next_data_0 = orig_data_0 + 16w1;
+            } else {
+                orig_data_0 = 16w0xdead;
+                next_data_0 = 16w0xbeef;
+            }
+            if (idx_0 < 8w6) {
+                reg_0[idx_0] = next_data_0;
+            }
+            hdr.output_data.word0 = (bit<32>)orig_data_0;
+            hdr.output_data.word1 = (bit<32>)next_data_0;
+        }
+        send_to_port_0();
+    }
+}
+
+control MyEC(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control MyID(packet_out pkt, out EMPTY clone_i2e_meta, out EMPTY resubmit_meta, out EMPTY normal_meta, inout headers_t hdr, in metadata_t user_meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<output_data_t>(hdr.output_data);
+    }
+}
+
+control MyED(packet_out pkt, out EMPTY clone_e2e_meta, out EMPTY recirculate_meta, inout headers_t hdr, in metadata_t user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+EgressPipeline<headers_t, metadata_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-persistent-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/psa-persistent-bmv2-midend.p4
@@ -1,0 +1,320 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+struct EMPTY {
+}
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
+struct headers_t {
+    ethernet_t    ethernet;
+    output_data_t output_data;
+}
+
+struct metadata_t {
+}
+
+parser MyIP(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in EMPTY resubmit_meta, in EMPTY recirculate_meta) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.ethernet);
+        pkt.extract<output_data_t>(hdr.output_data);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in EMPTY normal_meta, in EMPTY clone_i2e_meta, in EMPTY clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    bit<8> hsiVar;
+    bit<16> hsVar;
+    @persistent @name("MyIC.reg") bit<16>[6] reg_0;
+    @name("MyIC.orig_data") bit<16> orig_data_0;
+    @name("MyIC.next_data") bit<16> next_data_0;
+    @noWarn("unused") @name(".send_to_port") action send_to_port_0() {
+        ostd.drop = false;
+        ostd.multicast_group = 32w0;
+        ostd.egress_port = 32w1;
+    }
+    @hidden action psapersistentbmv2l78() {
+        orig_data_0 = reg_0[8w0];
+    }
+    @hidden action psapersistentbmv2l78_0() {
+        orig_data_0 = reg_0[8w1];
+    }
+    @hidden action psapersistentbmv2l78_1() {
+        orig_data_0 = reg_0[8w2];
+    }
+    @hidden action psapersistentbmv2l78_2() {
+        orig_data_0 = reg_0[8w3];
+    }
+    @hidden action psapersistentbmv2l78_3() {
+        orig_data_0 = reg_0[8w4];
+    }
+    @hidden action psapersistentbmv2l78_4() {
+        orig_data_0 = reg_0[8w5];
+    }
+    @hidden action psapersistentbmv2l78_5() {
+        orig_data_0 = hsVar;
+    }
+    @hidden action psapersistentbmv2l78_6() {
+        hsiVar = hdr.ethernet.dstAddr[7:0];
+    }
+    @hidden action psapersistentbmv2l82() {
+        next_data_0 = hdr.ethernet.dstAddr[47:32];
+    }
+    @hidden action psapersistentbmv2l85() {
+        next_data_0 = orig_data_0;
+    }
+    @hidden action psapersistentbmv2l88() {
+        next_data_0 = orig_data_0 + 16w1;
+    }
+    @hidden action psapersistentbmv2l90() {
+        orig_data_0 = 16w0xdead;
+        next_data_0 = 16w0xbeef;
+    }
+    @hidden action psapersistentbmv2l94() {
+        reg_0[8w0] = next_data_0;
+    }
+    @hidden action psapersistentbmv2l94_0() {
+        reg_0[8w1] = next_data_0;
+    }
+    @hidden action psapersistentbmv2l94_1() {
+        reg_0[8w2] = next_data_0;
+    }
+    @hidden action psapersistentbmv2l94_2() {
+        reg_0[8w3] = next_data_0;
+    }
+    @hidden action psapersistentbmv2l94_3() {
+        reg_0[8w4] = next_data_0;
+    }
+    @hidden action psapersistentbmv2l94_4() {
+        reg_0[8w5] = next_data_0;
+    }
+    @hidden action psapersistentbmv2l94_5() {
+        hsiVar = hdr.ethernet.dstAddr[7:0];
+    }
+    @hidden action psapersistentbmv2l96() {
+        hdr.output_data.word0 = (bit<32>)orig_data_0;
+        hdr.output_data.word1 = (bit<32>)next_data_0;
+    }
+    @hidden table tbl_psapersistentbmv2l78 {
+        actions = {
+            psapersistentbmv2l78_6();
+        }
+        const default_action = psapersistentbmv2l78_6();
+    }
+    @hidden table tbl_psapersistentbmv2l78_0 {
+        actions = {
+            psapersistentbmv2l78();
+        }
+        const default_action = psapersistentbmv2l78();
+    }
+    @hidden table tbl_psapersistentbmv2l78_1 {
+        actions = {
+            psapersistentbmv2l78_0();
+        }
+        const default_action = psapersistentbmv2l78_0();
+    }
+    @hidden table tbl_psapersistentbmv2l78_2 {
+        actions = {
+            psapersistentbmv2l78_1();
+        }
+        const default_action = psapersistentbmv2l78_1();
+    }
+    @hidden table tbl_psapersistentbmv2l78_3 {
+        actions = {
+            psapersistentbmv2l78_2();
+        }
+        const default_action = psapersistentbmv2l78_2();
+    }
+    @hidden table tbl_psapersistentbmv2l78_4 {
+        actions = {
+            psapersistentbmv2l78_3();
+        }
+        const default_action = psapersistentbmv2l78_3();
+    }
+    @hidden table tbl_psapersistentbmv2l78_5 {
+        actions = {
+            psapersistentbmv2l78_4();
+        }
+        const default_action = psapersistentbmv2l78_4();
+    }
+    @hidden table tbl_psapersistentbmv2l78_6 {
+        actions = {
+            psapersistentbmv2l78_5();
+        }
+        const default_action = psapersistentbmv2l78_5();
+    }
+    @hidden table tbl_psapersistentbmv2l82 {
+        actions = {
+            psapersistentbmv2l82();
+        }
+        const default_action = psapersistentbmv2l82();
+    }
+    @hidden table tbl_psapersistentbmv2l85 {
+        actions = {
+            psapersistentbmv2l85();
+        }
+        const default_action = psapersistentbmv2l85();
+    }
+    @hidden table tbl_psapersistentbmv2l88 {
+        actions = {
+            psapersistentbmv2l88();
+        }
+        const default_action = psapersistentbmv2l88();
+    }
+    @hidden table tbl_psapersistentbmv2l90 {
+        actions = {
+            psapersistentbmv2l90();
+        }
+        const default_action = psapersistentbmv2l90();
+    }
+    @hidden table tbl_psapersistentbmv2l94 {
+        actions = {
+            psapersistentbmv2l94_5();
+        }
+        const default_action = psapersistentbmv2l94_5();
+    }
+    @hidden table tbl_psapersistentbmv2l94_0 {
+        actions = {
+            psapersistentbmv2l94();
+        }
+        const default_action = psapersistentbmv2l94();
+    }
+    @hidden table tbl_psapersistentbmv2l94_1 {
+        actions = {
+            psapersistentbmv2l94_0();
+        }
+        const default_action = psapersistentbmv2l94_0();
+    }
+    @hidden table tbl_psapersistentbmv2l94_2 {
+        actions = {
+            psapersistentbmv2l94_1();
+        }
+        const default_action = psapersistentbmv2l94_1();
+    }
+    @hidden table tbl_psapersistentbmv2l94_3 {
+        actions = {
+            psapersistentbmv2l94_2();
+        }
+        const default_action = psapersistentbmv2l94_2();
+    }
+    @hidden table tbl_psapersistentbmv2l94_4 {
+        actions = {
+            psapersistentbmv2l94_3();
+        }
+        const default_action = psapersistentbmv2l94_3();
+    }
+    @hidden table tbl_psapersistentbmv2l94_5 {
+        actions = {
+            psapersistentbmv2l94_4();
+        }
+        const default_action = psapersistentbmv2l94_4();
+    }
+    @hidden table tbl_psapersistentbmv2l96 {
+        actions = {
+            psapersistentbmv2l96();
+        }
+        const default_action = psapersistentbmv2l96();
+    }
+    @hidden table tbl_send_to_port {
+        actions = {
+            send_to_port_0();
+        }
+        const default_action = send_to_port_0();
+    }
+    apply {
+        if (hdr.ethernet.isValid()) {
+            if (hdr.ethernet.dstAddr[15:8] >= 8w1 && hdr.ethernet.dstAddr[15:8] <= 8w3) {
+                tbl_psapersistentbmv2l78.apply();
+                if (hsiVar == 8w0) {
+                    tbl_psapersistentbmv2l78_0.apply();
+                } else if (hsiVar == 8w1) {
+                    tbl_psapersistentbmv2l78_1.apply();
+                } else if (hsiVar == 8w2) {
+                    tbl_psapersistentbmv2l78_2.apply();
+                } else if (hsiVar == 8w3) {
+                    tbl_psapersistentbmv2l78_3.apply();
+                } else if (hsiVar == 8w4) {
+                    tbl_psapersistentbmv2l78_4.apply();
+                } else if (hsiVar == 8w5) {
+                    tbl_psapersistentbmv2l78_5.apply();
+                } else if (hsiVar >= 8w5) {
+                    tbl_psapersistentbmv2l78_6.apply();
+                }
+            }
+            if (hdr.ethernet.dstAddr[15:8] == 8w1) {
+                tbl_psapersistentbmv2l82.apply();
+            } else if (hdr.ethernet.dstAddr[15:8] == 8w2) {
+                tbl_psapersistentbmv2l85.apply();
+            } else if (hdr.ethernet.dstAddr[15:8] == 8w3) {
+                tbl_psapersistentbmv2l88.apply();
+            } else {
+                tbl_psapersistentbmv2l90.apply();
+            }
+            if (hdr.ethernet.dstAddr[7:0] < 8w6) {
+                tbl_psapersistentbmv2l94.apply();
+                if (hsiVar == 8w0) {
+                    tbl_psapersistentbmv2l94_0.apply();
+                } else if (hsiVar == 8w1) {
+                    tbl_psapersistentbmv2l94_1.apply();
+                } else if (hsiVar == 8w2) {
+                    tbl_psapersistentbmv2l94_2.apply();
+                } else if (hsiVar == 8w3) {
+                    tbl_psapersistentbmv2l94_3.apply();
+                } else if (hsiVar == 8w4) {
+                    tbl_psapersistentbmv2l94_4.apply();
+                } else if (hsiVar == 8w5) {
+                    tbl_psapersistentbmv2l94_5.apply();
+                }
+            }
+            tbl_psapersistentbmv2l96.apply();
+        }
+        tbl_send_to_port.apply();
+    }
+}
+
+control MyEC(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control MyID(packet_out pkt, out EMPTY clone_i2e_meta, out EMPTY resubmit_meta, out EMPTY normal_meta, inout headers_t hdr, in metadata_t user_meta, in psa_ingress_output_metadata_t istd) {
+    @hidden action psapersistentbmv2l122() {
+        pkt.emit<ethernet_t>(hdr.ethernet);
+        pkt.emit<output_data_t>(hdr.output_data);
+    }
+    @hidden table tbl_psapersistentbmv2l122 {
+        actions = {
+            psapersistentbmv2l122();
+        }
+        const default_action = psapersistentbmv2l122();
+    }
+    apply {
+        tbl_psapersistentbmv2l122.apply();
+    }
+}
+
+control MyED(packet_out pkt, out EMPTY clone_e2e_meta, out EMPTY recirculate_meta, inout headers_t hdr, in metadata_t user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline<headers_t, metadata_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyIP(), MyIC(), MyID()) ip;
+EgressPipeline<headers_t, metadata_t, EMPTY, EMPTY, EMPTY, EMPTY>(MyEP(), MyEC(), MyED()) ep;
+PSA_Switch<headers_t, metadata_t, headers_t, metadata_t, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY>(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4
@@ -1,0 +1,96 @@
+#include <core.p4>
+#include <bmv2/psa.p4>
+
+struct EMPTY {
+}
+
+typedef bit<48> EthernetAddress;
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header output_data_t {
+    bit<32> word0;
+    bit<32> word1;
+    bit<32> word2;
+    bit<32> word3;
+}
+
+struct headers_t {
+    ethernet_t    ethernet;
+    output_data_t output_data;
+}
+
+struct metadata_t {
+}
+
+parser MyIP(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_ingress_parser_input_metadata_t istd, in EMPTY resubmit_meta, in EMPTY recirculate_meta) {
+    state start {
+        pkt.extract(hdr.ethernet);
+        pkt.extract(hdr.output_data);
+        transition accept;
+    }
+}
+
+parser MyEP(packet_in pkt, out headers_t hdr, inout metadata_t user_meta, in psa_egress_parser_input_metadata_t istd, in EMPTY normal_meta, in EMPTY clone_i2e_meta, in EMPTY clone_e2e_meta) {
+    state start {
+        transition accept;
+    }
+}
+
+control MyIC(inout headers_t hdr, inout metadata_t user_meta, in psa_ingress_input_metadata_t istd, inout psa_ingress_output_metadata_t ostd) {
+    @persistent bit<16>[6] reg;
+    bit<8> idx;
+    bit<8> action_type;
+    bit<16> orig_data;
+    bit<16> next_data;
+    apply {
+        if (hdr.ethernet.isValid()) {
+            idx = hdr.ethernet.dstAddr[7:0];
+            action_type = hdr.ethernet.dstAddr[15:8];
+            bool validAction = action_type >= 1 && action_type <= 3;
+            if (validAction) {
+                orig_data = reg[idx];
+            }
+            if (action_type == 1) {
+                next_data = hdr.ethernet.dstAddr[47:32];
+            } else if (action_type == 2) {
+                next_data = orig_data;
+            } else if (action_type == 3) {
+                next_data = orig_data + 1;
+            } else {
+                orig_data = 0xdead;
+                next_data = 0xbeef;
+            }
+            if (idx < 6) {
+                reg[idx] = next_data;
+            }
+            hdr.output_data.word0 = (bit<32>)orig_data;
+            hdr.output_data.word1 = (bit<32>)next_data;
+        }
+        send_to_port(ostd, (PortId_t)1);
+    }
+}
+
+control MyEC(inout headers_t hdr, inout metadata_t user_meta, in psa_egress_input_metadata_t istd, inout psa_egress_output_metadata_t ostd) {
+    apply {
+    }
+}
+
+control MyID(packet_out pkt, out EMPTY clone_i2e_meta, out EMPTY resubmit_meta, out EMPTY normal_meta, inout headers_t hdr, in metadata_t user_meta, in psa_ingress_output_metadata_t istd) {
+    apply {
+        pkt.emit(hdr.ethernet);
+        pkt.emit(hdr.output_data);
+    }
+}
+
+control MyED(packet_out pkt, out EMPTY clone_e2e_meta, out EMPTY recirculate_meta, inout headers_t hdr, in metadata_t user_meta, in psa_egress_output_metadata_t istd, in psa_egress_deparser_input_metadata_t edstd) {
+    apply {
+    }
+}
+
+IngressPipeline(MyIP(), MyIC(), MyID()) ip;
+EgressPipeline(MyEP(), MyEC(), MyED()) ep;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4-error
+++ b/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4-error
@@ -1,0 +1,9 @@
+psa-persistent-bmv2.p4(85): [--Wwarn=uninitialized_use] warning: orig_data may be uninitialized
+                next_data = orig_data;
+                            ^^^^^^^^^
+psa-persistent-bmv2.p4(88): [--Wwarn=uninitialized_use] warning: orig_data may be uninitialized
+                next_data = orig_data + 1;
+                            ^^^^^^^^^
+psa-persistent-bmv2.p4(96): [--Wwarn=uninitialized_use] warning: orig_data may be uninitialized
+            hdr.output_data.word0 = (bit<32>) orig_data;
+                                              ^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4-stderr
@@ -1,0 +1,9 @@
+psa-persistent-bmv2.p4(85): [--Wwarn=uninitialized_use] warning: orig_data may be uninitialized
+                next_data = orig_data;
+                            ^^^^^^^^^
+psa-persistent-bmv2.p4(88): [--Wwarn=uninitialized_use] warning: orig_data may be uninitialized
+                next_data = orig_data + 1;
+                            ^^^^^^^^^
+psa-persistent-bmv2.p4(96): [--Wwarn=uninitialized_use] warning: orig_data may be uninitialized
+            hdr.output_data.word0 = (bit<32>) orig_data;
+                                              ^^^^^^^^^

--- a/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4.bfrt.json
+++ b/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4.bfrt.json
@@ -1,0 +1,5 @@
+{
+  "schema_version" : "1.0.0",
+  "tables" : [],
+  "learn_filters" : []
+}

--- a/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4.entries.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4.entries.txtpb
@@ -1,0 +1,3 @@
+# proto-file: p4/v1/p4runtime.proto
+# proto-message: p4.v1.WriteRequest
+

--- a/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4.p4info.txtpb
@@ -1,0 +1,14 @@
+# proto-file: p4/config/v1/p4info.proto
+# proto-message: p4.config.v1.P4Info
+
+pkg_info {
+  arch: "psa"
+}
+actions {
+  preamble {
+    id: 27646489
+    name: "send_to_port"
+    alias: "send_to_port"
+    annotations: "@noWarn(\"unused\")"
+  }
+}

--- a/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4.spec
+++ b/testdata/p4_16_samples_outputs/psa-persistent-bmv2.p4.spec
@@ -1,0 +1,154 @@
+
+
+struct ethernet_t {
+	bit<48> dstAddr
+	bit<48> srcAddr
+	bit<16> etherType
+}
+
+struct output_data_t {
+	bit<32> word0
+	bit<32> word1
+	bit<32> word2
+	bit<32> word3
+}
+
+struct psa_ingress_output_metadata_t {
+	bit<8> class_of_service
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+	bit<8> resubmit
+	bit<32> multicast_group
+	bit<32> egress_port
+}
+
+struct psa_egress_output_metadata_t {
+	bit<8> clone
+	bit<16> clone_session_id
+	bit<8> drop
+}
+
+struct psa_egress_deparser_input_metadata_t {
+	bit<32> egress_port
+}
+
+header ethernet instanceof ethernet_t
+header output_data instanceof output_data_t
+
+struct metadata_t {
+	bit<32> psa_ingress_input_metadata_ingress_port
+	bit<8> psa_ingress_output_metadata_drop
+	bit<32> psa_ingress_output_metadata_multicast_group
+	bit<32> psa_ingress_output_metadata_egress_port
+	bit<48> Ingress_tmp
+	bit<48> Ingress_tmp_0
+	bit<48> Ingress_tmp_1
+	bit<48> Ingress_tmp_3
+	bit<48> Ingress_tmp_4
+	bit<48> Ingress_tmp_5
+	bit<48> Ingress_tmp_7
+	bit<48> Ingress_tmp_8
+	bit<48> Ingress_tmp_9
+	bit<48> Ingress_tmp_11
+	bit<48> Ingress_tmp_12
+	bit<48> Ingress_tmp_13
+	bit<48> Ingress_tmp_15
+	bit<48> Ingress_tmp_16
+	bit<48> Ingress_tmp_17
+	bit<48> Ingress_tmp_19
+	bit<48> Ingress_tmp_20
+	bit<48> Ingress_tmp_22
+	bit<48> Ingress_tmp_23
+	bit<48> Ingress_tmp_24
+	bit<48> Ingress_tmp_25
+	bit<48> Ingress_tmp_26
+	bit<8> Ingress_idx
+	bit<16> Ingress_orig_data
+	bit<16> Ingress_next_data
+}
+metadata instanceof metadata_t
+
+regarray reg_0 size 0x6 initval 0
+apply {
+	rx m.psa_ingress_input_metadata_ingress_port
+	mov m.psa_ingress_output_metadata_drop 0x1
+	extract h.ethernet
+	extract h.output_data
+	jmpnv LABEL_END h.ethernet
+	mov m.Ingress_tmp_22 h.ethernet.dstAddr
+	and m.Ingress_tmp_22 0xFF
+	mov m.Ingress_tmp_23 m.Ingress_tmp_22
+	and m.Ingress_tmp_23 0xFF
+	mov m.Ingress_idx m.Ingress_tmp_23
+	mov m.Ingress_tmp h.ethernet.dstAddr
+	shr m.Ingress_tmp 0x8
+	mov m.Ingress_tmp_0 m.Ingress_tmp
+	and m.Ingress_tmp_0 0xFF
+	mov m.Ingress_tmp_1 m.Ingress_tmp_0
+	and m.Ingress_tmp_1 0xFF
+	mov m.Ingress_tmp_3 h.ethernet.dstAddr
+	shr m.Ingress_tmp_3 0x8
+	mov m.Ingress_tmp_4 m.Ingress_tmp_3
+	and m.Ingress_tmp_4 0xFF
+	mov m.Ingress_tmp_5 m.Ingress_tmp_4
+	and m.Ingress_tmp_5 0xFF
+	jmplt LABEL_END_0 m.Ingress_tmp_1 0x1
+	jmpgt LABEL_END_0 m.Ingress_tmp_5 0x3
+	regrd m.Ingress_orig_data reg_0 m.Ingress_idx
+	LABEL_END_0 :	mov m.Ingress_tmp_15 h.ethernet.dstAddr
+	shr m.Ingress_tmp_15 0x8
+	mov m.Ingress_tmp_16 m.Ingress_tmp_15
+	and m.Ingress_tmp_16 0xFF
+	mov m.Ingress_tmp_17 m.Ingress_tmp_16
+	and m.Ingress_tmp_17 0xFF
+	jmpneq LABEL_FALSE_1 m.Ingress_tmp_17 0x1
+	mov m.Ingress_tmp_24 h.ethernet.dstAddr
+	shr m.Ingress_tmp_24 0x20
+	mov m.Ingress_tmp_25 m.Ingress_tmp_24
+	and m.Ingress_tmp_25 0xFFFF
+	mov m.Ingress_tmp_26 m.Ingress_tmp_25
+	and m.Ingress_tmp_26 0xFFFF
+	mov m.Ingress_next_data m.Ingress_tmp_26
+	jmp LABEL_END_1
+	LABEL_FALSE_1 :	mov m.Ingress_tmp_11 h.ethernet.dstAddr
+	shr m.Ingress_tmp_11 0x8
+	mov m.Ingress_tmp_12 m.Ingress_tmp_11
+	and m.Ingress_tmp_12 0xFF
+	mov m.Ingress_tmp_13 m.Ingress_tmp_12
+	and m.Ingress_tmp_13 0xFF
+	jmpneq LABEL_FALSE_2 m.Ingress_tmp_13 0x2
+	mov m.Ingress_next_data m.Ingress_orig_data
+	jmp LABEL_END_1
+	LABEL_FALSE_2 :	mov m.Ingress_tmp_7 h.ethernet.dstAddr
+	shr m.Ingress_tmp_7 0x8
+	mov m.Ingress_tmp_8 m.Ingress_tmp_7
+	and m.Ingress_tmp_8 0xFF
+	mov m.Ingress_tmp_9 m.Ingress_tmp_8
+	and m.Ingress_tmp_9 0xFF
+	jmpneq LABEL_FALSE_3 m.Ingress_tmp_9 0x3
+	mov m.Ingress_next_data m.Ingress_orig_data
+	add m.Ingress_next_data 0x1
+	jmp LABEL_END_1
+	LABEL_FALSE_3 :	mov m.Ingress_orig_data 0xDEAD
+	mov m.Ingress_next_data 0xBEEF
+	LABEL_END_1 :	mov m.Ingress_tmp_19 h.ethernet.dstAddr
+	and m.Ingress_tmp_19 0xFF
+	mov m.Ingress_tmp_20 m.Ingress_tmp_19
+	and m.Ingress_tmp_20 0xFF
+	jmplt LABEL_TRUE_4 m.Ingress_tmp_20 0x6
+	jmp LABEL_END_4
+	LABEL_TRUE_4 :	regwr reg_0 m.Ingress_idx m.Ingress_next_data
+	LABEL_END_4 :	mov h.output_data.word0 m.Ingress_orig_data
+	mov h.output_data.word1 m.Ingress_next_data
+	LABEL_END :	mov m.psa_ingress_output_metadata_drop 0
+	mov m.psa_ingress_output_metadata_multicast_group 0x0
+	mov m.psa_ingress_output_metadata_egress_port 0x1
+	jmpneq LABEL_DROP m.psa_ingress_output_metadata_drop 0x0
+	emit h.ethernet
+	emit h.output_data
+	tx m.psa_ingress_output_metadata_egress_port
+	LABEL_DROP :	drop
+}
+
+


### PR DESCRIPTION
This is a proof-of-concept implementation for an idea that I had related to https://github.com/p4lang/p4-spec/issues/1177.

Basically, the idea is to allow some metadata to be "persistent" -- it lives on across pipeline invocations for different packets.  That's a common theme between between Registers, that spec discussion, and this PR.

This PR introduces a new annotation `@persistent` that can be placed on metadata (local instance) declarations to make them persistent across packets.  None of the semantics of P4 change -- the metadata will just have the data at entry to the pipeline or control or parser that it had when it completed last time.

For backends that don't support this, but do support a Register extern, this is easy to convert into a Register instances and uses, and I've added a midend pass to do just that, using it in bmv2/dpdk backends as a proof of concept (and working testcase).  A `@persistent` metadata array is converted into a Register with the size of the array becoming the size of the register -- a non-array `@persistent` metadata becomes a Register of size 1.
