### PR TITLE
Extended Type_InfInt handling in ExpressionEvaluator

### DIFF
--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -712,6 +712,9 @@ void ExpressionEvaluator::setNonConstant(const IR::Expression *expression) {
     } else if (type->is<IR::Type_Bits>()) {
         set(expression,
             new SymbolicInteger(ScalarValue::ValueState::NotConstant, type->to<IR::Type_Bits>()));
+    } else if (type->is<IR::Type_InfInt>()) {
+        set(expression,
+            new SymbolicInteger(ScalarValue::ValueState::NotConstant, IR::Type_Bits::get(0)));
     } else {
         BUG("Non Type_Bits type %1% for expression %2%", type, expression);
     }
@@ -853,7 +856,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary *expression) {
     cf.setCalledBy(this);
     auto result = clone->apply(cf);
 
-    if (type->is<IR::Type_Bits>()) {
+    if (type->is<IR::Type_Bits>() || type->is<IR::Type_InfInt>()) {
         BUG_CHECK(result->is<IR::Constant>(), "%1%: expected a constant", result);
         set(expression, new SymbolicInteger(result->to<IR::Constant>()));
     } else if (type->is<IR::Type_Boolean>()) {

--- a/testdata/p4_16_samples/parser-unroll-test1.p4
+++ b/testdata/p4_16_samples/parser-unroll-test1.p4
@@ -76,7 +76,9 @@ parser MyParser(packet_in packet,
 
     @name (".parse_srcRouting") state parse_srcRouting {
         packet.extract(hdr.srcRoutes[index]);
-        index = index + 1;
+        // Check arbitrary size int handling in interpreter
+        index = (int<32>)((int)index + 1);
+        hdr.srcRoutes[index - 1].port = (bit<15>)((int)hdr.srcRoutes[index - 1].port + 1);
         transition select(hdr.srcRoutes[index - 1].bos) {
             1: parse_ipv4;
             default: parse_srcRouting;

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1-first.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1-first.p4
@@ -58,7 +58,8 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
     }
     @name(".parse_srcRouting") state parse_srcRouting {
         packet.extract<srcRoute_t>(hdr.srcRoutes[index]);
-        index = index + 32s1;
+        index = (int<32>)((int)index + 1);
+        hdr.srcRoutes[index + -32s1].port = (bit<15>)((int)hdr.srcRoutes[index + -32s1].port + 1);
         transition select(hdr.srcRoutes[index + -32s1].bos) {
             1w1: parse_ipv4;
             default: parse_srcRouting;

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1-frontend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1-frontend.p4
@@ -53,7 +53,8 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
     @name(".parse_srcRouting") state parse_srcRouting {
         tmp = index_0;
         packet.extract<srcRoute_t>(hdr.srcRoutes[tmp]);
-        index_0 = index_0 + 32s1;
+        index_0 = (int<32>)((int)index_0 + 1);
+        hdr.srcRoutes[index_0 + -32s1].port = (bit<15>)((int)hdr.srcRoutes[index_0 + -32s1].port + 1);
         transition select(hdr.srcRoutes[index_0 + -32s1].bos) {
             1w1: parse_ipv4;
             default: parse_srcRouting;

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1-midend.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1-midend.p4
@@ -49,7 +49,8 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
     }
     @name(".parse_srcRouting") state parse_srcRouting {
         packet.extract<srcRoute_t>(hdr.srcRoutes[32s0]);
-        index_0 = index_0 + 32s1;
+        index_0 = (int<32>)((int)index_0 + 1);
+        hdr.srcRoutes[32s0].port = (bit<15>)((int)hdr.srcRoutes[32s0].port + 1);
         transition select(hdr.srcRoutes[32s0].bos) {
             1w1: parse_ipv4;
             default: parse_srcRouting1;
@@ -57,7 +58,8 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
     }
     state parse_srcRouting1 {
         packet.extract<srcRoute_t>(hdr.srcRoutes[32s1]);
-        index_0 = index_0 + 32s1;
+        index_0 = (int<32>)((int)index_0 + 1);
+        hdr.srcRoutes[32s1].port = (bit<15>)((int)hdr.srcRoutes[32s1].port + 1);
         transition select(hdr.srcRoutes[32s1].bos) {
             1w1: parse_ipv4;
             default: parse_srcRouting2;
@@ -65,7 +67,8 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
     }
     state parse_srcRouting2 {
         packet.extract<srcRoute_t>(hdr.srcRoutes[32s2]);
-        index_0 = index_0 + 32s1;
+        index_0 = (int<32>)((int)index_0 + 1);
+        hdr.srcRoutes[32s2].port = (bit<15>)((int)hdr.srcRoutes[32s2].port + 1);
         transition select(hdr.srcRoutes[32s2].bos) {
             1w1: parse_ipv4;
             default: parse_srcRouting3;

--- a/testdata/p4_16_samples_outputs/parser-unroll-test1.p4
+++ b/testdata/p4_16_samples_outputs/parser-unroll-test1.p4
@@ -58,7 +58,8 @@ parser MyParser(packet_in packet, out headers hdr, inout metadata meta, inout st
     }
     @name(".parse_srcRouting") state parse_srcRouting {
         packet.extract(hdr.srcRoutes[index]);
-        index = index + 1;
+        index = (int<32>)((int)index + 1);
+        hdr.srcRoutes[index - 1].port = (bit<15>)((int)hdr.srcRoutes[index - 1].port + 1);
         transition select(hdr.srcRoutes[index - 1].bos) {
             1: parse_ipv4;
             default: parse_srcRouting;


### PR DESCRIPTION
Extended `ExpressionEvaluator` to correctly evaluate `Type_InfInt` type and operations.