### PR TITLE
Disallow switch of string types.

### DIFF
--- a/frontends/p4/typeChecking/typeCheckStmt.cpp
+++ b/frontends/p4/typeChecking/typeCheckStmt.cpp
@@ -55,7 +55,8 @@ const IR::Node *TypeInferenceBase::postorder(const IR::SwitchStatement *stat) {
                 typeError("%1%: 'switch' label must be an action name or 'default'", c->label);
             }
         }
-    } else {
+    } else if (type->is<IR::Type::Bits>() || type->is<IR::Type_InfInt>() ||
+               type->is<IR::Type_Enum>() || type->is<IR::Type_SerEnum>()) {
         // switch (expression)
         Comparison comp;
         comp.left = stat->expression;
@@ -88,6 +89,8 @@ const IR::Node *TypeInferenceBase::postorder(const IR::SwitchStatement *stat) {
             }
         }
         if (changed) stat = sclone;
+    } else {
+        typeError("%1%: 'switch' type can't be %2%", stat->expression, type);
     }
     return stat;
 }

--- a/testdata/p4_16_errors/switch_string.p4
+++ b/testdata/p4_16_errors/switch_string.p4
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nvidia Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <core.p4>
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+
+header t1 {
+    bit<256>    data;
+    bit<32>     x;
+    bit<32>     y;
+}
+
+struct headers_t {
+    t1          t1;
+}
+
+control c(inout headers_t hdrs) {
+    action a0() {
+        hdrs.t1.y = hdrs.t1.data[1 +: 32];
+    }
+
+    apply {
+        switch ("hello") {
+            "hello": { a0(); }
+            default: {  }
+        }
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/stmt-switch-on-unsupported-type.p4-stderr
+++ b/testdata/p4_16_errors_outputs/stmt-switch-on-unsupported-type.p4-stderr
@@ -1,6 +1,6 @@
 stmt-switch-on-unsupported-type.p4(3): [--Wwarn=unused] warning: control 'ctrl' is unused
 control ctrl()() {
         ^^^^
-stmt-switch-on-unsupported-type.p4(5): [--Werror=type-error] error: ...: could not find default value
+stmt-switch-on-unsupported-type.p4(5): [--Werror=type-error] error: ...: 'switch' type can't be ANYTYPE
     switch (...) { }
             ^^^

--- a/testdata/p4_16_errors_outputs/switch_string.p4
+++ b/testdata/p4_16_errors_outputs/switch_string.p4
@@ -1,0 +1,31 @@
+#include <core.p4>
+
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+header t1 {
+    bit<256> data;
+    bit<32>  x;
+    bit<32>  y;
+}
+
+struct headers_t {
+    t1 t1;
+}
+
+control c(inout headers_t hdrs) {
+    action a0() {
+        hdrs.t1.y = hdrs.t1.data[1+:32];
+    }
+    apply {
+        switch ("hello") {
+            "hello": {
+                a0();
+            }
+            default: {
+            }
+        }
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/switch_string.p4-stderr
+++ b/testdata/p4_16_errors_outputs/switch_string.p4-stderr
@@ -1,0 +1,3 @@
+switch_string.p4(27): [--Werror=type-error] error: "hello": 'switch' type can't be string
+        switch ("hello") {
+                      ^


### PR DESCRIPTION
Without this patch, a switch of a string constant will crash SimplifySwitch.  It seems like the best way to avoid that is to disallow it typechecking