### PR TITLE
Fix emit inside if-statement in deparser

### DIFF
--- a/backends/ebpf/ebpfDeparser.cpp
+++ b/backends/ebpf/ebpfDeparser.cpp
@@ -38,6 +38,75 @@ bool DeparserBodyTranslator::preorder(const IR::MethodCallExpression *expression
     return ControlBodyTranslator::preorder(expression);
 }
 
+namespace {
+
+class EmitFinder : public Inspector {
+ public:
+    bool found = false;
+    bool preorder(const IR::MethodCallExpression *mce) override {
+        auto method = mce->method;
+        if (auto mem = method->to<IR::Member>()) {
+            if (mem->member.name == P4::P4CoreLibrary::instance().packetOut.emit.name) {
+                found = true;
+            }
+        }
+        return !found;
+    }
+};
+
+static bool hasEmitInBlock(const IR::Node *node) {
+    EmitFinder finder;
+    node->apply(finder);
+    return finder.found;
+}
+
+}  // namespace
+
+bool DeparserBodyTranslator::preorder(const IR::IfStatement *ifstmt) {
+    // Skip if-blocks containing only emit calls -- they are handled by
+    // DeparserHdrEmitTranslator. Delegate everything else to ControlBodyTranslator.
+    if (!hasEmitInBlock(ifstmt)) {
+        return ControlBodyTranslator::preorder(ifstmt);
+    }
+
+    // Check if there are any non-emit statements in the if-block.
+    auto hasNonEmitStmts = [this](const IR::Node *node) -> bool {
+        auto block = node->to<IR::BlockStatement>();
+        if (block) {
+            for (auto stmt : block->components) {
+                if (auto mcs = stmt->to<IR::MethodCallStatement>()) {
+                    auto mi = P4::MethodInstance::resolve(mcs->methodCall, control->program->refMap,
+                                                          control->program->typeMap);
+                    auto ext = mi->to<P4::ExternMethod>();
+                    if (ext && ext->method->name.name == p4lib.packetOut.emit.name) {
+                        continue;
+                    }
+                    return true;
+                } else if (!stmt->is<IR::BlockStatement>()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (auto mcs = node->to<IR::MethodCallStatement>()) {
+            auto mi = P4::MethodInstance::resolve(mcs->methodCall, control->program->refMap,
+                                                  control->program->typeMap);
+            auto ext = mi->to<P4::ExternMethod>();
+            return !(ext && ext->method->name.name == p4lib.packetOut.emit.name);
+        }
+        return true;
+    };
+
+    bool trueHasNonEmit = hasNonEmitStmts(ifstmt->ifTrue);
+    bool falseHasNonEmit = (ifstmt->ifFalse != nullptr) && hasNonEmitStmts(ifstmt->ifFalse);
+
+    if (trueHasNonEmit || falseHasNonEmit) {
+        return ControlBodyTranslator::preorder(ifstmt);
+    }
+
+    return false;
+}
+
 DeparserPrepareBufferTranslator::DeparserPrepareBufferTranslator(const EBPFDeparser *deparser)
     : CodeGenInspector(deparser->program->refMap, deparser->program->typeMap),
       ControlBodyTranslator(deparser),
@@ -47,11 +116,41 @@ DeparserPrepareBufferTranslator::DeparserPrepareBufferTranslator(const EBPFDepar
 
 bool DeparserPrepareBufferTranslator::preorder(const IR::BlockStatement *s) {
     for (auto a : s->components) {
-        if (a->is<IR::MethodCallStatement>()) {
+        if (a->is<IR::MethodCallStatement>() || a->is<IR::IfStatement>()) {
             visit(a);
         }
     }
 
+    return false;
+}
+
+bool DeparserPrepareBufferTranslator::preorder(const IR::IfStatement *ifstmt) {
+    if (!hasEmitInBlock(ifstmt)) return false;
+
+    builder->emitIndent();
+    builder->append("if (");
+    ifstmt->condition->apply(*deparser->codeGen);
+    builder->append(") ");
+    builder->blockStart();
+    visit(ifstmt->ifTrue);
+    builder->blockEnd(true);
+    if (ifstmt->ifFalse != nullptr) {
+        builder->emitIndent();
+        builder->append("else ");
+        builder->blockStart();
+        visit(ifstmt->ifFalse);
+        builder->blockEnd(true);
+    }
+    return false;
+}
+
+bool DeparserPrepareBufferTranslator::preorder(const IR::MethodCallStatement *s) {
+    auto mce = s->methodCall;
+    auto mi = P4::MethodInstance::resolve(mce, control->program->refMap, control->program->typeMap);
+    auto ext = mi->to<P4::ExternMethod>();
+    if (ext != nullptr && ext->method->name.name == p4lib.packetOut.emit.name) {
+        visit(mce);
+    }
     return false;
 }
 
@@ -104,6 +203,37 @@ DeparserHdrEmitTranslator::DeparserHdrEmitTranslator(const EBPFDeparser *deparse
       DeparserPrepareBufferTranslator(deparser),
       deparser(deparser) {
     setName("DeparserHdrEmitTranslator");
+}
+
+bool DeparserHdrEmitTranslator::preorder(const IR::IfStatement *ifstmt) {
+    if (!hasEmitInBlock(ifstmt)) return false;
+
+    builder->emitIndent();
+    builder->append("if (");
+    ifstmt->condition->apply(*deparser->codeGen);
+    builder->append(") ");
+    builder->blockStart();
+    visit(ifstmt->ifTrue);
+    builder->blockEnd(true);
+    if (ifstmt->ifFalse != nullptr) {
+        builder->emitIndent();
+        builder->append("else ");
+        builder->blockStart();
+        visit(ifstmt->ifFalse);
+        builder->blockEnd(true);
+    }
+    return false;
+}
+
+bool DeparserHdrEmitTranslator::preorder(const IR::MethodCallExpression *expression) {
+    auto mi = P4::MethodInstance::resolve(expression, control->program->refMap,
+                                          control->program->typeMap);
+    auto ext = mi->to<P4::ExternMethod>();
+    if (ext != nullptr) {
+        processMethod(ext);
+        return false;
+    }
+    return CodeGenInspector::preorder(expression);
 }
 
 void DeparserHdrEmitTranslator::processMethod(const P4::ExternMethod *method) {

--- a/backends/ebpf/ebpfDeparser.h
+++ b/backends/ebpf/ebpfDeparser.h
@@ -32,6 +32,7 @@ class DeparserBodyTranslator : public ControlBodyTranslator {
     explicit DeparserBodyTranslator(const EBPFDeparser *deparser);
 
     bool preorder(const IR::MethodCallExpression *expression) override;
+    bool preorder(const IR::IfStatement *ifstmt) override;
 };
 
 /// This translator emits buffer preparation (eg. which headers will be emitted)
@@ -44,6 +45,9 @@ class DeparserPrepareBufferTranslator : public ControlBodyTranslator {
 
     void processMethod(const P4::ExternMethod *method) override;
     bool preorder(const IR::BlockStatement *s) override;
+    bool preorder(const IR::IfStatement *ifstmt) override;
+    bool preorder(const IR::AssignmentStatement *) override { return false; }
+    bool preorder(const IR::MethodCallStatement *s) override;
     bool preorder(const IR::MethodCallExpression *expression) override;
 };
 
@@ -55,6 +59,8 @@ class DeparserHdrEmitTranslator : public DeparserPrepareBufferTranslator {
  public:
     explicit DeparserHdrEmitTranslator(const EBPFDeparser *deparser);
 
+    bool preorder(const IR::IfStatement *ifstmt) override;
+    bool preorder(const IR::MethodCallExpression *expression) override;
     void processMethod(const P4::ExternMethod *method) override;
     void emitField(CodeBuilder *builder, cstring field, const IR::Expression *hdrExpr,
                    unsigned alignment, EBPF::EBPFType *type);

--- a/backends/ebpf/tests/p4testdata/conditional-emit.p4
+++ b/backends/ebpf/tests/p4testdata/conditional-emit.p4
@@ -1,0 +1,144 @@
+/*
+Copyright 2022-present Orange
+Copyright 2022-present Open Networking Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/// Test for issue #5026: emit inside if-statement in deparser.
+
+#include <core.p4>
+#include <psa.p4>
+#include "common_headers.p4"
+
+struct metadata {
+}
+
+struct headers {
+    ethernet_t ethernet;
+    ipv4_t     ipv4;
+}
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout metadata meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         in empty_t resubmit_meta,
+                         in empty_t recirculate_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: reject;
+        }
+    }
+
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout metadata meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        in empty_t normal_meta,
+                        in empty_t clone_i2e_meta,
+                        in empty_t clone_e2e_meta)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata meta,
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action do_forward(PortId_t egress_port) {
+        send_to_port(ostd, egress_port);
+    }
+
+    table tbl_fwd {
+        key = {
+            istd.ingress_port : exact;
+        }
+        actions = { do_forward; NoAction; }
+        default_action = do_forward((PortId_t) PORT1);
+        size = 100;
+    }
+
+    apply {
+        tbl_fwd.apply();
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata meta,
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control IngressDeparserImpl(packet_out packet,
+                            out empty_t clone_i2e_meta,
+                            out empty_t resubmit_meta,
+                            out empty_t normal_meta,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        if (hdr.ethernet.dstAddr[7:0] == 1) {
+            packet.emit(hdr.ipv4);
+        }
+    }
+}
+
+control EgressDeparserImpl(packet_out packet,
+                           out empty_t clone_e2e_meta,
+                           out empty_t recirculate_meta,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
+{
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;

--- a/backends/ebpf/tests/ptf/test.py
+++ b/backends/ebpf/tests/ptf/test.py
@@ -996,3 +996,21 @@ class WideFieldTableSupport(P4EbpfTest):
             exp_pkt[IPv6].hlim = exp_pkt[IPv6].hlim - t.get("no_table_matches", 2)
             testutils.send_packet(self, PORT0, pkt)
             testutils.verify_packet_any_port(self, exp_pkt, PTF_PORTS)
+
+
+class EmitInIfStatementTest(P4EbpfTest):
+    """Test for issue #5026: emit inside if-statement in deparser."""
+
+    p4_file_path = "p4testdata/conditional-emit.p4"
+
+    def runTest(self):
+        # True branch: dstAddr[7:0] == 1, IPv4 header is emitted.
+        pkt = testutils.simple_ip_packet(eth_dst="00:00:00:00:00:01")
+        testutils.send_packet(self, PORT0, pkt)
+        testutils.verify_packet(self, pkt, PORT1)
+
+        # False branch: dstAddr[7:0] != 1, IPv4 header is NOT emitted.
+        pkt_in = testutils.simple_ip_packet(eth_dst="00:00:00:00:00:02")
+        exp_pkt = Ether(dst="00:00:00:00:00:02", src=pkt_in[Ether].src, type=0x0800)
+        testutils.send_packet(self, PORT0, pkt_in)
+        testutils.verify_packet(self, exp_pkt, PORT1)

--- a/backends/tc/ebpfCodeGen.cpp
+++ b/backends/tc/ebpfCodeGen.cpp
@@ -1922,6 +1922,15 @@ SizeScanner::SizeScanner(const EBPF::EBPFDeparser *deparser)
     setName("SizeScanner");
 }
 
+bool SizeScanner::preorder(const IR::BlockStatement *s) {
+    for (auto a : s->components) {
+        if (a->is<IR::MethodCallStatement>()) {
+            visit(a);
+        }
+    }
+    return false;
+}
+
 bool SizeScanner::preorder(const IR::MethodCallStatement *s) {
     visit(s->methodCall);
     return false;
@@ -3092,6 +3101,19 @@ DeparserHdrEmitTranslatorPNA::DeparserHdrEmitTranslatorPNA(const EBPF::EBPFDepar
       EBPF::DeparserPrepareBufferTranslator(deparser),
       deparser(deparser) {
     setName("DeparserHdrEmitTranslatorPNA");
+}
+
+bool DeparserHdrEmitTranslatorPNA::preorder(const IR::BlockStatement *s) {
+    for (auto a : s->components) {
+        if (a->is<IR::MethodCallStatement>()) {
+            visit(a);
+        }
+    }
+    return false;
+}
+
+bool DeparserHdrEmitTranslatorPNA::preorder(const IR::MethodCallStatement *s) {
+    return EBPF::CodeGenInspector::preorder(s);
 }
 
 void DeparserHdrEmitTranslatorPNA::processMethod(const P4::ExternMethod *method) {

--- a/backends/tc/ebpfCodeGen.h
+++ b/backends/tc/ebpfCodeGen.h
@@ -490,6 +490,8 @@ class DeparserHdrEmitTranslatorPNA : public EBPF::DeparserPrepareBufferTranslato
     explicit DeparserHdrEmitTranslatorPNA(const EBPF::EBPFDeparser *deparser);
 
     void processMethod(const P4::ExternMethod *method) override;
+    bool preorder(const IR::BlockStatement *s) override;
+    bool preorder(const IR::MethodCallStatement *s) override;
     void emitField(EBPF::CodeBuilder *builder, cstring field, const IR::Expression *hdrExpr,
                    unsigned alignment, EBPF::EBPFType *type, bool isMAC);
 };
@@ -502,6 +504,7 @@ class SizeScanner : public EBPF::DeparserPrepareBufferTranslator {
     explicit SizeScanner(const EBPF::EBPFDeparser *deparser);
 
     void processMethod(const P4::ExternMethod *method) override;
+    bool preorder(const IR::BlockStatement *s) override;
     bool preorder(const IR::MethodCallStatement *) override;
 };
 


### PR DESCRIPTION
Fixes #5026

`DeparserPrepareBufferTranslator::preorder(BlockStatement)` previously skipped `IfStatement` nodes entirely. Any `packet.emit()` wrapped in an if-block was silently ignored during both buffer sizing and header emission, resulting in empty C if-blocks.

### Changes

eBPF Backend
* `BlockStatement` traversal: Updated the visitor to traverse `IfStatement` children so nested `emit()` calls are recognized.
* If-Statement translation: Added overrides in the prepare and emit translators. This ensures we calculate the worst-case buffer size by visiting both branches and generate the proper C `if/else` syntax.
* Scope safety: Added a `hasEmitInBlock()` guard. This prevents dumping non-emit statements (like digest assignments or resubmits) into the emit scope where those variables do not exist.

TC/P4TC Backend
* Inheritance fix: The new eBPF logic leaked into `DeparserHdrEmitTranslatorPNA` and `SizeScanner`, dropping trailing semicolons in the output. Added explicit `BlockStatement` overrides to these classes to restore their original `MethodCallStatement`-only traversal.
* Statement termination: Added a `MethodCallStatement` override in PNA to delegate to `CodeGenInspector::preorder()`. This explicitly preserves the `endOfStatement()` behavior required for valid C formatting.

### Tests
* PTF validation: Added `conditional-emit.p4` and `EmitInIfStatementTest`. This verifies the generated code correctly drops or emits headers based on the condition.