### PR TITLE
use ordered_map for ProgramStructure field

### DIFF
--- a/backends/common/programStructure.h
+++ b/backends/common/programStructure.h
@@ -51,7 +51,7 @@ class ProgramStructure {
     /// We place scalar user metadata fields (i.e., bit<>, bool)
     /// in the scalarsName metadata object, so we may need to rename
     /// these fields.  This map holds the new names.
-    std::map<const IR::StructField *, cstring> scalarMetadataFields;
+    ordered_map<const IR::StructField *, cstring> scalarMetadataFields;
     /// All match kinds
     std::set<cstring> match_kinds;
     /// map IR node to compile-time allocated resource blocks.


### PR DESCRIPTION
Use an ordered_map for ProgramStructure::scalarMetadataFields to make iteration order consitent when generating JSON in PortableCodeGenerator.