### PR TITLE
Modernize: Use std::filesystem::path for p4includePath

### DIFF
--- a/backends/bmv2/portable_common/options.cpp
+++ b/backends/bmv2/portable_common/options.cpp
@@ -16,7 +16,7 @@ std::vector<const char *> *PortableOptions::process(int argc, char *const argv[]
     this->exe_name = cstring(executablePath.stem().c_str());
     searchForIncludePath(p4includePath,
                          {"p4include/bmv2"_cs, "../p4include/bmv2"_cs, "../../p4include/bmv2"_cs},
-                         executablePath.c_str());
+                         executablePath);
 
     auto remainingOptions = CompilerOptions::process(argc, argv);
 

--- a/backends/dpdk/options.cpp
+++ b/backends/dpdk/options.cpp
@@ -17,21 +17,23 @@ std::vector<const char *> *DpdkOptions::process(int argc, char *const argv[]) {
 
     searchForIncludePath(p4includePath,
                          {"p4include/dpdk"_cs, "../p4include/dpdk"_cs, "../../p4include/dpdk"_cs},
-                         executablePath.c_str());
+                         executablePath);
 
     auto *remainingOptions = CompilerOptions::process(argc, argv);
 
     return remainingOptions;
 }
 
+// TODO: Store include paths as std::vector<std::filesystem::path> and convert
+// to a "-I"-separated string only when building the preprocessor command.
 const char *DpdkOptions::getIncludePath() const {
     char *driverP4IncludePath =
         isv1() ? getenv("P4C_14_INCLUDE_PATH") : getenv("P4C_16_INCLUDE_PATH");
     cstring path = cstring::empty;
     if (driverP4IncludePath != nullptr) path += " -I"_cs + cstring(driverP4IncludePath);
 
-    path += cstring(" -I") + (isv1() ? p4_14includePath : p4includePath);
-    if (!isv1()) path += " -I"_cs + p4includePath + "/dpdk"_cs;
+    path += " -I"_cs + (isv1() ? p4_14includePath.string() : p4includePath.string());
+    if (!isv1()) path += " -I"_cs + (p4includePath / "dpdk").string();
     return path.c_str();
 }
 

--- a/backends/tofino/bf-p4c/bf-p4c-options.cpp
+++ b/backends/tofino/bf-p4c/bf-p4c-options.cpp
@@ -724,10 +724,9 @@ std::vector<const char *> *BFN_Options::process(int argc, char *const argv[]) {
     //
     // Therefore, we need to search ../share/p4c/p4include from the
     // directory that p4c resides in.
-    searchForIncludePath(p4includePath, {"../share/p4c/p4include"_cs}, executablePath.c_str());
+    searchForIncludePath(p4includePath, {"../share/p4c/p4include"_cs}, executablePath);
 
-    searchForIncludePath(p4_14includePath, {"../share/p4c/p4_14include"_cs},
-                         executablePath.c_str());
+    searchForIncludePath(p4_14includePath, {"../share/p4c/p4_14include"_cs}, executablePath);
 
     auto remainingOptions = CompilerOptions::process(argc, argv);
 

--- a/frontends/common/parser_options.h
+++ b/frontends/common/parser_options.h
@@ -36,12 +36,12 @@ class ToP4;
 
 /// Standard include paths for .p4 header files. The values are determined by
 /// `configure`.
-// TODO: This should be std::filesystem::path.
-extern const char *p4includePath;
-extern const char *p4_14includePath;
+extern std::filesystem::path p4includePath;
+extern std::filesystem::path p4_14includePath;
 
 /// Try to guess whether a file is a "system" file
 bool isSystemFile(cstring filename);
+bool isSystemFile(const std::filesystem::path &filename);
 
 /// Base class for compiler options.
 /// This class contains the options for the front-ends.
@@ -108,9 +108,9 @@ class ParserOptions : public Util::Options {
     bool isAnnotationDisabled(const IR::Annotation *a) const;
     /// Search and set 'includePathOut' to be the first valid path from the
     /// list of possible relative paths.
-    static bool searchForIncludePath(const char *&includePathOut,
+    static bool searchForIncludePath(std::filesystem::path &includePathOut,
                                      const std::vector<cstring> &userSpecifiedPaths,
-                                     const char *exename);
+                                     const std::filesystem::path &exename);
     /// If true do not generate #include statements.
     /// Used for debugging.
     bool noIncludes = false;

--- a/test/gtest/helpers.cpp
+++ b/test/gtest/helpers.cpp
@@ -143,7 +143,7 @@ P4CTestEnvironment::P4CTestEnvironment() {
     std::filesystem::path srcFilePath{__FILE__};
     auto srcFileDir = std::filesystem::absolute(srcFilePath.parent_path());
     auto includeDir = srcFileDir / "../../p4include";
-    P4::p4includePath = strdup(includeDir.c_str());
+    P4::p4includePath = includeDir;
     auto corePath = includeDir / "core.p4";
     auto v1modelPath = includeDir / "v1model.p4";
     auto psaPath = includeDir / "bmv2/psa.p4";


### PR DESCRIPTION
Replaces C-string path handling with std::filesystem::path.

## Key Changes

### Path Handling:
- Converted `p4includePath` and `p4_14includePath` to `std::filesystem::path`
- Added Windows compatibility in [isSystemFile](cci:1://file:///home/attaullah/code/reference/p4-dev/tools/p4c/backends/p4fmt/p4formatter.cpp:31:0-35:1) by enforcing generic path separators (`/`)
- Removed `strdup` usage in tests