### PR TITLE
[P4Smith] Correctly generate 1-bit concat expressions

### DIFF
--- a/backends/p4tools/modules/smith/common/expressions.cpp
+++ b/backends/p4tools/modules/smith/common/expressions.cpp
@@ -578,11 +578,10 @@ IR::Expression *ExpressionGenerator::constructBinaryBitExpr(const IR::Type_Bits 
         case 12: {
             // pick an concatenation that matches the type
             size_t typeWidth = tb->width_bits();
-            size_t split = Utils::getRandInt(1, typeWidth - 1);
-            // TODO(fruffy): lazy fallback
-            if (split >= typeWidth) {
+            if (typeWidth < 2) {
                 return genBitLiteral(tb);
             }
+            size_t split = Utils::getRandInt(1, typeWidth - 1);
             const auto *tl = IR::Type_Bits::get(typeWidth - split, false);
             const auto *tr = IR::Type_Bits::get(split, false);
             // width must be known so we cast


### PR DESCRIPTION
Currently, we detect the situation where we're attempting to generate a concatenation expression for a 1-bit type by first determining the split (using `getRandInt`, a wrapper for a Boost random number generator) and then checking if the split is greater than the type's width.

However, the Boost function called by `getRandInt` requires that `min <= max`. With the current behavior, we call the function with `min = 1`, `max = 0` before falling back to generating a bit literal. While this succeeds in Release mode, it trips an assertion in Debug mode, causing a P4Smith failure. This PR instead checks the type width before determining the split, avoiding the erroneous call.