### PR TITLE
Fix #5653: Infer type for untyped {#} literals in header contexts

### DIFF
--- a/frontends/p4/typeChecking/typeCheckExpr.cpp
+++ b/frontends/p4/typeChecking/typeCheckExpr.cpp
@@ -259,6 +259,23 @@ const IR::Node *TypeInferenceBase::postorder(const IR::Operation_Relation *expre
     }
 
     if (equTest) {
+        auto left = expression->left;
+        auto right = expression->right;
+        if (left->is<IR::Invalid>() && ltype->is<IR::Type_Unknown>() &&
+            (rtype->is<IR::Type_Header>() || rtype->is<IR::Type_HeaderUnion>())) {
+            left = convertUntypedInvalid(left, rtype);
+            ltype = rtype;
+        } else if (right->is<IR::Invalid>() && rtype->is<IR::Type_Unknown>() &&
+                   (ltype->is<IR::Type_Header>() || ltype->is<IR::Type_HeaderUnion>())) {
+            right = convertUntypedInvalid(right, ltype);
+            rtype = ltype;
+        }
+        if (left != expression->left || right != expression->right) {
+            auto e = expression->clone();
+            e->left = left;
+            e->right = right;
+            expression = e;
+        }
         Comparison c;
         c.left = expression->left;
         c.right = expression->right;

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -543,11 +543,34 @@ bool TypeInferenceBase::canCastBetween(const IR::Type *dest, const IR::Type *src
     return false;
 }
 
+const IR::Expression *TypeInferenceBase::convertUntypedInvalid(const IR::Expression *expr,
+                                                               const IR::Type *contextType) {
+    if (!expr->is<IR::Invalid>()) return expr;
+    auto concreteType = contextType;
+    if (auto ts = concreteType->to<IR::Type_SpecializedCanonical>())
+        concreteType = ts->substituted;
+    if (!concreteType->is<IR::Type_Header>() && !concreteType->is<IR::Type_HeaderUnion>())
+        return expr;
+
+    auto type = contextType->getP4Type();
+    setType(type, new IR::Type_Type(contextType));
+    const IR::Expression *result;
+    if (concreteType->is<IR::Type_Header>()) {
+        result = new IR::InvalidHeader(expr->srcInfo, type, type);
+    } else {
+        result = new IR::InvalidHeaderUnion(expr->srcInfo, type, type);
+    }
+    setType(result, contextType);
+    setCompileTimeConstant(result);
+    return result;
+}
+
 const IR::Expression *TypeInferenceBase::assignment(const IR::Node *errorPosition,
                                                     const IR::Type *destType,
                                                     const IR::Expression *sourceExpression) {
     if (destType->is<IR::Type_Unknown>()) BUG("Unknown destination type");
     if (destType->is<IR::Type_Dontcare>()) return sourceExpression;
+    sourceExpression = convertUntypedInvalid(sourceExpression, destType);
     const IR::Type *initType = getType(sourceExpression);
     if (initType == nullptr) return sourceExpression;
 

--- a/frontends/p4/typeChecking/typeChecker.h
+++ b/frontends/p4/typeChecking/typeChecker.h
@@ -144,6 +144,10 @@ class TypeInferenceBase : public virtual Visitor, public ResolutionContext {
         @returns new sourceExpression. */
     const IR::Expression *assignment(const IR::Node *errorPosition, const IR::Type *destType,
                                      const IR::Expression *sourceExpression);
+    /** If @expr is an untyped invalid literal {#} and @contextType is a header or
+        header_union, convert it to InvalidHeader/InvalidHeaderUnion. */
+    const IR::Expression *convertUntypedInvalid(const IR::Expression *expr,
+                                                  const IR::Type *contextType);
     const IR::SelectCase *matchCase(const IR::SelectExpression *select,
                                     const IR::Type_BaseList *selectType,
                                     const IR::SelectCase *selectCase, const IR::Type *caseType);

--- a/testdata/p4_16_samples/issue5653.p4
+++ b/testdata/p4_16_samples/issue5653.p4
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: 2026
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression test for issue #5653: comparison with {#} literal fails to compile.
+ */
+
+#include <core.p4>
+
+header h_t { bit<8> f; }
+header h2_t { bit<16> g; }
+header_union hu_t { h_t a; h2_t b; }
+
+struct meta_t {
+    h_t h;
+    bit<8> f;
+}
+
+struct nested_t {
+    meta_t m;
+}
+
+control C(inout meta_t meta, inout nested_t nested, inout hu_t hu) {
+    action a() {
+        if (meta.h == {#})
+            meta.f = 1;
+        if (meta.h != {#})
+            meta.f = 2;
+        meta.h = {#};
+        if (!meta.h.isValid())
+            meta.f = 3;
+        h_t hcast = (h_t){#};
+        if (hcast == (h_t){#}) {}
+        if (hu == {#}) {}
+        if (hu != {#}) {}
+        hu = {#};
+        if (nested.m.h == {#})
+            nested.m.f = 4;
+    }
+
+    table t {
+        actions = { a; }
+        default_action = a;
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+parser P(inout meta_t meta, inout nested_t nested, inout hu_t hu) {
+    state start {
+        meta.h = {#};
+        if (meta.h == {#}) {
+            meta.h.setInvalid();
+        }
+        transition accept;
+    }
+}
+
+control proto(inout meta_t meta, inout nested_t nested, inout hu_t hu);
+parser par(inout meta_t meta, inout nested_t nested, inout hu_t hu);
+package top(par p, proto c);
+
+top(P(), C()) main;

--- a/testdata/p4_16_samples_outputs/issue5653-first.p4
+++ b/testdata/p4_16_samples_outputs/issue5653-first.p4
@@ -1,0 +1,76 @@
+#include <core.p4>
+
+header h_t {
+    bit<8> f;
+}
+
+header h2_t {
+    bit<16> g;
+}
+
+header_union hu_t {
+    h_t  a;
+    h2_t b;
+}
+
+struct meta_t {
+    h_t    h;
+    bit<8> f;
+}
+
+struct nested_t {
+    meta_t m;
+}
+
+control C(inout meta_t meta, inout nested_t nested, inout hu_t hu) {
+    @name("a") action a_0() {
+        if (meta.h == (h_t){#}) {
+            meta.f = 8w1;
+        }
+        if (meta.h != (h_t){#}) {
+            meta.f = 8w2;
+        }
+        meta.h = (h_t){#};
+        if (meta.h.isValid()) {
+            ;
+        } else {
+            meta.f = 8w3;
+        }
+        @name("hcast") h_t hcast_0 = (h_t){#};
+        hu = (hu_t){#};
+        if (nested.m.h == (h_t){#}) {
+            nested.m.f = 8w4;
+        }
+    }
+    @name("t") table t_0 {
+        actions = {
+            a_0();
+        }
+        default_action = a_0();
+    }
+    apply {
+        t_0.apply();
+    }
+}
+
+parser P(inout meta_t meta, inout nested_t nested, inout hu_t hu) {
+    state start {
+        meta.h = (h_t){#};
+        transition select(meta.h == (h_t){#}) {
+            true: start_true;
+            false: start_join;
+        }
+    }
+    state start_true {
+        meta.h.setInvalid();
+        transition start_join;
+    }
+    state start_join {
+        transition accept;
+    }
+}
+
+control proto(inout meta_t meta, inout nested_t nested, inout hu_t hu);
+parser par(inout meta_t meta, inout nested_t nested, inout hu_t hu);
+package top(par p, proto c);
+top(P(), C()) main;

--- a/testdata/p4_16_samples_outputs/issue5653-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue5653-frontend.p4
@@ -1,0 +1,75 @@
+#include <core.p4>
+
+header h_t {
+    bit<8> f;
+}
+
+header h2_t {
+    bit<16> g;
+}
+
+header_union hu_t {
+    h_t  a;
+    h2_t b;
+}
+
+struct meta_t {
+    h_t    h;
+    bit<8> f;
+}
+
+struct nested_t {
+    meta_t m;
+}
+
+control C(inout meta_t meta, inout nested_t nested, inout hu_t hu) {
+    @name("C.a") action a_0() {
+        if (meta.h == (h_t){#}) {
+            meta.f = 8w1;
+        }
+        if (meta.h != (h_t){#}) {
+            meta.f = 8w2;
+        }
+        meta.h = (h_t){#};
+        if (meta.h.isValid()) {
+            ;
+        } else {
+            meta.f = 8w3;
+        }
+        hu = (hu_t){#};
+        if (nested.m.h == (h_t){#}) {
+            nested.m.f = 8w4;
+        }
+    }
+    @name("C.t") table t {
+        actions = {
+            a_0();
+        }
+        default_action = a_0();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+parser P(inout meta_t meta, inout nested_t nested, inout hu_t hu) {
+    state start {
+        meta.h = (h_t){#};
+        transition select(meta.h == (h_t){#}) {
+            true: start_true;
+            false: start_join;
+        }
+    }
+    state start_true {
+        meta.h.setInvalid();
+        transition start_join;
+    }
+    state start_join {
+        transition accept;
+    }
+}
+
+control proto(inout meta_t meta, inout nested_t nested, inout hu_t hu);
+parser par(inout meta_t meta, inout nested_t nested, inout hu_t hu);
+package top(par p, proto c);
+top(P(), C()) main;

--- a/testdata/p4_16_samples_outputs/issue5653-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue5653-midend.p4
@@ -1,0 +1,109 @@
+#include <core.p4>
+
+header h_t {
+    bit<8> f;
+}
+
+header h2_t {
+    bit<16> g;
+}
+
+header_union hu_t {
+    h_t  a;
+    h2_t b;
+}
+
+struct meta_t {
+    h_t    h;
+    bit<8> f;
+}
+
+struct nested_t {
+    meta_t m;
+}
+
+control C(inout meta_t meta, inout nested_t nested, inout hu_t hu) {
+    h_t ih;
+    h_t ih_0;
+    h_t ih_1;
+    h_t ih_2_a;
+    h2_t ih_2_b;
+    h_t ih_3;
+    @name("C.a") action a_0() {
+        ih.setInvalid();
+        ih_0.setInvalid();
+        ih_1.setInvalid();
+        ih_3.setInvalid();
+        if (!meta.h.isValid() && !ih.isValid() || meta.h.isValid() && ih.isValid() && meta.h.f == ih.f) {
+            meta.f = 8w1;
+        }
+        if (!meta.h.isValid() && !ih_0.isValid() || meta.h.isValid() && ih_0.isValid() && meta.h.f == ih_0.f) {
+            ;
+        } else {
+            meta.f = 8w2;
+        }
+        meta.h = ih_1;
+        if (meta.h.isValid()) {
+            ;
+        } else {
+            meta.f = 8w3;
+        }
+        if (ih_2_a.isValid()) {
+            hu.a.setValid();
+            hu.a = ih_2_a;
+            hu.b.setInvalid();
+        } else {
+            hu.a.setInvalid();
+        }
+        if (ih_2_b.isValid()) {
+            hu.b.setValid();
+            hu.b = ih_2_b;
+            hu.a.setInvalid();
+        } else {
+            hu.b.setInvalid();
+        }
+        if (!nested.m.h.isValid() && !ih_3.isValid() || nested.m.h.isValid() && ih_3.isValid() && nested.m.h.f == ih_3.f) {
+            nested.m.f = 8w4;
+        }
+    }
+    @name("C.t") table t {
+        actions = {
+            a_0();
+        }
+        default_action = a_0();
+    }
+    apply {
+        t.apply();
+    }
+}
+
+parser P(inout meta_t meta, inout nested_t nested, inout hu_t hu) {
+    h_t ih_4;
+    h_t ih_5;
+    state start {
+        ih_4.setInvalid();
+        ih_5.setInvalid();
+        meta.h = ih_4;
+        transition select((bit<1>)(!meta.h.isValid() && !ih_5.isValid() || meta.h.isValid() && ih_5.isValid() && meta.h.f == ih_5.f)) {
+            1w1: start_true;
+            1w0: start_join;
+            default: noMatch;
+        }
+    }
+    state start_true {
+        meta.h.setInvalid();
+        transition start_join;
+    }
+    state start_join {
+        transition accept;
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
+    }
+}
+
+control proto(inout meta_t meta, inout nested_t nested, inout hu_t hu);
+parser par(inout meta_t meta, inout nested_t nested, inout hu_t hu);
+package top(par p, proto c);
+top(P(), C()) main;

--- a/testdata/p4_16_samples_outputs/issue5653.p4
+++ b/testdata/p4_16_samples_outputs/issue5653.p4
@@ -1,0 +1,73 @@
+#include <core.p4>
+
+header h_t {
+    bit<8> f;
+}
+
+header h2_t {
+    bit<16> g;
+}
+
+header_union hu_t {
+    h_t  a;
+    h2_t b;
+}
+
+struct meta_t {
+    h_t    h;
+    bit<8> f;
+}
+
+struct nested_t {
+    meta_t m;
+}
+
+control C(inout meta_t meta, inout nested_t nested, inout hu_t hu) {
+    action a() {
+        if (meta.h == {#}) {
+            meta.f = 1;
+        }
+        if (meta.h != {#}) {
+            meta.f = 2;
+        }
+        meta.h = {#};
+        if (!meta.h.isValid()) {
+            meta.f = 3;
+        }
+        h_t hcast = (h_t){#};
+        if (hcast == (h_t){#}) {
+        }
+        if (hu == {#}) {
+        }
+        if (hu != {#}) {
+        }
+        hu = {#};
+        if (nested.m.h == {#}) {
+            nested.m.f = 4;
+        }
+    }
+    table t {
+        actions = {
+            a;
+        }
+        default_action = a;
+    }
+    apply {
+        t.apply();
+    }
+}
+
+parser P(inout meta_t meta, inout nested_t nested, inout hu_t hu) {
+    state start {
+        meta.h = {#};
+        if (meta.h == {#}) {
+            meta.h.setInvalid();
+        }
+        transition accept;
+    }
+}
+
+control proto(inout meta_t meta, inout nested_t nested, inout hu_t hu);
+parser par(inout meta_t meta, inout nested_t nested, inout hu_t hu);
+package top(par p, proto c);
+top(P(), C()) main;


### PR DESCRIPTION
## Summary

This PR addresses the issue of type checking of untyped `{#}` literals when they are used in header or header union compare or assignment expressions.

At present, expressions like `meta.h == {#}` and `meta.h = {#}` do not work because the `{#}` expression is considered as an untyped `Invalid` expression and no contextual type is inferred. This PR changes the way untyped `{#}` literals are converted by making sure they are converted to the proper typed invalid expression considering their contexts.

## Changes

* `convertUntypedInvalid()` function is added to convert untyped `{#}` literals to `InvalidHeader` and `InvalidHeaderUnion` expressions.
* Contextual type inference is done for comparison (`==`, `!=`) operations where `{#}` is used.
* Conversion logic is reused while type checking for assignment operation.
* Regression test is added for compare/assignment of headers using untyped `{#}` literals.

## Testing

* Checked if `meta.h == {#}` and `meta.h != {#}` expressions can be compiled successfully.
* Checked if `meta.h = {#}` works without casting the `{#}` literal to `header`.
* Executed the new regression test (`issue5653.p4`).

Fixes #5653