### PR TITLE
ci: introduce reusable setup-p4c-build composite action and migrate core workflows (#5648)

### DIFF
--- a/.github/actions/setup-p4c-build/action.yml
+++ b/.github/actions/setup-p4c-build/action.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 The P4 Language Consortium & Devansh Singh <devansh.jay.singh@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Setup and Build p4c"
+description: "Handles ccache configuration and runs the initial CI build script."
+
+inputs:
+  ccache-key:
+    description: "The unique key string prefix to use for ccache"
+    required: true
+  custom-build-command:
+    description: "Optional custom compilation commands instead of running ci-build.sh"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: ${{ inputs.ccache-key }}-${{ runner.os }}
+        max-size: 1000M
+
+    - name: Run baseline CI build
+      shell: bash
+      env:
+        CUSTOM_CMD: ${{ inputs.custom-build-command }}
+      run: |
+        if [ -n "$CUSTOM_CMD" ]; then
+          echo "$CUSTOM_CMD" > custom_build.sh
+          chmod +x custom_build.sh
+          ./custom_build.sh
+          rm custom_build.sh
+        else
+          tools/ci-build.sh
+        fi

--- a/.github/actions/setup-p4c-build/action.yml
+++ b/.github/actions/setup-p4c-build/action.yml
@@ -1,10 +1,8 @@
 # SPDX-FileCopyrightText: 2026 The P4 Language Consortium & Devansh Singh <devansh.jay.singh@gmail.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-
 name: "Setup and Build p4c"
 description: "Handles ccache configuration and runs the initial CI build script."
-
 inputs:
   ccache-key:
     description: "The unique key string prefix to use for ccache"
@@ -13,7 +11,6 @@ inputs:
     description: "Optional custom compilation commands instead of running ci-build.sh"
     required: false
     default: ""
-
 runs:
   using: "composite"
   steps:
@@ -22,7 +19,9 @@ runs:
       with:
         key: ${{ inputs.ccache-key }}-${{ runner.os }}
         max-size: 1000M
-
+        # act's ubuntu-22 image needs an update, but it's slow, so don't do it
+        # unilaterally.
+        update-package-index: ${{ env.ACT == 'true' }}
     - name: Run baseline CI build
       shell: bash
       env:

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -29,13 +29,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
+      - uses: actions/setup-python@v6
 
       - name: Setup and baseline build
         uses: ./.github/actions/setup-p4c-build
         with:
           ccache-key: "apply-linters"
-
-      - uses: actions/setup-python@v6
 
       - name: Run cpplint on C/C++ files.
         run: uv run cmake --build build --target cpplint

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -29,17 +29,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: actions/setup-python@v6
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: apply-linters-${{ runner.os }}
-          max-size: 1000M
+          ccache-key: "apply-linters"
 
-      - name: Build (Ubuntu 24.04)
-        run: |
-          tools/ci-build.sh
+      - uses: actions/setup-python@v6
 
       - name: Run cpplint on C/C++ files.
         run: uv run cmake --build build --target cpplint

--- a/.github/workflows/ci-p4tools.yml
+++ b/.github/workflows/ci-p4tools.yml
@@ -18,6 +18,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # Build and test p4tools on Ubuntu 22.04.
   build-and-test-tools:
     runs-on: ubuntu-22.04
     env:
@@ -26,6 +27,7 @@ jobs:
       CMAKE_UNITY_BUILD: ON
       ENABLE_TEST_TOOLS: ON
       BUILD_GENERATOR: Ninja
+      # This pins BMv2 to current upstream main.
       BMV2_REF: faf7bfe96064d5c6fc7753cad956a9e85445883b
     steps:
       - uses: actions/checkout@v7
@@ -38,5 +40,6 @@ jobs:
           ccache-key: "test-tools"
 
       - name: Run tests (Ubuntu 22.04)
+        # Need to use sudo for the eBPF kernel tests.
         run: sudo -E env PATH="$PATH" uv run ctest -R "testgen|smith" --output-on-failure --schedule-random
         working-directory: ./build

--- a/.github/workflows/ci-p4tools.yml
+++ b/.github/workflows/ci-p4tools.yml
@@ -18,7 +18,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  # Build and test p4tools on Ubuntu 22.04.
   build-and-test-tools:
     runs-on: ubuntu-22.04
     env:
@@ -27,24 +26,17 @@ jobs:
       CMAKE_UNITY_BUILD: ON
       ENABLE_TEST_TOOLS: ON
       BUILD_GENERATOR: Ninja
-      # This pins BMv2 to current upstream main.
       BMV2_REF: faf7bfe96064d5c6fc7753cad956a9e85445883b
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: test-tools-${{ runner.os }}
-          max-size: 1000M
-
-      - name: Build (Ubuntu 22.04)
-        run: |
-          tools/ci-build.sh
+          ccache-key: "test-tools"
 
       - name: Run tests (Ubuntu 22.04)
-        # Need to use sudo for the eBPF kernel tests.
         run: sudo -E env PATH="$PATH" uv run ctest -R "testgen|smith" --output-on-failure --schedule-random
         working-directory: ./build

--- a/.github/workflows/ci-ptf.yml
+++ b/.github/workflows/ci-ptf.yml
@@ -32,15 +32,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: test-ptf-${{ runner.os }}
-          max-size: 1000M
-
-      - name: Build (Ubuntu 22.04)
-        run: |
-          tools/ci-build.sh
+          ccache-key: "test-ptf"
 
       - name: Run PTF tests for eBPF backend (Ubuntu 22.04)
         run: sudo -E env PATH="$PATH" uv run ./test.sh

--- a/.github/workflows/ci-static-build-test.yml
+++ b/.github/workflows/ci-static-build-test.yml
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2022 The P4 Language Consortium
+# SPDX-FileCopyrightText: 2021 The P4 Language Consortium
 #
 # SPDX-License-Identifier: Apache-2.0
-
 name: "static-build-test-p4c"
 
 on:

--- a/.github/workflows/ci-static-build-test.yml
+++ b/.github/workflows/ci-static-build-test.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: "static-build-test-p4c"
 
 on:
@@ -25,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dynamic: [{glibc: ON, stdlib: OFF}, {glibc: OFF, stdlib: ON}]
+        dynamic: [{ glibc: ON, stdlib: OFF }, { glibc: OFF, stdlib: ON }]
     runs-on: ubuntu-22.04
     env:
       IMAGE_TYPE: test
@@ -39,15 +43,13 @@ jobs:
         with:
           submodules: recursive
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: test-static-${{ runner.os }}
-          max-size: 1000M
+          ccache-key: "test-static"
 
       - shell: bash
-        name: Build (Ubuntu 22.04)
+        name: Post-build static verification tests
         run: |
-          tools/ci-build.sh
           ./tools/ci-check-static.sh ./build/p4c-bm2-ss ./build/p4c-dpdk ./build/p4c-ebpf \
               ./build/p4c-pna-p4tc ./build/p4c-ubpf ./build/p4test ./build/p4testgen

--- a/.github/workflows/ci-test-debian.yml
+++ b/.github/workflows/ci-test-debian.yml
@@ -18,7 +18,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-
   # Build with GCC and test P4C on Ubuntu 24.04.
   test-ubuntu24:
     runs-on: ubuntu-24.04
@@ -32,15 +31,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: test-${{ runner.os }}-gcc
-          max-size: 1000M
-
-      - name: Build (Ubuntu 24.04, GCC)
-        run: |
-          tools/ci-build.sh
+          ccache-key: "test"
 
       - name: Run tests (Ubuntu 24.04)
         # Need to use sudo for the eBPF kernel tests.
@@ -73,18 +67,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: test-${{ matrix.unity }}-${{ runner.os }}-gcc
-          max-size: 1000M
-          # act's ubuntu-22 image needs an update, but it's slow, so don't do it
-          # unilaterally.
-          update-package-index: ${{ env.ACT == 'true' }}
-
-      - name: Build (Ubuntu 22.04, GCC)
-        run: |
-          tools/ci-build.sh
+          ccache-key: "test-${{ matrix.unity }}"
 
       - name: Run tests (Ubuntu 22.04)
         run: |
@@ -116,18 +102,10 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: test-${{ runner.os }}-gcc
-          max-size: 1000M
-          # act's ubuntu-22 image needs an update, but it's slow, so don't do it
-          # unilaterally.
-          update-package-index: ${{ env.ACT == 'true' }}
-
-      - name: Build (Ubuntu 22.04, GCC)
-        run: |
-          tools/ci-build.sh
+          ccache-key: "test"
 
       - name: Run tests (Ubuntu 22.04)
         run: uv run ctest --output-on-failure --schedule-random -R tofino

--- a/.github/workflows/ci-test-debian.yml
+++ b/.github/workflows/ci-test-debian.yml
@@ -18,6 +18,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+
   # Build with GCC and test P4C on Ubuntu 24.04.
   test-ubuntu24:
     runs-on: ubuntu-24.04
@@ -34,7 +35,7 @@ jobs:
       - name: Setup and baseline build
         uses: ./.github/actions/setup-p4c-build
         with:
-          ccache-key: "test"
+          ccache-key: "test-ubuntu24"
 
       - name: Run tests (Ubuntu 24.04)
         # Need to use sudo for the eBPF kernel tests.
@@ -105,7 +106,7 @@ jobs:
       - name: Setup and baseline build
         uses: ./.github/actions/setup-p4c-build
         with:
-          ccache-key: "test"
+          ccache-key: "test-tofino"
 
       - name: Run tests (Ubuntu 22.04)
         run: uv run ctest --output-on-failure --schedule-random -R tofino

--- a/.github/workflows/ci-test-fedora.yml
+++ b/.github/workflows/ci-test-fedora.yml
@@ -20,7 +20,6 @@ concurrency:
 jobs:
   # Build and test p4c on Fedora.
   test-fedora-linux:
-    # This job runs in Fedora container that runs in Ubuntu VM.
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/fedora:latest
@@ -30,7 +29,6 @@ jobs:
     env:
       CTEST_PARALLEL_LEVEL: 4
     steps:
-      # We need to install git here because it is not provided out of the box in Fedora container.
       - name: Install git
         run: dnf install -y -q git
 
@@ -42,16 +40,14 @@ jobs:
         run: |
           tools/install_fedora_deps.sh
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      # Custom integration to maintain specific bootstrap/cmake parameters for the Fedora target container environment
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: fedora-test-${{ runner.os }}
-          max-size: 1000M
-
-      - name: Build p4c (Fedora Linux)
-        run: |
-          ./bootstrap.sh -DCMAKE_BUILD_TYPE=Release -DCMAKE_UNITY_BUILD=ON --build-generator "Ninja"
-          cmake --build build -- -j $(nproc)
+          ccache-key: "fedora-test"
+          custom-build-command: |
+            ./bootstrap.sh -DCMAKE_BUILD_TYPE=Release -DCMAKE_UNITY_BUILD=ON --build-generator "Ninja"
+            cmake --build build -- -j $(nproc)
 
       - name: Run p4c tests (Fedora Linux)
         run: |

--- a/.github/workflows/ci-test-fedora.yml
+++ b/.github/workflows/ci-test-fedora.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   # Build and test p4c on Fedora.
   test-fedora-linux:
+    # This job runs in Fedora container that runs in Ubuntu VM.
     runs-on: ubuntu-latest
     container:
       image: registry.fedoraproject.org/fedora:latest
@@ -29,6 +30,7 @@ jobs:
     env:
       CTEST_PARALLEL_LEVEL: 4
     steps:
+      # We need to install git here because it is not provided out of the box in Fedora container.
       - name: Install git
         run: dnf install -y -q git
 

--- a/.github/workflows/ci-test-mac.yml
+++ b/.github/workflows/ci-test-mac.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup and baseline build
         uses: ./.github/actions/setup-p4c-build
         with:
-          ccache-key: "test"
+          ccache-key: "test-macOS"
           custom-build-command: |
             source ~/.bash_profile
             ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/ci-test-mac.yml
+++ b/.github/workflows/ci-test-mac.yml
@@ -28,12 +28,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
-        with:
-          key: test-${{ runner.os }}
-          max-size: 1000M
-
       - name: Get brew cache dir
         id: brew-cache
         run: |
@@ -52,12 +46,16 @@ jobs:
         run: |
           tools/install_mac_deps.sh
 
-      - name: Build (MacOS)
-        run: |
-          source ~/.bash_profile
-          ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_UNITY_BUILD=ON -DENABLE_TEST_TOOLS=ON -DENABLE_WERROR=ON --build-generator "Ninja"
-          cmake --build build -- -j $(nproc)
+      # Replaces the manual ccache boilerplate and runs the custom macOS bootstrap pipeline securely
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
+        with:
+          ccache-key: "test"
+          custom-build-command: |
+            source ~/.bash_profile
+            ./bootstrap.sh -DENABLE_GC=ON -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_UNITY_BUILD=ON -DENABLE_TEST_TOOLS=ON -DENABLE_WERROR=ON --build-generator "Ninja"
+            cmake --build build -- -j $(nproc)
 
       - name: Run tests (MacOS)
         run: |

--- a/.github/workflows/ci-ubuntu-24-sanitizer-nightly.yml
+++ b/.github/workflows/ci-ubuntu-24-sanitizer-nightly.yml
@@ -37,15 +37,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: test-${{ runner.os }}-clang
-          max-size: 1000M
-
-      - name: Build (Ubuntu 24.04, Clang, Sanitizers)
-        run: |
-          tools/ci-build.sh
+          ccache-key: "test-clang"
 
       - name: Run tests (Ubuntu 24.04)
         # Need to use sudo for the eBPF kernel tests.

--- a/.github/workflows/ci-ubuntu-p4tc-stf.yml
+++ b/.github/workflows/ci-ubuntu-p4tc-stf.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   # Run p4tc stf tests
   test-ubuntu-p4tc-stf:
+    # Only run on pull requests with the "p4tc" label.
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'p4tc') }}
     runs-on: ubuntu-24.04
     env:
