### PR TITLE
Properly typecheck annotations on functions

### DIFF
--- a/frontends/p4/typeChecking/typeCheckDecl.cpp
+++ b/frontends/p4/typeChecking/typeCheckDecl.cpp
@@ -322,12 +322,13 @@ template <class Node>
 TypeInferenceBase::PreorderResult TypeInferenceBase::preorderFunctionImpl(Node *function) {
     if (done()) return {function, false};
 
-    visit(function->type);
+    visit(function->annotations, "annotations");
+    visit(function->type, "type");
     auto type = getTypeType(function->type);
     if (type == nullptr) return {function, false};
     setType(getOriginal(), type);
     setType(function, type);
-    visit(function->body);
+    visit(function->body, "body");
 
     return {function, true};
 }

--- a/testdata/p4_16_samples/structured-annotation.p4
+++ b/testdata/p4_16_samples/structured-annotation.p4
@@ -16,3 +16,11 @@
 control c() {
     apply {}
 }
+
+@number[2]
+@empty[]
+@kv[k1=1,k2=2]
+@MixedExprList[1,TEXT_CONST,true,1==2,5+NUM_CONST]
+@Labels[short="Short Label", hover="My Longer Table Label to appear in hover-help"]
+@MixedKV[label="text", my_bool=true, int_val=6]
+void fn() { }

--- a/testdata/p4_16_samples_outputs/structured-annotation-first.p4
+++ b/testdata/p4_16_samples_outputs/structured-annotation-first.p4
@@ -3,3 +3,5 @@
     }
 }
 
+@number[2] @empty[] @kv[k1=1, k2=2] @MixedExprList[1, "hello", true, false, 11] @Labels[short="Short Label", hover="My Longer Table Label to appear in hover-help"] @MixedKV[label="text", my_bool=true, int_val=6] void fn() {
+}

--- a/testdata/p4_16_samples_outputs/structured-annotation.p4
+++ b/testdata/p4_16_samples_outputs/structured-annotation.p4
@@ -3,3 +3,5 @@
     }
 }
 
+@number[2] @empty[] @kv[k1=1, k2=2] @MixedExprList[1, "hello", true, 1 == 2, 5 + 6] @Labels[short="Short Label", hover="My Longer Table Label to appear in hover-help"] @MixedKV[label="text", my_bool=true, int_val=6] void fn() {
+}

--- a/testdata/p4_16_samples_outputs/structured-annotation.p4-stderr
+++ b/testdata/p4_16_samples_outputs/structured-annotation.p4-stderr
@@ -1,6 +1,9 @@
 structured-annotation.p4(16): [--Wwarn=unused] warning: control 'c' is unused
 control c() {
         ^
+structured-annotation.p4(26): [--Wwarn=unused] warning: 'fn' is unused
+void fn() { }
+     ^^
 structured-annotation.p4(16): [--Winfo=removed] info: removing control 'c'
 control c() {
         ^


### PR DESCRIPTION
- avoid crashes later when these annotations have types looked up in the type map