### PR TITLE
Prevent unsigned underflow in SymbolicArray::shift()

### DIFF
--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -473,6 +473,13 @@ SymbolicArray::SymbolicArray(const IR::Type_Array *type, bool uninitialized,
 }
 
 void SymbolicArray::shift(int amount) {
+    // Clamp shift amount to prevent integer underflow in loop bounds.
+    // If the shift magnitude exceeds the array size, the entire stack
+    // becomes invalid, so the sign no longer matters.
+    if (static_cast<size_t>(std::abs(amount)) > values.size()) {
+        amount = static_cast<int>(values.size());
+    }
+
     if (amount < 0) {
         for (unsigned i = 0; i < values.size() + amount; i++) values[i] = values[i - amount];
         for (unsigned i = values.size() + amount; i < values.size(); i++) {


### PR DESCRIPTION
## Summary

Prevent unsigned underflow in `SymbolicArray::shift()` when the requested shift exceeds the array size.

`SymbolicArray::shift()` computes loop bounds using `values.size() + amount` and `values.size() - amount`. If the shift magnitude exceeds the array size, unsigned arithmetic can underflow and produce incorrect loop bounds.

Clamp oversized shift amounts before computing the loop bounds while preserving the existing behavior for valid shifts.