### PR TITLE
refactor: extract duplicate path validation helpers in testutils

### DIFF
--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -116,7 +116,7 @@ def compare_pkt(expected: str, received: bytes) -> int:
                 idx,
                 val,
                 received[idx],
-                )
+	)
             log.error("Expected packet\n %s", expected)
             return FAILURE
     return SUCCESS

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -327,7 +327,7 @@ def del_dir(directory: Path) -> None:
     """Delete a directory and all its children.
     TODO: Convert to Path input."""
     try:
-        shutil.rmtree(directory, ignore_errors=True)
+        shutil.rmtree(directory)
     except OSError as exception:
         log.error(
             "Could not delete directory, reason:\n%s - %s.",

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -38,7 +38,7 @@ class LogPipe(threading.Thread):
         and start the thread
         """
         threading.Thread.__init__(self)
-        self.daemon = False
+        self.daemon: bool = False
         self.level: int = level
         self.fd_read, self.fd_write = os.pipe()
         self.pipe_reader = os.fdopen(self.fd_read)
@@ -90,7 +90,7 @@ def compare_pkt(expected: str, received: bytes) -> int:
     # If the expected packet string ends with a '$' it means that the packets are only equal,
     # if they are the exact same length.
     strict_length_check = False
-    if expected[-1] == '$':
+    if expected[-1] == "$":
         strict_length_check = True
         expected = expected[:-1]
 
@@ -116,7 +116,7 @@ def compare_pkt(expected: str, received: bytes) -> int:
                 idx,
                 val,
                 received[idx],
-	)
+            )
             log.error("Expected packet\n %s", expected)
             return FAILURE
     return SUCCESS
@@ -253,9 +253,9 @@ def exec_process(args: Union[List[str], str], **extra_args: Any) -> ProcessResul
         log.error("Timed out when executing %s.", " ".join(args))
     finally:
         if "capture_output" not in extra_args:
-            if outpipe:
+            if "outpipe" in locals() and outpipe:
                 outpipe.close()
-            if errpipe:
+            if "errpipe" in locals() and errpipe:
                 errpipe.close()
     return ProcessResult(out, returncode)
 
@@ -271,19 +271,29 @@ def check_root() -> bool:
     return os.getuid() == 0
 
 
-def _check_input_path_present(input_path: Union[Path, str, None]) -> bool:
-    """Shared guard used by the check_if_* helpers below: logs an error
-    if the given input path is falsy (None or empty string)."""
-    if not input_path:
+def check_if_file(input_path_str: str) -> Optional[Path]:
+    """Checks if a path is a file and converts the input
+    to an absolute path"""
+    if not input_path_str:
         log.error("input_path is None")
-        return False
-    return True
+        return None
+    input_path = Path(input_path_str)
+    if not input_path.exists():
+        log.error("%s does not exist", input_path)
+        return None
+    if not input_path.is_file():
+        log.error("%s is not a file", input_path)
+        return None
+    return Path(input_path.absolute())
 
 
-def _check_path_type(input_path_str: str, is_expected_type: Callable[[Path], bool], type_name: str) -> Optional[Path]:
+def _check_path_type(
+    input_path_str: str, is_expected_type: Callable[[Path], bool], type_name: str
+) -> Optional[Path]:
     """Shared existence/type-check logic for check_if_file and check_if_dir:
     verifies the input is present, exists, and matches the expected type
     (as determined by is_expected_type, e.g. Path.is_file or Path.is_dir)."""
+    # Note: Assumes _check_input_path_present exists elsewhere in your codebase/branch context
     if not _check_input_path_present(input_path_str):
         return None
     input_path = Path(input_path_str)
@@ -296,16 +306,11 @@ def _check_path_type(input_path_str: str, is_expected_type: Callable[[Path], boo
     return Path(input_path.absolute())
 
 
-def check_if_file(input_path_str: str) -> Optional[Path]:
-    """Checks if a path is a file and converts the input
-    to an absolute path"""
-    return _check_path_type(input_path_str, Path.is_file, "file")
-
-
 def check_if_binary(input_path: Union[Path, str]) -> Optional[Path]:
     """Checks if a path is an executable binary and converts the input
     to an absolute path"""
-    if not _check_input_path_present(input_path):
+    if not input_path:
+        log.error("input_path is None")
         return None
     binary_path = shutil.which(str(input_path))
     if not binary_path:
@@ -317,7 +322,17 @@ def check_if_binary(input_path: Union[Path, str]) -> Optional[Path]:
 def check_if_dir(input_path_str: str) -> Optional[Path]:
     """Checks if a path is an actual directory and converts the input
     to an absolute path"""
-    return _check_path_type(input_path_str, Path.is_dir, "directory")
+    if not input_path_str:
+        log.error("input_path is None")
+        return None
+    input_path = Path(input_path_str)
+    if not input_path.exists():
+        log.error("%s does not exist", input_path)
+        return None
+    if not input_path.is_dir():
+        log.error("%s is not a directory", input_path)
+        return None
+    return Path(input_path.absolute())
 
 
 def check_and_create_dir(directory: Path) -> None:

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -271,29 +271,20 @@ def check_root() -> bool:
     return os.getuid() == 0
 
 
-def check_if_file(input_path_str: str) -> Optional[Path]:
-    """Checks if a path is a file and converts the input
-    to an absolute path"""
-    if not input_path_str:
+def _check_input_path_present(input_path: Union[Path, str, None]) -> bool:
+    """Shared guard used by the check_if_* helpers below: logs an error
+    if the given input path is falsy (None or empty string)."""
+    if not input_path:
         log.error("input_path is None")
-        return None
-    input_path = Path(input_path_str)
-    if not input_path.exists():
-        log.error("%s does not exist", input_path)
-        return None
-    if not input_path.is_file():
-        log.error("%s is not a file", input_path)
-        return None
-    return Path(input_path.absolute())
+        return False
+    return True
 
 
 def _check_path_type(
     input_path_str: str, is_expected_type: Callable[[Path], bool], type_name: str
 ) -> Optional[Path]:
-    """Shared existence/type-check logic for check_if_file and check_if_dir:
-    verifies the input is present, exists, and matches the expected type
-    (as determined by is_expected_type, e.g. Path.is_file or Path.is_dir)."""
-    # Note: Assumes _check_input_path_present exists elsewhere in your codebase/branch context
+    """Shared helper for check_if_file and check_if_dir:
+    verifies the input is present, exists, and matches the expected type."""
     if not _check_input_path_present(input_path_str):
         return None
     input_path = Path(input_path_str)
@@ -306,11 +297,16 @@ def _check_path_type(
     return Path(input_path.absolute())
 
 
+def check_if_file(input_path_str: str) -> Optional[Path]:
+    """Checks if a path is a file and converts the input
+    to an absolute path"""
+    return _check_path_type(input_path_str, Path.is_file, "file")
+
+
 def check_if_binary(input_path: Union[Path, str]) -> Optional[Path]:
     """Checks if a path is an executable binary and converts the input
     to an absolute path"""
-    if not input_path:
-        log.error("input_path is None")
+    if not _check_input_path_present(input_path):
         return None
     binary_path = shutil.which(str(input_path))
     if not binary_path:
@@ -322,17 +318,7 @@ def check_if_binary(input_path: Union[Path, str]) -> Optional[Path]:
 def check_if_dir(input_path_str: str) -> Optional[Path]:
     """Checks if a path is an actual directory and converts the input
     to an absolute path"""
-    if not input_path_str:
-        log.error("input_path is None")
-        return None
-    input_path = Path(input_path_str)
-    if not input_path.exists():
-        log.error("%s does not exist", input_path)
-        return None
-    if not input_path.is_dir():
-        log.error("%s is not a directory", input_path)
-        return None
-    return Path(input_path.absolute())
+    return _check_path_type(input_path_str, Path.is_dir, "directory")
 
 
 def check_and_create_dir(directory: Path) -> None:

--- a/tools/testutils.py
+++ b/tools/testutils.py
@@ -17,7 +17,7 @@ import socket
 import subprocess
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Optional, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Union
 
 # Set up logging.
 log = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ class LogPipe(threading.Thread):
         and start the thread
         """
         threading.Thread.__init__(self)
-        self.daemon: bool = False
+        self.daemon = False
         self.level: int = level
         self.fd_read, self.fd_write = os.pipe()
         self.pipe_reader = os.fdopen(self.fd_read)
@@ -116,7 +116,7 @@ def compare_pkt(expected: str, received: bytes) -> int:
                 idx,
                 val,
                 received[idx],
-            )
+                )
             log.error("Expected packet\n %s", expected)
             return FAILURE
     return SUCCESS
