### PR TITLE
Add back test case for #5333

### DIFF
--- a/testdata/p4_16_samples/issue5331_srcinfo.p4
+++ b/testdata/p4_16_samples/issue5331_srcinfo.p4
@@ -1,0 +1,28 @@
+extern void __e(in bit<16> x);
+control C(in bit<16> x) {
+    action a3(bit<16> y) {
+        __e(y);
+    }
+
+    action a2(bit<6> y) {
+        a3(x << (9 + y));
+    }
+
+    action a() {
+        a2(9);
+    }
+
+    table t {
+        actions = { a; }
+        default_action = a;
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+control proto(in bit<16> x);
+package top(proto p);
+
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue5331_srcinfo-first.p4
+++ b/testdata/p4_16_samples_outputs/issue5331_srcinfo-first.p4
@@ -1,0 +1,25 @@
+extern void __e(in bit<16> x);
+control C(in bit<16> x) {
+    action a3(bit<16> y) {
+        __e(y);
+    }
+    action a2(bit<6> y) {
+        a3(x << 6w9 + y);
+    }
+    action a() {
+        a2(6w9);
+    }
+    table t {
+        actions = {
+            a();
+        }
+        default_action = a();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto(in bit<16> x);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue5331_srcinfo-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue5331_srcinfo-frontend.p4
@@ -1,0 +1,19 @@
+extern void __e(in bit<16> x);
+control C(in bit<16> x) {
+    @name("C.a") action a() {
+        __e(x << 6w18);
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            a();
+        }
+        default_action = a();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto(in bit<16> x);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue5331_srcinfo-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue5331_srcinfo-midend.p4
@@ -1,0 +1,19 @@
+extern void __e(in bit<16> x);
+control C(in bit<16> x) {
+    @name("C.a") action a() {
+        __e(x << 6w18);
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            a();
+        }
+        default_action = a();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto(in bit<16> x);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue5331_srcinfo.p4
+++ b/testdata/p4_16_samples_outputs/issue5331_srcinfo.p4
@@ -1,0 +1,25 @@
+extern void __e(in bit<16> x);
+control C(in bit<16> x) {
+    action a3(bit<16> y) {
+        __e(y);
+    }
+    action a2(bit<6> y) {
+        a3(x << 9 + y);
+    }
+    action a() {
+        a2(9);
+    }
+    table t {
+        actions = {
+            a;
+        }
+        default_action = a;
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto(in bit<16> x);
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/issue5331_srcinfo.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue5331_srcinfo.p4-stderr
@@ -1,0 +1,3 @@
+issue5331_srcinfo.p4(4): [--Wwarn=overflow] warning: x << 18: shifting value with 16 bits by 18
+        __e(y);
+            ^


### PR DESCRIPTION
testdata/p4_16_samples_outputs/issue5331_srcinfo.p4 got removed in #5334 (the explicit cast error got removed and I didn't have another test case for #5333 at that time). Now I've found a new slightly different test case for #5333, so I'm adding it back.