### PR TITLE
Prevent unintended backtick parsing

### DIFF
--- a/.github/workflows/ci-auto-release.yml
+++ b/.github/workflows/ci-auto-release.yml
@@ -36,7 +36,10 @@ jobs:
           echo "::set-output name=content::$CHANGELOG"
 
       - name: Display changelog
-        run: echo "${{ steps.changelog.outputs.content }}"
+        run: |
+          cat <<'EOF'
+          ${{ steps.changelog.outputs.content }}
+          EOF
 
       - name: Get version
         run: |
@@ -46,7 +49,7 @@ jobs:
       - name: Get commit message
         id: message
         run: |
-          COMMIT_MSG=$(cat << EOF
+          COMMIT_MSG=$(cat << 'EOF'
           Release v${{ env.VERSION }}
           Signed-off-by: rst0git <9142901+rst0git@users.noreply.github.com>
 
@@ -61,7 +64,7 @@ jobs:
       - name: Get pull request body message
         id: body
         run: |
-          MSG=$(cat << EOF
+          MSG=$(cat << 'EOF'
           Auto-generated pull request for version ${{ env.VERSION }}.
 
           Please use **Squash and merge** to include the changelog in the release message.


### PR DESCRIPTION
The workflow started failing because bash saw an unmatched backtick inside a double-quoted string.

Fixes #5394