### PR TITLE
bmv2: error instead of crash when the HashAlgorithm is not an enum member

### DIFF
--- a/backends/bmv2/simple_switch/simpleSwitch.cpp
+++ b/backends/bmv2/simple_switch/simpleSwitch.cpp
@@ -253,8 +253,12 @@ Util::IJson *ExternConverter_hash::convertExternFunction(ConversionContext *ctxt
     auto base = ctxt->conv->convert(mc->arguments->at(2)->expression);
     parameters->append(base);
     auto calculation = new Util::JsonObject();
-    auto ei = P4::EnumInstance::resolve(mc->arguments->at(1)->expression, ctxt->typeMap);
-    CHECK_NULL(ei);
+    auto algoExpr = mc->arguments->at(1)->expression;
+    auto ei = P4::EnumInstance::resolve(algoExpr, ctxt->typeMap);
+    if (ei == nullptr) {
+        modelError("%1%: expected a HashAlgorithm member", algoExpr);
+        return nullptr;
+    }
     if (supportedHashAlgorithms.find(ei->name) == supportedHashAlgorithms.end()) {
         ::P4::error(ErrorType::ERR_UNSUPPORTED_ON_TARGET, "%1%: unexpected algorithm", ei->name);
         return nullptr;
@@ -957,9 +961,13 @@ void SimpleSwitchBackend::convertChecksum(const IR::BlockStatement *block,
                         modelError("%1%: Expected 4 arguments", mc);
                         return;
                     }
+                    auto algoExpr = mi->expr->arguments->at(3)->expression;
+                    auto ei = P4::EnumInstance::resolve(algoExpr, typeMap);
+                    if (ei == nullptr) {
+                        modelError("%1%: expected a HashAlgorithm member", algoExpr);
+                        return;
+                    }
                     auto cksum = new Util::JsonObject();
-                    auto ei =
-                        P4::EnumInstance::resolve(mi->expr->arguments->at(3)->expression, typeMap);
                     cstring algo = ExternConverter::convertHashAlgorithm(ei->name);
                     auto calcExpr = mi->expr->arguments->at(1)->expression;
                     EnsureExpressionIsSimple eeis(verify ? v1model.verify_checksum.name

--- a/testdata/p4_16_bmv_errors/issue5464-bmv2.p4
+++ b/testdata/p4_16_bmv_errors/issue5464-bmv2.p4
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Abhishek Agarwal
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// From issue #5464: the program declares its own HashAlgorithm, no v1model.p4.
+
+extern packet_in { }
+extern packet_out { }
+struct standard_metadata_t { }
+enum HashAlgorithm { csum16 }
+extern void verify_checksum<T, O>(in bool condition, T data, O checksum, HashAlgorithm algo);
+parser Parser<H, M>(packet_in b, H parsedHdr, M meta, standard_metadata_t standard_metadata);
+control VerifyChecksum<H, M>(inout H hdr, M meta);
+control Ingress<H, M>(inout H hdr, M meta, standard_metadata_t standard_metadata);
+control Egress<H, M>(inout H hdr, M meta, standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, M meta);
+control Deparser<H>(packet_out b, H hdr);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg,
+                       ComputeChecksum<H, M> ck, Deparser<H> dep);
+
+struct headers_t { }
+struct metadata_t {
+    bit<1> result;
+    bit<1> b;
+}
+
+parser EmptyParser(packet_in b, headers_t headers, metadata_t meta,
+                   standard_metadata_t standard_metadata)() {
+    state start { }
+}
+
+control EmptyVerifyChecksum(inout headers_t hdr, metadata_t meta)() {
+    apply {
+        verify_checksum(false, { }, meta.result, HashAlgorithm.csum16);
+    }
+}
+
+control EmptyIngress(inout headers_t headers, metadata_t meta,
+                     standard_metadata_t standard_metadata)() {
+    apply { }
+}
+
+control EmptyEgress(inout headers_t hdr, metadata_t meta, standard_metadata_t standard_metadata)() {
+    apply { }
+}
+
+control EmptyComputeChecksum(inout headers_t hdr, metadata_t meta)() {
+    apply { }
+}
+
+control EmptyDeparser(packet_out b, headers_t hdr)() {
+    apply { }
+}
+
+V1Switch(EmptyParser(), EmptyVerifyChecksum(), EmptyIngress(), EmptyEgress(),
+         EmptyComputeChecksum(), EmptyDeparser()) main;

--- a/testdata/p4_16_bmv_errors/issue5464-hash-bmv2.p4
+++ b/testdata/p4_16_bmv_errors/issue5464-hash-bmv2.p4
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Abhishek Agarwal
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Like issue5464-bmv2.p4, but the enum reaches hash() instead of verify_checksum().
+
+extern packet_in { }
+extern packet_out { }
+struct standard_metadata_t { }
+enum HashAlgorithm { csum16 }
+extern void hash<O, T, D, M>(out O result, in HashAlgorithm algo, in T base, in D data, in M max);
+parser Parser<H, M>(packet_in b, out H parsedHdr, inout M meta,
+                    inout standard_metadata_t standard_metadata);
+control VerifyChecksum<H, M>(inout H hdr, inout M meta);
+control Ingress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control Egress<H, M>(inout H hdr, inout M meta, inout standard_metadata_t standard_metadata);
+control ComputeChecksum<H, M>(inout H hdr, inout M meta);
+control Deparser<H>(packet_out b, in H hdr);
+package V1Switch<H, M>(Parser<H, M> p, VerifyChecksum<H, M> vr, Ingress<H, M> ig, Egress<H, M> eg,
+                       ComputeChecksum<H, M> ck, Deparser<H> dep);
+
+struct headers_t { }
+struct metadata_t {
+    bit<16> result;
+    bit<16> b;
+}
+
+parser EmptyParser(packet_in b, out headers_t hdr, inout metadata_t meta,
+                   inout standard_metadata_t standard_metadata) {
+    state start {
+        transition accept;
+    }
+}
+
+control EmptyVerifyChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control EmptyIngress(inout headers_t hdr, inout metadata_t meta,
+                     inout standard_metadata_t standard_metadata) {
+    apply {
+        hash(meta.result, HashAlgorithm.csum16, 16w0, { meta.b }, 16w1);
+    }
+}
+
+control EmptyEgress(inout headers_t hdr, inout metadata_t meta,
+                    inout standard_metadata_t standard_metadata) {
+    apply { }
+}
+
+control EmptyComputeChecksum(inout headers_t hdr, inout metadata_t meta) {
+    apply { }
+}
+
+control EmptyDeparser(packet_out b, in headers_t hdr) {
+    apply { }
+}
+
+V1Switch(EmptyParser(), EmptyVerifyChecksum(), EmptyIngress(), EmptyEgress(),
+         EmptyComputeChecksum(), EmptyDeparser()) main;


### PR DESCRIPTION
Closes #5464.

The program in the issue declares its own `HashAlgorithm` instead of including v1model.p4. The bmv2 midend converts every enum outside v1model.p4 to bit<32> (https://github.com/p4lang/p4c/blob/a19f1c3d85a867a6288fd983f7bad505ac47d728/backends/bmv2/common/midend.h#L24-L31), so by the time the backend sees the algorithm argument it is a constant, `EnumInstance::resolve` returns null and `convertChecksum` dereferences it (https://github.com/p4lang/p4c/blob/a19f1c3d85a867a6288fd983f7bad505ac47d728/backends/bmv2/simple_switch/simpleSwitch.cpp#L961-L963). The `hash()` converter has the same shape behind a `CHECK_NULL` (https://github.com/p4lang/p4c/blob/a19f1c3d85a867a6288fd983f7bad505ac47d728/backends/bmv2/simple_switch/simpleSwitch.cpp#L256-L257), so there it is a Compiler Bug rather than a segfault.

Both sites now report "expected a HashAlgorithm member" through modelError, the way the clone converters already handle a bad argument.

The two tests under p4_16_bmv_errors fail on main because run-bmv2-test.py treats any "Compiler Bug" output as a failure, and pass with the fix. That suite does not compare stderr.
