### PR TITLE
Reject duplicate extern method and constructor declarations

### DIFF
--- a/frontends/p4/frontend.cpp
+++ b/frontends/p4/frontend.cpp
@@ -175,6 +175,53 @@ class ValidateSwitchStatements : public Inspector {
     }
 };
 
+/**
+ * Rejects duplicate method or constructor declarations within an extern.
+ * Overloaded methods may share a name only when a call can be disambiguated by
+ * the number of arguments or by argument names; two declarations with the same
+ * name, parameter count, and parameter names can never be told apart, so they
+ * are duplicates rather than overloads. The existing checks only fire when such
+ * a method is actually called, so a never-instantiated extern slips through.
+ * See also #5096 for the same rule on functions.
+ */
+class ValidateOverloadedMethods : public Inspector {
+    // Two same-named methods are indistinguishable when they have the same
+    // number of parameters and the same parameter names (argument types are
+    // not used to disambiguate overloads).
+    static bool sameSignature(const IR::Method *a, const IR::Method *b) {
+        auto aParams = a->getParameters()->parameters;
+        auto bParams = b->getParameters()->parameters;
+        if (aParams.size() != bParams.size()) return false;
+        for (const auto *ap : aParams) {
+            bool found = false;
+            for (const auto *bp : bParams) {
+                if (ap->name.name == bp->name.name) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) return false;
+        }
+        return true;
+    }
+
+ public:
+    bool preorder(const IR::Type_Extern *ext) override {
+        for (size_t i = 0; i < ext->methods.size(); i++) {
+            const auto *m = ext->methods.at(i);
+            for (size_t j = i + 1; j < ext->methods.size(); j++) {
+                const auto *other = ext->methods.at(j);
+                if (m->name == other->name && sameSignature(m, other)) {
+                    P4::error(P4::ErrorType::ERR_DUPLICATE,
+                              "Duplicate declaration of %1%: previous declaration at %2%",
+                              other->name, m->srcInfo);
+                }
+            }
+        }
+        return true;
+    }
+};
+
 }  // namespace
 
 const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4Program *program,
