### PR TITLE
ci: minor workflow cleanups (set-output deprecation, async addLabels, explicit duration cast)

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -101,7 +101,7 @@ jobs:
             
             if (labelsToAdd.length > 0) {
               if (isIssue) {
-                github.rest.issues.addLabels({
+                await github.rest.issues.addLabels({
                   issue_number: itemNumber,
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -109,7 +109,7 @@ jobs:
                 });
               } else {
                 // PRs use the issues API for labels
-                github.rest.issues.addLabels({
+                await github.rest.issues.addLabels({
                   issue_number: itemNumber,
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/.github/workflows/ci-bazel.yml
+++ b/.github/workflows/ci-bazel.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Save bazel cache
         uses: actions/cache/save@v5
-        if: always() && (github.ref_name == 'main' || env.duration > 180)
+        if: always() && (github.ref_name == 'main' || fromJSON(env.duration) > 180)
         with:
           path: ~/.cache/bazel
           key: ${{ runner.os }}-bazel-direct-${{ hashFiles('**/*.bazel*', '**/*.bzl') }}-${{ github.run_id }}
@@ -104,7 +104,7 @@ jobs:
 
       - name: Save bazel cache
         uses: actions/cache/save@v5
-        if: always() && (github.ref_name == 'main' || env.duration > 180)
+        if: always() && (github.ref_name == 'main' || fromJSON(env.duration) > 180)
         with:
           path: ~/.cache/bazel
           key: ${{ runner.os }}-bazel-indirect-${{ hashFiles('**/*.bazel*', '**/*.bzl') }}-${{ github.run_id }}

--- a/.github/workflows/ci-container-image.yml
+++ b/.github/workflows/ci-container-image.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
+
       - name: Determine Docker image tag
         id: get-tag
         shell: bash
@@ -38,15 +39,18 @@ jobs:
               TAG=${GITHUB_REF////_}
           fi
           echo "Tag is $TAG"
-          echo "::set-output name=tag::$TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
       - name: Login to DockerHub
         if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build and push Docker image to registry
         uses: docker/build-push-action@v7
         with:


### PR DESCRIPTION
This PR bundles three small, unrelated cleanups to GitHub Actions workflow files:

1. ci-container-image.yml - Replace the deprecated ::set-output command with $GITHUB_OUTPUT, since set-output is deprecated by GitHub and may stop working in the future.
2. auto-label.yml - Add await to the github.rest.issues.addLabels() calls so that label-adding failures are properly surfaced instead of silently ignored.
3. ci-bazel.yml - Use fromJSON(env.duration) instead of relying on implicit string-to-number coercion when comparing the build duration against the cache threshold, for clarity.