### PR TITLE
Make DuplicateActionControlPlaneNameCheck an Inspector

### DIFF
--- a/frontends/p4/duplicateActionControlPlaneNameCheck.cpp
+++ b/frontends/p4/duplicateActionControlPlaneNameCheck.cpp
@@ -24,7 +24,7 @@ void DuplicateActionControlPlaneNameCheck::checkForDuplicateName(cstring name,
     }
 }
 
-const IR::Node *DuplicateActionControlPlaneNameCheck::postorder(IR::P4Action *action) {
+void DuplicateActionControlPlaneNameCheck::postorder(const IR::P4Action *action) {
     bool topLevel = stack.empty();
     auto nameAnno = action->getAnnotation(IR::Annotation::nameAnnotation);
     if (!nameAnno && topLevel) {
@@ -54,7 +54,6 @@ const IR::Node *DuplicateActionControlPlaneNameCheck::postorder(IR::P4Action *ac
         }
         checkForDuplicateName(name, action);
     }
-    return action;
 }
 
 }  // namespace P4

--- a/frontends/p4/duplicateActionControlPlaneNameCheck.h
+++ b/frontends/p4/duplicateActionControlPlaneNameCheck.h
@@ -31,7 +31,7 @@ namespace P4 {
  * design, that were not created by the P4 developer.  We should not
  * issue an error if that pass creates duplicate hierarchical names.
  */
-class DuplicateActionControlPlaneNameCheck : public Transform {
+class DuplicateActionControlPlaneNameCheck : public Inspector {
     std::vector<cstring> stack;
     /// Used for detection of conflicting control plane names among actions.
     absl::flat_hash_map<cstring, const IR::Node *> actions;
@@ -43,32 +43,27 @@ class DuplicateActionControlPlaneNameCheck : public Transform {
         setName("DuplicateActionControlPlaneNameCheck");
         visitDagOnce = false;
     }
-    const IR::Node *preorder(IR::P4Parser *parser) override {
+    bool preorder(const IR::P4Parser *) override {
         // There cannot be any action definitions inside a parser, so
         // do not traverse through its nodes.
-        prune();
-        return parser;
+        return false;
     }
 
-    const IR::Node *preorder(IR::P4Control *control) override {
+    bool preorder(const IR::P4Control *control) override {
         stack.push_back(getName(control));
-        return control;
+        return true;
     }
-    const IR::Node *postorder(IR::P4Control *control) override {
-        stack.pop_back();
-        return control;
-    }
+    void postorder(const IR::P4Control *) override { stack.pop_back(); }
 
-    const IR::Node *preorder(IR::P4Table *table) override {
+    bool preorder(const IR::P4Table *) override {
         // There cannot be any action definitions inside a table, so
         // do not traverse through its nodes.
-        prune();
-        return table;
+        return false;
     }
 
     void checkForDuplicateName(cstring name, const IR::Node *node);
 
-    const IR::Node *postorder(IR::P4Action *action) override;
+    void postorder(const IR::P4Action *action) override;
 };
 
 }  // namespace P4


### PR DESCRIPTION
Using a Transform when there is no actual change is wasteful