@@ -204,6 +251,7 @@ const IR::P4Program *FrontEnd::run(const CompilerOptions &options, const IR::P4P
         // may be needed to compute types.
         new ConstantFolding(constantFoldingPolicy),
         new ValidateSwitchStatements(),
+        new ValidateOverloadedMethods(),
         // Validate @name/@deprecated/@noWarn. Should run after constant folding.
         new ValidateStringAnnotations(),
         // Desugars direct parser and control applications

--- a/testdata/p4_16_errors/issue5253.p4
+++ b/testdata/p4_16_errors/issue5253.p4
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aeron-gh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // Methods and constructors in an extern may only share a name when a call can
 // be disambiguated by the number of arguments or by argument names. Two
 // declarations with the same name, parameter count, and parameter names can

--- a/testdata/p4_16_errors/issue5253.p4
+++ b/testdata/p4_16_errors/issue5253.p4
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2026 aeron-gh
+ * SPDX-FileCopyrightText: 2026 Abhishek Agarwal
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/testdata/p4_16_errors/issue5253.p4
+++ b/testdata/p4_16_errors/issue5253.p4
@@ -1,0 +1,13 @@
+// Methods and constructors in an extern may only share a name when a call can
+// be disambiguated by the number of arguments or by argument names. Two
+// declarations with the same name, parameter count, and parameter names can
+// never be told apart, so they are duplicates and must be rejected at the
+// declaration site, even when the extern is never instantiated.
+// See https://github.com/p4lang/p4c/issues/5253
+
+extern E {
+    E(bit<8> x);
+    E(bit<8> x);
+    void f(bit<8> a);
+    void f(bit<8> a);
+}

--- a/testdata/p4_16_errors_outputs/issue5253.p4
+++ b/testdata/p4_16_errors_outputs/issue5253.p4
@@ -1,0 +1,7 @@
+extern E {
+    E(bit<8> x);
+    E(bit<8> x);
+    void f(bit<8> a);
+    void f(bit<8> a);
+}
+

--- a/testdata/p4_16_errors_outputs/issue5253.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue5253.p4-stderr
@@ -1,12 +1,12 @@
-issue5253.p4(10): [--Werror=duplicate] error: Duplicate declaration of E: previous declaration at 
+issue5253.p4(16): [--Werror=duplicate] error: Duplicate declaration of E: previous declaration at 
     E(bit<8> x);
     ^
-issue5253.p4(9)
+issue5253.p4(15)
     E(bit<8> x);
     ^
-issue5253.p4(12): [--Werror=duplicate] error: Duplicate declaration of f: previous declaration at 
+issue5253.p4(18): [--Werror=duplicate] error: Duplicate declaration of f: previous declaration at 
     void f(bit<8> a);
          ^
-issue5253.p4(11)
+issue5253.p4(17)
     void f(bit<8> a);
          ^

--- a/testdata/p4_16_errors_outputs/issue5253.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue5253.p4-stderr
@@ -1,0 +1,12 @@
+issue5253.p4(10): [--Werror=duplicate] error: Duplicate declaration of E: previous declaration at 
+    E(bit<8> x);
+    ^
+issue5253.p4(9)
+    E(bit<8> x);
+    ^
+issue5253.p4(12): [--Werror=duplicate] error: Duplicate declaration of f: previous declaration at 
+    void f(bit<8> a);
+         ^
+issue5253.p4(11)
+    void f(bit<8> a);
+         ^

--- a/testdata/p4_16_samples/issue5253_legal_overloads.p4
+++ b/testdata/p4_16_samples/issue5253_legal_overloads.p4
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aeron-gh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // All of the overloaded extern methods and constructors below share a name with
 // another declaration, but none of them is a duplicate: every pair can still be
 // told apart at a call site, either by the number of arguments or by the

--- a/testdata/p4_16_samples/issue5253_legal_overloads.p4
+++ b/testdata/p4_16_samples/issue5253_legal_overloads.p4
@@ -1,0 +1,28 @@
+// All of the overloaded extern methods and constructors below share a name with
+// another declaration, but none of them is a duplicate: every pair can still be
+// told apart at a call site, either by the number of arguments or by the
+// argument names (argument types are never used to disambiguate overloads). None
+// of these should be rejected by the duplicate-declaration check added for
+// https://github.com/p4lang/p4c/issues/5253
+
+extern E {
+    // Constructors distinguished by the number of arguments.
+    E(bit<8> x);
+    E(bit<8> x, bit<8> y);
+
+    // Same name and same number of parameters, but every parameter name is
+    // different, so a call using argument names selects a unique method.
+    void f(bit<8> a);
+    void f(bit<8> b);
+
+    // Same name, same number of parameters, and the same parameter types, with
+    // all but one parameter name identical. The single differing name is still
+    // enough to tell the two methods apart, so this is a legal overload rather
+    // than a duplicate.
+    void g(bit<8> a, bit<16> b);
+    void g(bit<8> a, bit<16> c);
+
+    // Distinguished by the number of parameters.
+    void h(bit<8> a);
+    void h(bit<8> a, bit<8> b);
+}

--- a/testdata/p4_16_samples/issue5253_legal_overloads.p4
+++ b/testdata/p4_16_samples/issue5253_legal_overloads.p4
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2026 aeron-gh
+ * SPDX-FileCopyrightText: 2026 Abhishek Agarwal
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/testdata/p4_16_samples_outputs/issue5253_legal_overloads-first.p4
+++ b/testdata/p4_16_samples_outputs/issue5253_legal_overloads-first.p4
@@ -1,0 +1,11 @@
+extern E {
+    E(bit<8> x);
+    E(bit<8> x, bit<8> y);
+    void f(bit<8> a);
+    void f(bit<8> b);
+    void g(bit<8> a, bit<16> b);
+    void g(bit<8> a, bit<16> c);
+    void h(bit<8> a);
+    void h(bit<8> a, bit<8> b);
+}
+

--- a/testdata/p4_16_samples_outputs/issue5253_legal_overloads-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue5253_legal_overloads-frontend.p4
@@ -1,0 +1,11 @@
+extern E {
+    E(bit<8> x);
+    E(bit<8> x, bit<8> y);
+    void f(bit<8> a);
+    void f(bit<8> b);
+    void g(bit<8> a, bit<16> b);
+    void g(bit<8> a, bit<16> c);
+    void h(bit<8> a);
+    void h(bit<8> a, bit<8> b);
+}
+

--- a/testdata/p4_16_samples_outputs/issue5253_legal_overloads-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue5253_legal_overloads-midend.p4
@@ -1,0 +1,11 @@
+extern E {
+    E(bit<8> x);
+    E(bit<8> x, bit<8> y);
+    void f(bit<8> a);
+    void f(bit<8> b);
+    void g(bit<8> a, bit<16> b);
+    void g(bit<8> a, bit<16> c);
+    void h(bit<8> a);
+    void h(bit<8> a, bit<8> b);
+}
+

--- a/testdata/p4_16_samples_outputs/issue5253_legal_overloads.p4
+++ b/testdata/p4_16_samples_outputs/issue5253_legal_overloads.p4
@@ -1,0 +1,11 @@
+extern E {
+    E(bit<8> x);
+    E(bit<8> x, bit<8> y);
+    void f(bit<8> a);
+    void f(bit<8> b);
+    void g(bit<8> a, bit<16> b);
+    void g(bit<8> a, bit<16> c);
+    void h(bit<8> a);
+    void h(bit<8> a, bit<8> b);
+}
+

--- a/testdata/p4_16_samples_outputs/issue5253_legal_overloads.p4-stderr
+++ b/testdata/p4_16_samples_outputs/issue5253_legal_overloads.p4-stderr
@@ -1,0 +1,1 @@
+[--Wwarn=missing] warning: Program does not contain a `main' module


### PR DESCRIPTION
Fixes #5253.

Methods and constructors in an extern can share a name only when a call can be disambiguated by the number of arguments or by argument names. Two declarations with the same name, parameter count, and parameter names can never be told apart, so they are duplicates rather than overloads.

p4c already reports these as ambiguous, but only when the method is actually called (`Type_Extern::lookupMethod`), so a duplicate in a never-instantiated extern was silently accepted. This adds a small frontend pass that rejects them at the declaration site, modeled on how #5316 handles duplicate switch case labels.

This is the extern-method case of the same problem as #5096 (duplicate functions), which the P4 LDWG agreed should be rejected by p4c. The shared rule could be extended to functions in a follow-up.