### PR TITLE
Replace deprecated ::set-output in container image workflow

### DIFF
--- a/.github/workflows/ci-container-image.yml
+++ b/.github/workflows/ci-container-image.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+
       - name: Determine Docker image tag
         id: get-tag
         shell: bash
@@ -38,15 +39,18 @@ jobs:
               TAG=${GITHUB_REF////_}
           fi
           echo "Tag is $TAG"
-          echo "::set-output name=tag::$TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
       - name: Login to DockerHub
         if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build and push Docker image to registry
         uses: docker/build-push-action@v7
         with:


### PR DESCRIPTION
## Summary

Replace the deprecated `::set-output` command with the supported `$GITHUB_OUTPUT` mechanism in the container image workflow.

## Problem

The `Determine Docker image tag` step currently uses:

```bash
echo "::set-output name=tag::$TAG"
```

GitHub deprecated this command and modern runners no longer populate step outputs from it. As a result, `steps.get-tag.outputs.tag` may be empty, causing invalid Docker image tags such as:

```text
p4lang/p4c:
```

## Fix

Replace the deprecated command with:

```bash
echo "tag=$TAG" >> "$GITHUB_OUTPUT"
```

This preserves the existing workflow behavior while correctly exposing the `tag` output to downstream steps.

## Testing

- Verified that the workflow syntax remains valid.
- Verified that `steps.get-tag.outputs.tag` continues to be referenced
  unchanged by downstream steps.
- Confirmed compatibility with current GitHub Actions runner behavior.