### PR TITLE
Error for failing to infer a struct type, instead of crash.

### DIFF
--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -149,6 +149,8 @@ const IR::Type *TypeInferenceBase::getTypeType(const IR::Node *element) const {
     const IR::Type *result = typeMap->getType(element);
     // See comment in getType() above.
     if (result == nullptr) {
+        if (auto *us = element->to<IR::Type_UnknownStruct>())
+            typeError("%1%: Cannot infer type for unknown struct type initializer", us);
         if (::P4::errorCount() == 0) BUG("Could not find type of %1%", element);
         return nullptr;
     }

--- a/testdata/p4_16_errors/unknown-struct1.p4
+++ b/testdata/p4_16_errors/unknown-struct1.p4
@@ -1,0 +1,27 @@
+#include <core.p4>
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+
+extern void func<T>(in T x);
+
+struct foobar {
+    bit<32>	a;
+    bit<32>     b;
+}
+
+header h1 {
+    bit<32>     f1;
+    bit<32>     f2;
+}
+
+struct headers_t {
+    h1          h;
+}
+
+control c(inout headers_t hdrs) {
+    apply {
+        func({ a = hdrs.h.f1, b = hdrs.h.f2 });
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/unknown-struct1.p4
+++ b/testdata/p4_16_errors_outputs/unknown-struct1.p4
@@ -1,0 +1,26 @@
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+extern void func<T>(in T x);
+struct foobar {
+    bit<32> a;
+    bit<32> b;
+}
+
+header h1 {
+    bit<32> f1;
+    bit<32> f2;
+}
+
+struct headers_t {
+    h1 h;
+}
+
+control c(inout headers_t hdrs) {
+    apply {
+        func({a = hdrs.h.f1,b = hdrs.h.f2});
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/unknown-struct1.p4-stderr
+++ b/testdata/p4_16_errors_outputs/unknown-struct1.p4-stderr
@@ -1,0 +1,6 @@
+unknown-struct1.p4(23): [--Werror=type-error] error: unknown struct: Cannot infer type for unknown struct type initializer
+        func({ a = hdrs.h.f1, b = hdrs.h.f2 });
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+unknown-struct1.p4(5): [--Werror=type-error] error: Error while analyzing func
+extern void func<T>(in T x);
+            ^^^^


### PR DESCRIPTION
A corner case that currently crashes with a BUG_CHECK, this changes it into an error.