### PR TITLE
Fix out-of-range boost::format placeholders in diagnostics

### DIFF
--- a/backends/ubpf/ubpfControl.cpp
+++ b/backends/ubpf/ubpfControl.cpp
@@ -509,7 +509,7 @@ bool UBPFControlBodyTranslator::comparison(const IR::Operation_Relation *b) {
         builder->append(")");
     } else {
         if (!et->is<EBPF::IHasWidth>())
-            BUG("%1%: Comparisons for type %2% not yet implemented", type);
+            BUG("%1%: Comparisons for type %2% not yet implemented", b, type);
         unsigned width = et->to<EBPF::IHasWidth>()->implementationWidthInBits();
         builder->append("memcmp(&");
         visit(b->left);

--- a/control-plane/p4RuntimeArchStandard.cpp
+++ b/control-plane/p4RuntimeArchStandard.cpp
@@ -107,7 +107,8 @@ class P4RuntimeArchHandlerV1Model final : public P4RuntimeArchHandlerCommon<Arch
         auto *typeSpec = TypeSpecConverter::convert(refMap, typeMap, typeArg, p4RtTypeInfo);
         BUG_CHECK(typeSpec != nullptr,
                   "P4 type %1% could not "
-                  "be converted to P4Info P4DataTypeSpec");
+                  "be converted to P4Info P4DataTypeSpec",
+                  typeArg);
         return Digest{controlPlaneName, typeSpec, nullptr};
     }
 

--- a/control-plane/p4RuntimeArchStandard.h
+++ b/control-plane/p4RuntimeArchStandard.h
@@ -1042,7 +1042,7 @@ class P4RuntimeArchHandlerPSAPNA : public P4RuntimeArchHandlerCommon<arch> {
         auto typeSpec =
             TypeSpecConverter::convert(this->refMap, this->typeMap, typeArg, p4RtTypeInfo);
         BUG_CHECK(typeSpec != nullptr,
-                  "P4 type %1% could not be converted to P4Info P4DataTypeSpec");
+                  "P4 type %1% could not be converted to P4Info P4DataTypeSpec", typeArg);
 
         return Digest{decl->controlPlaneName(), typeSpec, decl->to<IR::IAnnotated>()};
     }

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -911,7 +911,7 @@ TypeInferenceBase::containerInstantiation(
             if (auto v = param->type->to<IR::Type_InfInt>()) {
                 auto tv = IR::Type_InfInt::get(param->type->srcInfo);
                 bool b = tvs.setBinding(v, tv);
-                BUG_CHECK(b, "failed replacing %2% with %3%", v, tv);
+                BUG_CHECK(b, "failed replacing %1% with %2%", v, tv);
             }
         }
         TypeVariableSubstitutionVisitor sv(&tvs, true);

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -940,7 +940,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation *expression) {
 
     auto clone = expression->clone();
     if (l->is<SymbolicInteger>()) {
-        BUG_CHECK(r->is<SymbolicInteger>(), "%1%: expected an SymbolicInteger");
+        BUG_CHECK(r->is<SymbolicInteger>(), "%1%: expected a SymbolicInteger", r);
         clone->left = l->to<SymbolicInteger>()->constant;
         clone->right = r->to<SymbolicInteger>()->constant;
         DoConstantFolding cf(refMap, typeMap);
@@ -950,7 +950,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Relation *expression) {
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));
         return;
     } else if (l->is<SymbolicBool>()) {
-        BUG_CHECK(r->is<SymbolicBool>(), "%1%: expected an SymbolicBool");
+        BUG_CHECK(r->is<SymbolicBool>(), "%1%: expected a SymbolicBool", r);
         clone->left = new IR::BoolLiteral(l->to<SymbolicBool>()->value);
         clone->right = new IR::BoolLiteral(r->to<SymbolicBool>()->value);
         DoConstantFolding cf(refMap, typeMap);


### PR DESCRIPTION
A number of error() and BUG_CHECK() messages use more %N% placeholders than
they pass arguments for. When one of those checks fires, boost::str throws
too_few_args, so the real message is lost behind the boost exception. This adds
the missing argument (or fixes the placeholder index) at each such site in the
frontend, midend, control-plane and ubpf backend.

I also fixed the grammar in two interpreter.cpp checks that read "expected an
SymbolicInteger" and "an SymbolicBool", now "a".

Partially addresses #5689.
