### PR TITLE
bmv2: handle parser select no-match cases

### DIFF
--- a/backends/bmv2/simple_switch/midend.cpp
+++ b/backends/bmv2/simple_switch/midend.cpp
@@ -40,6 +40,7 @@
 #include "midend/local_copyprop.h"
 #include "midend/midEndLast.h"
 #include "midend/nestedStructs.h"
+#include "midend/noMatch.h"
 #include "midend/orderArguments.h"
 #include "midend/parserUnroll.h"
 #include "midend/removeAssertAssume.h"
@@ -87,6 +88,7 @@ SimpleSwitchMidEnd::SimpleSwitchMidEnd(CompilerOptions &options, std::ostream *o
              new P4::SimplifySelectCases(&typeMap, true),  // require constant keysets
              new P4::ExpandLookahead(&typeMap),
              new P4::ExpandEmit(&typeMap),
+             new P4::HandleNoMatch(),
              new P4::SimplifyParsers(),
              new P4::StrengthReduction(&typeMap),
              new P4::EliminateTuples(&typeMap),

--- a/testdata/p4_16_samples/bmv2_select_no_default.p4
+++ b/testdata/p4_16_samples/bmv2_select_no_default.p4
@@ -1,0 +1,71 @@
+/*
+Regression test for missing HandleNoMatch pass in BMV2 backend.
+A select expression without a default case should implicitly transition
+to a noMatch state that calls verify(false, error.NoMatch) and then reject.
+*/
+#include <core.p4>
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+struct metadata_t {
+}
+
+parser MyParser(packet_in packet,
+                out headers_t hdr,
+                inout metadata_t meta,
+                inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x0800: accept;  // IPv4
+            0x0806: accept;  // ARP
+            // No default case - should implicitly add noMatch->reject
+        }
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control MyIngress(inout headers_t hdr,
+                  inout metadata_t meta,
+                  inout standard_metadata_t standard_metadata) {
+    apply {
+        standard_metadata.egress_spec = 1;
+    }
+}
+
+control MyEgress(inout headers_t hdr,
+                 inout metadata_t meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply { }
+}
+
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control MyDeparser(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+V1Switch(
+    MyParser(),
+    MyVerifyChecksum(),
+    MyIngress(),
+    MyEgress(),
+    MyComputeChecksum(),
+    MyDeparser()
+) main;

--- a/testdata/p4_16_samples_outputs/bmv2_select_no_default-first.p4
+++ b/testdata/p4_16_samples_outputs/bmv2_select_no_default-first.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+struct metadata_t {
+}
+
+parser MyParser(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: accept;
+            16w0x806: accept;
+        }
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+        standard_metadata.egress_spec = 9w1;
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+V1Switch<headers_t, metadata_t>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/bmv2_select_no_default-frontend.p4
+++ b/testdata/p4_16_samples_outputs/bmv2_select_no_default-frontend.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+struct metadata_t {
+}
+
+parser MyParser(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: accept;
+            16w0x806: accept;
+        }
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+        standard_metadata.egress_spec = 9w1;
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+V1Switch<headers_t, metadata_t>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/bmv2_select_no_default-midend.p4
+++ b/testdata/p4_16_samples_outputs/bmv2_select_no_default-midend.p4
@@ -1,0 +1,70 @@
+#include <core.p4>
+
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+struct metadata_t {
+}
+
+parser MyParser(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract<ethernet_t>(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            16w0x800: accept;
+            16w0x806: accept;
+            default: noMatch;
+        }
+    }
+    state noMatch {
+        verify(false, error.NoMatch);
+        transition reject;
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    @hidden action bmv2_select_no_default44() {
+        standard_metadata.egress_spec = 9w1;
+    }
+    @hidden table tbl_bmv2_select_no_default44 {
+        actions = {
+            bmv2_select_no_default44();
+        }
+        const default_action = bmv2_select_no_default44();
+    }
+    apply {
+        tbl_bmv2_select_no_default44.apply();
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit<ethernet_t>(hdr.ethernet);
+    }
+}
+
+V1Switch<headers_t, metadata_t>(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/bmv2_select_no_default.p4
+++ b/testdata/p4_16_samples_outputs/bmv2_select_no_default.p4
@@ -1,0 +1,56 @@
+#include <core.p4>
+
+#define V1MODEL_VERSION 20180101
+#include <v1model.p4>
+
+header ethernet_t {
+    bit<48> dstAddr;
+    bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+struct headers_t {
+    ethernet_t ethernet;
+}
+
+struct metadata_t {
+}
+
+parser MyParser(packet_in packet, out headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    state start {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            0x800: accept;
+            0x806: accept;
+        }
+    }
+}
+
+control MyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control MyIngress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+        standard_metadata.egress_spec = 1;
+    }
+}
+
+control MyEgress(inout headers_t hdr, inout metadata_t meta, inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+control MyComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply {
+    }
+}
+
+control MyDeparser(packet_out packet, in headers_t hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+    }
+}
+
+V1Switch(MyParser(), MyVerifyChecksum(), MyIngress(), MyEgress(), MyComputeChecksum(), MyDeparser()) main;

--- a/testdata/p4_16_samples_outputs/bmv2_select_no_default.p4.entries.txtpb
+++ b/testdata/p4_16_samples_outputs/bmv2_select_no_default.p4.entries.txtpb
@@ -1,0 +1,2 @@
+# proto-file: p4/v1/p4runtime.proto
+# proto-message: p4.v1.WriteRequest

--- a/testdata/p4_16_samples_outputs/bmv2_select_no_default.p4.p4info.txtpb
+++ b/testdata/p4_16_samples_outputs/bmv2_select_no_default.p4.p4info.txtpb
@@ -1,0 +1,6 @@
+# proto-file: p4/config/v1/p4info.proto
+# proto-message: p4.config.v1.P4Info
+
+pkg_info {
+  arch: "v1model"
+}


### PR DESCRIPTION
## What changed

The BMv2 `simple_switch` midend was missing the `HandleNoMatch` pass. As a result, parser `select` expressions without an explicit `default` case were not lowered with the required `error.NoMatch` handling.

This change adds `HandleNoMatch` to the `simple_switch` midend before `SimplifyParsers`.

## Before

For example, a parser select without an explicit default:

    transition select(hdr.etherType) {
        0x0800: accept;
        0x0806: accept;
    }

The generated parser did not contain the implicit no-match transition:

    default: noMatch;

or the corresponding state:

    state noMatch {
        verify(false, error.NoMatch);
        transition reject;
    }

## After

`HandleNoMatch` is now executed by the `simple_switch` midend before `SimplifyParsers`.

The same parser is now transformed to:

    transition select(hdr.etherType) {
        0x0800: accept;
        0x0806: accept;
        default: noMatch;
    }

with the generated no-match state:

    state noMatch {
        verify(false, error.NoMatch);
        transition reject;
    }

A regression test is included for a parser `select` without an explicit `default` case.

## Validation

- `p4c-bm2-ss` builds successfully.
- `bmv2_select_no_default` CTest passes.
- The regression input contains no explicit `default` case.
- The generated midend contains `default: noMatch`.
- The generated `noMatch` state contains `verify(false, error.NoMatch)`.
- `git diff --check` passes.