### PR TITLE
Add Agents.MD files to help Codex/Claude/Gemini navigate the P4 repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Two-level map of the repository (major folders only):
+```text
+.
+|-- .github/               # CI config (workflows/).
+|-- backends/              # Backends.
+|   |-- {bmv2,dpdk,ebpf,graphs,p4fmt,p4test,p4tools,tc,tofino,ubpf}/ # Targets.
+|-- bazel/                 # Bazel build.
+|-- build/                 # Local build output (generated).
+|-- cmake/                 # CMake helpers.
+|-- control-plane/         # Control-plane APIs.
+|-- debian/                # Debian packaging.
+|-- docs/                  # Docs.
+|-- extensions/            # Extensions.
+|-- frontends/             # Frontend stages.
+|   |-- {common,p4,p4-14,parsers}/ # Frontend layers.
+|-- ir/                    # IR definitions.
+|-- json_outputs/          # JSON output helpers.
+|-- lib/                   # Shared libraries.
+|-- midend/                # Midend passes.
+|-- p4include/             # P4 headers.
+|-- test/                  # Unit tests.
+|-- testdata/              # Test inputs/outputs.
+|   |-- {p4_14_*,p4_16_*,p4tc_*}/ # Test suites.
+|-- tests/                 # Integration tests.
+|-- tools/                 # Dev scripts.
+```
+
+## Build, Test, and Development Commands
+- `mkdir -p build `
+- `cmake -B build -DCMAKE_BUILD_TYPE=Release`: configure.
+- `cmake --build build`: compile.
+- `cmake --build build --target check`: run tests.
+
+
+Optional tools:
+- `cmake --build build --target clang-format cpplint black isort`: format/lint checks (`*-fix-errors` to fix).
+
+## Coding Style & Naming Conventions
+- Follow the P4 coding standard philosophy and `.clang-tidy`.
+- C++ uses `clang-format` and `cpplint`; Python uses `black` and `isort`.
+- Prefer IR node casts via `node->to<Node>()`; use `node->checkedTo<Node>()` when `nullptr` is not acceptable. Avoid `dynamic_cast`.
+- Main C++ dependency is Abseil; do not introduce new Boost dependencies.
+
+## P4 Language Notes
+- Follow the P4 language spec.
+- `p4include/` has `core.p4` plus target models: `v1model.p4` (BMv2), `ebpf_model.p4`, `ubpf_model.p4`, `xdp_model.p4`, `pna.p4`, and `p4include/{bmv2,dpdk,tc}/{pna,psa}.p4`. Tofino uses `backends/tofino/bf-p4c/p4include/tna.p4`.
+
+## Backend Guides
+- See `backends/{bmv2,dpdk,ebpf,graphs,p4fmt,p4test,p4tools,tc,tofino,ubpf}/AGENTS.md` for backend-specific guidance.
+
+## Testing Guidelines
+- Run the full suite with `cmake --build build --target check` (additional `check-*` targets are defined in CMake files when present).
+- Idiomatic filtered runs: `ctest --test-dir build -j<N> --output-on-failure -R <filter>` (use the relevant suite or backend filter).
+- Expected outputs live under `testdata/*_outputs/`; refresh them with `P4TEST_REPLACE=1 cmake --build build --target check`.
+- Pass compiler flags via `P4C_ARGS`, e.g. `P4C_ARGS="-Xp4c=MY_CUSTOM_FLAG" cmake --build build --target check`.
+
+## Commit & Pull Request Guidelines
+- Use DCO sign-off for every commit (`git commit --signoff`).
+- Use a ~50-character summary plus a body explaining why/how and linking issues.
+- Single-commit PRs inherit the message; multi-commit PRs should include a synopsis and be squashed on merge.
+- Code review is required; tests and format/lint must pass.
+- Install hooks to enforce formatting checks: `./tools/install_git_hooks.sh`.

