### PR TITLE
Enable printing of packet in/out contents during BMv2 tests

### DIFF
--- a/backends/bmv2/bmv2stf.py
+++ b/backends/bmv2/bmv2stf.py
@@ -753,6 +753,8 @@ class RunBMV2(object):
                     "--log-flush",
                     "--use-files",
                     str(wait),
+                    "--dump-packet-data",
+                    str(10240),
                     "--thrift-port",
                     thriftPort,
                     "--device-id",


### PR DESCRIPTION
It is true that packets in/out are recorded to pcap files during BMv2 tests, and this is definitely useful.  I am currently debugging an issue in recently built open source P4 code where the packets recorded in the pcap files seem to be different than what is logged by BMv2 with the `--dump-packet-data 10240` option given to BMv2, so it can be very useful to have this enabled all of the time.

The cost for enabling it is just a few extra lines in the BMv2 log files, typically two extra lines per packet, where typically there are hundreds of lines of log file output per packet for other (useful) reasons, so enabling this option is a negligible extra overhead in logging.