### PR TITLE
Install macOS brew dependencies without --ignore-dependencies

### DIFF
--- a/tools/install_mac_deps.sh
+++ b/tools/install_mac_deps.sh
@@ -15,7 +15,7 @@ brew_install() {
     if brew list $1 &>/dev/null; then
         echo "${1} is already installed"
     else
-        brew install --ignore-dependencies $1 && echo "$1 is installed"
+        brew install $1 && echo "$1 is installed"
     fi
 }
 


### PR DESCRIPTION
The macOS runner's preinstalled ccache (4.13.6) links `libblake3.0.dylib`, but
Homebrew bumped blake3 so that dylib is gone. ccache then fails to load with a
dyld error in the ccache setup step, before p4c is built, which has been
evicting PRs from the merge queue.

`tools/install_mac_deps.sh` installs ccache with a skip-if-already-present
check, so the broken preinstalled ccache is never relinked. This reinstalls it
so it links against the current blake3. Editing this file also refreshes the
Homebrew cache key.

Fixes #5697.
