### PR TITLE
Allow default action header and header union arguments to take the `{#}` literal

### DIFF
--- a/frontends/p4/typeChecking/typeCheckExpr.cpp
+++ b/frontends/p4/typeChecking/typeCheckExpr.cpp
@@ -1201,11 +1201,15 @@ const IR::Node *TypeInferenceBase::postorder(const IR::Cast *expression) {
                 setType(type, new IR::Type_Type(castType));
                 auto result = new IR::InvalidHeader(ih->srcInfo, type, type);
                 setType(result, castType);
+                setCompileTimeConstant(result);
+                setCompileTimeConstant(getOriginal<IR::Expression>());
                 return result;
             } else if (concreteCastType->is<IR::Type_HeaderUnion>()) {
                 setType(type, new IR::Type_Type(castType));
                 auto result = new IR::InvalidHeaderUnion(ih->srcInfo, type, type);
                 setType(result, castType);
+                setCompileTimeConstant(result);
+                setCompileTimeConstant(getOriginal<IR::Expression>());
                 return result;
             } else {
                 typeError("%1%: 'invalid' expression type `%2%` must be a header or header union",

--- a/midend/eliminateInvalidHeaders.cpp
+++ b/midend/eliminateInvalidHeaders.cpp
@@ -54,8 +54,9 @@ const IR::Node *DoEliminateInvalidHeaders::postorder(IR::P4Action *action) {
 const IR::Node *DoEliminateInvalidHeaders::postorder(IR::InvalidHeader *expression) {
     if (!isInContext<IR::BlockStatement>() && !isInContext<IR::P4Action>() &&
         !isInContext<IR::ParserState>()) {
-        // We need some place to insert the setInvalid call.
-        ::P4::error("%1%: Cannot eliminate invalid header", expression);
+        // We have no place to insert the setInvalid call.
+        // This could happen, for example, when {#} is used as the argument to a header
+        // param of a table's default action.
         return expression;
     }
     cstring name = nameGen.newName("ih");
@@ -74,8 +75,9 @@ const IR::Node *DoEliminateInvalidHeaders::postorder(IR::InvalidHeader *expressi
 const IR::Node *DoEliminateInvalidHeaders::postorder(IR::InvalidHeaderUnion *expression) {
     if (!isInContext<IR::BlockStatement>() && !isInContext<IR::P4Action>() &&
         !isInContext<IR::ParserState>()) {
-        // We need some place to insert the setInvalid call.
-        ::P4::error("%1%: Cannot eliminate invalid header union", expression);
+        // We have no place to insert the setInvalid call.
+        // This could happen, for example, when {#} is used as the argument to a header union
+        // param of a table's default action.
         return expression;
     }
     cstring name = nameGen.newName("ih");

--- a/testdata/p4_16_samples/invalid_header_default_action_arg.p4
+++ b/testdata/p4_16_samples/invalid_header_default_action_arg.p4
@@ -1,0 +1,19 @@
+header h_t { bit<8> f; }
+header_union hu_t { h_t h1; h_t h2; }
+control C() {
+    action a(h_t h, hu_t hu) {}
+
+    table t {
+        actions = { a; }
+        default_action = a((h_t){#}, (hu_t){#});
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/invalid_header_default_action_arg-first.p4
+++ b/testdata/p4_16_samples_outputs/invalid_header_default_action_arg-first.p4
@@ -1,0 +1,26 @@
+header h_t {
+    bit<8> f;
+}
+
+header_union hu_t {
+    h_t h1;
+    h_t h2;
+}
+
+control C() {
+    action a(h_t h, hu_t hu) {
+    }
+    table t {
+        actions = {
+            a();
+        }
+        default_action = a((h_t){#}, (hu_t){#});
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/invalid_header_default_action_arg-frontend.p4
+++ b/testdata/p4_16_samples_outputs/invalid_header_default_action_arg-frontend.p4
@@ -1,0 +1,26 @@
+header h_t {
+    bit<8> f;
+}
+
+header_union hu_t {
+    h_t h1;
+    h_t h2;
+}
+
+control C() {
+    @name("C.a") action a(@name("h") h_t h, @name("hu") hu_t hu) {
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            a();
+        }
+        default_action = a((h_t){#}, (hu_t){#});
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/invalid_header_default_action_arg-midend.p4
+++ b/testdata/p4_16_samples_outputs/invalid_header_default_action_arg-midend.p4
@@ -1,0 +1,26 @@
+header h_t {
+    bit<8> f;
+}
+
+header_union hu_t {
+    h_t h1;
+    h_t h2;
+}
+
+control C() {
+    @name("C.a") action a(@name("h") h_t h, @name("hu") hu_t hu) {
+    }
+    @name("C.t") table t_0 {
+        actions = {
+            a();
+        }
+        default_action = a((h_t){#}, (hu_t){#});
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/invalid_header_default_action_arg.p4
+++ b/testdata/p4_16_samples_outputs/invalid_header_default_action_arg.p4
@@ -1,0 +1,26 @@
+header h_t {
+    bit<8> f;
+}
+
+header_union hu_t {
+    h_t h1;
+    h_t h2;
+}
+
+control C() {
+    action a(h_t h, hu_t hu) {
+    }
+    table t {
+        actions = {
+            a;
+        }
+        default_action = a((h_t){#}, (hu_t){#});
+    }
+    apply {
+        t.apply();
+    }
+}
+
+control proto();
+package top(proto p);
+top(C()) main;

--- a/testdata/p4_16_samples_outputs/invalid_header_default_action_arg.p4-stderr
+++ b/testdata/p4_16_samples_outputs/invalid_header_default_action_arg.p4-stderr
@@ -1,0 +1,6 @@
+invalid_header_default_action_arg.p4(4): [--Wwarn=unused] warning: 'h' is unused
+    action a(h_t h, hu_t hu) {}
+                 ^
+invalid_header_default_action_arg.p4(4): [--Wwarn=unused] warning: 'hu' is unused
+    action a(h_t h, hu_t hu) {}
+                         ^^


### PR DESCRIPTION
- `EliminateInvalidHeaders` does not consider that `{#}` can be used as an argument to a table's action or default action. I removed the error, but I am open to leaving the error and making it conditional on `!isInContext<IR::P4Table>()` instead.
- `TypeInferenceBase::postorder(const IR::Cast *expression)` does not mark a `{#}` literal cast as a compile-time constant