### PR TITLE
Allow multiple declarators in a declaration

### DIFF
--- a/frontends/parsers/p4/p4parser.ypp
+++ b/frontends/parsers/p4/p4parser.ypp
@@ -79,12 +79,14 @@ inline std::ostream& operator<<(std::ostream& out, const OptionalConst& oc) {
 // forbidden in C++. We avoid the problem using a typedef.
 typedef const IR::Type ConstType;
 
-struct NameTypePair {
+struct DeclaratorInfo {
+    Util::SourceInfo srcInfo;
     IR::ID name;
     const IR::Type *type;
+    const IR::Expression *init;
 };
 
-inline std::ostream &operator<<(std::ostream &out, const NameTypePair &nt) {
+inline std::ostream &operator<<(std::ostream &out, const DeclaratorInfo &nt) {
     return out << nt.name << ":" << nt.type;
 }
 
@@ -107,7 +109,7 @@ class Token {
 
     Token() : Token(0, cstring::empty, nullptr) { }
     Token(int type, cstring text) : Token(type, text, nullptr) { }
-    Token(int type, const char* text) : Token(type, cstring(text), nullptr) { }    
+    Token(int type, const char* text) : Token(type, cstring(text), nullptr) { }
     Token(int type, UnparsedConstant unparsedConstant)
             : Token(type, unparsedConstant.text,
                     new UnparsedConstant(unparsedConstant)) { }
@@ -261,7 +263,8 @@ using namespace P4;
 
 
 %type<IR::ID>               name dot_name nonTypeName nonTableKwName annotationName
-%type<NameTypePair>         declarator
+%type<DeclaratorInfo>       declarator
+%type<std::vector<DeclaratorInfo>> declaratorList initDeclaratorList
 %type<IR::Direction>        direction
 %type<IR::Path*>            prefixedNonTypeName prefixedType
 %type<IR::TypeParameters*>  optTypeParameters typeParameters typeParameterList
@@ -296,20 +299,20 @@ using namespace P4;
                             forStatement breakStatement continueStatement
 %type<IR::BlockStatement*>  blockStatement parserBlockStatement controlBody
                             optObjInitializer
-%type<IR::StatOrDecl*>      statementOrDeclaration parserStatement
-                            declOrAssignmentOrMethodCallStatement
-%type<IR::IndexedVector<IR::StatOrDecl>>  objDeclarations statOrDeclList parserStatements
+%type<IR::StatOrDecl*>      declOrAssignmentOrMethodCallStatement
+%type<IR::IndexedVector<IR::StatOrDecl>>  objDeclarations parserStatement
+                            statementOrDeclaration parserStatements statOrDeclList
                             forInitStatements forInitStatementsNonEmpty
                             forUpdateStatements forUpdateStatementsNonEmpty
 %type<IR::SwitchCase*>      switchCase
 %type<IR::Vector<IR::SwitchCase>> switchCases
 %type<IR::Vector<IR::Type>> typeArgumentList realTypeArgumentList
 %type<IR::ParserState*>     parserState
-%type<IR::IndexedVector<IR::ParserState>> parserStates
-%type<IR::Declaration*>     constantDeclaration actionDeclaration
-                            variableDeclaration variableDeclarationWithoutSemicolon instantiation functionDeclaration
-                            objDeclaration tableDeclaration controlLocalDeclaration
-                            parserLocalElement valueSetDeclaration
+%type<IR::IndexedVector<IR::ParserState>>  parserStates
+%type<IR::IndexedVector<IR::Declaration>> constantDeclaration variableDeclaration parserLocalElement controlLocalDeclaration
+%type<IR::Declaration*>     actionDeclaration variableDeclarationWithoutSemicolon instantiation
+                            functionDeclaration objDeclaration tableDeclaration
+                            valueSetDeclaration
 %type<IR::Type_Declaration*>  headerTypeDeclaration structTypeDeclaration
                               headerUnionDeclaration derivedTypeDeclaration
                               parserDeclaration controlDeclaration enumDeclaration
@@ -321,8 +324,7 @@ using namespace P4;
 %type<IR::Type_Parser*>     parserTypeDeclaration
 %type<IR::Type_Control*>    controlTypeDeclaration
 %type<IR::IndexedVector<IR::Declaration>>  parserLocalElements controlLocalDeclarations
-%type<IR::StructField*>     structField
-%type<IR::IndexedVector<IR::StructField>>  structFieldList
+%type<IR::IndexedVector<IR::StructField>>  structField structFieldList
 %type<IR::IndexedVector<IR::SerEnumMember>> specifiedIdentifierList
 %type<IR::SerEnumMember*>   specifiedIdentifier
 %type<IR::Method*>          methodPrototype functionPrototype
@@ -479,14 +481,18 @@ p4rtControllerType
 program : input END { YYACCEPT; };
 
 input
-    : %empty             { driver.result = $$ = new IR::P4Program; }
-    | input declaration  { if ($2) $1->objects.push_back($2->getNode());
-                           $$ = $1; }
-    | input ";"          { $$ = $1; }   // empty declaration
+    : %empty              { driver.result = $$ = new IR::P4Program; }
+    | input declaration   { $$ = $1;
+                            if (!$2) { /* do nothing */ }
+                            else if (auto *v = $2->to<IR::VectorBase>())
+                                $$->objects.append(*v);
+                            else
+                                $$->objects.push_back($2); }
+    | input ";"           { $$ = $1; }   // empty declaration
     ;
 
 declaration
-    : constantDeclaration     { $$ = $1; }
+    : constantDeclaration     { $$ = new IR::IndexedVector<IR::Declaration>(std::move($1)); }
     | externDeclaration       { $$ = $1; }
     | actionDeclaration       { $$ = $1; }
     | parserDeclaration       { $$ = $1; }
@@ -832,14 +838,14 @@ parserDeclaration
 
 parserLocalElements
     : %empty                                 { $$ = {}; }
-    | parserLocalElements parserLocalElement { ($$ = std::move($1)).push_back($2); $$.srcInfo = @1 + @2; }
+    | parserLocalElements parserLocalElement { ($$ = std::move($1)).append($2); $$.srcInfo = @1 + @2; }
     ;
 
 parserLocalElement
-    : constantDeclaration             { $$ = $1; }
-    | instantiation                   { $$ = $1; }
-    | variableDeclaration             { $$ = $1; }
-    | valueSetDeclaration             { $$ = $1; }
+    : constantDeclaration             { $$ = std::move($1); }
+    | instantiation                   { $$.push_back($1); }
+    | variableDeclaration             { $$ = std::move($1); }
+    | valueSetDeclaration             { $$.push_back($1); }
     ;
 
 parserTypeDeclaration
@@ -867,16 +873,16 @@ parserState
 
 parserStatements
     : %empty                           { $$ = {}; }
-    | parserStatements parserStatement { ($$ = std::move($1)).push_back($2); $$.srcInfo = @1 + @2; }
+    | parserStatements parserStatement { ($$ = std::move($1)).append($2); $$.srcInfo = @1 + @2; }
     ;
 
 parserStatement
-    : assignmentOrMethodCallStatement { $$ = $1; }
-    | emptyStatement                  { $$ = $1; }
-    | variableDeclaration             { $$ = $1; }
-    | constantDeclaration             { $$ = $1; }
-    | parserBlockStatement            { $$ = $1; }
-    | conditionalStatement            { $$ = $1; }
+    : assignmentOrMethodCallStatement { $$.push_back($1); }
+    | emptyStatement                  { $$.push_back($1); }
+    | variableDeclaration             { for (auto *decl : $1) $$.push_back(decl); }
+    | constantDeclaration             { for (auto *decl : $1) $$.push_back(decl); }
+    | parserBlockStatement            { $$.push_back($1); }
+    | conditionalStatement            { $$.push_back($1); }
     ;
 
 parserBlockStatement
@@ -982,14 +988,16 @@ controlTypeDeclaration
 
 controlLocalDeclarations
     : %empty { $$ = {}; }
-    | controlLocalDeclarations controlLocalDeclaration { ($$ = std::move($1)).push_back($2); $$.srcInfo = @1 + @2; }
+    | controlLocalDeclarations controlLocalDeclaration {
+                ($$ = std::move($1)).append($2);
+                $$.srcInfo = @1 + @2; }
     ;
 
 controlLocalDeclaration
     : constantDeclaration      { $$ = $1; }
-    | actionDeclaration        { $$ = $1; }
-    | tableDeclaration         { $$ = $1; }
-    | instantiation            { $$ = $1; }
+    | actionDeclaration        { $$.push_back($1); }
+    | tableDeclaration         { $$.push_back($1); }
+    | instantiation            { $$.push_back($1); }
     | variableDeclaration      { $$ = $1; }
     ;
 
@@ -1203,12 +1211,22 @@ headerUnionDeclaration
 
 structFieldList
     : %empty                           { $$ = {}; }
-    | structFieldList structField      { ($$ = std::move($1)).push_back($2); $$.srcInfo = @1 + @2; }
+    | structFieldList structField      { ($$ = std::move($1)).append($2); $$.srcInfo = @1 + @2; }
     ;
 
 structField
-    : optAnnotations typeRef declarator ";"  {
-                $$ = new IR::StructField(@3, $3.name, std::move($1), $3.type); }
+    : optAnnotations typeRef declaratorList ";"  {
+        for (auto &decl : $3)
+            $$.push_back(new IR::StructField(decl.srcInfo, decl.name, std::move($1), decl.type)); }
+    ;
+
+declaratorList
+    : declarator { $$.emplace_back($1); }
+    | declaratorList "," <ConstType*>{ $$ = $<ConstType*>0; } declarator {
+            if ($1.size() == 1)
+                warning(ErrorType::WARN_EXTENSION,
+                        "%1%Multiple declarators is a non-standard extension", @4);
+            ($$=$1).emplace_back($4); }
     ;
 
 enumDeclaration
@@ -1352,7 +1370,7 @@ blockStatement
 
 statOrDeclList
     : %empty                                { $$ = {}; }
-    | statOrDeclList statementOrDeclaration { ($$ = std::move($1)).push_back($2);
+    | statOrDeclList statementOrDeclaration { ($$ = std::move($1)).append($2);
                                               $$.srcInfo = @1 + @2; }
     ;
 
@@ -1377,14 +1395,14 @@ switchLabel
     ;
 
 statementOrDeclaration
-    : variableDeclaration      { $$ = $1; }
-    | constantDeclaration      { $$ = $1; }
-    | statement                { $$ = $1; }
+    : variableDeclaration      { for (auto *decl : $1) $$.push_back(decl); }
+    | constantDeclaration      { for (auto *decl : $1) $$.push_back(decl); }
+    | statement                { $$.push_back($1); }
       // The transition to instantiation below is not required by the
       // languge spec, but it does help p4c give a more clear error
       // message if one erroneously attempts to perform an
       // instantiation inside of a block.
-    | instantiation            { $$ = $1; }
+    | instantiation            { $$.push_back($1); }
     ;
 
 forStatement
@@ -1529,7 +1547,16 @@ actionDeclaration
 /************************* VARIABLES *****************************/
 
 variableDeclaration
-    : variableDeclarationWithoutSemicolon ";"    { $$ = $1; }
+    : annotations typeRef initDeclaratorList ";" {
+            for (auto &decl : $3) {
+                $$.push_back(new IR::Declaration_Variable(decl.srcInfo, decl.name, std::move($1),
+                                                           decl.type, decl.init));
+                driver.structure->declareObject(decl.name, decl.type->toString()); } }
+    | typeRef initDeclaratorList ";" {
+            for (auto &decl : $2) {
+                $$.push_back(new IR::Declaration_Variable(decl.srcInfo, decl.name,
+                                                           decl.type, decl.init));
+                driver.structure->declareObject(decl.name, decl.type->toString()); } }
     ;
 
 variableDeclarationWithoutSemicolon
@@ -1542,15 +1569,26 @@ variableDeclarationWithoutSemicolon
     ;
 
 constantDeclaration
-    : optAnnotations CONST typeRef declarator "=" initializer ";" {
-                $$ = new IR::Declaration_Constant(@4, $4.name, std::move($1), $4.type, $6);
-                driver.structure->declareObject($4.name, $4.type->toString()); }
+    : optAnnotations CONST typeRef initDeclaratorList ";" {
+            for (auto &decl : $4) {
+                if (!decl.init)
+                    P4::error(ErrorType::ERR_EXPECTED,
+                              "Const %1% declaration requires an initializer", decl.name);
+                $$.push_back(new IR::Declaration_Constant(decl.srcInfo, decl.name, std::move($1),
+                                                          decl.type, decl.init));
+                driver.structure->declareObject(decl.name, decl.type->toString()); } }
     ;
 
 declarator
-    : name                { $$.name = $1; $$.type = $<ConstType *>0; }
-    | declarator "[" expression "]"
-                          { $$ = $1; $$.type = new IR::Type_Array(@2+@4, $1.type, $3); }
+    : name    { $$.srcInfo = @1;
+                $$.name = $1;
+                $$.type = $<ConstType *>0;
+                $$.init = nullptr; }
+    | declarator "[" expression "]" {
+                $$ = $1;
+                $$.srcInfo += @4;
+                $$.type = new IR::Type_Array(@2+@4, $1.type, $3);
+                $$.init = nullptr; }
     ;
 
 optInitializer
@@ -1560,6 +1598,18 @@ optInitializer
 
 initializer
     : expression                          { $$ = $1; }
+    ;
+
+initDeclaratorList
+    : declarator optInitializer {
+            $$.emplace_back($1);
+            $$.back().init = $2; }
+    | initDeclaratorList "," <ConstType*>{ $$ = $<ConstType*>0; } declarator optInitializer {
+            if ($1.size() == 1)
+                warning(ErrorType::WARN_EXTENSION,
+                        "%1%Multiple declarators is a non-standard extension", @4);
+            ($$=$1).emplace_back($4);
+            $$.back().init = $5; }
     ;
 
 /**************** Expressions ****************/

--- a/lib/error_catalog.cpp
+++ b/lib/error_catalog.cpp
@@ -66,6 +66,7 @@ std::map<int, cstring> ErrorCatalog::errorCatalog = {
     {ErrorType::WARN_DUPLICATE, "duplicate"_cs},
     {ErrorType::WARN_BRANCH_HINT, "branch"_cs},
     {ErrorType::WARN_TABLE_KEYS, "keys"_cs},
+    {ErrorType::WARN_EXTENSION, "extension"_cs},
 
     // Info messages
     {ErrorType::INFO_INFERRED, "inferred"_cs},
@@ -76,6 +77,9 @@ void ErrorCatalog::initReporter(ErrorReporter &reporter) {
     // by default, ignore warnings about branch hints -- user can turn them
     // on with --Wwarn=branch
     reporter.setDiagnosticAction("branch"_cs, DiagnosticAction::Ignore);
+    // by default, ignore warnings about extensions -- user can turn them
+    // on with --Wwarn=extension
+    reporter.setDiagnosticAction("extension"_cs, DiagnosticAction::Ignore);
 }
 
 }  // namespace P4

--- a/lib/error_catalog.h
+++ b/lib/error_catalog.h
@@ -82,6 +82,7 @@ class ErrorType {
     static constexpr int WARN_DUPLICATE = 1025;    // duplicate objects
     static constexpr int WARN_BRANCH_HINT = 1026;  // branch frequency/likely hints
     static constexpr int WARN_TABLE_KEYS = 1027;   // something is wrong with a table key
+    static constexpr int WARN_EXTENSION = 1028;    // non-standard extension
     // Backends should extend this class with additional warnings in the range 1500-2141.
     static constexpr int WARN_MIN_BACKEND = 1500;  // first allowed backend warning code
     static constexpr int WARN_MAX = 2141;          // last allowed warning code

--- a/testdata/p4_16_samples/multidecls.p4
+++ b/testdata/p4_16_samples/multidecls.p4
@@ -1,0 +1,47 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr, src_addr;
+    bit<16> eth_type;
+}
+
+header ipv4_t {
+    bit<4>  version, ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen, identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl, protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr, dstAddr;
+}
+
+struct Headers {
+    ethernet_t  eth_hdr;
+    ipv4_t      ip_hdr;
+}
+
+control ingress(inout Headers h) {
+    bit<32>     addr, temp;
+    action dummy_action() {    }
+    table t1 {
+        key = { addr : exact; }
+        actions = {
+            dummy_action();
+        }
+    }
+    apply {
+        if (h.ip_hdr.protocol > 5) {
+            addr = h.ip_hdr.srcAddr;
+            temp = h.eth_hdr.src_addr[31:0];
+        } else {
+            addr = h.ip_hdr.dstAddr;
+            temp = h.eth_hdr.dst_addr[31:0];
+        }
+        t1.apply();
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> c);
+top(ingress()) main;

--- a/testdata/p4_16_samples_outputs/multidecls-first.p4
+++ b/testdata/p4_16_samples_outputs/multidecls-first.p4
@@ -1,0 +1,58 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    ipv4_t     ip_hdr;
+}
+
+control ingress(inout Headers h) {
+    bit<32> addr;
+    bit<32> temp;
+    action dummy_action() {
+    }
+    table t1 {
+        key = {
+            addr: exact @name("addr");
+        }
+        actions = {
+            dummy_action();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        if (h.ip_hdr.protocol > 8w5) {
+            addr = h.ip_hdr.srcAddr;
+            temp = h.eth_hdr.src_addr[31:0];
+        } else {
+            addr = h.ip_hdr.dstAddr;
+            temp = h.eth_hdr.dst_addr[31:0];
+        }
+        t1.apply();
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_samples_outputs/multidecls-frontend.p4
+++ b/testdata/p4_16_samples_outputs/multidecls-frontend.p4
@@ -1,0 +1,57 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    ipv4_t     ip_hdr;
+}
+
+control ingress(inout Headers h) {
+    @name("ingress.addr") bit<32> addr_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.dummy_action") action dummy_action() {
+    }
+    @name("ingress.t1") table t1_0 {
+        key = {
+            addr_0: exact @name("addr");
+        }
+        actions = {
+            dummy_action();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        if (h.ip_hdr.protocol > 8w5) {
+            addr_0 = h.ip_hdr.srcAddr;
+        } else {
+            addr_0 = h.ip_hdr.dstAddr;
+        }
+        t1_0.apply();
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_samples_outputs/multidecls-midend.p4
+++ b/testdata/p4_16_samples_outputs/multidecls-midend.p4
@@ -1,0 +1,75 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    ipv4_t     ip_hdr;
+}
+
+control ingress(inout Headers h) {
+    @name("ingress.addr") bit<32> addr_0;
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.dummy_action") action dummy_action() {
+    }
+    @name("ingress.t1") table t1_0 {
+        key = {
+            addr_0: exact @name("addr");
+        }
+        actions = {
+            dummy_action();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    @hidden action multidecls35() {
+        addr_0 = h.ip_hdr.srcAddr;
+    }
+    @hidden action multidecls38() {
+        addr_0 = h.ip_hdr.dstAddr;
+    }
+    @hidden table tbl_multidecls35 {
+        actions = {
+            multidecls35();
+        }
+        const default_action = multidecls35();
+    }
+    @hidden table tbl_multidecls38 {
+        actions = {
+            multidecls38();
+        }
+        const default_action = multidecls38();
+    }
+    apply {
+        if (h.ip_hdr.protocol > 8w5) {
+            tbl_multidecls35.apply();
+        } else {
+            tbl_multidecls38.apply();
+        }
+        t1_0.apply();
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_samples_outputs/multidecls.p4
+++ b/testdata/p4_16_samples_outputs/multidecls.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    ipv4_t     ip_hdr;
+}
+
+control ingress(inout Headers h) {
+    bit<32> addr;
+    bit<32> temp;
+    action dummy_action() {
+    }
+    table t1 {
+        key = {
+            addr: exact;
+        }
+        actions = {
+            dummy_action();
+        }
+    }
+    apply {
+        if (h.ip_hdr.protocol > 5) {
+            addr = h.ip_hdr.srcAddr;
+            temp = h.eth_hdr.src_addr[31:0];
+        } else {
+            addr = h.ip_hdr.dstAddr;
+            temp = h.eth_hdr.dst_addr[31:0];
+        }
+        t1.apply();
+    }
+}
+
+control c<H>(inout H h);
+package top<H>(c<H> c);
+top(ingress()) main;


### PR DESCRIPTION
Some people consider multiple declarators in a declaration as one of the big mistakes of C, and think they should never be used.  Some coding standards require that every variable be declared in a separate declaration, as P4 currently requires.

Other people coming to P4 from C or C++ are annoyed by this restriction, and try to write code with multiple declarators.

This change allows such declarations as an extension, and can warn about them as a non-standard extension.