--- a/backends/bmv2/AGENTS.md
+++ b/backends/bmv2/AGENTS.md
@@ -1,0 +1,80 @@
+# Repository Guidelines — bmv2
+
+## Purpose
+The BMv2 backend generates code for the Behavioral Model v2 target and supports P4_14 and P4_16 programs for the `v1model.p4` architecture.
+
+## Key Entry Points
+- `backends/bmv2/README.md`: backend overview, dependencies, and limitations.
+- `backends/bmv2/CMakeLists.txt`: build targets and options.
+- `backends/bmv2/`: compiler implementation and helpers.
+
+## Dependencies
+- BMv2 behavioral model (see `backends/bmv2/README.md`).
+- Python `scapy` for testing.
+
+## Tests & Outputs
+- Test targets are backend-specific; see `backends/bmv2/CMakeLists.txt` and any `*.cmake` files for custom targets.
+- Idiomatic filtered runs: `ctest --test-dir build -j<N> --output-on-failure -R bmv2`.
+- Integration inputs and expected outputs live under `testdata/`.
+
+## Scope & Purpose
+This folder implements the BMv2 backend for the P4C compiler. It produces JSON for the BMv2 behavioral model and builds three target-specific compiler binaries:
+- `p4c-bm2-ss` for `simple_switch` (v1model).
+- `p4c-bm2-psa` for PSA.
+- `p4c-bm2-pna` for PNA NIC.
+
+## Directory Layout
+Top-level folders and what they own:
+- `common/`: shared backend helpers (JSON object model, extern handling, parser/deparser lowering, control flow graph, etc.).
+- `simple_switch/`: v1model backend (Simple Switch) entrypoints and midend/backend glue.
+- `psa_switch/`: PSA backend entrypoints and midend/backend glue.
+- `pna_nic/`: PNA NIC backend entrypoints and midend/backend glue.
+- `portable_common/`: common pieces shared by PSA/PNA (portable options, midend, helpers).
+
+Top-level files and scripts:
+- `CMakeLists.txt`: build + test wiring for all BMv2 targets, including test suites and XFAIL lists.
+- `README.md`: backend overview and unsupported language features.
+- `bmv2.def`: IR op definitions specific to BMv2 (e.g., IntMod operation).
+- `run-bmv2-test.py`: STF-based test runner.
+- `run-bmv2-ptf-test.py`: PTF-based test runner for gRPC-based simple_switch.
+- `bmv2stf.py`: STF execution driver and grammar handling.
+
+## Key Entry Points
+All three `main.cpp` entrypoints follow the same compilation flow:
+1. Parse options (target-specific options class).
+2. Run frontend (unless loading from JSON).
+3. Serialize P4Runtime info if requested.
+4. Run target midend.
+5. Run target backend to generate BMv2 JSON output.
+
+Where to look for each target:
+- `simple_switch/main.cpp` + `simple_switch/midend.*` + `simple_switch/simpleSwitch.*`
+- `psa_switch/main.cpp` + `psa_switch/midend.*` + `psa_switch/psaSwitch.*`
+- `pna_nic/main.cpp` + `pna_nic/midend.*` + `pna_nic/pnaNic.*` + `pna_nic/pnaProgramStructure.*`
+
+Common options are defined in `common/options.h`. Target-specific options extend these in:
+- `simple_switch/options.h`
+- `psa_switch/options.h`
+- `portable_common/options.h` (shared by PSA/PNA)
+
+## Build & Test Wiring (CMake)
+`CMakeLists.txt`:
+- Builds `bmv2backend` (shared library) and `portable-common` (shared PSA/PNA library).
+- Builds `p4c-bm2-ss`, `p4c-bm2-psa`, and `p4c-bm2-pna`.
+- Adds a `linkbmv2` target to create symlinks expected by legacy test scripts.
+- Defines BMv2 test suites, PSA/PNA variants, PTF suites, and XFAIL lists.
+
+## Test Runners
+- `run-bmv2-test.py`: compiles and executes STF tests; uses `bmv2stf.py` for STF parsing and runtime.
+- `run-bmv2-ptf-test.py`: sets up a namespace environment and runs PTF tests against `simple_switch_grpc`.
+
+## Generated/Derived Artifacts (Gotchas)
+- `parsetab.py` and `parser.out` are PLY-generated from the STF grammar. Do not edit manually.
+- `__pycache__/` contains runtime bytecode and is not source.
+- JSON dump behavior differs subtly between targets; verify the conditions in each `main.cpp` if you rely on `--dump-json` behavior.
+
+## Suggested Reading Order
+1. `README.md` for capabilities/limitations.
+2. `CMakeLists.txt` for build/test wiring.
+3. `common/` for shared backend behavior.
+4. Target-specific folder (`simple_switch/`, `psa_switch/`, `pna_nic/`).

