### PR TITLE
Fix freehash() deleting wrong union member

### DIFF
--- a/lib/hashvec.cpp
+++ b/lib/hashvec.cpp
@@ -149,7 +149,7 @@ void hash_vector_base::freehash() {
             delete[] hash.s2;
             break;
         case sizeof(uint32_t):
-            delete[] hash.s2;
+            delete[] hash.s3;
             break;
     }
     hash.s1 = nullptr;


### PR DESCRIPTION
The uint32_t case was deleting hash.s2 instead of hash.s3 — looks like a copy-paste error from the uint16_t case above.