### PR TITLE
[bazel] Prepare p4c for BCR

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,8 +2,9 @@ load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
-load("//:bazel/bison.bzl", "genyacc")
-load("//:bazel/flex.bzl", "genlex")
+load("//bazel:bison.bzl", "genyacc")
+load("//bazel:flex.bzl", "genlex")
+
 
 package(
     default_applicable_licenses = ["//:license"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,13 +33,13 @@ git_override(
     strip_prefix = "proto",
 )
 
-p4c_repositories = use_extension("//:bazel/repositories.bzl", "p4c_repositories")
+p4c_repositories = use_extension("//bazel:repositories.bzl", "p4c_repositories")
 use_repo(
     p4c_repositories,
     "inja",
 )
 
-p4c_ir_extensions = use_extension("//:bazel/extensions.bzl", "p4c_ir_extensions")
+p4c_ir_extensions = use_extension("//bazel:extensions.bzl", "p4c_ir_extensions")
 use_repo(
     p4c_ir_extensions,
     "p4c_ir_extensions",

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,0 +1,3 @@
+exports_files([
+    "p4_library.bzl",
+])

--- a/bazel/example/MODULE.bazel
+++ b/bazel/example/MODULE.bazel
@@ -25,6 +25,6 @@ git_override(
     strip_prefix = "proto",
 )
 
-p4c_ir_extensions = use_extension("@p4c//:bazel/extensions.bzl", "p4c_ir_extensions")
+p4c_ir_extensions = use_extension("@p4c//bazel:extensions.bzl", "p4c_ir_extensions")
 p4c_ir_extensions.ir_extensions(srcs = ["//:my_custom_statement.ir"])
 use_repo(p4c_ir_extensions, "p4c_ir_extensions")

--- a/bazel/example/p4/BUILD.bazel
+++ b/bazel/example/p4/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@p4c//:bazel/p4_library.bzl", "p4_graphs", "p4_library")
-
+load("@p4c//bazel:p4_library.bzl", "p4_library")
 p4_library(
     name = "program",
     src = "program.p4",

--- a/bazel/extensions.bzl
+++ b/bazel/extensions.bzl
@@ -4,7 +4,7 @@ This extension allows users to register custom IR definitions by providing a lis
 of files containing the extensions.
 
 Example usage in MODULE.bazel:
-    p4c_ir_extensions = use_extension("@p4c//:bazel/extensions.bzl", "p4c_ir_extensions")
+    p4c_ir_extensions = use_extension("@p4c//bazel:extensions.bzl", "p4c_ir_extensions")
     p4c_ir_extensions.ir_extensions(srcs = ["//path/to:ir_extensions_files"])
     use_repo(p4c_ir_extensions, "p4c_ir_extensions")
 """


### PR DESCRIPTION
This PR updates p4c’s Bazel setup so it works properly with Bazel bzlmod.

### What is changed
- Added a BUILD.bazel file inside the `bazel/` folder
- Updated Bazel load paths to use `//bazel:...` format
- Updated example Bazel files to match the new paths

### Why this change
Without this, p4c Bazel rules cannot be used correctly when bzlmod is enabled.
This change does not affect existing WORKSPACE based builds.

No functional code changes are included.