### PR TITLE
bmv2: fix backend crash on non-zero runtime bit-slices crossing byte boundaries

### DIFF
--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -725,7 +725,7 @@ void ExpressionConverter::postorder(const IR::Slice *expression) {
     BUG_CHECK(bitwidth == h - l + 1, "%1%: unexpected slice width", expression);
     auto le = get(expr);
     if (!le) return;
-    // Shift non-zero slices down to bit 0 so the result is right-aligned 
+    // Shift non-zero slices down to bit 0 so the result is right-aligned
     // to the target width before masking off upper bits.
     if (l != 0) {
         auto shifted = new Util::JsonObject();

--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -721,17 +721,32 @@ void ExpressionConverter::postorder(const IR::Slice *expression) {
     auto expr = expression->e0;
     int h = expression->getH();
     int l = expression->getL();
-    auto mask = Util::maskFromSlice(h, l);
+    auto bitwidth = expression->type->width_bits();
+    BUG_CHECK(bitwidth == h - l + 1, "%1%: unexpected slice width", expression);
+    auto le = get(expr);
+    if (!le) return;
+    // Shift non-zero slices down to bit 0 so the result is right-aligned 
+    // to the target width before masking off upper bits.
+    if (l != 0) {
+        auto shifted = new Util::JsonObject();
+        shifted->emplace("type", "expression");
+        auto shr = new Util::JsonObject();
+        shifted->emplace("value", shr);
+        shr->emplace("op", ">>");
+        shr->emplace("left"_cs, le);
+        auto amount = new Util::JsonObject();
+        amount->emplace("type", "hexstr");
+        amount->emplace("value", stringRepr(l));
+        shr->emplace("right"_cs, amount);
+        le = shifted;
+    }
     result->emplace("type", "expression");
     auto band = new Util::JsonObject();
     result->emplace("value", band);
     band->emplace("op", "&");
     auto right = new Util::JsonObject();
-    auto bitwidth = expression->type->width_bits();
     right->emplace("type", "hexstr");
-    right->emplace("value", stringRepr(mask, ROUNDUP(bitwidth, 8)));
-    auto le = get(expr);
-    if (!le) return;
+    right->emplace("value", stringRepr(Util::mask(bitwidth), ROUNDUP(bitwidth, 8)));
     band->emplace("left"_cs, le);
     band->emplace("right"_cs, right);
     mapExpression(expression, result);

--- a/backends/tc/options.h
+++ b/backends/tc/options.h
@@ -10,6 +10,7 @@
 
 #include "backends/ebpf/ebpfOptions.h"
 #include "frontends/common/options.h"
+#include "lib/error.h"
 
 namespace P4::TC {
 
@@ -55,6 +56,12 @@ class TCOptions : public CompilerOptions {
                     xdp2tcMode = XDP2TC_HEAD;
                 } else if (!strcmp(arg, "cpumap")) {
                     xdp2tcMode = XDP2TC_CPUMAP;
+                } else {
+                    ::P4::error(ErrorType::ERR_INVALID,
+                                "Unknown --xdp2tc mode '%1%'; expected one of: meta, head, "
+                                "cpumap",
+                                arg);
+                    return false;
                 }
                 return true;
             },
@@ -63,7 +70,15 @@ class TCOptions : public CompilerOptions {
         registerOption(
             "--num-timer-profiles", "profiles",
             [this](const char *arg) {
-                timerProfiles = std::atoi(arg);
+                char *end = nullptr;
+                long value = strtol(arg, &end, 10);
+                if (*end != 0 || value <= 0) {
+                    ::P4::error(ErrorType::ERR_INVALID,
+                                "--num-timer-profiles expects a positive integer, got '%1%'",
+                                arg);
+                    return false;
+                }
+                timerProfiles = static_cast<unsigned>(value);
                 return true;
             },
             "Defines the number of timer profiles. Default is 4.");
@@ -74,4 +89,4 @@ using TCContext = P4CContextWithOptions<TCOptions>;
 
 }  // namespace P4::TC
 
-#endif /* BACKENDS_TC_OPTIONS_H_ */
+#endif  // BACKENDS_TC_OPTIONS_H_

--- a/backends/tc/options.h
+++ b/backends/tc/options.h
@@ -74,8 +74,7 @@ class TCOptions : public CompilerOptions {
                 long value = strtol(arg, &end, 10);
                 if (*end != 0 || value <= 0) {
                     ::P4::error(ErrorType::ERR_INVALID,
-                                "--num-timer-profiles expects a positive integer, got '%1%'",
-                                arg);
+                                "--num-timer-profiles expects a positive integer, got '%1%'", arg);
                     return false;
                 }
                 timerProfiles = static_cast<unsigned>(value);

--- a/test/gtest/hexvec_test.cpp
+++ b/test/gtest/hexvec_test.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 The P4 Language Consortium & Devansh Singh
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <vector>
+
+#include "lib/hex.h"
+
+namespace P4::Test {
+
+namespace {
+template <typename T>
+std::string format(std::vector<T> &v) {
+    std::ostringstream out;
+    out << hexvec(v);
+    return out.str();
+}
+}  // namespace
+
+TEST(HexVec, Empty) {
+    std::vector<int> v;
+    EXPECT_EQ(format(v), "[]");
+}
+
+TEST(HexVec, SingleElement) {
+    std::vector<uint8_t> v = {0xab};
+    EXPECT_EQ(format(v), "[ab]");
+}
+
+TEST(HexVec, MultipleElements) {
+    std::vector<uint8_t> v = {0x01, 0xff, 0x0a};
+    EXPECT_EQ(format(v), "[1 ff a]");
+}
+
+}  // namespace P4::Test
+

--- a/test/gtest/hexvec_test.cpp
+++ b/test/gtest/hexvec_test.cpp
@@ -35,4 +35,3 @@ TEST(HexVec, MultipleElements) {
 }
 
 }  // namespace P4::Test
-

--- a/testdata/p4_16_samples/slice-runtime-crossbyte-bmv2.p4
+++ b/testdata/p4_16_samples/slice-runtime-crossbyte-bmv2.p4
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The P4 Language Consortium & Devansh Singh
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Regression test for non-zero bit-slice expressions across byte boundaries.
+
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H h;
+}
+
+struct Meta {}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+        // Extract bits [16:9] from dynamic packet data to test un-folded slicing
+        h.h.a = h.eth_hdr.dst_addr[16:9];
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples/slice-runtime-crossbyte-bmv2.stf
+++ b/testdata/p4_16_samples/slice-runtime-crossbyte-bmv2.stf
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 The P4 Language Consortium & Devansh Singh
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verify slice [16:9] extraction from dst_addr (0x015600 >> 9 & 0xFF = 0xAB).
+# Expect h.a to update to 0xAB while the rest of the packet passes through.
+packet 0 00 00 00 01 56 00 00 00 00 00 00 00 00 00 00
+expect 0 00 00 00 01 56 00 00 00 00 00 00 00 00 ab

--- a/testdata/p4_16_samples/slice-runtime-crossbyte-bmv2.stf
+++ b/testdata/p4_16_samples/slice-runtime-crossbyte-bmv2.stf
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Verify slice [16:9] extraction from dst_addr (0x015600 >> 9 & 0xFF = 0xAB).
-# Expect h.a to update to 0xAB while the rest of the packet passes through.
+# dst_addr = 0x000000015600, whose bits [16:9] equal 0xAB (171):
+#   87552 = 0x015600, and (87552 >> 9) & 0xff == 0xab.
+# h.a is overwritten by h.eth_hdr.dst_addr[16:9], everything else passes
+# through unchanged (dst_addr itself is never modified by the program).
 packet 0 00 00 00 01 56 00 00 00 00 00 00 00 00 00 00
-expect 0 00 00 00 01 56 00 00 00 00 00 00 00 00 ab
+expect 0 00 00 00 01 56 00 00 00 00 00 00 00 00 00 ab

--- a/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2-first.p4
+++ b/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2-first.p4
@@ -1,0 +1,62 @@
+#include <core.p4>
+
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+        h.h.a = h.eth_hdr.dst_addr[16:9];
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit<Headers>(h);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2-frontend.p4
+++ b/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2-frontend.p4
@@ -1,0 +1,59 @@
+#include <core.p4>
+
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+        h.h.a = h.eth_hdr.dst_addr[16:9];
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit<Headers>(h);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2-midend.p4
+++ b/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2-midend.p4
@@ -1,0 +1,69 @@
+#include <core.p4>
+
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        pkt.extract<ethernet_t>(hdr.eth_hdr);
+        pkt.extract<H>(hdr.h);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    @hidden action sliceruntimecrossbytebmv2l43() {
+        h.h.a = h.eth_hdr.dst_addr[16:9];
+    }
+    @hidden table tbl_sliceruntimecrossbytebmv2l43 {
+        actions = {
+            sliceruntimecrossbytebmv2l43();
+        }
+        const default_action = sliceruntimecrossbytebmv2l43();
+    }
+    apply {
+        tbl_sliceruntimecrossbytebmv2l43.apply();
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit<ethernet_t>(h.eth_hdr);
+        pkt.emit<H>(h.h);
+    }
+}
+
+V1Switch<Headers, Meta>(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2.p4
+++ b/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2.p4
@@ -1,0 +1,62 @@
+#include <core.p4>
+
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> eth_type;
+}
+
+header H {
+    bit<8> a;
+}
+
+struct Headers {
+    ethernet_t eth_hdr;
+    H          h;
+}
+
+struct Meta {
+}
+
+parser p(packet_in pkt, out Headers hdr, inout Meta m, inout standard_metadata_t sm) {
+    state start {
+        transition parse_hdrs;
+    }
+    state parse_hdrs {
+        pkt.extract(hdr.eth_hdr);
+        pkt.extract(hdr.h);
+        transition accept;
+    }
+}
+
+control ingress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+        h.h.a = h.eth_hdr.dst_addr[16:9];
+    }
+}
+
+control vrfy(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control update(inout Headers h, inout Meta m) {
+    apply {
+    }
+}
+
+control egress(inout Headers h, inout Meta m, inout standard_metadata_t sm) {
+    apply {
+    }
+}
+
+control deparser(packet_out pkt, in Headers h) {
+    apply {
+        pkt.emit(h);
+    }
+}
+
+V1Switch(p(), vrfy(), ingress(), egress(), update(), deparser()) main;

--- a/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2.p4.entries.txtpb
+++ b/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2.p4.entries.txtpb
@@ -1,0 +1,3 @@
+# proto-file: p4/v1/p4runtime.proto
+# proto-message: p4.v1.WriteRequest
+

--- a/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2.p4.p4info.txtpb
@@ -1,5 +1,6 @@
-﻿# proto-file: p4/config/v1/p4info.proto
+# proto-file: p4/config/v1/p4info.proto
 # proto-message: p4.config.v1.P4Info
 
 pkg_info {
-  arch: 1model`n}
+  arch: "v1model"
+}

--- a/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/slice-runtime-crossbyte-bmv2.p4.p4info.txtpb
@@ -1,0 +1,5 @@
+﻿# proto-file: p4/config/v1/p4info.proto
+# proto-message: p4.config.v1.P4Info
+
+pkg_info {
+  arch: 1model`n}

--- a/testdata/p4tc_samples_outputs/slice-runtime-crossbyte-bmv2.p4.p4info.txtpb
+++ b/testdata/p4tc_samples_outputs/slice-runtime-crossbyte-bmv2.p4.p4info.txtpb
@@ -1,0 +1,6 @@
+# proto-file: p4/config/v1/p4info.proto
+# proto-message: p4.config.v1.P4Info
+
+pkg_info {
+  arch: "v1model"
+}

--- a/testdata/p4tc_samples_outputs/slice-runtime-crossbyte-bmv2.p4.p4info.txtpb
+++ b/testdata/p4tc_samples_outputs/slice-runtime-crossbyte-bmv2.p4.p4info.txtpb
@@ -1,6 +1,0 @@
-# proto-file: p4/config/v1/p4info.proto
-# proto-message: p4.config.v1.P4Info
-
-pkg_info {
-  arch: "v1model"
-}


### PR DESCRIPTION
### Summary
Fixes an internal compiler crash (BUG_CHECK) in the bmv2 backend when generating codegen for non-constant bit-slice expressions x[h:l] where l > 0 and the slice spans across a byte boundary.

### Problem
In ExpressionConverter::postorder(const IR::Slice*), a bit-slice was being emitted as an x & mask JSON expression using Util::maskFromSlice(h, l). This positioned the mask at the original bit offset l..h. However, the byte width used to serialize the mask was computed using ROUNDUP(bitwidth, 8) where bitwidth = h - l + 1. When l > 0 and h >= 8, the positioned mask requires more bytes than allocated for bitwidth, causing stringRepr() to throw a BUG_CHECK failure. Constant-folded slices (like existing test cases) were unaffected because the midend eliminates Slice nodes before reaching BMv2 codegen. A runtime/packet-derived slice hits this path directly.

### Fix
- Right-shifts the expression down to bit 0 (>> l) before masking whenever l != 0.
- Masks the result using Util::mask(bitwidth), which is right-aligned to bit 0 and fits safely within ROUNDUP(bitwidth, 8) bytes by construction.
- Added a defensive BUG_CHECK verifying bitwidth == h - l + 1.

### Testing
Added testdata/p4_16_samples/slice-runtime-crossbyte-bmv2.p4 and matching .stf test to verify that dynamic (non-foldable) slices crossing byte boundaries compile and simulate correctly on BMv2.