### PR TITLE
Add isFinal paratemer to StaticAssert pass

### DIFF
--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -230,7 +230,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
             new SpecializeGenericFunctions(&typeMap),
         }),
         new CheckCoreMethods(&typeMap),
-        new StaticAssert(&typeMap),
+        new StaticAssert(&typeMap, policy->isStaticAssertFinal()),
     });
     metricsPassManager.addUnusedCode(passes, true);
     passes.addPasses({

--- a/frontends/p4/frontend.h
+++ b/frontends/p4/frontend.h
@@ -58,6 +58,11 @@ class FrontEndPolicy : public RemoveUnusedPolicy {
     /// @returns Defaults to true
     virtual bool foldInlinedFrom() const { return true; }
 
+    /// Returns whether static_assert() should be fully evaluated in the frontend.
+    /// If false, evaluation may be deferred to a later pass.
+    /// @returns Defaults to true
+    virtual bool isStaticAssertFinal() const { return true; }
+
     /// Indicates whether the frontend should run some optimizations (inlining, action localization,
     /// etc.).
     /// @returns default to enabled optimizations unless -O0 was given in the options (i.e. enabled

--- a/frontends/p4/staticAssert.h
+++ b/frontends/p4/staticAssert.h
@@ -26,9 +26,10 @@ const cstring staticAssertMethodName = "static_assert"_cs;
 class DoStaticAssert : public Transform, public ResolutionContext {
     TypeMap *typeMap;
     bool removeStatement = false;
+    bool isFinal = true;
 
  public:
-    explicit DoStaticAssert(TypeMap *typeMap) : typeMap(typeMap) {
+    explicit DoStaticAssert(TypeMap *typeMap, bool isFinal) : typeMap(typeMap), isFinal(isFinal) {
         CHECK_NULL(typeMap);
         setName("DoStaticAssert");
     }
@@ -67,6 +68,8 @@ class DoStaticAssert : public Transform, public ResolutionContext {
                         return method;
                     }
                     return new IR::BoolLiteral(method->srcInfo, true);
+                } else if (!isFinal) {
+                    return method;
                 } else {
                     ::P4::error(ErrorType::ERR_UNEXPECTED,
                                 "Could not evaluate static_assert to a constant: %1%", arg);
@@ -88,9 +91,9 @@ class DoStaticAssert : public Transform, public ResolutionContext {
 
 class StaticAssert : public PassManager {
  public:
-    explicit StaticAssert(TypeMap *typeMap) {
+    explicit StaticAssert(TypeMap *typeMap, bool isFinal = true) {
         passes.push_back(new ReadOnlyTypeInference(typeMap));
-        passes.push_back(new DoStaticAssert(typeMap));
+        passes.push_back(new DoStaticAssert(typeMap, isFinal));
         setName("StaticAssert");
     }
 };


### PR DESCRIPTION
Add an optional `isFinal` parameter (default = true) to the `StaticAssert` constructor.

When `isFinal` is set to `false`, `DoStaticAssert` will no longer emit an error if a `static_assert` expression cannot be evaluated to a constant. Instead, the call will be left unchanged. This allows downstream projects to perform static assertion checking at a later stage (e.g. in the midend), where more expressions may be constant-foldable.

The default value preserves the existing behaviour, so this change is fully backward compatible.