### PR TITLE
Support `-W` option for passing warning flags to `cpp` (C preprocessor)

### DIFF
--- a/frontends/common/parser_options.cpp
+++ b/frontends/common/parser_options.cpp
@@ -166,6 +166,13 @@ ParserOptions::ParserOptions(std::string_view defaultMessage) : Util::Options(de
             return true;
         },
         "Like -Mt, override target but quote special characters (passed to preprocessor)");
+    registerOption(
+        "-W", "warning flag",
+        [this](const char *arg) {
+            preprocessor_options += std::string(" -W") + arg;
+            return true;
+        },
+        "Specify warning flag (passed to preprocessor)");
 
     registerOption(
         "--p4v", "{14|16}",


### PR DESCRIPTION
Adds the `-W<warning flag>` option, which just passes `-W<warning flag>` to `cpp`. Needed for example, to pass `-Werror` to convert all `cpp` warnings into errors.
Example:
```
#define X 1
#define X 2

control c() {
    apply {}
}

control none();
package top(none n);
top(c()) main;
```
```
p4c$ p4test cpp-w-option.p4 --dump t
cpp-w-option.p4:2: warning: "X" redefined
    2 | #define X 2
      |
cpp-w-option.p4:1: note: this is the location of the previous definition
    1 | #define X 1
      |
```
```
p4c$ p4test cpp-w-option.p4 --dump t -Werror
cpp-w-option.p4:2: error: "X" redefined [-Werror]
    2 | #define X 2
      |
cpp-w-option.p4:1: note: this is the location of the previous definition
    1 | #define X 1
      |
cc1: all warnings being treated as errors
[--Werror=I/O error] error: Preprocessor returned exit code 256; aborting compilation
[--Werror=overlimit] error: 1 errors encountered, aborting compilation
```