### PR TITLE
Add support for rvalue references in ir-generator

### DIFF
--- a/tools/ir-generator/ir-generator-lex.l
+++ b/tools/ir-generator/ir-generator-lex.l
@@ -70,6 +70,7 @@ static std::string      comment_block;
 
 "//".*           { yylval.str = cstring(yytext); return COMMENTBLOCK; }
 
+"&&"            { return ANDAND; }
 "::"            { return DBLCOL; }
 "abstract"      { return ABSTRACT; }
 "class"         { return CLASS; }

--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -80,6 +80,7 @@ static IrNamespace *current_namespace = LookupScope().resolve(0);
     }                           emit;
 }
 
+%token ANDAND
 %token          ABSTRACT APPLY CLASS CONST DBLCOL DEFAULT DELETE ENUM INLINE INTERFACE NAMESPACE
                 NEW NULLOK OPERATOR OPTIONAL PRIVATE PROTECTED PUBLIC STATIC VARIANT VIRTUAL
 %token<str>     BLOCK COMMENTBLOCK IDENTIFIER INCLUDE INTEGER NO STRING ZERO
@@ -374,6 +375,9 @@ type: nonRefType
     | type '&'                          { $$ = new ReferenceType($1); }
     | type CONST '&'                    { $$ = new ReferenceType($1, true); }
     | CONST nonRefType '&'              { $$ = new ReferenceType($2, true); }
+    | type ANDAND                       { $$ = new ReferenceType($1, false, true); }
+    | type CONST ANDAND                 { $$ = new ReferenceType($1, true, true); }
+    | CONST nonRefType ANDAND           { $$ = new ReferenceType($2, true, true); }
     | type '*'                          { $$ = new PointerType($1); }
     | type CONST '*'                    { $$ = new PointerType($1, true); }
     | CONST nonRefType '*'              { $$ = new PointerType($2, true); }

--- a/tools/ir-generator/type.cpp
+++ b/tools/ir-generator/type.cpp
@@ -162,7 +162,7 @@ cstring TemplateInstantiation::toString() const {
 cstring ReferenceType::toString() const {
     std::string rv = base->toString().c_str();
     if (isConst) rv += " const";
-    rv += " &";
+    rv += isRValue ? " &&" : " &";
     return rv;
 }
 

--- a/tools/ir-generator/type.h
+++ b/tools/ir-generator/type.h
@@ -143,11 +143,13 @@ class TemplateInstantiation : public Type {
 class ReferenceType : public Type {
     const Type *base;
     bool isConst;
+    bool isRValue;
 
  public:
-    explicit ReferenceType(const Type *t, bool c = false) : base(t), isConst(c) {}
-    ReferenceType(Util::SourceInfo si, const Type *t, bool c = false)
-        : Type(si), base(t), isConst(c) {}
+    explicit ReferenceType(const Type *t, bool c = false, bool rv = false)
+        : base(t), isConst(c), isRValue(rv) {}
+    ReferenceType(Util::SourceInfo si, const Type *t, bool c = false, bool rv = false)
+        : Type(si), base(t), isConst(c), isRValue(rv) {}
     bool isResolved() const override { return false; }
     const IrClass *resolve(const IrNamespace *ns) const override {
         base->resolve(ns);
@@ -156,7 +158,9 @@ class ReferenceType : public Type {
     cstring toString() const override;
     bool operator==(const Type &t) const override { return t == *this; }
     bool operator==(const ReferenceType &t) const override {
-        return isConst == t.isConst && *base == *t.base;
+        return isConst == t.isConst &&
+            isRValue == t.isRValue &&
+            *base == *t.base;
     }
     static ReferenceType OstreamRef, VisitorRef;
 };


### PR DESCRIPTION
This patch adds support for parsing and representing rvalue references (&&) in ir-generator.

Changes:
- Added lexer support for && token
- Added parser rules for rvalue references
- Extended ReferenceType with isRValue
- Updated equality and stringification logic

