### PR TITLE
Fix compound shift type checking

### DIFF
--- a/frontends/p4/typeChecking/typeCheckStmt.cpp
+++ b/frontends/p4/typeChecking/typeCheckStmt.cpp
@@ -167,7 +167,7 @@ const IR::Node *TypeInferenceBase::postorder(const IR::OpAssignmentStatement *as
 const IR::Node *TypeInferenceBase::shiftAssign(const IR::OpAssignmentStatement *assign) {
     LOG3("TI Visiting " << dbp(getOriginal()));
     auto ltype = getType(assign->left);
-    auto rtype = getType(assign->left);
+    auto rtype = getType(assign->right);
     if (!ltype) return assign;
     if (!isLeftValue(assign->left)) {
         typeError("Expression %1% cannot be the target of an assignment", assign->left);

--- a/testdata/p4_16_errors/compound-shift-err.p4
+++ b/testdata/p4_16_errors/compound-shift-err.p4
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2026 The P4 Language Consortium
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <core.p4>
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+
+@test_keep_opassign
+
+header t1 {
+    bit<32> f1;
+    bool    b1;
+}
+
+struct headers_t {
+    t1 head;
+}
+
+control c(inout headers_t hdrs) {
+    apply {
+        hdrs.head.f1 <<= hdrs.head.b1;
+        hdrs.head.f1 >>= hdrs.head.b1;
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/compound-shift-err.p4
+++ b/testdata/p4_16_errors_outputs/compound-shift-err.p4
@@ -1,0 +1,22 @@
+#include <core.p4>
+
+
+control generic<M>(inout M m);
+package top<M>(generic<M> c);
+@test_keep_opassign header t1 {
+    bit<32> f1;
+    bool    b1;
+}
+
+struct headers_t {
+    t1 head;
+}
+
+control c(inout headers_t hdrs) {
+    apply {
+        hdrs.head.f1 <<= hdrs.head.b1;
+        hdrs.head.f1 >>= hdrs.head.b1;
+    }
+}
+
+top(c()) main;

--- a/testdata/p4_16_errors_outputs/compound-shift-err.p4-stderr
+++ b/testdata/p4_16_errors_outputs/compound-shift-err.p4-stderr
@@ -1,0 +1,6 @@
+compound-shift-err.p4(25): [--Werror=type-error] error: <<=: cannot be applied with 'hdrs.head.b1' with type 'bool'
+        hdrs.head.f1 <<= hdrs.head.b1;
+                         ^^^^^^^^^^^^
+compound-shift-err.p4(26): [--Werror=type-error] error: >>=: cannot be applied with 'hdrs.head.b1' with type 'bool'
+        hdrs.head.f1 >>= hdrs.head.b1;
+                         ^^^^^^^^^^^^


### PR DESCRIPTION
The type checker was looking at the left-hand side twice when checking compound shift assignments (`<<=` and `>>=`).

Because of this, an invalid right-hand side such as a `bool` could get through type checking without any error.

This change fixes the lookup so the actual right-hand side is checked. A regression test was also added for this case.

### Before

For example:

```p4
bit<32> f1;
bool b1;

f1 <<= b1;
f1 >>= b1;
```

was incorrectly accepted by `p4test` with exit code `0`.

The regression test therefore failed with:

```text
Program was expected to fail
```

### After

The same program is now rejected with the expected type errors:

```text
error: <<=: cannot be applied with 'hdrs.head.b1' with type 'bool'
error: >>=: cannot be applied with 'hdrs.head.b1' with type 'bool'
```

`p4test` exits with code `1`, and the regression test passes.

### Testing

* `compound-shift-err` — passed
* `compound-assignment` — passed
* `opassign1` — passed
* relevant shift tests — passed
* `clang-format --dry-run --Werror` — passed
* `git diff --check` — passed
