### PR TITLE
Fix out-of-range boost::format placeholders in bf-p4c diagnostics

### DIFF
--- a/backends/dpdk/control-plane/bfruntime_arch_handler.h
+++ b/backends/dpdk/control-plane/bfruntime_arch_handler.h
@@ -303,7 +303,7 @@ class BFRuntimeArchHandler : public P4RuntimeArchHandlerCommon<arch> {
         auto typeSpec =
             TypeSpecConverter::convert(this->refMap, this->typeMap, typeArg, p4RtTypeInfo);
         BUG_CHECK(typeSpec != nullptr,
-                  "P4 type %1% could not be converted to P4Info P4DataTypeSpec");
+                  "P4 type %1% could not be converted to P4Info P4DataTypeSpec", typeArg);
 
         return Digest{decl->controlPlaneName(), typeSpec, decl->to<IR::IAnnotated>()};
     }

--- a/backends/tofino/bf-p4c/control-plane/bfruntime_arch_handler.h
+++ b/backends/tofino/bf-p4c/control-plane/bfruntime_arch_handler.h
@@ -1061,7 +1061,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
         auto typeSpec =
             P4::ControlPlaneAPI::TypeSpecConverter::convert(refMap, typeMap, typeArg, p4RtTypeInfo);
         BUG_CHECK(typeSpec != nullptr,
-                  "P4 type %1% could not be converted to P4Info P4DataTypeSpec");
+                  "P4 type %1% could not be converted to P4Info P4DataTypeSpec", typeArg);
         return Digest{decl->controlPlaneName(), typeSpec, decl->to<IR::IAnnotated>()};
     }
 
@@ -1113,7 +1113,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
             auto typeSpec = P4::ControlPlaneAPI::TypeSpecConverter::convert(refMap, typeMap,
                                                                             typeList, p4RtTypeInfo);
             BUG_CHECK(typeSpec != nullptr,
-                      "P4 type %1% could not be converted to P4Info P4DataTypeSpec");
+                      "P4 type %1% could not be converted to P4Info P4DataTypeSpec", typeList);
             return DynHash{decl->controlPlaneName(), typeSpec, decl->to<IR::IAnnotated>(),
                            hashFieldInfo, hashWidth};
         }

--- a/backends/tofino/bf-p4c/mau/instruction_adjustment.cpp
+++ b/backends/tofino/bf-p4c/mau/instruction_adjustment.cpp
@@ -782,7 +782,8 @@ const IR::MAU::Instruction *ExpressionsToHash::preorder(IR::MAU::Instruction *in
             auto alu_parameter = action_format.find_param_alloc(expr_lookup, nullptr);
             BUG_CHECK(alu_parameter != nullptr,
                       "%1% Constant in instruction has not correctly "
-                      "been converted to hash");
+                      "been converted to hash",
+                      con);
             auto *hge = new IR::MAU::HashGenExpression(con->srcInfo, con->type, con,
                                                        IR::MAU::HashFunction::identity());
             auto *hd = new IR::MAU::HashDist(hge->srcInfo, hge->type, hge);

--- a/backends/tofino/bf-p4c/mau/instruction_memory.cpp
+++ b/backends/tofino/bf-p4c/mau/instruction_memory.cpp
@@ -216,7 +216,7 @@ bool InstructionMemory::shared_instr(const IR::MAU::Table *tbl, Use &alloc, bool
         BUG_CHECK(instr_pos != cached_use->all_instrs.end(),
                   "%s: Error when programming action "
                   "%s on shared action profile %s and table %s",
-                  ad_use->srcInfo, ad_use->name, tbl->name);
+                  ad_use->srcInfo, action->name, ad_use->name, tbl->name);
 
         Use::VLIW_Instruction single_instr = instr_pos->second;
         single_instr.mem_code = -1;

--- a/backends/tofino/bf-p4c/mau/ixbar_expr.cpp
+++ b/backends/tofino/bf-p4c/mau/ixbar_expr.cpp
@@ -312,7 +312,8 @@ void BuildP4HashFunction::OutsideHashGenExpr::postorder(const IR::Slice *sl) {
 
     BUG_CHECK(self._func->hash_bits.contains(slice_bits),
               "%s: Slice over hash function is "
-              "not able to be resolved");
+              "not able to be resolved",
+              sl);
     self._func->hash_bits = slice_bits;
 }
 

--- a/backends/tofino/bf-p4c/mau/resource_estimate.cpp
+++ b/backends/tofino/bf-p4c/mau/resource_estimate.cpp
@@ -173,7 +173,7 @@ int IdleTimePerWord(const IR::MAU::IdleTime *idletime) {
         case 6:
             return 1;
         default:
-            BUG("%s: Invalid idletime precision %s", idletime->precision);
+            BUG("%s: Invalid idletime precision %s", idletime, idletime->precision);
     }
 }
 

--- a/backends/tofino/bf-p4c/midend/simplify_nested_if.h
+++ b/backends/tofino/bf-p4c/midend/simplify_nested_if.h
@@ -145,7 +145,8 @@ class UniqueAndValidDest : public SimplifyComplexConditionPolicy {
             if (!valid_fields->count(mem->member.name)) {
                 error(
                     "Invalid field name %1%, the valid fields to use are "
-                    "digest_type, resubmit_type and mirror_type");
+                    "digest_type, resubmit_type and mirror_type",
+                    mem);
             }
         }
 

