### PR TITLE
Print warnings in a deterministic order

### DIFF
--- a/frontends/p4/sideEffects.cpp
+++ b/frontends/p4/sideEffects.cpp
@@ -355,7 +355,7 @@ class GetWrittenExpressions : public Inspector, public ResolutionContext {
     // precisely the side effects without an inter-procedural
     // analysis.
     static const IR::Expression *everything;
-    std::set<const IR::Expression *> written;
+    ordered_set<const IR::Expression *> written;
 
     explicit GetWrittenExpressions(TypeMap *typeMap) : typeMap(typeMap) {
         CHECK_NULL(typeMap);
@@ -407,7 +407,7 @@ const IR::Node *DoSimplifyExpressions::preorder(IR::MethodCallExpression *mce) {
     // structs if possible.
     std::set<const IR::Parameter *> useTemporary;
     // Set of expressions modified while evaluating this method call.
-    std::set<const IR::Expression *> modifies;
+    ordered_set<const IR::Expression *> modifies;
     // FIXME: We need to be able to cache results here and not to recompute over
     // and over again
     GetWrittenExpressions gwe(typeMap);

--- a/testdata/p4_16_samples_outputs/issue2176-bmv2.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2176-bmv2.p4-stderr
@@ -6,7 +6,7 @@ issue2176-bmv2.p4(43): [--Wwarn=ordering] warning: h.h.b: 'out' argument has fie
                     ^^^^^
 issue2176-bmv2.p4(43)
         do_action_2(h.h.b, h.h.b, h.h.b);
-                                  ^^^^^
+                           ^^^^^
 issue2176-bmv2.p4(43): [--Wwarn=ordering] warning: h.h.b: 'out' argument has fields in common with h.h.b
         do_action_2(h.h.b, h.h.b, h.h.b);
                            ^^^^^


### PR DESCRIPTION
The following code will print warnings for each `e` in `modifies` in a non-deterministic order:
```
    for (auto p : *mi->substitution.getParametersInArgumentOrder()) {
        if (useTemporary.find(p) != useTemporary.end()) continue;
        auto arg = mi->substitution.lookup(p);
        if (typeMap->isCompileTimeConstant(arg->expression)) continue;
        for (auto e : modifies) {
            // Here we use just raw equality: equivalent but not equal expressions
            // should be compared.
            if (e != arg->expression && mayAlias(arg->expression, e, getContext())) {
                LOG3("Using temporary for " << dbp(mce) << " param " << dbp(p) << " aliasing"
                                            << dbp(e));
                if (p->hasOut())
                    warn(ErrorType::WARN_ORDERING,
                         "%1%: 'out' argument has fields in common with %2%", arg, e);
                useTemporary.emplace(p);
                break;
            }
        }
    }
```