### PR TITLE
Get rid of Bison warning

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -21,9 +21,7 @@ limitations under the License.
 // Set up names.
 %defines
 %define api.namespace {P4}
-// TODO: Update, once we drop Ubuntu 18.04 support.
-// %define api.parser.class {P4Parser}
-%define parser_class_name {P4Parser}
+%define api.parser.class {P4Parser}
 
 // Use the C++-native variant representation of tokens.
 %define api.token.constructor


### PR DESCRIPTION
To my knowledge we don't support Ubuntu 18.04 anymore. This gets rid of the Bison warning:
```
[126/563] [BISON][v1Parser] Building parser with bison 3.8.2
/frontends/parsers/v1/v1parser.ypp:26.1-36: warning: deprecated directive: '%define parser_class_name {V1Parser}', use '%define api.parser.class {V1Parser}' [-Wdeprecated]
   26 | %define parser_class_name {V1Parser}
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | %define api.parser.class {V1Parser}
/frontends/parsers/v1/v1parser.ypp: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
[128/563] [BISON][p4Parser] Building parser with bison 3.8.2
/frontends/parsers/p4/p4parser.ypp:26.1-36: warning: deprecated directive: '%define parser_class_name {P4Parser}', use '%define api.parser.class {P4Parser}' [-Wdeprecated]
   26 | %define parser_class_name {P4Parser}
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | %define api.parser.class {P4Parser}
/frontends/parsers/p4/p4parser.ypp: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
```