### PR TITLE
Return unique_ptr from openFile for clear ownership semantics

### DIFF
--- a/backends/bmv2/pna_nic/main.cpp
+++ b/backends/bmv2/pna_nic/main.cpp
@@ -101,8 +101,10 @@ int main(int argc, char *const argv[]) {
         toplevel = midEnd.process(program);
         if (::P4::errorCount() > 1 || toplevel == nullptr || toplevel->getMain() == nullptr)
             return 1;
-        if (options.dumpJsonFile.empty())
-            JSONGenerator(*openFile(options.dumpJsonFile, true), true).emit(program);
+        if (options.dumpJsonFile.empty()) {
+            auto dumpJsonStream = openFile(options.dumpJsonFile, true);
+            JSONGenerator(*dumpJsonStream, true).emit(program);
+        }
     } catch (const std::exception &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;
@@ -123,8 +125,7 @@ int main(int argc, char *const argv[]) {
     if (::P4::errorCount() > 0) return 1;
 
     if (!options.outputFile.empty()) {
-        std::ostream *out = openFile(options.outputFile, false);
-        if (out != nullptr) {
+        if (auto out = openFile(options.outputFile, false)) {
             backend->serialize(*out);
             out->flush();
         }

--- a/backends/bmv2/psa_switch/main.cpp
+++ b/backends/bmv2/psa_switch/main.cpp
@@ -101,8 +101,10 @@ int main(int argc, char *const argv[]) {
         toplevel = midEnd.process(program);
         if (::P4::errorCount() > 1 || toplevel == nullptr || toplevel->getMain() == nullptr)
             return 1;
-        if (!options.dumpJsonFile.empty())
-            JSONGenerator(*openFile(options.dumpJsonFile, true), true).emit(program);
+        if (!options.dumpJsonFile.empty()) {
+            auto dumpJsonStream = openFile(options.dumpJsonFile, true);
+            JSONGenerator(*dumpJsonStream, true).emit(program);
+        }
     } catch (const std::exception &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;
@@ -123,8 +125,7 @@ int main(int argc, char *const argv[]) {
     if (::P4::errorCount() > 0) return 1;
 
     if (!options.outputFile.empty()) {
-        std::ostream *out = openFile(options.outputFile, false);
-        if (out != nullptr) {
+        if (auto out = openFile(options.outputFile, false)) {
             backend->serialize(*out);
             out->flush();
         }

--- a/backends/bmv2/simple_switch/main.cpp
+++ b/backends/bmv2/simple_switch/main.cpp
@@ -104,8 +104,10 @@ int main(int argc, char *const argv[]) {
         toplevel = midEnd.process(program);
         if (::P4::errorCount() > 1 || toplevel == nullptr || toplevel->getMain() == nullptr)
             return 1;
-        if (!options.dumpJsonFile.empty() && !options.loadIRFromJson)
-            JSONGenerator(*openFile(options.dumpJsonFile, true), true).emit(program);
+        if (!options.dumpJsonFile.empty() && !options.loadIRFromJson) {
+            auto dumpJsonStream = openFile(options.dumpJsonFile, true);
+            JSONGenerator(*dumpJsonStream, true).emit(program);
+        }
     } catch (const std::exception &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;
@@ -126,8 +128,7 @@ int main(int argc, char *const argv[]) {
     if (::P4::errorCount() > 0) return 1;
 
     if (!options.outputFile.empty()) {
-        std::ostream *out = openFile(options.outputFile, false);
-        if (out != nullptr) {
+        if (auto out = openFile(options.outputFile, false)) {
             backend->serialize(*out);
             out->flush();
         }

--- a/backends/dpdk/backend.cpp
+++ b/backends/dpdk/backend.cpp
@@ -116,8 +116,8 @@ void DpdkBackend::convert(const IR::ToplevelBlock *tlb) {
         new VisitFunctor([this, genContextJson] {
             // Serialize context json object into user specified file
             if (!options.ctxtFile.empty()) {
-                if (std::ostream *out = openFile(options.ctxtFile, false)) {
-                    genContextJson->serializeContextJson(out);
+                if (auto out = openFile(options.ctxtFile, false)) {
+                    genContextJson->serializeContextJson(out.get());
                     out->flush();
                 } else
                     ::P4::error(ErrorType::ERR_IO, "Could not open file: %1%", options.ctxtFile);

--- a/backends/ebpf/ebpfBackend.cpp
+++ b/backends/ebpf/ebpfBackend.cpp
@@ -38,12 +38,12 @@ void emitFilterModel(const EbpfOptions &options, Target *target, const IR::Tople
 
     if (options.outputFile.empty()) return;
 
-    auto *cstream = openFile(options.outputFile, false);
+    auto cstream = openFile(options.outputFile, false);
     if (cstream == nullptr) return;
 
     std::filesystem::path hfile = options.outputFile;
     hfile.replace_extension(".h");
-    auto *hstream = openFile(hfile, false);
+    auto hstream = openFile(hfile, false);
     if (hstream == nullptr) return;
 
     ebpfprog->emitH(&h, hfile);
@@ -94,11 +94,10 @@ void run_ebpf_backend(const EbpfOptions &options, const IR::ToplevelBlock *tople
 
         if (options.outputFile.empty()) return;
 
-        auto cstream = openFile(options.outputFile, false);
-        if (cstream == nullptr) return;
-
-        backend->codegen(*cstream);
-        cstream->flush();
+        if (auto cstream = openFile(options.outputFile, false)) {
+            backend->codegen(*cstream);
+            cstream->flush();
+        }
     } else {
         ::P4::error(ErrorType::ERR_UNKNOWN,
                     "Unknown architecture %s; legal choices are 'filter', and 'psa'", options.arch);

--- a/backends/ebpf/p4c-ebpf.cpp
+++ b/backends/ebpf/p4c-ebpf.cpp
@@ -83,8 +83,10 @@ void compile(EbpfOptions &options) {
     EBPF::MidEnd midend;
     midend.addDebugHook(hook);
     auto toplevel = midend.run(options, program);
-    if (!options.dumpJsonFile.empty())
-        JSONGenerator(*openFile(options.dumpJsonFile, true)).emit(program);
+    if (!options.dumpJsonFile.empty()) {
+        auto dumpJsonStream = openFile(options.dumpJsonFile, true);
+        JSONGenerator(*dumpJsonStream).emit(program);
+    }
     if (::P4::errorCount() > 0) return;
 
     EBPF::run_ebpf_backend(options, toplevel, &midend.refMap, &midend.typeMap);

--- a/backends/graphs/graph_visitor.cpp
+++ b/backends/graphs/graph_visitor.cpp
@@ -23,14 +23,13 @@ namespace P4::graphs {
 
 void Graph_visitor::writeGraphToFile(const Graph &g, const std::string &name) {
     auto path = graphsDir / (name + ".dot");
-    auto out = openFile(path, false);
-    if (out == nullptr) {
+    if (auto out = openFile(path, false)) {
+        // Custom label writers not supported with subgraphs, so we populate
+        // *_attribute_t properties instead using our GraphAttributeSetter class.
+        boost::write_graphviz(*out, g);
+    } else {
         ::P4::error(ErrorType::ERR_IO, "Failed to open file %1%", path);
-        return;
     }
-    // Custom label writers not supported with subgraphs, so we populate
-    // *_attribute_t properties instead using our GraphAttributeSetter class.
-    boost::write_graphviz(*out, g);
 }
 
 const char *Graph_visitor::getType(const VertexType &v_type) {

--- a/backends/graphs/p4c-graphs.cpp
+++ b/backends/graphs/p4c-graphs.cpp
@@ -180,8 +180,10 @@ int main(int argc, char *const argv[]) {
     const IR::ToplevelBlock *top = nullptr;
     try {
         top = midEnd.process(program);
-        if (!options.dumpJsonFile.empty())
-            JSONGenerator(*openFile(options.dumpJsonFile, true)).emit(program);
+        if (!options.dumpJsonFile.empty()) {
+            auto dumpJsonStream = openFile(options.dumpJsonFile, true);
+            JSONGenerator(*dumpJsonStream).emit(program);
+        }
     } catch (const std::exception &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;

--- a/backends/p4fmt/main.cpp
+++ b/backends/p4fmt/main.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <filesystem>
+#include <memory>
 #include <sstream>
 
 #include "lib/nullstream.h"
@@ -22,17 +23,19 @@ int main(int argc, char *const argv[]) {
     };
 
     std::ostream *out = nullptr;
+    std::unique_ptr<std::ostream> outFile;
     // Write to stdout in absence of an output file.
     if (options.outputFile().empty()) {
         out = &std::cout;
     } else {
-        out = openFile(options.outputFile(), false);
-        if ((out == nullptr) || !(*out)) {
+        outFile = openFile(options.outputFile(), false);
+        if ((outFile == nullptr) || !(*outFile)) {
             ::P4::error(ErrorType::ERR_NOT_FOUND, "%2%: No such file or directory.",
                         options.outputFile().string());
             options.usage();
             return EXIT_FAILURE;
         }
+        out = outFile.get();
     }
 
     (*out) << formattedOutput.str();

--- a/backends/p4test/p4test.cpp
+++ b/backends/p4test/p4test.cpp
@@ -223,8 +223,10 @@ int main(int argc, char *const argv[]) {
             }
         }
         if (program) {
-            if (!options.dumpJsonFile.empty())
-                JSONGenerator(*openFile(options.dumpJsonFile, true), true).emit(program);
+            if (!options.dumpJsonFile.empty()) {
+                auto dumpJsonStream = openFile(options.dumpJsonFile, true);
+                JSONGenerator(*dumpJsonStream, true).emit(program);
+            }
             if (options.debugJson) {
                 std::stringstream ss1, ss2;
                 JSONGenerator gen1(ss1), gen2(ss2);

--- a/backends/p4tools/modules/smith/smith.cpp
+++ b/backends/p4tools/modules/smith/smith.cpp
@@ -65,7 +65,7 @@ int Smith::mainImpl(const CompilerResult & /*result*/) {
     if (outputFile.empty()) {
         outputFile = "out.p4";
     }
-    auto *ostream = openFile(outputFile, false);
+    auto ostream = openFile(outputFile, false);
     if (ostream == nullptr) {
         error("must have [file]");
         exit(EXIT_FAILURE);
@@ -83,13 +83,13 @@ int Smith::mainImpl(const CompilerResult & /*result*/) {
     printInfo("============ Program seed %1% =============\n", *smithOptions.seed);
     const auto &smithTarget = SmithTarget::get();
 
-    auto result = smithTarget.writeTargetPreamble(ostream);
+    auto result = smithTarget.writeTargetPreamble(ostream.get());
     if (result != EXIT_SUCCESS) {
         return result;
     }
     const auto *generatedProgram = smithTarget.generateP4Program();
     // Use ToP4 to write the P4 program to the specified stream.
-    P4::ToP4 top4(ostream, false);
+    P4::ToP4 top4(ostream.get(), false);
     generatedProgram->apply(top4);
     ostream->flush();
     P4Scope::endLocalScope();

--- a/backends/tc/backend.cpp
+++ b/backends/tc/backend.cpp
@@ -1933,8 +1933,7 @@ void Backend::serialize() const {
     }
     std::filesystem::path outputFile = options.outputFolder / (progName + ".template");
 
-    auto outstream = openFile(outputFile, false);
-    if (outstream != nullptr) {
+    if (auto outstream = openFile(outputFile, false)) {
         *outstream << pipeline->toString();
         outstream->flush();
         std::filesystem::permissions(outputFile.c_str(),

--- a/backends/tc/tc.cpp
+++ b/backends/tc/tc.cpp
@@ -82,8 +82,10 @@ int main(int argc, char *const argv[]) {
             ::P4::error("Cannot process input file. Program does not contain a 'main' module");
             return 1;
         }
-        if (!options.dumpJsonFile.empty())
-            JSONGenerator(*openFile(options.dumpJsonFile, true)).emit(toplevel);
+        if (!options.dumpJsonFile.empty()) {
+            auto dumpJsonStream = openFile(options.dumpJsonFile, true);
+            JSONGenerator(*dumpJsonStream).emit(toplevel);
+        }
     } catch (const Util::P4CExceptionBase &bug) {
         std::cerr << bug.what() << std::endl;
         return 1;
@@ -95,8 +97,7 @@ int main(int argc, char *const argv[]) {
     if (!backend.process()) return 1;
     std::string progName = backend.tcIR->getPipelineName().string();
     std::string introspecFile = options.outputFolder / (progName + ".json");
-    std::ostream *outIntro = openFile(introspecFile, false);
-    if (outIntro != nullptr) {
+    if (auto outIntro = openFile(introspecFile, false)) {
         bool serialized = backend.serializeIntrospectionJson(*outIntro);
         if (!serialized) {
             std::remove(introspecFile.c_str());

--- a/backends/tofino/bf-p4c/p4c-barefoot.cpp
+++ b/backends/tofino/bf-p4c/p4c-barefoot.cpp
@@ -477,7 +477,8 @@ int main(int ac, char **av) {
                     : std::filesystem::path(BFNContext::get().getOutputDirectory() +
                                             "/frontend-ir.json");
             // Print out the IR for p4i after frontend (--toJson "-" signifies stdout)
-            auto &irFile = irFilePath != "-" ? *openFile(irFilePath, false) : std::cout;
+            auto irFileStream = irFilePath != "-" ? openFile(irFilePath, false) : nullptr;
+            auto &irFile = irFileStream ? *irFileStream : std::cout;
             LOG3("IR dump after frontend to " << irFilePath);
             JSONGenerator(irFile, true).emit(program);
         }

--- a/backends/ubpf/ubpfBackend.cpp
+++ b/backends/ubpf/ubpfBackend.cpp
@@ -54,13 +54,13 @@ void run_ubpf_backend(const EbpfOptions &options, const IR::ToplevelBlock *tople
 
     if (options.outputFile.empty()) return;
 
-    auto *cstream = openFile(options.outputFile, false);
+    auto cstream = openFile(options.outputFile, false);
     if (cstream == nullptr) return;
 
     std::filesystem::path hfile = options.outputFile;
     hfile.replace_extension(".h");
 
-    auto *hstream = openFile(hfile, false);
+    auto hstream = openFile(hfile, false);
     if (hstream == nullptr) return;
 
     UbpfCodeBuilder c(target);

--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1614,12 +1614,11 @@ void P4RuntimeSerializer::serializeP4RuntimeIfRequired(const P4RuntimeAPI &p4Run
         for (unsigned i = 0; i < files.size(); i++) {
             cstring file = files.at(i);
             P4::P4RuntimeFormat format = formats.at(i);
-            std::ostream *out = openFile(file.string(), false);
-            if (!out) {
+            if (auto out = openFile(file.string(), false)) {
+                p4Runtime.serializeP4InfoTo(out.get(), format);
+            } else {
                 ::P4::error(ErrorType::ERR_IO, "Couldn't open P4Runtime API file: %1%", file);
-                continue;
             }
-            p4Runtime.serializeP4InfoTo(out, format);
         }
     }
 
@@ -1636,13 +1635,12 @@ void P4RuntimeSerializer::serializeP4RuntimeIfRequired(const P4RuntimeAPI &p4Run
         for (unsigned i = 0; i < files.size(); i++) {
             cstring file = files.at(i);
             P4::P4RuntimeFormat format = formats.at(i);
-            std::ostream *out = openFile(file.string(), false);
-            if (!out) {
+            if (auto out = openFile(file.string(), false)) {
+                p4Runtime.serializeEntriesTo(out.get(), format);
+            } else {
                 ::P4::error(ErrorType::ERR_IO, "Couldn't open P4Runtime static entries file: %1%",
                             options.p4RuntimeEntriesFile);
-                continue;
             }
-            p4Runtime.serializeEntriesTo(out, format);
         }
     }
 }

--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -105,8 +105,8 @@ class PrettyPrint : public Inspector {
     }
     bool preorder(const IR::P4Program *program) override {
         if (!ppfile.empty()) {
-            std::ostream *ppStream = openFile(ppfile, true);
-            P4::ToP4 top4(ppStream, false, inputfile);
+            auto ppStream = openFile(ppfile, true);
+            P4::ToP4 top4(ppStream.get(), false, inputfile);
             (void)program->apply(top4);
         }
         return false;  // prune

--- a/lib/nullstream.cpp
+++ b/lib/nullstream.cpp
@@ -22,17 +22,17 @@ limitations under the License.
 
 namespace P4 {
 
-std::ostream *openFile(const std::filesystem::path &name, bool nullOnError) {
+std::unique_ptr<std::ostream> openFile(const std::filesystem::path &name, bool nullOnError) {
     if (name.empty()) {
-        if (nullOnError) return new nullstream();
+        if (nullOnError) return std::make_unique<nullstream>();
         ::P4::error(ErrorType::ERR_INVALID, "Empty name for openFile");
         return nullptr;
     }
-    std::ofstream *file = new std::ofstream(name);
+    auto file = std::make_unique<std::ofstream>(name);
     if (!file->good()) {
         ::P4::error(ErrorType::ERR_IO, "Error writing output to file %1%: %2%", name,
                     strerror(errno));
-        if (nullOnError) return new nullstream();
+        if (nullOnError) return std::make_unique<nullstream>();
         return nullptr;
     }
     return file;

--- a/lib/nullstream.h
+++ b/lib/nullstream.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <filesystem>
 #include <iostream>
+#include <memory>
 #include <ostream>
 #include <streambuf>
 
@@ -46,8 +47,7 @@ typedef onullstream<char> nullstream;
 
 // If nullOnError is 'true', on error a nullstream is returned
 // otherwise a nullptr is returned
-// FIXME: This should return unique_ptr instead to track lifetime
-std::ostream *openFile(const std::filesystem::path &name, bool nullOnError);
+std::unique_ptr<std::ostream> openFile(const std::filesystem::path &name, bool nullOnError);
 
 }  // namespace P4
 

--- a/tools/ir-generator/generator.cpp
+++ b/tools/ir-generator/generator.cpp
@@ -41,9 +41,9 @@ void usage(const char *progname) {
 }
 
 int main(int argc, char *argv[]) {
-    std::ostream *t = new nullstream();
-    std::ostream *header = new nullstream();
-    std::ostream *impl = new nullstream();
+    std::unique_ptr<std::ostream> t = std::make_unique<nullstream>();
+    std::unique_ptr<std::ostream> header = std::make_unique<nullstream>();
+    std::unique_ptr<std::ostream> impl = std::make_unique<nullstream>();
 
     while (true) {
         int opt = getopt(argc, argv, "o:i:t:hP");


### PR DESCRIPTION
openFile() previously returned a raw std::ostream*, transferring ownership without clear semantics. Analysis showed none of the ~26 call sites ever deleted this pointer, causing consistent memory leaks. This PR changes the return type to std::unique_ptr<std::ostream> (per the existing FIXME), enforcing RAII and ensuring streams are automatically closed when they go out of scope.