### PR TITLE
Fix unification of serializable enums

### DIFF
--- a/frontends/p4/typeChecking/typeCheckExpr.cpp
+++ b/frontends/p4/typeChecking/typeCheckExpr.cpp
@@ -2269,6 +2269,12 @@ const IR::SelectCase *TypeInferenceBase::matchCase(const IR::SelectExpression *s
         }
         useSelType = selectType->components.at(0);
     }
+    if (auto senum = useSelType->to<IR::Type_SerEnum>()) {
+        // With select of a serial enum type, the cases may be either the serenum type,
+        // or the underlying type, so match against the underlying type, because implicit
+        // casts to the senum type are not allowed.
+        useSelType = getTypeType(senum->type);
+    }
     auto tvs = unifyCast(
         select, useSelType, caseType,
         "'match' case label '%1%' has type '%2%' which does not match the expected type '%3%'",

--- a/frontends/p4/typeChecking/typeUnification.cpp
+++ b/frontends/p4/typeChecking/typeUnification.cpp
@@ -445,12 +445,6 @@ bool TypeUnification::unify(const BinaryConstraint *constraint) {
         bool success = (*src) == (*dest);
         if (!success) return constraint->reportError(constraints->getCurrentSubstitution());
         return true;
-    } else if (auto se = dest->to<IR::Type_SerEnum>()) {
-        if (constraint->is<P4::CanBeImplicitlyCastConstraint>()) {
-            constraints->add(constraint->create(se->type, src));
-            return true;
-        }
-        return constraint->reportError(constraints->getCurrentSubstitution());
     } else if (dest->is<IR::Type_Declaration>() && src->is<IR::Type_Declaration>()) {
         if (dest->to<IR::Type_Declaration>()->name != src->to<IR::Type_Declaration>()->name)
             return constraint->reportError(constraints->getCurrentSubstitution());

--- a/testdata/p4_16_errors/enumcrash2.p4
+++ b/testdata/p4_16_errors/enumcrash2.p4
@@ -1,0 +1,30 @@
+#include <core.p4>
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+
+header t1 {
+    bit<32>     f1;
+}
+
+struct headers_t {
+    t1          head;
+}
+
+
+typedef bit<1> Foo_t;
+enum Foo_t Foo { A = 1w0 , B = 1w1 };
+
+extern Object {
+    Object(int size);
+    void set(Foo t);
+}
+
+Object(10) obj;
+
+control c(inout headers_t hdrs) {
+    apply {
+        obj.set(1w1);
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/enumCast.p4-stderr
+++ b/testdata/p4_16_errors_outputs/enumCast.p4-stderr
@@ -7,30 +7,65 @@ enumCast.p4(26): [--Werror=type-error] error: 'y': values of type 'int' cannot b
 enumCast.p4(3)
 enum bit<32> X {
              ^
-enumCast.p4(27): [--Werror=type-error] error: 'y = 32w1': values of type 'bit<32>' cannot be implicitly cast to type 'X'
+enumCast.p4(27): [--Werror=type-error] error: 'y = 32w1'
         y = 32w1; // Error: no implicit cast to enum
           ^
+  ---- Actual error:
+enumCast.p4(3): Cannot cast implicitly type 'bit<32>' to type 'X'
+  enum bit<32> X {
+               ^
+  ---- Originating from:
+enumCast.p4(27): Source expression '32w1' produces a result of type 'bit<32>' which cannot be assigned to a left-value with type 'X'
+          y = 32w1; // Error: no implicit cast to enum
+              ^^^^
 enumCast.p4(3)
-enum bit<32> X {
-             ^
-enumCast.p4(33): [--Werror=type-error] error: 'a = b': values of type 'E2' cannot be implicitly cast to type 'E1'
+  enum bit<32> X {
+               ^
+enumCast.p4(33): [--Werror=type-error] error: 'a = b'
         a = b; // Error: b is automatically cast to bit<8>,
           ^
-enumCast.p4(12)
-enum bit<8> E2 {
-            ^^
+  ---- Actual error:
+enumCast.p4(12): Cannot cast implicitly type 'E2' to type 'E1'
+  enum bit<8> E2 {
+              ^^
 enumCast.p4(8)
-enum bit<8> E1 {
-            ^^
-enumCast.p4(35): [--Werror=type-error] error: 'a = 0 + 1': values of type 'bit<8>' cannot be implicitly cast to type 'E1'
+  enum bit<8> E1 {
+              ^^
+  ---- Originating from:
+enumCast.p4(33): Source expression 'b' produces a result of type 'E2' which cannot be assigned to a left-value with type 'E1'
+          a = b; // Error: b is automatically cast to bit<8>,
+              ^
+enumCast.p4(12)
+  enum bit<8> E2 {
+              ^^
+enumCast.p4(8)
+  enum bit<8> E1 {
+              ^^
+enumCast.p4(35): [--Werror=type-error] error: 'a = 0 + 1'
         a = E1.e1 + 1; // Error: E.e1 is automatically cast to bit<8>,
           ^
+  ---- Actual error:
+enumCast.p4(8): Cannot cast implicitly type 'bit<8>' to type 'E1'
+  enum bit<8> E1 {
+              ^^
+  ---- Originating from:
+enumCast.p4(35): Source expression '0 + 1' produces a result of type 'bit<8>' which cannot be assigned to a left-value with type 'E1'
+          a = E1.e1 + 1; // Error: E.e1 is automatically cast to bit<8>,
+              ^^^^^^^^^
 enumCast.p4(8)
-enum bit<8> E1 {
-            ^^
-enumCast.p4(38): [--Werror=type-error] error: 'a = 0 + 1': values of type 'bit<8>' cannot be implicitly cast to type 'E1'
+  enum bit<8> E1 {
+              ^^
+enumCast.p4(38): [--Werror=type-error] error: 'a = 0 + 1'
         a = E1.e1 + E1.e2; // Error: both arguments to the addition are automatically
           ^
+  ---- Actual error:
+enumCast.p4(8): Cannot cast implicitly type 'bit<8>' to type 'E1'
+  enum bit<8> E1 {
+              ^^
+  ---- Originating from:
+enumCast.p4(38): Source expression '0 + 1' produces a result of type 'bit<8>' which cannot be assigned to a left-value with type 'E1'
+          a = E1.e1 + E1.e2; // Error: both arguments to the addition are automatically
+              ^^^^^^^^^^^^^
 enumCast.p4(8)
-enum bit<8> E1 {
-            ^^
+  enum bit<8> E1 {
+              ^^

--- a/testdata/p4_16_errors_outputs/enumcrash2.p4
+++ b/testdata/p4_16_errors_outputs/enumcrash2.p4
@@ -1,0 +1,31 @@
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+header t1 {
+    bit<32> f1;
+}
+
+struct headers_t {
+    t1 head;
+}
+
+typedef bit<1> Foo_t;
+enum Foo_t Foo {
+    A = 1w0,
+    B = 1w1
+}
+
+extern Object {
+    Object(int size);
+    void set(Foo t);
+}
+
+Object(10) obj;
+control c(inout headers_t hdrs) {
+    apply {
+        obj.set(1w1);
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/enumcrash2.p4-stderr
+++ b/testdata/p4_16_errors_outputs/enumcrash2.p4-stderr
@@ -1,0 +1,24 @@
+enumcrash2.p4(26): [--Werror=type-error] error: 'obj.set(1w1)'
+        obj.set(1w1);
+        ^^^^^^^^^^^^
+  ---- Actual error:
+enumcrash2.p4(15): Cannot cast implicitly type 'bit<1>' to type 'Foo'
+  enum Foo_t Foo { A = 1w0 , B = 1w1 };
+             ^^^
+  ---- Originating from:
+enumcrash2.p4(26): Type of argument '1w1' (bit<1>) does not match type of parameter 't' (Foo)
+          obj.set(1w1);
+                  ^^^
+enumcrash2.p4(19)
+      void set(Foo t);
+                   ^
+enumcrash2.p4(15)
+  enum Foo_t Foo { A = 1w0 , B = 1w1 };
+             ^^^
+  ---- Originating from:
+enumcrash2.p4(19): Function type 'set' does not match invocation type '<Method call>'
+      void set(Foo t);
+           ^^^
+enumcrash2.p4(26)
+          obj.set(1w1);
+          ^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/issue2220.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue2220.p4-stderr
@@ -1,6 +1,27 @@
-issue2220.p4(11): [--Werror=type-error] error: '{ val = 8w0 }': values of type 'bit<8>' cannot be implicitly cast to type 'myEnum'
+issue2220.p4(11): [--Werror=type-error] error: 's1'
  S s1 = { val = (bit<8>)0 };
-        ^^^^^^^^^^^^^^^^^^^
-issue2220.p4(3)
-enum bit<8> myEnum { One = 1 }
-            ^^^^^^
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  ---- Actual error:
+issue2220.p4(3): Cannot cast implicitly type 'bit<8>' to type 'myEnum'
+  enum bit<8> myEnum { One = 1 }
+              ^^^^^^
+  ---- Originating from:
+issue2220.p4(3): Type of initializer 'bit<8>' does not match type 'myEnum' of field 'val' in 'struct S'
+  enum bit<8> myEnum { One = 1 }
+              ^^^^^^
+issue2220.p4(6)
+      myEnum val;
+             ^^^
+issue2220.p4(5)
+  struct S {
+         ^
+  ---- Originating from:
+issue2220.p4(11): Source expression '{ val = 8w0 }' produces a result of type 'unknown struct' which cannot be assigned to a left-value with type 'struct S'
+   S s1 = { val = (bit<8>)0 };
+          ^^^^^^^^^^^^^^^^^^^
+issue2220.p4(11)
+   S s1 = { val = (bit<8>)0 };
+          ^^^^^^^^^^^^^^^^^^^
+issue2220.p4(5)
+  struct S {
+         ^

--- a/testdata/p4_16_errors_outputs/issue3534.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue3534.p4-stderr
@@ -7,12 +7,20 @@ e f1(in bool c, in bit<2> v0, in e v1)
 issue3534.p4(11): [--Wwarn=unused] warning: 'f2' is unused
 e f2(in bool c, in e v0, in bit<2> v1)
   ^^
-issue3534.p4(5): [--Werror=type-error] error: 'return ?:': values of type 'bit<2>' cannot be implicitly cast to type 'e'
+issue3534.p4(5): [--Werror=type-error] error: 'return ?:'
   return c ? v0 : v1; // { dg-error "" }
   ^^^^^^
+  ---- Actual error:
+issue3534.p4(1): Cannot cast implicitly type 'bit<2>' to type 'e'
+  enum bit<2> e{ t = 1}
+              ^
+  ---- Originating from:
+issue3534.p4(5): Source expression '?:' produces a result of type 'bit<2>' which cannot be assigned to a left-value with type 'e'
+    return c ? v0 : v1; // { dg-error "" }
+           ^^^^^^^^^^^
 issue3534.p4(1)
-enum bit<2> e{ t = 1}
-            ^
+  enum bit<2> e{ t = 1}
+              ^
 issue3534.p4(9): [--Werror=type-error] error: '?:'
   return c ? v0 : v1; // { dg-error "" }
          ^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/serEnumImplCast.p4-stderr
+++ b/testdata/p4_16_errors_outputs/serEnumImplCast.p4-stderr
@@ -1,9 +1,17 @@
 serEnumImplCast.p4(10): [--Wwarn=unused] warning: control 'c' is unused
 control c(inout meta_t m) {
         ^
-serEnumImplCast.p4(16): [--Werror=type-error] error: '2w0': values of type 'bit<2>' cannot be implicitly cast to type 'foo_t'
+serEnumImplCast.p4(16): [--Werror=type-error] error: '2w0'
         default_action = set_x(2w0); // not allowed to implicitly cast to serenum
                                ^^^
+  ---- Actual error:
+serEnumImplCast.p4(3): Cannot cast implicitly type 'bit<2>' to type 'foo_t'
+  enum bit<2> foo_t { A = 0, B = 1, C = 2, D = 3 }
+              ^^^^^
+  ---- Originating from:
+serEnumImplCast.p4(16): Source expression '2w0' produces a result of type 'bit<2>' which cannot be assigned to a left-value with type 'foo_t'
+          default_action = set_x(2w0); // not allowed to implicitly cast to serenum
+                                 ^^^
 serEnumImplCast.p4(3)
-enum bit<2> foo_t { A = 0, B = 1, C = 2, D = 3 }
-            ^^^^^
+  enum bit<2> foo_t { A = 0, B = 1, C = 2, D = 3 }
+              ^^^^^

--- a/testdata/p4_16_errors_outputs/serenum-type.p4-stderr
+++ b/testdata/p4_16_errors_outputs/serenum-type.p4-stderr
@@ -1,6 +1,26 @@
 serenum-type.p4(8): [--Werror=type-error] error: EthT: Illegal type for enum; only bit<> and int<> are allowed; note that type-declared types are not allowed even if they are fixed-size
 enum EthT EthTypes {
      ^^^^
+serenum-type.p4(34): [--Werror=type-error] error: 'SelectExpression'
+        transition select(e.type) {
+                   ^
+  ---- Actual error:
+serenum-type.p4(8): Cannot cast implicitly type 'EthTypes' to type 'EthT'
+  enum EthT EthTypes {
+            ^^^^^^^^
+serenum-type.p4(6)
+  type Base2_t EthT;
+               ^^^^
+  ---- Originating from:
+serenum-type.p4(35): 'match' case label 'EthTypes.IPv4' has type 'EthTypes' which does not match the expected type 'EthT'
+              EthTypes.IPv4: accept;
+              ^^^^^^^^^^^^^
+serenum-type.p4(8)
+  enum EthT EthTypes {
+            ^^^^^^^^
+serenum-type.p4(6)
+  type Base2_t EthT;
+               ^^^^
 serenum-type.p4(49): [--Werror=type-error] error: '(EthTypes)16w0'
             h.eth.type = (EthTypes)(bit<16>)0;
                          ^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/serenum-typedef.p4-stderr
+++ b/testdata/p4_16_errors_outputs/serenum-typedef.p4-stderr
@@ -25,6 +25,26 @@ serenum-typedef.p4(31): [--Werror=type-error] error: unrepresentable_p: Serializ
 serenum-typedef.p4(28)
 enum bit<4> UnrepresentableBit {
      ^^^^^^
+serenum-typedef.p4(50): [--Werror=type-error] error: 'SelectExpression'
+        transition select(e.type) {
+                   ^
+  ---- Actual error:
+serenum-typedef.p4(8): Cannot cast implicitly type 'EthTypes' to type 'Base_t'
+  enum EthT EthTypes {
+            ^^^^^^^^
+serenum-typedef.p4(3)
+  type bit<16> Base_t;
+               ^^^^^^
+  ---- Originating from:
+serenum-typedef.p4(51): 'match' case label 'EthTypes.IPv4' has type 'EthTypes' which does not match the expected type 'Base_t'
+              EthTypes.IPv4: accept;
+              ^^^^^^^^^^^^^
+serenum-typedef.p4(8)
+  enum EthT EthTypes {
+            ^^^^^^^^
+serenum-typedef.p4(3)
+  type bit<16> Base_t;
+               ^^^^^^
 serenum-typedef.p4(65): [--Werror=type-error] error: '(EthTypes)16w0'
             h.eth.type = (EthTypes)(bit<16>)0;
                          ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
- implicit casts FROM the underlying type TO the serializable enum type are not allowed, so should be errors
- when matching a serializable enum in a select/case, use the underlying type for unification, as case tags may be either the serenum type or the underlying type.