### PR TITLE
[P4Smith] Fix several bugs when generating signed bit expressions

### DIFF
--- a/backends/p4tools/modules/smith/common/expressions.cpp
+++ b/backends/p4tools/modules/smith/common/expressions.cpp
@@ -486,20 +486,24 @@ IR::Expression *ExpressionGenerator::constructBinaryBitExpr(const IR::Type_Bits 
             // pick a division that matches the type
             // TODO(fruffy): Make more sophisticated
             // this requires only compile time known values
+            P4Scope::req.not_negative = true;
             IR::Expression *left = genBitLiteral(tb);
             P4Scope::req.not_zero = true;
             IR::Expression *right = genBitLiteral(tb);
             P4Scope::req.not_zero = false;
+            P4Scope::req.not_negative = false;
             expr = new IR::Div(tb, left, right);
         } break;
         case 2: {
             // pick a modulo that matches the type
             // TODO(fruffy): Make more sophisticated
             // this requires only compile time known values
+            P4Scope::req.not_negative = true;
             IR::Expression *left = genBitLiteral(tb);
             P4Scope::req.not_zero = true;
             IR::Expression *right = genBitLiteral(tb);
             P4Scope::req.not_zero = false;
+            P4Scope::req.not_negative = false;
             expr = new IR::Mod(tb, left, right);
         } break;
         case 3: {

--- a/backends/p4tools/modules/smith/common/expressions.cpp
+++ b/backends/p4tools/modules/smith/common/expressions.cpp
@@ -486,24 +486,26 @@ IR::Expression *ExpressionGenerator::constructBinaryBitExpr(const IR::Type_Bits 
             // pick a division that matches the type
             // TODO(fruffy): Make more sophisticated
             // this requires only compile time known values
+            bool savedNotNegative = P4Scope::req.not_negative;
             P4Scope::req.not_negative = true;
             IR::Expression *left = genBitLiteral(tb);
             P4Scope::req.not_zero = true;
             IR::Expression *right = genBitLiteral(tb);
             P4Scope::req.not_zero = false;
-            P4Scope::req.not_negative = false;
+            P4Scope::req.not_negative = savedNotNegative;
             expr = new IR::Div(tb, left, right);
         } break;
         case 2: {
             // pick a modulo that matches the type
             // TODO(fruffy): Make more sophisticated
             // this requires only compile time known values
+            bool savedNotNegative = P4Scope::req.not_negative;
             P4Scope::req.not_negative = true;
             IR::Expression *left = genBitLiteral(tb);
             P4Scope::req.not_zero = true;
             IR::Expression *right = genBitLiteral(tb);
             P4Scope::req.not_zero = false;
-            P4Scope::req.not_negative = false;
+            P4Scope::req.not_negative = savedNotNegative;
             expr = new IR::Mod(tb, left, right);
         } break;
         case 3: {
@@ -554,9 +556,10 @@ IR::Expression *ExpressionGenerator::constructBinaryBitExpr(const IR::Type_Bits 
                 P4Scope::prop.width_unknown = false;
             }
             // TODO(fruffy): Make this more sophisticated,
+            bool savedNotNegative = P4Scope::req.not_negative;
             P4Scope::req.not_negative = true;
             IR::Expression *right = constructBitExpr(tb);
-            P4Scope::req.not_negative = false;
+            P4Scope::req.not_negative = savedNotNegative;
             // TODO(fruffy): Make this more sophisticated
             // shifts are limited to 8 bits
             if (P4Scope::constraints.const_lshift_count) {
@@ -576,9 +579,10 @@ IR::Expression *ExpressionGenerator::constructBinaryBitExpr(const IR::Type_Bits 
             }
 
             // TODO(fruffy): Make this more sophisticated,
+            bool savedNotNegative = P4Scope::req.not_negative;
             P4Scope::req.not_negative = true;
             IR::Expression *right = constructBitExpr(tb);
-            P4Scope::req.not_negative = false;
+            P4Scope::req.not_negative = savedNotNegative;
             // shifts are limited to 8 bits
             right = new IR::Cast(IR::Type_Bits::get(8, false), right);
             // pick a right-shift that matches the type
@@ -953,23 +957,25 @@ IR::Expression *ExpressionGenerator::constructBinaryIntExpr() {
         case 1: {
             // pick a division that matches the type
             // TODO(fruffy): Make more sophisticated
+            bool savedNotNegative = P4Scope::req.not_negative;
             P4Scope::req.not_negative = true;
             IR::Expression *left = genIntLiteral();
             P4Scope::req.not_zero = true;
             IR::Expression *right = genIntLiteral();
             P4Scope::req.not_zero = false;
-            P4Scope::req.not_negative = false;
+            P4Scope::req.not_negative = savedNotNegative;
             expr = new IR::Div(tp, left, right);
         } break;
         case 2: {
             // pick a modulo that matches the type
             // TODO(fruffy): Make more sophisticated
+            bool savedNotNegative = P4Scope::req.not_negative;
             P4Scope::req.not_negative = true;
             IR::Expression *left = genIntLiteral();
             P4Scope::req.not_zero = true;
             IR::Expression *right = genIntLiteral();
             P4Scope::req.not_zero = false;
-            P4Scope::req.not_negative = false;
+            P4Scope::req.not_negative = savedNotNegative;
             expr = new IR::Mod(tp, left, right);
         } break;
         case 3: {
@@ -988,22 +994,24 @@ IR::Expression *ExpressionGenerator::constructBinaryIntExpr() {
             // width must be known so we cast
             IR::Expression *left = constructIntExpr();
             // TODO(fruffy): Make this more sophisticated,
+            bool savedNotNegative = P4Scope::req.not_negative;
             P4Scope::req.not_negative = true;
             IR::Expression *right = constructIntExpr();
             // shifts are limited to 8 bits
             right = new IR::Cast(IR::Type_Bits::get(8, false), right);
-            P4Scope::req.not_negative = false;
+            P4Scope::req.not_negative = savedNotNegative;
             expr = new IR::Shl(tp, left, right);
         } break;
         case 6: {
             // width must be known so we cast
             IR::Expression *left = constructIntExpr();
             // TODO(fruffy): Make this more sophisticated,
+            bool savedNotNegative = P4Scope::req.not_negative;
             P4Scope::req.not_negative = true;
             IR::Expression *right = constructIntExpr();
             // shifts are limited to 8 bits
             right = new IR::Cast(IR::Type_Bits::get(8, false), right);
-            P4Scope::req.not_negative = false;
+            P4Scope::req.not_negative = savedNotNegative;
             expr = new IR::Shr(tp, left, right);
         } break;
         case 7: {

--- a/backends/p4tools/modules/smith/common/expressions.cpp
+++ b/backends/p4tools/modules/smith/common/expressions.cpp
@@ -218,14 +218,33 @@ IR::Constant *ExpressionGenerator::genIntLiteral(size_t bit_width) {
     }
     return new IR::Constant(value);
 }
-IR::Constant *ExpressionGenerator::genBitLiteral(const IR::Type *tb) {
-    big_int maxSize = IR::getMaxBvVal(tb->width_bits());
-    big_int value;
-    if (maxSize == 0) {
-        value = 0;
-        return new IR::Constant(tb, value);
+
+IR::Constant *ExpressionGenerator::genBitLiteral(const IR::Type *tp) {
+    const auto *tb = tp->to<IR::Type_Bits>();
+    big_int maxUnsignedVal = IR::getMaxBvVal(tb->width_bits());
+    if (maxUnsignedVal == 0) {
+        return new IR::Constant(tb, 0);
     }
-    return new IR::Constant(tb, Utils::getRandBigInt(P4Scope::req.not_zero ? 1 : 0, maxSize));
+    if (tb->isSigned) {
+        // int<N>
+        big_int half = (maxUnsignedVal + 1) / 2;
+        big_int lo = P4Scope::req.not_negative ? big_int(0) : -half;
+        big_int hi = half - 1;
+        if (P4Scope::req.not_zero) {
+            lo = lo + 1;
+        }
+        big_int res = Utils::getRandBigInt(lo, hi);
+        if (P4Scope::req.not_zero && res == 0) {
+            // When not_zero && !not_negative, lo = -half + 1, so 0 is still in range. Map it to
+            // -half to get the desired uniform range.
+            res = -half;
+        }
+        return new IR::Constant(tb, res);
+    }
+    // bit<N>
+    big_int lo = P4Scope::req.not_zero ? 1 : 0;
+    big_int res = Utils::getRandBigInt(lo, maxUnsignedVal);
+    return new IR::Constant(tb, res);
 }
 
 IR::Expression *ExpressionGenerator::genExpression(const IR::Type *tp) {

--- a/backends/p4tools/modules/smith/common/expressions.cpp
+++ b/backends/p4tools/modules/smith/common/expressions.cpp
@@ -640,8 +640,9 @@ IR::Expression *ExpressionGenerator::constructTernaryBitExpr(const IR::Type_Bits
     }
     P4Scope::prop.depth++;
 
-    std::vector<int64_t> percent = {Probabilities::get().EXPRESSION_BIT_BINARY_SLICE,
-                                    Probabilities::get().EXPRESSION_BIT_BINARY_MUX};
+    // Slices are always unsigned, and should not be constructed for int<N> target types
+    int64_t pctSlice = tb->isSigned ? 0 : Probabilities::get().EXPRESSION_BIT_BINARY_SLICE;
+    std::vector<int64_t> percent = {pctSlice, Probabilities::get().EXPRESSION_BIT_BINARY_MUX};
 
     switch (Utils::getRandInt(percent)) {
         case 0: {

--- a/backends/p4tools/modules/smith/common/expressions.h
+++ b/backends/p4tools/modules/smith/common/expressions.h
@@ -72,7 +72,7 @@ class ExpressionGenerator : public Generator {
 
     static IR::Constant *genIntLiteral(size_t bit_width = INTEGER_WIDTH);
 
-    static IR::Constant *genBitLiteral(const IR::Type *tb);
+    static IR::Constant *genBitLiteral(const IR::Type *tp);
 
     [[nodiscard]] virtual std::vector<int> availableBitWidths() const {
         return {4, 8, 16, 32, 64, 128};


### PR DESCRIPTION
Smith has some support for int types, but has several small bugs which can result in compiler warnings or generation of an undesired value. This PR fixes 4 such bugs:

1. `ExpressionGenerator::genBitLiteral` currently does not check the signedness of the passed type at all and always generates an unsigned value based on the width of the target type. This sometimes resulted in an overflow warning when generating a value outside the signed type's range: `[--Wwarn=overflow] warning: 6s40: signed value does not fit in 6 bits`.
This PR correctly sets the range to avoid emitting unnecessary warnings in this case, and additionally implements handling for the `not_negative` and `not_zero` scope requirements which are set when generating operands for divisions, mods, and bitshifts.

2. `ExpressionGenerator::constructBinaryBitExpr` currently requires that the RHS operand of divs and mods is nonzero, but does not require that the operands are nonnegative.

3. The `not_negative` scope requirement for division, mod, and bitshift operands is currently set and unset without any knowledge of the calling context. In theory, this can result in the value being clobbered when these operations are nested. For example, if we fuzzed the expression `A << ((B << C) + D)`, the language spec requires that `C` and `(B << C) + D` be nonnegative (because they are the RHS of bitshift operations). However, when Smith generates this expression, `P4Scope::req.not_negative` is set to false after `B << C` is generated, allowing `D` to be constructed as a large negative value (in turn causing `(B << C) + D` to be negative).
Note that `P4Scope::req.not_zero` is similarly set and unset without regard for calling context, but is not addressed in this PR. Currently, `not_zero` is only used/modified when generating div/mod operands, for which Smith only generates literals (not recursive expressions). This means the clobbering issue cannot occur in this case. If Smith is extended to generate more complex div/mod expressions in the future, a similar save/restore pattern will need to be applied to `not_zero`.

4. `ExpressionGenerator::constructTernaryBitExpr` currently generates either a bitslice or a mux. However, according to the P4 spec, bit slices are always unsigned, so they should not be generated when the target type is signed.

It should be noted that Smith currently has the probability of generating a signed-bit basetype set to 0, so none of these bugs currently exhibit unless the weights are modified or a target explicitly adds an object with signed-bit type to the scope.