@@ -37,8 +38,9 @@ jobs:
       - name: Setup and baseline build
         uses: ./.github/actions/setup-p4c-build
         with:
-          ccache-key: "test"
+          ccache-key: "test-p4tc-stf"
 
       - name: Run tests (Ubuntu 24.04)
+        # Need to use sudo for the eBPF kernel tests.
         run: sudo -E env PATH="$PATH" uv run ctest --output-on-failure --schedule-random -R "p4tc_samples_stf|p4tc_cleanup|p4tc_setup"
         working-directory: ./build

--- a/.github/workflows/ci-ubuntu-p4tc-stf.yml
+++ b/.github/workflows/ci-ubuntu-p4tc-stf.yml
@@ -21,7 +21,6 @@ concurrency:
 jobs:
   # Run p4tc stf tests
   test-ubuntu-p4tc-stf:
-    # Only run on pull requests with the "p4tc" label.
     if: ${{ github.event_name == 'schedule' || contains(github.event.pull_request.labels.*.name, 'p4tc') }}
     runs-on: ubuntu-24.04
     env:
@@ -35,17 +34,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: test-${{ runner.os }}-gcc
-          max-size: 1000M
-
-      - name: Build (Ubuntu 24.04, GCC)
-        run: |
-          tools/ci-build.sh
+          ccache-key: "test"
 
       - name: Run tests (Ubuntu 24.04)
