### PR TITLE
Fix simplifySwitch handling of enums

### DIFF
--- a/testdata/p4_16_samples/issue2617.p4
+++ b/testdata/p4_16_samples/issue2617.p4
@@ -67,20 +67,35 @@ control c(out bit<32> v) {
             2:
         }
 
-        switch (E.C) {
-            E.A: { v = v + 1; }
-            default: { v = v + 2; }
+        switch (32w1) {
+            X.A: { v = v + 20; }
+            X.B: { v = v + 10; }
+            2:
         }
 
         switch (E.C) {
-            E.A: { v = v + 1; }
-            default: { v = v + 3; }
+            E.A: { v = v + 200; }
+            default: { v = v + 100; }
+        }
+
+        switch (E.B) {
+            E.B: { v = v + 1000; }
+            default: { v = v + 2000; }
         }
 
         switch (X.B) {
-            X.A: { v = v + 10; }
-            X.B: { v = v + 20; }
+            X.A: { v = v + 20000; }
+            X.B: { v = v + 10000; }
         }
+
+#if 0
+        // typechecking currently disallows this, and we have an error check in
+        // p4_16_errors/issue3623-2.p4
+        switch (X.B) {
+            0: { v = v + 200000; }
+            32w1: { v = v + 100000; }
+        }
+#endif
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2617-first.p4
+++ b/testdata/p4_16_samples_outputs/issue2617-first.p4
@@ -59,28 +59,38 @@ control c(out bit<32> v) {
             32w2: {
             }
         }
-        switch (E.C) {
-            E.A: {
-                v = v + 32w1;
+        switch (32w1) {
+            X.A: {
+                v = v + 32w20;
             }
-            default: {
-                v = v + 32w2;
+            X.B: {
+                v = v + 32w10;
+            }
+            32w2: {
             }
         }
         switch (E.C) {
             E.A: {
-                v = v + 32w1;
+                v = v + 32w200;
             }
             default: {
-                v = v + 32w3;
+                v = v + 32w100;
+            }
+        }
+        switch (E.B) {
+            E.B: {
+                v = v + 32w1000;
+            }
+            default: {
+                v = v + 32w2000;
             }
         }
         switch (X.B) {
             X.A: {
-                v = v + 32w10;
+                v = v + 32w20000;
             }
             X.B: {
-                v = v + 32w20;
+                v = v + 32w10000;
             }
         }
     }

--- a/testdata/p4_16_samples_outputs/issue2617-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue2617-frontend.p4
@@ -17,9 +17,10 @@ parser p1(out bit<32> v) {
 control c(out bit<32> v) {
     apply {
         v = 32w1;
-        v = v + 32w2;
-        v = v + 32w3;
-        v = v + 32w20;
+        v = v + 32w10;
+        v = v + 32w100;
+        v = v + 32w1000;
+        v = v + 32w10000;
     }
 }
 

--- a/testdata/p4_16_samples_outputs/issue2617-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue2617-midend.p4
@@ -17,9 +17,10 @@ parser p1(out bit<32> v) {
 control c(out bit<32> v) {
     @hidden action issue2617l66() {
         v = 32w1;
-        v = 32w3;
-        v = 32w6;
-        v = 32w26;
+        v = 32w11;
+        v = 32w111;
+        v = 32w1111;
+        v = 32w11111;
     }
     @hidden table tbl_issue2617l66 {
         actions = {

--- a/testdata/p4_16_samples_outputs/issue2617.p4
+++ b/testdata/p4_16_samples_outputs/issue2617.p4
@@ -66,28 +66,37 @@ control c(out bit<32> v) {
             }
             2: 
         }
-        switch (E.C) {
-            E.A: {
-                v = v + 1;
+        switch (32w1) {
+            X.A: {
+                v = v + 20;
             }
-            default: {
-                v = v + 2;
+            X.B: {
+                v = v + 10;
             }
+            2: 
         }
         switch (E.C) {
             E.A: {
-                v = v + 1;
+                v = v + 200;
             }
             default: {
-                v = v + 3;
+                v = v + 100;
+            }
+        }
+        switch (E.B) {
+            E.B: {
+                v = v + 1000;
+            }
+            default: {
+                v = v + 2000;
             }
         }
         switch (X.B) {
             X.A: {
-                v = v + 10;
+                v = v + 20000;
             }
             X.B: {
-                v = v + 20;
+                v = v + 10000;
             }
         }
     }

--- a/testdata/p4_16_samples_outputs/issue2617.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue2617.p4-stderr
@@ -4,6 +4,9 @@ issue2617.p4(17): [--Wwarn=parser-transition] warning: SelectCase: unreachable c
 issue2617.p4(67): [--Wwarn=missing] warning: SwitchCase: fallthrough with no statement
             2:
             ^
+issue2617.p4(73): [--Wwarn=missing] warning: SwitchCase: fallthrough with no statement
+            2:
+            ^
 issue2617.p4(37): [--Wwarn=unreachable] warning: accept state in parser p1 is unreachable
 parser p1(out bit<32> v) {
        ^^


### PR DESCRIPTION
We have this nice `EnumInstance` stuff for resolving enums of all kinds, so we should use it.

fixes #5269 