### PR TITLE
Infer type arguments for generic extern instances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,13 @@ Optional tools:
 - Expected outputs live under `testdata/*_outputs/`; refresh them with `P4TEST_REPLACE=1 cmake --build build --target check`.
 - Pass compiler flags via `P4C_ARGS`, e.g. `P4C_ARGS="-Xp4c=MY_CUSTOM_FLAG" cmake --build build --target check`.
 
+### Contributing a Test
+- Every language or compiler fix needs a P4 program under `testdata/p4_16_samples/` (use `testdata/p4_16_errors/` for programs that must be rejected).
+- Name the file after the GitHub issue it covers (`issue1234.p4`) or after the feature under test (`generic-extern-inference.p4`); add the `-bmv2`, `_ebpf`, `_ubpf`, or `psa-`/`pna-` markers only when the program targets that backend.
+- If it targets a particular backend and compiles, add a packet test (PTF/STF) to ensure compilation behaves as expected.
+- Suites are globbed at configure time, so re-run cmake after adding a file, otherwise `ctest` will not see the new test.
+- Generate the reference outputs and commit them together with the test: `P4TEST_REPLACE=1 ctest --test-dir build -R <test-name>`. This writes `<name>{,-first,-frontend,-midend}.p4` and `<name>.p4-stderr` into `testdata/p4_16_samples_outputs/`.
+
 ## Commit & Pull Request Guidelines
 - Use DCO sign-off for every commit (`git commit --signoff`).
 - Use a ~50-character summary plus a body explaining why/how and linking issues.