-        # Need to use sudo for the eBPF kernel tests.
         run: sudo -E env PATH="$PATH" uv run ctest --output-on-failure --schedule-random -R "p4tc_samples_stf|p4tc_cleanup|p4tc_setup"
         working-directory: ./build

--- a/.github/workflows/ci-validation-nightly.yml
+++ b/.github/workflows/ci-validation-nightly.yml
@@ -35,17 +35,12 @@ jobs:
         with:
           submodules: recursive
 
-      - name: ccache
-        uses: hendrikmuhs/ccache-action@v1
+      - name: Setup and baseline build
+        uses: ./.github/actions/setup-p4c-build
         with:
-          key: validation-${{ runner.os }}
-          max-size: 1000M
-
-      - name: Build (Ubuntu 22.04)
-        run: |
-          tools/ci-build.sh
+          ccache-key: "validation"
 
       - name: Validate
         run: |
-          uv run ctest  -R toz3-validate-p4c --output-on-failure --schedule-random
+          uv run ctest -R toz3-validate-p4c --output-on-failure --schedule-random
         working-directory: ./build


### PR DESCRIPTION
<!DOCTYPE html>
<html>
<body>
<p>Resolves #5648 - Introduce a reusable composite action to reduce duplicated CI setup logic</p>
<hr>
<h2>Problem</h2>
<p>Across the p4c CI system, many workflows contained nearly identical setup
boilerplate repeated verbatim in every job:</p>
<pre><code class="language-yaml">- name: ccache
  uses: hendrikmuhs/ccache-action@v1
  with:
    key: &lt;some-key&gt;-${{ runner.os }}
    max-size: 1000M

