### PR TITLE
bazel: build flex and bison hermetically via Bazel toolchains

### DIFF
--- a/.github/workflows/ci-bazel.yml
+++ b/.github/workflows/ci-bazel.yml
@@ -49,9 +49,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bazel-direct-
 
-      - name: Install Flex and Bison
-        run: sudo apt install bison flex libfl-dev
-
       - name: Save start time
         run: echo "START_TIME=$(date +%s)" >> "$GITHUB_ENV"
 
@@ -88,9 +85,6 @@ jobs:
           key: ${{ runner.os }}-bazel-indirect-${{ hashFiles('**/*.bazel*', '**/*.bzl') }}
           restore-keys: |
             ${{ runner.os }}-bazel-indirect-
-
-      - name: Install Flex and Bison
-        run: sudo apt install bison flex libfl-dev
 
       - name: Save start time
         run: echo "START_TIME=$(date +%s)" >> "$GITHUB_ENV"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,7 @@ load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
 load("//bazel:bison.bzl", "genyacc")
-load("//bazel:flex.bzl", "genlex")
+load("//bazel:flex.bzl", "flex_lexer_h", "genlex")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -89,33 +89,22 @@ genyacc(
     visibility = ["//visibility:private"],
 )
 
-genrule(
-    name = "p4lexer_lex",
-    srcs = ["frontends/parsers/p4/p4lexer.ll"],
-    outs = ["frontends/parsers/p4/p4lexer.lex"],
-    cmd = "sed '/%option outfile=\"lex.yy.c\"/d' $(SRCS) > $(OUTS)",
+flex_lexer_h(
+    name = "flex_lexer_h",
     visibility = ["//visibility:private"],
 )
 
 genlex(
     name = "p4lexer",
-    src = "frontends/parsers/p4/p4lexer.lex",
+    src = "frontends/parsers/p4/p4lexer.ll",
     out = "frontends/parsers/p4/p4lexer.cc",
     prefix = "yy",
     visibility = ["//visibility:private"],
 )
 
-genrule(
-    name = "v1lexer_lex",
-    srcs = ["frontends/parsers/v1/v1lexer.ll"],
-    outs = ["frontends/parsers/v1/v1lexer.lex"],
-    cmd = "sed '/%option outfile=\"lex.yy.c\"/d' $(SRCS) > $(OUTS)",
-    visibility = ["//visibility:private"],
-)
-
 genlex(
     name = "v1lexer",
-    src = "frontends/parsers/v1/v1lexer.lex",
+    src = "frontends/parsers/v1/v1lexer.ll",
     out = "frontends/parsers/v1/v1lexer.cc",
     prefix = "yy",
     visibility = ["//visibility:private"],
@@ -240,6 +229,7 @@ cc_library(
     ],
     deps = [
         ":config_h",
+        ":flex_lexer_h",
         ":lib",
         ":p4info_dpdk_cc_proto",
         "@abseil-cpp//absl/container:btree",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,8 +17,13 @@ bazel_dep(name = "googleapis", version = "0.0.0-20260223-edfe7983")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1")
 bazel_dep(name = "protobuf", version = "33.5")
+bazel_dep(name = "rules_bison", version = "0.4")
 bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_flex", version = "0.4")
 bazel_dep(name = "rules_license", version = "1.0.0")
+
+# Transitive dep of rules_bison and rules_flex; pinned to 0.3 for Bazel 9+ compatibility.
+bazel_dep(name = "rules_m4", version = "0.3")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "z3", version = "4.15.2")
 bazel_dep(name = "p4runtime", version = "1.5.0")

--- a/bazel/bison.bzl
+++ b/bazel/bison.bzl
@@ -1,64 +1,64 @@
 """Build rule for generating C or C++ sources with Bison."""
 
 def _genyacc_impl(ctx):
-    """Implementation for genyacc rule.
+    """Implementation for genyacc rule."""
+    bison_tc = ctx.toolchains["@rules_bison//bison:toolchain_type"].bison_toolchain
 
-    Expects to find bison binary on the PATH.
-    """
-
-    # Argument list
-    args = []
-    args.append("--defines=%s" % ctx.outputs.header_out.path)
-    args.append("--output-file=%s" % ctx.outputs.source_out.path)
+    args = ctx.actions.args()
+    args.add("--defines=" + ctx.outputs.header_out.path)
+    args.add("--output-file=" + ctx.outputs.source_out.path)
     if ctx.attr.prefix:
-        args.append("--name-prefix=%s" % ctx.attr.prefix)
-    args += [ctx.expand_location(opt) for opt in ctx.attr.extra_options]
-    args.append(ctx.file.src.path)
+        args.add("--name-prefix=" + ctx.attr.prefix)
+    args.add_all([ctx.expand_location(opt) for opt in ctx.attr.extra_options])
+    args.add(ctx.file.src.path)
 
-    # Output files
     outputs = ctx.outputs.extra_outs + [
         ctx.outputs.header_out,
         ctx.outputs.source_out,
     ]
 
-    ctx.actions.run_shell(
-        use_default_shell_env = True,
-        command = "bison " + " ".join(args),
-        inputs = ctx.files.src,
+    ctx.actions.run(
+        executable = bison_tc.bison_tool,
+        arguments = [args],
+        inputs = depset(direct = ctx.files.src),
         outputs = outputs,
+        env = bison_tc.bison_env,
         mnemonic = "Yacc",
-        progress_message = "Generating %s and %s from %s" %
-                           (
-                               ctx.outputs.source_out.short_path,
-                               ctx.outputs.header_out.short_path,
-                               ctx.file.src.short_path,
-                           ),
+        progress_message = "Generating %s and %s from %s" % (
+            ctx.outputs.source_out.short_path,
+            ctx.outputs.header_out.short_path,
+            ctx.file.src.short_path,
+        ),
     )
 
 genyacc = rule(
     implementation = _genyacc_impl,
     doc = "Generate C/C++-language sources from a Yacc file using Bison.",
     attrs = {
-        "src": attr.label(
-            mandatory = True,
-            allow_single_file = [".y", ".yy", ".yc", ".ypp"],
-            doc = "The .y, .yy, or .yc source file for this rule",
+        "extra_options": attr.string_list(
+            doc = "A list of extra options to pass to Bison.  These are " +
+                  "subject to $(location ...) expansion.",
         ),
+        "extra_outs": attr.output_list(doc = "A list of extra generated output files."),
         "header_out": attr.output(
             mandatory = True,
             doc = "The generated 'defines' header file",
         ),
-        "source_out": attr.output(mandatory = True, doc = "The generated source file"),
         "prefix": attr.string(
             doc = "External symbol prefix for Bison. This string is " +
                   "passed to bison as the -p option, causing the resulting C " +
                   "file to define external functions named 'prefix'parse, " +
                   "'prefix'lex, etc. instead of yyparse, yylex, etc.",
         ),
-        "extra_outs": attr.output_list(doc = "A list of extra generated output files."),
-        "extra_options": attr.string_list(
-            doc = "A list of extra options to pass to Bison.  These are " +
-                  "subject to $(location ...) expansion.",
+        "source_out": attr.output(mandatory = True, doc = "The generated source file"),
+        "src": attr.label(
+            mandatory = True,
+            allow_single_file = [".y", ".yy", ".yc", ".ypp"],
+            doc = "The .y, .yy, or .yc source file for this rule",
         ),
     },
+    toolchains = [
+        "@rules_bison//bison:toolchain_type",
+        "@rules_m4//m4:toolchain_type",
+    ],
 )

--- a/bazel/flex.bzl
+++ b/bazel/flex.bzl
@@ -1,23 +1,73 @@
-"""Build rule for generating C or C++ sources with Flex."""
+"""Build rules for generating C or C++ sources with Flex."""
 
-def genlex(name, src, out, prefix, includes = [], visibility = None):
-    """Generate a C++ lexer from a lex file using Flex.
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
-    Expects to find flex binary on the PATH.
+def _genlex_impl(ctx):
+    """Implementation for genlex rule."""
+    flex_tc = ctx.toolchains["@rules_flex//flex:toolchain_type"].flex_toolchain
 
-    Args:
-      name: The name of the rule.
-      src: The .lex source file.
-      out: The generated source file.
-      includes: A list of headers included by the .lex file.
-      prefix: Passed to flex as the -P option.
-      visibility: visibility of this rule to other packages.
-    """
-    cmd = "flex -o $(location %s) -P %s $(location %s)" % (out, prefix, src)
-    native.genrule(
-        name = name,
-        outs = [out],
-        srcs = [src] + includes,
-        cmd = cmd,
-        visibility = visibility,
+    args = ctx.actions.args()
+    args.add("-o", ctx.outputs.out.path)
+    if ctx.attr.prefix:
+        args.add("-P")
+        args.add(ctx.attr.prefix)
+    args.add(ctx.file.src.path)
+
+    ctx.actions.run(
+        executable = flex_tc.flex_tool,
+        arguments = [args],
+        inputs = depset(direct = [ctx.file.src] + ctx.files.includes),
+        outputs = [ctx.outputs.out],
+        env = flex_tc.flex_env,
+        mnemonic = "Flex",
+        progress_message = "Generating %s from %s" % (
+            ctx.outputs.out.short_path,
+            ctx.file.src.short_path,
+        ),
     )
+
+genlex = rule(
+    implementation = _genlex_impl,
+    doc = "Generate a C or C++ lexer from a lex file using Flex.",
+    attrs = {
+        "includes": attr.label_list(
+            allow_files = True,
+            doc = "A list of headers included by the .lex file.",
+        ),
+        "out": attr.output(
+            mandatory = True,
+            doc = "The generated source file.",
+        ),
+        "prefix": attr.string(
+            doc = "Passed to flex as the -P option.",
+        ),
+        "src": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "The .l, .ll, or .lex source file.",
+        ),
+    },
+    toolchains = [
+        "@rules_flex//flex:toolchain_type",
+        "@rules_m4//m4:toolchain_type",
+    ],
+)
+
+def _flex_lexer_h_impl(ctx):
+    """Exposes FlexLexer.h from the Flex toolchain as a CcInfo library."""
+    hdr = ctx.toolchains["@rules_flex//flex:toolchain_type"].flex_toolchain.flex_lexer_h
+    compilation_context = cc_common.create_compilation_context(
+        headers = depset([hdr]),
+        system_includes = depset([hdr.dirname]),
+    )
+    return [
+        CcInfo(compilation_context = compilation_context),
+        DefaultInfo(files = depset([hdr])),
+    ]
+
+flex_lexer_h = rule(
+    implementation = _flex_lexer_h_impl,
+    doc = "Exposes FlexLexer.h from the Flex toolchain as a cc_library dependency.",
+    toolchains = ["@rules_flex//flex:toolchain_type"],
+)

--- a/frontends/parsers/p4/p4lexer.ll
+++ b/frontends/parsers/p4/p4lexer.ll
@@ -35,7 +35,6 @@ using Parser = P4::P4Parser;
 %}
 
 %option c++
-%option outfile="lex.yy.c"
 %option yyclass="P4::P4Lexer"
 %option prefix="p4"
 %option nodefault noyywrap nounput noinput noyyget_leng

--- a/frontends/parsers/v1/v1lexer.ll
+++ b/frontends/parsers/v1/v1lexer.ll
@@ -30,7 +30,6 @@ using Parser = V1::V1Parser;
 %}
 
 %option c++
-%option outfile="lex.yy.c"
 %option yyclass="V1::V1Lexer"
 %option prefix="v1"
 %option nodefault noyywrap nounput noinput noyyget_leng


### PR DESCRIPTION
To upstream p4c to the Bazel Central Registry, we need to make the Bazel build hermetic, i.e. it cannot depend on system dependencies. 

## Summary

- Adds `rules_bison 0.4`, `rules_flex 0.4`, and `rules_m4 0.3` from the Bazel Central Registry to `MODULE.bazel`
- Rewrites `bazel/bison.bzl` (`genyacc`) and `bazel/flex.bzl` (`genlex`) to use the hermetic toolchain executables instead of system-installed binaries on `PATH`
- Adds a `flex_lexer_h` rule that exposes `FlexLexer.h` from the Flex toolchain as a `CcInfo` dependency (replacing the `libfl-dev` system package)
- Removes the intermediate sed preprocessing genrules (`p4lexer_lex`, `v1lexer_lex`) that stripped `%option outfile` — no longer needed since the rule passes `-o` explicitly
- Removes `sudo apt install bison flex libfl-dev` from CI

All existing `genyacc`/`genlex` call-site interfaces and generated output filenames are preserved, so no changes are needed in any C++ source files.

## Test plan

- [x] `format_bazel_files` CI job passes (buildifier formatting)
- [x] `build_direct` job passes without system flex/bison installed
- [x] `build_indirect` job passes without system flex/bison installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)