### PR TITLE
Remove unnecessary table stepper object from pna exr_stepper

### DIFF
--- a/backends/p4tools/modules/testgen/targets/pna/dpdk/expr_stepper.cpp
+++ b/backends/p4tools/modules/testgen/targets/pna/dpdk/expr_stepper.cpp
@@ -34,8 +34,6 @@ void PnaDpdkExprStepper::evalExternMethodCall(const ExternInfo &externInfo) {
 }
 
 bool PnaDpdkExprStepper::preorder(const IR::P4Table *table) {
-    // Delegate to the tableStepper.
-    PnaDpdkTableStepper tableStepper(this, table);
     return PnaDpdkTableStepper(this, table).eval();
 }
 


### PR DESCRIPTION
Seems this `tableStepper` object is unused here? Can this be removed?