--- a/backends/dpdk/AGENTS.md
+++ b/backends/dpdk/AGENTS.md
@@ -1,0 +1,17 @@
+# Repository Guidelines — dpdk
+
+## Purpose
+This folder contains the dpdk backend implementation and supporting code.
+
+## Key Entry Points
+- `backends/dpdk/`: backend sources and local helpers.
+- `backends/dpdk/CMakeLists.txt`: build targets and options.
+- `backends/dpdk/README.md`: backend-specific usage notes.
+
+## Tests & Outputs
+- Test targets are backend-specific; see `backends/dpdk/CMakeLists.txt` and any `*.cmake` files for custom targets.
+- Idiomatic filtered runs: `ctest --test-dir build -j<N> --output-on-failure -R dpdk`.
+- Integration inputs and expected outputs live under `testdata/`.
+
+## Navigation Tips
+- Start from the backend driver/entrypoint in `backends/dpdk/` and follow includes from there.

--- a/backends/ebpf/AGENTS.md
+++ b/backends/ebpf/AGENTS.md
@@ -1,0 +1,17 @@
+# Repository Guidelines — ebpf
+
+## Purpose
+This folder contains the ebpf backend implementation and supporting code.
+
+## Key Entry Points
+- `backends/ebpf/`: backend sources and local helpers.
+- `backends/ebpf/CMakeLists.txt`: build targets and options.
+- `backends/ebpf/README.md`: backend-specific usage notes.
+
+## Tests & Outputs
+- Test targets are backend-specific; see `backends/ebpf/CMakeLists.txt` and any `*.cmake` files for custom targets.
+- Idiomatic filtered runs: `ctest --test-dir build -j<N> --output-on-failure -R ebpf`.
+- Integration inputs and expected outputs live under `testdata/`.
+
+## Navigation Tips
+- Start from the backend driver/entrypoint in `backends/ebpf/` and follow includes from there.

--- a/backends/graphs/AGENTS.md
+++ b/backends/graphs/AGENTS.md
@@ -1,0 +1,17 @@
+# Repository Guidelines — graphs
+
+## Purpose
+This folder contains the graphs backend implementation and supporting code.
+
+## Key Entry Points
+- `backends/graphs/`: backend sources and local helpers.
+- `backends/graphs/CMakeLists.txt`: build targets and options.
+- `backends/graphs/README.md`: backend-specific usage notes.
+
+## Tests & Outputs
+- Test targets are backend-specific; see `backends/graphs/CMakeLists.txt` and any `*.cmake` files for custom targets.
+- Idiomatic filtered runs: `ctest --test-dir build -j<N> --output-on-failure -R graphs`.
+- Integration inputs and expected outputs live under `testdata/`.
+
+## Navigation Tips
+- Start from the backend driver/entrypoint in `backends/graphs/` and follow includes from there.

--- a/backends/p4fmt/AGENTS.md
+++ b/backends/p4fmt/AGENTS.md
@@ -1,0 +1,17 @@
+# Repository Guidelines — p4fmt
+
+## Purpose
+This folder contains the p4fmt backend implementation and supporting code.
+
+## Key Entry Points
+- `backends/p4fmt/`: backend sources and local helpers.
+- `backends/p4fmt/CMakeLists.txt`: build targets and options.
+- `backends/p4fmt/README.md`: backend-specific usage notes.
+
+## Tests & Outputs
+- Test targets are backend-specific; see `backends/p4fmt/CMakeLists.txt` and any `*.cmake` files for custom targets.
+- Idiomatic filtered runs: `ctest --test-dir build -j<N> --output-on-failure -R p4fmt`.
+- Integration inputs and expected outputs live under `testdata/`.
+
+## Navigation Tips
+- Start from the backend driver/entrypoint in `backends/p4fmt/` and follow includes from there.

--- a/backends/p4test/AGENTS.md
+++ b/backends/p4test/AGENTS.md
@@ -1,0 +1,18 @@
+# Repository Guidelines — p4test
+
+## Purpose
+`p4test` is a backend-agnostic testing tool that exercises the P4 compiler front-end and mid-end. It underpins many test cases in the top-level `tests/` directory.
+
+## Key Entry Points
+- `backends/p4test/README.md`: usage and intent.
+- `backends/p4test/CMakeLists.txt`: build targets and test variants.
+- `backends/p4test/`: implementation and supporting passes.
+
+## Tests & Variants
+- Variants and drivers are defined in `backends/p4test/CMakeLists.txt`.
+- Idiomatic filtered runs: `ctest --test-dir build -j<N> --output-on-failure -R p4test`.
+- The top-level `tests/` directory references `p4test` for many suites.
+- Integration inputs and expected outputs live under `testdata/`.
+
+## Navigation Tips
+- Start in `backends/p4test/` and follow variant setup in `CMakeLists.txt` to see how tests are wired.