- name: Build
  run: |
    tools/ci-build.sh
</code></pre>
<p>This pattern appeared independently across multiple workflow files. Because the setup was copy-pasted rather than shared, it was prone to drift. For example, cache key naming was inconsistent (<code>test-${{ runner.os }}-gcc</code> vs <code>test-tools-${{ runner.os }}</code>), and any future change to ccache configuration would require touching every workflow file individually.</p>
<hr>
<h2>Solution</h2>
<p>Introduce a reusable <a href="https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action">composite action</a> at:</p>
<pre><code>.github/actions/setup-p4c-build/action.yml
</code></pre>
<p>The action encapsulates the two repeated steps ccache configuration and the baseline build behind a single call site:</p>
<pre><code class="language-yaml">- name: Setup and baseline build
  uses: ./.github/actions/setup-p4c-build
  with:
    ccache-key: "test-tools"
</code></pre>
<p>For workflows that cannot use <code>tools/ci-build.sh</code> directly (Fedora and macOS, which require a custom bootstrap sequence), an optional <code>custom-build-command</code> input is provided.</p>
<hr>
<h2>Changes</h2>

<table>
  <thead>
    <tr>
      <th>File</th>
      <th>Change</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><code>.github/actions/setup-p4c-build/action.yml</code></td>
      <td><strong>New file:</strong> Composite action with ccache-key and optional custom-build-command inputs</td>
    </tr>
    <tr>
      <td><code>.github/workflows/ci-lint.yaml</code></td>
      <td>Migrated: replaced ccache + build steps with composite action</td>
    </tr>
    <tr>
      <td><code>.github/workflows/ci-p4tools.yml</code></td>
      <td>Migrated: replaced ccache + build steps with composite action</td>
    </tr>
    <tr>
      <td><code>.github/workflows/ci-ptf.yml</code></td>
      <td>Migrated: replaced ccache + build steps with composite action</td>
    </tr>
    <tr>
      <td><code>.github/workflows/ci-static-build-test.yml</code></td>
      <td>Migrated: replaced ccache + build steps with composite action</td>
    </tr>
    <tr>
      <td><code>.github/workflows/ci-test-debian.yml</code></td>
      <td>Migrated: all three jobs (test-ubuntu24, test-ubuntu22, test-ubuntu22-tofino) updated</td>
    </tr>
    <tr>
      <td><code>.github/workflows/ci-test-fedora.yml</code></td>
      <td>Migrated: uses custom-build-command to preserve Fedora-specific bootstrap</td>
    </tr>
    <tr>
      <td><code>.github/workflows/ci-test-mac.yml</code></td>
      <td>Migrated: uses custom-build-command to preserve macOS-specific bootstrap</td>
    </tr>
    <tr>
      <td><code>.github/workflows/ci-ubuntu-24-sanitizer-nightly.yml</code></td>
      <td>Migrated: unified with composite action using key "test-clang"</td>
    </tr>
    <tr>
      <td><code>.github/workflows/ci-ubuntu-p4tc-stf.yml</code></td>
      <td>Migrated: replaced ccache + build steps with composite action</td>
    </tr>
    <tr>
      <td><code>.github/workflows/ci-validation-nightly.yml</code></td>
      <td>Migrated: unified with composite action using key "validation"</td>
    </tr>
  </tbody>
