### PR TITLE
Fix interpreter crash when calling isValid() on a header union in parser

### DIFF
--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -1123,13 +1123,16 @@ void ExpressionEvaluator::postorder(const IR::MethodCallExpression *expression) 
             return;
         } else {
             BUG_CHECK(name == IR::Type_Header::isValid, "%1%: unexpected method", bim->name);
-            if (auto hv = structVar->to<SymbolicHeader>()) {
-                auto v = hv->valid;
-                set(expression, v);
-                return;
-            } else {
+            SymbolicBool *v = nullptr;
+            if (auto hv = structVar->to<SymbolicHeader>())
+                v = hv->valid;
+            else if (auto hu = structVar->to<SymbolicHeaderUnion>())
+                v = hu->isValid();
+            else
                 BUG("Unexpected expression (%1%) type: %2%", base, base->type);
-            }
+
+            set(expression, v);
+            return;
         }
     }
 

--- a/testdata/p4_16_samples/header_union_is_valid_in_parser.p4
+++ b/testdata/p4_16_samples/header_union_is_valid_in_parser.p4
@@ -1,0 +1,22 @@
+#include <core.p4>
+@command_line("--loopsUnroll")
+
+header H {
+    bit<32> a;
+}
+
+header_union HU {
+    H h1;
+    H h2;
+}
+
+parser p(in HU hu, out bool b) {
+    state start {
+        b = hu.isValid();
+        transition accept;
+    }
+}
+
+parser proto(in HU hu, out bool b);
+package top(proto p);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/header_union_is_valid_in_parser-first.p4
+++ b/testdata/p4_16_samples_outputs/header_union_is_valid_in_parser-first.p4
@@ -1,0 +1,21 @@
+#include <core.p4>
+
+@command_line("--loopsUnroll") header H {
+    bit<32> a;
+}
+
+header_union HU {
+    H h1;
+    H h2;
+}
+
+parser p(in HU hu, out bool b) {
+    state start {
+        b = hu.isValid();
+        transition accept;
+    }
+}
+
+parser proto(in HU hu, out bool b);
+package top(proto p);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/header_union_is_valid_in_parser-frontend.p4
+++ b/testdata/p4_16_samples_outputs/header_union_is_valid_in_parser-frontend.p4
@@ -1,0 +1,21 @@
+#include <core.p4>
+
+@command_line("--loopsUnroll") header H {
+    bit<32> a;
+}
+
+header_union HU {
+    H h1;
+    H h2;
+}
+
+parser p(in HU hu, out bool b) {
+    state start {
+        b = hu.isValid();
+        transition accept;
+    }
+}
+
+parser proto(in HU hu, out bool b);
+package top(proto p);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/header_union_is_valid_in_parser-midend.p4
+++ b/testdata/p4_16_samples_outputs/header_union_is_valid_in_parser-midend.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+
+@command_line("--loopsUnroll") header H {
+    bit<32> a;
+}
+
+header_union HU {
+    H h1;
+    H h2;
+}
+
+parser p(in HU hu, out bool b) {
+    @name("tmp") bit<32> tmp_0;
+    state start {
+        tmp_0 = 32w0;
+        transition select(hu.h1.isValid()) {
+            true: start_true;
+            false: start_join;
+        }
+    }
+    state start_true {
+        tmp_0 = tmp_0 + 32w1;
+        transition start_join;
+    }
+    state start_join {
+        transition select(hu.h2.isValid()) {
+            true: start_true_0;
+            false: start_join_0;
+        }
+    }
+    state start_true_0 {
+        tmp_0 = tmp_0 + 32w1;
+        transition start_join_0;
+    }
+    state start_join_0 {
+        b = tmp_0 == 32w1;
+        transition accept;
+    }
+}
+
+parser proto(in HU hu, out bool b);
+package top(proto p);
+top(p()) main;

--- a/testdata/p4_16_samples_outputs/header_union_is_valid_in_parser.p4
+++ b/testdata/p4_16_samples_outputs/header_union_is_valid_in_parser.p4
@@ -1,0 +1,21 @@
+#include <core.p4>
+
+@command_line("--loopsUnroll") header H {
+    bit<32> a;
+}
+
+header_union HU {
+    H h1;
+    H h2;
+}
+
+parser p(in HU hu, out bool b) {
+    state start {
+        b = hu.isValid();
+        transition accept;
+    }
+}
+
+parser proto(in HU hu, out bool b);
+package top(proto p);
+top(p()) main;


### PR DESCRIPTION
The expression evaluator does not expect that `isValid()` can be called not only on a header but also on a header union.