### PR TITLE
Convert Path from find_file to str in the driver

### DIFF
--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -54,7 +54,7 @@ class BackendDriver:
         if cmd_name in self._commands:
             print("Warning: overwriting command", cmd_name, file=sys.stderr)
         self._commands[cmd_name] = []
-        self._commands[cmd_name].append(cmd)
+        self._commands[cmd_name].append(os.fspath(cmd))
 
     def add_command_option(self, cmd_name, option):
         """Add an option to a command"""


### PR DESCRIPTION
find_file() returns a Path since #5692. The bf-p4c driver stores the result as a command and later calls .find on it in checkAndRunCmd, which only exists on str:

```
  File "p4c_src/barefoot.py", line 1039, in checkAndRunCmd
    if cmd[0].find('/') != 0 and (find_bin(cmd[0]) == None):
AttributeError: 'PosixPath' object has no attribute 'find'
```

Seen in open-p4studio CI when bumping the p4c submodule past #5692 (p4lang/open-p4studio#136, both Ubuntu jobs, while building the P4-14 programs). Normalise in add_command so both drivers keep working with str.

p4c CI does not cover this path, the bf-p4c driver test is commented out in backends/tofino/bf-p4c/CMakeLists.txt.
