### PR TITLE
[#5331] Propagate source info when substituting parameters during inlining

### DIFF
--- a/frontends/p4/evaluator/substituteParameters.cpp
+++ b/frontends/p4/evaluator/substituteParameters.cpp
@@ -29,9 +29,13 @@ const IR::Node *SubstituteParameters::postorder(IR::PathExpression *expr) {
         (refMap ? refMap->getDeclaration(expr->path, true) : getDeclaration(expr->path, true));
     auto param = decl->to<IR::Parameter>();
     if (param != nullptr && subst->contains(param)) {
-        auto value = subst->lookup(param)->expression;
+        const auto *value = subst->lookup(param)->expression;
         LOG1("Replaced " << dbp(expr) << " with " << dbp(value));
-        return value;
+        // Return a new Expression with source info of the PathExpression
+        // being substituted.
+        auto *cloned = value->clone();
+        cloned->srcInfo = expr->srcInfo;
+        return cloned;
     }
 
     // Path expressions always need to be cloned.

--- a/testdata/p4_16_samples/issue5331_srcinfo.p4
+++ b/testdata/p4_16_samples/issue5331_srcinfo.p4
@@ -1,0 +1,23 @@
+control C(out bit<64> v64) {
+    action a2(in bit<1> value) {
+        v64 = (bit<64>)(int<64>)(int<1>)value;
+    }
+
+    action a() {
+        a2(1);
+    }
+
+    table t {
+        actions = { a; }
+        default_action = a;
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+control proto(out bit<64> v64);
+package top(proto p);
+
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/gauntlet_short_circuit-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_short_circuit-bmv2.p4-stderr
@@ -12,5 +12,3 @@ bit<8> do_function(out bit<8> val) {
        ^^^^^^^^^^^
 [--Wwarn=uninitialized_use] warning: val_0 may be uninitialized
 [--Wwarn=uninitialized_use] warning: val_0 may be uninitialized
-[--Wwarn=uninitialized_use] warning: val_0 may be uninitialized
-[--Wwarn=uninitialized_use] warning: val_0 may be uninitialized

--- a/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_1-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/gauntlet_side_effect_order_1-bmv2.p4-stderr
@@ -22,5 +22,3 @@ gauntlet_side_effect_order_1-bmv2.p4(33)
 [--Wwarn=uninitialized_use] warning: val_1 may be uninitialized
 [--Wwarn=uninitialized_use] warning: val_1 may be uninitialized
 [--Wwarn=uninitialized_use] warning: val_1 may be uninitialized
-[--Wwarn=uninitialized_use] warning: val_1 may be uninitialized
-[--Wwarn=uninitialized_use] warning: val_1 may be uninitialized

--- a/testdata/p4_16_samples_outputs/issue1717.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue1717.p4-stderr
@@ -19,7 +19,9 @@ issue1717.p4(52): [--Wwarn=uninitialized_use] warning: h1.isValid may be uniniti
 issue1717.p4(52): [--Wwarn=uninitialized_use] warning: h2.f may be uninitialized
         size = v(h1, h2);
                      ^^
-[--Wwarn=invalid_header] warning: accessing a field of an invalid header h2_0
-[--Wwarn=invalid_header] warning: accessing a field of an invalid header h1_0
-[--Wwarn=invalid_header] warning: accessing a field of an invalid header h2_0
-[--Wwarn=invalid_header] warning: accessing a field of an invalid header h1_0
+issue1717.p4(41): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h2_0
+    bool b1 = h2.minSizeInBits == 32;
+              ^^
+issue1717.p4(44): [--Wwarn=invalid_header] warning: accessing a field of an invalid header h1_0
+    return h1.isValid +
+           ^^

--- a/testdata/p4_16_samples_outputs/issue5331_srcinfo-first.p4
+++ b/testdata/p4_16_samples_outputs/issue5331_srcinfo-first.p4
@@ -1,0 +1,21 @@
+control C(out bit<64> v64) {
+    action a2(in bit<1> value) {
+        v64 = (bit<64>)(int<64>)(int<1>)value;
+    }
+    action a() {
+        a2(1w1);
+    }
+    table t {
+        actions = {
+            a();
+        }
+        default_action = a();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto(out bit<64> v64);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue5331_srcinfo-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue5331_srcinfo-frontend.p4
@@ -1,0 +1,20 @@
+control C(out bit<64> v64) {
+    @name("C.value") bit<1> value;
+    @name("C.a") action a() {
+        value = 1w1;
+        v64 = (bit<64>)(int<64>)(int<1>)value;
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            a();
+        }
+        default_action = a();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto(out bit<64> v64);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue5331_srcinfo-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue5331_srcinfo-midend.p4
@@ -1,0 +1,18 @@
+control C(out bit<64> v64) {
+    @name("C.a") action a() {
+        v64 = 64w18446744073709551615;
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            a();
+        }
+        default_action = a();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto(out bit<64> v64);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue5331_srcinfo.p4
+++ b/testdata/p4_16_samples_outputs/issue5331_srcinfo.p4
@@ -1,0 +1,21 @@
+control C(out bit<64> v64) {
+    action a2(in bit<1> value) {
+        v64 = (bit<64>)(int<64>)(int<1>)value;
+    }
+    action a() {
+        a2(1);
+    }
+    table t {
+        actions = {
+            a;
+        }
+        default_action = a;
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto(out bit<64> v64);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue5331_srcinfo.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue5331_srcinfo.p4-stderr
@@ -1,0 +1,6 @@
+issue5331_srcinfo.p4(3): [--Wwarn=overflow] warning: 1s1: signed value does not fit in 1 bits
+        v64 = (bit<64>)(int<64>)(int<1>)value;
+                                        ^^^^^
+issue5331_srcinfo.p4(3): [--Wwarn=mismatch] warning: -64w1: negative value with unsigned type
+        v64 = (bit<64>)(int<64>)(int<1>)value;
+                                        ^^^^^


### PR DESCRIPTION
Addresses the issue of propagating source info during action and function inlining, discussed in #5331.