--- a/frontends/p4/specialize.cpp
+++ b/frontends/p4/specialize.cpp
@@ -217,6 +217,9 @@ void FindSpecializations::postorder(const IR::ConstructorCallExpression *express
 
 void FindSpecializations::postorder(const IR::Declaration_Instance *decl) {
     if (decl->arguments->size() == 0 && !decl->type->is<IR::Type_Specialized>()) return;
+    // Only extern instances can be declared as arrays, and this pass only specializes
+    // parsers and controls.
+    if (decl->type->is<IR::Type_Array>()) return;
 
     auto type = specMap->typeMap->getType(decl, true);
     if (type->is<IR::Type_SpecializedCanonical>()) {

--- a/frontends/p4/typeChecking/bindVariables.cpp
+++ b/frontends/p4/typeChecking/bindVariables.cpp
@@ -41,6 +41,41 @@ class HasInfInt : public Inspector {
     }
 };
 
+/// The type arguments of @p type as they can be written in the P4 program.
+/// Returns nullptr if any of them cannot be represented as a P4 type.
+const IR::Vector<IR::Type> *p4TypeArguments(const IR::Type_SpecializedCanonical *type) {
+    auto typeArgs = new IR::Vector<IR::Type>();
+    for (auto arg : *type->arguments) {
+        auto p4type = arg->getP4Type();
+        if (p4type == nullptr) return nullptr;
+        typeArgs->push_back(p4type);
+    }
+    return typeArgs;
+}
+
+/// Given the type written in a declaration or in a constructor call (a type name, possibly
+/// wrapped in array types) whose type arguments have been inferred to be @p type, return that
+/// type with the inferred arguments written out explicitly.
+///
+/// Returns nullptr if the arguments cannot be inserted, which is the case when the written name
+/// does not refer to the generic type declaration itself: a name which is a typedef for an
+/// already specialized type must not be given type arguments.
+const IR::Type *addTypeArguments(const IR::Type *declaredType,
+                                 const IR::Type_SpecializedCanonical *type) {
+    if (auto at = declaredType->to<IR::Type_Array>()) {
+        auto elementType = addTypeArguments(at->elementType, type);
+        if (elementType == nullptr) return nullptr;
+        return new IR::Type_Array(at->srcInfo, elementType, at->size);
+    }
+    auto tn = declaredType->to<IR::Type_Name>();
+    if (tn == nullptr) return nullptr;
+    auto baseType = type->baseType->to<IR::Type_Declaration>();
+    if (baseType == nullptr || tn->path->name != baseType->name) return nullptr;
+    auto typeArgs = p4TypeArguments(type);
+    if (typeArgs == nullptr) return nullptr;
+    return new IR::Type_Specialized(tn->srcInfo, tn, typeArgs);
+}
+
 }  // namespace
 
 /// Validate the type of a type variable.  The type must not contain
@@ -84,7 +119,16 @@ const IR::Node *DoBindTypeVariables::postorder(IR::Declaration_Instance *decl) {
     if (decl->type->is<IR::Type_Specialized>()) return decl;
     auto type = typeMap->getType(getOriginal(), true);
     while (auto at = type->to<IR::Type_Array>()) type = at->elementType;
-    if (auto tsc = type->to<IR::Type_SpecializedCanonical>()) type = tsc->substituted;
+    if (auto tsc = type->to<IR::Type_SpecializedCanonical>()) {
+        // The declaration did not supply explicit type arguments, but they have all been
+        // inferred: make them explicit in the program, just as if they had been written in the
+        // first place.
+        if (auto newType = addTypeArguments(decl->type, tsc)) {
+            decl->type = newType;
+            return decl;
+        }
+        type = tsc->substituted;
+    }
     BUG_CHECK(type->is<IR::IMayBeGenericType>(), "%1%: unexpected type %2% for declaration", decl,
               type);
     auto mt = type->to<IR::IMayBeGenericType>();
@@ -124,6 +168,14 @@ const IR::Node *DoBindTypeVariables::postorder(IR::MethodCallExpression *express
 const IR::Node *DoBindTypeVariables::postorder(IR::ConstructorCallExpression *expression) {
     if (expression->constructedType->is<IR::Type_Specialized>()) return expression;
     auto type = typeMap->getType(getOriginal(), true);
+    if (auto tsc = type->to<IR::Type_SpecializedCanonical>()) {
+        // The type arguments of the generic type have been inferred: make them explicit.
+        if (auto newType = addTypeArguments(expression->constructedType, tsc)) {
+            expression->constructedType = newType;
+            return expression;
+        }
+        type = tsc->substituted;
+    }
     BUG_CHECK(type->is<IR::IMayBeGenericType>(), "%1%: unexpected type %2% for expression",
               expression, type);
     auto mt = type->to<IR::IMayBeGenericType>();

--- a/frontends/p4/typeChecking/typeCheckDecl.cpp
+++ b/frontends/p4/typeChecking/typeCheckDecl.cpp
@@ -258,6 +258,13 @@ TypeInferenceBase::PreorderResult TypeInferenceBase::preorderDeclarationInstance
         // Otherwise, we use the type received from checkExternConstructor, which
         // has substituted the type variables with fresh ones.
         if (type->template is<IR::Type_Extern>()) type = newType;
+        // If the type arguments of a generic extern were inferred from the constructor arguments,
+        // the abstract methods have to be checked against the extern type specialized with them,
+        // and not against the generic declaration.
+        if (auto *sc = type->template to<IR::Type_SpecializedCanonical>()) {
+            if (auto *specialized = sc->substituted->template to<IR::Type_Extern>())
+                et = specialized;
+        }
         if (arrayType) type = relayerArrayType(type, arrayType);
         setType(orig, type);
         setType(decl, type);

--- a/frontends/p4/typeChecking/typeCheckExpr.cpp
+++ b/frontends/p4/typeChecking/typeCheckExpr.cpp
@@ -2243,6 +2243,9 @@ const IR::Node *TypeInferenceBase::postorder(const IR::ConstructorCallExpression
     if (auto *e = simpleType->to<IR::Type_Extern>()) {
         auto [contType, newArgs] = checkExternConstructor(expression, e, expression->arguments);
         if (newArgs == nullptr) return expression;
+        // If the type arguments were supplied explicitly, the type of the constructed object is
+        // the specialized type; otherwise it is the type inferred by checkExternConstructor.
+        if (type->is<IR::Type_SpecializedCanonical>()) contType = type;
         if (expression->arguments != newArgs)
             expression = new IR::ConstructorCallExpression(expression->srcInfo,
                                                            expression->constructedType, newArgs);

--- a/frontends/p4/typeChecking/typeChecker.cpp
+++ b/frontends/p4/typeChecking/typeChecker.cpp
@@ -17,6 +17,21 @@
 
 namespace P4 {
 
+namespace {
+/// True if the type contains any type variables, i.e., Type_Var, Type_InfInt or Type_Any.
+class HasTypeVariables : public Inspector {
+    bool found = false;
+    void postorder(const IR::Type *type) override { found = found || type->is<IR::ITypeVar>(); }
+
+ public:
+    static bool find(const IR::Type *type) {
+        HasTypeVariables htv;
+        type->apply(htv);
+        return htv.found;
+    }
+};
+}  // namespace
+
 #if DEBUG_TYPES
 TypeChecking::TypeChecking(ReferenceMap *refMap, TypeMap *typeMap, bool updateExpressions) {
     addPasses({new P4::TypeInference(typeMap, /* readOnly */ true, /* checkArrays */ true,
@@ -872,8 +887,38 @@ TypeInferenceBase::checkExternConstructor(const IR::Node *errorPosition, const I
         if (!named) ++paramIt;
     }
     if (changed) arguments = newArgs;
-    auto objectType = new IR::Type_Extern(ext->srcInfo, ext->name, methodType->typeParameters,
-                                          freshExtern->methods);
+    const IR::Type *objectType = nullptr;
+    if (!methodType->typeParameters->empty()) {
+        // The extern type is generic.  If all of its type parameters have been inferred from the
+        // constructor arguments, then the type of the constructed object is the extern type
+        // specialized with the inferred type arguments -- exactly as if those arguments had been
+        // supplied explicitly in the program.
+        auto typeArgs = new IR::Vector<IR::Type>();
+        bool allInferred = true;
+        for (auto tv : methodType->typeParameters->parameters) {
+            const IR::Type *arg = tvs->lookup(tv);
+            if (arg != nullptr) {
+                // The binding may itself contain type variables.
+                arg = arg->apply(substVisitor, getChildContext())->to<IR::Type>();
+            }
+            if (arg == nullptr || HasTypeVariables::find(arg)) {
+                allInferred = false;
+                break;
+            }
+            typeArgs->push_back(arg);
+        }
+        if (allInferred) {
+            auto specialized = specialize(ext, typeArgs, getChildContext());
+            if (specialized == nullptr) return none;
+            objectType =
+                new IR::Type_SpecializedCanonical(ext->srcInfo, ext, typeArgs, specialized);
+        }
+    }
+    // Some type parameters could not be inferred: they are preserved as free type variables in the
+    // type, so that they can be bound (or diagnosed) later.
+    if (objectType == nullptr)
+        objectType = new IR::Type_Extern(ext->srcInfo, ext->name, methodType->typeParameters,
+                                         freshExtern->methods);
     learn(objectType, this, getChildContext());
     return {objectType, arguments};
 }

--- a/testdata/p4_16_errors/generic-extern-inference-abstract_e.p4
+++ b/testdata/p4_16_errors/generic-extern-inference-abstract_e.p4
@@ -1,0 +1,15 @@
+// The abstract methods of a generic extern type are checked against the type arguments which
+// were inferred from the constructor arguments.
+
+extern AbstractExtern<AbsT> {
+    AbstractExtern(AbsT arg);
+    abstract void handle(in AbsT v);
+}
+
+control c() {
+    // AbsT is inferred to be bit<16>, so the implementation must not take a bit<8>.
+    AbstractExtern(16w1) wrongAbstractType = {
+        void handle(in bit<8> v) {}
+    };
+    apply {}
+}

--- a/testdata/p4_16_errors/generic-extern-inference-typedef_e.p4
+++ b/testdata/p4_16_errors/generic-extern-inference-typedef_e.p4
@@ -1,0 +1,15 @@
+// A typedef of a specialized generic extern type is not itself generic, so it cannot be given
+// type arguments.  This is the reason why inferred type arguments are only written out for names
+// which refer to the generic declaration itself.
+
+extern Parametrized<ArgT> {
+    Parametrized(ArgT arg);
+    ArgT get();
+}
+
+typedef Parametrized<bit<16>> Parametrized16;
+
+control c() {
+    Parametrized16<bit<16>>(16w1) alreadySpecialized;
+    apply {}
+}

--- a/testdata/p4_16_errors/generic-extern-inference_e.p4
+++ b/testdata/p4_16_errors/generic-extern-inference_e.p4
@@ -1,0 +1,25 @@
+// The type arguments of a generic extern type may be omitted only if the compiler can infer
+// them from the constructor arguments.
+// The positive cases are in testdata/p4_16_samples/generic-extern-inference.p4.
+
+extern Parametrized<ArgT> {
+    Parametrized(ArgT arg);
+    ArgT get();
+}
+
+extern TwoParameters<A, B> {
+    TwoParameters(A arg);
+    B get();
+}
+
+control c1() {
+    // B does not appear among the constructor parameters, so it cannot be inferred.
+    TwoParameters(16w1) notInferable;
+    apply {}
+}
+
+control c2() {
+    // The argument is an unsized integer constant, so no width can be inferred for ArgT.
+    Parametrized(1) noWidth;
+    apply {}
+}

--- a/testdata/p4_16_errors_outputs/generic-extern-inference-abstract_e.p4
+++ b/testdata/p4_16_errors_outputs/generic-extern-inference-abstract_e.p4
@@ -1,0 +1,14 @@
+extern AbstractExtern<AbsT> {
+    AbstractExtern(AbsT arg);
+    abstract void handle(in AbsT v);
+}
+
+control c() {
+    AbstractExtern(16w1) wrongAbstractType = {
+        void handle(in bit<8> v) {
+        }
+    };
+    apply {
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/generic-extern-inference-abstract_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/generic-extern-inference-abstract_e.p4-stderr
@@ -1,0 +1,18 @@
+generic-extern-inference-abstract_e.p4(9): [--Wwarn=unused] warning: control 'c' is unused
+control c() {
+        ^
+generic-extern-inference-abstract_e.p4(11): [--Wwarn=unused] warning: 'wrongAbstractType' is unused
+    AbstractExtern(16w1) wrongAbstractType = {
+                         ^^^^^^^^^^^^^^^^^
+generic-extern-inference-abstract_e.p4(11): [--Werror=type-error] error: 'wrongAbstractType'
+    AbstractExtern(16w1) wrongAbstractType = {
+                         ^^^^^^^^^^^^^^^^^
+  ---- Actual error:
+  Cannot unify type 'bit<8>' with type 'bit<16>'
+  ---- Originating from:
+generic-extern-inference-abstract_e.p4(12): Method 'handle' does not have the expected type 'handle'
+          void handle(in bit<8> v) {}
+               ^^^^^^
+generic-extern-inference-abstract_e.p4(6)
+      abstract void handle(in AbsT v);
+                    ^^^^^^

--- a/testdata/p4_16_errors_outputs/generic-extern-inference-typedef_e.p4
+++ b/testdata/p4_16_errors_outputs/generic-extern-inference-typedef_e.p4
@@ -1,0 +1,12 @@
+extern Parametrized<ArgT> {
+    Parametrized(ArgT arg);
+    ArgT get();
+}
+
+typedef Parametrized<bit<16>> Parametrized16;
+control c() {
+    Parametrized16<bit<16>>(16w1) alreadySpecialized;
+    apply {
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/generic-extern-inference-typedef_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/generic-extern-inference-typedef_e.p4-stderr
@@ -1,0 +1,12 @@
+generic-extern-inference-typedef_e.p4(12): [--Wwarn=unused] warning: control 'c' is unused
+control c() {
+        ^
+generic-extern-inference-typedef_e.p4(13): [--Wwarn=unused] warning: 'alreadySpecialized' is unused
+    Parametrized16<bit<16>>(16w1) alreadySpecialized;
+                                  ^^^^^^^^^^^^^^^^^^
+generic-extern-inference-typedef_e.p4(13): [--Werror=type-error] error: Parametrized16<bit<16>>: Type Parametrized<...> is not generic and thus it cannot be specialized using type arguments
+    Parametrized16<bit<16>>(16w1) alreadySpecialized;
+    ^^^^^^^^^^^^^^^^^^^^^^^
+generic-extern-inference-typedef_e.p4(10)
+typedef Parametrized<bit<16>> Parametrized16;
+        ^^^^^^^^^^^^^^^^^^^^^

--- a/testdata/p4_16_errors_outputs/generic-extern-inference_e.p4
+++ b/testdata/p4_16_errors_outputs/generic-extern-inference_e.p4
@@ -1,0 +1,22 @@
+extern Parametrized<ArgT> {
+    Parametrized(ArgT arg);
+    ArgT get();
+}
+
+extern TwoParameters<A, B> {
+    TwoParameters(A arg);
+    B get();
+}
+
+control c1() {
+    TwoParameters(16w1) notInferable;
+    apply {
+    }
+}
+
+control c2() {
+    Parametrized(1) noWidth;
+    apply {
+    }
+}
+

--- a/testdata/p4_16_errors_outputs/generic-extern-inference_e.p4-stderr
+++ b/testdata/p4_16_errors_outputs/generic-extern-inference_e.p4-stderr
@@ -1,0 +1,21 @@
+generic-extern-inference_e.p4(15): [--Wwarn=unused] warning: control 'c1' is unused
+control c1() {
+        ^^
+generic-extern-inference_e.p4(17): [--Wwarn=unused] warning: 'notInferable' is unused
+    TwoParameters(16w1) notInferable;
+                        ^^^^^^^^^^^^
+generic-extern-inference_e.p4(21): [--Wwarn=unused] warning: control 'c2' is unused
+control c2() {
+        ^^
+generic-extern-inference_e.p4(23): [--Wwarn=unused] warning: 'noWidth' is unused
+    Parametrized(1) noWidth;
+                    ^^^^^^^
+generic-extern-inference_e.p4(17): [--Werror=type-error] error: notInferable: could not infer a type for variable B
+    TwoParameters(16w1) notInferable;
+                        ^^^^^^^^^^^^
+generic-extern-inference_e.p4(10)
+extern TwoParameters<A, B> {
+                        ^
+generic-extern-inference_e.p4(23): [--Werror=type-error] error: 1: could not infer a width
+    Parametrized(1) noWidth;
+                 ^

--- a/testdata/p4_16_samples/generic-extern-inference.p4
+++ b/testdata/p4_16_samples/generic-extern-inference.p4
@@ -1,0 +1,65 @@
+// Type arguments of a generic extern type can be inferred from the constructor
+// arguments, in which case the instantiation does not have to be specialized
+// explicitly (see P4-16 specification, section "Type specialization").
+// Such an instance can be used wherever an explicitly specialized one can be,
+// in particular as the argument of a generic method.
+
+extern PlainExtern {
+    PlainExtern(bit<16> arg);
+}
+
+extern ParametrizedExtern<ArgT> {
+    ParametrizedExtern(ArgT arg);
+    ArgT get();
+}
+
+extern OtherExtern {
+    OtherExtern();
+    void apply_any<CatchAllT>(CatchAllT arg);
+}
+
+extern AbstractExtern<AbsT> {
+    AbstractExtern(AbsT arg);
+    abstract void handle(in AbsT v);
+    AbsT get();
+}
+
+// A name which is not generic itself, but stands for a specialized generic type.
+typedef ParametrizedExtern<bit<32>> ParametrizedExtern32;
+
+parser Parser(out bit<16> result) {
+    PlainExtern(16w1) plain;
+    ParametrizedExtern(16w1) inferred;            // ArgT is inferred to be bit<16>
+    ParametrizedExtern<bit<8>>(8w2) specialized;  // ArgT is supplied explicitly
+    ParametrizedExtern32(32w3) aliased;
+    ParametrizedExtern(16w4) inferredArray[2];
+    ParametrizedExtern<bit<16>>(16w5) specializedArray[2];
+    OtherExtern() ctrl;
+
+    state start {
+        ctrl.apply_any(plain);
+        ctrl.apply_any(inferred);
+        ctrl.apply_any(specialized);
+        ctrl.apply_any(aliased);
+        result = inferred.get() + inferredArray[0].get() + specializedArray[1].get();
+        transition accept;
+    }
+}
+
+control Control(inout bit<16> result) {
+    // The abstract method is implemented for the inferred type argument bit<16>.
+    AbstractExtern(16w6) abstractInferred = {
+        void handle(in bit<16> v) {
+            result = result + v;
+        }
+    };
+
+    apply {
+        result = result + abstractInferred.get();
+    }
+}
+
+parser P(out bit<16> result);
+control C(inout bit<16> result);
+package Top(P p, C c);
+Top(Parser(), Control()) main;

--- a/testdata/p4_16_samples_outputs/generic-extern-inference-first.p4
+++ b/testdata/p4_16_samples_outputs/generic-extern-inference-first.p4
@@ -1,0 +1,54 @@
+extern PlainExtern {
+    PlainExtern(bit<16> arg);
+}
+
+extern ParametrizedExtern<ArgT> {
+    ParametrizedExtern(ArgT arg);
+    ArgT get();
+}
+
+extern OtherExtern {
+    OtherExtern();
+    void apply_any<CatchAllT>(CatchAllT arg);
+}
+
+extern AbstractExtern<AbsT> {
+    AbstractExtern(AbsT arg);
+    abstract void handle(in AbsT v);
+    AbsT get();
+}
+
+typedef ParametrizedExtern<bit<32>> ParametrizedExtern32;
+parser Parser(out bit<16> result) {
+    PlainExtern(16w1) plain;
+    ParametrizedExtern<bit<16>>(16w1) inferred;
+    ParametrizedExtern<bit<8>>(8w2) specialized;
+    ParametrizedExtern32(32w3) aliased;
+    ParametrizedExtern<bit<16>>[2](16w4) inferredArray;
+    ParametrizedExtern<bit<16>>[2](16w5) specializedArray;
+    OtherExtern() ctrl;
+    state start {
+        ctrl.apply_any<PlainExtern>(plain);
+        ctrl.apply_any<ParametrizedExtern<bit<16>>>(inferred);
+        ctrl.apply_any<ParametrizedExtern<bit<8>>>(specialized);
+        ctrl.apply_any<ParametrizedExtern<bit<32>>>(aliased);
+        result = inferred.get() + inferredArray[0].get() + specializedArray[1].get();
+        transition accept;
+    }
+}
+
+control Control(inout bit<16> result) {
+    AbstractExtern<bit<16>>(16w6) abstractInferred = {
+        void handle(in bit<16> v) {
+            result = result + v;
+        }
+    };
+    apply {
+        result = result + abstractInferred.get();
+    }
+}
+
+parser P(out bit<16> result);
+control C(inout bit<16> result);
+package Top(P p, C c);
+Top(Parser(), Control()) main;

--- a/testdata/p4_16_samples_outputs/generic-extern-inference-frontend.p4
+++ b/testdata/p4_16_samples_outputs/generic-extern-inference-frontend.p4
@@ -1,0 +1,74 @@
+extern PlainExtern {
+    PlainExtern(bit<16> arg);
+}
+
+extern ParametrizedExtern<ArgT> {
+    ParametrizedExtern(ArgT arg);
+    ArgT get();
+}
+
+extern OtherExtern {
+    OtherExtern();
+    void apply_any<CatchAllT>(CatchAllT arg);
+}
+
+extern AbstractExtern<AbsT> {
+    AbstractExtern(AbsT arg);
+    abstract void handle(in AbsT v);
+    AbsT get();
+}
+
+typedef ParametrizedExtern<bit<32>> ParametrizedExtern32;
+parser Parser(out bit<16> result) {
+    @name("Parser.tmp") bit<16> tmp;
+    @name("Parser.tmp_0") bit<16> tmp_0;
+    @name("Parser.tmp_1") bit<16> tmp_1;
+    @name("Parser.tmp_2") bit<16> tmp_2;
+    @name("Parser.tmp_3") bit<16> tmp_3;
+    @name("Parser.tmp_4") bit<16> tmp_4;
+    @name("Parser.tmp_5") bit<16> tmp_5;
+    @name("Parser.plain") PlainExtern(16w1) plain_0;
+    @name("Parser.inferred") ParametrizedExtern<bit<16>>(16w1) inferred_0;
+    @name("Parser.specialized") ParametrizedExtern<bit<8>>(8w2) specialized_0;
+    @name("Parser.aliased") ParametrizedExtern32(32w3) aliased_0;
+    @name("Parser.inferredArray") ParametrizedExtern<bit<16>>[2](16w4) inferredArray_0;
+    @name("Parser.specializedArray") ParametrizedExtern<bit<16>>[2](16w5) specializedArray_0;
+    @name("Parser.ctrl") OtherExtern() ctrl_0;
+    state start {
+        ctrl_0.apply_any<PlainExtern>(plain_0);
+        ctrl_0.apply_any<ParametrizedExtern<bit<16>>>(inferred_0);
+        ctrl_0.apply_any<ParametrizedExtern<bit<8>>>(specialized_0);
+        ctrl_0.apply_any<ParametrizedExtern<bit<32>>>(aliased_0);
+        tmp_1 = inferred_0.get();
+        tmp_0 = tmp_1;
+        tmp_2 = inferredArray_0[0].get();
+        tmp_3 = tmp_0 + tmp_2;
+        tmp = tmp_3;
+        tmp_4 = specializedArray_0[1].get();
+        tmp_5 = tmp + tmp_4;
+        result = tmp_5;
+        transition accept;
+    }
+}
+
+control Control(inout bit<16> result) {
+    @name("Control.tmp_6") bit<16> tmp_6;
+    @name("Control.tmp_7") bit<16> tmp_7;
+    @name("Control.tmp_8") bit<16> tmp_8;
+    @name("Control.abstractInferred") AbstractExtern<bit<16>>(16w6) abstractInferred_0 = {
+        void handle(in bit<16> v) {
+            result = result + v;
+        }
+    };
+    apply {
+        tmp_6 = result;
+        tmp_7 = abstractInferred_0.get();
+        tmp_8 = tmp_6 + tmp_7;
+        result = tmp_8;
+    }
+}
+
+parser P(out bit<16> result);
+control C(inout bit<16> result);
+package Top(P p, C c);
+Top(Parser(), Control()) main;

--- a/testdata/p4_16_samples_outputs/generic-extern-inference-midend.p4
+++ b/testdata/p4_16_samples_outputs/generic-extern-inference-midend.p4
@@ -1,0 +1,70 @@
+extern PlainExtern {
+    PlainExtern(bit<16> arg);
+}
+
+extern ParametrizedExtern<ArgT> {
+    ParametrizedExtern(ArgT arg);
+    ArgT get();
+}
+
+extern OtherExtern {
+    OtherExtern();
+    void apply_any<CatchAllT>(CatchAllT arg);
+}
+
+extern AbstractExtern<AbsT> {
+    AbstractExtern(AbsT arg);
+    abstract void handle(in AbsT v);
+    AbsT get();
+}
+
+parser Parser(out bit<16> result) {
+    @name("Parser.tmp_1") bit<16> tmp_1;
+    @name("Parser.tmp_2") bit<16> tmp_2;
+    @name("Parser.tmp_4") bit<16> tmp_4;
+    @name("Parser.plain") PlainExtern(16w1) plain_0;
+    @name("Parser.inferred") ParametrizedExtern<bit<16>>(16w1) inferred_0;
+    @name("Parser.specialized") ParametrizedExtern<bit<8>>(8w2) specialized_0;
+    @name("Parser.aliased") ParametrizedExtern<bit<32>>(32w3) aliased_0;
+    @name("Parser.inferredArray") ParametrizedExtern<bit<16>>[2](16w4) inferredArray_0;
+    @name("Parser.specializedArray") ParametrizedExtern<bit<16>>[2](16w5) specializedArray_0;
+    @name("Parser.ctrl") OtherExtern() ctrl_0;
+    state start {
+        ctrl_0.apply_any<PlainExtern>(plain_0);
+        ctrl_0.apply_any<ParametrizedExtern<bit<16>>>(inferred_0);
+        ctrl_0.apply_any<ParametrizedExtern<bit<8>>>(specialized_0);
+        ctrl_0.apply_any<ParametrizedExtern<bit<32>>>(aliased_0);
+        tmp_1 = inferred_0.get();
+        tmp_2 = inferredArray_0[0].get();
+        tmp_4 = specializedArray_0[1].get();
+        result = tmp_1 + tmp_2 + tmp_4;
+        transition accept;
+    }
+}
+
+control Control(inout bit<16> result) {
+    @name("Control.tmp_7") bit<16> tmp_7;
+    @name("Control.abstractInferred") AbstractExtern<bit<16>>(16w6) abstractInferred_0 = {
+        void handle(in bit<16> v) {
+            result = result + v;
+        }
+    };
+    @hidden action genericexterninference58() {
+        tmp_7 = abstractInferred_0.get();
+        result = result + tmp_7;
+    }
+    @hidden table tbl_genericexterninference58 {
+        actions = {
+            genericexterninference58();
+        }
+        const default_action = genericexterninference58();
+    }
+    apply {
+        tbl_genericexterninference58.apply();
+    }
+}
+
+parser P(out bit<16> result);
+control C(inout bit<16> result);
+package Top(P p, C c);
+Top(Parser(), Control()) main;

--- a/testdata/p4_16_samples_outputs/generic-extern-inference.p4
+++ b/testdata/p4_16_samples_outputs/generic-extern-inference.p4
@@ -1,0 +1,54 @@
+extern PlainExtern {
+    PlainExtern(bit<16> arg);
+}
+
+extern ParametrizedExtern<ArgT> {
+    ParametrizedExtern(ArgT arg);
+    ArgT get();
+}
+
+extern OtherExtern {
+    OtherExtern();
+    void apply_any<CatchAllT>(CatchAllT arg);
+}
+
+extern AbstractExtern<AbsT> {
+    AbstractExtern(AbsT arg);
+    abstract void handle(in AbsT v);
+    AbsT get();
+}
+
+typedef ParametrizedExtern<bit<32>> ParametrizedExtern32;
+parser Parser(out bit<16> result) {
+    PlainExtern(16w1) plain;
+    ParametrizedExtern(16w1) inferred;
+    ParametrizedExtern<bit<8>>(8w2) specialized;
+    ParametrizedExtern32(32w3) aliased;
+    ParametrizedExtern[2](16w4) inferredArray;
+    ParametrizedExtern<bit<16>>[2](16w5) specializedArray;
+    OtherExtern() ctrl;
+    state start {
+        ctrl.apply_any(plain);
+        ctrl.apply_any(inferred);
+        ctrl.apply_any(specialized);
+        ctrl.apply_any(aliased);
+        result = inferred.get() + inferredArray[0].get() + specializedArray[1].get();
+        transition accept;
+    }
+}
+
+control Control(inout bit<16> result) {
+    AbstractExtern(16w6) abstractInferred = {
+        void handle(in bit<16> v) {
+            result = result + v;
+        }
+    };
+    apply {
+        result = result + abstractInferred.get();
+    }
+}
+
+parser P(out bit<16> result);
+control C(inout bit<16> result);
+package Top(P p, C c);
+Top(Parser(), Control()) main;


### PR DESCRIPTION
The specification says on type specialization:
"In cases where the compiler can infer type arguments type specialization is not necessary."  It also says that constructor calls are treated like ordinary method calls when it comes to deriving types. And that an extern instance may be handed to a method as an argument. Both lines below are legal, and the second one has to behave exactly like the first:

    ParametrizedExtern<bit<16>>(16w1) a;   // written out
    ParametrizedExtern(16w1) b;            // derived by the compiler
    ctrl.apply_any(a);
    ctrl.apply_any(b);

The second call is currently rejected with "Type parameters needed for arg".  The reason was that the compiler recorded the wrong type for an instance whose type argument it had derived itself.  While checking the constructor call it derived that the parameter stands for bit<16>, but then described the new object as "generic extern with a unresolved parameter type", instead of "extern with the parameter set to bit<16>".  So, the instance had a leftover dummy  type.  Passing it to a method meant handing that dummy to the method's own type inference, which is then rejected. 

Investigating this problem uncovered several issues:

* typeChecking/typeChecker.cpp is where the constructor call is checked, and where the wrong type was built.  It now collects the type arguments it derived and, if it managed to derive all of them, describes the object as the extern specialized with those arguments. If some argument is still unknown, we defer to the original error.

* typeChecking/typeCheckExpr.cpp handles the case that creates an instance inside an expression rather than in a declaration.  It now keeps the specialized type when the arguments were written by hand, like the declaration case.

* The typeCheckDecl.cpp checks that abstract methods are implemented correctly. It compared the implementation against the generic declaration. An implementation written for bit<16> was compared against the still-open parameter and reported as having the wrong type. We now make it compare against the specialized type.

* typeChecking/bindVariables.cpp had two problems. 1) It did not handle arrays. An array of instances made the compiler crash while building the new type.  2) it added type arguments to any type name, including a name introduced by typedef which already might have been specialized; For example, `typedef PE<bit<16>> PE16;` produced something like PE16<bit<16>>, which is not legal because PE16 is not itself generic definition (see one of the error cases). Arguments are now added only to a name that really refers to the generic declaration, arrays are rebuilt around the specialized element type. Cases where nothing can be written out have the original behavior.

* specialize.cpp crashed on any array of extern instances, including ones with hand written type arguments, because it assumed the declared type is either a plain name or a specialized name.  Only externs can be declared as arrays and this pass only specializes parsers and controls, so arrays are now skipped. Maybe something worth extending or keeping track of...