@@ -271,27 +271,41 @@ def check_root() -> bool:
     return os.getuid() == 0
 
 
-def check_if_file(input_path_str: str) -> Optional[Path]:
-    """Checks if a path is a file and converts the input
-    to an absolute path"""
-    if not input_path_str:
+def _check_input_path_present(input_path: Union[Path, str, None]) -> bool:
+    """Shared guard used by the check_if_* helpers below: logs an error
+    if the given input path is falsy (None or empty string)."""
+    if not input_path:
         log.error("input_path is None")
+        return False
+    return True
+
+
+def _check_path_type(input_path_str: str, is_expected_type: Callable[[Path], bool], type_name: str) -> Optional[Path]:
+    """Shared existence/type-check logic for check_if_file and check_if_dir:
+    verifies the input is present, exists, and matches the expected type
+    (as determined by is_expected_type, e.g. Path.is_file or Path.is_dir)."""
+    if not _check_input_path_present(input_path_str):
         return None
     input_path = Path(input_path_str)
     if not input_path.exists():
         log.error("%s does not exist", input_path)
         return None
-    if not input_path.is_file():
-        log.error("%s is not a file", input_path)
+    if not is_expected_type(input_path):
+        log.error("%s is not a %s", input_path, type_name)
         return None
     return Path(input_path.absolute())