--- a/backends/tofino/bf-p4c/parde/clot/allocate_clot.cpp
+++ b/backends/tofino/bf-p4c/parde/clot/allocate_clot.cpp
@@ -1229,7 +1229,7 @@ class GreedyClotAllocator : public Visitor {
             for (auto &[stack, index_map] : pseudoheader_stacks) {
                 ordered_set<unsigned> indices_to_remove;
                 BUG_CHECK(header_stack_map.count(stack),
-                          "Header stack %1% missing from CLOT header stack map");
+                          "Header stack %1% missing from CLOT header stack map", stack);
                 for (auto &[index, pseudoheader] : index_map) {
                     bool failed = false;
                     for (auto &[_, state_indices] : header_stack_map.at(stack)) {

--- a/backends/tofino/bf-p4c/parde/clot/clot_info.cpp
+++ b/backends/tofino/bf-p4c/parde/clot/clot_info.cpp
@@ -167,7 +167,7 @@ std::map<int, const PHV::Field *> ClotInfo::get_csum_fields(const Clot *clot) co
                 BUG_CHECK(
                     checksum_field == other_field,
                     "CLOT %d has more than one checksum field at overwrite offset %d: %s and %s",
-                    checksum_field->name, other_field->name);
+                    clot->tag, offset, checksum_field->name, other_field->name);
             }
 
             checksum_fields[offset] = checksum_field;

--- a/backends/tofino/bf-p4c/phv/live_range_split.h
+++ b/backends/tofino/bf-p4c/phv/live_range_split.h
@@ -75,7 +75,7 @@ class ContainerOccupancy {
           maxStage(maxStage),
           vec((maxStage - minStage + 1) * 2),
           containerWidth(containerWidth) {
-        BUG_CHECK(minStage >= -1, "ContainerOccupancy minStage (%1%) must be >= -1");
+        BUG_CHECK(minStage >= -1, "ContainerOccupancy minStage (%1%) must be >= -1", minStage);
         BUG_CHECK(maxStage >= minStage, "Invalid ContainerOccupancy stage range (%1% > %2%)",
                   minStage, maxStage);
     }

--- a/backends/tofino/bf-p4c/phv/mau_backtracker.cpp
+++ b/backends/tofino/bf-p4c/phv/mau_backtracker.cpp
@@ -109,7 +109,7 @@ ordered_set<int> MauBacktracker::inSameStage(
     const ordered_set<int> &t1Stages = tableMap.at(TableSummary::getTableName(t1));
     const ordered_set<int> &t2Stages = tableMap.at(TableSummary::getTableName(t2));
     BUG_CHECK(t1Stages.size() > 0, "No allocation for table %1%", t1->name);
-    BUG_CHECK(t2Stages.size() > 0, "No allocation for table %2%", t2->name);
+    BUG_CHECK(t2Stages.size() > 0, "No allocation for table %1%", t2->name);
     for (int a : t1Stages) {
         for (int b : t2Stages) {
             int stage_a = a / NUM_LOGICAL_TABLES_PER_STAGE;

--- a/backends/tofino/bf-p4c/phv/solver/action_constraint_solver.cpp
+++ b/backends/tofino/bf-p4c/phv/solver/action_constraint_solver.cpp
@@ -128,7 +128,8 @@ void assign_input_bug_check(const ordered_map<ContainerID, ContainerSpec> &specs
                   assign.dst.container, i, assign);
     }
 
-    BUG_CHECK(!assign.dst.is_ad_or_const, "destination cannot be const or action data: %1%");
+    BUG_CHECK(!assign.dst.is_ad_or_const, "destination cannot be const or action data: %1%",
+              assign);
     if (!assign.src.is_ad_or_const) {
         BUG_CHECK(assign.dst.range.size() == assign.src.range.size(),
                   "assignment range mismatch: %1%", assign);

--- a/backends/tofino/bf-p4c/phv/solver/symbolic_bitvec.cpp
+++ b/backends/tofino/bf-p4c/phv/solver/symbolic_bitvec.cpp
@@ -185,8 +185,8 @@ cstring BitVec::to_cstring() const {
 }
 
 BitVec BitVec::slice(int start, int sz) const {
-    BUG_CHECK(start >= 0 && start < int(bits.size()), "invalid start: %1%");
-    BUG_CHECK(start + sz <= int(bits.size()), "invalid sz: %1%");
+    BUG_CHECK(start >= 0 && start < int(bits.size()), "invalid start: %1%", start);
+    BUG_CHECK(start + sz <= int(bits.size()), "invalid sz: %1%", sz);
     auto s = std::vector<const Expr *>(bits.begin() + start, bits.begin() + start + sz);
     return BitVec{s};
 }

--- a/backends/tofino/bf-p4c/specs/phv_spec.cpp
+++ b/backends/tofino/bf-p4c/specs/phv_spec.cpp
@@ -49,7 +49,7 @@ const std::map<PHV::Size, std::set<PHV::Type>> PhvSpec::groupsToTypes() const {
 unsigned PhvSpec::numContainerTypes() const { return definedTypes.size(); }
 
 PHV::Type PhvSpec::idToContainerType(unsigned id) const {
-    BUG_CHECK(id < definedTypes.size(), "Container type id %1% is out of range");
+    BUG_CHECK(id < definedTypes.size(), "Container type id %1% is out of range", id);
     return definedTypes[id];
 }
 


### PR DESCRIPTION
Follow-up to #5690 for the Tofino and DPDK backends: the same out-of-range
boost::format placeholders in BUG_CHECK/BUG/error messages, where the format
string used more placeholders than the arguments passed.

Split from #5690 so the core and backend changes can be reviewed independently.

Closes #5689.
