### PR TITLE
Fix boost::format argument mismatches in bf-p4c diagnostics

### DIFF
--- a/backends/tofino/bf-p4c/arch/fromv1.0/field_list.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/field_list.cpp
@@ -37,16 +37,18 @@ const IR::Node *P4V1::FieldListConverter::convertFieldList(const IR::Node *node)
     for (auto anno : fl->annotations) {
         if (anno->name == pragma_string) {
             if (anno->getExpr().size() != 3)
-                error("Invalid pragma specification -- ", pragma_string);
+                error("Invalid pragma specification -- %1%", pragma_string);
 
             if (!anno->getExpr(0)->is<IR::StringLiteral>())
-                error("Invalid field in pragma specification -- ", anno->getExpr(0));
+                error("Invalid field in pragma specification -- %1%", anno->getExpr(0));
 
             auto field = anno->getExpr(0)->to<IR::StringLiteral>()->value;
             if (!anno->getExpr()[1]->is<IR::Constant>() || !anno->getExpr()[2]->is<IR::Constant>())
-                error("Invalid slice bit position(s) in pragma specification -- ", pragma_string);
+                error("Invalid slice bit position(s) in pragma specification -- %1%",
+                      pragma_string);
 
-            if (sliced_fields.count(field)) error("Duplicate slice definition for field ", field);
+            if (sliced_fields.count(field))
+                error("Duplicate slice definition for field %1%", field);
             sliced_fields.insert(field);
 
             auto msb = anno->getExpr()[1]->to<IR::Constant>()->asInt();

--- a/backends/tofino/bf-p4c/arch/fromv1.0/stateful_alu.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/stateful_alu.cpp
@@ -858,7 +858,7 @@ IR::IndexedVector<IR::Node>::iterator find_in_scope(IR::Vector<IR::Node> *scope,
             }
         }
     }
-    BUG("%v not in scope", name);
+    BUG("%1% not in scope", name);
     return scope->end();
 }
 