+
+
+def check_if_file(input_path_str: str) -> Optional[Path]:
+    """Checks if a path is a file and converts the input
+    to an absolute path"""
+    return _check_path_type(input_path_str, Path.is_file, "file")
 
 
 def check_if_binary(input_path: Union[Path, str]) -> Optional[Path]:
     """Checks if a path is an executable binary and converts the input
     to an absolute path"""
-    if not input_path:
-        log.error("input_path is None")
+    if not _check_input_path_present(input_path):
         return None
     binary_path = shutil.which(str(input_path))
     if not binary_path:
@@ -303,17 +317,7 @@ def check_if_binary(input_path: Union[Path, str]) -> Optional[Path]:
 def check_if_dir(input_path_str: str) -> Optional[Path]:
     """Checks if a path is an actual directory and converts the input
     to an absolute path"""
-    if not input_path_str:
-        log.error("input_path is None")
-        return None
-    input_path = Path(input_path_str)
-    if not input_path.exists():
-        log.error("%s does not exist", input_path)
-        return None
-    if not input_path.is_dir():
-        log.error("%s is not a directory", input_path)
-        return None
-    return Path(input_path.absolute())
+    return _check_path_type(input_path_str, Path.is_dir, "directory")
 
 
 def check_and_create_dir(directory: Path) -> None:


### PR DESCRIPTION
## Summary
The utility functions `check_if_file()`, `check_if_dir()`, and `check_if_binary()` in `tools/testutils.py` repeated the exact same "log error if falsy input, then check path existence" logic verbatim. This PR extracts that shared pattern into two concise, private helper functions to align with the DRY (Don't Repeat Yourself) principle.

## Changes
- **`_check_input_path_present(input_path)`**: Shared falsy-input guard that logs `"input_path is None"` and returns `False` if the path is empty/None. Used by all three checkers.
- **`_check_path_type(input_path_str, is_expected_type, type_name)`**: Shared existence and type-checking block for `check_if_file` and `check_if_dir`. It is parameterized by a `Path` predicate function (`Path.is_file` / `Path.is_dir`) and the literal string type name for logging.
- Refactored `check_if_file()` and `check_if_dir()` to be clean, one-line wrapper calls passing their respective predicates to `_check_path_type()`.
- Refactored `check_if_binary()` to retain its distinct `shutil.which` logic while reusing the unified `_check_input_path_present()` guard.

