### PR TITLE
fix(testutils): make del_dir() OSError handler reachable

### DIFF
--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -327,7 +327,7 @@ def del_dir(directory: Path) -> None:
     """Delete a directory and all its children.
     TODO: Convert to Path input."""
     try:
-        shutil.rmtree(directory, ignore_errors=True)
+        shutil.rmtree(directory)
     except OSError as exception:
         log.error(
             "Could not delete directory, reason:\n%s - %s.",


### PR DESCRIPTION
## Summary
`del_dir()` in `tools/testutils.py` calls `shutil.rmtree(directory, ignore_errors=True)` inside a `try/except OSError` block. Since `ignore_errors=True` already suppresses all errors from `rmtree`, the `except OSError` block can never execute — it's dead code that gives the false impression deletion failures are being logged.

## Problem
- The `except OSError` block is unreachable as written, so failed directory deletions are silently and doubly discarded with no diagnostic trail.
- This can mask real problems (e.g. permission errors, files in use) during test cleanup without any log output.

## Fix
Removed `ignore_errors=True` so `rmtree` can raise `OSError` again, making the existing `except` block reachable and its `log.error(...)` call actually fire on failure.

## Behavior change
`del_dir()` can now raise `OSError` after logging the failure, rather than always succeeding silently. If silent-ignore was actually the desired behavior, an alternative fix is to keep `ignore_errors=True`, drop the now-provably-dead `except` block, and add a comment documenting the intentional silent ignore happy to switch to that approach instead if preferred.