--- a/backends/p4tools/AGENTS.md
+++ b/backends/p4tools/AGENTS.md
@@ -1,0 +1,82 @@
+# Repository Guidelines — p4tools
+
+## Purpose
+P4Tools is the P4C subproject that bundles tooling for testing and fuzzing P4 programs. It ships two main tools:
+- **P4Testgen**: symbolic-execution-based input/output test generation.
+- **P4Smith**: random valid P4 program generation.
+
+## Folder Map (Root)
+`backends/p4tools/` contains:
+- `cmake/`: CMake helper modules for building P4Tools and its tests.
+- `common/`: shared C++ infrastructure used by all tools.
+  - `compiler/`: P4 compiler passes and midend helpers.
+  - `control_plane/`: control-plane modeling utilities.
+  - `core/`: core abstractions (targets, Z3 solver, execution state).
+  - `lib/`: reusable data structures and utilities.
+- `modules/`: tool implementations and their targets.
+  - `testgen/`: P4Testgen implementation.
+  - `smith/`: P4Smith implementation.
+- `p4tools.def`: IR extensions used by P4Tools.
+- `CMakeLists.txt`: top-level CMake wiring and module discovery.
+- `BUILD.bazel`: Bazel build rules (limited scope).
+
+## Core Concepts
+- **IR Extensions**: `p4tools.def` adds custom IR nodes such as `StateVariable`,
+  `TaintExpression`, `Extracted_Varbits`, and `ConcolicVariable`. These are
+  compiled into the P4C IR via `IR_DEF_FILES`.
+- **Shared Infrastructure**: `common/` hosts libraries, solver bindings, and
+  compiler helpers used by both tools.
+- **Modular Targets**: Both P4Testgen and P4Smith are extensible via target
+  subdirectories under `modules/*/targets/`, each providing a `register.h`.
+
+## Build System (CMake)
+Top-level CMake behavior:
+- `CMakeLists.txt` auto-discovers tool modules under `modules/*`.
+- Each module gets a toggle `ENABLE_TOOLS_MODULE_<NAME>`.
+- Each tool discovers targets under `modules/<tool>/targets/*` and creates
+  `ENABLE_TOOLS_TARGET_<TARGET>` toggles.
+- `common/CMakeLists.txt` fetches Z3 via `cmake/Z3.cmake` and exports it with the
+  `p4tools-common` library.
+
+P4Testgen specifics:
+- `modules/testgen/CMakeLists.txt` fetches `inja` and wires `p4testgen`.
+- `linkp4testgen` creates symlinks for the binary and `p4include`.
+- Optional gtests are built as `testgen-gtest` when `ENABLE_GTESTS=ON`.
+
+P4Smith specifics:
+- `modules/smith/CMakeLists.txt` wires `p4smith` and generates `version.h`.
+
+Build enablement:
+- Configure the parent P4C build with `-DENABLE_TEST_TOOLS=ON`.
+- Z3 is required; supported versions are constrained (see `README.md`).
+
+## Build System (Bazel)
+`BUILD.bazel` provides a limited Bazel build:
+- Only `p4testgen` is wired by default.
+- `TESTGEN_TARGETS` currently includes only `bmv2`.
+- Target registration is generated into `modules/testgen/register.h` via a
+  Bazel `genrule`.
+If you add a new Testgen target and need Bazel support, extend `TESTGEN_TARGETS`
+and the corresponding `filegroup`/`genrule`.
+
+## Extension Points
+To add a new target:
+1. Create `modules/testgen/targets/<name>/` or `modules/smith/targets/<name>/`.
+2. Provide a `CMakeLists.txt` and a `register.h`.
+3. Ensure the target registers itself in the generated `register.h`.
+4. If Bazel support is required, add it to `BUILD.bazel` (`TESTGEN_TARGETS`).
+
+## Tests & Benchmarks
+- `testgen-gtest` is built when `ENABLE_GTESTS=ON`.
+- Idiomatic filtered runs:
+  `ctest --test-dir build -j<N> --output-on-failure -R testgen`
+  `ctest --test-dir build -j<N> --output-on-failure -R smith`
+- CTest labels are defined per target under `modules/testgen/targets/*`.
+- Benchmarks and plotting scripts live in `modules/testgen/benchmarks/`.
+
+## Key Entry Points
+- `README.md`: overview, dependencies, and layout.
+- `modules/testgen/README.md`: P4Testgen usage, extensions, and limitations.
+- `modules/smith/README.md`: P4Smith usage and extension notes.
+- `CMakeLists.txt`: module/target discovery and build wiring.
+- `p4tools.def`: IR extensions used across tools.

