### PR TITLE
Type add_command and convert the assembler paths at the call site

### DIFF
--- a/backends/tofino/bf-p4c/driver/barefoot.py
+++ b/backends/tofino/bf-p4c/driver/barefoot.py
@@ -427,12 +427,12 @@ class BarefootBackend(BackendDriver):
         """
         # Add assembler options.
         if os.environ['P4C_BUILD_TYPE'] == "DEVELOPER":
-            bfas = find_file('.', 'bfas')
+            bfas = str(find_file('.', 'bfas'))
         else:
-            bfas = find_file(os.environ['P4C_BIN_DIR'], 'bfas')
+            bfas = str(find_file(os.environ['P4C_BIN_DIR'], 'bfas'))
 
-        bfrt_schema = find_file(os.environ['P4C_BIN_DIR'], 'bfrt_schema.py')
-        p4c_gen_conf = find_file(os.environ['P4C_BIN_DIR'], 'p4c-gen-conf')
+        bfrt_schema = str(find_file(os.environ['P4C_BIN_DIR'], 'bfrt_schema.py'))
+        p4c_gen_conf = str(find_file(os.environ['P4C_BIN_DIR'], 'p4c-gen-conf'))
         self.add_command('assembler', bfas)
         self.add_command('bf-rt-verifier', bfrt_schema)
         self.add_command('p4c-gen-conf', p4c_gen_conf)

--- a/tools/driver/p4c_src/driver.py
+++ b/tools/driver/p4c_src/driver.py
@@ -46,7 +46,7 @@ class BackendDriver:
     def __str__(self):
         return self._backend
 
-    def add_command(self, cmd_name, cmd):
+    def add_command(self, cmd_name: str, cmd: str) -> None:
         """Add a command
 
         If the command was previously set, it is overwritten
@@ -54,7 +54,7 @@ class BackendDriver:
         if cmd_name in self._commands:
             print("Warning: overwriting command", cmd_name, file=sys.stderr)
         self._commands[cmd_name] = []
-        self._commands[cmd_name].append(os.fspath(cmd))
+        self._commands[cmd_name].append(cmd)
 
     def add_command_option(self, cmd_name, option):
         """Add an option to a command"""


### PR DESCRIPTION
Follow up to the review comment on #5750. `add_command` now says it takes a str, and the three `find_file` results in the bf-p4c driver are converted where they are assigned, so the coercion is at the call site instead of hidden in the base class.
