### PR TITLE
Increase minimum required BISON version to 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ endif ()
 # Required tools and libraries.
 find_package (PythonInterp 3 REQUIRED)
 find_package (FLEX 2.0 REQUIRED)
-find_package (BISON 3.0 REQUIRED)
+find_package (BISON 3.1 REQUIRED)
 # If we enable GTest, install GoogleTest with the appropriate options.
 if (ENABLE_GTESTS)
   include(GoogleTest)


### PR DESCRIPTION
https://github.com/p4lang/p4c/pull/5338 utilized a feature (typed midrule actions?) that was introduced in Bison version 3.1, so the minimum required Bison version is now 3.1. On older versions, building the compiler will result in an error similar to the following:
```
[2917/3565] [BISON][p4Parser] Building parser with bison 3.0.4
FAILED: p4c/frontends/parsers/p4/p4parser.cpp p4c/frontends/parsers/p4/p4parser.output p4c/frontends/parsers/p4/p4parser.hpp 
cd /c/build/p4c/frontends && /bin/bison -Werror=conflicts-sr -Werror=conflicts-rr -d --verbose -o /c/build/p4c/frontends/parsers/p4/p4parser.cpp /c/p4c/frontends/parsers/p4/p4parser.ypp
/c/p4c/frontends/parsers/p4/p4parser.ypp:810.50-61: error: syntax error, unexpected <tag>
       : annotations typeRef "(" argumentList ")" <ConstType*>{ $$ = $2; } declarator optObjInitializer ";"
                                                  ^^^^^^^^^^^^
```

```
*** Typed midrule actions

  Because their type is unknown to Bison, the values of midrule actions are
  not treated like the others: they don't have %printer and %destructor
  support.  It also prevents C++ (Bison) variants to handle them properly.

  Typed midrule actions address these issues.  Instead of:

    exp: { $<ival>$ = 1; } { $<ival>$ = 2; }   { $$ = $<ival>1 + $<ival>2; }

  write:

    exp: <ival>{ $$ = 1; } <ival>{ $$ = 2; }   { $$ = $1 + $2; }
```

https://lists.gnu.org/archive/html/help-bison/2018-08/msg00024.html