### PR TITLE
Remove non-working non-standard typeRef from forCollectionExpr

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -1467,7 +1467,6 @@ forUpdateStatementsNonEmpty
 forCollectionExpr
     : expression                        { $$ = $1; }
     | expression ".." expression        { $$ = new IR::Range(@1 + @3, $1, $3); }
-    | typeRef                           { $$ = new IR::ConstructorCallExpression(@1, $1, {}); }
     ;
 
 /************************* TABLE *********************************/


### PR DESCRIPTION
I don't entirely remember what we were trying to do with this production allowing `for`..`in` loops over a typeref, but whatever it was, it never made it into the P4 language spec.  So removing this avoids the crash seen in #5435 and #5481