### PR TITLE
fix(tc): correct return-type annotations

### DIFF
--- a/backends/tc/tcenv.py
+++ b/backends/tc/tcenv.py
@@ -46,11 +46,11 @@ class NS:
         self.port_mapping = (self.port0_pair, self.port1_pair)
         self.virtme = virtme
 
-    def ns_init_cmd(self) -> int:
+    def ns_init_cmd(self) -> str:
         """Initialize the namespace."""
         return f"{self.mnt_dir}/build-simple-p4 {self.ns_name} {self.port0} {self.port0_pair} {self.port1} {self.port1_pair} {self.block_num}"
 
-    def ns_del_cmd(self) -> int:
+    def ns_del_cmd(self) -> str:
         """Initialize the namespace."""
 
         return f"ip netns del {self.ns_name}"


### PR DESCRIPTION
## Summary
`NS.ns_init_cmd()` and `NS.ns_del_cmd()` in `backends/tc/tcenv.py` are annotated as returning `int`, but both simply `return` an f-string (a shell command to be executed later). This looks like a copy/paste artifact from the similarly named `ns_init()` / `ns_del()` methods, which *do* return `int` return codes from `testutils.exec_process(...).returncode`.

## Problem
- Incorrect annotations will trip up static type checkers (mypy) and mislead anyone reading or calling these methods based on their signature.
- The confusion is compounded by the near-identical naming between `ns_init_cmd`/`ns_init` and `ns_del_cmd`/`ns_del`.

## Fix
Corrected the return-type annotations of `ns_init_cmd()` and `ns_del_cmd()` from `-> int` to `-> str`, matching their actual (and correct) behavior. No runtime logic was changed.
