### PR TITLE
Cache ReadsWrites instances for alias analysis

### DIFF
--- a/frontends/p4/alias.h
+++ b/frontends/p4/alias.h
@@ -242,6 +242,10 @@ class ReadsWrites : public Inspector, public ResolutionContext {
     }
 
     const SetOfLocations *get(const IR::Expression *expression, const Visitor::Context *ctxt) {
+        if (auto it = rw.find(expression); it != rw.end()) {
+            LOG3("SetOfLocations(" << expression << ")=" << it->second << " [cached]");
+            return it->second;
+        }
         expression->apply(*this, ctxt);
         auto result = ::P4::get(rw, expression);
         CHECK_NULL(result);
@@ -258,6 +262,8 @@ class ReadsWrites : public Inspector, public ResolutionContext {
         LOG3("Checking overlap between " << llocs << " and " << rlocs);
         return llocs->overlaps(rlocs);
     }
+
+    void clear() { rw.clear(); }
 };
 
 }  // namespace P4

--- a/frontends/p4/sideEffects.h
+++ b/frontends/p4/sideEffects.h
@@ -19,11 +19,14 @@ limitations under the License.
 
 /* makes explicit side effect ordering */
 
+#include "absl/container/flat_hash_map.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "frontends/common/resolveReferences/resolveReferences.h"
+#include "frontends/p4/alias.h"
 #include "frontends/p4/methodInstance.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
+#include "lib/hash.h"
 
 namespace P4 {
 
@@ -149,6 +152,10 @@ class DoSimplifyExpressions : public Transform, P4WriteContext, public Resolutio
     TypeMap *typeMap;
     // Expressions holding temporaries that are already added.
     std::set<const IR::Expression *> *added;
+    ReadsWrites readsWrites;
+    absl::flat_hash_map<const IR::MethodCallExpression *, ordered_set<const IR::Expression *>,
+                        Util::Hash>
+        writtenExpressionsCache;
 
     IR::IndexedVector<IR::Declaration> toInsert;  // temporaries
     IR::IndexedVector<IR::StatOrDecl> statements;
@@ -160,7 +167,7 @@ class DoSimplifyExpressions : public Transform, P4WriteContext, public Resolutio
     const IR::Expression *addAssignment(Util::SourceInfo srcInfo, cstring varName,
                                         const IR::Expression *expression);
     bool mayAlias(const IR::Expression *left, const IR::Expression *right,
-                  const Visitor::Context *ctxt) const;
+                  const Visitor::Context *ctxt);
     bool containsHeaderType(const IR::Type *type);
 
  public:

--- a/midend/copyStructures.cpp
+++ b/midend/copyStructures.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 
 #include "copyStructures.h"
 
-#include "frontends/p4/alias.h"
 #include "ir/irutils.h"
 
 namespace P4 {
@@ -27,10 +26,7 @@ const IR::Node *RemoveAliases::postorder(IR::AssignmentStatement *statement) {
         return statement;
     }
 
-    // FIXME: This recreates ReadWrites() over and over again, loosing all
-    // declaration lookup caching
-    ReadsWrites rw;
-    if (!rw.mayAlias(statement->left, statement->right, getContext())) {
+    if (!readsWrites.mayAlias(statement->left, statement->right, getContext())) {
         return statement;
     }
     auto tmp = nameGen.newName("tmp");

--- a/midend/copyStructures.h
+++ b/midend/copyStructures.h
@@ -17,6 +17,7 @@ limitations under the License.
 #ifndef MIDEND_COPYSTRUCTURES_H_
 #define MIDEND_COPYSTRUCTURES_H_
 
+#include "frontends/p4/alias.h"
 #include "frontends/p4/typeChecking/typeChecker.h"
 #include "ir/ir.h"
 
@@ -104,6 +105,7 @@ class DoCopyStructures : public Transform {
 class RemoveAliases : public Transform {
     MinimalNameGenerator nameGen;
     TypeMap *typeMap;
+    ReadsWrites readsWrites;
 
     IR::IndexedVector<IR::Declaration> declarations;
 
@@ -122,6 +124,7 @@ class RemoveAliases : public Transform {
     const IR::Node *postorder(IR::AssignmentStatement *statement) override;
     const IR::Node *postorder(IR::P4Parser *parser) override;
     const IR::Node *postorder(IR::P4Control *control) override;
+    void end_apply(const IR::Node *) override { readsWrites.clear(); }
 };
 
 class CopyStructures : public PassRepeated {


### PR DESCRIPTION
Addresses the FIXMEs in sideEffects.cpp and copyStructures.cpp noting that ReadsWrites was being recreated on every mayAlias() call, losing all declaration lookup caching.

Now ReadsWrites is kept as a class member and reused across calls. Also added a cache check in ReadsWrites::get() to return early when we've already analyzed an expression, and cached GetWrittenExpressions results per MethodCallExpression.