### PR TITLE
Avoid crash after error in typechecking

### DIFF
--- a/frontends/p4/typeChecking/typeCheckTypes.cpp
+++ b/frontends/p4/typeChecking/typeCheckTypes.cpp
@@ -97,7 +97,8 @@ const IR::Node *TypeInferenceBase::postorder(const IR::Type_Table *type) {
 }
 
 const IR::Node *TypeInferenceBase::postorder(const IR::Type_Type *type) {
-    BUG("Should never be found in IR: %1%", type);
+    BUG_CHECK(errorCount() > 0, "Should never be found in IR: %1%", type);
+    return type;
 }
 
 const IR::Node *TypeInferenceBase::postorder(const IR::P4Control *cont) {

--- a/testdata/p4_16_errors/enumcrash1.p4
+++ b/testdata/p4_16_errors/enumcrash1.p4
@@ -1,0 +1,7 @@
+
+enum Foo { A, B, C };
+extern void testfn<T>(T arg);
+
+action test() {
+    testfn(arg = Foo.D);
+}

--- a/testdata/p4_16_errors_outputs/enumcrash1.p4
+++ b/testdata/p4_16_errors_outputs/enumcrash1.p4
@@ -1,0 +1,10 @@
+enum Foo {
+    A,
+    B,
+    C
+}
+
+extern void testfn<T>(T arg);
+action test() {
+    testfn(arg = Foo.D);
+}

--- a/testdata/p4_16_errors_outputs/enumcrash1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/enumcrash1.p4-stderr
@@ -1,0 +1,3 @@
+enumcrash1.p4(6): [--Werror=type-error] error: Foo.D: Invalid enum tag
+    testfn(arg = Foo.D);
+                 ^^^^^


### PR DESCRIPTION
A corner case where after an error, we keep running typechecking in a slightly invalid state, so we could hit this BUG