### PR TITLE
Fix typo in cast error message: presion -> precision

### DIFF
--- a/frontends/common/constantFolding.cpp
+++ b/frontends/common/constantFolding.cpp
@@ -967,7 +967,7 @@ const IR::Node *DoConstantFolding::postorder(IR::Cast *e) {
             const auto *ctype = constant->type;
             if (!ctype->is<IR::Type_Bits>() && !ctype->is<IR::Type_InfInt>()) {
                 ::P4::error(ErrorType::ERR_INVALID,
-                            "%1%: Cannot cast %1% to arbitrary presion integer", ctype);
+                            "%1%: Cannot cast %1% to arbitrary precision integer", ctype);
                 return e;
             }
             return new IR::Constant(e->srcInfo, etype, constant->value, constant->base);


### PR DESCRIPTION
The error emitted when casting an incompatible constant to an arbitrary-precision integer read "arbitrary presion integer". Corrected the spelling to "precision".

Source: `DoConstantFolding::postorder(IR::Cast *)` in frontends/common/constantFolding.cpp.