### PR TITLE
Make ErrorType constants constexpr

### DIFF
--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -25,62 +25,6 @@ namespace P4 {
 
 using namespace P4::literals;
 
-// -------- Errors -------------
-const int ErrorType::LEGACY_ERROR = 0;
-const int ErrorType::ERR_UNKNOWN = 1;
-const int ErrorType::ERR_UNSUPPORTED = 2;
-const int ErrorType::ERR_UNEXPECTED = 3;
-const int ErrorType::ERR_UNINITIALIZED = 4;
-const int ErrorType::ERR_EXPECTED = 5;
-const int ErrorType::ERR_NOT_FOUND = 6;
-const int ErrorType::ERR_INVALID = 7;
-const int ErrorType::ERR_EXPRESSION = 8;
-const int ErrorType::ERR_OVERLIMIT = 9;
-const int ErrorType::ERR_INSUFFICIENT = 10;
-const int ErrorType::ERR_TYPE_ERROR = 11;
-const int ErrorType::ERR_UNSUPPORTED_ON_TARGET = 12;
-const int ErrorType::ERR_DUPLICATE = 13;
-const int ErrorType::ERR_IO = 14;
-const int ErrorType::ERR_UNREACHABLE = 15;
-const int ErrorType::ERR_MODEL = 16;
-const int ErrorType::ERR_TABLE_KEYS = 17;
-const int ErrorType::ERR_RESERVED = 18;
-
-// ------ Warnings -----------
-const int ErrorType::LEGACY_WARNING = ERR_MAX + 1;
-const int ErrorType::WARN_FAILED = 1001;
-const int ErrorType::WARN_UNKNOWN = 1002;
-const int ErrorType::WARN_INVALID = 1003;
-const int ErrorType::WARN_UNSUPPORTED = 1004;
-const int ErrorType::WARN_DEPRECATED = 1005;
-const int ErrorType::WARN_UNINITIALIZED = 1006;
-const int ErrorType::WARN_UNUSED = 1007;
-const int ErrorType::WARN_MISSING = 1008;
-const int ErrorType::WARN_ORDERING = 1009;
-const int ErrorType::WARN_MISMATCH = 1010;
-const int ErrorType::WARN_OVERFLOW = 1011;
-const int ErrorType::WARN_IGNORE_PROPERTY = 1012;
-const int ErrorType::WARN_TYPE_INFERENCE = 1013;
-const int ErrorType::WARN_PARSER_TRANSITION = 1014;
-const int ErrorType::WARN_UNREACHABLE = 1015;
-const int ErrorType::WARN_SHADOWING = 1016;
-const int ErrorType::WARN_IGNORE = 1017;
-const int ErrorType::WARN_UNINITIALIZED_OUT_PARAM = 1018;
-const int ErrorType::WARN_UNINITIALIZED_USE = 1019;
-const int ErrorType::WARN_INVALID_HEADER = 1020;
-const int ErrorType::WARN_DUPLICATE_PRIORITIES = 1021;
-const int ErrorType::WARN_ENTRIES_OUT_OF_ORDER = 1022;
-const int ErrorType::WARN_MULTI_HDR_EXTRACT = 1023;
-const int ErrorType::WARN_EXPRESSION = 1024;
-const int ErrorType::WARN_DUPLICATE = 1025;
-const int ErrorType::WARN_BRANCH_HINT = 1026;
-const int ErrorType::WARN_TABLE_KEYS = 1027;
-
-// ------ Info messages -----------
-const int ErrorType::INFO_INFERRED = WARN_MAX + 1;
-const int ErrorType::INFO_PROGRESS = 2143;
-const int ErrorType::INFO_REMOVED = 2144;
-
 // map from errorCode to ErrorSig
 std::map<int, cstring> ErrorCatalog::errorCatalog = {
     // Errors

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -36,73 +36,74 @@ class ErrorType {
  public:
     // -------- Errors -------------
     // errors as initially defined with a format string
-    // FIXME: make these constexpr
-    static const int LEGACY_ERROR;
-    static const int ERR_UNKNOWN;                // unknown construct (in context)
-    static const int ERR_UNSUPPORTED;            // unsupported construct
-    static const int ERR_UNEXPECTED;             // unexpected construct
-    static const int ERR_UNINITIALIZED;          // uninitialized reads/writes
-    static const int ERR_EXPECTED;               // language, compiler expects a different construct
-    static const int ERR_NOT_FOUND;              // A different way to say ERR_EXPECTED
-    static const int ERR_INVALID;                // invalid construct
-    static const int ERR_EXPRESSION;             // expression related errors
-    static const int ERR_OVERLIMIT;              // program node exceeds target limits
-    static const int ERR_INSUFFICIENT;           // program node does not have enough of ...
-    static const int ERR_TYPE_ERROR;             // P4 type checking errors
-    static const int ERR_UNSUPPORTED_ON_TARGET;  // target can not handle construct
-    static const int ERR_DUPLICATE;              // duplicate objects
-    static const int ERR_IO;                     // IO error
-    static const int ERR_UNREACHABLE;            // unreachable code
-    static const int ERR_MODEL;                  // something is wrong with the target model
-    static const int ERR_TABLE_KEYS;             // something is wrong with a table key
-    static const int ERR_RESERVED;               // Reserved for target use
+    static constexpr int LEGACY_ERROR = 0;
+    static constexpr int ERR_UNKNOWN = 1;        // unknown construct (in context)
+    static constexpr int ERR_UNSUPPORTED = 2;    // unsupported construct
+    static constexpr int ERR_UNEXPECTED = 3;     // unexpected construct
+    static constexpr int ERR_UNINITIALIZED = 4;  // uninitialized reads/writes
+    static constexpr int ERR_EXPECTED = 5;       // language, compiler expects a different construct
+    static constexpr int ERR_NOT_FOUND = 6;      // A different way to say ERR_EXPECTED
+    static constexpr int ERR_INVALID = 7;        // invalid construct
+    static constexpr int ERR_EXPRESSION = 8;     // expression related errors
+    static constexpr int ERR_OVERLIMIT = 9;      // program node exceeds target limits
+    static constexpr int ERR_INSUFFICIENT = 10;  // program node does not have enough of ...
+    static constexpr int ERR_TYPE_ERROR = 11;    // P4 type checking errors
+    static constexpr int ERR_UNSUPPORTED_ON_TARGET = 12;  // target can not handle construct
+    static constexpr int ERR_DUPLICATE = 13;              // duplicate objects
+    static constexpr int ERR_IO = 14;                     // IO error
+    static constexpr int ERR_UNREACHABLE = 15;            // unreachable code
+    static constexpr int ERR_MODEL = 16;       // something is wrong with the target model
+    static constexpr int ERR_TABLE_KEYS = 17;  // something is wrong with a table key
+    static constexpr int ERR_RESERVED = 18;    // Reserved for target use
     // Backends should extend this class with additional errors in the range 500-999.
-    static const int ERR_MIN_BACKEND = 500;  // first allowed backend error code
-    static const int ERR_MAX = 999;          // last allowed error code
+    static constexpr int ERR_MIN_BACKEND = 500;  // first allowed backend error code
+    static constexpr int ERR_MAX = 999;          // last allowed error code
 
     // -------- Warnings -----------
     // warnings as initially defined with a format string
-    static const int LEGACY_WARNING;
-    static const int WARN_FAILED;                   // non-fatal failure!
-    static const int WARN_UNKNOWN;                  // unknown construct (in context)
-    static const int WARN_INVALID;                  // invalid construct
-    static const int WARN_UNSUPPORTED;              // unsupported construct
-    static const int WARN_DEPRECATED;               // deprecated feature
-    static const int WARN_UNINITIALIZED;            // unitialized instance
-    static const int WARN_UNINITIALIZED_USE;        // use of uninitialized value
-    static const int WARN_UNINITIALIZED_OUT_PARAM;  // output parameter may be uninitialized
-    static const int WARN_UNUSED;                   // unused instance
-    static const int WARN_MISSING;                  // missing construct
-    static const int WARN_ORDERING;                 // inconsistent statement ordering
-    static const int WARN_MISMATCH;                 // mismatched constructs
-    static const int WARN_OVERFLOW;                 // values do not fit
-    static const int WARN_IGNORE_PROPERTY;          // invalid property for object, ignored
-    static const int WARN_TYPE_INFERENCE;           // type inference can not infer, substitutes
-    static const int WARN_PARSER_TRANSITION;        // parser transition non-fatal issues
-    static const int WARN_UNREACHABLE;              // unreachable code
-    static const int WARN_SHADOWING;                // instance shadowing
-    static const int WARN_IGNORE;                   // simply ignore
-    static const int WARN_INVALID_HEADER;           // access to fields of an invalid header
-    static const int WARN_DUPLICATE_PRIORITIES;     // two entries with the same priority
-    static const int WARN_ENTRIES_OUT_OF_ORDER;     // entries with priorities out of order
-    static const int WARN_MULTI_HDR_EXTRACT;        // same header may be extracted more than once
-    static const int WARN_EXPRESSION;               // expression related warnings
-    static const int WARN_DUPLICATE;                // duplicate objects
-    static const int WARN_BRANCH_HINT;              // branch frequency/likely hints
-    static const int WARN_TABLE_KEYS;               // something is wrong with a table key
+    static constexpr int LEGACY_WARNING = ERR_MAX + 1;
+    static constexpr int WARN_FAILED = 1001;             // non-fatal failure!
+    static constexpr int WARN_UNKNOWN = 1002;            // unknown construct (in context)
+    static constexpr int WARN_INVALID = 1003;            // invalid construct
+    static constexpr int WARN_UNSUPPORTED = 1004;        // unsupported construct
+    static constexpr int WARN_DEPRECATED = 1005;         // deprecated feature
+    static constexpr int WARN_UNINITIALIZED = 1006;      // unitialized instance
+    static constexpr int WARN_UNINITIALIZED_USE = 1019;  // use of uninitialized value
+    static constexpr int WARN_UNINITIALIZED_OUT_PARAM =
+        1018;                                          // output parameter may be uninitialized
+    static constexpr int WARN_UNUSED = 1007;           // unused instance
+    static constexpr int WARN_MISSING = 1008;          // missing construct
+    static constexpr int WARN_ORDERING = 1009;         // inconsistent statement ordering
+    static constexpr int WARN_MISMATCH = 1010;         // mismatched constructs
+    static constexpr int WARN_OVERFLOW = 1011;         // values do not fit
+    static constexpr int WARN_IGNORE_PROPERTY = 1012;  // invalid property for object, ignored
+    static constexpr int WARN_TYPE_INFERENCE = 1013;   // type inference can not infer, substitutes
+    static constexpr int WARN_PARSER_TRANSITION = 1014;     // parser transition non-fatal issues
+    static constexpr int WARN_UNREACHABLE = 1015;           // unreachable code
+    static constexpr int WARN_SHADOWING = 1016;             // instance shadowing
+    static constexpr int WARN_IGNORE = 1017;                // simply ignore
+    static constexpr int WARN_INVALID_HEADER = 1020;        // access to fields of an invalid header
+    static constexpr int WARN_DUPLICATE_PRIORITIES = 1021;  // two entries with the same priority
+    static constexpr int WARN_ENTRIES_OUT_OF_ORDER = 1022;  // entries with priorities out of order
+    static constexpr int WARN_MULTI_HDR_EXTRACT =
+        1023;                                      // same header may be extracted more than once
+    static constexpr int WARN_EXPRESSION = 1024;   // expression related warnings
+    static constexpr int WARN_DUPLICATE = 1025;    // duplicate objects
+    static constexpr int WARN_BRANCH_HINT = 1026;  // branch frequency/likely hints
+    static constexpr int WARN_TABLE_KEYS = 1027;   // something is wrong with a table key
     // Backends should extend this class with additional warnings in the range 1500-2141.
-    static const int WARN_MIN_BACKEND = 1500;  // first allowed backend warning code
-    static const int WARN_MAX = 2141;          // last allowed warning code
+    static constexpr int WARN_MIN_BACKEND = 1500;  // first allowed backend warning code
+    static constexpr int WARN_MAX = 2141;          // last allowed warning code
 
     // -------- Info messages -------------
     // info messages as initially defined with a format string
-    static const int INFO_INFERRED;  // information inferred by compiler
-    static const int INFO_PROGRESS;  // compilation progress
-    static const int INFO_REMOVED;   // instance removed
+    static constexpr int INFO_INFERRED = WARN_MAX + 1;  // information inferred by compiler
+    static constexpr int INFO_PROGRESS = 2143;          // compilation progress
+    static constexpr int INFO_REMOVED = 2144;           // instance removed
 
     // Backends should extend this class with additional info messages in the range 3000-3999.
-    static const int INFO_MIN_BACKEND = 3000;  // first allowed backend info code
-    static const int INFO_MAX = 3999;          // last allowed info code
+    static constexpr int INFO_MIN_BACKEND = 3000;  // first allowed backend info code
+    static constexpr int INFO_MAX = 3999;          // last allowed info code
 };
 
 class ErrorCatalog {


### PR DESCRIPTION
Resolves the `FIXME: make these constexpr` in `error_catalog.h`.

Moves all `ErrorType` constant values from out-of-line definitions in `error_catalog.cpp` into `static constexpr int` declarations in the header. This makes the constants available at compile time.
The `.cpp` file is kept for the `ErrorCatalog::errorCatalog` map and `initReporter()`.