### PR TITLE
Fix crash on non-constant header union stack index in a parser

### DIFF
--- a/midend/flattenUnions.cpp
+++ b/midend/flattenUnions.cpp
@@ -250,12 +250,14 @@ const IR::Node *DoFlattenHeaderUnionStack::postorder(IR::ArrayIndex *e) {
     if (auto stack = ftype->to<IR::Type_Array>()) {
         unsigned stackSize = stack->size->to<IR::Constant>()->asUnsigned();
         if (stack->elementType->is<IR::Type_HeaderUnion>()) {
-            if (!e->right->is<IR::Constant>())
+            if (!e->right->is<IR::Constant>()) {
                 ::P4::error(
                     ErrorType::ERR_INVALID,
                     "Target expects constant array indices for accessing header union stack "
                     "elements, %1% is not a constant",
                     e->right);
+                return e;
+            }
             unsigned cst = e->right->to<IR::Constant>()->asUnsigned();
             if (cst >= stackSize)
                 ::P4::error(ErrorType::ERR_OVERLIMIT, "Array index out of bound for %1%", e);

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -1047,6 +1047,13 @@ void ExpressionEvaluator::postorder(const IR::ArrayIndex *expression) {
             set(expression, result);
             return;
         }
+        if (lv->elemType == nullptr) {
+            // AnyElement can't model header union stack elements (null elemType)
+            auto result = new SymbolicStaticError(
+                expression, "Non-constant index into a header union stack is not supported");
+            set(expression, result);
+            return;
+        }
         auto v0 = new AnyElement(lv);
         if (!evaluatingLeftValue)
             set(expression, v0->collapse());

--- a/testdata/p4_16_errors/issue5703_header_union_stack.p4
+++ b/testdata/p4_16_errors/issue5703_header_union_stack.p4
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Abhishek Agarwal
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <core.p4>
+@command_line("--loopsUnroll")
+
+header h1 { bit<8>  a; }
+header h2 { bit<16> b; }
+header_union HU { h1 x; h2 y; }
+
+struct headers_t { HU[4] hus; }
+struct meta_t    { bit<8> idx; }
+
+parser P(packet_in pkt, out headers_t hdrs, inout meta_t m);
+package top(P p);
+
+parser myp(packet_in pkt, out headers_t hdrs, inout meta_t m) {
+    state start {
+        // Non-constant index into a header union stack. This used to crash the
+        // compiler (issue 5703); now it reports an error instead.
+        pkt.extract(hdrs.hus[m.idx].x);
+        transition accept;
+    }
+}
+
+top(myp()) main;

--- a/testdata/p4_16_errors_outputs/issue5703_header_union_stack-first.p4
+++ b/testdata/p4_16_errors_outputs/issue5703_header_union_stack-first.p4
@@ -1,0 +1,34 @@
+#include <core.p4>
+
+
+@command_line("--loopsUnroll") header h1 {
+    bit<8> a;
+}
+
+header h2 {
+    bit<16> b;
+}
+
+header_union HU {
+    h1 x;
+    h2 y;
+}
+
+struct headers_t {
+    HU[4] hus;
+}
+
+struct meta_t {
+    bit<8> idx;
+}
+
+parser P(packet_in pkt, out headers_t hdrs, inout meta_t m);
+package top(P p);
+parser myp(packet_in pkt, out headers_t hdrs, inout meta_t m) {
+    state start {
+        pkt.extract<h1>(hdrs.hus[m.idx].x);
+        transition accept;
+    }
+}
+
+top(myp()) main;

--- a/testdata/p4_16_errors_outputs/issue5703_header_union_stack-frontend.p4
+++ b/testdata/p4_16_errors_outputs/issue5703_header_union_stack-frontend.p4
@@ -1,0 +1,36 @@
+#include <core.p4>
+
+
+@command_line("--loopsUnroll") header h1 {
+    bit<8> a;
+}
+
+header h2 {
+    bit<16> b;
+}
+
+header_union HU {
+    h1 x;
+    h2 y;
+}
+
+struct headers_t {
+    HU[4] hus;
+}
+
+struct meta_t {
+    bit<8> idx;
+}
+
+parser P(packet_in pkt, out headers_t hdrs, inout meta_t m);
+package top(P p);
+parser myp(packet_in pkt, out headers_t hdrs, inout meta_t m) {
+    @name("myp.tmp") bit<8> tmp;
+    state start {
+        tmp = m.idx;
+        pkt.extract<h1>(hdrs.hus[tmp].x);
+        transition accept;
+    }
+}
+
+top(myp()) main;

--- a/testdata/p4_16_errors_outputs/issue5703_header_union_stack.p4
+++ b/testdata/p4_16_errors_outputs/issue5703_header_union_stack.p4
@@ -1,0 +1,34 @@
+#include <core.p4>
+
+
+@command_line("--loopsUnroll") header h1 {
+    bit<8> a;
+}
+
+header h2 {
+    bit<16> b;
+}
+
+header_union HU {
+    h1 x;
+    h2 y;
+}
+
+struct headers_t {
+    HU[4] hus;
+}
+
+struct meta_t {
+    bit<8> idx;
+}
+
+parser P(packet_in pkt, out headers_t hdrs, inout meta_t m);
+package top(P p);
+parser myp(packet_in pkt, out headers_t hdrs, inout meta_t m) {
+    state start {
+        pkt.extract(hdrs.hus[m.idx].x);
+        transition accept;
+    }
+}
+
+top(myp()) main;

--- a/testdata/p4_16_errors_outputs/issue5703_header_union_stack.p4-stderr
+++ b/testdata/p4_16_errors_outputs/issue5703_header_union_stack.p4-stderr
@@ -1,0 +1,6 @@
+issue5703_header_union_stack.p4(24): [--Wwarn=ignore-prop] warning: Result of 'pkt.extract(hdrs.hus[m.idx].x)' is not defined: Error: Non-constant index into a header union stack is not supported
+        pkt.extract(hdrs.hus[m.idx].x);
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[--Wwarn=invalid] warning: Uninitialized value prevents loop unrolling:
+m.idx
+[--Werror=invalid] error: Target expects constant array indices for accessing header union stack elements, m.idx is not a constant


### PR DESCRIPTION
A non-constant index into a header union stack in a parser crashed the compiler
when parser unrolling ran. There are two crash sites on that path, both fixed
here:

- ParsersUnroll: `SymbolicArray::elemType` is null for a header union stack
  element (it is typed as `Type_Header`). Indexing with a non-constant value
  builds an `AnyElement`, which passes that null type to `SymbolicHeader` and
  crashes at the `CHECK_NULL` in the `SymbolicStruct` constructor. The evaluator
  now returns a `SymbolicStaticError` for this case.
- FlattenHeaderUnion: the branch that reports "Target expects constant array
  indices ..." was missing a return, so it then dereferenced a null Constant. It
  now returns after reporting the error.

With both fixes the compiler reports the existing flattenUnions error instead of
crashing. Added testdata/p4_16_errors/issue5703_header_union_stack.p4.

Closes #5703.
