### PR TITLE
tofino: keep non-scratch parser match register slices

### DIFF
--- a/backends/tofino/bf-p4c/parde/allocate_parser_match_register.cpp
+++ b/backends/tofino/bf-p4c/parde/allocate_parser_match_register.cpp
@@ -1406,7 +1406,11 @@ class MatcherAllocator : public Visitor {
 
             // Map scratch register with match register allocated by scratch groups.
             for (const auto &reg_slice : reg_slices) {
-                if (!is_scratch_register(reg_slice.first)) continue;
+                if (!is_scratch_register(reg_slice.first)) {
+                    serializable_reg_slices.emplace_back(MatchRegister(reg_slice.first),
+                                                         reg_slice.second);
+                    continue;
+                }
 
                 cstring name = reg_slice.first.name;
 


### PR DESCRIPTION
#5063 rewrote `MatcherAllocator::bind_use` to build a new vector instead of updating the slices in place, but kept the `continue` that used to mean "nothing to remap for an ordinary register". It now means "drop this slice", so `save_reg_slices` only ever receives the scratch entries.

https://github.com/p4lang/p4c/blob/a19f1c3d85a867a6288fd983f7bad505ac47d728/backends/tofino/bf-p4c/parde/allocate_parser_match_register.cpp#L1399-L1434
https://github.com/p4lang/p4c/blob/8ffb734bd26/backends/tofino/bf-p4c/parde/allocate_parser_match_register.cpp#L1399-L1431

Tofino1 has no scratch registers, so there every select on saved packet data loses its registers; Tofino2 keeps only the slices routed through a `save_byteN`. The lowered select then has no regs, and a state with no regs and no counters is treated as an unconditional match in `hoist_common_match_operations.cpp` and `merge_lowered_parser_states.cpp`, so every transition but the first is dropped. The emitted parser has no `match:` line and a bare `*` on each transition.

Seen in open-p4studio: the build at its current p4c pin has no such warnings, one with p4c main has 342 "Can't match parser state due to previous match" across 29 .bfa files on both targets, and on Tofino2 the deparser still emits a CLOT that the parser no longer produces, so bfas fails with "No length for clot 0" and crashes.

With this patch the same SDE build passes: https://github.com/aeron-gh/open-p4studio/actions/runs/33861176201

The same empty slices also make the `BUG_CHECK` for a counter load from the packet fire, since it expects exactly one register slice.

Closes #5752.

