### PR TITLE
Make slice typeError messages consistent

### DIFF
--- a/frontends/p4/typeChecking/typeCheckExpr.cpp
+++ b/frontends/p4/typeChecking/typeCheckExpr.cpp
@@ -1451,7 +1451,7 @@ const IR::Node *TypeInferenceBase::postorder(const IR::Slice *expression) {
         return expression;
     }
     if (l >= bst->size) {
-        typeError("Bit index %1% greater than width %2%", msb, bst->size);
+        typeError("Bit index %1% greater than width %2%", lsb, bst->size);
         return expression;
     }
     if (l > m) {
@@ -1518,11 +1518,11 @@ const IR::Node *TypeInferenceBase::postorder(const IR::PlusSlice *expression) {
 
     if (auto lsb = expression->e1->to<IR::Constant>()) {
         if (lsb->value >= type->width_bits()) {
-            typeError("%1%: lsb offset too large", lsb);
+            typeError("Bit index %1% greater than width %2%", lsb, type->width_bits());
             return expression;
         }
         if (lsb->value < 0) {
-            typeError("%1%: negative lsb offset", lsb);
+            typeError("%1%: negative bit index %2%", expression, lsb);
             return expression;
         }
     }

--- a/testdata/p4_16_errors_outputs/issue5441.p4
+++ b/testdata/p4_16_errors_outputs/issue5441.p4
@@ -1,5 +1,6 @@
 #include <core.p4>
 
+
 control MAPipe(out bit<16> a, in bit<32> b);
 package SimpleArch(MAPipe p);
 control MyMAPipe(out bit<16> a, in bit<32> b) {

--- a/testdata/p4_16_errors_outputs/issue5441.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue5441.p4-stderr
@@ -1,6 +1,9 @@
-issue5441.p4(8): [--Werror=type-error] error: -1: negative lsb offset
+issue5441.p4(8): [--Werror=type-error] error: b[-1+:16]: negative bit index -1
+        a = b[-1+:16];
+            ^^^^^^^^^
+issue5441.p4(8)
         a = b[-1+:16];
                ^
-issue5441.p4(9): [--Werror=type-error] error: 4294967293: lsb offset too large
+issue5441.p4(9): [--Werror=type-error] error: Bit index 4294967293 greater than width 32
         a = b[4294967293+:16];
               ^^^^^^^^^^


### PR DESCRIPTION
I noticed these messages were inconsistent with the other messages for essentially the same thing (out-of-range bit offsets in Slice and PlusSlice), so I made them all the same.