### PR TITLE
Add support for rvalue references in ir-generator

### DIFF
--- a/ir/expression.def
+++ b/ir/expression.def
@@ -579,6 +579,7 @@ class MethodCallExpression : Expression {
                          Vector<Argument> args)
     : MethodCallExpression(si, m, new Vector<Type>(std::move(ta)),
                            new Vector<Argument>(std::move(args))) {}
+
     MethodCallExpression(Util::SourceInfo si, const Expression *m, Vector<Argument> args)
     : MethodCallExpression(si, m, new Vector<Argument>(std::move(args))) {}
 #end
@@ -592,11 +593,8 @@ class ConstructorCallExpression : Expression {
                         constructedType->is<Type_Specialized>(),
                         "%1%: unexpected type", constructedType);
         arguments->check_null(); }
-#emit
-    // FIXME -- should not need #emit here, but ir-generator does not understand rvalue refs
     ConstructorCallExpression(Util::SourceInfo si, const IR::Type *t, Vector<Argument> &&args)
     : ConstructorCallExpression(si, t, new Vector<Argument>(std::move(args))) {}
-#end
 }
 
 class BaseListExpression : Expression {

--- a/ir/ir.def
+++ b/ir/ir.def
@@ -430,22 +430,18 @@ class Declaration_Instance : Declaration, IAnnotated, IInstance {
     inline NameMap<Property> properties = {};  // P4_14 externs only, at the moment
     optional NullOK BlockStatement initializer = nullptr;
         // experimental only; contains just declarations, no code
-
     const Vector<Annotation> &getAnnotations() const override { return annotations; }
     Vector<Annotation> &getAnnotations() override { return annotations; }
     Type getType() const override { return type; }
     ID Name() const override { return name; }
     validate{ arguments->check_null(); }
-#emit
-    // FIXME -- should not need #emit here, but ir-generator does not understand rvalue refs
-    // see FIXME notes in expression.def
+
     Declaration_Instance(Util::SourceInfo si, ID id, Vector<Annotation> &&ann, const Type *t, 
                          Vector<Argument> &&args, const BlockStatement *init = nullptr)
     : Declaration_Instance(si, id, ann, t, new Vector<Argument>(std::move(args)), init) {}
     Declaration_Instance(Util::SourceInfo si, ID id, const Type *t, Vector<Argument> &&args,
                          const BlockStatement *init = nullptr)
     : Declaration_Instance(si, id, t, new Vector<Argument>(std::move(args)), init) {}
-#end
 }
 
 /// Toplevel program representation

--- a/ir/type.def
+++ b/ir/type.def
@@ -746,12 +746,8 @@ class Type_Specialized : Type {
     }
     Type_Specialized(cstring bt, std::initializer_list<Type> args)
     : baseType(new Type_Name(bt)), arguments(new Vector<Type>(args)) {}
-#emit
-    // FIXME -- should not need #emit here, but ir-generator does not understand rvalue refs
-    // see FIXME notes in expression.def
     Type_Specialized(Util::SourceInfo si, const Type_Name *bt, Vector<Type> &&args)
     : Type_Specialized(si, bt, new Vector<Type>(std::move(args))) {}
-#end
 }
 
 /** Canonical representation of a Type_Specialized;

--- a/tools/ir-generator/ir-generator-lex.l
+++ b/tools/ir-generator/ir-generator-lex.l
@@ -70,6 +70,7 @@ static std::string      comment_block;
 
 "//".*           { yylval.str = cstring(yytext); return COMMENTBLOCK; }
 
+"&&"            { return ANDAND; }
 "::"            { return DBLCOL; }
 "abstract"      { return ABSTRACT; }
 "class"         { return CLASS; }

--- a/tools/ir-generator/ir-generator.ypp
+++ b/tools/ir-generator/ir-generator.ypp
@@ -80,6 +80,7 @@ static IrNamespace *current_namespace = LookupScope().resolve(0);
     }                           emit;
 }
 
+%token ANDAND
 %token          ABSTRACT APPLY CLASS CONST DBLCOL DEFAULT DELETE ENUM INLINE INTERFACE NAMESPACE
                 NEW NULLOK OPERATOR OPTIONAL PRIVATE PROTECTED PUBLIC STATIC VARIANT VIRTUAL
 %token<str>     BLOCK COMMENTBLOCK IDENTIFIER INCLUDE INTEGER NO STRING ZERO
@@ -374,6 +375,9 @@ type: nonRefType
     | type '&'                          { $$ = new ReferenceType($1); }
     | type CONST '&'                    { $$ = new ReferenceType($1, true); }
     | CONST nonRefType '&'              { $$ = new ReferenceType($2, true); }
+    | type ANDAND                       { $$ = new ReferenceType($1, false, true); }
+    | type CONST ANDAND                 { $$ = new ReferenceType($1, true, true); }
+    | CONST nonRefType ANDAND           { $$ = new ReferenceType($2, true, true); }
     | type '*'                          { $$ = new PointerType($1); }
     | type CONST '*'                    { $$ = new PointerType($1, true); }
     | CONST nonRefType '*'              { $$ = new PointerType($2, true); }

--- a/tools/ir-generator/type.cpp
+++ b/tools/ir-generator/type.cpp
@@ -162,7 +162,7 @@ cstring TemplateInstantiation::toString() const {
 cstring ReferenceType::toString() const {
     std::string rv = base->toString().c_str();
     if (isConst) rv += " const";
-    rv += " &";
+    rv += isRValue ? " &&" : " &";
     return rv;
 }
 

--- a/tools/ir-generator/type.h
+++ b/tools/ir-generator/type.h
@@ -143,11 +143,13 @@ class TemplateInstantiation : public Type {
 class ReferenceType : public Type {
     const Type *base;
     bool isConst;
+    bool isRValue;
 
  public:
-    explicit ReferenceType(const Type *t, bool c = false) : base(t), isConst(c) {}
-    ReferenceType(Util::SourceInfo si, const Type *t, bool c = false)
-        : Type(si), base(t), isConst(c) {}
+    explicit ReferenceType(const Type *t, bool c = false, bool rv = false)
+        : base(t), isConst(c), isRValue(rv) {}
+    ReferenceType(Util::SourceInfo si, const Type *t, bool c = false, bool rv = false)
+        : Type(si), base(t), isConst(c), isRValue(rv) {}
     bool isResolved() const override { return false; }
     const IrClass *resolve(const IrNamespace *ns) const override {
         base->resolve(ns);
@@ -156,7 +158,7 @@ class ReferenceType : public Type {
     cstring toString() const override;
     bool operator==(const Type &t) const override { return t == *this; }
     bool operator==(const ReferenceType &t) const override {
-        return isConst == t.isConst && *base == *t.base;
+        return isConst == t.isConst && isRValue == t.isRValue && *base == *t.base;
     }
     static ReferenceType OstreamRef, VisitorRef;
 };


### PR DESCRIPTION
This patch adds support for parsing and representing rvalue references (&&) in ir-generator.

Changes:
- Added lexer support for && token
- Added parser rules for rvalue references
- Extended ReferenceType with isRValue
- Updated equality and stringification logic

Fixes #5601 