### PR TITLE
ci: grant contents:write permission for release job

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -17,6 +17,8 @@ jobs:
   build:
     if: ${{ github.repository == 'p4lang/p4c' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

The `ci-release` workflow was failing with a 403 error when trying to create GitHub releases:

```
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration",...}
Skip retry — your GitHub token/PAT does not have the required permission to create a release
```

The root cause: `softprops/action-gh-release` needs `contents: write` to create releases and tags, but the `GITHUB_TOKEN` was defaulting to `contents: read` (the repository default).

## Fix

Add `permissions: contents: write` to the `build` job. This is scoped to just the job that needs it, following the principle of least privilege.

Fixes: https://github.com/p4lang/p4c/actions/runs/22552815794/job/65325342980