### PR TITLE
Fix CMake PATHS keyword in BMv2 PNA NIC search

### DIFF
--- a/cmake/FindBMV2.cmake
+++ b/cmake/FindBMV2.cmake
@@ -80,7 +80,7 @@ endif()
   
 # check for pna_nic
 find_program (PNA_NIC_CLI pna_nic_CLI
-  paths ${BMV2_PNA_NIC_SEARCH_PATHS} )
+  PATHS ${BMV2_PNA_NIC_SEARCH_PATHS} )
 if (PNA_NIC_CLI)
   find_program (PNA_NIC pna_nic
     PATHS ${BMV2_PNA_NIC_SEARCH_PATHS} )


### PR DESCRIPTION
This PR fixes a typo in the CMake configuration for BMv2 program detection in `FindBMV2.cmake`.

### Changes made:
- Corrected incorrect keyword `paths` to `PATHS` in the `find_program` call for `pna_nic_CLI`
- Ensures CMake properly recognizes and uses the provided search paths for locating BMv2 PNA NIC binaries

### Impact:
- Fixes a potential issue where the search path hint may be ignored by CMake due to incorrect keyword casing
- Improves reliability of BMv2 program detection during build and testing

### Notes:
This is a small, isolated fix with no functional changes to build logic beyond correcting the CMake keyword usage.