### PR TITLE
Fix broken documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ We welcome and appreciate new contributions. Check out [git usage](docs/README.m
 * Writing unit test code [Guidelines](docs/README.md#adding-new-test-data).
 * Write documentation [Guidelines](docs/README.md#writing-documentation).
 * [Coding conventions](docs/README.md#coding-conventions).
-* Opening pull requests and writing commit messages [Guidelines](docs/CodingStandardPhilosophy.md#Git-commits-and-pull-requests).
+* Opening pull requests and writing commit messages [Guidelines](docs/CodingStandardPhilosophy.md#git-commits-and-pull-requests).
 * Code has to be reviewed before it is merged.
 * Make sure all tests pass when you send a pull request.
 * Participate in the code review process and address any feedback or comments.

--- a/backends/p4tools/modules/smith/README.md
+++ b/backends/p4tools/modules/smith/README.md
@@ -34,7 +34,6 @@ Refer to the full page here: [P4Smith](https://p4lang.github.io/p4c/p4smith.html
 - [Installation](#installation)
 - [Extensions](#extensions)
 - [Usage](#usage)
-- [Limitations](#limitations)
 - [Further Reading](#further-reading)
 - [Contributing](#contributing)
 - [License](#license)

--- a/backends/p4tools/modules/testgen/README.md
+++ b/backends/p4tools/modules/testgen/README.md
@@ -65,7 +65,7 @@ P4Testgen depends on the P4Tools framework and is automatically installed with P
 P4Testgen is available as part of the [official P4C docker image](https://hub.docker.com/r/p4lang/p4c/). On Debian-based systems, it is also possible to install a P4Testgen binary by following [these](https://github.com/p4lang/p4c#installing-packaged-versions-of-p4c) instructions.
 
 ### Dependencies
-In addition to [P4Tools'](../README.md#dependencies) own dependencies P4Testgen depends on the following external software:
+In addition to [P4Tools'](../../README.md#dependencies) own dependencies P4Testgen depends on the following external software:
   * [inja](https://github.com/pantor/inja) template engine for testcase generation.
 
 These dependencies are automatically installed via CMakelist's [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) module.

--- a/docs/README.md
+++ b/docs/README.md
@@ -341,7 +341,7 @@ To add a new input test with a sample P4 code file (under `testdata/p4_16_sample
 
 * We generally follow the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html). This is partially enforced by `cpplint` and `clang-format` and their respective configuration files. We have customized Google's `cpplint.py` tool for our purposes.  The tool can be invoked with `make cpplint`. To be able to run `clang-format` on Ubuntu 20.04, install it with `pip3 install --user clang-format`. Do not use the Debian package. Both tools run in a git hook and as part of CI.
 
-* Commenting Style is guided by the [following rules](#documentation-comments-style-guide).
+* Commenting Style is guided by the [following rules](#cc-documentation-comments-style-guide).
   
 * Watch out for `const`; it is very important.
 


### PR DESCRIPTION
Fixes four broken links in the docs:

- testgen/README.md: `../README.md#dependencies` resolved to a nonexistent modules/README.md; corrected to `../../README.md#dependencies` (the P4Tools README, which has the Dependencies section).
- smith/README.md: removed a Table of Contents entry pointing to a Limitations section that does not exist.
- CONTRIBUTING.md: lowercased the `#git-commits-and-pull-requests` anchor to match the generated heading id.
- docs/README.md: the commenting-style link matched no heading; pointed it at `#cc-documentation-comments-style-guide`.

Note: I used an AI assistant to help spot these link issues, but I checked each one myself against the target files and the generated anchors.
