### PR TITLE
Fix the metrics gtest paths for build dirs outside the source root

### DIFF
--- a/test/gtest/metrics_test.cpp
+++ b/test/gtest/metrics_test.cpp
@@ -25,15 +25,11 @@ using namespace P4::literals;
 namespace P4::Test {
 namespace fs = std::filesystem;
 
-/// testdata lives in the source tree, which is not necessarily the parent of the
-/// build directory, so build the paths from sourcePath instead of a relative one.
-static std::string srcPath(const std::string &relPath) {
-    return (fs::path(sourcePath) / relPath).string();
-}
+static fs::path srcPath(const fs::path &relPath) { return fs::path(sourcePath) / relPath; }
 
 class MetricPassesTest : public P4CTest {
  protected:
-    std::string inputFile;
+    fs::path inputFile;
     std::string programName;
     fs::path metricsOutputPath;
     fs::path txtMetricsOutputPath;
@@ -71,8 +67,7 @@ class MetricPassesTest : public P4CTest {
         const IR::P4Program *result = frontend.run(opts, program, &std::cerr);
         ASSERT_NE(result, nullptr) << "Frontend pipeline failed for " << inputFile;
 
-        // ExportMetricsPass writes next to the input file, with the extension stripped.
-        metricsOutputPath = fs::path(inputFile).replace_extension();
+        metricsOutputPath = inputFile.parent_path() / inputFile.stem();
         txtMetricsOutputPath = jsonMetricsOutputPath = metricsOutputPath;
         txtMetricsOutputPath += "_metrics.txt";
         jsonMetricsOutputPath += "_metrics.json";
@@ -94,7 +89,7 @@ class MetricPassesTest : public P4CTest {
         return buf.str();
     }
 
-    void compareWithExpectedOutput(const std::string &expectedPath) {
+    void compareWithExpectedOutput(const fs::path &expectedPath) {
         std::string actual = readFileContent(jsonMetricsOutputPath);
         std::string expected = readFileContent(expectedPath);
 

--- a/test/gtest/metrics_test.cpp
+++ b/test/gtest/metrics_test.cpp
@@ -25,6 +25,12 @@ using namespace P4::literals;
 namespace P4::Test {
 namespace fs = std::filesystem;
 
+/// testdata lives in the source tree, which is not necessarily the parent of the
+/// build directory, so build the paths from sourcePath instead of a relative one.
+static std::string srcPath(const std::string &relPath) {
+    return (fs::path(sourcePath) / relPath).string();
+}
+
 class MetricPassesTest : public P4CTest {
  protected:
     std::string inputFile;
@@ -65,8 +71,8 @@ class MetricPassesTest : public P4CTest {
         const IR::P4Program *result = frontend.run(opts, program, &std::cerr);
         ASSERT_NE(result, nullptr) << "Frontend pipeline failed for " << inputFile;
 
-        metricsOutputPath =
-            "../testdata/p4_16_samples/metrics/" + fs::path(inputFile).stem().string();
+        // ExportMetricsPass writes next to the input file, with the extension stripped.
+        metricsOutputPath = fs::path(inputFile).replace_extension();
         txtMetricsOutputPath = jsonMetricsOutputPath = metricsOutputPath;
         txtMetricsOutputPath += "_metrics.txt";
         jsonMetricsOutputPath += "_metrics.json";
@@ -88,12 +94,12 @@ class MetricPassesTest : public P4CTest {
         return buf.str();
     }
 
-    void compareWithExpectedOutput(const std::string &expectedRelPath) {
+    void compareWithExpectedOutput(const std::string &expectedPath) {
         std::string actual = readFileContent(jsonMetricsOutputPath);
-        std::string expected = readFileContent(expectedRelPath);
+        std::string expected = readFileContent(expectedPath);
 
         ASSERT_NE(actual, "") << "Cannot open file: " << jsonMetricsOutputPath << std::endl;
-        ASSERT_NE(expected, "") << "Cannot open file: " << expectedRelPath << std::endl;
+        ASSERT_NE(expected, "") << "Cannot open file: " << expectedPath << std::endl;
         EXPECT_EQ(actual, expected);
     }
 
@@ -103,12 +109,12 @@ class MetricPassesTest : public P4CTest {
     }
 };
 
-#define DEFINE_METRIC_TEST(N)                                                                  \
-    TEST_F(MetricPassesTest, MetricsTest##N) {                                                 \
-        inputFile = "../testdata/p4_16_samples/metrics/metrics_test_" #N ".p4";                \
-        SetUpFrontend(true);                                                                   \
-        compareWithExpectedOutput("../testdata/p4_16_samples_outputs/metrics/metrics_test_" #N \
-                                  "_metrics.json");                                            \
+#define DEFINE_METRIC_TEST(N)                                                                    \
+    TEST_F(MetricPassesTest, MetricsTest##N) {                                                   \
+        inputFile = srcPath("testdata/p4_16_samples/metrics/metrics_test_" #N ".p4");            \
+        SetUpFrontend(true);                                                                     \
+        compareWithExpectedOutput(                                                               \
+            srcPath("testdata/p4_16_samples_outputs/metrics/metrics_test_" #N "_metrics.json")); \
     }
 
 DEFINE_METRIC_TEST(1)
@@ -121,14 +127,14 @@ DEFINE_METRIC_TEST(7)
 DEFINE_METRIC_TEST(8)
 
 TEST_F(MetricPassesTest, MetricsTest9) {
-    inputFile = "../testdata/p4_16_samples/metrics/metrics_test_8.p4";
+    inputFile = srcPath("testdata/p4_16_samples/metrics/metrics_test_8.p4");
     SetUpFrontend(false);
     compareWithExpectedOutput(
-        "../testdata/p4_16_samples_outputs/metrics/metrics_test_9_metrics.json");
+        srcPath("testdata/p4_16_samples_outputs/metrics/metrics_test_9_metrics.json"));
 }
 
 TEST_F(MetricPassesTest, MetricsTest10) {
-    inputFile = "../testdata/p4_16_samples/metrics/metrics_test_8.p4";
+    inputFile = srcPath("testdata/p4_16_samples/metrics/metrics_test_8.p4");
     SetUpFrontend(true);
 
     // Check if the metric values got written to compiler context.


### PR DESCRIPTION
test/gtest/metrics_test.cpp builds its testdata paths as "../testdata/...". The gtest binary runs with WORKING_DIRECTORY ${P4C_BINARY_DIR} (test/CMakeLists.txt:94), so those paths only resolve when the build directory sits directly under the source root. Anywhere else all 10 MetricPassesTest cases fail:

    cc1: fatal error: ../testdata/p4_16_samples/metrics/metrics_test_1.p4:
    No such file or directory
    [  FAILED  ] MetricPassesTest.MetricsTest1

This is not only about out of tree build directories. It also breaks for a build directory one level deeper inside the root, such as build/release.

metrics_test.cpp already includes test/gtest/env.h and already uses buildPath from it, so this switches the testdata paths to sourcePath from the same header. test/gtest/parser_unroll.cpp does the same thing.

Two things worth pre-empting:

- Why not copy the inputs into the build directory, the way test_fromJSON.p4  is handled a few lines above in test/CMakeLists.txt? That is one file. Here  it would be 8 inputs plus 9 expected outputs.
- The generated _metrics.txt and _metrics.json files still land next to the input file in the source tree. That is unchanged. Under the documented  <src>/build layout "../testdata/" already pointed there.

Checked with an out of source build: the 10 MetricPassesTest cases pass, and the full gtest binary is green.

