### PR TITLE
Fix wrong expected output of `gauntlet_enum_assign-bmv2.stf` (#5540)

### DIFF
--- a/testdata/p4_16_samples/gauntlet_enum_assign-bmv2.stf
+++ b/testdata/p4_16_samples/gauntlet_enum_assign-bmv2.stf
@@ -1,1 +1,2 @@
 packet 0 00
+expect 2 00 $


### PR DESCRIPTION
Fixes #5540.

Please let me know if any other changes are required when modifying the STF test file.