### PR TITLE
Update dependency list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ sudo dpkg -i /path/to/package.deb
     ```
 
 2.  Install [dependencies](#dependencies). You can find specific instructions
-    for Ubuntu 22.04 [here](#ubuntu-dependencies) and for macOS 11
+    for Ubuntu [here](#ubuntu-dependencies) and for macOS
     [here](#macos-dependencies).  You can also look at the
     [CI installation script](https://github.com/p4lang/p4c/blob/main/tools/ci-build.sh).
 
@@ -267,11 +267,11 @@ If you plan to contribute to P4C, you'll find more useful information
 
 ## Dependencies
 
-Ubuntu 22.04 is the officially supported platform for P4C. There's also
-unofficial support for macOS 11. Other platforms are untested; you can try to
-use them, but YMMV.
+Ubuntu 22.04 and Ubuntu 24.04 are the officially supported platforms for P4C.
+There's also unofficial support for macOS, including Apple Silicon. Other
+platforms are untested; you can try to use them, but YMMV.
 
-- A C++17 compiler. GCC 9.1 or later or Clang 6.0 or later is required.
+- A C++20 compiler. P4C is built with `CMAKE_CXX_STANDARD 20`.
 
 - `git` for version control
 
@@ -348,10 +348,10 @@ Please note that while all Protobuf versions newer than 3.0 should work for
 P4C itself, you may run into trouble with Abseil, some extensions and other p4lang
 projects unless you install version 3.25.3.
 
-P4C also depends on Google Abseil library. This library is also a pre-requisite for Protobuf of any version newer than 3.21. Therefore the use of Protobuf of suitable version automatically fulfils Abseil dependency. P4C typically installs its own version of Abseil using CMake's `FetchContent` module (Abseil LTS 20240116.1 at the moment).
+P4C also depends on Google Abseil library. This library is also a pre-requisite for Protobuf of any version newer than 3.21. Therefore the use of Protobuf of suitable version automatically fulfils Abseil dependency. P4C typically installs its own version of Abseil using CMake's `FetchContent` module (Abseil LTS 20240722.1 at the moment).
 
 #### CMake
-P4C requires a CMake version of at least 3.16.3 or higher. On older systems, a newer version of CMake can be installed using `pip3 install --user cmake==3.16.3`. We have a CI test on Ubuntu 18.04 that uses this option, but there is no guarantee that this will lead to a successful build.
+P4C requires a CMake version of at least 3.16.3 or higher. On older systems, a newer version of CMake can be installed using `pip3 install --user cmake==3.16.3`, but there is no guarantee that this will lead to a successful build.
 
 ### Fedora dependencies
 


### PR DESCRIPTION
Part of #4777. This only corrects the parts of the dependency list that disagree with the code and CI today. It does not try to settle which platforms should be supported, and it does not cover the missing Tofino packages (jsl, rapid-json, pyinstaller, jsonschema) that ChrisDodd mentioned in that issue.

- C++17 -> C++20. `CMakeLists.txt` sets `CMAKE_CXX_STANDARD 20` with  `CMAKE_CXX_STANDARD_REQUIRED ON` since #4347, and `docs/C++.md` already says C++20. The README was never updated, so it still asked for a C++17 compiler.
- Dropped "GCC 9.1 or later or Clang 6.0 or later". Neither supports C++20, and neither is tested. CMake does not enforce a minimum compiler version, so I did not invent one.
- Ubuntu 24.04 is tested in CI, so it is listed alongside 22.04.
- Removed the claim that there is a CI test on Ubuntu 18.04. That workflow lives in `.github/workflows/disabled/`.
- macOS 11 -> macOS. CI runs on `macos-latest` and `tools/install_mac_deps.sh` has an arm64 path, so Apple Silicon is mentioned.
- Abseil LTS 20240116.1 -> 20240722.1, matching `cmake/Abseil.cmake`.

Protobuf 3.25.3 and CMake 3.16.3 still match the code, so they are unchanged.
