### PR TITLE
tc: break circular includes in backend.h, ebpfCodeGen.h, tcExterns.h

### DIFF
--- a/backends/tc/backend.cpp
+++ b/backends/tc/backend.cpp
@@ -23,6 +23,7 @@ and limitations under the License.
 #include "backend.h"
 #include "backends/ebpf/ebpfOptions.h"
 #include "backends/ebpf/target.h"
+#include "ebpfCodeGen.h"
 
 namespace P4::TC {
 

--- a/backends/tc/backend.h
+++ b/backends/tc/backend.h
@@ -21,7 +21,6 @@ and limitations under the License.
 
 #include "backends/ebpf/psa/ebpfPsaGen.h"
 #include "control-plane/p4RuntimeArchHandler.h"
-#include "ebpfCodeGen.h"
 #include "frontends/p4/evaluator/evaluator.h"
 #include "frontends/p4/parseAnnotations.h"
 #include "frontends/p4/parserCallGraph.h"

--- a/backends/tc/ebpfCodeGen.h
+++ b/backends/tc/ebpfCodeGen.h
@@ -17,19 +17,12 @@ and limitations under the License.
 #ifndef BACKENDS_TC_EBPFCODEGEN_H_
 #define BACKENDS_TC_EBPFCODEGEN_H_
 
-// FIXME: these include each other and present file
 #include "backend.h"
 #include "tcExterns.h"
 
 namespace P4::TC {
 
 using namespace P4::literals;
-
-class ConvertToBackendIR;
-class EBPFPnaParser;
-class EBPFRegisterPNA;
-class EBPFHashPNA;
-class EBPFRandomPNA;
 
 //  Similar to class PSAEbpfGenerator in backends/ebpf/psa/ebpfPsaGen.h
 

--- a/backends/tc/tcExterns.cpp
+++ b/backends/tc/tcExterns.cpp
@@ -16,6 +16,8 @@ and limitations under the License.
 
 #include "tcExterns.h"
 
+#include "ebpfCodeGen.h"
+
 namespace P4::TC {
 
 void EBPFRegisterPNA::emitInitializer(EBPF::CodeBuilder *builder, const P4::ExternMethod *method,

--- a/backends/tc/tcExterns.h
+++ b/backends/tc/tcExterns.h
@@ -15,7 +15,6 @@ and limitations under the License.
 #define BACKENDS_TC_TCEXTERNS_H_
 
 #include "backend.h"
-#include "ebpfCodeGen.h"
 
 namespace P4::TC {
 


### PR DESCRIPTION
`backend.h`, `ebpfCodeGen.h`, and `tcExterns.h` include each other in two cycles:

- `ebpfCodeGen.h → backend.h → ebpfCodeGen.h`
- `ebpfCodeGen.h → tcExterns.h → ebpfCodeGen.h`

Both `backend.h` and `tcExterns.h` only use types from `ebpfCodeGen.h` by pointer (already forward-declared), so the `#include` has been moved to their corresponding `.cpp` files instead.

Also removed 5 forward declarations in `ebpfCodeGen.h` that were needed as a workaround for the include-order dependency — the full definitions are already available through the included headers.

Resolves the FIXME comment at `ebpfCodeGen.h:20`.