### PR TITLE
docker: install missing Boost runtime library

### DIFF
--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -420,6 +420,9 @@ if [ "$CMAKE_ONLY" == "OFF" ]; then
 fi
 
 if [[ "${IMAGE_TYPE}" == "build" ]] ; then
+  # Keep runtime library required by installed backend executables.
+  sudo apt-get install -y --no-install-recommends libboost-iostreams1.71.0
+
   sudo apt-get purge -y ${P4C_DEPS} git
   sudo apt-get autoremove --purge -y
   rm -rf "${P4C_DIR}" /var/cache/apt/* /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #5593

The Docker image currently removes the Boost iostreams runtime
library during image cleanup:

```
apt-get purge -y ${P4C_DEPS}
apt-get autoremove --purge -y
```

However, several installed backend executables still depend on:

```
libboost_iostreams.so.1.71.0
```

Examples include:

* p4c-bm2-ss
* p4c-ebpf
* p4test
* p4testgen

Reproduction:

```
docker run --rm -it p4lang/p4c:latest p4c-bm2-ss --help
```

Result:

```
error while loading shared libraries:
libboost_iostreams.so.1.71.0: cannot open shared object file
```

This change explicitly installs the runtime package before cleanup,
so the installed binaries remain executable.
