### PR TITLE
Fix duplicate table entry detection for equivalent key values

### DIFF
--- a/midend/checkTableEntries.cpp
+++ b/midend/checkTableEntries.cpp
@@ -19,40 +19,100 @@
 
 using namespace P4::literals;
 
-/* Given an expression for a entry key , extract the mask and test value.
+static int get_width_bits(const P4::IR::Type *type) {
+    if (!type) return 0;
+    if (auto *tb = type->to<P4::IR::Type_Bits>()) return tb->width_bits();
+    if (auto *se = type->to<P4::IR::Type_SerEnum>()) return get_width_bits(se->type);
+    if (auto *td = type->to<P4::IR::Type_Typedef>()) return get_width_bits(td->type);
+    if (auto *nt = type->to<P4::IR::Type_Newtype>()) return get_width_bits(nt->type);
+    if (type->is<P4::IR::Type_Boolean>()) return 1;
+    return 0;
+}
+
+/* Given an expression for an entry key, extract the mask and test value.
  * A key value will match this entry iff (key & mask == val) */
-void P4::CheckTableEntries::get_mask_val(const IR::Expression *e, big_int &mask, big_int &val) {
+bool P4::CheckTableEntries::get_mask_val(const IR::Expression *e, int width, big_int &mask,
+                                         big_int &val) {
+    while (auto *c = e->to<IR::Cast>()) e = c->expr;
     if (auto *m = e->to<IR::Mask>()) {
-        auto *l = m->left->to<IR::Constant>();
-        auto *r = m->right->to<IR::Constant>();
-        if (l && r) {
-            mask = r->value;
-            val = l->value;
-        } else
-            error(ErrorType::ERR_UNEXPECTED, "%1% Unexpected entry key expression", e);
+        auto *l = m->left;
+        while (auto *c = l->to<IR::Cast>()) l = c->expr;
+        auto *r = m->right;
+        while (auto *c = r->to<IR::Cast>()) r = c->expr;
+        auto *lc = l->to<IR::Constant>();
+        auto *rc = r->to<IR::Constant>();
+        if (lc && rc) {
+            mask = rc->value;
+            val = lc->value;
+            if (width > 0) {
+                mask &= IR::Constant::GetMask(width).value;
+                val &= mask;
+            }
+            return true;
+        }
     } else if (auto *k = e->to<IR::Constant>()) {
         val = k->value;
-        if (auto w = k->type->width_bits(); w > 0)
+        int w = width > 0 ? width : get_width_bits(k->type);
+        if (w > 0) {
             mask = IR::Constant::GetMask(w).value;
-        else
+            val &= mask;
+        } else {
             mask = -1;
+        }
+        return true;
     } else if (auto *bl = e->to<IR::BoolLiteral>()) {
         mask = 1;
         val = bl->value ? 1 : 0;
+        return true;
     } else if (e->is<IR::DefaultExpression>()) {
         mask = val = 0;
-    } else {
-        error(ErrorType::ERR_UNEXPECTED, "%1% Unexpected entry key expression", e);
+        return true;
     }
+    return false;
 }
 
-/* Check two ternary entry keys to see if first one "covers" the second one -- that is, the
- * the first one will always match if the second one does.  That is,  ∀v: v∈k2 -> v∈k1
- */
-bool P4::CheckTableEntries::ternary_covers(const IR::Expression *k1, const IR::Expression *k2) {
+/* Check if two entry key components match the exact same value/range. */
+bool P4::CheckTableEntries::keys_equal(const IR::Expression *k1, const IR::Expression *k2,
+                                       int width) {
+    while (auto *c = k1->to<IR::Cast>()) k1 = c->expr;
+    while (auto *c = k2->to<IR::Cast>()) k2 = c->expr;
+
+    if (auto *r1 = k1->to<IR::Range>()) {
+        if (auto *r2 = k2->to<IR::Range>()) {
+            auto *l1 = r1->left;
+            while (auto *c = l1->to<IR::Cast>()) l1 = c->expr;
+            auto *right1 = r1->right;
+            while (auto *c = right1->to<IR::Cast>()) right1 = c->expr;
+            auto *l2 = r2->left;
+            while (auto *c = l2->to<IR::Cast>()) l2 = c->expr;
+            auto *right2 = r2->right;
+            while (auto *c = right2->to<IR::Cast>()) right2 = c->expr;
+
+            auto *c_l1 = l1->to<IR::Constant>();
+            auto *c_r1 = right1->to<IR::Constant>();
+            auto *c_l2 = l2->to<IR::Constant>();
+            auto *c_r2 = right2->to<IR::Constant>();
+            if (c_l1 && c_r1 && c_l2 && c_r2)
+                return c_l1->value == c_l2->value && c_r1->value == c_r2->value;
+        }
+        return k1->equiv(*k2);
+    }
+
+    big_int m1, v1, m2, v2;
+    if (get_mask_val(k1, width, m1, v1) && get_mask_val(k2, width, m2, v2)) {
+        return m1 == m2 && (v1 & m1) == (v2 & m2);
+    }
+
+    return k1->equiv(*k2);
+}
+
+/* Check if the first ternary entry key covers the second one, meaning every
+ * value matched by the second key is also matched by the first key. */
+bool P4::CheckTableEntries::ternary_covers(const IR::Expression *k1, const IR::Expression *k2,
+                                           int width) {
     big_int k1_mask, k1_val, k2_mask, k2_val;
-    get_mask_val(k1, k1_mask, k1_val);
-    get_mask_val(k2, k2_mask, k2_val);
+    if (!get_mask_val(k1, width, k1_mask, k1_val) || !get_mask_val(k2, width, k2_mask, k2_val))
+        return false;
     if ((k1_mask & k2_mask) != k1_mask) return false;
     return (k1_val & k1_mask) == (k2_val & k1_mask);
 }
@@ -77,33 +137,41 @@ bool P4::CheckTableEntries::preorder(const IR::P4Table *tbl) {
         BUG_CHECK(entry->keys->size() == ternary_keys.size(), "%1% key size mismatch", entry);
 
         for (auto *prev : prev_keys) {
-            bool no_match = false, ternary_match = false;
+            bool is_duplicate = true;
+            bool is_covered = true;
+
             for (unsigned i = 0; i < entry->keys->size(); ++i) {
-                if (entry->keys->components[i]->equiv(*prev->components[i])) {
-                    // matches
-                } else if (ternary_keys[i]) {
-                    ternary_match = true;
-                    if (!ternary_covers(prev->components[i], entry->keys->components[i])) {
-                        no_match = true;
-                        break;
-                    }
-                } else {
-                    no_match = true;
-                    break;
+                auto *k1 = prev->components[i];
+                auto *k2 = entry->keys->components[i];
+                auto *key_el = key->keyElements[i];
+                int width = get_width_bits(key_el->expression->type);
+
+                if (keys_equal(k1, k2, width)) {
+                    continue;
                 }
+
+                is_duplicate = false;
+                if (ternary_keys[i] && ternary_covers(k1, k2, width)) {
+                    continue;
+                }
+
+                is_covered = false;
+                break;
             }
-            if (no_match) continue;
-            if (ternary_match)
+
+            if (is_duplicate) {
+                if (genError)
+                    error(ErrorType::ERR_TABLE_KEYS, "%1%%2%Duplicate entry keys",
+                          entry->keys->srcInfo, prev->srcInfo);
+                else
+                    warning(ErrorType::WARN_TABLE_KEYS, "%1%%2%Duplicate entry keys",
+                            entry->keys->srcInfo, prev->srcInfo);
+                break;
+            } else if (is_covered) {
                 warning(ErrorType::WARN_TABLE_KEYS, "%1%%2%Ternary entry covered by previous entry",
                         entry->keys->srcInfo, prev->srcInfo);
-            else if (genError)
-                error(ErrorType::ERR_TABLE_KEYS, "%1%%2%Duplicate entry keys", entry->keys->srcInfo,
-                      prev->srcInfo);
-            else
-                warning(ErrorType::WARN_TABLE_KEYS, "%1%%2%Duplicate entry keys",
-                        entry->keys->srcInfo, prev->srcInfo);
-            // don't bother with more than one error/warning per entry
-            break;
+                break;
+            }
         }
         prev_keys.push_back(entry->keys);
     }

--- a/midend/checkTableEntries.h
+++ b/midend/checkTableEntries.h
@@ -28,8 +28,9 @@ class CheckTableEntries : public Inspector {
     bool preorder(const IR::P4Table *);
     bool preorder(const IR::P4Parser *) { return false; }
     bool preorder(const IR::Statement *) { return false; }
-    void get_mask_val(const IR::Expression *, big_int &mask, big_int &val);
-    bool ternary_covers(const IR::Expression *k1, const IR::Expression *k2);
+    bool get_mask_val(const IR::Expression *, int width, big_int &mask, big_int &val);
+    bool keys_equal(const IR::Expression *k1, const IR::Expression *k2, int width);
+    bool ternary_covers(const IR::Expression *k1, const IR::Expression *k2, int width);
 
  public:
     explicit CheckTableEntries(bool err = false) : genError(err) {}

--- a/testdata/p4_16_errors/table-entries-dup-base.p4
+++ b/testdata/p4_16_errors/table-entries-dup-base.p4
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nvidia Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <core.p4>
+
+struct Headers {
+    bit<8> a;
+    bit<8> b;
+    bit<8> c;
+}
+
+control ingress(inout Headers h) {
+    action a1(bit<8> v) { h.a = v; }
+
+    table t_exact {
+        key = { h.b : exact; }
+        actions = { a1; NoAction; }
+        const entries = {
+            0x02 : a1(1);
+            2    : a1(2);
+        }
+    }
+
+    apply {
+        t_exact.apply();
+    }
+}
+
+control c<T>(inout T d);
+package top<T>(c<T> _c);
+
+top(ingress()) main;

--- a/testdata/p4_16_errors_outputs/table-entries-dup-base-first.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-dup-base-first.p4
@@ -1,0 +1,35 @@
+#include <core.p4>
+
+
+struct Headers {
+    bit<8> a;
+    bit<8> b;
+    bit<8> c;
+}
+
+control ingress(inout Headers h) {
+    action a1(bit<8> v) {
+        h.a = v;
+    }
+    table t_exact {
+        key = {
+            h.b: exact @name("h.b");
+        }
+        actions = {
+            a1();
+            NoAction();
+        }
+        const entries = {
+                        8w0x2 : a1(8w1);
+                        8w2 : a1(8w2);
+        }
+        default_action = NoAction();
+    }
+    apply {
+        t_exact.apply();
+    }
+}
+
+control c<T>(inout T d);
+package top<T>(c<T> _c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_errors_outputs/table-entries-dup-base-frontend.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-dup-base-frontend.p4
@@ -1,0 +1,37 @@
+#include <core.p4>
+
+
+struct Headers {
+    bit<8> a;
+    bit<8> b;
+    bit<8> c;
+}
+
+control ingress(inout Headers h) {
+    @noWarn("unused") @name(".NoAction") action NoAction_1() {
+    }
+    @name("ingress.a1") action a1(@name("v") bit<8> v) {
+        h.a = v;
+    }
+    @name("ingress.t_exact") table t_exact_0 {
+        key = {
+            h.b: exact @name("h.b");
+        }
+        actions = {
+            a1();
+            NoAction_1();
+        }
+        const entries = {
+                        8w0x2 : a1(8w1);
+                        8w2 : a1(8w2);
+        }
+        default_action = NoAction_1();
+    }
+    apply {
+        t_exact_0.apply();
+    }
+}
+
+control c<T>(inout T d);
+package top<T>(c<T> _c);
+top<Headers>(ingress()) main;

--- a/testdata/p4_16_errors_outputs/table-entries-dup-base.p4
+++ b/testdata/p4_16_errors_outputs/table-entries-dup-base.p4
@@ -1,0 +1,34 @@
+#include <core.p4>
+
+
+struct Headers {
+    bit<8> a;
+    bit<8> b;
+    bit<8> c;
+}
+
+control ingress(inout Headers h) {
+    action a1(bit<8> v) {
+        h.a = v;
+    }
+    table t_exact {
+        key = {
+            h.b: exact;
+        }
+        actions = {
+            a1;
+            NoAction;
+        }
+        const entries = {
+                        0x2 : a1(1);
+                        2 : a1(2);
+        }
+    }
+    apply {
+        t_exact.apply();
+    }
+}
+
+control c<T>(inout T d);
+package top<T>(c<T> _c);
+top(ingress()) main;

--- a/testdata/p4_16_errors_outputs/table-entries-dup-base.p4-stderr
+++ b/testdata/p4_16_errors_outputs/table-entries-dup-base.p4-stderr
@@ -1,0 +1,6 @@
+table-entries-dup-base.p4(23): [--Werror=keys] error: Duplicate entry keys
+            2 : a1(2);
+            ^
+table-entries-dup-base.p4(22)
+            0x02 : a1(1);
+            ^^^^


### PR DESCRIPTION
## What does this PR change?

`CheckTableEntries` used `IR::Node::equiv()` to compare table entry keys. For `IR::Constant`, this comparison also considered the literal base, so semantically identical values written in different representations, such as `0x02` and `2`, were treated as different keys.

As a result, duplicate table entries could be silently accepted without a diagnostic.

This PR fixes the duplicate-key check by:

- comparing key values semantically rather than by literal representation;
- normalizing constants and masks using the declared table key width;
- detecting duplicate keys for exact, LPM, range, and ternary match kinds;
- preserving the distinction between duplicate keys and ternary entries covered by a previous entry;
- adding a regression test for mixed-base duplicate keys.

## Before

For example:

```p4
const entries = {
    0x02 : a1(1);
    2    : a1(2);
}
```

Both keys represent the same value, but the previous implementation treated them as different.

Result:

```text
Exit code: 0
No duplicate-key diagnostic
```

## After

The same input now correctly produces:

```text
error: Duplicate entry keys
Exit code: 1
```

## Testing

Added regression test:

`testdata/p4_16_errors/table-entries-dup-base.p4`

The targeted table-entry test suite was also run:

```text
ctest -R table-entries -E dpdk -V

100% tests passed, 0 tests failed out of 20
```