### PR TITLE
Translate mirror_qid and mirror_coalesce_length from P4-14

### DIFF
--- a/backends/tofino/bf-p4c/arch/fromv1.0/programStructure.h
+++ b/backends/tofino/bf-p4c/arch/fromv1.0/programStructure.h
@@ -332,6 +332,10 @@ class ConvertMetadata : public Transform {
             mkMember("ig_intr_md_for_dprsr"_cs, "mirror_deflect_on_drop"_cs, 1));
         cvt(INGRESS, "ig_intr_md_for_mb.mirror_egress_port"_cs, portWidth,
             mkMember("ig_intr_md_for_dprsr"_cs, "mirror_egress_port"_cs, portWidth));
+        cvt(INGRESS, "ig_intr_md_for_mb.mirror_qid"_cs, 7,
+            mkMember("ig_intr_md_for_dprsr"_cs, "mirror_qid"_cs, 7));
+        cvt(INGRESS, "ig_intr_md_for_mb.mirror_coalesce_length"_cs, 8,
+            mkMember("ig_intr_md_for_dprsr"_cs, "mirror_coalesce_length"_cs, 8));
         cvt(INGRESS, "standard_metadata.ingress_port"_cs, 9,
             mkMember("ig_intr_md"_cs, "ingress_port"_cs, portWidth));
 
@@ -360,6 +364,10 @@ class ConvertMetadata : public Transform {
             mkMember("eg_intr_md_for_dprsr"_cs, "mirror_deflect_on_drop"_cs, 1));
         cvt(EGRESS, "eg_intr_md_for_mb.mirror_egress_port"_cs, portWidth,
             mkMember("eg_intr_md_for_dprsr"_cs, "mirror_egress_port"_cs, portWidth));
+        cvt(EGRESS, "eg_intr_md_for_mb.mirror_qid"_cs, 7,
+            mkMember("eg_intr_md_for_dprsr"_cs, "mirror_qid"_cs, 7));
+        cvt(EGRESS, "eg_intr_md_for_mb.mirror_coalesce_length"_cs, 8,
+            mkMember("eg_intr_md_for_dprsr"_cs, "mirror_coalesce_length"_cs, 8));
         cvt(EGRESS, "meta.standard_metadata.ingress_port"_cs, 9,
             mkMember("meta"_cs, "ig_intr_md"_cs, "ingress_port"_cs, portWidth));
         cvt(EGRESS, "standard_metadata.ingress_port"_cs, 9,


### PR DESCRIPTION
Closes #5735.

Both fields exist in the P4-14 mirror buffer header and in the P4-16 deparser struct, but ConvertMetadata had no entry for them, so a P4-14 program using them was left with a reference to a header that is dropped later. Add the two cvt() entries per gress, widths 7 and 8, matching the v1model.cpp list.

No new test, bf-p4c has no P4-14 test suite. An open-p4studio PR pointing the submodule at this change will run the SDE tests against it.
