### PR TITLE
Fix wrong boost::format placeholders in two midend BUG_CHECK messages

### DIFF
--- a/midend/complexComparison.cpp
+++ b/midend/complexComparison.cpp
@@ -110,7 +110,7 @@ const IR::Expression *RemoveComplexComparisons::explode(Util::SourceInfo srcInfo
     } else if (auto at = leftType->to<IR::Type_Array>()) {
         auto size = at->getSize();
         const IR::Expression *result = new IR::BoolLiteral(true);
-        BUG_CHECK(rightType->is<IR::Type_Array>(), "%1%: comparing stack with %1%", left,
+        BUG_CHECK(rightType->is<IR::Type_Array>(), "%1%: comparing stack with %2%", left,
                   rightType);
         for (unsigned i = 0; i < size; i++) {
             auto index = new IR::Constant(i);

--- a/midend/flattenUnions.cpp
+++ b/midend/flattenUnions.cpp
@@ -261,12 +261,12 @@ const IR::Node *DoFlattenHeaderUnionStack::postorder(IR::ArrayIndex *e) {
                 ::P4::error(ErrorType::ERR_OVERLIMIT, "Array index out of bound for %1%", e);
             if (auto mem = e->left->to<IR::Member>()) {
                 auto uName = stackMap[mem->member.name];
-                BUG_CHECK(uName.size() > cst, "Header stack element mapping not found for %1", e);
+                BUG_CHECK(uName.size() > cst, "Header stack element mapping not found for %1%", e);
                 auto member = new IR::Member(stack->elementType, mem->expr, IR::ID(uName[cst]));
                 return member;
             } else if (auto path = e->left->to<IR::PathExpression>()) {
                 auto uName = stackMap[path->path->name.name];
-                BUG_CHECK(uName.size() > cst, "Header stack element mapping not found for %1", e);
+                BUG_CHECK(uName.size() > cst, "Header stack element mapping not found for %1%", e);
                 auto path1 =
                     new IR::PathExpression(stack->elementType, new IR::Path(IR::ID(uName[cst])));
                 return path1;


### PR DESCRIPTION
Two midend BUG_CHECK messages reference the wrong boost::format placeholder,
so when the check fires boost throws instead of printing the intended message.

flattenUnions.cpp writes "%1" without the closing %, which throws
bad_format_string. complexComparison.cpp uses %1% twice while passing two
arguments, which throws too_many_args and would print the left operand where
the right belongs.

Same class of placeholder mismatch as #5690 and #5693.
