### PR TITLE
Avoid 'fatal error : Broken pipe' from preprocessor

### DIFF
--- a/frontends/common/parseInput.h
+++ b/frontends/common/parseInput.h
@@ -78,7 +78,7 @@ const IR::P4Program *parseP4File(const ParserOptions &options) {
         fclose(file);
     } else {
         auto preprocessorResult = options.preprocess();
-        if (::P4::errorCount() > 0 || !preprocessorResult.has_value()) {
+        if (!preprocessorResult.has_value()) {
             return nullptr;
         }
         // Need to assign file here because the parser requires an lvalue.


### PR DESCRIPTION
If there was some error message earlier (perhaps from argument processing), returning NULL here after starting the preprocessor without reading/parsing its output will generate a spurious "fatal error: when writing output to : Broken pipe" from the preprocessor.