### PR TITLE
Fix incorrect file reported in P4Runtime entries error message

### DIFF
--- a/control-plane/p4RuntimeSerializer.cpp
+++ b/control-plane/p4RuntimeSerializer.cpp
@@ -1639,7 +1639,7 @@ void P4RuntimeSerializer::serializeP4RuntimeIfRequired(const P4RuntimeAPI &p4Run
                 p4Runtime.serializeEntriesTo(out.get(), format);
             } else {
                 ::P4::error(ErrorType::ERR_IO, "Couldn't open P4Runtime static entries file: %1%",
-                            options.p4RuntimeEntriesFile);
+                            file);
             }
         }
     }


### PR DESCRIPTION
This PR fixes incorrect error reporting for P4Runtime static entries file handling in `p4RuntimeSerializer.cpp`.

### Problem
When a P4Runtime entries file fails to open inside the loop, the error message incorrectly reports the global option:
`options.p4RuntimeEntriesFile`

This leads to misleading error messages when multiple entries files are processed.

### Fix
Replaced the incorrect variable with the loop-local file variable:
`file`

### Impact
- Error messages now correctly identify the specific file that failed to open
- Improves debugging accuracy when using multiple P4Runtime entries files
- No functional changes to serialization or processing logic

### Notes
This is a small correctness fix with no behavioral changes to the system.