### PR TITLE
Fix typo in BMv2 test message

### DIFF
--- a/cmake/FindBMV2.cmake
+++ b/cmake/FindBMV2.cmake
@@ -92,5 +92,5 @@ endif (PNA_NIC_CLI)
 mark_as_advanced(PNA_NIC PNA_NIC_CLI)
 
 find_package_handle_standard_args ("BMV2"
-  "Program 'pna_nic_CLI' (https://github.com/p4lang/behavioral-model.git) not found;\nSearched ${BMV2_PNA_NIC_SEARCH_PATHS}.\nWill not run PNA PNA BMv2 tests."
+  "Program 'pna_nic_CLI' (https://github.com/p4lang/behavioral-model.git) not found;\nSearched ${BMV2_PNA_NIC_SEARCH_PATHS}.\nWill not run PNA BMv2 tests."
   PNA_NIC PNA_NIC_CLI)


### PR DESCRIPTION
This PR fixes a minor typographical error in the BMv2 test message in `cmake/FindBMV2.cmake`.

### Change:
- Removed duplicated word "PNA" in the message:
  "Will not run PNA PNA BMv2 tests." → "Will not run PNA BMv2 tests."

### Impact:
- Purely cosmetic fix
- Improves readability of build/test output messages
- No functional or behavioral changes to the build system

### Notes:
This is a small, isolated documentation-style fix and does not affect any build logic or program detection behavior.