### PR TITLE
Fix boost::format argument mismatches in core diagnostics

### DIFF
--- a/frontends/p4-14/fromv1.0/converters.h
+++ b/frontends/p4-14/fromv1.0/converters.h
@@ -541,9 +541,8 @@ class FixExtracts final : public Transform {
                 fixedHeaderType = new IR::Type_Header(IR::ID(hname), fields);
                 // extract length from annotation
                 auto anno = f->getAnnotation(IR::Annotation::lengthAnnotation);
-                BUG_CHECK(anno != nullptr, "No length annotation on varbit field", f);
-                BUG_CHECK(anno->getExpr().size() == 1, "Expected exactly 1 argument",
-                          anno->getExpr());
+                BUG_CHECK(anno != nullptr, "%1%: no length annotation on varbit field", f);
+                BUG_CHECK(anno->getExpr().size() == 1, "%1%: expected exactly 1 argument", anno);
                 headerLength = anno->getExpr(0);
                 // We keep going through the loop just to check whether there is another
                 // varbit field in the header.

--- a/ir/ir.cpp
+++ b/ir/ir.cpp
@@ -270,7 +270,7 @@ const IR::PackageBlock *ToplevelBlock::getMain() const {
     }
     auto main = mainDecls[0];
     if (mainDecls.size() > 1) {
-        ::P4::error(ErrorType::ERR_DUPLICATE, "Program has multiple `%s' instances: %1%, %2%",
+        ::P4::error(ErrorType::ERR_DUPLICATE, "Program has multiple `%1%' instances: %2%, %3%",
                     IR::P4Program::main, main->getNode(), mainDecls[1]->getNode());
         return nullptr;
     }


### PR DESCRIPTION
Part of #5730, core only. The bf-p4c cases are left for a separate PR since that tree is reviewed separately.

Each of these passes more arguments than the format string has placeholders, so boost::format throws at the extra `%` instead of printing the message.

- `ir/ir.cpp:273` mixed a printf-style `%s` with positional `%1%`/`%2%` and passed  three arguments. Now fully positional, `%1%` through `%3%`. The sibling call just  above at line 268 uses a bare `%s` with a single argument and is fine, so it is
  unchanged.
- `frontends/p4-14/fromv1.0/converters.h:544` and `:545` had no placeholder at all but passed one argument each. Added `%1%`, in the `"%1%: ..."` form the rest of  that file already uses.

One thing worth a look: on line 545 I also changed the argument from `anno->getExpr()` to `anno`. An expression vector does not print usefully, and `anno` is an IR node so it carries source info. Happy to keep the original argument
and change only the format string if you prefer.

I could not exercise these paths, so this is from reading the code. They are all error or BUG paths, which is why they have gone unnoticed.
