### PR TITLE
Support push_front/pop_front on a header union stack

### DIFF
--- a/midend/flattenUnions.cpp
+++ b/midend/flattenUnions.cpp
@@ -180,6 +180,55 @@ const IR::Node *HandleValidityHeaderUnion::postorder(IR::P4Control *control) {
     return control;
 }
 
+const IR::Node *DoExpandHeaderUnionStackPushPop::postorder(IR::MethodCallStatement *mcs) {
+    auto mem = mcs->methodCall->method->to<IR::Member>();
+    if (!mem) return mcs;
+    bool push = mem->member == IR::Type_Array::push_front;
+    if (!push && mem->member != IR::Type_Array::pop_front) return mcs;
+    auto stack = typeMap->getType(mem->expr, true)->to<IR::Type_Array>();
+    if (!stack) return mcs;
+    auto hu = stack->elementType->to<IR::Type_HeaderUnion>();
+    if (!hu) return mcs;  // regular header stacks are lowered by the backend
+    auto cst = mcs->methodCall->arguments->at(0)->expression->to<IR::Constant>();
+    if (!cst || !cst->fitsInt()) return mcs;
+
+    int n = cst->asInt();
+    int size = stack->getSize();
+    auto srcInfo = mcs->srcInfo;
+    if (n <= 0) return new IR::BlockStatement(srcInfo);
+
+    IR::IndexedVector<IR::StatOrDecl> block;
+    auto elem = [&](int i) {
+        return new IR::ArrayIndex(srcInfo, mem->expr->clone(), new IR::Constant(i));
+    };
+    // Copy element by element. A whole-union assignment would need CopyStructures, which
+    // has already run; HandleValidityHeaderUnion lowers each copy and keeps validity right.
+    auto copy = [&](int dst, int src) {
+        for (auto f : hu->fields)
+            block.push_back(
+                new IR::AssignmentStatement(srcInfo, new IR::Member(srcInfo, elem(dst), f->name),
+                                            new IR::Member(srcInfo, elem(src), f->name)));
+    };
+    auto invalidate = [&](int i) {
+        for (auto f : hu->fields) {
+            auto method = new IR::Member(srcInfo, new IR::Member(srcInfo, elem(i), f->name),
+                                         IR::ID(IR::Type_Header::setInvalid));
+            block.push_back(new IR::MethodCallStatement(
+                srcInfo,
+                new IR::MethodCallExpression(srcInfo, method, new IR::Vector<IR::Argument>())));
+        }
+    };
+
+    if (push) {  // shift up, invalidate the new front elements
+        for (int t = size - 1; t >= n; t--) copy(t, t - n);
+        for (int i = 0; i < n && i < size; i++) invalidate(i);
+    } else {  // shift down, invalidate the new back elements
+        for (int t = 0; t + n < size; t++) copy(t, t + n);
+        for (int i = (size - n > 0 ? size - n : 0); i < size; i++) invalidate(i);
+    }
+    return new IR::BlockStatement(srcInfo, std::move(block));
+}
+
 bool DoFlattenHeaderUnionStack::hasHeaderUnionStackField(IR::Type_Struct *s) {
     for (auto sf : s->fields) {
         auto ftype = typeMap->getType(sf, true);

--- a/midend/flattenUnions.h
+++ b/midend/flattenUnions.h
@@ -155,6 +155,21 @@ class HandleValidityHeaderUnion : public Transform {
                                   IR::IndexedVector<IR::StatOrDecl> &code_block);
 };
 
+/** Lower push_front/pop_front on a header union stack into member-wise element
+ * copies plus setInvalid on the vacated elements. Runs before
+ * HandleValidityHeaderUnion (so the copies get validity handling) and before
+ * DoFlattenHeaderUnionStack (which only rewrites [] index accesses).
+ */
+class DoExpandHeaderUnionStackPushPop : public Transform {
+    P4::TypeMap *typeMap;
+
+ public:
+    explicit DoExpandHeaderUnionStackPushPop(P4::TypeMap *typeMap) : typeMap(typeMap) {
+        setName("DoExpandHeaderUnionStackPushPop");
+    }
+    const IR::Node *postorder(IR::MethodCallStatement *mcs) override;
+};
+
 class RemoveUnusedHUDeclarations : public Transform {
     const UsedDeclSet &used;
 
@@ -191,6 +206,14 @@ class FlattenHeaderUnion : public PassManager {
  public:
     FlattenHeaderUnion(P4::ReferenceMap *refMap, P4::TypeMap *typeMap, bool loopsUnroll = true) {
         passes.push_back(new P4::TypeChecking(refMap, typeMap));
+        // Lower push_front/pop_front on header union stacks first; the new nodes need
+        // types before HandleValidityHeaderUnion.
+        if (loopsUnroll) {
+            passes.push_back(new DoExpandHeaderUnionStackPushPop(typeMap));
+            passes.push_back(new P4::ClearTypeMap(typeMap));
+            passes.push_back(new P4::TypeInference(typeMap, false));
+            passes.push_back(new P4::TypeChecking(refMap, typeMap));
+        }
         passes.push_back(new HandleValidityHeaderUnion(refMap, typeMap));
         // Stack flattening is only applicable if parser loops are unrolled and
         // header union stack elements are accessed using [] notation. This pass does not handle

--- a/testdata/p4_16_samples/issue5706_header_union_stack.p4
+++ b/testdata/p4_16_samples/issue5706_header_union_stack.p4
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Abhishek Agarwal
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <core.p4>
+@command_line("--loopsUnroll")
+
+header h1 { bit<8>  a; }
+header h2 { bit<16> b; }
+header_union HU { h1 x; h2 y; }
+
+struct headers_t { HU[4] hus; }
+
+control C(inout headers_t hdrs);
+package top(C c);
+
+control c(inout headers_t hdrs) {
+    apply {
+        // push_front/pop_front on a header union stack (issue 5706). These are
+        // expanded into element moves so they work with --loopsUnroll instead of
+        // reporting a bogus "field is not a member" error.
+        hdrs.hus.push_front(1);
+        hdrs.hus.pop_front(2);
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue5706_header_union_stack-first.p4
+++ b/testdata/p4_16_samples_outputs/issue5706_header_union_stack-first.p4
@@ -1,0 +1,30 @@
+#include <core.p4>
+
+
+@command_line("--loopsUnroll") header h1 {
+    bit<8> a;
+}
+
+header h2 {
+    bit<16> b;
+}
+
+header_union HU {
+    h1 x;
+    h2 y;
+}
+
+struct headers_t {
+    HU[4] hus;
+}
+
+control C(inout headers_t hdrs);
+package top(C c);
+control c(inout headers_t hdrs) {
+    apply {
+        hdrs.hus.push_front(1);
+        hdrs.hus.pop_front(2);
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue5706_header_union_stack-frontend.p4
+++ b/testdata/p4_16_samples_outputs/issue5706_header_union_stack-frontend.p4
@@ -1,0 +1,30 @@
+#include <core.p4>
+
+
+@command_line("--loopsUnroll") header h1 {
+    bit<8> a;
+}
+
+header h2 {
+    bit<16> b;
+}
+
+header_union HU {
+    h1 x;
+    h2 y;
+}
+
+struct headers_t {
+    HU[4] hus;
+}
+
+control C(inout headers_t hdrs);
+package top(C c);
+control c(inout headers_t hdrs) {
+    apply {
+        hdrs.hus.push_front(1);
+        hdrs.hus.pop_front(2);
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue5706_header_union_stack-midend.p4
+++ b/testdata/p4_16_samples_outputs/issue5706_header_union_stack-midend.p4
@@ -1,0 +1,115 @@
+#include <core.p4>
+
+
+@command_line("--loopsUnroll") header h1 {
+    bit<8> a;
+}
+
+header h2 {
+    bit<16> b;
+}
+
+struct headers_t {
+    h1 hus0_x;
+    h2 hus0_y;
+    h1 hus1_x;
+    h2 hus1_y;
+    h1 hus2_x;
+    h2 hus2_y;
+    h1 hus3_x;
+    h2 hus3_y;
+}
+
+control C(inout headers_t hdrs);
+package top(C c);
+control c(inout headers_t hdrs) {
+    @hidden action issue5706_header_union_stack24() {
+        if (hdrs.hus2_x.isValid()) {
+            hdrs.hus3_x.setValid();
+            hdrs.hus3_x = hdrs.hus2_x;
+            hdrs.hus3_y.setInvalid();
+        } else {
+            hdrs.hus3_x.setInvalid();
+        }
+        if (hdrs.hus2_y.isValid()) {
+            hdrs.hus3_y.setValid();
+            hdrs.hus3_y = hdrs.hus2_y;
+            hdrs.hus3_x.setInvalid();
+        } else {
+            hdrs.hus3_y.setInvalid();
+        }
+        if (hdrs.hus1_x.isValid()) {
+            hdrs.hus2_x.setValid();
+            hdrs.hus2_x = hdrs.hus1_x;
+            hdrs.hus2_y.setInvalid();
+        } else {
+            hdrs.hus2_x.setInvalid();
+        }
+        if (hdrs.hus1_y.isValid()) {
+            hdrs.hus2_y.setValid();
+            hdrs.hus2_y = hdrs.hus1_y;
+            hdrs.hus2_x.setInvalid();
+        } else {
+            hdrs.hus2_y.setInvalid();
+        }
+        if (hdrs.hus0_x.isValid()) {
+            hdrs.hus1_x.setValid();
+            hdrs.hus1_x = hdrs.hus0_x;
+            hdrs.hus1_y.setInvalid();
+        } else {
+            hdrs.hus1_x.setInvalid();
+        }
+        if (hdrs.hus0_y.isValid()) {
+            hdrs.hus1_y.setValid();
+            hdrs.hus1_y = hdrs.hus0_y;
+            hdrs.hus1_x.setInvalid();
+        } else {
+            hdrs.hus1_y.setInvalid();
+        }
+        hdrs.hus0_x.setInvalid();
+        hdrs.hus0_y.setInvalid();
+        if (hdrs.hus2_x.isValid()) {
+            hdrs.hus0_x.setValid();
+            hdrs.hus0_x = hdrs.hus2_x;
+            hdrs.hus0_y.setInvalid();
+        } else {
+            hdrs.hus0_x.setInvalid();
+        }
+        if (hdrs.hus2_y.isValid()) {
+            hdrs.hus0_y.setValid();
+            hdrs.hus0_y = hdrs.hus2_y;
+            hdrs.hus0_x.setInvalid();
+        } else {
+            hdrs.hus0_y.setInvalid();
+        }
+        if (hdrs.hus3_x.isValid()) {
+            hdrs.hus1_x.setValid();
+            hdrs.hus1_x = hdrs.hus3_x;
+            hdrs.hus1_y.setInvalid();
+        } else {
+            hdrs.hus1_x.setInvalid();
+        }
+        if (hdrs.hus3_y.isValid()) {
+            hdrs.hus1_y.setValid();
+            hdrs.hus1_y = hdrs.hus3_y;
+            hdrs.hus1_x.setInvalid();
+        } else {
+            hdrs.hus1_y.setInvalid();
+        }
+        hdrs.hus2_x.setInvalid();
+        hdrs.hus2_y.setInvalid();
+        hdrs.hus3_x.setInvalid();
+        hdrs.hus3_y.setInvalid();
+    }
+    @hidden table tbl_issue5706_header_union_stack24 {
+        actions = {
+            issue5706_header_union_stack24();
+        }
+        const default_action = issue5706_header_union_stack24();
+    }
+    apply {
+        tbl_issue5706_header_union_stack24.apply();
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_samples_outputs/issue5706_header_union_stack.p4
+++ b/testdata/p4_16_samples_outputs/issue5706_header_union_stack.p4
@@ -1,0 +1,30 @@
+#include <core.p4>
+
+
+@command_line("--loopsUnroll") header h1 {
+    bit<8> a;
+}
+
+header h2 {
+    bit<16> b;
+}
+
+header_union HU {
+    h1 x;
+    h2 y;
+}
+
+struct headers_t {
+    HU[4] hus;
+}
+
+control C(inout headers_t hdrs);
+package top(C c);
+control c(inout headers_t hdrs) {
+    apply {
+        hdrs.hus.push_front(1);
+        hdrs.hus.pop_front(2);
+    }
+}
+
+top(c()) main;


### PR DESCRIPTION
push_front/pop_front on a header union stack reported a bogus "field is not a
member" error under --loopsUnroll (#5706). DoFlattenHeaderUnionStack rewrites []
index accesses but had no handler for these method calls, so once it split the
stack into per-element fields, the push/pop calls referred to a deleted field.

This adds a small pass that lowers push_front/pop_front on a header union stack
into element copies plus setInvalid on the vacated elements, using [] notation. It
runs before HandleValidityHeaderUnion (so the copies get the usual union validity
handling) and before DoFlattenHeaderUnionStack (so the [] accesses flatten as
usual).

Added a p4_16_samples test.

Closes #5706.