--- a/backends/tofino/bf-p4c/arch/fromv1.0/v1_converters.cpp
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/v1_converters.cpp
@@ -547,7 +547,7 @@ const IR::Node *TypeNameExpressionConverter::postorder(IR::Type_Name *node) {
     auto path = node->path->to<IR::Path>();
     if (auto newName = P4::get(enumsToTranslate, path->name)) {
         if (!structure->enums.count(newName)) {
-            BUG("Cannot translation for type ", node);
+            BUG("Cannot translation for type %1%", node);
             return node;
         }
         return new IR::Type_Name(IR::ID(node->srcInfo, newName));

--- a/backends/tofino/bf-p4c/arch/psa/psa.cpp
+++ b/backends/tofino/bf-p4c/arch/psa/psa.cpp
@@ -714,7 +714,7 @@ class TranslateProgram : public Inspector {
             if (mode->value == "resilient")
                 sel_mode->member = IR::ID("RESILIENT");
             else if (mode->value != "fair" && mode->value != "non_resilient")
-                BUG("Selector mode provided for the selector is not supported", node);
+                BUG("%1%: selector mode provided for the selector is not supported", node);
         } else {
             LOG1("WARNING: No mode specified for the selector %s. Assuming fair" << node);
         }

--- a/backends/tofino/bf-p4c/arch/v1model.cpp
+++ b/backends/tofino/bf-p4c/arch/v1model.cpp
@@ -2008,7 +2008,7 @@ class ConstructSymbolTable : public Inspector {
             if (mode->value == "resilient")
                 sel_mode->member = IR::ID("RESILIENT");
             else if (mode->value != "fair" && mode->value != "non_resilient")
-                BUG("Selector mode provided for the selector is not supported", node);
+                BUG("%1%: selector mode provided for the selector is not supported", node);
         } else {
             LOG1("WARNING: No mode specified for the selector %s. Assuming fair" << node);
         }

--- a/backends/tofino/bf-p4c/bf-p4c-options.cpp
+++ b/backends/tofino/bf-p4c/bf-p4c-options.cpp
@@ -529,7 +529,7 @@ BFN_Options::BFN_Options() {
         [this](const char *arg) {
             int temp = std::atoi(arg);
             if ((!temp && (*arg != '0')) || (temp <= 0) || (temp > 100)) {
-                ::error("Invalid traffic limit % value %s. Valid arguments: {1..100}", arg);
+                ::error("Invalid traffic limit %% value %s. Valid arguments: {1..100}", arg);
                 return false;
             }
             traffic_limit = temp;

--- a/backends/tofino/bf-p4c/control-plane/bfruntime_arch_handler.h
+++ b/backends/tofino/bf-p4c/control-plane/bfruntime_arch_handler.h
@@ -1475,7 +1475,7 @@ class BFRuntimeArchHandlerCommon : public P4::ControlPlaneAPI::P4RuntimeArchHand
         auto impl = getTableImplementationProperty(table);
         if (impl == nullptr) return std::nullopt;
         if (!impl->value->template is<IR::ExpressionValue>()) {
-            error("Expected %1% property value for table %2% to be an expression: %2%",
+            error("Expected %1% property value for table %2% to be an expression: %3%",
                   implementationString, table->controlPlaneName(), impl);
             return std::nullopt;
         }

--- a/backends/tofino/bf-p4c/mau/asm_output.cpp
+++ b/backends/tofino/bf-p4c/mau/asm_output.cpp
@@ -3558,7 +3558,7 @@ bool MauAsmOutput::EmitAttached::preorder(const IR::MAU::StatefulAlu *salu) {
             // Ideally, this check should never fail as an empty action is validated in
             // 'CheckStatefulAlu' earlier in backend.
             BUG_CHECK((act->action.size() > 0),
-                      " Stateful %1% must have instructions assigned for action '%1%'."
+                      " Stateful %1% must have instructions assigned for action '%2%'."
                       " Please verify the action is valid.",
                       salu, act);
             act->apply(EmitAction(self, out, tbl, indent));

--- a/backends/tofino/bf-p4c/mau/attached_output.cpp
+++ b/backends/tofino/bf-p4c/mau/attached_output.cpp
@@ -136,7 +136,7 @@ void Format::create_alu_ops_for_action(ActionAnalysis::ContainerActionsMap &ca_m
                      read.speciality != ActionAnalysis::ActionParam::METER_ALU) ||
                     read.type == ActionAnalysis::ActionParam::CONSTANT) {
                     BUG("Illegal instruction with both meter alu action data and non meter alu "
-                        "data 1% : %2%",
+                        "data %1% : %2%",
                         container.toString(), cont_action.to_string());
                 }
                 create_meter_alu(*alu, read, container_bits);

--- a/backends/tofino/bf-p4c/mau/instruction_selection.cpp
+++ b/backends/tofino/bf-p4c/mau/instruction_selection.cpp
@@ -431,8 +431,8 @@ const IR::Node *Synth2PortSetup::postorder(IR::MAU::Primitive *prim) {
             return new IR::MAU::StatefulCounter(prim->srcInfo, t, salu);
         }
         auto *salu_inst = salu->calledAction(tbl, act);
-        BUG_CHECK(salu_inst != nullptr, "%s: Could not find called action for stateful memory in ",
-                  prim->srcInfo, salu->name);
+        BUG_CHECK(salu_inst != nullptr,
+                  "%1%: could not find called action for stateful memory in %2%", prim, salu->name);
         auto salu_index = salu_inst->inst_code;
         if (salu_index < 0) {
             // FIXME -- should be allocating/setting this
@@ -1054,7 +1054,7 @@ const IR::Expression *DoInstructionSelection::postorder(IR::Operation_Relation *
         } else if (e->is<IR::Geq>()) {
             opName = isSigned ? "gteqs" : "gtequ";
         } else {
-            error("%1%: Unknown relational operator", e, e->node_type_name());
+            error("%1%: unknown relational operator %2%", e, e->node_type_name());
         }
         return new IR::MAU::Instruction(e->srcInfo, cstring(opName), new IR::TempVar(e->type),
                                         e->left, e->right);

--- a/backends/tofino/bf-p4c/mau/table_placement.cpp
+++ b/backends/tofino/bf-p4c/mau/table_placement.cpp
@@ -2788,7 +2788,7 @@ TablePlacement::Placed *TablePlacement::try_place_table(Placed *rv, const StageU
     LOG4("    furthest stage: " << furthest_stage
                                 << ", initial # of attached entries: " << initial_attached_entries);
 
-    if (rv->stage >= 100) ::fatal_error("too many stages: %1", rv->stage);
+    if (rv->stage >= 100) ::fatal_error("too many stages: %1%", rv->stage);
 
     auto *min_placed = new Placed(*rv);
     if (min_placed->entries > 1) min_placed->entries = 1;

--- a/backends/tofino/bf-p4c/midend/blockmap.h
+++ b/backends/tofino/bf-p4c/midend/blockmap.h
@@ -41,7 +41,7 @@ class FillFromBlockMap : public Transform {
             else
                 BUG("Type_Name %1% maps to %2% rather than a type decl", type, decl);
         } else {
-            BUG("Type_Name %1% doesn't map to a declaration", type, decl);
+            BUG("Type_Name %1% doesn't map to a declaration", type);
         }
     }
 

--- a/backends/tofino/bf-p4c/midend/register_read_write.cpp
+++ b/backends/tofino/bf-p4c/midend/register_read_write.cpp
@@ -341,7 +341,7 @@ void RegisterReadWrite::AnalyzeActionWithRegisterCalls::createRegisterExecute(
 
 void RegisterReadWrite::AnalyzeActionWithRegisterCalls::createRegisterAction(
     RegActionInfo &info, const IR::Statement *reg_stmt, const IR::Declaration *act) {
-    BUG_CHECK(reg_stmt, "No register call statment present to analyze in action - ", act);
+    BUG_CHECK(reg_stmt, "No register call statment present to analyze in action - %1%", act);
 
     auto [call, assign_lhs] = extractRegisterReadWrite(reg_stmt);
     if (!call) return;
@@ -460,7 +460,7 @@ bool RegisterReadWrite::AnalyzeActionWithRegisterCalls::preorder(const IR::Decla
     LOG1("RegisterReadWrite: analysing action: " << act << indent);
 
     auto control = findContext<IR::P4Control>();
-    BUG_CHECK(control, "No control found for P4 Action ", act);
+    BUG_CHECK(control, "No control found for P4 Action %1%", act);
 
     for (auto reg : self.action_register_calls[act]) {
         RegActionInfo info;

--- a/backends/tofino/bf-p4c/midend/simplifyIfStatement.cpp
+++ b/backends/tofino/bf-p4c/midend/simplifyIfStatement.cpp
@@ -54,7 +54,7 @@ const IR::Node *ElimCallExprInIfCond::postorder(IR::MethodCallExpression *method
         // may need to modify to support function();
         return methodCall;
     } else {
-        BUG("Unexpected method call", methodCall);
+        BUG("%1%: unexpected method call", methodCall);
     }
     auto &path = *linearizer.linearPath;
     auto tempVar = refMap->newName(path.to_cstring().string_view());

--- a/backends/tofino/bf-p4c/parde/allocate_parser_match_register.cpp
+++ b/backends/tofino/bf-p4c/parde/allocate_parser_match_register.cpp
@@ -252,7 +252,7 @@ struct DelayDefs : public ParserModifier {
 
                 BUG_CHECK(!seen || shift == trans->shift,
                           "Multiple transitions seen from %1% to %2% with different shift amounts: "
-                          "%1% %2%",
+                          "%3% %4%",
                           state->name, trans->next->name, shift, trans->shift);
                 shift = trans->shift;
                 seen = true;

--- a/backends/tofino/bf-p4c/phv/pragma/pa_container_type.cpp
+++ b/backends/tofino/bf-p4c/phv/pragma/pa_container_type.cpp
@@ -84,7 +84,7 @@ bool PragmaContainerType::add_constraint(const IR::BFN::Pipe *pipe, const IR::Ex
     } else if (kind == PHV::Kind::tagalong) {
         warning(
             "@prama pa_container_type currently does not support tagalong containers, "
-            "skipped",
+            "skipped: %1%",
             field_name);
         return false;
     }

--- a/backends/tofino/bf-p4c/phv/pragma/phv_pragmas.cpp
+++ b/backends/tofino/bf-p4c/phv/pragma/phv_pragmas.cpp
@@ -166,7 +166,7 @@ void PHV::Pragmas::reportNoMatchingPHV(const IR::BFN::Pipe *pipe, const IR::Expr
         if (pipe && pipe->canon_name()) {
             // If the pipe is named
             warning(ErrorType::WARN_INVALID,
-                    "No matching PHV field `%1' in the pipe `%2%'. Ignoring pragma.", field_name,
+                    "No matching PHV field `%1%' in the pipe `%2%'. Ignoring pragma.", field_name,
                     pipe->canon_name());
         } else {
             warning(ErrorType::WARN_INVALID, "No matching PHV field `%1%'. Ignoring pragma.",

--- a/backends/tofino/bf-p4c/phv/solver/action_constraint_solver.cpp
+++ b/backends/tofino/bf-p4c/phv/solver/action_constraint_solver.cpp
@@ -109,7 +109,7 @@ void assign_input_bug_check(const ordered_map<ContainerID, ContainerSpec> &specs
                             const Assign &assign) {
     for (const auto op : {assign.src, assign.dst}) {
         if (op.is_ad_or_const) {
-            BUG_CHECK(op.container == "", "action data or const must have nil container", op);
+            BUG_CHECK(op.container == "", "%1%: action data or const must have nil container", op);
             continue;
         }
         BUG_CHECK(op.container != "", "empty container string not allowed unless ad_or_const: %1%",

--- a/backends/tofino/bf-p4c/phv/v2/greedy_tx_score.cpp
+++ b/backends/tofino/bf-p4c/phv/v2/greedy_tx_score.cpp
@@ -61,7 +61,7 @@ ContGress from(const gress_t &t) {
             return ContGress::ingress;
         }
         default:
-            BUG("unknown gress: ", t);
+            BUG("unknown gress: %1%", t);
     }
 }
 


### PR DESCRIPTION
Part of #5730, bf-p4c only. The core cases are in #5731.

These diagnostics pass more arguments than the format string has placeholders, or have a malformed placeholder, so boost::format throws instead of printing the message. This covers 24 sites across 19 files.

### Malformed placeholders

- `mau/table_placement.cpp` `%1` -> `%1%`
- `phv/pragma/phv_pragmas.cpp` `` `%1' `` -> `` `%1%' ``. The other branch of the same function already has the correct form.
- `mau/attached_output.cpp` `1%` -> `%1%`, the characters were transposed
- `arch/fromv1.0/stateful_alu.cpp` `%v` -> `%1%`. `%v` is an Abseil `str_format` conversion, used by `appendFormat` elsewhere in the tree, but boost does not know it.
- `bf-p4c-options.cpp` a stray `%` before "value" is now `%%`

### Index fixes

- `control-plane/bfruntime_arch_handler.h` the third argument needs `%3%`
- `mau/asm_output.cpp` the action needs `%2%`, `%1%` was repeated
- `parde/allocate_parser_match_register.cpp` the two shift amounts need `%3% %4%`
- `mau/instruction_selection.cpp:1057` added `%2%` for the node type name

### Missing placeholder

The rest had no placeholder at all while still passing an argument, usually with the message left hanging on a separator, for example:

```cpp
error("Invalid pragma specification -- ", pragma_string);
BUG("unknown gress: ", t);
```

Three of these are not purely mechanical and are worth a look:

- `midend/blockmap.h` I dropped the `decl` argument rather than adding a placeholder. That branch is the "doesn't map to a declaration" case, so there is no declaration to print. The sibling BUG just above legitimately prints both.
- `mau/instruction_selection.cpp:434` I changed the argument from `prim->srcInfo` to `prim`. `Util::SourceInfo` maps to `f % ""`, so a leading `%1%` would have rendered as an empty string. Passing the node prints it and still supplies the location.
- `phv/pragma/pa_container_type.cpp` I appended `: %1%` and left the existing "@ prama" typo alone to keep this diff to one thing.

I only reformatted the lines I touched, so the pre-existing clang-format violation further down `table_placement.cpp` is untouched.

Re-running the scan over the tofino tree reports no remaining mismatches.

I could not exercise these paths, so this is from reading the code. They are all on error or BUG paths, which is why they have gone unnoticed.
