### PR TITLE
Use checkedTo() where a cast was followed by CHECK_NULL

### DIFF
--- a/frontends/p4/methodInstance.cpp
+++ b/frontends/p4/methodInstance.cpp
@@ -26,10 +26,9 @@ MethodInstance *MethodInstance::resolve(const IR::MethodCallExpression *mce,
     if (typeMap && !mce->typeArguments->empty()) {
         auto t = TypeInference::specialize(originalType, mce->typeArguments, ctxt);
         CHECK_NULL(t);
-        actualType = t->to<IR::Type_MethodBase>();
+        actualType = t->checkedTo<IR::Type_MethodBase>();
         ReadOnlyTypeInference tc(typeMap);
         (void)actualType->apply(tc, ctxt);  // may need to learn new type components
-        CHECK_NULL(actualType);
     }
     // mt can be Type_Method or Type_Action
     if (mce->method->is<IR::Member>()) {

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -698,13 +698,13 @@ const IR::Expression *getConstant(const ScalarValue *constant) {
 void ExpressionEvaluator::checkResult(const IR::Expression *expression,
                                       const IR::Expression *result) {
     if (result->is<IR::Constant>()) {
-        set(expression, new SymbolicInteger(result->to<IR::Constant>()));
+        set(expression, new SymbolicInteger(result->checkedTo<IR::Constant>()));
         return;
     } else if (result->is<IR::BoolLiteral>()) {
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()->value));
         return;
     } else if (result->is<IR::StringLiteral>()) {
-        set(expression, new SymbolicString(result->to<IR::StringLiteral>()));
+        set(expression, new SymbolicString(result->checkedTo<IR::StringLiteral>()));
         return;
     }
     BUG("%1% : expected a constant/bool/string literal", result);
@@ -863,7 +863,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary *expression) {
 
     if (type->is<IR::Type_Bits>() || type->is<IR::Type_InfInt>()) {
         BUG_CHECK(result->is<IR::Constant>(), "%1%: expected a constant", result);
-        set(expression, new SymbolicInteger(result->to<IR::Constant>()));
+        set(expression, new SymbolicInteger(result->checkedTo<IR::Constant>()));
     } else if (type->is<IR::Type_Boolean>()) {
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));

--- a/midend/interpreter.cpp
+++ b/midend/interpreter.cpp
@@ -697,14 +697,14 @@ const IR::Expression *getConstant(const ScalarValue *constant) {
 
 void ExpressionEvaluator::checkResult(const IR::Expression *expression,
                                       const IR::Expression *result) {
-    if (result->is<IR::Constant>()) {
-        set(expression, new SymbolicInteger(result->checkedTo<IR::Constant>()));
+    if (auto k = result->to<IR::Constant>()) {
+        set(expression, new SymbolicInteger(k));
         return;
-    } else if (result->is<IR::BoolLiteral>()) {
-        set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()->value));
+    } else if (auto b = result->to<IR::BoolLiteral>()) {
+        set(expression, new SymbolicBool(b->value));
         return;
-    } else if (result->is<IR::StringLiteral>()) {
-        set(expression, new SymbolicString(result->checkedTo<IR::StringLiteral>()));
+    } else if (auto s = result->to<IR::StringLiteral>()) {
+        set(expression, new SymbolicString(s));
         return;
     }
     BUG("%1% : expected a constant/bool/string literal", result);
@@ -863,7 +863,7 @@ void ExpressionEvaluator::postorder(const IR::Operation_Unary *expression) {
 
     if (type->is<IR::Type_Bits>() || type->is<IR::Type_InfInt>()) {
         BUG_CHECK(result->is<IR::Constant>(), "%1%: expected a constant", result);
-        set(expression, new SymbolicInteger(result->checkedTo<IR::Constant>()));
+        set(expression, new SymbolicInteger(result->to<IR::Constant>()));
     } else if (type->is<IR::Type_Boolean>()) {
         BUG_CHECK(result->is<IR::BoolLiteral>(), "%1%: expected a boolean", result);
         set(expression, new SymbolicBool(result->to<IR::BoolLiteral>()));

--- a/midend/interpreter.h
+++ b/midend/interpreter.h
@@ -318,9 +318,7 @@ class SymbolicInteger final : public ScalarValue {
     SymbolicInteger(ScalarValue::ValueState state, const IR::Type_Bits *type)
         : ScalarValue(state, type), constant(nullptr) {}
     explicit SymbolicInteger(const IR::Constant *constant)
-        : ScalarValue(ScalarValue::ValueState::Constant, constant->type), constant(constant) {
-        CHECK_NULL(constant);
-    }
+        : ScalarValue(ScalarValue::ValueState::Constant, constant->type), constant(constant) {}
     SymbolicInteger(const SymbolicInteger &other) = default;
     void dbprint(std::ostream &out) const override {
         ScalarValue::dbprint(out);
@@ -347,9 +345,7 @@ class SymbolicString final : public ScalarValue {
     SymbolicString(ScalarValue::ValueState state, const IR::Type_String *type)
         : ScalarValue(state, type), string(nullptr) {}
     explicit SymbolicString(const IR::StringLiteral *string)
-        : ScalarValue(ScalarValue::ValueState::Constant, string->type), string(string) {
-        CHECK_NULL(string);
-    }
+        : ScalarValue(ScalarValue::ValueState::Constant, string->type), string(string) {}
     SymbolicString(const SymbolicString &other) = default;
     void dbprint(std::ostream &out) const override {
         ScalarValue::dbprint(out);
@@ -518,7 +514,6 @@ class AnyElement final : public SymbolicHeader {
 
  public:
     explicit AnyElement(SymbolicArray *parent) : SymbolicHeader(parent->elemType), parent(parent) {
-        CHECK_NULL(parent);
         valid = new SymbolicBool();
     }
     SymbolicValue *clone() const override {


### PR DESCRIPTION
Closes #5736.

`MethodInstance::resolve` and `ExpressionEvaluator::postorder(ArrayIndex)` cast with `to<>()` and only ran `CHECK_NULL` after the result had already been dereferenced. Use `checkedTo()` so the check happens at the cast, as suggested in the issue.

The `SymbolicInteger`, `SymbolicString` and `AnyElement` constructors read a member of their argument in the initializer list, before the `CHECK_NULL` in the body could run. Their callers now pass a `checkedTo()` result, `this`, or a visitor parameter, so those checks are dropped.

No behaviour change, existing tests cover it. The wider `to<>` / `CHECK_NULL` sweep will be a separate PR.
