### PR TITLE
Add parser state tracking, testgen option for parser state tracking

### DIFF
--- a/backends/p4tools/common/lib/trace_event_types.cpp
+++ b/backends/p4tools/common/lib/trace_event_types.cpp
@@ -240,6 +240,11 @@ void ExtractSuccess::print(std::ostream &os) const {
 
 int ExtractSuccess::getOffset() const { return offset; }
 
+const std::vector<std::pair<IR::StateVariable, const IR::Expression *>> &ExtractSuccess::getFields()
+    const {
+    return fields;
+}
+
 const IR::Expression *ExtractSuccess::getExtractedHeader() const { return extractedHeader; }
 
 /* =============================================================================================

--- a/backends/p4tools/common/lib/trace_event_types.h
+++ b/backends/p4tools/common/lib/trace_event_types.h
@@ -188,6 +188,10 @@ class ExtractSuccess : public TraceEvent {
     /// @returns the offset stored in this class.
     [[nodiscard]] int getOffset() const;
 
+    /// @returns the bit fields stored in this class
+    [[nodiscard]] const std::vector<std::pair<IR::StateVariable, const IR::Expression *>> &
+    getFields() const;
+
     ExtractSuccess(const IR::Expression *extractedHeader, int offset,
                    const IR::Expression *condition,
                    std::vector<std::pair<IR::StateVariable, const IR::Expression *>> fields);

--- a/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
+++ b/backends/p4tools/modules/testgen/core/small_step/cmd_stepper.cpp
@@ -342,6 +342,9 @@ bool CmdStepper::preorder(const IR::ParserState *parserState) {
     logStep(parserState);
 
     auto &nextState = state.clone();
+    if (TestgenOptions::get().coverageOptions.coverParserStates) {
+        nextState.markVisited(parserState);
+    }
     nextState.add(*new TraceEvents::ParserState(parserState));
 
     if (parserState->name == IR::ParserState::accept) {

--- a/backends/p4tools/modules/testgen/options.cpp
+++ b/backends/p4tools/modules/testgen/options.cpp
@@ -280,7 +280,7 @@ TestgenOptions::TestgenOptions()
         "--track-coverage", "coverageItem",
         [this](const char *arg) {
             static std::set<cstring> const COVERAGE_OPTIONS = {"STATEMENTS"_cs, "TABLE_ENTRIES"_cs,
-                                                               "ACTIONS"_cs};
+                                                               "ACTIONS"_cs, "PARSER_STATES"_cs};
             hasCoverageTracking = true;
             auto selectionString = cstring(arg).toUpper();
             auto it = COVERAGE_OPTIONS.find(selectionString);
@@ -297,6 +297,10 @@ TestgenOptions::TestgenOptions()
                     coverageOptions.coverActions = true;
                     return true;
                 }
+                if (selectionString == "PARSER_STATES") {
+                    coverageOptions.coverParserStates = true;
+                    return true;
+                }
             }
             error(
                 "Coverage tracking for label %1% not supported. Supported coverage tracking "
@@ -307,7 +311,8 @@ TestgenOptions::TestgenOptions()
         },
         "Specifies, which IR nodes to track for coverage in the targeted P4 program. Multiple "
         "options are possible: Currently supported: STATEMENTS, TABLE_ENTRIES (table rules encoded "
-        "in the table entries in P4), ACTIONS (actions invoked, directly or by tables). "
+        "in the table entries in P4), ACTIONS (actions invoked, directly or by tables), "
+        "PARSER_STATES (parser states which a particular path chose to visit)."
         "Defaults to no coverage.");
 
     registerOption(

--- a/backends/p4tools/modules/testgen/options.h
+++ b/backends/p4tools/modules/testgen/options.h
@@ -89,7 +89,8 @@ class TestgenOptions : public AbstractP4cToolOptions {
     bool assertionModeEnabled = false;
 
     /// Specifies general options which IR nodes to track for coverage in the targeted P4 program.
-    /// Multiple options are possible. Currently supported: STATEMENTS, TABLE_ENTRIES.
+    /// Multiple options are possible.
+    /// Currently supported: STATEMENTS, TABLE_ENTRIES, ACTIONS, PARSER_STATES
     P4::Coverage::CoverageOptions coverageOptions;
 
     /// Indicates that coverage tracking is enabled for some coverage criteria. This is used for

--- a/midend/coverage.cpp
+++ b/midend/coverage.cpp
@@ -56,6 +56,13 @@ bool CollectNodes::preorder(const IR::P4Action *act) {
     return true;
 }
 
+bool CollectNodes::preorder(const IR::ParserState *state) {
+    if (coverageOptions.coverParserStates && state->getSourceInfo().isValid()) {
+        coverableNodes.insert(state);
+    }
+    return true;
+}
+
 void printCoverageReport(const CoverageSet &all, const CoverageSet &visited) {
     if (all.empty()) {
         return;

--- a/midend/coverage.h
+++ b/midend/coverage.h
@@ -29,6 +29,8 @@ struct CoverageOptions {
     bool coverTableEntries = false;
     /// Cover IR::P4Action
     bool coverActions = false;
+    /// Cover IR::ParserState
+    bool coverParserStates = false;
 
     /// Skip tests which do not increase coverage.
     bool onlyCoveringTests = false;
@@ -57,6 +59,9 @@ class CollectNodes : public Inspector {
 
     /// Actions coverage.
     bool preorder(const IR::P4Action *act) override;
+
+    /// Parser state coverage.
+    bool preorder(const IR::ParserState *state) override;
 
  public:
     explicit CollectNodes(CoverageOptions coverageOptions);


### PR DESCRIPTION
This PR aims to add parser state tracking to the tracking infrastructure and testgen for generating tests to cover a given parser. 

This also adds a `getFields` helper which I found useful for certain test backends in testgen.