### PR TITLE
Fix out-of-range format placeholder in p4fmt output file error

### DIFF
--- a/backends/p4fmt/main.cpp
+++ b/backends/p4fmt/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *const argv[]) {
     } else {
         outFile = openFile(options.outputFile(), false);
         if ((outFile == nullptr) || !(*outFile)) {
-            ::P4::error(ErrorType::ERR_NOT_FOUND, "%2%: No such file or directory.",
+            ::P4::error(ErrorType::ERR_NOT_FOUND, "%1%: No such file or directory.",
                         options.outputFile().string());
             options.usage();
             return EXIT_FAILURE;


### PR DESCRIPTION
When p4fmt cannot open its output file, it reports the error with:

```cpp
::P4::error(ErrorType::ERR_NOT_FOUND, "%2%: No such file or directory.",
            options.outputFile().string());
```

The format string references `%2%`, but only one argument is passed. `boost::format` throws `too_few_args` when a placeholder index exceeds the number of supplied arguments, so this line aborts p4fmt with an uncaught exception instead of printing the error and usage.

Changing `%2%` to `%1%` prints the intended message:

```
<outfile>: No such file or directory.
```