--- a/backends/tc/AGENTS.md
+++ b/backends/tc/AGENTS.md
@@ -1,0 +1,17 @@
+# Repository Guidelines — tc
+
+## Purpose
+This folder contains the tc backend implementation and supporting code.
+
+## Key Entry Points
+- `backends/tc/`: backend sources and local helpers.
+- `backends/tc/CMakeLists.txt`: build targets and options.
+- `backends/tc/README.md`: backend-specific usage notes.
+
+## Tests & Outputs
+- Test targets are backend-specific; see `backends/tc/CMakeLists.txt` and any `*.cmake` files for custom targets.
+- Idiomatic filtered runs: `ctest --test-dir build -j<N> --output-on-failure -R tc`.
+- Integration inputs and expected outputs live under `testdata/`.
+
+## Navigation Tips
+- Start from the backend driver/entrypoint in `backends/tc/` and follow includes from there.

--- a/backends/tofino/AGENTS.md
+++ b/backends/tofino/AGENTS.md
@@ -1,0 +1,25 @@
+# Repository Guidelines — tofino
+
+## Purpose
+The Tofino backend targets the Tofino 1/2 chip family. It transforms frontend P4 IR into a Tofino-specific pipeline IR and performs resource allocation for the target architecture.
+
+## Key Entry Points
+- `backends/tofino/bf-p4c/README.md`: design overview, dependencies, and terminology.
+- `backends/tofino/CMakeLists.txt`: build targets and options.
+- `backends/tofino/bf-p4c/`: main compiler logic.
+- `backends/tofino/bf-p4c/parde/`, `mau/`, `phv/`: parser/deparser, match-action, and PHV allocation subsystems.
+
+## Architecture Notes
+- Mid-end transforms frontend IR into a Tofino pipeline IR rooted at `IR::BFN::Pipe`.
+- Backend focuses on resource allocation and architecture-specific scheduling across parser/deparser and MAU stages.
+
+## Dependencies (Tests)
+- Tests rely on the Tofino assembler and model; see `backends/tofino/bf-p4c/README.md` for setup and required versions.
+
+## Tests & Outputs
+- Test targets are backend-specific; see `backends/tofino/` CMake files and `bf-p4c/` CMake/CMakelists for custom targets.
+- Idiomatic filtered runs: `ctest --test-dir build -j<N> --output-on-failure -R tofino`.
+- Integration inputs and expected outputs live under `testdata/`.
+
+## Navigation Tips
+- Start in `bf-p4c/` and follow the pipeline IR (`IR::BFN::*`) and subsystem directories (`parde/`, `mau/`, `phv/`).

--- a/backends/ubpf/AGENTS.md
+++ b/backends/ubpf/AGENTS.md
@@ -1,0 +1,17 @@
+# Repository Guidelines — ubpf
+
+## Purpose
+This folder contains the ubpf backend implementation and supporting code.
+
+## Key Entry Points
+- `backends/ubpf/`: backend sources and local helpers.
+- `backends/ubpf/CMakeLists.txt`: build targets and options.
+- `backends/ubpf/README.md`: backend-specific usage notes.
+
+## Tests & Outputs
+- Test targets are backend-specific; see `backends/ubpf/CMakeLists.txt` and any `*.cmake` files for custom targets.
+- Idiomatic filtered runs: `ctest --test-dir build -j<N> --output-on-failure -R ubpf`.
+- Integration inputs and expected outputs live under `testdata/`.
+
+## Navigation Tips
+- Start from the backend driver/entrypoint in `backends/ubpf/` and follow includes from there.


### PR DESCRIPTION
This is something I have been thinking about. We should start adding AGENTS.md files to P4C to help guide agents in understanding our complex code base. There are several benefits here. 

1) We encode some of the domain-specific knowledge per back end. We rely on this as P4C developers anyway---and there is a lot of it in this codebase. Writing it down can help newcomers as well. 
2) When someone uses AI tools to solve a task, these tools can use the files to actually do productive contributions. My hope is that this can help in improving the quality of the AI PRs we are getting. 
3) We ourselves might use AI tools, and this can also help us make sure these tools do the right thing. I have been personally using AGENTS.md and skills a lot for my own work. Once you get them right they are very effective. 

What do you think? This is an early draft but we can grow these files as needed while developing. 

@asl @kfcripps @ChrisDodd @smolkaj @jafingerhut @qobilidop @vbnogueira 