### PR TITLE
bazel: add p4include package, testdata exports, and fix macOS build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,25 +19,30 @@ license(
 
 exports_files(["LICENSE"])
 
-filegroup(
+# Deprecated: use //p4include instead.
+alias(
     name = "p4include",
-    srcs = glob(["p4include/**/*.p4"]),
+    actual = "//p4include",
+    deprecation = "Use @p4c//p4include instead of @p4c//:p4include.",
 )
 
 genrule(
     name = "sed_config_h",
     srcs = ["cmake/config.h.cmake"],
     outs = ["config.h"],
-    # TODO: We should actually check these properly instead of just #undefing them.
-    # Maybe select() can help here?
     # CONFIG_PKGDATADIR is where p4c should look for p4include at runtime.
     # This will work only if the binary is executed by Bazel. For a general
     # solution, we would need to make p4c aware of Bazel, specifically:
     # https://github.com/bazelbuild/bazel/blob/master/tools/cpp/runfiles/runfiles_src.h
+    # pipe2 is Linux-only (crash.cpp has a pipe()+fcntl() fallback); ucontext.h
+    # requires _XOPEN_SOURCE on macOS SDKs ≥14 and is crash-handler register dumps
+    # only. Both are safe to leave undefined everywhere.
     cmd = "sed -e 's|cmakedefine|define|g' \
              -e 's|define HAVE_LIBGC 1|undef HAVE_LIBGC|g' \
              -e 's|define HAVE_LIBBACKTRACE 1|undef HAVE_LIBBACKTRACE|g' \
              -e 's|define HAVE_MM_MALLOC_H 1|undef HAVE_MM_MALLOC_H|g' \
+             -e 's|define HAVE_PIPE2 1|undef HAVE_PIPE2|g' \
+             -e 's|define HAVE_UCONTEXT_H 1|undef HAVE_UCONTEXT_H|g' \
              -e 's|@MAX_LOGGING_LEVEL@|10|g' \
              -e 's|@CONFIG_PKGDATADIR@|external/%s|g' \
              < $(SRCS) > $(OUTS)" % repository_name(),

--- a/p4include/BUILD.bazel
+++ b/p4include/BUILD.bazel
@@ -1,0 +1,7 @@
+exports_files(glob(["**/*.p4"]))
+
+filegroup(
+    name = "p4include",
+    srcs = glob(["**/*.p4"]),
+    visibility = ["//visibility:public"],
+)

--- a/testdata/p4_16_samples/BUILD.bazel
+++ b/testdata/p4_16_samples/BUILD.bazel
@@ -1,0 +1,4 @@
+exports_files(glob([
+    "*.p4",
+    "*.stf",
+]))


### PR DESCRIPTION
## Summary

Three Bazel build improvements for downstream consumers:

1. **`//p4include` package** — moves p4include into its own Bazel package with
   `exports_files` and a `filegroup`, so downstream genrules can reference
   individual include files (e.g. `@p4c//p4include:core.p4`) and derive the
   include directory path via `$(execpath)` + `$(dirname)`. The root
   `//:p4include` alias is preserved but deprecated.

2. **`//testdata/p4_16_samples` exports** — `exports_files` so external
   workspaces can reference `.p4` and `.stf` test files directly via Bazel
   labels.

3. **macOS `sed_config_h` fix** — unconditionally undefine `HAVE_PIPE2`
   (Linux-only; `crash.cpp` already has a `pipe()+fcntl()` fallback) and
   `HAVE_UCONTEXT_H` (requires `_XOPEN_SOURCE` on macOS SDK ≥14; only used
   for crash-handler register dumps). Both features degrade gracefully when
   absent.

### Motivation

These targets are used by the [4ward](https://github.com/smolkaj/4ward) P4
simulator, which depends on p4c via the Bazel Central Registry. Currently 4ward
must use a fork with these additions. Landing them upstream would let 4ward
(and other Bzlmod consumers) use BCR p4c directly with no `git_override`.

## Test plan

- [x] No existing targets affected (`//:p4include` preserved as deprecated alias)
- [x] Tested by 4ward's CI: 49 unit tests + 186 corpus tests + 186 BMv2
  differential tests all pass with these changes