### PR TITLE
[P4Smith] Remove for-in-loop variable initializer

### DIFF
--- a/backends/p4tools/modules/smith/common/statements.cpp
+++ b/backends/p4tools/modules/smith/common/statements.cpp
@@ -444,8 +444,7 @@ IR::ForInStatement *StatementGenerator::genForInLoopStatement(bool is_in_func) {
     big_int upperBound = IR::getMaxBvVal(bitFieldWidth);
 
     // Create the IR nodes for the for-in-loop component expressions.
-    auto declVar =
-        new IR::Declaration_Variable(IR::ID(loopVar), varType);
+    auto declVar = new IR::Declaration_Variable(IR::ID(loopVar), varType);
     auto collectionExpr =
         new IR::Range(new IR::Constant(varType, lowerBound), new IR::Constant(varType, upperBound));
     auto *bodyStmt = genBlockStatement(is_in_func);


### PR DESCRIPTION
P4Smith was initializing the loop variable of for-in loops within the variable's declaration, which doesn't make sense (because it should loop over the collection expression) and doesn't match the parser rule.