### PR TITLE
Fix Tofino manifest flag parsing

### DIFF
--- a/backends/tofino/bf-p4c/logging/manifest.cpp
+++ b/backends/tofino/bf-p4c/logging/manifest.cpp
@@ -91,7 +91,7 @@ Manifest::InputFiles::InputFiles(const BFN_Options &options) {
     const char *const sep = " ";
     for (const auto *word = strtok_r(ppFlags, sep, &brkt); word;
          word = strtok_r(nullptr, sep, &brkt)) {
-        if ('0' == word[0]) {
+        if ('-' == word[0]) {
             if ('I' == word[1])
                 m_includePaths.insert(cstring(word + 2));
             else if ('D' == word[1])


### PR DESCRIPTION
## Summary\n- fix Tofino manifest preprocessor flag parsing to recognize '-' prefixed options\n- restore capture of -I, -D, and -U flags in the generated manifest\n\n## Testing\n- build not run locally because this machine only has /usr/bin/bison 2.3 while the repository requires Bison >= 3.3 for CMake configuration