### PR TITLE
Drop dead mirror_copy_to_cpu_ctrl translation

### DIFF
--- a/backends/tofino/bf-p4c/arch/fromv1.0/programStructure.h
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/programStructure.h
@@ -330,10 +330,6 @@ class ConvertMetadata : public Transform {
             mkMember("ig_intr_md_for_dprsr"_cs, "mirror_ingress_cos"_cs, 3));
         cvt(INGRESS, "ig_intr_md_for_mb.mirror_deflect_on_drop"_cs, 1,
             mkMember("ig_intr_md_for_dprsr"_cs, "mirror_deflect_on_drop"_cs, 1));
-        cvt(INGRESS, "ig_intr_md_for_mb.mirror_copy_to_cpu_ctrl"_cs, 1,
-            mkMember("ig_intr_md_for_dprsr"_cs, "mirror_copy_to_cpu_ctrl"_cs, 1));
-        cvt(INGRESS, "ig_intr_md_for_mb.mirror_copy_to_cpu_ctrl"_cs, 1,
-            mkMember("ig_intr_md_for_dprsr"_cs, "mirror_copy_to_cpu_ctrl"_cs, 1));
         cvt(INGRESS, "ig_intr_md_for_mb.mirror_egress_port"_cs, portWidth,
             mkMember("ig_intr_md_for_dprsr"_cs, "mirror_egress_port"_cs, portWidth));
         cvt(INGRESS, "standard_metadata.ingress_port"_cs, 9,
@@ -362,10 +358,6 @@ class ConvertMetadata : public Transform {
             mkMember("eg_intr_md_for_dprsr"_cs, "mirror_ingress_cos"_cs, 3));
         cvt(EGRESS, "eg_intr_md_for_mb.mirror_deflect_on_drop"_cs, 1,
             mkMember("eg_intr_md_for_dprsr"_cs, "mirror_deflect_on_drop"_cs, 1));
-        cvt(EGRESS, "eg_intr_md_for_mb.mirror_copy_to_cpu_ctrl"_cs, 1,
-            mkMember("eg_intr_md_for_dprsr"_cs, "mirror_copy_to_cpu_ctrl"_cs, 1));
-        cvt(EGRESS, "eg_intr_md_for_mb.mirror_copy_to_cpu_ctrl"_cs, 1,
-            mkMember("eg_intr_md_for_dprsr"_cs, "mirror_copy_to_cpu_ctrl"_cs, 1));
         cvt(EGRESS, "eg_intr_md_for_mb.mirror_egress_port"_cs, portWidth,
             mkMember("eg_intr_md_for_dprsr"_cs, "mirror_egress_port"_cs, portWidth));
         cvt(EGRESS, "meta.standard_metadata.ingress_port"_cs, 9,


### PR DESCRIPTION
Part of #5735.

`ConvertMetadata` registered a P4-14 to TNA rename for `mirror_copy_to_cpu_ctrl`, twice per gress. The field is commented out of the P4-14 mirror buffer headers (`XXX(TF2LAB-105)`) and is not in the P4-16 deparser structs, so neither side of the rename exists on any target. The sibling tables in `arch/v1model.cpp` and `specs/arch_spec.cpp` already have it disabled with the same note.

No behaviour change, `cvt()` inserts with `std::map::emplace` so even the first entry was dead data.

The missing `mirror_qid` and `mirror_coalesce_length` translations from the issue are a behaviour change, so they are not included here.
