### PR TITLE
Fix non-unity/unified build

### DIFF
--- a/backends/tofino/bf-p4c/mau/stateful_alu.h
+++ b/backends/tofino/bf-p4c/mau/stateful_alu.h
@@ -99,6 +99,7 @@
 #include "backends/tofino/bf-p4c/specs/device.h"
 #include "frontends/common/resolveReferences/referenceMap.h"
 #include "ir/ir.h"
+#include "ir/pass_manager.h"
 #include "mau_visitor.h"
 
 using namespace P4;

--- a/backends/tofino/bf-p4c/parde/allocate_parser_match_register.h
+++ b/backends/tofino/bf-p4c/parde/allocate_parser_match_register.h
@@ -19,6 +19,12 @@
 #ifndef BACKENDS_TOFINO_BF_P4C_PARDE_ALLOCATE_PARSER_MATCH_REGISTER_H_
 #define BACKENDS_TOFINO_BF_P4C_PARDE_ALLOCATE_PARSER_MATCH_REGISTER_H_
 
+#include "ir/pass_manager.h"
+
+using namespace P4;
+
+class PhvInfo;
+
 /**
  * @ingroup LowerParserIR
  * @brief This pass performs the parser match register allocation.


### PR DESCRIPTION
Some missing things needed in header files when not using a unity or unified build.