### PR TITLE
Update BMv2 Pin for P4tools, remove header-stack-ops-bmv2.p4 from xfail

### DIFF
--- a/.github/workflows/ci-p4tools.yml
+++ b/.github/workflows/ci-p4tools.yml
@@ -28,7 +28,7 @@ jobs:
       ENABLE_TEST_TOOLS: ON
       BUILD_GENERATOR: Ninja
       # This pins BMv2 to current upstream main.
-      BMV2_REF: faf7bfe96064d5c6fc7753cad956a9e85445883b
+      BMV2_REF: 883d4eae360de7b6ad0aaf52ba6d30a2401cd0e0
     steps:
       - uses: actions/checkout@v7
         with:

--- a/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
+++ b/backends/p4tools/modules/testgen/targets/bmv2/test/BMV2PTFXfail.cmake
@@ -47,7 +47,6 @@ p4tools_add_xfail_reason(
   "Exception in thread"
   # The error here is unclear. It looks like a segmentation fault.
   extract_for_header_union.p4
-  header-stack-ops-bmv2.p4
 )
 
 p4tools_add_xfail_reason(


### PR DESCRIPTION
https://github.com/p4lang/behavioral-model/pull/1435 fixed a crash in BMv2. Remove the test from xfails