### PR TITLE
Fix Tofino DefUse for slices wider than 64 bits

### DIFF
--- a/backends/tofino/bf-p4c/midend/defuse.cpp
+++ b/backends/tofino/bf-p4c/midend/defuse.cpp
@@ -355,7 +355,7 @@ const IR::Expression *ComputeDefUse::do_read(def_info_t &di, const IR::Expressio
             BUG_CHECK(e == sl, "slice %s is not primary in ComputeDefUse::do_read", sl);
         }
         e = sl;
-        if (!di.live.getrange(range.lo, range.size())) return e;
+        if (di.live.getslice(range.lo, range.size()).empty()) return e;
     } else if (auto *ai = ctxt->node->to<IR::ArrayIndex>()) {
         if (auto idx = ai->right->to<IR::Constant>()) {
             int i = idx->asInt();


### PR DESCRIPTION
## Summary

This fixes the DefUse liveness check in the Tofino backend for slices wider than 64 bits.

The current code uses `getrange()` to check whether a slice has any live bits. However, `getrange()` is limited to ranges that fit in `uintmax_t`, so it can fail for wider slices.

This replaces it with `getslice(...).empty()`, which works with arbitrary-width ranges. The same change is already present in the upstream midend.

## Testing

I was not able to build or run the Tofino backend locally because the required proprietary dependencies are not available in this checkout.

I checked that `getrange()` has the width limit, and that `getslice()` returns a `bitvec` that supports wider ranges. I also compared this change with the existing fix in `midend/def_use.cpp`.

If possible, could someone run the relevant Tofino regression tests in the internal test environment?
