### PR TITLE
Increase minimum required BISON version to 3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ endif ()
 # Required tools and libraries.
 find_package (PythonInterp 3 REQUIRED)
 find_package (FLEX 2.0 REQUIRED)
-find_package (BISON 3.1 REQUIRED)
+find_package (BISON 3.3 REQUIRED)
 # If we enable GTest, install GoogleTest with the appropriate options.
 if (ENABLE_GTESTS)
   include(GoogleTest)


### PR DESCRIPTION
As of https://github.com/p4lang/p4c/pull/5501, the minimum required Bison version is 3.3. Without this change, and with Bison 3.1 for example, we get the error:
```
[2922/3355] [BISON][p4Parser] Building parser with bison 3.1
FAILED: frontends/parsers/p4/p4parser.cpp frontends/parsers/p4/p4parser.output frontends/parsers/p4/p4parser.hpp 
cd /p4c/build/frontends && /usr/local/bin/bison -Werror=conflicts-sr -Werror=conflicts-rr -d --verbose -o /p4c/build/frontends/parsers/p4/p4parser.cpp /p4c/frontends/parsers/p4/p4parser.ypp
/p4c/frontends/parsers/p4/p4parser.ypp:24.9-24: error: %define variable 'api.parser.class' is not used
 %define api.parser.class {P4Parser}
         ^^^^^^^^^^^^^^^^
```