### PR TITLE
Fix Tofino MAU bitvec overlap checks for wide ranges

### DIFF
--- a/backends/tofino/bf-p4c/mau/instruction_adjustment.cpp
+++ b/backends/tofino/bf-p4c/mau/instruction_adjustment.cpp
@@ -1209,7 +1209,7 @@ void MergeInstructions::build_actiondata_source(ActionAnalysis::ContainerAction 
                 if (read.is_conditional) continue;
 
                 src1_writebits = adi.alignment.write_bits();
-                BUG_CHECK(!read_bits.getrange(read.range().lo, read.range().size()),
+                BUG_CHECK(read_bits.getslice(read.range().lo, read.range().size()).empty(),
                           "Overlapping AD read params ...?");
                 read_bits.setrange(read.range().lo, read.range().size());
                 *src1_p = read.expr;


### PR DESCRIPTION
Replace `bitvec::getrange()` with `getslice().empty()` when checking action-data overlap.

`getrange()` is limited to ranges up to `sizeof(uintmax_t) * CHAR_BIT`, while action-data ranges may be wider. Using `getslice().empty()` correctly handles wide ranges without changing the existing behavior for supported widths.