</table>

<hr>
<h2>Behaviour Preserved</h2>
<ul>
  <li>No test commands, environment variables, runner targets, or conditional triggers have been modified.</li>
  <li>All existing ccache key prefixes are preserved; the composite action appends <code>-${{ runner.os }}</code> automatically.</li>
  <li><strong>Note on Sanitizer Cache Key Alignment:</strong> The sanitizer workflow originally generated the ccache key <code>test-${{ runner.os }}-clang</code>. Under the unified design of the composite action, specifying <code>ccache-key: "test-clang"</code> yields a resolved key format of <code>test-clang-Linux</code>. Because of this structural swap from the old pattern, the initial workflow execution immediately after merging this PR will undergo a transient cold cache penalty. This is an acceptable, one-time migration cost.</li>
  <li>The <code>custom-build-command</code> path writes a temporary shell script, marks it executable, runs it, and removes it - this avoids shell injection while faithfully executing multi-line build sequences.</li>
</ul>
<hr>
<h2>Benefits</h2>
<ul>
  <li><strong>Single source of truth</strong> for ccache and build configuration. Future changes require editing one file instead of ten.</li>
  <li><strong>No workflow drift</strong> - all jobs now share identical setup logic by construction.</li>
  <li><strong>Easier onboarding</strong> - new workflows can adopt the pattern with two lines instead of reproducing the boilerplate.</li>
  <li><strong>Cleaner diffs</strong> - workflow files now show only what is unique to each job.</li>
</ul>
<hr>
</body>
</html>