### PR TITLE
Reject ternary/lpm/range match on error-typed table keys

### DIFF
--- a/frontends/p4/typeChecking/typeCheckStmt.cpp
+++ b/frontends/p4/typeChecking/typeCheckStmt.cpp
@@ -243,6 +243,16 @@ const IR::Node *TypeInferenceBase::postorder(const IR::KeyElement *elem) {
     if (type != nullptr && type != IR::Type_MatchKind::get())
         typeError("%1% must be a %2% value", elem->matchType,
                   IR::Type_MatchKind::get()->toString());
+    // A ternary/lpm/range match treats the key as a numeric value or range, which is
+    // meaningless for a non-numeric 'error' key. See https://github.com/p4lang/p4c/issues/5637
+    if (ktype->is<IR::Type_Error>()) {
+        cstring matchKind = elem->matchType->path->name.name;
+        if (matchKind == "ternary" || matchKind == "lpm" || matchKind == "range")
+            typeError(
+                "match kind '%1%' cannot be used with a key of type %2%; "
+                "use 'exact' or 'optional' instead",
+                elem->matchType, ktype->toString());
+    }
     if (isCompileTimeConstant(elem->expression) && !readOnly)
         warn(ErrorType::WARN_IGNORE_PROPERTY, "%1%: constant key element", elem);
     return elem;

--- a/testdata/p4_16_errors/issue5637.p4
+++ b/testdata/p4_16_errors/issue5637.p4
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aeron-gh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// A 'ternary', 'lpm', or 'range' match treats the key as a numeric value or
+// range, which is meaningless for a non-numeric 'error' key. Each of the three
+// tables below must be rejected. See https://github.com/p4lang/p4c/issues/5637
+
+#include <core.p4>
+
+match_kind {
+    range
+}
+
+struct meta_t {
+    error e1;
+    error e2;
+    error e3;
+}
+
+control C(inout meta_t m);
+package top(C c);
+
+control MyControl(inout meta_t m) {
+    action noop() {}
+
+    table t_ternary {
+        key = { m.e1 : ternary; }
+        actions = { noop; }
+    }
+    table t_lpm {
+        key = { m.e2 : lpm; }
+        actions = { noop; }
+    }
+    table t_range {
+        key = { m.e3 : range; }
+        actions = { noop; }
+    }
+
+    apply {
+        t_ternary.apply();
+        t_lpm.apply();
+        t_range.apply();
+    }
+}
+
+top(MyControl()) main;

--- a/testdata/p4_16_errors_outputs/issue5637.p4
+++ b/testdata/p4_16_errors_outputs/issue5637.p4
@@ -1,0 +1,49 @@
+#include <core.p4>
+
+match_kind {
+    range
+}
+
+struct meta_t {
+    error e1;
+    error e2;
+    error e3;
+}
+
+control C(inout meta_t m);
+package top(C c);
+control MyControl(inout meta_t m) {
+    action noop() {
+    }
+    table t_ternary {
+        key = {
+            m.e1: ternary;
+        }
+        actions = {
+            noop;
+        }
+    }
+    table t_lpm {
+        key = {
+            m.e2: lpm;
+        }
+        actions = {
+            noop;
+        }
+    }
+    table t_range {
+        key = {
+            m.e3: range;
+        }
+        actions = {
+            noop;
+        }
+    }
+    apply {
+        t_ternary.apply();
+        t_lpm.apply();
+        t_range.apply();
+    }
+}
+
+top(MyControl()) main;

--- a/testdata/p4_16_errors_outputs/issue5637.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue5637.p4-stderr
@@ -1,0 +1,9 @@
+issue5637.p4(30): [--Werror=type-error] error: match kind 'ternary' cannot be used with a key of type error; use 'exact' or 'optional' instead
+        key = { m.e1 : ternary; }
+                       ^^^^^^^
+issue5637.p4(34): [--Werror=type-error] error: match kind 'lpm' cannot be used with a key of type error; use 'exact' or 'optional' instead
+        key = { m.e2 : lpm; }
+                       ^^^
+issue5637.p4(38): [--Werror=type-error] error: match kind 'range' cannot be used with a key of type error; use 'exact' or 'optional' instead
+        key = { m.e3 : range; }
+                       ^^^^^

--- a/testdata/p4_16_samples/issue5637_legal_match_kinds.p4
+++ b/testdata/p4_16_samples/issue5637_legal_match_kinds.p4
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2026 aeron-gh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// An 'error' key is non-numeric, so 'exact' and 'optional' are legal match kinds
+// for it. None of the keys below should be rejected by the check added for
+// https://github.com/p4lang/p4c/issues/5637
+
+#include <core.p4>
+
+match_kind {
+    optional
+}
+
+struct meta_t {
+    error e1;
+    error e2;
+}
+
+control C(inout meta_t m);
+package top(C c);
+
+control MyControl(inout meta_t m) {
+    action noop() {}
+
+    table t_exact {
+        key = { m.e1 : exact; }
+        actions = { noop; }
+    }
+    table t_optional {
+        key = { m.e2 : optional; }
+        actions = { noop; }
+    }
+
+    apply {
+        t_exact.apply();
+        t_optional.apply();
+    }
+}
+
+top(MyControl()) main;

--- a/testdata/p4_16_samples/metrics/metrics_test_4.p4
+++ b/testdata/p4_16_samples/metrics/metrics_test_4.p4
@@ -186,7 +186,7 @@ control ingress(
             meta.flag            : exact;
             meta.ser_enum_field  : lpm;
             meta.enum_field      : exact;
-            meta.err_field       : ternary;
+            meta.err_field       : optional;
         }
         actions = {
             set_output;

--- a/testdata/p4_16_samples_outputs/issue5637_legal_match_kinds-first.p4
+++ b/testdata/p4_16_samples_outputs/issue5637_legal_match_kinds-first.p4
@@ -1,0 +1,43 @@
+#include <core.p4>
+
+match_kind {
+    optional
+}
+
+struct meta_t {
+    error e1;
+    error e2;
+}
+
+control C(inout meta_t m);
+package top(C c);
+control MyControl(inout meta_t m) {
+    action noop() {
+    }
+    table t_exact {
+        key = {
+            m.e1: exact @name("m.e1");
+        }
+        actions = {
+            noop();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    table t_optional {
+        key = {
+            m.e2: optional @name("m.e2");
+        }
+        actions = {
+            noop();
+            @defaultonly NoAction();
+        }
+        default_action = NoAction();
+    }
+    apply {
+        t_exact.apply();
+        t_optional.apply();
+    }
+}
+
+top(MyControl()) main;

--- a/testdata/p4_16_samples_outputs/issue5637_legal_match_kinds-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue5637_legal_match_kinds-frontend.p4
@@ -1,0 +1,49 @@
+#include <core.p4>
+
+match_kind {
+    optional
+}
+
+struct meta_t {
+    error e1;
+    error e2;
+}
+
+control C(inout meta_t m);
+package top(C c);
+control MyControl(inout meta_t m) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_2() {
+    }
+    @name("MyControl.noop") action noop() {
+    }
+    @name("MyControl.noop") action noop_1() {
+    }
+    @name("MyControl.t_exact") table t_exact_0 {
+        key = {
+            m.e1: exact @name("m.e1");
+        }
+        actions = {
+            noop();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    @name("MyControl.t_optional") table t_optional_0 {
+        key = {
+            m.e2: optional @name("m.e2");
+        }
+        actions = {
+            noop_1();
+            @defaultonly NoAction_2();
+        }
+        default_action = NoAction_2();
+    }
+    apply {
+        t_exact_0.apply();
+        t_optional_0.apply();
+    }
+}
+
+top(MyControl()) main;

--- a/testdata/p4_16_samples_outputs/issue5637_legal_match_kinds-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue5637_legal_match_kinds-midend.p4
@@ -1,0 +1,49 @@
+#include <core.p4>
+
+match_kind {
+    optional
+}
+
+struct meta_t {
+    error e1;
+    error e2;
+}
+
+control C(inout meta_t m);
+package top(C c);
+control MyControl(inout meta_t m) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @noWarn("unused") @name(".NoAction") action NoAction_2() {
+    }
+    @name("MyControl.noop") action noop() {
+    }
+    @name("MyControl.noop") action noop_1() {
+    }
+    @name("MyControl.t_exact") table t_exact_0 {
+        key = {
+            m.e1: exact @name("m.e1");
+        }
+        actions = {
+            noop();
+            @defaultonly NoAction_1();
+        }
+        default_action = NoAction_1();
+    }
+    @name("MyControl.t_optional") table t_optional_0 {
+        key = {
+            m.e2: optional @name("m.e2");
+        }
+        actions = {
+            noop_1();
+            @defaultonly NoAction_2();
+        }
+        default_action = NoAction_2();
+    }
+    apply {
+        t_exact_0.apply();
+        t_optional_0.apply();
+    }
+}
+
+top(MyControl()) main;

--- a/testdata/p4_16_samples_outputs/issue5637_legal_match_kinds.p4
+++ b/testdata/p4_16_samples_outputs/issue5637_legal_match_kinds.p4
@@ -1,0 +1,39 @@
+#include <core.p4>
+
+match_kind {
+    optional
+}
+
+struct meta_t {
+    error e1;
+    error e2;
+}
+
+control C(inout meta_t m);
+package top(C c);
+control MyControl(inout meta_t m) {
+    action noop() {
+    }
+    table t_exact {
+        key = {
+            m.e1: exact;
+        }
+        actions = {
+            noop;
+        }
+    }
+    table t_optional {
+        key = {
+            m.e2: optional;
+        }
+        actions = {
+            noop;
+        }
+    }
+    apply {
+        t_exact.apply();
+        t_optional.apply();
+    }
+}
+
+top(MyControl()) main;


### PR DESCRIPTION
The compiler currently accepts a table key of type `error` with a `ternary`, `lpm` or `range` match kind. Those match kinds interpret the key as a numeric value, mask or range, which has no meaning for an `error` value. Only `exact` and `optional`, which compare for equality, make sense for such a key.

This adds a check in the type checker that rejects `ternary`, `lpm` and `range` on an `error` key and tells the user to use `exact` or `optional` instead.

Tests:
- `testdata/p4_16_errors/issue5637.p4` covers the three rejected match kinds.
- `testdata/p4_16_samples/issue5637_legal_match_kinds.p4` confirms `exact` and `optional` on an `error` key still compile.
- `metrics_test_4.p4` had `ternary` on an error field, so it now uses `optional`.

This follows the LDWG discussion in p4lang/p4-spec#1389, which also raised the same question for `bool` keys (e.g. `psa-bool-ternary-const-entry-bmv2.p4`). I left `bool` untouched on purpose: that case is still open in the spec and has an accepted test relying on it, whereas the LDWG conclusion for `error` was to disallow it. If the spec later decides `bool` too, it can follow the same pattern.

Fixes #5637.
