### PR TITLE
Enable some tests for the tofino compiler

### DIFF
--- a/backends/tofino/CMakeLists.txt
+++ b/backends/tofino/CMakeLists.txt
@@ -231,3 +231,11 @@ add_subdirectory(bf-p4c)
 # Initialize bf-asm after bf-p4c.
 add_subdirectory(bf-asm)
 
+set (XFAIL_TESTS
+)
+set (TOFINO_TEST_SUITES
+  "${P4C_SOURCE_DIR}/testdata/p4_14_samples/*.p4"
+)
+set (TOFINO_TEST_DRIVER ${CMAKE_CURRENT_SOURCE_DIR}/scripts/run-tofino-test.sh)
+p4c_add_tests("tofino" ${TOFINO_TEST_DRIVER} "${TOFINO_TEST_SUITES}" "${XFAIL_TESTS}")
+

--- a/backends/tofino/scripts/run-tofino-test.sh
+++ b/backends/tofino/scripts/run-tofino-test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+repo="$1"; shift
+
+exec ./p4c --target tofino --std 14 "$@"


### PR DESCRIPTION
Just runs the compiler and assembler; does not attempt to run STF

A number of these fail by timing out, so we want a way to filter those out and not run them (a list of files to exclude from the glob pattern probably).  Some others fail in expected ways, so could be XFAILs